### PR TITLE
Exempt Groovy 4 Gradleception from reporting cache misses

### DIFF
--- a/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.cache-miss-monitor.gradle.kts
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.cache-miss-monitor.gradle.kts
@@ -98,7 +98,7 @@ fun Project.isExpectedCompileCacheMiss() =
         "Component_GradlePlugin_Performance_PerformanceLatestMaster",
         "Component_GradlePlugin_Performance_PerformanceLatestReleased",
         "Check_Gradleception",
-        "Gradle_Master_Check_GradleceptionWithGroovy4"
+        "Check_GradleceptionWithGroovy4"
     ) || isBuildCommitDistribution
 
 val Project.isBuildCommitDistribution: Boolean

--- a/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.cache-miss-monitor.gradle.kts
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.cache-miss-monitor.gradle.kts
@@ -97,7 +97,8 @@ fun Project.isExpectedCompileCacheMiss() =
         "Check_CompileAllBuild",
         "Component_GradlePlugin_Performance_PerformanceLatestMaster",
         "Component_GradlePlugin_Performance_PerformanceLatestReleased",
-        "Check_Gradleception"
+        "Check_Gradleception",
+        "Gradle_Master_Check_GradleceptionWithGroovy4"
     ) || isBuildCommitDistribution
 
 val Project.isBuildCommitDistribution: Boolean

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -344,8 +344,9 @@ fun Project.isPerformanceProject() = setOf("build-scan-performance", "performanc
  *
  * Our performance tests don't work with PTS, yet.
  * Smoke and soak tests are hard to grasp for PTS, that is why we run them without.
+ * When running on Windows with PTS, SimplifiedKotlinScriptEvaluatorTest fails. See https://github.com/gradle/gradle-private/issues/3615.
  */
-fun Project.supportsPredictiveTestSelection() = !isPerformanceProject() && !setOf("smoke-test", "soak").contains(name)
+fun Project.supportsPredictiveTestSelection() = !isPerformanceProject() && !setOf("smoke-test", "soak", "kotlin-dsl").contains(name)
 
 /**
  * Test lifecycle tasks that correspond to CIBuildModel.TestType (see .teamcity/Gradle_Check/model/CIBuildModel.kt).


### PR DESCRIPTION
Should except the [Gradleception - Groovy 4.x Java8 Linux](https://builds.gradle.org/admin/editBuild.html?id=buildType:Gradle_Master_Check_GradleceptionWithGroovy4) build configuration from causing cache misses.