### PR TITLE
Fix misleading javadoc in Manifest and ManifestMergeSpec

### DIFF
--- a/subprojects/platform-jvm/src/main/java/org/gradle/api/java/archives/Manifest.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/api/java/archives/Manifest.java
@@ -82,7 +82,7 @@ public interface Manifest {
 
     /**
      * Specifies other manifests to be merged into this manifest. A merge path can either be another instance of
-     * {@link org.gradle.api.java.archives.Manifest} or a file path as interpreted by {@link org.gradle.api.Project#files(Object...)}.
+     * {@link org.gradle.api.java.archives.Manifest} or a file path as interpreted by {@link org.gradle.api.Project#file(Object)}.
      *
      * The merge is not happening instantaneously. It happens either before writing or when {@link #getEffectiveManifest()}
      * is called.

--- a/subprojects/platform-jvm/src/main/java/org/gradle/api/java/archives/ManifestMergeSpec.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/api/java/archives/ManifestMergeSpec.java
@@ -45,7 +45,7 @@ public interface ManifestMergeSpec {
     /**
      * Adds a merge path to a manifest that should be merged into the base manifest. A merge path can be either another
      * {@link org.gradle.api.java.archives.Manifest} or a path that is evaluated as per
-     * {@link org.gradle.api.Project#files(Object...)} . If multiple merge paths are specified, the manifest are merged
+     * {@link org.gradle.api.Project#file(Object)} . If multiple merge paths are specified, the manifest are merged
      * in the order in which they are added.
      *
      * @param mergePaths The paths of manifests to be merged


### PR DESCRIPTION
Closes #13198

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [X] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [X] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [X] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [X] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [X] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes