### PR TITLE
Fix CC compatibility of the MapProperty

### DIFF
--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/MapCollectors.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/MapCollectors.java
@@ -20,6 +20,7 @@ import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableMap;
 import org.gradle.api.Action;
+import org.gradle.api.internal.lambdas.SerializableLambdas;
 
 import java.util.Map;
 
@@ -123,7 +124,8 @@ public class MapCollectors {
                 // transform preserving side effects
                 visitor.execute(ExecutionTimeValue.value(value.toValue().transform(v -> ImmutableMap.of(key, v))));
             } else {
-                visitor.execute(ExecutionTimeValue.changingValue(value.getChangingValue().map(v -> ImmutableMap.of(key, v))));
+                visitor.execute(ExecutionTimeValue.changingValue(
+                    value.getChangingValue().map(SerializableLambdas.transformer(v -> ImmutableMap.of(key, v)))));
             }
         }
 


### PR DESCRIPTION
Non-serializable transform could not be restored from the configuration cache.

Addresses some cases from #19252