### PR TITLE
De-incubate or remove many API points

### DIFF
--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/InsecureProtocolOption.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/InsecureProtocolOption.java
@@ -16,14 +16,11 @@
 
 package org.gradle.buildinit;
 
-import org.gradle.api.Incubating;
-
 /**
  * Options for handling insecure protocols when generating a project with repositories.
  *
  * @since 7.3
  */
-@Incubating
 public enum InsecureProtocolOption {
     /**
      * Fail if a URL with an insecure protocol is found.

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/tasks/InitBuild.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/tasks/InitBuild.java
@@ -18,7 +18,6 @@ package org.gradle.buildinit.tasks;
 
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
-import org.gradle.api.Incubating;
 import org.gradle.api.file.Directory;
 import org.gradle.api.internal.tasks.userinput.UserInputHandler;
 import org.gradle.api.provider.Property;
@@ -117,7 +116,6 @@ public class InitBuild extends DefaultTask {
      */
     @Input
     @Optional
-    @Incubating
     @Option(option = "incubating", description = "Allow the generated build to use new features and APIs")
     public Property<Boolean> getUseIncubating() {
         return useIncubatingAPIs;

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/tasks/InitBuild.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/tasks/InitBuild.java
@@ -168,7 +168,6 @@ public class InitBuild extends DefaultTask {
      */
     @Input
     @Option(option = "insecure-protocol", description = "How to handle insecure URLs used for Maven Repositories.")
-    @Incubating
     public Property<InsecureProtocolOption> getInsecureProtocol() {
         return insecureProtocol;
     }

--- a/subprojects/core-api/src/main/java/org/gradle/api/AntBuilder.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/AntBuilder.java
@@ -54,7 +54,6 @@ public abstract class AntBuilder extends groovy.ant.AntBuilder {
      *
      * @since 7.1
      */
-    @Incubating
     public abstract void importBuild(Object antBuildFile, String baseDirectory);
 
     /**
@@ -89,7 +88,6 @@ public abstract class AntBuilder extends groovy.ant.AntBuilder {
      *
      * @since 7.1
      */
-    @Incubating
     public abstract void importBuild(Object antBuildFile, String baseDirectory, Transformer<? extends String, ? super String> taskNamer);
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ConfigurationPublications.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ConfigurationPublications.java
@@ -17,7 +17,6 @@
 package org.gradle.api.artifacts;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.attributes.HasConfigurableAttributes;
 import org.gradle.api.capabilities.Capability;
@@ -60,8 +59,7 @@ public interface ConfigurationPublications extends HasConfigurableAttributes<Con
      * @param provider The provider of the artifacts to add.
      * @since 7.4
      */
-    @Incubating
-    void artifacts(Provider<? extends Iterable<? extends Object>> provider);
+    void artifacts(Provider<? extends Iterable<?>> provider);
 
     /**
      * Lazily adds a collection of outgoing artifacts to this configuration, configuring each artifact using the given action. These artifacts are included in all variants.
@@ -69,8 +67,7 @@ public interface ConfigurationPublications extends HasConfigurableAttributes<Con
      * @param provider The provider of the artifacts to add.
      * @since 7.4
      */
-    @Incubating
-    void artifacts(Provider<? extends Iterable<? extends Object>> provider, Action<? super ConfigurablePublishArtifact> configureAction);
+    void artifacts(Provider<? extends Iterable<?>> provider, Action<? super ConfigurablePublishArtifact> configureAction);
 
     /**
      * Returns the variants of this configuration, if any.

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ResolvedVariantResult.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ResolvedVariantResult.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.artifacts.result;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.capabilities.Capability;
@@ -32,11 +31,10 @@ import java.util.Optional;
 public interface ResolvedVariantResult {
     /**
      * The component which owns this variant.
-     * @return the component identifier of this variant
      *
+     * @return the component identifier of this variant
      * @since 6.8
      */
-    @Incubating
     ComponentIdentifier getOwner();
 
     /**
@@ -63,10 +61,8 @@ public interface ResolvedVariantResult {
      * found in another module. This corresponds to variants which are marked
      * as "available-at" in Gradle Module Metadata.
      *
-     * @return an optional variant, which if present means it's available externally
-     *
+     * @return the external variant, if any
      * @since 6.8
      */
-    @Incubating
     Optional<ResolvedVariantResult> getExternalVariant();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/AttributeContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/AttributeContainer.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.attributes;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.HasInternalProtocol;
 import org.gradle.internal.scan.UsedByScanPlugin;
@@ -74,7 +73,6 @@ public interface AttributeContainer extends HasAttributes {
      * @return this container
      * @since 7.4
      */
-    @Incubating
     <T> AttributeContainer attributeProvider(Attribute<T> key, Provider<? extends T> provider);
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/plugin/GradlePluginApiVersion.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/plugin/GradlePluginApiVersion.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.attributes.plugin;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.Named;
 import org.gradle.api.attributes.Attribute;
 
@@ -25,7 +24,6 @@ import org.gradle.api.attributes.Attribute;
  *
  * @since 7.0
  */
-@Incubating
 public interface GradlePluginApiVersion extends Named {
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/ConfigurableIncludedPluginBuild.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/ConfigurableIncludedPluginBuild.java
@@ -16,14 +16,11 @@
 
 package org.gradle.api.initialization;
 
-import org.gradle.api.Incubating;
-
 /**
  * A plugin build that is to be included in the composite.
  *
  * @since 7.0
  */
-@Incubating
 public interface ConfigurableIncludedPluginBuild extends IncludedBuild {
 
     /**
@@ -32,6 +29,5 @@ public interface ConfigurableIncludedPluginBuild extends IncludedBuild {
      * @param name the name of the build
      * @since 7.0
      */
-    @Incubating
     void setName(String name);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/Settings.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/Settings.java
@@ -275,7 +275,6 @@ public interface Settings extends PluginAware, ExtensionAware {
      *
      * @since 6.8
      */
-    @Incubating
     ProviderFactory getProviders();
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/reflect/TypeOf.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/reflect/TypeOf.java
@@ -17,7 +17,6 @@
 package org.gradle.api.reflect;
 
 import com.google.common.base.Function;
-import org.gradle.api.Incubating;
 import org.gradle.internal.Cast;
 import org.gradle.model.internal.type.ModelType;
 
@@ -250,7 +249,6 @@ public abstract class TypeOf<T> {
      * @return this type's FQN
      * @since 7.4
      */
-    @Incubating
     public String getFullyQualifiedName() {
         return type.getName();
     }

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskInputFilePropertyBuilder.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskInputFilePropertyBuilder.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.tasks;
 
-import org.gradle.api.Incubating;
 import org.gradle.internal.HasInternalProtocol;
 
 /**
@@ -89,24 +88,25 @@ public interface TaskInputFilePropertyBuilder extends TaskFilePropertyBuilder {
     TaskInputFilePropertyBuilder ignoreEmptyDirectories(boolean ignoreEmptyDirectories);
 
     /**
-     * Normalize line endings in text files during up-to-date checks and build cache key calculations.  This setting will have no effect on binary files.
+     * Normalize line endings in text files during up-to-date checks and build cache key calculations. This setting will have no effect on binary files.
      *
+     * <p>
      * Line ending normalization is only supported with ASCII encoding and its supersets (i.e.
-     * UTF-8, ISO-8859-1, etc).  Other encodings (e.g. UTF-16) will be treated as binary files
+     * UTF-8, ISO-8859-1, etc). Other encodings (e.g. UTF-16) will be treated as binary files
      * and will not be subject to line ending normalization.
+     * </p>
      *
      * @since 7.2
      */
-    @Incubating
     TaskInputFilePropertyBuilder normalizeLineEndings();
 
     /**
-     * Sets whether line endings should be normalized during up-to-date checks and build cache key calculations.  Defaults to false.
+     * Sets whether line endings should be normalized during up-to-date checks and build cache key calculations. Defaults to false.
      *
      * See {@link #normalizeLineEndings()}.
      *
+     * @param normalizeLineEndings whether line endings should be normalized
      * @since 7.2
      */
-    @Incubating
-    TaskInputFilePropertyBuilder normalizeLineEndings(boolean ignoreLineEndings);
+    TaskInputFilePropertyBuilder normalizeLineEndings(boolean normalizeLineEndings);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/plugin/management/PluginManagementSpec.java
+++ b/subprojects/core-api/src/main/java/org/gradle/plugin/management/PluginManagementSpec.java
@@ -17,7 +17,6 @@
 package org.gradle.plugin.management;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.initialization.ConfigurableIncludedPluginBuild;
 import org.gradle.internal.HasInternalProtocol;
@@ -70,7 +69,6 @@ public interface PluginManagementSpec {
      *
      * @since 7.0
      */
-    @Incubating
     void includeBuild(String rootProject);
 
     /**
@@ -81,7 +79,6 @@ public interface PluginManagementSpec {
      *
      * @since 7.0
      */
-    @Incubating
     void includeBuild(String rootProject, Action<ConfigurableIncludedPluginBuild> configuration);
 
 }

--- a/subprojects/core-api/src/main/java/org/gradle/work/NormalizeLineEndings.java
+++ b/subprojects/core-api/src/main/java/org/gradle/work/NormalizeLineEndings.java
@@ -16,8 +16,6 @@
 
 package org.gradle.work;
 
-import org.gradle.api.Incubating;
-
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -52,7 +50,6 @@ import java.lang.annotation.Target;
  *
  * @since 7.2
  */
-@Incubating
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.FIELD})

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputFilePropertyRegistration.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputFilePropertyRegistration.java
@@ -123,8 +123,8 @@ public class DefaultTaskInputFilePropertyRegistration extends AbstractTaskFilePr
     }
 
     @Override
-    public TaskInputFilePropertyBuilder normalizeLineEndings(boolean ignoreLineEndings) {
-        this.lineEndingSensitivity = ignoreLineEndings ? LineEndingSensitivity.NORMALIZE_LINE_ENDINGS : LineEndingSensitivity.DEFAULT;
+    public TaskInputFilePropertyBuilder normalizeLineEndings(boolean normalizeLineEndings) {
+        this.lineEndingSensitivity = normalizeLineEndings ? LineEndingSensitivity.NORMALIZE_LINE_ENDINGS : LineEndingSensitivity.DEFAULT;
         return this;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/VerificationException.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/VerificationException.java
@@ -17,14 +17,12 @@
 package org.gradle.api.tasks;
 
 import org.gradle.api.GradleException;
-import org.gradle.api.Incubating;
 
 /**
  * Signals that tests have failed. This is only thrown when tests are executed and some tests have failed execution.
  *
  * @since 7.4
  */
-@Incubating
 public class VerificationException extends GradleException {
     public VerificationException(String message) {
         super(message);

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/TaskReportTask.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/TaskReportTask.java
@@ -149,7 +149,6 @@ public class TaskReportTask extends ConventionReportTask {
      *
      * @since 7.4
      */
-    @Incubating
     @Console
     @Option(option = "types", description = "Show task class types")
     public Property<Boolean> getShowTypes() {

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerScope.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerScope.kt
@@ -248,7 +248,6 @@ private constructor(
      * @see [DependencyHandler.addProvider]
      * @since 7.0
      */
-    @Incubating
     operator fun <T : Any> Configuration.invoke(dependency: Provider<T>) =
         addProvider(name, dependency)
 
@@ -273,7 +272,6 @@ private constructor(
      * @see [DependencyHandler.addProviderConvertible]
      * @since 7.4
      */
-    @Incubating
     operator fun <T : Any> Configuration.invoke(dependency: ProviderConvertible<T>) =
         addProviderConvertible(name, dependency)
 
@@ -298,7 +296,6 @@ private constructor(
      * @see [DependencyHandler.addProvider]
      * @since 7.0
      */
-    @Incubating
     operator fun <T : Any> String.invoke(dependency: Provider<T>) =
         addProvider(this, dependency)
 
@@ -323,7 +320,6 @@ private constructor(
      * @see [DependencyHandler.addProviderConvertible]
      * @since 7.4
      */
-    @Incubating
     operator fun <T : Any> String.invoke(dependency: ProviderConvertible<T>) =
         addProviderConvertible(this, dependency)
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecScope.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecScope.kt
@@ -16,7 +16,6 @@
 
 package org.gradle.kotlin.dsl
 
-import org.gradle.api.Incubating
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderConvertible
 import org.gradle.plugin.use.PluginDependenciesSpec
@@ -63,7 +62,6 @@ infix fun PluginDependencySpec.version(version: String?): PluginDependencySpec =
  *
  * @since 7.2
  */
-@Incubating
 infix fun PluginDependencySpec.version(version: Provider<String>): PluginDependencySpec = version(version)
 
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/FeatureSpec.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/FeatureSpec.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.plugins;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.internal.HasInternalProtocol;
 
@@ -78,6 +77,5 @@ public interface FeatureSpec {
      *
      * @since 6.7
      */
-    @Incubating
     void disablePublication();
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/tasks/SourceSet.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/tasks/SourceSet.java
@@ -18,7 +18,6 @@ package org.gradle.api.tasks;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.plugins.ExtensionAware;
@@ -395,7 +394,6 @@ public interface SourceSet extends ExtensionAware {
      *
      * @since 6.7
      */
-    @Incubating
     static boolean isMain(SourceSet sourceSet) {
         return MAIN_SOURCE_SET_NAME.equals(sourceSet.getName());
     }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -21,7 +21,6 @@ import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import org.gradle.StartParameter;
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.NonNullApi;
@@ -903,7 +902,6 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
      *
      * @since 7.3
      */
-    @Incubating
     @Nested
     public Property<TestFramework> getTestFrameworkProperty() {
         return testFramework;


### PR DESCRIPTION
I left `org.gradle.api.tasks.diagnostics.TaskReportTask.getDisplayGroups()` incubating because it seems like it should be a `Property`, and it has weird behavior with the existing group flag.