### PR TITLE
Disable stacktraces by default for integration tests

### DIFF
--- a/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceErrorHandlingIntegrationTest.groovy
+++ b/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceErrorHandlingIntegrationTest.groovy
@@ -79,7 +79,6 @@ class HttpBuildCacheServiceErrorHandlingIntegrationTest extends HttpBuildCacheFi
 
         when:
         executer.withStackTraceChecksDisabled()
-        executer.withStacktraceDisabled()
         withBuildCache().run "customTask"
 
         then:
@@ -102,7 +101,6 @@ class HttpBuildCacheServiceErrorHandlingIntegrationTest extends HttpBuildCacheFi
 
         when:
         executer.withStackTraceChecksDisabled()
-        executer.withStacktraceDisabled()
         withBuildCache().run "customTask"
 
         then:
@@ -163,7 +161,6 @@ class HttpBuildCacheServiceErrorHandlingIntegrationTest extends HttpBuildCacheFi
 
         when:
         executer.withArgument("-D${SOCKET_TIMEOUT_SYSTEM_PROPERTY}=1000")
-        executer.withStacktraceDisabled()
         withBuildCache().run("customTask")
 
         then:
@@ -180,7 +177,6 @@ class HttpBuildCacheServiceErrorHandlingIntegrationTest extends HttpBuildCacheFi
         settingsFile << withHttpBuildCacheServer()
 
         when:
-        executer.withStacktraceDisabled()
         withBuildCache().run("customTask", "customTask2")
 
         then:
@@ -200,7 +196,6 @@ class HttpBuildCacheServiceErrorHandlingIntegrationTest extends HttpBuildCacheFi
         settingsFile << withHttpBuildCacheServer()
 
         when:
-        executer.withStacktraceDisabled()
         withBuildCache().run("-D${BuildCacheControllerFactory.REMOTE_CONTINUE_ON_ERROR_PROPERTY}=true", "customTask", "customTask2")
 
         then:

