### PR TITLE
Store feature preview state in configuration cache

### DIFF
--- a/subprojects/build-option/build.gradle.kts
+++ b/subprojects/build-option/build.gradle.kts
@@ -11,5 +11,6 @@ dependencies {
     implementation(project(":base-services"))
 
     implementation(project(":base-annotations"))
+    implementation(project(":messaging"))
     implementation(libs.commonsLang)
 }

--- a/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/DefaultFeatureFlags.java
+++ b/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/DefaultFeatureFlags.java
@@ -43,4 +43,9 @@ public class DefaultFeatureFlags implements FeatureFlags {
     public void enable(FeatureFlag flag) {
         enabled.add(flag);
     }
+
+    @Override
+    public boolean isEnabledWithApi(FeatureFlag flag) {
+        return enabled.contains(flag);
+    }
 }

--- a/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/DefaultFeatureFlags.java
+++ b/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/DefaultFeatureFlags.java
@@ -16,19 +16,24 @@
 
 package org.gradle.internal.buildoption;
 
+import org.gradle.internal.event.ListenerManager;
+
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
 public class DefaultFeatureFlags implements FeatureFlags {
     private final Set<FeatureFlag> enabled = new CopyOnWriteArraySet<FeatureFlag>();
     private final InternalOptions options;
+    private final FeatureFlagListener broadcaster;
 
-    public DefaultFeatureFlags(InternalOptions options) {
+    public DefaultFeatureFlags(InternalOptions options, ListenerManager listenerManager) {
         this.options = options;
+        this.broadcaster = listenerManager.getBroadcaster(FeatureFlagListener.class);
     }
 
     @Override
     public boolean isEnabled(FeatureFlag flag) {
+        broadcaster.flagRead(flag);
         if (flag.getSystemPropertyName() != null) {
             // Can explicitly disable property using system property
             Option.Value<Boolean> option = options.getOption(new InternalFlag(flag.getSystemPropertyName()));

--- a/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/FeatureFlagListener.java
+++ b/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/FeatureFlagListener.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.buildoption;
+
+import org.gradle.internal.service.scopes.EventScope;
+import org.gradle.internal.service.scopes.Scopes;
+
+@EventScope(Scopes.BuildTree.class)
+public interface FeatureFlagListener {
+    void flagRead(FeatureFlag flag);
+}

--- a/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/FeatureFlags.java
+++ b/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/FeatureFlags.java
@@ -27,7 +27,14 @@ public interface FeatureFlags {
     boolean isEnabled(FeatureFlag flag);
 
     /**
-     * Explicitly enable the given flag.
+     * Explicitly enable the given flag. The resulting flag status may still be overridden.
      */
     void enable(FeatureFlag flag);
+
+    /**
+     * Checks if the given flag was enabled with {@link #enable(FeatureFlag)}. This method doesn't take overrides into account.
+     * @param flag the flag to check
+     * @return {@code true} if the flag was enabled
+     */
+    boolean isEnabledWithApi(FeatureFlag flag);
 }

--- a/subprojects/build-option/src/test/groovy/org/gradle/internal/buildoption/DefaultFeatureFlagsTest.groovy
+++ b/subprojects/build-option/src/test/groovy/org/gradle/internal/buildoption/DefaultFeatureFlagsTest.groovy
@@ -28,6 +28,7 @@ class DefaultFeatureFlagsTest extends Specification {
 
         expect:
         !flags.isEnabled(flag)
+        !flags.isEnabledWithApi(flag)
     }
 
     def "flag with associated system property is disabled by default"() {
@@ -36,6 +37,7 @@ class DefaultFeatureFlagsTest extends Specification {
 
         expect:
         !flags.isEnabled(flag)
+        !flags.isEnabledWithApi(flag)
     }
 
     def "can explicitly enable flag"() {
@@ -45,6 +47,7 @@ class DefaultFeatureFlagsTest extends Specification {
 
         expect:
         flags.isEnabled(flag)
+        flags.isEnabledWithApi(flag)
     }
 
     def "can explicitly enable flag with associated system property"() {
@@ -54,6 +57,7 @@ class DefaultFeatureFlagsTest extends Specification {
 
         expect:
         flags.isEnabled(flag)
+        flags.isEnabledWithApi(flag)
     }
 
     def "can use a system property to enable flag"() {
@@ -64,6 +68,7 @@ class DefaultFeatureFlagsTest extends Specification {
 
         expect:
         flags.isEnabled(flag)
+        !flags.isEnabledWithApi(flag)
     }
 
     def "can use a system property to disable a flag that has been enabled"() {
@@ -76,5 +81,6 @@ class DefaultFeatureFlagsTest extends Specification {
 
         expect:
         !flags.isEnabled(flag)
+        flags.isEnabledWithApi(flag)
     }
 }

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheFeatureFlagsIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheFeatureFlagsIntegrationTest.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache
+
+import org.gradle.api.internal.FeaturePreviews
+import org.gradle.configurationcache.fixtures.ExternalProcessFixture
+
+import static org.gradle.configurationcache.fixtures.ExternalProcessFixture.exec
+
+class ConfigurationCacheFeatureFlagsIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
+    def "toggling feature flag with system property invalidates cache"() {
+        given:
+        def configurationCache = newConfigurationCacheFixture()
+        ExternalProcessFixture execFixture = new ExternalProcessFixture(testDirectory)
+
+        def snippets = exec().groovy.newSnippets(execFixture)
+
+        buildFile("""
+            ${snippets.imports}
+
+            ${snippets.body}
+
+            task check {}
+        """)
+
+        when:
+        configurationCacheRun("check")
+
+        then:
+        configurationCache.assertStateStored()
+
+        when:
+        configurationCacheFails("-D${FeaturePreviews.Feature.STABLE_CONFIGURATION_CACHE.systemPropertyName}=true", "check")
+
+        then:
+        problems.assertFailureHasProblems(failure) {
+            withProblem("Build file 'build.gradle': external process started")
+        }
+    }
+}

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
@@ -19,6 +19,7 @@ package org.gradle.configurationcache
 import org.gradle.api.artifacts.component.BuildIdentifier
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.BuildDefinition
+import org.gradle.api.internal.FeaturePreviews
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.SettingsInternal.BUILD_SRC
 import org.gradle.api.internal.project.ProjectState
@@ -63,6 +64,7 @@ import org.gradle.internal.build.IncludedBuildState
 import org.gradle.internal.build.PublicBuildPath
 import org.gradle.internal.build.RootBuildState
 import org.gradle.internal.build.event.BuildEventListenerRegistryInternal
+import org.gradle.internal.buildoption.FeatureFlags
 import org.gradle.internal.buildtree.BuildTreeWorkGraph
 import org.gradle.internal.composite.IncludedBuildInternal
 import org.gradle.internal.enterprise.core.GradleEnterprisePluginAdapter
@@ -312,6 +314,7 @@ class ConfigurationCacheState(
         withGradleIsolate(gradle, userTypesCodec) {
             withDebugFrame({ "environment state" }) {
                 writeCachedEnvironmentState(gradle)
+                writePreviewFlags(gradle)
             }
             withDebugFrame({ "gradle enterprise" }) {
                 writeGradleEnterprisePluginManager(gradle)
@@ -326,6 +329,7 @@ class ConfigurationCacheState(
     suspend fun DefaultReadContext.readBuildTreeState(gradle: GradleInternal) {
         withGradleIsolate(gradle, userTypesCodec) {
             readCachedEnvironmentState(gradle)
+            readPreviewFlags(gradle)
             // It is important that the Gradle Enterprise plugin be read before
             // build cache configuration, as it may contribute build cache configuration.
             readGradleEnterprisePluginManager(gradle)
@@ -607,6 +611,22 @@ class ConfigurationCacheState(
         val environmentChangeTracker = gradle.serviceOf<EnvironmentChangeTracker>()
         val storedState = read() as EnvironmentChangeTracker.CachedEnvironmentState
         environmentChangeTracker.loadFrom(storedState)
+    }
+
+    private
+    suspend fun DefaultWriteContext.writePreviewFlags(gradle: GradleInternal) {
+        val featureFlags = gradle.serviceOf<FeatureFlags>()
+        val enabledFeatures = FeaturePreviews.Feature.values().filter { featureFlags.isEnabledWithApi(it) }
+        writeCollection(enabledFeatures)
+    }
+
+    private
+    suspend fun DefaultReadContext.readPreviewFlags(gradle: GradleInternal) {
+        val featureFlags = gradle.serviceOf<FeatureFlags>()
+        readCollection {
+            val enabledFeature = read() as FeaturePreviews.Feature
+            featureFlags.enable(enabledFeature)
+        }
     }
 
     private

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintWriter.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintWriter.kt
@@ -59,6 +59,8 @@ import org.gradle.configurationcache.serialization.DefaultWriteContext
 import org.gradle.configurationcache.services.ConfigurationCacheEnvironment
 import org.gradle.configurationcache.services.EnvironmentChangeTracker
 import org.gradle.groovy.scripts.ScriptSource
+import org.gradle.internal.buildoption.FeatureFlag
+import org.gradle.internal.buildoption.FeatureFlagListener
 import org.gradle.internal.concurrent.CompositeStoppable
 import org.gradle.internal.execution.TaskExecutionTracker
 import org.gradle.internal.execution.UnitOfWork
@@ -93,6 +95,7 @@ class ConfigurationCacheFingerprintWriter(
     ProjectDependencyObservedListener,
     CoupledProjectsListener,
     FileResourceListener,
+    FeatureFlagListener,
     ConfigurationCacheEnvironment.Listener {
 
     interface Host {
@@ -405,6 +408,12 @@ class ConfigurationCacheFingerprintWriter(
             if (projectDependencies.add(dependency)) {
                 projectScopedWriter.write(dependency)
             }
+        }
+    }
+
+    override fun flagRead(flag: FeatureFlag) {
+        flag.systemPropertyName?.let { propertyName ->
+            sink().systemPropertyRead(propertyName, System.getProperty(propertyName))
         }
     }
 

--- a/subprojects/docs/build.gradle
+++ b/subprojects/docs/build.gradle
@@ -746,10 +746,6 @@ tasks.named("docsTest") { task ->
                 "snippet-ear-ear-with-war_groovy_earWithWar.sample",
                 "snippet-ear-ear-with-war_kotlin_earWithWar.sample",
 
-                // TODO(https://github.com/gradle/gradle/issues/21714)
-                "snippet-groovy-compilation-avoidance_groovy_groovyCompilationAvoidance.sample",
-                "snippet-groovy-compilation-avoidance_kotlin_groovyCompilationAvoidance.sample",
-
                 // TODO(https://github.com/gradle/gradle/issues/13469) Ivy Publish plugin support
                 "snippet-ivy-publish-conditional-publishing_groovy_publishingIvyConditionally.sample",
                 "snippet-ivy-publish-descriptor-customization_groovy_publishingIvyGenerateDescriptor.sample",

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/AbstractGroovyCompileAvoidanceIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/AbstractGroovyCompileAvoidanceIntegrationSpec.groovy
@@ -17,8 +17,6 @@
 package org.gradle.java.compile
 
 import org.gradle.integtests.fixtures.CompiledLanguage
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
-
 
 abstract class AbstractGroovyCompileAvoidanceIntegrationSpec extends AbstractJavaGroovyCompileAvoidanceIntegrationSpec {
     CompiledLanguage language = CompiledLanguage.GROOVY
@@ -136,7 +134,6 @@ abstract class AbstractGroovyCompileAvoidanceIntegrationSpec extends AbstractJav
         executedAndNotSkipped ":b:compileGroovy"
     }
 
-    @ToBeFixedForConfigurationCache(because = "groovy ast transformation")
     def "recompile with change of local ast transformation"() {
         given:
         executer.beforeExecute {
@@ -178,7 +175,6 @@ abstract class AbstractGroovyCompileAvoidanceIntegrationSpec extends AbstractJav
         failure.assertHasCause('Bad AST transformation!')
     }
 
-    @ToBeFixedForConfigurationCache(because = "groovy ast transformation")
     def "recompile with change of global ast transformation"() {
         given:
         executer.beforeExecute {


### PR DESCRIPTION
Feature flags are configured at the configuration time and may be accessed at the execution time, so storing their values is necessary to ensure correctness. Some flags, currently "stable configuration cache", affect the configuration and can be toggled with system properties. It makes sense to mark such system properties as configuration cache inputs.
Fixes #21714 

