### PR TITLE
Fix configuration cache compatibility of UsesSample tests

### DIFF
--- a/subprojects/docs/src/docs/userguide/authoring-builds/working_with_files.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/working_with_files.adoc
@@ -207,7 +207,7 @@ In this case, we're taking the runtime dependencies of the project — `configur
 
 Many tasks need to create directories to store the files they generate, which is why Gradle automatically manages this aspect of tasks when they explicitly define file and directory outputs. You can learn about this feature in the <<more_about_tasks.adoc#sec:up_to_date_checks,incremental build>> section of the user manual. All core Gradle tasks ensure that any output directories they need are created if necessary using this mechanism.
 
-In cases where you need to create a directory manually, you can use the link:{groovyDslPath}/org.gradle.api.Project.html#org.gradle.api.Project:mkdir(java.lang.Object)[Project.mkdir(java.lang.Object)] method from within your build scripts or custom task implementations. Here's a simple example that creates a single `images` directory in the project folder:
+In cases where you need to create a directory manually, you can use the standard `{javaApi}/java/nio/file/Files.html#createDirectories-java.nio.file.Path-java.nio.file.attribute.FileAttribute++...++-[Files.createDirectories]` or `{javaApi}/java/io/File.html#mkdirs--[File.mkdirs]` methods from within your build scripts or custom task implementations. Here's a simple example that creates a single `images` directory in the project folder:
 
 .Manually creating a directory
 ====

--- a/subprojects/docs/src/snippets/bestPractices/logicDuringConfiguration-do/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/bestPractices/logicDuringConfiguration-do/groovy/build.gradle
@@ -12,8 +12,9 @@ dependencies {
 }
 
 tasks.register('printArtifactNames') {
+    FileCollection compileClasspath = configurations.compileClasspath
     doLast {
-        def libraryNames = configurations.compileClasspath.collect { it.name }
+        def libraryNames = compileClasspath.collect { it.name }
         logger.quiet libraryNames
     }
 }

--- a/subprojects/docs/src/snippets/bestPractices/logicDuringConfiguration-do/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/bestPractices/logicDuringConfiguration-do/kotlin/build.gradle.kts
@@ -12,8 +12,9 @@ dependencies {
 }
 
 tasks.register("printArtifactNames") {
+    val compileClasspath: FileCollection = configurations.compileClasspath.get()
     doLast {
-        val libraryNames = configurations.compileClasspath.get().map { it.name }
+        val libraryNames = compileClasspath.map { it.name }
         logger.quiet(libraryNames.toString())
     }
 }

--- a/subprojects/docs/src/snippets/bestPractices/logicDuringConfiguration-do/tests/logicDuringExecutionPhase.sample.conf
+++ b/subprojects/docs/src/snippets/bestPractices/logicDuringConfiguration-do/tests/logicDuringExecutionPhase.sample.conf
@@ -1,2 +1,2 @@
 executable: gradle
