### PR TITLE
Avoid mutating forking options in JavaCompile

### DIFF
--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/DefaultGroovyJavaJointCompileSpecFactory.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/DefaultGroovyJavaJointCompileSpecFactory.java
@@ -20,6 +20,7 @@ import org.gradle.api.tasks.compile.CompileOptions;
 import org.gradle.jvm.toolchain.JavaInstallationMetadata;
 
 import javax.annotation.Nullable;
+import java.io.File;
 
 public class DefaultGroovyJavaJointCompileSpecFactory extends AbstractJavaCompileSpecFactory<DefaultGroovyJavaJointCompileSpec> {
     public DefaultGroovyJavaJointCompileSpecFactory(CompileOptions compileOptions, @Nullable JavaInstallationMetadata javaInstallationMetadata) {
@@ -27,13 +28,13 @@ public class DefaultGroovyJavaJointCompileSpecFactory extends AbstractJavaCompil
     }
 
     @Override
-    protected DefaultGroovyJavaJointCompileSpec getCommandLineSpec() {
-        return new DefaultCommandLineGroovyJavaJointCompileSpec();
+    protected DefaultGroovyJavaJointCompileSpec getCommandLineSpec(File executable) {
+        return new DefaultCommandLineGroovyJavaJointCompileSpec(executable);
     }
 
     @Override
-    protected DefaultGroovyJavaJointCompileSpec getForkingSpec() {
-        return new DefaultForkingGroovyJavaJointCompileSpec();
+    protected DefaultGroovyJavaJointCompileSpec getForkingSpec(File javaHome) {
+        return new DefaultForkingGroovyJavaJointCompileSpec(javaHome);
     }
 
     @Override
@@ -42,8 +43,28 @@ public class DefaultGroovyJavaJointCompileSpecFactory extends AbstractJavaCompil
     }
 
     private static class DefaultCommandLineGroovyJavaJointCompileSpec extends DefaultGroovyJavaJointCompileSpec implements CommandLineJavaCompileSpec {
+        private final File executable;
+
+        private DefaultCommandLineGroovyJavaJointCompileSpec(File executable) {
+            this.executable = executable;
+        }
+
+        @Override
+        public File getExecutable() {
+            return executable;
+        }
     }
 
     private static class DefaultForkingGroovyJavaJointCompileSpec extends DefaultGroovyJavaJointCompileSpec implements ForkingJavaCompileSpec {
+        private final File javaHome;
+
+        private DefaultForkingGroovyJavaJointCompileSpec(File javaHome) {
+            this.javaHome = javaHome;
+        }
+
+        @Override
+        public File getJavaHome() {
+            return javaHome;
+        }
     }
 }

--- a/subprojects/language-groovy/src/test/groovy/org/gradle/api/internal/tasks/compile/DefaultGroovyJavaJointCompileSpecFactoryTest.groovy
+++ b/subprojects/language-groovy/src/test/groovy/org/gradle/api/internal/tasks/compile/DefaultGroovyJavaJointCompileSpecFactoryTest.groovy
@@ -22,10 +22,16 @@ import org.gradle.api.tasks.compile.CompileOptions
 import org.gradle.internal.jvm.Jvm
 import org.gradle.jvm.toolchain.JavaInstallationMetadata
 import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.junit.Rule
 import spock.lang.Specification
 
 class DefaultGroovyJavaJointCompileSpecFactoryTest extends Specification {
-    def "produces correct spec type" () {
+
+    @Rule
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
+
+    def "produces correct spec type"() {
         CompileOptions options = new CompileOptions(Mock(ObjectFactory))
         options.fork = fork
         options.forkOptions.executable = executable
@@ -47,8 +53,14 @@ class DefaultGroovyJavaJointCompileSpecFactoryTest extends Specification {
     }
 
     def 'produces correct spec type for toolchains'() {
+        // Make sure other Java home is valid from Jvm.forHome point of view and compiler executable exists
+        def otherJavaHome = tmpDir.createDir("other-java-home")
+        otherJavaHome.createDir("bin")
+        otherJavaHome.file("bin/java").touch()
+        otherJavaHome.file("bin/javac").touch()
+
         def version = currentVM == 'current' ? Jvm.current().javaVersion.majorVersion : currentVM
-        def javaHome = currentVM == 'current' ? Jvm.current().javaHome : new File('other').absoluteFile
+        def javaHome = currentVM == 'current' ? Jvm.current().javaHome : otherJavaHome.absoluteFile
 
         JavaInstallationMetadata metadata = Mock(JavaInstallationMetadata)
         metadata.languageVersion >> JavaLanguageVersion.of(version)
@@ -68,12 +80,12 @@ class DefaultGroovyJavaJointCompileSpecFactoryTest extends Specification {
         CommandLineJavaCompileSpec.isAssignableFrom(spec.getClass()) == implementsCommandLine
 
         where:
-        currentVM   | fork  | implementsForking | implementsCommandLine
-        'current'   | false | false             | false
-        'current'   | true  | true              | false
-        '7'         | false | false             | true
-        '7'         | true  | false             | true
-        '14'        | false | true              | false
-        '14'        | true  | true              | false
+        currentVM | fork  | implementsForking | implementsCommandLine
+        'current' | false | false             | false
+        'current' | true  | true              | false
+        '7'       | false | false             | true
+        '7'       | true  | false             | true
+        '14'      | false | true              | false
+        '14'      | true  | true              | false
     }
 }

--- a/subprojects/language-groovy/src/test/groovy/org/gradle/api/internal/tasks/compile/DefaultGroovyJavaJointCompileSpecFactoryTest.groovy
+++ b/subprojects/language-groovy/src/test/groovy/org/gradle/api/internal/tasks/compile/DefaultGroovyJavaJointCompileSpecFactoryTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.compile.CompileOptions
 import org.gradle.internal.jvm.Jvm
+import org.gradle.internal.os.OperatingSystem
 import org.gradle.jvm.toolchain.JavaInstallationMetadata
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -56,8 +57,8 @@ class DefaultGroovyJavaJointCompileSpecFactoryTest extends Specification {
         // Make sure other Java home is valid from Jvm.forHome point of view and compiler executable exists
         def otherJavaHome = tmpDir.createDir("other-java-home")
         otherJavaHome.createDir("bin")
-        otherJavaHome.file("bin/java").touch()
-        otherJavaHome.file("bin/javac").touch()
+        otherJavaHome.file(OperatingSystem.current().getExecutableName("bin/java")).touch()
+        otherJavaHome.file(OperatingSystem.current().getExecutableName("bin/javac")).touch()
 
         def version = currentVM == 'current' ? Jvm.current().javaVersion.majorVersion : currentVM
         def javaHome = currentVM == 'current' ? Jvm.current().javaHome : otherJavaHome.absoluteFile

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileToolchainIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileToolchainIntegrationTest.groovy
@@ -22,11 +22,45 @@ import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.internal.jvm.Jvm
 import org.gradle.util.Requires
+import org.gradle.util.internal.TextUtil
 import spock.lang.IgnoreIf
+import spock.lang.Issue
 
 import static org.junit.Assume.assumeNotNull
 
 class JavaCompileToolchainIntegrationTest extends AbstractIntegrationSpec {
+
+    @Issue("https://github.com/gradle/gradle/issues/22398")
+    def "ignore #what in fork options if not forking"() {
+        def otherJvm = AvailableJavaHomes.differentVersion
+        def path = TextUtil.normaliseFileSeparators(otherJvm.javaHome.absolutePath + appendPath)
+
+        file("src/main/java/Foo.java") << "public class Foo {}"
+
+        buildFile << """
+            apply plugin: "java"
+
+            compileJava {
+                ${configure.replace("<path>", path)}
+            }
+        """
+
+        when:
+        run(":compileJava", "--info")
+
+        then:
+        executedAndNotSkipped(":compileJava")
+        // TODO: this line needs to be changed to the current JVM toolchain when the issue is fixed
+        outputContains("Compiling with toolchain '${otherJvm.javaHome.absolutePath}'")
+        outputContains("Compiling with JDK Java compiler API")
+        outputDoesNotContain("Compiling with Java command line compiler")
+        outputDoesNotContain("Started Gradle worker daemon")
+
+        where:
+        what         | configure                                       | appendPath
+        "java home"  | 'options.forkOptions.javaHome = file("<path>")' | ''
+        "executable" | 'options.forkOptions.executable = "<path>"'     | '/bin/javac'
+    }
 
     @IgnoreIf({ AvailableJavaHomes.differentJdk == null })
     def "can manually set java compiler via #type toolchain on java compile task"() {
@@ -380,9 +414,9 @@ public class Foo {
         ]
     }
 
-    /*
-    This test covers the case where in Java8 the class name becomes fully qualified in the deprecation message which is
-    somehow caused by invoking javacTask.getElements() in the IncrementalCompileTask of the incremental compiler plugin.
+    /**
+     * This test covers the case where in Java8 the class name becomes fully qualified in the deprecation message which is
+     * somehow caused by invoking javacTask.getElements() in the IncrementalCompileTask of the incremental compiler plugin.
      */
     def "Java deprecation messages with different JDKs"() {
         def jdk = AvailableJavaHomes.getJdk(javaVersion)

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileToolchainIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileToolchainIntegrationTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.internal.jvm.Jvm
+import org.gradle.internal.os.OperatingSystem
 import org.gradle.util.Requires
 import org.gradle.util.internal.TextUtil
 import spock.lang.IgnoreIf
@@ -59,7 +60,7 @@ class JavaCompileToolchainIntegrationTest extends AbstractIntegrationSpec {
         where:
         what         | configure                                       | appendPath
         "java home"  | 'options.forkOptions.javaHome = file("<path>")' | ''
-        "executable" | 'options.forkOptions.executable = "<path>"'     | '/bin/javac'
+        "executable" | 'options.forkOptions.executable = "<path>"'     | OperatingSystem.current().getExecutableName('/bin/javac')
     }
 
     @IgnoreIf({ AvailableJavaHomes.differentJdk == null })

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/AbstractJavaCompileSpecFactory.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/AbstractJavaCompileSpecFactory.java
@@ -18,9 +18,11 @@ package org.gradle.api.internal.tasks.compile;
 
 import org.gradle.api.tasks.compile.CompileOptions;
 import org.gradle.internal.Factory;
+import org.gradle.internal.jvm.Jvm;
 import org.gradle.jvm.toolchain.JavaInstallationMetadata;
 
 import javax.annotation.Nullable;
+import java.io.File;
 
 public abstract class AbstractJavaCompileSpecFactory<T extends JavaCompileSpec> implements Factory<T> {
     private final CompileOptions compileOptions;
@@ -32,43 +34,42 @@ public abstract class AbstractJavaCompileSpecFactory<T extends JavaCompileSpec> 
         this.toolchain = toolchain;
     }
 
-    public AbstractJavaCompileSpecFactory(CompileOptions compileOptions) {
-        this(compileOptions, null);
-    }
-
     @Override
     public T create() {
         if (toolchain != null) {
             return chooseSpecForToolchain();
         }
         if (compileOptions.isFork()) {
-            if (compileOptions.getForkOptions().getExecutable() != null || compileOptions.getForkOptions().getJavaHome() != null) {
-                return getCommandLineSpec();
-            } else {
-                return getForkingSpec();
+            File customJavaHome = compileOptions.getForkOptions().getJavaHome();
+            if (customJavaHome != null) {
+                return getCommandLineSpec(Jvm.forHome(customJavaHome).getJavacExecutable());
             }
+
+            String customExecutable = compileOptions.getForkOptions().getExecutable();
+            if (customExecutable != null) {
+                return getCommandLineSpec(new File(customExecutable));
+            }
+
+            return getForkingSpec(Jvm.current().getJavaHome());
         } else {
             return getDefaultSpec();
         }
     }
 
     private T chooseSpecForToolchain() {
+        File toolchainJavaHome = toolchain.getInstallationPath().getAsFile();
         if (!toolchain.getLanguageVersion().canCompileOrRun(8)) {
-            return getCommandLineSpec();
+            return getCommandLineSpec(Jvm.forHome(toolchainJavaHome).getJavacExecutable());
         }
-        if (compileOptions.isFork()) {
-            return getForkingSpec();
-        } else {
-            if (toolchain.isCurrentJvm()) {
-                return getDefaultSpec();
-            }
-            return getForkingSpec();
+        if (!compileOptions.isFork() && toolchain.isCurrentJvm()) {
+            return getDefaultSpec();
         }
+        return getForkingSpec(toolchainJavaHome);
     }
 
-    abstract protected T getCommandLineSpec();
+    abstract protected T getCommandLineSpec(File executable);
 
-    abstract protected T getForkingSpec();
+    abstract protected T getForkingSpec(File javaHome);
 
     abstract protected T getDefaultSpec();
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/CommandLineJavaCompileSpec.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/CommandLineJavaCompileSpec.java
@@ -16,5 +16,10 @@
 
 package org.gradle.api.internal.tasks.compile;
 
+import java.io.File;
+
 public interface CommandLineJavaCompileSpec {
+
+    File getExecutable();
+
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DaemonJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DaemonJavaCompiler.java
@@ -55,10 +55,16 @@ public class DaemonJavaCompiler extends AbstractDaemonCompiler<JavaCompileSpec> 
 
     @Override
     protected DaemonForkOptions toDaemonForkOptions(JavaCompileSpec spec) {
+        if (!(spec instanceof ForkingJavaCompileSpec)) {
+            throw new IllegalArgumentException(String.format("Expected a %s, but got %s", ForkingJavaCompileSpec.class.getSimpleName(), spec.getClass().getSimpleName()));
+        }
+
+        File executable = Jvm.forHome(((ForkingJavaCompileSpec) spec).getJavaHome()).getJavaExecutable();
+
         MinimalJavaCompilerDaemonForkOptions forkOptions = spec.getCompileOptions().getForkOptions();
         JavaForkOptions javaForkOptions = new BaseForkOptionsConverter(forkOptionsFactory).transform(forkOptions);
         javaForkOptions.setWorkingDir(daemonWorkingDir);
-        javaForkOptions.setExecutable(findSuitableExecutable(spec));
+        javaForkOptions.setExecutable(executable);
 
         ClassPath compilerClasspath = classPathRegistry.getClassPath("JAVA-COMPILER");
         FlatClassLoaderStructure classLoaderStructure = new FlatClassLoaderStructure(new VisitableURLClassLoader.Spec("compiler", compilerClasspath.getAsURLs()));
@@ -68,20 +74,6 @@ public class DaemonJavaCompiler extends AbstractDaemonCompiler<JavaCompileSpec> 
             .withClassLoaderStructure(classLoaderStructure)
             .keepAliveMode(KeepAliveMode.SESSION)
             .build();
-    }
-
-    private File findSuitableExecutable(JavaCompileSpec spec) {
-        if (spec instanceof ForkingJavaCompileSpec) {
-            return Jvm.forHome(((ForkingJavaCompileSpec) spec).getJavaHome()).getJavaExecutable();
-        }
-
-        final MinimalJavaCompilerDaemonForkOptions forkOptions = spec.getCompileOptions().getForkOptions();
-        if (forkOptions.getExecutable() != null) {
-            return new File(forkOptions.getExecutable());
-        } else if (forkOptions.getJavaHome() != null) {
-            return Jvm.forHome(forkOptions.getJavaHome()).getJavaExecutable();
-        }
-        return Jvm.current().getJavaExecutable();
     }
 
     public static class JavaCompilerParameters extends CompilerParameters {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DaemonJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DaemonJavaCompiler.java
@@ -71,6 +71,10 @@ public class DaemonJavaCompiler extends AbstractDaemonCompiler<JavaCompileSpec> 
     }
 
     private File findSuitableExecutable(JavaCompileSpec spec) {
+        if (spec instanceof ForkingJavaCompileSpec) {
+            return Jvm.forHome(((ForkingJavaCompileSpec) spec).getJavaHome()).getJavaExecutable();
+        }
+
         final MinimalJavaCompilerDaemonForkOptions forkOptions = spec.getCompileOptions().getForkOptions();
         if (forkOptions.getExecutable() != null) {
             return new File(forkOptions.getExecutable());

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJavaCompileSpecFactory.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJavaCompileSpecFactory.java
@@ -19,19 +19,22 @@ package org.gradle.api.internal.tasks.compile;
 import org.gradle.api.tasks.compile.CompileOptions;
 import org.gradle.jvm.toolchain.JavaInstallationMetadata;
 
+import javax.annotation.Nullable;
+import java.io.File;
+
 public class DefaultJavaCompileSpecFactory extends AbstractJavaCompileSpecFactory<DefaultJavaCompileSpec> {
-    public DefaultJavaCompileSpecFactory(CompileOptions compileOptions, JavaInstallationMetadata toolchain) {
+    public DefaultJavaCompileSpecFactory(CompileOptions compileOptions, @Nullable JavaInstallationMetadata toolchain) {
         super(compileOptions, toolchain);
     }
 
     @Override
-    protected DefaultJavaCompileSpec getCommandLineSpec() {
-        return new DefaultCommandLineJavaSpec();
+    protected DefaultJavaCompileSpec getCommandLineSpec(File executable) {
+        return new DefaultCommandLineJavaSpec(executable);
     }
 
     @Override
-    protected DefaultJavaCompileSpec getForkingSpec() {
-        return new DefaultForkingJavaCompileSpec();
+    protected DefaultJavaCompileSpec getForkingSpec(File javaHome) {
+        return new DefaultForkingJavaCompileSpec(javaHome);
     }
 
     @Override
@@ -40,8 +43,28 @@ public class DefaultJavaCompileSpecFactory extends AbstractJavaCompileSpecFactor
     }
 
     private static class DefaultCommandLineJavaSpec extends DefaultJavaCompileSpec implements CommandLineJavaCompileSpec {
+        private final File executable;
+
+        private DefaultCommandLineJavaSpec(File executable) {
+            this.executable = executable;
+        }
+
+        @Override
+        public File getExecutable() {
+            return executable;
+        }
     }
 
     private static class DefaultForkingJavaCompileSpec extends DefaultJavaCompileSpec implements ForkingJavaCompileSpec {
+        private final File javaHome;
+
+        private DefaultForkingJavaCompileSpec(File javaHome) {
+            this.javaHome = javaHome;
+        }
+
+        @Override
+        public File getJavaHome() {
+            return javaHome;
+        }
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/ForkingJavaCompileSpec.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/ForkingJavaCompileSpec.java
@@ -16,5 +16,10 @@
 
 package org.gradle.api.internal.tasks.compile;
 
+import java.io.File;
+
 public interface ForkingJavaCompileSpec {
+
+    File getJavaHome();
+
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -298,7 +298,7 @@ public class JavaCompile extends AbstractCompile implements HasCompileOptions {
         boolean toolchainCompatibleWithJava8 = isToolchainCompatibleWithJava8();
         boolean isSourcepathUserDefined = compileOptions.getSourcepath() != null && !compileOptions.getSourcepath().isEmpty();
 
-        final DefaultJavaCompileSpec spec = createBaseSpec();
+        DefaultJavaCompileSpec spec = new DefaultJavaCompileSpecFactory(compileOptions, getToolchain()).create();
 
         spec.setDestinationDir(getDestinationDirectory().getAsFile().get());
         spec.setWorkingDir(getProjectLayout().getProjectDirectory().getAsFile());
@@ -325,19 +325,6 @@ public class JavaCompile extends AbstractCompile implements HasCompileOptions {
     @Input
     JavaVersion getJavaVersion() {
         return JavaVersion.toVersion(getCompilerTool().get().getMetadata().getLanguageVersion().asInt());
-    }
-
-    private DefaultJavaCompileSpec createBaseSpec() {
-        final ForkOptions forkOptions = compileOptions.getForkOptions();
-        if (javaCompiler.isPresent()) {
-            applyToolchain(forkOptions);
-        }
-        return new DefaultJavaCompileSpecFactory(compileOptions, getToolchain()).create();
-    }
-
-    private void applyToolchain(ForkOptions forkOptions) {
-        final JavaInstallationMetadata metadata = getToolchain();
-        forkOptions.setJavaHome(metadata.getInstallationPath().getAsFile());
     }
 
     @Nullable

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/DefaultJavaCompilerFactoryTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/DefaultJavaCompilerFactoryTest.groovy
@@ -57,8 +57,28 @@ class DefaultJavaCompilerFactoryTest extends Specification {
     }
 
     private static class TestCommandLineJavaSpec extends DefaultJavaCompileSpec implements CommandLineJavaCompileSpec {
+        private final File executable;
+
+        private TestCommandLineJavaSpec(File executable) {
+            this.executable = executable;
+        }
+
+        @Override
+        public File getExecutable() {
+            return executable;
+        }
     }
 
     private static class TestForkingJavaCompileSpec extends DefaultJavaCompileSpec implements ForkingJavaCompileSpec {
+        private final File javaHome;
+
+        private TestForkingJavaCompileSpec(File javaHome) {
+            this.javaHome = javaHome;
+        }
+
+        @Override
+        public File getJavaHome() {
+            return javaHome;
+        }
     }
 }

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/tasks/compile/JavaCompileTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/tasks/compile/JavaCompileTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.api.tasks.compile
 
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.internal.file.TestFiles
-import org.gradle.api.internal.tasks.compile.DefaultJavaCompileSpec
+import org.gradle.api.internal.tasks.compile.ForkingJavaCompileSpec
 import org.gradle.internal.jvm.Jvm
 import org.gradle.jvm.toolchain.JavaCompiler
 import org.gradle.jvm.toolchain.JavaInstallationMetadata
@@ -97,7 +97,8 @@ class JavaCompileTest extends AbstractProjectBuilderSpec {
         spec.release == 9
         spec.getSourceCompatibility() == null
         spec.getTargetCompatibility() == null
-        spec.compileOptions.forkOptions.javaHome == javaHome
+        spec.compileOptions.forkOptions.javaHome == null
+        (spec as ForkingJavaCompileSpec).javaHome == javaHome
     }
 
     def 'uses custom source and target compatibility combined with toolchain compiler'() {
@@ -122,7 +123,8 @@ class JavaCompileTest extends AbstractProjectBuilderSpec {
         then:
         spec.getSourceCompatibility() == '11'
         spec.getTargetCompatibility() == '14'
-        spec.compileOptions.forkOptions.javaHome == javaHome
+        spec.compileOptions.forkOptions.javaHome == null
+        (spec as ForkingJavaCompileSpec).javaHome == javaHome
     }
 
     def "spec is configured using the toolchain compiler in-process using the current jvm as toolchain and sets release"() {
@@ -141,11 +143,11 @@ class JavaCompileTest extends AbstractProjectBuilderSpec {
         def spec = javaCompile.createSpec()
 
         then:
-        spec instanceof DefaultJavaCompileSpec
-        spec.compileOptions.forkOptions.javaHome == javaHome
         spec.getSourceCompatibility() == null
         spec.getTargetCompatibility() == null
         spec.release == 12
+        spec.compileOptions.forkOptions.javaHome == null
+        (spec as ForkingJavaCompileSpec).javaHome == javaHome
     }
 
     @Issue('https://bugs.openjdk.java.net/browse/JDK-8139607')
@@ -165,11 +167,11 @@ class JavaCompileTest extends AbstractProjectBuilderSpec {
         def spec = javaCompile.createSpec()
 
         then:
-        spec instanceof DefaultJavaCompileSpec
-        spec.compileOptions.forkOptions.javaHome == javaHome
         spec.getSourceCompatibility() == '9'
         spec.getTargetCompatibility() == '9'
         spec.release == null
+        spec.compileOptions.forkOptions.javaHome == null
+        (spec as ForkingJavaCompileSpec).javaHome == javaHome
     }
 
     def "spec is configured using the toolchain compiler in-process using the current jvm as toolchain and set source and target compatibility"() {
@@ -188,11 +190,11 @@ class JavaCompileTest extends AbstractProjectBuilderSpec {
         def spec = javaCompile.createSpec()
 
         then:
-        spec instanceof DefaultJavaCompileSpec
-        spec.compileOptions.forkOptions.javaHome == javaHome
         spec.getSourceCompatibility() == '8'
         spec.getTargetCompatibility() == '8'
         spec.release == null
+        spec.compileOptions.forkOptions.javaHome == null
+        (spec as ForkingJavaCompileSpec).javaHome == javaHome
     }
 
     def "incremental compilation is enabled by default"() {

--- a/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/scala/DefaultScalaJavaJointCompileSpecFactory.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/scala/DefaultScalaJavaJointCompileSpecFactory.java
@@ -23,6 +23,7 @@ import org.gradle.api.tasks.compile.CompileOptions;
 import org.gradle.jvm.toolchain.JavaInstallationMetadata;
 
 import javax.annotation.Nullable;
+import java.io.File;
 
 public class DefaultScalaJavaJointCompileSpecFactory extends AbstractJavaCompileSpecFactory<DefaultScalaJavaJointCompileSpec> {
     public DefaultScalaJavaJointCompileSpecFactory(CompileOptions compileOptions, @Nullable JavaInstallationMetadata javaInstallationMetadata) {
@@ -30,13 +31,13 @@ public class DefaultScalaJavaJointCompileSpecFactory extends AbstractJavaCompile
     }
 
     @Override
-    protected DefaultScalaJavaJointCompileSpec getCommandLineSpec() {
-        return new DefaultCommandLineScalaJavaJointCompileSpec();
+    protected DefaultScalaJavaJointCompileSpec getCommandLineSpec(File executable) {
+        return new DefaultCommandLineScalaJavaJointCompileSpec(executable);
     }
 
     @Override
-    protected DefaultScalaJavaJointCompileSpec getForkingSpec() {
-        return new DefaultForkingScalaJavaJointCompileSpec();
+    protected DefaultScalaJavaJointCompileSpec getForkingSpec(File javaHome) {
+        return new DefaultForkingScalaJavaJointCompileSpec(javaHome);
     }
 
     @Override
@@ -45,8 +46,28 @@ public class DefaultScalaJavaJointCompileSpecFactory extends AbstractJavaCompile
     }
 
     private static class DefaultCommandLineScalaJavaJointCompileSpec extends DefaultScalaJavaJointCompileSpec implements CommandLineJavaCompileSpec {
+        private final File executable;
+
+        private DefaultCommandLineScalaJavaJointCompileSpec(File executable) {
+            this.executable = executable;
+        }
+
+        @Override
+        public File getExecutable() {
+            return executable;
+        }
     }
 
     private static class DefaultForkingScalaJavaJointCompileSpec extends DefaultScalaJavaJointCompileSpec implements ForkingJavaCompileSpec {
+        private final File javaHome;
+
+        private DefaultForkingScalaJavaJointCompileSpec(File javaHome) {
+            this.javaHome = javaHome;
+        }
+
+        @Override
+        public File getJavaHome() {
+            return javaHome;
+        }
     }
 }

--- a/subprojects/scala/src/test/groovy/org/gradle/api/internal/tasks/scala/DefaultScalaJavaJointCompileSpecFactoryTest.groovy
+++ b/subprojects/scala/src/test/groovy/org/gradle/api/internal/tasks/scala/DefaultScalaJavaJointCompileSpecFactoryTest.groovy
@@ -24,15 +24,26 @@ import org.gradle.api.tasks.compile.CompileOptions
 import org.gradle.internal.jvm.Jvm
 import org.gradle.jvm.toolchain.JavaInstallationMetadata
 import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.junit.Rule
 import spock.lang.Specification
 import spock.lang.Subject
 
 @Subject(DefaultScalaJavaJointCompileSpecFactory)
 class DefaultScalaJavaJointCompileSpecFactoryTest extends Specification {
 
+    @Rule
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
+
     def 'produces correct spec type for toolchains'() {
+        // Make sure other Java home is valid from Jvm.forHome point of view and compiler executable exists
+        def otherJavaHome = tmpDir.createDir("other-java-home")
+        otherJavaHome.createDir("bin")
+        otherJavaHome.file("bin/java").touch()
+        otherJavaHome.file("bin/javac").touch()
+
         def version = currentVM == 'current' ? Jvm.current().javaVersion.majorVersion : currentVM
-        def javaHome = currentVM == 'current' ? Jvm.current().javaHome : new File('other').absoluteFile
+        def javaHome = currentVM == 'current' ? Jvm.current().javaHome : otherJavaHome.absoluteFile
 
         JavaInstallationMetadata metadata = Mock(JavaInstallationMetadata)
         metadata.languageVersion >> JavaLanguageVersion.of(version)
@@ -52,13 +63,13 @@ class DefaultScalaJavaJointCompileSpecFactoryTest extends Specification {
         CommandLineJavaCompileSpec.isAssignableFrom(spec.getClass()) == implementsCommandLine
 
         where:
-        currentVM   | fork  | implementsForking | implementsCommandLine
-        'current'   | false | false             | false
-        'current'   | true  | true              | false
-        '7'         | false | false             | true
-        '7'         | true  | false             | true
-        '14'        | false | true              | false
-        '14'        | true  | true              | false
+        currentVM | fork  | implementsForking | implementsCommandLine
+        'current' | false | false             | false
+        'current' | true  | true              | false
+        '7'       | false | false             | true
+        '7'       | true  | false             | true
+        '14'      | false | true              | false
+        '14'      | true  | true              | false
     }
 
 }

--- a/subprojects/scala/src/test/groovy/org/gradle/api/internal/tasks/scala/DefaultScalaJavaJointCompileSpecFactoryTest.groovy
+++ b/subprojects/scala/src/test/groovy/org/gradle/api/internal/tasks/scala/DefaultScalaJavaJointCompileSpecFactoryTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.internal.tasks.compile.ForkingJavaCompileSpec
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.compile.CompileOptions
 import org.gradle.internal.jvm.Jvm
+import org.gradle.internal.os.OperatingSystem
 import org.gradle.jvm.toolchain.JavaInstallationMetadata
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -39,8 +40,8 @@ class DefaultScalaJavaJointCompileSpecFactoryTest extends Specification {
         // Make sure other Java home is valid from Jvm.forHome point of view and compiler executable exists
         def otherJavaHome = tmpDir.createDir("other-java-home")
         otherJavaHome.createDir("bin")
-        otherJavaHome.file("bin/java").touch()
-        otherJavaHome.file("bin/javac").touch()
+        otherJavaHome.file(OperatingSystem.current().getExecutableName("bin/java")).touch()
+        otherJavaHome.file(OperatingSystem.current().getExecutableName("bin/javac")).touch()
 
         def version = currentVM == 'current' ? Jvm.current().javaVersion.majorVersion : currentVM
         def javaHome = currentVM == 'current' ? Jvm.current().javaHome : otherJavaHome.absoluteFile


### PR DESCRIPTION
Currently, the toolchains integration with `JavaCompile` mutates the Java home on `forkOptions` to tell the compiler which version must be actually used to execute the compilation. This leads into a problem that Java home option mutation can overwrite the value configured by the user and it's no longer possible to make a decision based on that when selecting a compiler spec. 

This will become relevant when the toolchain integration starts to allow specifying configuring toolchains and forkOptions simultaneously.
- https://github.com/gradle/gradle/pull/22108

This PR removes the mutation of the `forkOptions` and instead introduces explicit properties for `ForkingJavaCompileSpec` and `CommandLineJavaCompileSpec` which are set from the toolchain when it is present.
