### PR TITLE
Mark GradleRunnerFileSystemWatchingIntegrationTest as @LocalOnly

### DIFF
--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerFileSystemWatchingIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerFileSystemWatchingIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.testkit.runner
 
+import com.gradle.enterprise.testing.annotations.LocalOnly
 import org.gradle.initialization.StartParameterBuildOptions
 import org.gradle.testkit.runner.fixtures.Debug
 import org.gradle.testkit.runner.fixtures.NoDebug
@@ -25,6 +26,7 @@ import org.gradle.util.TestPrecondition
 import static org.junit.Assume.assumeTrue
 
 @SuppressWarnings('IntegrationTestFixtures')
+@LocalOnly
 class GradleRunnerFileSystemWatchingIntegrationTest extends BaseGradleRunnerIntegrationTest {
 
     def setup() {


### PR DESCRIPTION
Because it fails on remote executors.

Somehow it seems to be failing on remote executors: https://ge.gradle.org/s/mfkdtfyptjpyo/tests/:test-kit:embeddedIntegTest/org.gradle.testkit.runner.GradleRunnerFileSystemWatchingIntegrationTest/file%20system%20watching%20is%20enabled%20on%20non-Windows%20OSes%20version%20=%20current%20embedded,%20debug%20=%20false?top-execution=1