--- a/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceIntegrationTest.groovy
+++ b/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceIntegrationTest.groovy
@@ -330,6 +330,7 @@ class HttpBuildCacheServiceIntegrationTest extends HttpBuildCacheFixture {
         """
 
         when:
+        executer.withStacktraceEnabled()
         executer.withStackTraceChecksDisabled()
         withBuildCache().run "jar"
 
@@ -418,6 +419,7 @@ class HttpBuildCacheServiceIntegrationTest extends HttpBuildCacheFixture {
         }
 
         when:
+        executer.withStacktraceEnabled()
         executer.withStackTraceChecksDisabled()
         withBuildCache().run "jar"
         then:
@@ -439,6 +441,7 @@ class HttpBuildCacheServiceIntegrationTest extends HttpBuildCacheFixture {
         }
 
         when:
+        executer.withStacktraceEnabled()
         executer.withStackTraceChecksDisabled()
         withBuildCache().run "jar"
         then:

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/UndefinedBuildExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/UndefinedBuildExecutionIntegrationTest.groovy
@@ -34,6 +34,7 @@ class UndefinedBuildExecutionIntegrationTest extends AbstractIntegrationSpec {
         failure.assertHasDescription("Directory '$testDirectory' does not contain a Gradle build.")
         failure.assertHasResolutions(
             "Run gradle init to create a new Gradle build in this directory.",
+            "Run with --stacktrace option to get the stack trace.",
             "Run with --info or --debug option to get more log output.") // Don't suggest running with --scan for a missing build
 
         testDirectory.assertIsEmptyDir()

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/ProjectLayoutIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/ProjectLayoutIntegrationTest.groovy
@@ -327,6 +327,7 @@ class ProjectLayoutIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
+        executer.withStacktraceEnabled()
         fails('help')
         errorOutput.contains('java.lang.NullPointerException')
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CacheTaskArchiveErrorIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CacheTaskArchiveErrorIntegrationTest.groovy
@@ -68,6 +68,8 @@ class CacheTaskArchiveErrorIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def "archive is not pushed to remote when packing fails"() {
+        executer.withStacktraceEnabled()
+
         when:
         file("input.txt") << "data"
         settingsFile << remoteCache.remoteCacheConfiguration()
@@ -128,6 +130,8 @@ class CacheTaskArchiveErrorIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def "corrupt archive loaded from local cache is purged"() {
+        executer.withStacktraceEnabled()
+
         when:
         file("input.txt") << "data"
         buildFile << """
@@ -188,6 +192,7 @@ class CacheTaskArchiveErrorIntegrationTest extends AbstractIntegrationSpec {
         localCache.listCacheFiles().size() == 1
 
         when:
+        executer.withStacktraceEnabled()
         cleanBuildDir()
 
         and:

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/InternalGradleFailuresIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/InternalGradleFailuresIntegrationTest.groovy
@@ -76,6 +76,7 @@ class InternalGradleFailuresIntegrationTest extends AbstractIntegrationSpec {
 
     def "Error message due to unwritable native directory is not scary"() {
         given:
+        executer.withStacktraceEnabled()
         def nativeDir = executer.gradleUserHomeDir.file("native")
         nativeDir.touch()
         executer.withNoExplicitNativeServicesDir()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/TomlDependenciesExtensionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/TomlDependenciesExtensionIntegrationTest.groovy
@@ -816,6 +816,7 @@ dependencyResolutionManagement {
 """
 
         when:
+        executer.withStacktraceEnabled()
         fails 'help'
 
         then:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/VersionCatalogExtensionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/VersionCatalogExtensionIntegrationTest.groovy
@@ -1846,6 +1846,7 @@ Second: 1.1"""
         """
 
         when:
+        executer.withStacktraceEnabled()
         fails "help"
 
         then:
@@ -1878,6 +1879,7 @@ Second: 1.1"""
         """
 
         when:
+        executer.withStacktraceEnabled()
         fails "help"
 
         then:

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/HelpTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/HelpTaskIntegrationTest.groovy
@@ -524,6 +524,7 @@ BUILD SUCCESSFUL"""
         failure.assertHasCause("Unknown command-line option '--tasssk'.")
         failure.assertHasResolutions(
             "Run gradle help --task :help to get task usage details.",
+            "Run with --stacktrace option to get the stack trace.",
             "Run with --info or --debug option to get more log output.",
             "Run with --scan to get full insights.",
         )

--- a/subprojects/docs/src/docsTest/java/org/gradle/docs/samples/IntegrationTestSamplesExecutor.java
+++ b/subprojects/docs/src/docsTest/java/org/gradle/docs/samples/IntegrationTestSamplesExecutor.java
@@ -108,7 +108,6 @@ class IntegrationTestSamplesExecutor extends CommandExecutor {
             .collect(toCollection(ArrayList::new));
         filteredFlags.add(getAvailableJdksFlag());
         GradleExecuter executer = gradle.inDirectory(workingDir).ignoreMissingSettingsFile()
-            .withStacktraceDisabled()
             .noDeprecationChecks()
             .withWarningMode(warningMode)
             .withToolchainDetectionEnabled()

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskErrorExecutionIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskErrorExecutionIntegrationTest.groovy
@@ -24,6 +24,9 @@ import org.gradle.test.fixtures.file.TestFile
 class TaskErrorExecutionIntegrationTest extends AbstractIntegrationSpec implements ValidationMessageChecker {
     def setup() {
         expectReindentedValidationMessage()
+        executer.beforeExecute {
+            withStacktraceEnabled()
+        }
     }
 
     def reportsTaskActionExecutionFailsWithError() {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -169,7 +169,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
     private boolean useOwnUserHomeServices;
     private ConsoleOutput consoleType;
     protected WarningMode warningMode = WarningMode.All;
-    private boolean showStacktrace = true;
+    private boolean showStacktrace = false;
     private boolean renderWelcomeMessage;
     private boolean disableToolchainDownload = true;
     private boolean disableToolchainDetection = true;

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -424,8 +424,8 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
 
         executer.withWarningMode(warningMode);
 
-        if (!showStacktrace) {
-            executer.withStacktraceDisabled();
+        if (showStacktrace) {
+            executer.withStacktraceEnabled();
         }
 
         if (renderWelcomeMessage) {
@@ -851,8 +851,8 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
     }
 
     @Override
-    public GradleExecuter withStacktraceDisabled() {
-        showStacktrace = false;
+    public GradleExecuter withStacktraceEnabled() {
+        showStacktrace = true;
         return this;
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
@@ -499,9 +499,9 @@ public interface GradleExecuter extends Stoppable {
     GradleExecuter withWarningMode(WarningMode warningMode);
 
     /**
-     * Execute the builds without adding the {@code "--stacktrace"} argument.
+     * Execute the builds with adding the {@code "--stacktrace"} argument.
      */
-    GradleExecuter withStacktraceDisabled();
+    GradleExecuter withStacktraceEnabled();
 
     /**
      * Renders the welcome message users see upon first invocation of a Gradle distribution with a given Gradle user home directory.

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionFailure.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionFailure.java
@@ -38,7 +38,7 @@ public class OutputScrapingExecutionFailure extends OutputScrapingExecutionResul
     private static final Pattern CAUSE_PATTERN = Pattern.compile("(?m)(^\\s*> )");
     private static final Pattern DESCRIPTION_PATTERN = Pattern.compile("(?ms)^\\* What went wrong:$(.+?)^\\* Try:$");
     private static final Pattern LOCATION_PATTERN = Pattern.compile("(?ms)^\\* Where:((.+?)'.+?') line: (\\d+)$");
-    private static final Pattern RESOLUTION_PATTERN = Pattern.compile("(?ms)^\\* Try:$(.+?)^\\* Exception is:$");
+    private static final Pattern RESOLUTION_PATTERN = Pattern.compile("(?ms)^\\* Try:$(.+?)^\\* (?:Exception is:|Get more help at https://help\\.gradle\\.org)$");
     private final String summary;
     private final List<Problem> problems = new ArrayList<>();
     private final List<Problem> problemsNotChecked = new ArrayList<>();

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
@@ -288,7 +288,7 @@ class GradleKotlinDslIntegrationTest : AbstractPluginIntegrationTest() {
 
     @Test
     fun `given an exception thrown during buildscript block execution, its stack trace should contain correct file and line info`() {
-
+        executer.withStacktraceEnabled()
         withBuildScript(
             """ // line 1
             // line 2

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
@@ -901,7 +901,6 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
         expect:
         succeeds "clean", "compileJava"
 
-        executer.withStacktraceDisabled()
         fails "-Pjava7", "clean", "compileJava"
         failure.assertHasErrorOutput "Main.java:8: error: cannot find symbol"
 

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/StacktraceIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/StacktraceIntegrationTest.groovy
@@ -23,7 +23,6 @@ class StacktraceIntegrationTest extends AbstractIntegrationSpec {
     def setup () {
         buildFile << 'throw new RuntimeException("show stacktrace was " + gradle.startParameter.showStacktrace)'
         settingsFile << 'rootProject.name = "stacktrace-integration-test-sample"'
-        executer.withStacktraceDisabled() // AbstractIntegrationSpec uses --stacktrace in the test builds by default
     }
 
     def "no stacktrace is present in the output by default"() {

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/rich/RichConsoleBasicGroupedTaskLoggingFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/rich/RichConsoleBasicGroupedTaskLoggingFunctionalTest.groovy
@@ -97,7 +97,6 @@ class RichConsoleBasicGroupedTaskLoggingFunctionalTest extends AbstractBasicGrou
             }
             throw new RuntimeException('Config Failure...')
         """
-        executer.withStacktraceDisabled()
 
         when:
         fails('failing')

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/dependencies/JavaConfigurationSetupIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/dependencies/JavaConfigurationSetupIntegrationTest.groovy
@@ -158,6 +158,7 @@ class JavaConfigurationSetupIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when:
+        executer.withStacktraceEnabled()
         if (deprecated(alternatives)) {
             executer.expectDeprecationWarning()
         }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/DefaultTestLogging.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/DefaultTestLogging.java
@@ -34,7 +34,7 @@ public class DefaultTestLogging implements TestLogging {
     private int displayGranularity = 2;
     private boolean showExceptions = true;
     private boolean showCauses = true;
-    private boolean showStackTraces = false;
+    private boolean showStackTraces = true;
     private TestExceptionFormat exceptionFormat = TestExceptionFormat.FULL;
     private Set<TestStackTraceFilter> stackTraceFilters = EnumSet.of(TestStackTraceFilter.TRUNCATE);
 

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/DefaultTestLogging.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/DefaultTestLogging.java
@@ -34,7 +34,7 @@ public class DefaultTestLogging implements TestLogging {
     private int displayGranularity = 2;
     private boolean showExceptions = true;
     private boolean showCauses = true;
-    private boolean showStackTraces = true;
+    private boolean showStackTraces = false;
     private TestExceptionFormat exceptionFormat = TestExceptionFormat.FULL;
     private Set<TestStackTraceFilter> stackTraceFilters = EnumSet.of(TestStackTraceFilter.TRUNCATE);
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestInputAnnotationFailuresIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestInputAnnotationFailuresIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.testing
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.internal.execution.WorkValidationException
 
 class TestInputAnnotationFailuresIntegrationTest extends AbstractIntegrationSpec {
     def "using @Input annotation on #elementType file elements fails validation with helpful error message"() {
@@ -57,7 +56,6 @@ class TestInputAnnotationFailuresIntegrationTest extends AbstractIntegrationSpec
         result.assertHasErrorOutput("2. Annotate with @InputFiles for collections of files.")
         result.assertHasErrorOutput(". If you want to track the path, return File.absolutePath as a String and keep @Input.")
         result.assertTaskNotExecuted('myTask')
-        result.assertHasErrorOutput(WorkValidationException.class.getTypeName())
 
         where:
         elementType             | elementName   | elementInitialization                                                             | elementRead
@@ -97,7 +95,6 @@ class TestInputAnnotationFailuresIntegrationTest extends AbstractIntegrationSpec
         result.assertHasErrorOutput("Reason: A property of type '$elementType' annotated with @Input cannot determine how to interpret the file.")
         result.assertHasErrorOutput("Possible solution: Annotate with @InputDirectory for directories.")
         result.assertTaskNotExecuted('myTask')
-        result.assertHasErrorOutput(WorkValidationException.class.getTypeName())
 
         where:
         elementType         | elementName   | elementInitialization                                                 | elementRead

--- a/subprojects/wrapper-shared/src/integTest/groovy/org/gradle/integtests/ZipSlipIntegrationTest.groovy
+++ b/subprojects/wrapper-shared/src/integTest/groovy/org/gradle/integtests/ZipSlipIntegrationTest.groovy
@@ -55,6 +55,8 @@ class ZipSlipIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def "Copy task refuses to unzip evil.zip"() {
+        executer.withStacktraceEnabled()
+
         given:
         buildFile << '''
             task copyEvilZip(type: Copy) {


### PR DESCRIPTION
When an integration test fails, it is typically not the stacktrace that's missing to understand the problem, and indeed can make the output more confusing.

Also, integration tests typically should _not_ test for the output with `--stacktrace`, as this output will not be seen by most of our users.

This is just changing the defaults; there is always the option to enable stacktraces if a test fails of course.