### PR TITLE
Make customizingResolution-deactivateGlobalSubstitution CC-compatible

### DIFF
--- a/subprojects/docs/build.gradle
+++ b/subprojects/docs/build.gradle
@@ -736,10 +736,6 @@ tasks.named("docsTest") { task ->
                 "publishing-credentials_groovy_publishCommandLineCredentials.sample",
                 "publishing-credentials_kotlin_publishCommandLineCredentials.sample",
 
-                // TODO(https://github.com/gradle/gradle/issues/21027) The test expects the build to fail, but the failure looks slightly different when the configuration cache is enabled.
-                //  We need to improve the test harness to work with such tests.
-                "snippet-dependency-management-customizing-resolution-deactivate-global-substitution_kotlin_resolve.sample",
-
                 // TODO(https://github.com/gradle/gradle/issues/14880)
                 "snippet-dependency-management-working-with-dependencies-iterate-dependencies_groovy_iterating-dependencies.sample",
                 "snippet-dependency-management-working-with-dependencies-iterate-dependencies_kotlin_iterating-dependencies.sample",

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-deactivateGlobalSubstitution/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-deactivateGlobalSubstitution/groovy/build.gradle
@@ -21,9 +21,10 @@ dependencies {
 }
 
 tasks.register('resolve') {
+    FileCollection runtimeClasspath = configurations.runtimeClasspath
+    FileCollection publishedRuntimeClasspath = configurations.publishedRuntimeClasspath
     doLast {
-        configurations.runtimeClasspath.files.each { println(it.name) }
-        configurations.publishedRuntimeClasspath.files.each { println(it.name) }
+        runtimeClasspath.files.each { println(it.name) }
+        publishedRuntimeClasspath.files.each { println(it.name) }
     }
 }
-

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-deactivateGlobalSubstitution/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-deactivateGlobalSubstitution/kotlin/build.gradle.kts
@@ -21,8 +21,11 @@ dependencies {
 }
 
 tasks.register("resolve") {
+    val runtimeClasspath: FileCollection = configurations.runtimeClasspath.get()
+    val publishedRuntimeClasspath: FileCollection = configurations["publishedRuntimeClasspath"]
+
     doLast {
-        configurations.runtimeClasspath.get().files.forEach { println(it.name) }
-        configurations["publishedRuntimeClasspath"].files.forEach { println(it.name) }
+        runtimeClasspath.files.forEach { println(it.name) }
+        publishedRuntimeClasspath.files.forEach { println(it.name) }
     }
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-deactivateGlobalSubstitution/tests/resolve.out
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-deactivateGlobalSubstitution/tests/resolve.out
@@ -1,10 +1,5 @@
-> Task :resolve FAILED
-module-a-0.9.jar
-1 actionable task: 1 executed
-
 FAILURE: Build failed with an exception.
 
 * What went wrong:
-Execution failed for task ':resolve'.
 > Could not resolve all files for configuration ':publishedRuntimeClasspath'.
    > Could not find org.test:module-a:1.0.


### PR DESCRIPTION
There were two major problems. The expected output was not suitable for the configuration cache. CC resolves the referenced configurations eagerly to serialize them before attempting to execute the task. The second problem was common to many snippets: direct references to the `Project.configurations` from the doLast action.

The test wasn't failing for Groovy script because CC was not seeing the referenced configurations due to the second issue. Normally, we detect such references at the second run, but this test expects failure, so the test was green, even though the failure cause is different.

Related to #21027
