### PR TITLE
Enable stricter validation of plugins by default

### DIFF
--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidatePlugins.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidatePlugins.java
@@ -59,7 +59,7 @@ import java.util.List;
 public abstract class ValidatePlugins extends DefaultTask {
 
     public ValidatePlugins() {
-        getEnableStricterValidation().convention(false);
+        getEnableStricterValidation().convention(true);
         getIgnoreFailures().convention(false);
         getFailOnWarning().convention(true);
     }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context
Suggested for Gradle 8.0.

This will improve the quality of plugins in the broader ecosystem by helping surface more issues with plugins. While this is set to `false` by default, plugin authors must know that this option exists and the value needs to be changed to get the full benefit of validations.

I'll make any required changes to tests & docs if this gets approval from someone in the Gradle team. Thanks!

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
