### PR TITLE
Avoid volatile writes from Atomics default values

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/time/MonotonicClock.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/time/MonotonicClock.java
@@ -57,7 +57,7 @@ class MonotonicClock implements Clock {
 
     private final AtomicLong syncMillisRef;
     private final AtomicLong syncNanosRef;
-    private final AtomicLong currentTime = new AtomicLong(0);
+    private final AtomicLong currentTime = new AtomicLong();
 
     MonotonicClock() {
         this(TimeSource.SYSTEM, SYNC_INTERVAL_MILLIS);

--- a/subprojects/build-cache/src/jmh/java/org/gradle/caching/internal/tasks/ChmodBenchmark.java
+++ b/subprojects/build-cache/src/jmh/java/org/gradle/caching/internal/tasks/ChmodBenchmark.java
@@ -87,7 +87,7 @@ public class ChmodBenchmark {
     public void setupIteration() throws IOException {
         this.tempDirPath = Files.createTempDirectory(tempRootDir, "iteration");
         this.tempDirFile = tempDirPath.toFile();
-        this.counter = new AtomicInteger(0);
+        this.counter = new AtomicInteger();
     }
 
     @TearDown(Level.Iteration)

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheClassLoaderCachingIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheClassLoaderCachingIntegrationTest.groovy
@@ -35,7 +35,7 @@ class ConfigurationCacheClassLoaderCachingIntegrationTest extends PersistentBuil
 
                 public class StaticData extends DefaultTask {
 
-                    private static final AtomicInteger value = new AtomicInteger(0);
+                    private static final AtomicInteger value = new AtomicInteger();
 
                     private final String projectName = getProject().getName();
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/cache/internal/DefaultGeneratedGradleJarCacheIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/cache/internal/DefaultGeneratedGradleJarCacheIntegrationTest.groovy
@@ -106,7 +106,7 @@ class DefaultGeneratedGradleJarCacheIntegrationTest extends Specification {
     def "only generates single JAR in cache when invoked by concurrent threads"() {
         given:
         def jarGenerationInvocations = 10
-        def triggeredJarFileGeneration = new AtomicInteger(0)
+        def triggeredJarFileGeneration = new AtomicInteger()
         def jarFiles = Collections.synchronizedList(new ArrayList<File>())
 
         when:

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultRealizableTaskCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultRealizableTaskCollection.java
@@ -47,7 +47,7 @@ public class DefaultRealizableTaskCollection<T extends Task> implements TaskColl
 
     private final TaskCollection<T> delegate;
     private final Class<T> type;
-    private final AtomicBoolean realized = new AtomicBoolean(false);
+    private final AtomicBoolean realized = new AtomicBoolean();
     private final MutableModelNode modelNode;
     private final Instantiator instantiator;
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/FileParameterUtils.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/FileParameterUtils.java
@@ -147,7 +147,7 @@ public class FileParameterUtils {
             }
         } else {
             FileCollectionInternal outputFileCollection = fileCollectionFactory.resolving(unpackedValue);
-            AtomicInteger index = new AtomicInteger(0);
+            AtomicInteger index = new AtomicInteger();
             outputFileCollection.visitStructure(new FileCollectionStructureVisitor() {
                 @Override
                 public void visitCollection(FileCollectionInternal.Source source, Iterable<File> contents) {

--- a/subprojects/core/src/test/groovy/org/gradle/testfixtures/ProjectBuilderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/testfixtures/ProjectBuilderTest.groovy
@@ -133,7 +133,7 @@ class ProjectBuilderTest extends Specification {
 
     def "Can trigger afterEvaluate programmatically"() {
         setup:
-        def latch = new AtomicBoolean(false)
+        def latch = new AtomicBoolean()
 
         when:
         def project = buildProject()
@@ -153,7 +153,7 @@ class ProjectBuilderTest extends Specification {
     @Issue("GRADLE-3136")
     def "Can trigger afterEvaluate programmatically after calling getTasksByName"() {
         setup:
-        def latch = new AtomicBoolean(false)
+        def latch = new AtomicBoolean()
 
         when:
         def project = buildProject()

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -230,7 +230,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     private final DomainObjectCollectionFactory domainObjectCollectionFactory;
     private final Lazy<List<DependencyConstraint>> consistentResolutionConstraints = Lazy.unsafe().of(this::consistentResolutionConstraints);
 
-    private final AtomicInteger copyCount = new AtomicInteger(0);
+    private final AtomicInteger copyCount = new AtomicInteger();
 
     private Action<? super ConfigurationInternal> beforeLocking;
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/store/ResolutionResultsStoreFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/store/ResolutionResultsStoreFactory.java
@@ -42,7 +42,7 @@ public class ResolutionResultsStoreFactory implements Closeable {
     private CachedStoreFactory<TransientConfigurationResults> oldModelCache;
     private CachedStoreFactory<ResolvedComponentResult> newModelCache;
 
-    private final AtomicInteger storeSetBaseId = new AtomicInteger(0);
+    private final AtomicInteger storeSetBaseId = new AtomicInteger();
 
     public ResolutionResultsStoreFactory(TemporaryFileProvider temp) {
         this(temp, DEFAULT_MAX_SIZE);

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformInvocationTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformInvocationTest.groovy
@@ -40,7 +40,7 @@ import org.gradle.test.fixtures.file.TestFile
 import java.util.concurrent.atomic.AtomicInteger
 
 class ArtifactTransformInvocationTest extends AbstractProjectBuilderSpec {
-    public static final AtomicInteger INVOCATION_COUNT = new AtomicInteger(0)
+    public static final AtomicInteger INVOCATION_COUNT = new AtomicInteger()
     public static final String SELECTED_PATH = "selected.txt"
 
     def artifactType = Attribute.of('artifactType', String)

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DirectoryWalkerTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DirectoryWalkerTest.groovy
@@ -42,7 +42,7 @@ class DirectoryWalkerTest extends AbstractDirectoryWalkerTest<DirectoryWalker> {
     def "both DirectoryWalker implementations return same set of files and attributes"() {
         given:
         def rootDir = tmpDir.createDir("root")
-        generateFilesAndSubDirectories(rootDir, 10, 5, 3, 1, new AtomicInteger(0))
+        generateFilesAndSubDirectories(rootDir, 10, 5, 3, 1, new AtomicInteger())
 
         when:
         def visitedWithReproducibleWalker = walkFiles(rootDir, true)

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/GeneratedSingletonFileTreeTest.java
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/GeneratedSingletonFileTreeTest.java
@@ -59,7 +59,7 @@ public class GeneratedSingletonFileTreeTest {
 
     @Test
     public void containsWontCreateFiles() {
-        final AtomicInteger callCounter = new AtomicInteger(0);
+        final AtomicInteger callCounter = new AtomicInteger();
         Action<OutputStream> fileAction = new Action<OutputStream>() {
             @Override
             public void execute(OutputStream outputStream) {

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DefaultFileWatcherRegistry.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DefaultFileWatcherRegistry.java
@@ -182,7 +182,7 @@ public class DefaultFileWatcherRegistry implements FileWatcherRegistry {
     public FileWatchingStatistics getAndResetStatistics() {
         MutableFileWatchingStatistics currentStatistics = fileWatchingStatistics;
         fileWatchingStatistics = new MutableFileWatchingStatistics();
-        AtomicInteger numberOfWatchedHierarchies = new AtomicInteger(0);
+        AtomicInteger numberOfWatchedHierarchies = new AtomicInteger();
         fileWatcherUpdater.getWatchedFiles().visitRoots(root -> numberOfWatchedHierarchies.incrementAndGet());
         return new FileWatchingStatistics() {
             @Override

--- a/subprojects/functional/src/test/groovy/org/gradle/internal/DeferrableTest.groovy
+++ b/subprojects/functional/src/test/groovy/org/gradle/internal/DeferrableTest.groovy
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicInteger
 class DeferrableTest extends Specification {
 
     def "mapping #description invocations only creates the second invocation once"() {
-        def mappingCount = new AtomicInteger(0)
+        def mappingCount = new AtomicInteger()
 
         def mapped = deferred.map { Integer input ->
             mappingCount.incrementAndGet()
@@ -47,7 +47,7 @@ class DeferrableTest extends Specification {
     }
 
     def "composing #description invocations only creates the second invocation once"() {
-        def creationCount = new AtomicInteger(0)
+        def creationCount = new AtomicInteger()
 
         def composed = first.flatMap { Integer input ->
             creationCount.incrementAndGet()

--- a/subprojects/functional/src/test/groovy/org/gradle/internal/lazy/LazyTest.groovy
+++ b/subprojects/functional/src/test/groovy/org/gradle/internal/lazy/LazyTest.groovy
@@ -153,7 +153,7 @@ class LazyTest extends Specification {
     def "locking lazy can handle concurrent threads"() {
         def supplier = Mock(Supplier)
         Lazy<Integer> lazy = Lazy.locking().of(supplier)
-        def total = new AtomicInteger(0)
+        def total = new AtomicInteger()
 
         int concurrency = 20
         def barrier = new CyclicBarrier(concurrency)
@@ -177,7 +177,7 @@ class LazyTest extends Specification {
     def "locking lazy can handle concurrent threads with map"() {
         def supplier = Mock(Supplier)
         Lazy<Integer> lazy = Lazy.locking().of(supplier).map { 2 * it }
-        def total = new AtomicInteger(0)
+        def total = new AtomicInteger()
 
         int concurrency = 20
         def barrier = new CyclicBarrier(concurrency)

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForConfigurationCacheExtension.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ToBeFixedForConfigurationCacheExtension.groovy
@@ -77,7 +77,7 @@ class ToBeFixedForConfigurationCacheExtension implements IAnnotationDrivenExtens
 
         @Override
         void intercept(IMethodInvocation invocation) throws Throwable {
-            final AtomicBoolean pass = new AtomicBoolean(false)
+            final AtomicBoolean pass = new AtomicBoolean()
             invocation.getFeature().getFeatureMethod().interceptors.add(
                 0,
                 new InnerIterationInterceptor(pass, iterationMatchers)

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AbstractBuildExperimentRunner.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AbstractBuildExperimentRunner.java
@@ -187,7 +187,7 @@ public abstract class AbstractBuildExperimentRunner implements BuildExperimentRu
         MeasuredOperationList results,
         Consumer<T> scenarioReporter
     ) {
-        AtomicInteger iterationCount = new AtomicInteger(0);
+        AtomicInteger iterationCount = new AtomicInteger();
         return invocationResult -> {
             int currentIteration = iterationCount.incrementAndGet();
             if (currentIteration > scenarioDefinition.getWarmUpCount()) {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/AbstractTablePageGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/AbstractTablePageGenerator.java
@@ -49,7 +49,7 @@ public abstract class AbstractTablePageGenerator extends HtmlPageGenerator<Resul
     }
 
     protected abstract class TableHtml extends MetricsHtml {
-        AtomicInteger counter = new AtomicInteger(0);
+        AtomicInteger counter = new AtomicInteger();
 
         public TableHtml(Writer writer) {
             super(writer);

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultInMemoryCacheDecoratorFactory.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultInMemoryCacheDecoratorFactory.java
@@ -64,7 +64,7 @@ public class DefaultInMemoryCacheDecoratorFactory implements InMemoryCacheDecora
     private CacheDetails getCache(final String cacheId, final int maxSize) {
         CacheDetails cacheDetails = caches.get(cacheId, () -> {
             Cache<Object, Object> entries = createInMemoryCache(cacheId, maxSize);
-            CacheDetails details = new CacheDetails(cacheId, maxSize, entries, new AtomicReference<>(null));
+            CacheDetails details = new CacheDetails(cacheId, maxSize, entries, new AtomicReference<>());
             LOG.debug("Creating in-memory store for cache {} (max size: {})", cacheId, maxSize);
             return details;
         });

--- a/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainIntegrationTest.groovy
+++ b/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainIntegrationTest.groovy
@@ -144,7 +144,7 @@ class JavaToolchainIntegrationTest extends AbstractIntegrationSpec {
 
             apply plugin: "java"
 
-            def toolchainSpecRef = new AtomicReference<JavaToolchainSpec>(null)
+            def toolchainSpecRef = new AtomicReference<JavaToolchainSpec>()
 
             javaToolchains.launcherFor {
                 toolchainSpecRef.set(delegate)

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
@@ -328,7 +328,7 @@ public class DirectorySnapshotter {
                 if (attrs.isSymbolicLink()) {
                     BasicFileAttributes targetAttributes = readAttributesOfSymlinkTarget(file, attrs);
                     if (targetAttributes.isDirectory()) {
-                        AtomicBoolean symlinkHasBeenFiltered = new AtomicBoolean(false);
+                        AtomicBoolean symlinkHasBeenFiltered = new AtomicBoolean();
                         DirectorySnapshot targetSnapshot = followSymlink(file, internedFileName, symlinkHasBeenFiltered);
                         if (targetSnapshot != null) {
                             DirectorySnapshot directorySnapshotAccessedViaSymlink = new DirectorySnapshot(

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/FileSystemSnapshotFilter.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/FileSystemSnapshotFilter.java
@@ -43,7 +43,7 @@ public class FileSystemSnapshotFilter {
 
     public static FileSystemSnapshot filterSnapshot(SnapshottingFilter.FileSystemSnapshotPredicate predicate, FileSystemSnapshot unfiltered) {
         DirectorySnapshotBuilder builder = MerkleDirectorySnapshotBuilder.noSortingRequired();
-        AtomicBoolean hasBeenFiltered = new AtomicBoolean(false);
+        AtomicBoolean hasBeenFiltered = new AtomicBoolean();
         unfiltered.accept(new RelativePathTracker(), new FilteringVisitor(predicate, builder, hasBeenFiltered));
         if (builder.getResult() == null) {
             return FileSystemSnapshot.EMPTY;

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/DirectorySnapshotterAsDirectoryWalkerTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/DirectorySnapshotterAsDirectoryWalkerTest.groovy
@@ -41,7 +41,7 @@ class DirectorySnapshotterAsDirectoryWalkerTest extends AbstractDirectoryWalkerT
     def "directory snapshotter returns the same details as directory walker"() {
         given:
         def rootDir = tmpDir.createDir("root")
-        generateFilesAndSubDirectories(rootDir, 10, 5, 3, 1, new AtomicInteger(0))
+        generateFilesAndSubDirectories(rootDir, 10, 5, 3, 1, new AtomicInteger())
         def patternSet = Mock(PatternSet)
         List<FileVisitDetails> visitedWithJdk7Walker = walkFiles(rootDir)
         Spec<FileTreeElement> assertingSpec = new Spec<FileTreeElement>() {

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/AggregateTestResultsProvider.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/AggregateTestResultsProvider.java
@@ -44,7 +44,7 @@ public class AggregateTestResultsProvider implements TestResultsProvider {
     public void visitClasses(final Action<? super TestClassResult> visitor) {
         final Map<String, OverlaidIdProxyingTestClassResult> aggregatedTestResults = new LinkedHashMap<String, OverlaidIdProxyingTestClassResult>();
         classOutputProviders = ArrayListMultimap.create();
-        final AtomicLong newIdCounter = new AtomicLong(0L);
+        final AtomicLong newIdCounter = new AtomicLong();
         for (final TestResultsProvider provider : providers) {
             provider.visitClasses(new Action<TestClassResult>() {
                 @Override


### PR DESCRIPTION
Hi,

this PR avoids some volatile writes from `Atomics` default values.

Cheers,
Christoph