### PR TITLE
Exclude merge simplification

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/factories/Intersections.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/factories/Intersections.java
@@ -63,6 +63,19 @@ class Intersections {
             }
         }
 
+        /*
+         * The following cases are roughly ordered by the frequency of occurrence.  The order
+         * these checks are performed if CRITICAL, as not all of the intersectXYZ methods consider
+         * every type possibility for the right hand side operand.  Instead, some of these methods
+         * assume they will be called in the order here, and thus that certain types will not ever
+         * be supplied as their RHS operands.
+         *
+         * If the order of these checks is ever changed, then each intersectXYZ method must be
+         * updated to handle a RHS operand in all possible subtypes.  There are currently 6 types
+         * that extends ExcludeSpec and are relevant (GroupExclude, GroupSetExclude, ModuleExclude, ModuleIdExclude,
+         * ModuleIdSetExclude, ModuleSetExclude).  ExcludeEverything and ExcludeNothing are special
+         * cases handled above, and ArtifactExclude and CompositeExclude are also not relevant here.
+         */
         if (left instanceof GroupExclude) {
             return intersectGroup((GroupExclude) left, right);
         } else if (right instanceof GroupExclude) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/factories/Intersections.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/factories/Intersections.java
@@ -295,6 +295,8 @@ class Intersections {
                 .filter(id -> groups.contains(id.getGroup()))
                 .collect(toSet());
             return moduleIdSet(filtered);
+        } else if (right instanceof  ModuleSetExclude) {
+            return factory.moduleIdSet(groups.stream().flatMap(group -> ((ModuleSetExclude) right).getModules().stream().map(module -> DefaultModuleIdentifier.newId(group, module))).collect(toSet()));
         }
         return null;
     }
@@ -332,6 +334,8 @@ class Intersections {
         } else if (right instanceof ModuleIdSetExclude) {
             Set<ModuleIdentifier> common = ((ModuleIdSetExclude) right).getModuleIds().stream().filter(id -> id.getName().equals(module)).collect(toSet());
             return moduleIdSet(common);
+        } else if (right instanceof GroupSetExclude) {
+            return factory.moduleIdSet(((GroupSetExclude) right).getGroups().stream().map(group -> DefaultModuleIdentifier.newId(group, module)).collect(toSet()));
         }
         return null;
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/factories/ExcludeTestSupport.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/factories/ExcludeTestSupport.groovy
@@ -57,6 +57,13 @@ trait ExcludeTestSupport {
         factory.moduleIdSet(RandomizedIteratorHashSet.of(ids.collect { newId(it[0], it[1]) } as Set<ModuleIdentifier>))
     }
 
+    ExcludeSpec moduleIdSet(String... ids) {
+        factory.moduleIdSet(RandomizedIteratorHashSet.of(ids.collect {
+            def split = it.split(':')
+            newId(split[0], split[1])
+        } as Set))
+    }
+
     ExcludeSpec anyOf(ExcludeSpec... specs) {
         switch (specs.length) {
             case 0:


### PR DESCRIPTION
Changes are based on real world use cases where keeping an allOf(group(s),module(s))
instead of making it a moduleId(Set) had pretty bad downstream consequences.