### PR TITLE
Fix CC compatibility of implicitTaskInputDependency snippet

### DIFF
--- a/subprojects/docs/build.gradle
+++ b/subprojects/docs/build.gradle
@@ -770,10 +770,6 @@ tasks.named("docsTest") { task ->
                 "snippet-maven-publish-conditional-publishing_groovy_publishingMavenConditionally.sample",
                 "snippet-maven-publish-conditional-publishing_kotlin_publishingMavenConditionally.sample",
 
-                // TODO(https://github.com/gradle/gradle/issues/19252)
-                "snippet-providers-implicit-task-input-dependency_groovy_implicitTaskInputDependency.sample",
-                "snippet-providers-implicit-task-input-dependency_kotlin_implicitTaskInputDependency.sample",
-
                 // TODO(https://github.com/gradle/gradle/issues/13470) Signing plugin support
                 "snippet-signing-configurations_groovy_signingArchivesOutput.sample",
                 "snippet-signing-configurations_kotlin_signingArchivesOutput.sample",

--- a/subprojects/docs/src/snippets/providers/implicitTaskInputDependency/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/providers/implicitTaskInputDependency/groovy/build.gradle
@@ -29,5 +29,5 @@ def producer = tasks.register('producer', Producer) {
 tasks.register('consumer', Consumer) {
     // Connect the producer task output to the consumer task input
     // Don't need to add a task dependency to the consumer task. This is automatically added
-    message = producer.map { it.outputFile.get().asFile.text }
+    message = producer.flatMap { it.outputFile }.map { it.asFile.text }
 }

--- a/subprojects/docs/src/snippets/providers/implicitTaskInputDependency/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/providers/implicitTaskInputDependency/kotlin/build.gradle.kts
@@ -29,5 +29,5 @@ val producer = tasks.register<Producer>("producer") {
 tasks.register<Consumer>("consumer") {
     // Connect the producer task output to the consumer task input
     // Don't need to add a task dependency to the consumer task. This is automatically added
-    message.set(producer.map { it.outputFile.get().asFile.readText() })
+    message.set(producer.flatMap { it.outputFile }.map { it.asFile.readText() })
 }


### PR DESCRIPTION
This doesn't address the root cause: TaskProvider.map {} loses the fact that the resulting value is produced by the task and should not be evaluated by the configuration cache. Provider chain with explicitly present `outputFile` property avoids this pitfall, as this property is declared as "changing content", so the configuration cache stops evaluating the provider's value and stores the transforms instead.

Arguably, using flatMap + map here is cleaner anyway, as calling `Provider.get()` is no longer necessary.
