### PR TITLE
Prompt for a reason when accepting all changes on the binary compatibility report

### DIFF
--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/EnrichedReportRenderer.groovy
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/EnrichedReportRenderer.groovy
@@ -63,9 +63,12 @@ class EnrichedReportRenderer extends GroovyReportRenderer {
                     return result;
                 }
 
-                function appendErrorCorrections() {
+                function appendErrorCorrections(reason) {
                     var result = JSON.parse('${currentApiChanges.replace('\n', '')}'); // JSON string from report uses double quotes, contain it within single quotes
-                    getAllErrorCorrections().forEach((correction) => result.acceptedApiChanges.push(correction));
+                    getAllErrorCorrections().forEach((correction) => {
+                        correction.acceptation = reason;
+                        result.acceptedApiChanges.push(correction);
+                    });
                     // Sort the array in place by type, then member
                     result.acceptedApiChanges = result.acceptedApiChanges.sort((a, b) => (a.type +'#' + a.member) > (b.type + '#' + b.member));
                     // Remove duplicates (equal adjacent elements) - a new, un@Incubating type will be here twice, as 2 errors are reported; use stringified JSON to compare
@@ -75,7 +78,13 @@ class EnrichedReportRenderer extends GroovyReportRenderer {
                 }
 
                 function acceptAllErrorCorrections() {
-                    var textToWrite = JSON.stringify(appendErrorCorrections(), null, 4) + "\\n";
+                    var reason = prompt("Enter a reason for accepting these changes:");
+                    if (!reason) {
+                        alert("You must enter a reason to accept all changes.");
+                        return;
+                    }
+
+                    var textToWrite = JSON.stringify(appendErrorCorrections(reason), null, 4) + "\\n";
                     var textFileAsBlob = new Blob([textToWrite], {type:'text/plain'});
                     var fileNameToSaveAs = 'accepted-public-api-changes.json';
 


### PR DESCRIPTION
A dialog now appears to prompt for a reason when accepting all changes in the binary compatibility report.  This will prevent you from accepting the changes without changing the reason from the default placeholder.