### PR TITLE
Make duplicate publication check configuration cache compatible

### DIFF
--- a/subprojects/docs/build.gradle
+++ b/subprojects/docs/build.gradle
@@ -756,10 +756,6 @@ tasks.named("docsTest") { task ->
                 "snippet-java-toolchain-filters_groovy_toolchainFilters.sample",
                 "snippet-java-toolchain-filters_kotlin_toolchainFilters.sample",
 
-                // TODO(https://github.com/gradle/gradle/issues/21640)
-                "snippet-maven-publish-conditional-publishing_groovy_publishingMavenConditionally.sample",
-                "snippet-maven-publish-conditional-publishing_kotlin_publishingMavenConditionally.sample",
-
                 // TODO(https://github.com/gradle/gradle/issues/13470) Signing plugin support
                 "snippet-signing-configurations_groovy_signingArchivesOutput.sample",
                 "snippet-signing-configurations_kotlin_signingArchivesOutput.sample",

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/IvyDuplicatePublicationTracker.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/IvyDuplicatePublicationTracker.java
@@ -36,6 +36,6 @@ public class IvyDuplicatePublicationTracker {
     }
 
     public void checkCanPublish(PublicationInternal<?> publication, @Nullable URI repositoryLocation, String repositoryName) {
-        duplicatePublicationTracker.checkCanPublish(project, publication, repositoryLocation, repositoryName);
+        duplicatePublicationTracker.checkCanPublish(project.getDisplayName(), publication.getName(), publication.getCoordinates(), repositoryLocation, repositoryName);
     }
 }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/MavenDuplicatePublicationTracker.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publisher/MavenDuplicatePublicationTracker.java
@@ -17,8 +17,8 @@
 package org.gradle.api.publish.maven.internal.publisher;
 
 import org.gradle.api.Project;
+import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
 import org.gradle.api.internal.artifacts.mvnsettings.LocalMavenRepositoryLocator;
-import org.gradle.api.publish.internal.PublicationInternal;
 import org.gradle.api.publish.internal.validation.DuplicatePublicationTracker;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
