### PR TITLE
Disable PTS for architecture tests

### DIFF
--- a/build-logic/buildquality/build.gradle.kts
+++ b/build-logic/buildquality/build.gradle.kts
@@ -25,6 +25,9 @@ dependencies {
     implementation(kotlin("compiler-embeddable") as String) {
         because("Required by IncubatingApiReportTask")
     }
+    implementation("com.gradle:gradle-enterprise-gradle-plugin") {
+        because("Arch-test plugin configures the PTS extension")
+    }
 
     testImplementation("org.junit.jupiter:junit-jupiter-engine")
 }

--- a/build-logic/buildquality/src/main/kotlin/gradlebuild.arch-test.gradle.kts
+++ b/build-logic/buildquality/src/main/kotlin/gradlebuild.arch-test.gradle.kts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import com.gradle.enterprise.gradleplugin.testselection.PredictiveTestSelectionExtension
 import gradlebuild.archtest.PackageCyclesExtension
 
 plugins {
@@ -60,6 +61,10 @@ testing {
                         testClassesDirs += sharedArchTestClasses.filter { it.isDirectory }
                         classpath += sourceSets.main.get().output.classesDirs
                         systemProperty("package.cycle.exclude.patterns", packageCyclesExtension.excludePatterns.get().joinToString(","))
+                        configure<PredictiveTestSelectionExtension> {
+                            // PTS doesn't work well with architecture tests which scan all classes
+                            enabled.set(false)
+                        }
                     }
                 }
             }

--- a/subprojects/architecture-test/build.gradle.kts
+++ b/subprojects/architecture-test/build.gradle.kts
@@ -1,6 +1,6 @@
-import gradlebuild.basics.flakyTestStrategy
 import gradlebuild.basics.FlakyTestStrategy
 import gradlebuild.basics.PublicApi
+import gradlebuild.basics.flakyTestStrategy
 
 plugins {
     id("gradlebuild.internal.java")
@@ -57,6 +57,11 @@ tasks.test {
 
     dependsOn(verifyAcceptedApiChangesOrdering)
     enabled = flakyTestStrategy !=  FlakyTestStrategy.ONLY
+
+    predictiveSelection {
+        // PTS doesn't work well with architecture tests which scan all classes
+        enabled.set(false)
+    }
 }
 
 class ArchUnitFreezeConfiguration(


### PR DESCRIPTION
Architecture tests do now combine well with PTS since they check all classes. So disabling PTS and using the build cache instead makes sense.