### PR TITLE
Remove warning about deprecated test source and resources in IdeaModule

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -466,7 +466,7 @@ The following are the features that have been promoted in this Gradle release.
 The `testResourcesDirs` and `testSourcesDirs` fields, and their getters and setters are now `@Deprecated`.
 Any usages of these elements should be replaced by the now stable `getTestSources()` and `getTestResources()` methods and their respective setters.
 These new methods return and are backed by `ConfigurableFileCollection` instances for improved flexibility in how these collections of files can be used.
-Gradle now warns upon usage of these deprecated methods that they will be removed in Gradle 8.0.
+Gradle now warns upon usage of these deprecated methods that they will be removed in Gradle 9.0.
 
 ### Replacement methods in `org.gradle.api.tasks.testing.TestReport`
 

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/IdeaModule.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/IdeaModule.java
@@ -344,10 +344,6 @@ public class IdeaModule {
      */
     @Deprecated
     public Set<File> getTestSourceDirs() {
-        DeprecationLogger.deprecateProperty(IdeaModule.class, "testSourceDirs").replaceWith("testSources")
-                .willBeRemovedInGradle8()
-                .withDslReference()
-                .nagUser();
         return testSourceDirs;
     }
 
@@ -356,10 +352,6 @@ public class IdeaModule {
      */
     @Deprecated
     public void setTestSourceDirs(Set<File> testSourceDirs) {
-        DeprecationLogger.deprecateProperty(IdeaModule.class, "testSourceDirs").replaceWith("testSources")
-                .willBeRemovedInGradle8()
-                .withDslReference()
-                .nagUser();
         this.testSourceDirs = testSourceDirs;
     }
 
@@ -402,10 +394,6 @@ public class IdeaModule {
      */
     @Deprecated
     public Set<File> getTestResourceDirs() {
-        DeprecationLogger.deprecateProperty(IdeaModule.class, "testResourceDirs").replaceWith("testResources")
-                .willBeRemovedInGradle8()
-                .withDslReference()
-                .nagUser();
         return testResourceDirs;
     }
 
@@ -418,10 +406,6 @@ public class IdeaModule {
      */
     @Deprecated
     public void setTestResourceDirs(Set<File> testResourceDirs) {
-        DeprecationLogger.deprecateProperty(IdeaModule.class, "testResourceDirs").replaceWith("testResources")
-                .willBeRemovedInGradle8()
-                .withDslReference()
-                .nagUser();
         this.testResourceDirs = testResourceDirs;
     }
 


### PR DESCRIPTION
Per discussion with @donat, usage of these will properties will not begin nagging until Gradle 8.0 (see #22323).