@@ -28,21 +28,22 @@ import java.net.URI;
 
 @ServiceScope(Scopes.Project.class)
 public class MavenDuplicatePublicationTracker {
-    private final Project project;
+    private final String projectDisplayName;
     private final DuplicatePublicationTracker duplicatePublicationTracker;
     private final LocalMavenRepositoryLocator mavenRepositoryLocator;
 
     public MavenDuplicatePublicationTracker(Project project, DuplicatePublicationTracker duplicatePublicationTracker, LocalMavenRepositoryLocator mavenRepositoryLocator) {
-        this.project = project;
+        this.projectDisplayName = project.getDisplayName();
         this.duplicatePublicationTracker = duplicatePublicationTracker;
         this.mavenRepositoryLocator = mavenRepositoryLocator;
     }
 
-    public void checkCanPublish(PublicationInternal publication, @Nullable URI repositoryLocation, String repositoryName) {
-        duplicatePublicationTracker.checkCanPublish(project, publication, repositoryLocation, repositoryName);
+    public void checkCanPublish(MavenNormalizedPublication publication, @Nullable URI repositoryLocation, String repositoryName) {
+        duplicatePublicationTracker.checkCanPublish(
+            projectDisplayName, publication.getName(), DefaultModuleVersionIdentifier.newId(publication.getProjectIdentity()), repositoryLocation, repositoryName);
     }
 
-    public void checkCanPublishToMavenLocal(PublicationInternal publication) {
+    public void checkCanPublishToMavenLocal(MavenNormalizedPublication publication) {
         checkCanPublish(publication, mavenRepositoryLocator.getLocalMavenRepository().toURI(), "mavenLocal");
     }
 }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/AbstractPublishToMaven.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/AbstractPublishToMaven.java
@@ -108,5 +108,4 @@ public abstract class AbstractPublishToMaven extends DefaultTask {
     protected MavenDuplicatePublicationTracker getDuplicatePublicationTracker() {
         throw new UnsupportedOperationException();
     }
-
 }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/PublishToMavenLocal.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/PublishToMavenLocal.java
@@ -41,13 +41,13 @@ public class PublishToMavenLocal extends AbstractPublishToMaven {
             throw new InvalidUserDataException("The 'publication' property is required");
         }
 
-        getDuplicatePublicationTracker().checkCanPublishToMavenLocal(publicationInternal);
         return publicationInternal.asNormalisedPublication();
     }
 
     @TaskAction
     public void publish() {
         MavenNormalizedPublication normalizedPublication = this.normalizedPublication.get();
+        getDuplicatePublicationTracker().checkCanPublishToMavenLocal(normalizedPublication);
         doPublish(normalizedPublication);
     }
 

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/PublishToMavenRepository.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/PublishToMavenRepository.java
@@ -23,6 +23,7 @@ import org.gradle.api.credentials.Credentials;
 import org.gradle.api.internal.GeneratedSubclasses;
 import org.gradle.api.internal.artifacts.BaseRepositoryFactory;
 import org.gradle.api.internal.artifacts.repositories.DefaultMavenArtifactRepository;
+import org.gradle.api.internal.credentials.CredentialListener;
 import org.gradle.api.internal.provider.MissingValueException;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
@@ -36,7 +37,6 @@ import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.TaskAction;
-import org.gradle.api.internal.credentials.CredentialListener;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.serialization.Cached;
 import org.gradle.internal.serialization.Transient;
@@ -59,6 +59,7 @@ public class PublishToMavenRepository extends AbstractPublishToMaven {
     private final Transient.Var<DefaultMavenArtifactRepository> repository = varOf();
     private final Cached<PublishSpec> spec = Cached.of(this::computeSpec);
     private final Property<Credentials> credentials = getProject().getObjects().property(Credentials.class);
+
     /**
      * The repository to publish to.
      *
@@ -93,7 +94,10 @@ public class PublishToMavenRepository extends AbstractPublishToMaven {
     @TaskAction
     public void publish() {
         PublishSpec spec = this.spec.get();
-        doPublish(spec.publication, spec.repository.get(getServices()));
+        MavenNormalizedPublication publication = spec.publication;
+        MavenArtifactRepository repository = spec.repository.get(getServices());
+        getDuplicatePublicationTracker().checkCanPublish(publication, repository.getUrl(), repository.getName());
+        doPublish(publication, repository);
     }
 
     private PublishSpec computeSpec() {
@@ -109,7 +113,6 @@ public class PublishToMavenRepository extends AbstractPublishToMaven {
 
         checkCredentialSafety(repository);
 
-        getDuplicatePublicationTracker().checkCanPublish(publicationInternal, repository.getUrl(), repository.getName());
         MavenNormalizedPublication normalizedPublication = publicationInternal.asNormalisedPublication();
         return new PublishSpec(
                 RepositorySpec.of(repository),

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/validation/DuplicatePublicationTracker.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/validation/DuplicatePublicationTracker.java
@@ -18,11 +18,9 @@ package org.gradle.api.publish.internal.validation;
 
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
-import org.gradle.api.Project;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
-import org.gradle.api.publish.internal.PublicationInternal;
 
 import javax.annotation.Nullable;
 import java.net.URI;
@@ -31,7 +29,7 @@ public class DuplicatePublicationTracker {
     private final static Logger LOG = Logging.getLogger(DuplicatePublicationTracker.class);
     private final Multimap<String, PublicationWithProject> published = LinkedHashMultimap.create();
 
-    public synchronized void checkCanPublish(Project project, PublicationInternal<?> publication, @Nullable URI repositoryLocation, String repositoryName) {
+    public synchronized void checkCanPublish(String projectDisplayName, String publicationName, ModuleVersionIdentifier projectIdentity, @Nullable URI repositoryLocation, String repositoryName) {
         // Don't track publications to repositories configured without a base URL
         if (repositoryLocation == null) {
             return;
@@ -39,15 +37,14 @@ public class DuplicatePublicationTracker {
 
         String repositoryKey = normalizeLocation(repositoryLocation);
 
-        PublicationWithProject publicationWithProject = new PublicationWithProject(project.getDisplayName(), publication);
+        PublicationWithProject publicationWithProject = new PublicationWithProject(projectDisplayName, publicationName, projectIdentity);
         if (published.get(repositoryKey).contains(publicationWithProject)) {
-            LOG.warn("Publication '" + publication.getCoordinates() + "' is published multiple times to the same location. It is likely that repository '" + repositoryName + "' is duplicated.");
+            LOG.warn("Publication '" + projectIdentity + "' is published multiple times to the same location. It is likely that repository '" + repositoryName + "' is duplicated.");
             return;
         }
 
-        ModuleVersionIdentifier projectIdentity = publication.getCoordinates();
         for (PublicationWithProject previousPublicationWithProject : published.get(repositoryKey)) {
-            if (previousPublicationWithProject.getPublication().getCoordinates().equals(projectIdentity)) {
+            if (previousPublicationWithProject.getCoordinates().equals(projectIdentity)) {
                 String firstPublication = previousPublicationWithProject.toString();
                 String secondPublication = publicationWithProject.toString();
                 if (secondPublication.compareTo(firstPublication) < 0) {
@@ -55,7 +52,7 @@ public class DuplicatePublicationTracker {
                     firstPublication = secondPublication;
                     secondPublication = temp;
                 }
-                LOG.warn("Multiple publications with coordinates '" + publication.getCoordinates() + "' are published to repository '" + repositoryName + "'. The publications " + firstPublication + " and " + secondPublication + " will overwrite each other!");
+                LOG.warn("Multiple publications with coordinates '" + projectIdentity + "' are published to repository '" + repositoryName + "'. The publications " + firstPublication + " and " + secondPublication + " will overwrite each other!");
             }
         }
 

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/validation/PublicationWithProject.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/validation/PublicationWithProject.java
@@ -16,7 +16,7 @@
 
 package org.gradle.api.publish.internal.validation;
 
-import org.gradle.api.publish.internal.PublicationInternal;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
 
 import java.util.Objects;
 
@@ -25,20 +25,22 @@ import java.util.Objects;
  */
 final class PublicationWithProject {
     private final String projectDisplayText;
-    private final PublicationInternal<?> publication;
+    private final String publicationName;
+    private final ModuleVersionIdentifier coordinates;
 
-    PublicationWithProject(String projectDisplayText, PublicationInternal<?> publication) {
+    public PublicationWithProject(String projectDisplayText, String publicationName, ModuleVersionIdentifier coordinates) {
         this.projectDisplayText = projectDisplayText;
-        this.publication = publication;
+        this.publicationName = publicationName;
+        this.coordinates = coordinates;
     }
 
-    public PublicationInternal<?> getPublication() {
-        return publication;
+    public ModuleVersionIdentifier getCoordinates() {
+        return coordinates;
     }
 
     @Override
     public String toString() {
-        return "'" + publication.getName() + "' in " + projectDisplayText;
+        return "'" + publicationName + "' in " + projectDisplayText;
     }
 
     @Override
@@ -50,11 +52,11 @@ final class PublicationWithProject {
             return false;
         }
         PublicationWithProject that = (PublicationWithProject) o;
-        return Objects.equals(projectDisplayText, that.projectDisplayText) && Objects.equals(publication, that.publication);
+        return Objects.equals(projectDisplayText, that.projectDisplayText) && Objects.equals(publicationName, that.publicationName) && Objects.equals(coordinates, that.coordinates);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(projectDisplayText, publication);
+        return Objects.hash(projectDisplayText, publicationName, coordinates);
     }
 }


### PR DESCRIPTION
So far, only for Maven publications, as Ivy plugin is not yet CC-compatible.

Checking for duplicate publication upon computing the Spec is not working properly for the configuration cache, as the cache computes it eagerly, ignoring the fact that the task may be disabled. This caused false positive warnings in the conditional publishing documentation snippet.

This commit moves duplicate check back to task execution time. To make it compatible with CC, all non-serializable data (Project, Publication) are replaced with simpler equivalents that can be safely obtained from the cached data.

Fixes #21640 