### PR TITLE
Remove trailing slash requirement for build cache URL

### DIFF
--- a/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheFixture.groovy
+++ b/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheFixture.groovy
@@ -37,7 +37,7 @@ class HttpBuildCacheFixture extends AbstractIntegrationSpec {
                     enabled = false
                 }
                 remote(HttpBuildCache) {
-                    url = "${uri}/"
+                    url = "${uri}"
                     push = true
                 }
             }

--- a/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceIntegrationTest.groovy
+++ b/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceIntegrationTest.groovy
@@ -159,6 +159,25 @@ class HttpBuildCacheServiceIntegrationTest extends HttpBuildCacheFixture {
         skipped ":customTask"
     }
 
+    def "url can be specified with trailing slash"() {
+        httpBuildCacheServer.start()
+        def buildCacheUrl = URI.create("${httpBuildCacheServer.uri}/")
+        settingsFile.text = useHttpBuildCache(buildCacheUrl)
+
+        when:
+        withBuildCache().run "jar"
+        then:
+        noneSkipped()
+
+        expect:
+        withBuildCache().run "clean"
+
+        when:
+        withBuildCache().run "jar"
+        then:
+        skipped ":compileJava"
+    }
+
     def "credentials can be specified via DSL"() {
         httpBuildCacheServer.withBasicAuth("user", "pass")
         settingsFile << """


### PR DESCRIPTION
### Context
There does not seem to be a reason to require a trailing `/` when creating an instance of `HttpBuildCacheService`. This sometimes causes us to [create workarounds](https://github.com/gradle/gradle-enterprise-build-validation-scripts/issues/155). 

To me, removing the trailing `/` is the most logical permanent fix for this. 

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