-args: tasks
+args: printArtifactNames

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-selectionRule/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-selectionRule/groovy/build.gradle
@@ -44,8 +44,9 @@ dependencies {
 // end::reject-version-1-1[]
 
 tasks.register('printRejectConfig') {
+    FileCollection rejectConfig = configurations.rejectConfig
     doLast {
-        configurations.rejectConfig.each { println "Resolved: ${it.name}" }
+        rejectConfig.each { println "Resolved: ${it.name}" }
     }
 }
 
@@ -78,8 +79,9 @@ dependencies {
 }
 
 tasks.register('printMetadataRulesConfig') {
+    FileCollection metadataRulesConfig = configurations.metadataRulesConfig
     doLast {
-        configurations.metadataRulesConfig.each { println "Resolved: ${it.name}" }
+        metadataRulesConfig.each { println "Resolved: ${it.name}" }
     }
 }
 
@@ -104,8 +106,9 @@ dependencies {
 }
 
 tasks.register('printTargetConfig') {
+    FileCollection targetConfig = configurations.targetConfig
     doLast {
-        configurations.targetConfig.each { println "Resolved: ${it.name}" }
+        targetConfig.each { println "Resolved: ${it.name}" }
     }
 }
 
@@ -132,7 +135,8 @@ dependencies {
 }
 
 tasks.register('resolveConfiguration') {
+    FileCollection sampleConfig = configurations.sampleConfig
     doLast {
-        configurations.sampleConfig.each { println it }
+        sampleConfig.each { println it }
     }
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-selectionRule/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-selectionRule/kotlin/build.gradle.kts
@@ -43,8 +43,9 @@ dependencies {
 // end::reject-version-1-1[]
 
 tasks.register("printRejectConfig") {
+    val rejectConfig: FileCollection = configurations["rejectConfig"]
     doLast {
-        configurations["rejectConfig"].forEach { println("Resolved: ${it.name}") }
+        rejectConfig.forEach { println("Resolved: ${it.name}") }
     }
 }
 
@@ -77,8 +78,9 @@ dependencies {
 }
 
 tasks.register("printMetadataRulesConfig") {
+    val metadataRulesConfig: FileCollection = configurations["metadataRulesConfig"]
     doLast {
-        configurations["metadataRulesConfig"].forEach { println("Resolved: ${it.name}") }
+        metadataRulesConfig.forEach { println("Resolved: ${it.name}") }
     }
 }
 
@@ -103,8 +105,9 @@ dependencies {
 }
 
 tasks.register("printTargetConfig") {
+    val targetConfig: FileCollection = configurations["targetConfig"]
     doLast {
-        configurations["targetConfig"].forEach { println("Resolved: ${it.name}") }
+        targetConfig.forEach { println("Resolved: ${it.name}") }
     }
 }
 
@@ -131,7 +134,8 @@ dependencies {
 }
 
 tasks.register("resolveConfiguration") {
+    val sampleConfig: FileCollection = configurations["sampleConfig"]
     doLast {
-        configurations["sampleConfig"].forEach { println(it) }
+        sampleConfig.forEach { println(it) }
     }
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-selectionRule/tests/componentSelectionRules.sample.conf
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-selectionRule/tests/componentSelectionRules.sample.conf
@@ -1,0 +1,2 @@
+executable: gradle
+args: printRejectConfig printMetadataRulesConfig printTargetConfig resolveConfiguration

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-selectionRule/tests/componentSelectionRulesReject.sample.conf
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-selectionRule/tests/componentSelectionRulesReject.sample.conf
@@ -1,2 +1,0 @@
-executable: gradle
-args: tasks

--- a/subprojects/docs/src/snippets/dependencyManagement/declaringDependencies-fileDependencies/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/declaringDependencies-fileDependencies/groovy/build.gradle
@@ -13,15 +13,16 @@ dependencies {
 // end::file-dependencies[]
 
 tasks.register('createLibs') {
+    def projectDir = layout.projectDirectory
     doLast {
-        file('ant').mkdirs()
-        file('libs').mkdirs()
-        file('tools').mkdirs()
-        file('ant/antcontrib.jar').createNewFile()
-        file('libs/commons-lang.jar').createNewFile()
-        file('libs/log4j.jar').createNewFile()
-        file('tools/a.exe').createNewFile()
-        file('tools/b.exe').createNewFile()
+        projectDir.file('ant').asFile.mkdirs()
+        projectDir.file('libs').asFile.mkdirs()
+        projectDir.file('tools').asFile.mkdirs()
+        projectDir.file('ant/antcontrib.jar').asFile.createNewFile()
+        projectDir.file('libs/commons-lang.jar').asFile.createNewFile()
+        projectDir.file('libs/log4j.jar').asFile.createNewFile()
+        projectDir.file('tools/a.exe').asFile.createNewFile()
+        projectDir.file('tools/b.exe').asFile.createNewFile()
     }
 }
 
@@ -32,5 +33,3 @@ tasks.register('copyLibs', Copy) {
     from configurations.deploymentTools
     into layout.buildDirectory.dir('libs')
 }
-
-

--- a/subprojects/docs/src/snippets/dependencyManagement/declaringDependencies-fileDependencies/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/declaringDependencies-fileDependencies/kotlin/build.gradle.kts
@@ -13,15 +13,16 @@ dependencies {
 // end::file-dependencies[]
 
 tasks.register("createLibs") {
+    val projectDir = layout.projectDirectory
     doLast {
-        file("ant").mkdirs()
-        file("libs").mkdirs()
-        file("tools").mkdirs()
-        file("ant/antcontrib.jar").createNewFile()
-        file("libs/commons-lang.jar").createNewFile()
-        file("libs/log4j.jar").createNewFile()
-        file("tools/a.exe").createNewFile()
-        file("tools/b.exe").createNewFile()
+        projectDir.file("ant").asFile.mkdirs()
+        projectDir.file("libs").asFile.mkdirs()
+        projectDir.file("tools").asFile.mkdirs()
+        projectDir.file("ant/antcontrib.jar").asFile.createNewFile()
+        projectDir.file("libs/commons-lang.jar").asFile.createNewFile()
+        projectDir.file("libs/log4j.jar").asFile.createNewFile()
+        projectDir.file("tools/a.exe").asFile.createNewFile()
+        projectDir.file("tools/b.exe").asFile.createNewFile()
     }
 }
 

--- a/subprojects/docs/src/snippets/dependencyManagement/declaringDependencies-fileDependencies/tests/file-dependencies.sample.conf
+++ b/subprojects/docs/src/snippets/dependencyManagement/declaringDependencies-fileDependencies/tests/file-dependencies.sample.conf
@@ -1,2 +1,2 @@
 executable: gradle
-args: tasks
+args: copyLibs

--- a/subprojects/docs/src/snippets/files/misc/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/files/misc/groovy/build.gradle
@@ -8,9 +8,12 @@ tasks.register('ensureDirectory') {
 
 // tag::move-example[]
 tasks.register('moveReports') {
+    // Store the build directory into a variable to avoid project reference in the configuration cache
+    def dir = buildDir
+
     doLast {
-        ant.move file: "${buildDir}/reports",
-                 todir: "${buildDir}/toArchive"
+        ant.move file: "${dir}/reports",
+                 todir: "${dir}/toArchive"
     }
 }
 // end::move-example[]

--- a/subprojects/docs/src/snippets/files/misc/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/files/misc/groovy/build.gradle
@@ -1,7 +1,12 @@
+import java.nio.file.Files
+
 // tag::mkdir-example[]
 tasks.register('ensureDirectory') {
+    // Store target directory into a variable to avoid project reference in the configuration cache
+    def directory = file("images")
+
     doLast {
-        mkdir "images"
+        Files.createDirectories(directory.toPath())
     }
 }
 // end::mkdir-example[]

--- a/subprojects/docs/src/snippets/files/misc/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/files/misc/kotlin/build.gradle.kts
@@ -1,7 +1,12 @@
+import java.nio.file.Files
+
 // tag::mkdir-example[]
 tasks.register("ensureDirectory") {
+    // Store target directory into a variable to avoid project reference in the configuration cache
+    val directory = file("images")
+
     doLast {
-        mkdir("images")
+        Files.createDirectories(directory.toPath())
     }
 }
 // end::mkdir-example[]

--- a/subprojects/docs/src/snippets/files/misc/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/files/misc/kotlin/build.gradle.kts
@@ -8,9 +8,12 @@ tasks.register("ensureDirectory") {
 
 // tag::move-example[]
 tasks.register("moveReports") {
+    // Store the build directory into a variable to avoid project reference in the configuration cache
+    val dir = buildDir
+
     doLast {
         ant.withGroovyBuilder {
-            "move"("file" to "${buildDir}/reports", "todir" to "${buildDir}/toArchive")
+            "move"("file" to "${dir}/reports", "todir" to "${dir}/toArchive")
         }
     }
 }

--- a/subprojects/docs/src/snippets/files/misc/kotlin/project2/build.gradle.kts
+++ b/subprojects/docs/src/snippets/files/misc/kotlin/project2/build.gradle.kts
@@ -3,6 +3,8 @@ val configFile = file("$rootDir/shared/config.xml")
 // end::using-root-dir-property[]
 
 tasks.register("checkConfigFile") {
+    val configFile = configFile  // Reduce scope of property for compatibility with the configuration cache
+
     doLast {
         require(configFile.exists())
     }

--- a/subprojects/docs/src/snippets/files/misc/tests/createDirectoryExample.sample.conf
+++ b/subprojects/docs/src/snippets/files/misc/tests/createDirectoryExample.sample.conf
@@ -1,2 +1,2 @@
 executable: gradle
-args: tasks
+args: ensureDirectory

--- a/subprojects/docs/src/snippets/files/misc/tests/usingRootDirProperty.sample.conf
+++ b/subprojects/docs/src/snippets/files/misc/tests/usingRootDirProperty.sample.conf
@@ -1,2 +1,2 @@
 executable: gradle
-args: tasks
+args: ":project2:checkConfigFile"

--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/bestpractices/SamplesAuthoringMaintainableBuildsIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/bestpractices/SamplesAuthoringMaintainableBuildsIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.integtests.samples.bestpractices
 
 import org.gradle.integtests.fixtures.AbstractSampleIntegrationTest
 import org.gradle.integtests.fixtures.Sample
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.UsesSample
 import org.junit.Rule
 
@@ -58,7 +57,6 @@ generateDocs - Generates the HTML documentation for this project.""")
     }
 
     @UsesSample('bestPractices/logicDuringConfiguration-do')
-    @ToBeFixedForConfigurationCache(iterationMatchers = ".*kotlin dsl.*")
     def "can execute logic during execution phase with #dsl dsl"() {
         executer.inDirectory(sample.dir.file(dsl))
 

--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/dependencymanagement/SamplesComponentSelectionRulesIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/dependencymanagement/SamplesComponentSelectionRulesIntegrationTest.groovy
@@ -17,7 +17,6 @@ package org.gradle.integtests.samples.dependencymanagement
 
 import org.gradle.integtests.fixtures.AbstractSampleIntegrationTest
 import org.gradle.integtests.fixtures.Sample
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.UsesSample
 import org.junit.Rule
 
@@ -27,7 +26,6 @@ class SamplesComponentSelectionRulesIntegrationTest extends AbstractSampleIntegr
     Sample sample = new Sample(testDirectoryProvider)
 
     @UsesSample("dependencyManagement/customizingResolution-selectionRule")
-    @ToBeFixedForConfigurationCache(iterationMatchers = ".*kotlin dsl")
     def "can run resolveConfiguration sample with #dsl dsl"() {
         executer.inDirectory(sample.dir.file(dsl))
 
@@ -44,7 +42,6 @@ class SamplesComponentSelectionRulesIntegrationTest extends AbstractSampleIntegr
     }
 
     @UsesSample("dependencyManagement/customizingResolution-selectionRule")
-    @ToBeFixedForConfigurationCache(iterationMatchers = ".*kotlin dsl")
     def "can run reject sample with #dsl dsl"() {
         executer.inDirectory(sample.dir.file(dsl))
 
@@ -59,7 +56,6 @@ class SamplesComponentSelectionRulesIntegrationTest extends AbstractSampleIntegr
     }
 
     @UsesSample("dependencyManagement/customizingResolution-selectionRule")
-    @ToBeFixedForConfigurationCache(iterationMatchers = ".*kotlin dsl")
     def "can run metadata rules sample with #dsl dsl"() {
         executer.inDirectory(sample.dir.file(dsl))
 
@@ -75,7 +71,6 @@ class SamplesComponentSelectionRulesIntegrationTest extends AbstractSampleIntegr
     }
 
     @UsesSample("dependencyManagement/customizingResolution-selectionRule")
-    @ToBeFixedForConfigurationCache(iterationMatchers = ".*kotlin dsl")
     def "can run targeted rule sample with #dsl dsl"() {
         executer.inDirectory(sample.dir.file(dsl))
 

--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/dependencymanagement/SamplesDeclaringDependenciesIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/dependencymanagement/SamplesDeclaringDependenciesIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.integtests.samples.dependencymanagement
 
 import org.gradle.integtests.fixtures.AbstractSampleIntegrationTest
 import org.gradle.integtests.fixtures.Sample
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.UsesSample
 import org.gradle.test.fixtures.file.TestFile
 import org.junit.Rule
@@ -91,7 +90,6 @@ class SamplesDeclaringDependenciesIntegrationTest extends AbstractSampleIntegrat
     }
 
     @UsesSample("dependencyManagement/declaringDependencies-fileDependencies")
-    @ToBeFixedForConfigurationCache(iterationMatchers = ".*kotlin dsl")
     def "can use declare and resolve file dependencies with #dsl dsl"() {
         TestFile dslDir = sample.dir.file(dsl)
         executer.inDirectory(dslDir)

--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/dependencymanagement/SamplesResolutionStrategyIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/dependencymanagement/SamplesResolutionStrategyIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.integtests.samples.dependencymanagement
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.Sample
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.UsesSample
 import org.gradle.test.fixtures.file.TestFile
 import org.junit.Rule
@@ -29,7 +28,6 @@ class SamplesResolutionStrategyIntegrationTest extends AbstractIntegrationSpec {
     Sample sample = new Sample(testDirectoryProvider)
 
     @UsesSample("dependencyManagement/customizingResolution-resolutionStrategy")
-    @ToBeFixedForConfigurationCache(iterationMatchers = ".*kotlin dsl")
     def "can resolve dependencies in #dsl dsl"() {
         TestFile dslDir = sample.dir.file(dsl)
         executer.inDirectory(dslDir)
@@ -70,7 +68,10 @@ class SamplesResolutionStrategyIntegrationTest extends AbstractIntegrationSpec {
                     conf "org.codehaus:groovy-all:2.4.10"
                     conf "log4j:log4j:1.2"
                 }
-                task resolveConf { doLast { configurations.conf.files } }
+                task resolveConf {
+                    FileCollection conf = configurations.conf
+                    doLast { conf.files }
+                }
             """
         }
         else if (dsl == 'kotlin') {
@@ -85,7 +86,10 @@ class SamplesResolutionStrategyIntegrationTest extends AbstractIntegrationSpec {
                     "conf"("org.codehaus:groovy-all:2.4.10")
                     "conf"("log4j:log4j:1.2")
                 }
-                task("resolveConf") { doLast { configurations["conf"].files } }
+                task("resolveConf") {
+                    val conf: FileCollection = configurations["conf"]
+                    doLast { conf.files }
+                }
             """
         }
     }

--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/files/SamplesFilesMiscIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/files/SamplesFilesMiscIntegrationTest.groovy
@@ -20,7 +20,9 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.Sample
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.UsesSample
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.junit.Rule
+import spock.lang.IgnoreIf
 
 class SamplesFilesMiscIntegrationTest extends AbstractIntegrationSpec {
 
@@ -45,7 +47,6 @@ class SamplesFilesMiscIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @UsesSample("files/misc")
-    @ToBeFixedForConfigurationCache(iterationMatchers = ".*kotlin dsl.*")
     def "can move a directory with #dsl dsl"() {
         given:
         def dslDir = sample.dir.file(dsl)
@@ -66,6 +67,28 @@ class SamplesFilesMiscIntegrationTest extends AbstractIntegrationSpec {
         toArchiveDir.file("reports/my-report.pdf").isFile()
         toArchiveDir.file("reports/numbers.csv").isFile()
         toArchiveDir.file("reports/metrics/scatterPlot.pdf").isFile()
+
+        where:
+        dsl << ['groovy', 'kotlin']
+    }
+
+    @UsesSample("files/misc")
+    @IgnoreIf({ GradleContextualExecuter.isNotConfigCache() })
+    def "can move a directory with #dsl dsl with configuration cache"() {
+        given:
+        def dslDir = sample.dir.file(dsl)
+
+        expect:
+        2.times {
+            def reportsDir = dslDir.file('build/reports')
+            reportsDir.createDir().file('my-report.pdf').touch()
+            reportsDir.file('numbers.csv').touch()
+
+            executer.inDirectory(dslDir)
+            succeeds("moveReports", "--rerun-tasks")
+
+            dslDir.file("build/toArchive").deleteDir()
+        }
 
         where:
         dsl << ['groovy', 'kotlin']
@@ -109,7 +132,6 @@ class SamplesFilesMiscIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @UsesSample("files/misc")
-    @ToBeFixedForConfigurationCache(iterationMatchers = ".*kotlin dsl.*")
     def "can use the rootDir property in a child project with #dsl dsl"() {
         given:
         def dslDir = sample.dir.file(dsl)

--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/files/SamplesFilesMiscIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/files/SamplesFilesMiscIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.integtests.samples.files
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.Sample
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.UsesSample
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.junit.Rule
@@ -30,7 +29,6 @@ class SamplesFilesMiscIntegrationTest extends AbstractIntegrationSpec {
     Sample sample = new Sample(testDirectoryProvider)
 
     @UsesSample("files/misc")
-    @ToBeFixedForConfigurationCache(iterationMatchers = ".*kotlin dsl.*")
     def "can create a directory with #dsl dsl"() {
         given:
         def dslDir = sample.dir.file(dsl)


### PR DESCRIPTION
Part of #21027

Most fixes are either pure "name punning" or adding an extra intermediate variable to capture stuff. Some affected samples are exposed in the user guide.