### PR TITLE
Revert "Remove deprecated IdeaModule.testSourceDirs and IdeaModule.te…

### DIFF
--- a/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
+++ b/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
@@ -697,38 +697,6 @@
             ]
         },
         {
-            "type": "org.gradle.plugins.ide.idea.model.IdeaModule",
-            "member": "Method org.gradle.plugins.ide.idea.model.IdeaModule.getTestResourceDirs()",
-            "acceptation": "Removed deprecated method in Gradle 8.0",
-            "changes": [
-                "Method has been removed"
-            ]
-        },
-        {
-            "type": "org.gradle.plugins.ide.idea.model.IdeaModule",
-            "member": "Method org.gradle.plugins.ide.idea.model.IdeaModule.getTestSourceDirs()",
-            "acceptation": "Removed deprecated method in Gradle 8.0",
-            "changes": [
-                "Method has been removed"
-            ]
-        },
-        {
-            "type": "org.gradle.plugins.ide.idea.model.IdeaModule",
-            "member": "Method org.gradle.plugins.ide.idea.model.IdeaModule.setTestResourceDirs(java.util.Set)",
-            "acceptation": "Removed deprecated method in Gradle 8.0",
-            "changes": [
-                "Method has been removed"
-            ]
-        },
-        {
-            "type": "org.gradle.plugins.ide.idea.model.IdeaModule",
-            "member": "Method org.gradle.plugins.ide.idea.model.IdeaModule.setTestSourceDirs(java.util.Set)",
-            "acceptation": "Removed deprecated method in Gradle 8.0",
-            "changes": [
-                "Method has been removed"
-            ]
-        },
-        {
             "type": "org.gradle.process.JavaExecSpec",
             "member": "Method org.gradle.process.JavaExecSpec.getMain()",
             "acceptation": "Removed for Gradle 8.0",

--- a/subprojects/architecture-test/src/changes/archunit_store/public-api-mutable-properties.txt
+++ b/subprojects/architecture-test/src/changes/archunit_store/public-api-mutable-properties.txt
@@ -711,6 +711,8 @@ Method <org.gradle.plugins.ide.idea.model.IdeaModule.getSingleEntryLibraries()> 
 Method <org.gradle.plugins.ide.idea.model.IdeaModule.getSourceDirs()> does not have raw return type assignable to org.gradle.api.provider.Property in (IdeaModule.java:232)
 Method <org.gradle.plugins.ide.idea.model.IdeaModule.getTargetBytecodeVersion()> does not have raw return type assignable to org.gradle.api.provider.Property in (IdeaModule.java:463)
 Method <org.gradle.plugins.ide.idea.model.IdeaModule.getTestOutputDir()> does not have raw return type assignable to org.gradle.api.provider.Property in (IdeaModule.java:405)
+Method <org.gradle.plugins.ide.idea.model.IdeaModule.getTestResourceDirs()> does not have raw return type assignable to org.gradle.api.provider.Property in (IdeaModule.java:405)
+Method <org.gradle.plugins.ide.idea.model.IdeaModule.getTestSourceDirs()> does not have raw return type assignable to org.gradle.api.provider.Property in (IdeaModule.java:347)
 Method <org.gradle.plugins.ide.idea.model.IdeaModule.isDownloadJavadoc()> does not have raw return type assignable to org.gradle.api.provider.Property in (IdeaModule.java:303)
 Method <org.gradle.plugins.ide.idea.model.IdeaModule.isDownloadSources()> does not have raw return type assignable to org.gradle.api.provider.Property in (IdeaModule.java:292)
 Method <org.gradle.plugins.ide.idea.model.IdeaModule.isOffline()> does not have raw return type assignable to org.gradle.api.provider.Property in (IdeaModule.java:499)

--- a/subprojects/docs/src/docs/dsl/org.gradle.plugins.ide.idea.model.IdeaModule.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.plugins.ide.idea.model.IdeaModule.xml
@@ -52,10 +52,21 @@
                 <td/>
             </tr>
             <tr>
+                <td>testSourceDirs</td>
+                <td><literal>[]</literal></td>
+                <td>project.sourceSets.test.allJava</td>
+            </tr>
+            <tr>
                 <td>resourceDirs</td>
                 <td><literal>[]</literal></td>
                 <td>resource dirs from <literal>project.sourceSets.main.resources</literal></td>
             </tr>
+            <tr>
+                <td>testResourceDirs</td>
+                <td><literal>[]</literal></td>
+                <td>resource dirs from <literal>project.sourceSets.test.resources</literal></td>
+            </tr>
+
             <tr>
                 <td>testSources</td>
                 <td><literal>[]</literal></td>

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -75,11 +75,6 @@ The legacy `AntlrSourceVirtualDirectory` API has been removed.
 This change affects the `antlr` plugin.
 In Gradle 8.0 and above, use the `AntlrSourceDirectorySet` source set extension instead.
 
-=== Legacy test sources configuration in `idea` plugin
-
-The deprecated `IdeaModule.getTestSourceDirs()` and `IdeaModule.getTestResourceDirs()` were removed in Gradle 8.0.
-You should use `IdeaModule.getTestSources()` and `IdeaModule.getTestResources()` instead.
-
 === Potential breaking changes
 
 === Wrapper task configuration

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r22/Idea13ModelCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r22/Idea13ModelCrossVersionSpec.groovy
@@ -21,18 +21,20 @@ import org.gradle.tooling.model.idea.IdeaProject
 class Idea13ModelCrossVersionSpec extends ToolingApiSpecification {
 
     def "provides generated sources dir information"() {
-        file('build.gradle').text = """
-            apply plugin: 'java'
-            apply plugin: 'idea'
 
-            idea {
-              module {
-                sourceDirs += file('foo')
-                generatedSourceDirs += file('foo')
-                generatedSourceDirs += file('foo2')
-              }
-            }
-        """
+        file('build.gradle').text = """
+apply plugin: 'java'
+apply plugin: 'idea'
+
+idea {
+  module {
+    sourceDirs += file('foo')
+    testSourceDirs += file('foo2')
+    generatedSourceDirs += file('foo')
+    generatedSourceDirs += file('foo2')
+  }
+}
+"""
 
         when:
         IdeaProject project = withConnection { connection -> connection.getModel(IdeaProject.class) }
@@ -42,6 +44,7 @@ class Idea13ModelCrossVersionSpec extends ToolingApiSpecification {
         def generatedSourceDirectories = contentRoot.sourceDirectories.findAll { it.generated }
         def generatedTestDirectories = contentRoot.testDirectories.findAll { it.generated }
         generatedSourceDirectories.collect { it.directory } == [file('foo')]
+        generatedTestDirectories.collect { it.directory } == [file('foo2')]
         generatedSourceDirectories.every { contentRoot.sourceDirectories.contains(it) }
         generatedTestDirectories.every { contentRoot.testDirectories.contains(it) }
     }

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r50/ToolingApiIdeaModelCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r50/ToolingApiIdeaModelCrossVersionSpec.groovy
@@ -31,6 +31,7 @@ import org.gradle.tooling.model.idea.IdeaProject
 @TargetGradleVersion(">=5.0")
 class ToolingApiIdeaModelCrossVersionSpec extends ToolingApiSpecification {
 
+
     def "provides source dir information"() {
 
         buildFile.text = "apply plugin: 'java'"

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaModuleIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaModuleIntegrationTest.groovy
@@ -34,7 +34,9 @@ class IdeaModuleIntegrationTest extends AbstractIdeIntegrationTest {
         //given
         testResources.dir.create {
             additionalCustomSources {}
+            additionalCustomTestSources {}
             additionalCustomResources {}
+            additionalCustomTestResources {}
             additionalCustomGeneratedResources {}
             muchBetterOutputDir {}
             muchBetterTestOutputDir {}
@@ -45,6 +47,8 @@ class IdeaModuleIntegrationTest extends AbstractIdeIntegrationTest {
         }
 
         //when
+        executer.expectDeprecationWarning('The IdeaModule.testSourceDirs property has been deprecated. This is scheduled to be removed in Gradle 8.0. Please use the testSources property instead.')
+        executer.expectDeprecationWarning('The IdeaModule.testResourceDirs property has been deprecated. This is scheduled to be removed in Gradle 8.0. Please use the testResources property instead.')
         runTask 'idea', '''
 apply plugin: "java"
 apply plugin: "idea"
@@ -62,8 +66,10 @@ idea {
         contentRoot = file('customModuleContentRoot')
 
         sourceDirs += file('additionalCustomSources')
+        testSourceDirs += file('additionalCustomTestSources')
         resourceDirs += file('additionalCustomResources')
         resourceDirs += file('additionalCustomGeneratedResources')
+        testResourceDirs += file('additionalCustomTestResources')
         generatedSourceDirs += file('additionalCustomGeneratedResources')
         excludeDirs += file('excludeMePlease')
 
@@ -91,8 +97,8 @@ idea {
 
         //then
         def iml = parseImlFile('customImlFolder/foo')
-        ['additionalCustomSources',
-         'additionalCustomResources',
+        ['additionalCustomSources', 'additionalCustomTestSources',
+         'additionalCustomResources', 'additionalCustomTestResources',
          'additionalCustomGeneratedResources',
          'src/main/java'].each { expectedSrcFolder ->
             assert iml.component.content.sourceFolder.find { it.@url.text().contains(expectedSrcFolder) }
@@ -100,6 +106,7 @@ idea {
         ['additionalCustomResources', 'additionalCustomGeneratedResources'].each { expectedSrcFolder ->
             assert iml.component.content.sourceFolder.find { it.@url.text().contains(expectedSrcFolder) && it.@type.text() == 'java-resource'}
         }
+        assert iml.component.content.sourceFolder.find { it.@url.text().contains('additionalCustomTestResources') && it.@type == 'java-test-resource' }
         assert iml.component.content.sourceFolder.find { it.@url.text().contains('additionalCustomGeneratedResources') && it.@generated.text() == 'true'}
 
         ['customModuleContentRoot', 'CUSTOM_VARIABLE'].each {
@@ -864,4 +871,20 @@ dependencies {
         dependencies.assertHasLibrary('PROVIDED', 'foo-1.0.jar')
     }
 
+    @Test // TODO: remove in Gradle 8.0
+    @ToBeFixedForConfigurationCache(because = "All other tests in this class are not for CC, this new test is temporary, to be removed in Gradle 8.0")
+    void "using deprecated IdeaModule properties emits deprecation warnings"() {
+        executer.expectDocumentedDeprecationWarning('The IdeaModule.testSourceDirs property has been deprecated. This is scheduled to be removed in Gradle 8.0. Please use the testSources property instead. See https://docs.gradle.org/current/dsl/org.gradle.plugins.ide.idea.model.IdeaModule.html#org.gradle.plugins.ide.idea.model.IdeaModule:testSourceDirs for more details.')
+        executer.expectDocumentedDeprecationWarning('The IdeaModule.testResourceDirs property has been deprecated. This is scheduled to be removed in Gradle 8.0. Please use the testResources property instead. See https://docs.gradle.org/current/dsl/org.gradle.plugins.ide.idea.model.IdeaModule.html#org.gradle.plugins.ide.idea.model.IdeaModule:testResourceDirs for more details.')
+        runIdeaTask '''
+apply plugin: "idea"
+
+idea {
+    module {
+        testSourceDirs += file('additionalCustomTestSources')
+        testResourceDirs += file('additionalCustomTestResources')
+    }
+}
+'''
+    }
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/IdeaPlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/IdeaPlugin.java
@@ -283,6 +283,13 @@ public class IdeaPlugin extends IdePlugin {
                 return project.getProjectDir();
             }
         });
+        Set<File> testSourceDirs = Sets.newLinkedHashSet();
+        conventionMapping.map("testSourceDirs", new Callable<Set<File>>() {
+            @Override
+            public Set<File> call() {
+                return testSourceDirs;
+            }
+        });
         Set<File> resourceDirs = Sets.newLinkedHashSet();
         conventionMapping.map("resourceDirs", new Callable<Set<File>>() {
             @Override
@@ -290,6 +297,14 @@ public class IdeaPlugin extends IdePlugin {
                 return resourceDirs;
             }
         });
+        Set<File> testResourceDirs = Sets.newLinkedHashSet();
+        conventionMapping.map("testResourceDirs", new Callable<Set<File>>() {
+            @Override
+            public Set<File> call() throws Exception {
+                return testResourceDirs;
+            }
+        });
+
         Set<File> excludeDirs = Sets.newLinkedHashSet();
         conventionMapping.map("excludeDirs", new Callable<Set<File>>() {
             @Override

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/IdeaModule.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/IdeaModule.java
@@ -26,6 +26,7 @@ import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.plugins.ide.idea.model.internal.IdeaDependenciesProvider;
 import org.gradle.plugins.ide.internal.IdeArtifactRegistry;
 import org.gradle.plugins.ide.internal.resolver.DefaultGradleApiSourcesResolver;
@@ -162,11 +163,21 @@ public class IdeaModule {
     private Set<File> sourceDirs;
     private Set<File> generatedSourceDirs = Sets.newLinkedHashSet();
     private Set<File> resourceDirs = Sets.newLinkedHashSet();
+    /**
+     * <strong>This field is {@code @Deprecated}, please use {@link #testResources} instead.</strong>
+     */
+    @Deprecated
+    private Set<File> testResourceDirs = Sets.newLinkedHashSet();
     private ConfigurableFileCollection testResources;
     private Map<String, Map<String, Collection<Configuration>>> scopes = Maps.newLinkedHashMap();
     private boolean downloadSources = true;
     private boolean downloadJavadoc;
     private File contentRoot;
+    /**
+     * <strong>This field is {@code @Deprecated}, please use {@link #testSources} instead.</strong>
+     */
+    @Deprecated
+    private Set<File> testSourceDirs;
     private ConfigurableFileCollection testSources;
     private Set<File> excludeDirs;
     private Boolean inheritOutputDirs;
@@ -188,6 +199,10 @@ public class IdeaModule {
 
         this.testSources = project.getObjects().fileCollection();
         this.testResources = project.getObjects().fileCollection();
+
+        // TODO: remove this whileDisabled wrapping for Gradle 8
+        testSources.from(project.provider(() -> DeprecationLogger.whileDisabled(() -> getTestSourceDirs())));
+        testResources.from(project.provider(() -> DeprecationLogger.whileDisabled(() -> getTestResourceDirs())));
     }
 
     /**
@@ -319,7 +334,39 @@ public class IdeaModule {
     }
 
     /**
+     * The directories containing the test sources.
+     *
+     * <strong>Note that late changes to default test directories may NOT be reflected in this collection and {@link #getTestSources()} should be preferred.</strong>
+     *
+     * For example see docs for {@link IdeaModule}
+     *
+     * <strong>This field is {@code @Deprecated}, please use {@link #getTestSources()} instead.</strong>
+     */
+    @Deprecated
+    public Set<File> getTestSourceDirs() {
+        DeprecationLogger.deprecateProperty(IdeaModule.class, "testSourceDirs").replaceWith("testSources")
+                .willBeRemovedInGradle8()
+                .withDslReference()
+                .nagUser();
+        return testSourceDirs;
+    }
+
+    /**
+     * <strong>This field is {@code @Deprecated}, please use {@link #getTestSources()} instead to access the new collection property.</strong>
+     */
+    @Deprecated
+    public void setTestSourceDirs(Set<File> testSourceDirs) {
+        DeprecationLogger.deprecateProperty(IdeaModule.class, "testSourceDirs").replaceWith("testSources")
+                .willBeRemovedInGradle8()
+                .withDslReference()
+                .nagUser();
+        this.testSourceDirs = testSourceDirs;
+    }
+
+    /**
      * The complete and up-to-date collection of test source directories
+     *
+     * This should be preferred to {@link #getTestSourceDirs()} as it will include late changes to default directories.
      *
      * @return lazily configurable collection of test source directories
      * @since 7.4
@@ -347,7 +394,41 @@ public class IdeaModule {
     }
 
     /**
+     * The directories containing the test resources. <p> For example see docs for {@link IdeaModule}
+     *
+     * <strong>This field is {@code @Deprecated}, please use {@link #getTestResources()} instead.</strong>
+     *
+     * @since 4.7
+     */
+    @Deprecated
+    public Set<File> getTestResourceDirs() {
+        DeprecationLogger.deprecateProperty(IdeaModule.class, "testResourceDirs").replaceWith("testResources")
+                .willBeRemovedInGradle8()
+                .withDslReference()
+                .nagUser();
+        return testResourceDirs;
+    }
+
+    /**
+     * Sets the directories containing the test resources. <p> For example see docs for {@link IdeaModule}
+     *
+     * <strong>This field is {@code @Deprecated}, please use {@link #getTestResources()} instead to access the new collection property.</strong>
+     *
+     * @since 4.7
+     */
+    @Deprecated
+    public void setTestResourceDirs(Set<File> testResourceDirs) {
+        DeprecationLogger.deprecateProperty(IdeaModule.class, "testResourceDirs").replaceWith("testResources")
+                .willBeRemovedInGradle8()
+                .withDslReference()
+                .nagUser();
+        this.testResourceDirs = testResourceDirs;
+    }
+
+    /**
      * The complete and up-to-date collection of test resource directories.
+     *
+     * This should be preferred to {@link #getTestResourceDirs()} as it will include late changes to default directories.
      *
      * @return lazily configurable collection of test resource directories
      * @since 7.4

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/IdeaPluginTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/IdeaPluginTest.groovy
@@ -227,7 +227,7 @@ class IdeaPluginTest extends AbstractProjectBuilderSpec {
         property(project.idea.module).contains(source)
 
         where:
-        property << [{ it.sourceDirs }, { it.resourceDirs }, { it.excludeDirs }]
+        property << [{ it.sourceDirs }, { it.testSourceDirs }, { it.resourceDirs }, { it.testResourceDirs }, { it.excludeDirs }]
     }
 
     @Issue('https://github.com/gradle/gradle/issues/8749')
@@ -244,7 +244,7 @@ class IdeaPluginTest extends AbstractProjectBuilderSpec {
         property(project.idea.module).contains(source)
 
         where:
-        property << [{ it.sourceDirs }, { it.resourceDirs }, { it.excludeDirs }]
+        property << [{ it.sourceDirs }, { it.testSourceDirs }, { it.resourceDirs }, { it.testResourceDirs }, { it.excludeDirs }]
     }
 
     private TypeOf<?> publicTypeOfExtension(String named) {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/NebulaPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/NebulaPluginsSmokeTest.groovy
@@ -76,6 +76,13 @@ class NebulaPluginsSmokeTest extends AbstractPluginValidatingSmokeTest implement
         then:
         runner('groovydoc')
             .expectDeprecationWarning(
+                "The IdeaModule.testSourceDirs property has been deprecated." +
+                " This is scheduled to be removed in Gradle 8.0." +
+                " Please use the testSources property instead." +
+                " See https://docs.gradle.org/${GradleVersion.current().version}/dsl/org.gradle.plugins.ide.idea.model.IdeaModule.html#org.gradle.plugins.ide.idea.model.IdeaModule:testSourceDirs for more details.",
+                ""
+            )
+            .expectDeprecationWarning(
                 "The Report.destination property has been deprecated." +
                 " This is scheduled to be removed in Gradle 9.0." +
                 " Please use the outputLocation property instead." +


### PR DESCRIPTION
We deprecated the properties in 7.6 therefore it's too early for the removal. Instead, we should:
- add deprecation warnings in 8.1.
- remove the properties in 9.0.

This reverts commit 63f27d07eacadfc65f0f9f55ee9f7e2d7efd3b53.