### PR TITLE
Polish implicit outer scope method call documentation

### DIFF
--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -169,7 +169,7 @@ Replace usages with the now stable `getDestinationDirectory()` and `getTestResul
 These deprecated elements will be removed in a future version of Gradle.
 
 [[referencing_script_configure_method_from_container_configure_closure_deprecated]]
-==== Implicitly referencing outer scope methods in some configuration blocks in Groovy DSL is now deprecated
+==== Deprecated implicit references to outer scope methods in some configuration blocks
 
 Prior to Gradle 7.6, Groovy scripts permitted access to root project configure methods
 within named container configure methods that handle failures with a `MissingMethodException`.

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -172,7 +172,7 @@ These deprecated elements will be removed in a future version of Gradle.
 ==== Deprecated implicit references to outer scope methods in some configuration blocks
 
 Prior to Gradle 7.6, Groovy scripts permitted access to root project configure methods
-within named container configure methods that handle failures with a `MissingMethodException`.
+within named container configure methods that throw `MissingMethodException`s.
 Consider the following snippets for examples of this behavior:
 
 Gradle permits access to the top-level `repositories` block from within the `configurations` block

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -171,14 +171,15 @@ These deprecated elements will be removed in a future version of Gradle.
 [[referencing_script_configure_method_from_container_configure_closure_deprecated]]
 ==== Implicitly referencing outer scope methods in some configuration blocks in Groovy DSL is now deprecated
 
-Prior to Gradle 7.6, Groovy scripts would permit accessing root project-level configure methods from
-within named container configure methods, as long as that container configure method would otherwise
-fail with a `MissingMethodException`. Consider the following snippets for examples of this behavior:
+Prior to Gradle 7.6, Groovy scripts permitted access to root project configure methods
+within named container configure methods that handle failures with a `MissingMethodException`.
+Consider the following snippets for examples of this behavior:
 
-Accessing the top-level `repositories` block from within the `configurations` block is permitted
-as long as the provided closure is otherwise an invalid configure closure for a Configuration.
-In this case, the `repositories` closure is executed as if it were called at the script-level, _and_
-an unconfigured `repositories` Configuration is created.
+Gradle permits access to the top-level `repositories` block from within the `configurations` block
+when the provided closure is otherwise an invalid configure closure for a Configuration.
+In this case, the `repositories` closure executes as if it were called at the script-level, and
+creates an unconfigured `repositories` Configuration:
+
 ```groovy
 configurations {
     repositories {
@@ -191,11 +192,12 @@ configurations {
 }
 ```
 
-The behavior also applies in closures which are not immediately executed. In this case, `afterResolve`
-is only executed when the `resolve` task runs. Regardless, the `distributions` closure is an otherwise
-invalid configure closure for a Configuration, though it is a valid top-level script closure. In this
-case, the `conf` Configuration is created immediately, and during the execution of the `resolve` task,
-the `distributions` block is executed as if it were declared at the script-level.
+The behavior also applies to closures which do not immediately execute.
+In this case, `afterResolve` only executes when the `resolve` task runs.
+The `distributions` closure is a valid top-level script closure.
+But it is an invalid configure closure for a Configuration.
+This example creates the `conf` Configuration immediately.
+During `resolve` task execution, the `distributions` block executed as if it were declared at the script-level:
 
 ```groovy
 configurations {
@@ -216,8 +218,10 @@ task resolve {
 }
 ```
 
-As of Gradle 7.6, this behavior is deprecated. Starting with Gradle 8.0, this behavior will be removed and instead
-the underlying `MissingMethodException` will be thrown. To mitigate this change, consider the following solutions:
+As of Gradle 7.6, this behavior is deprecated.
+Starting with Gradle 8.0, this behavior will be removed.
+Instead, Gradle will throw the underlying `MissingMethodException`.
+To mitigate this change, consider the following solutions:
 
 ```groovy
 configurations {


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Improvements to documentation created in https://github.com/gradle/gradle/pull/22289

### Context
Didn't get a chance to review this the first time while I was out.
Rendered docs preview: https://builds.gradle.org/repository/download/Gradle_Release_Check_BuildDistributions/57127328:id/distributions/gradle-7.6-docs.zip!/gradle-7.6-20221013205043%2B0000/docs/userguide/upgrading_version_7.html#referencing_script_configure_method_from_container_configure_closure_deprecated

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [X] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [X] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [X] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [X] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [X] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
