### PR TITLE
Finalize all the things

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/StaticValue.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/StaticValue.java
@@ -18,10 +18,9 @@ package org.gradle.api.internal.tasks;
 
 import org.gradle.api.Buildable;
 import org.gradle.api.Task;
-import org.gradle.api.internal.provider.HasConfigurableValueInternal;
+import org.gradle.api.internal.provider.HasFinalizableValue;
 import org.gradle.api.internal.provider.PropertyInternal;
 import org.gradle.api.internal.tasks.properties.PropertyValue;
-import org.gradle.api.provider.HasConfigurableValue;
 import org.gradle.internal.state.ModelObject;
 
 import javax.annotation.Nullable;
@@ -59,8 +58,8 @@ public class StaticValue implements PropertyValue {
 
     @Override
     public void maybeFinalizeValue() {
-        if (value instanceof HasConfigurableValue) {
-            ((HasConfigurableValueInternal) value).implicitFinalizeValue();
+        if (value instanceof HasFinalizableValue) {
+            ((HasFinalizableValue) value).implicitFinalizeValue();
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/bean/AbstractNestedRuntimeBeanNode.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/bean/AbstractNestedRuntimeBeanNode.java
@@ -20,13 +20,12 @@ import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import org.gradle.api.Buildable;
 import org.gradle.api.GradleException;
-import org.gradle.api.internal.provider.HasConfigurableValueInternal;
+import org.gradle.api.internal.provider.HasFinalizableValue;
 import org.gradle.api.internal.tasks.TaskDependencyContainer;
 import org.gradle.api.internal.tasks.properties.PropertyValue;
 import org.gradle.api.internal.tasks.properties.PropertyVisitor;
 import org.gradle.api.internal.tasks.properties.TypeMetadata;
 import org.gradle.api.internal.tasks.properties.annotations.PropertyAnnotationHandler;
-import org.gradle.api.provider.HasConfigurableValue;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.deprecation.DeprecationLogger;
@@ -105,18 +104,14 @@ public abstract class AbstractNestedRuntimeBeanNode extends RuntimeBeanNode<Obje
 
         @Override
         public void maybeFinalizeValue() {
-            if (isConfigurable()) {
-                Object value = cachedInvoker.get();
-                ((HasConfigurableValueInternal) value).implicitFinalizeValue();
+            Object value = cachedInvoker.get();
+            if (value instanceof HasFinalizableValue) {
+                ((HasFinalizableValue) value).implicitFinalizeValue();
             }
         }
 
         private boolean isProvider() {
             return Provider.class.isAssignableFrom(method.getReturnType());
-        }
-
-        private boolean isConfigurable() {
-            return HasConfigurableValue.class.isAssignableFrom(method.getReturnType());
         }
 
         private boolean isBuildable() {

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionInternal.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionInternal.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.file;
 
 
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.provider.HasFinalizableValue;
 import org.gradle.api.internal.tasks.TaskDependencyContainer;
 import org.gradle.api.specs.Spec;
 import org.gradle.internal.logging.text.TreeFormatter;
@@ -25,12 +26,17 @@ import org.gradle.internal.logging.text.TreeFormatter;
 import java.io.File;
 import java.util.function.Supplier;
 
-public interface FileCollectionInternal extends FileCollection, TaskDependencyContainer {
+public interface FileCollectionInternal extends FileCollection, TaskDependencyContainer, HasFinalizableValue {
     @Override
     FileCollectionInternal filter(Spec<? super File> filterSpec);
 
     @Override
     FileTreeInternal getAsFileTree();
+
+    @Override
+    default void implicitFinalizeValue() {
+        System.out.printf(">> Implicitly finalizing file collection %s: %s%n", this.getClass().getSimpleName(), this);
+    }
 
     /**
      * Returns a copy of this collection, with the given collection replaced with the value returned by the given supplier.

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/HasFinalizableValue.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/HasFinalizableValue.java
@@ -18,10 +18,12 @@ package org.gradle.api.internal.provider;
 
 import org.gradle.api.provider.HasConfigurableValue;
 
-public interface HasConfigurableValueInternal extends HasConfigurableValue, HasFinalizableValue {
+public interface HasFinalizableValue {
     /**
-     * Same semantics as {@link org.gradle.api.provider.HasConfigurableValue#finalizeValue()}, but finalizes the value of this object lazily, when the value is queried.
+     * Same semantics as {@link HasConfigurableValue#finalizeValue()}.
      * Implementations may then fail on subsequent changes, or generate a deprecation warning and ignore changes.
      */
+    // TODO Make this explicit finalization
+    // TODO Return the finalized value?
     void implicitFinalizeValue();
 }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/PropertyInternal.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/PropertyInternal.java
@@ -29,4 +29,7 @@ public interface PropertyInternal<T> extends ProviderInternal<T>, HasConfigurabl
      * Associates this property with the task that produces its value.
      */
     void attachProducer(ModelObject owner);
+
+    @Override
+    void implicitFinalizeValue();
 }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ProviderInternal.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ProviderInternal.java
@@ -109,7 +109,7 @@ import java.util.function.BiFunction;
  * <p>There are further optimizations that could be implemented with configuration caching. For example, when a work node has only fixed inputs, the node could be executed prior to writing the work graph to
  * the configuration cache, so that its outputs in turn become fixed. The node can then be discarded from the graph and replaced with its (now fixed) outputs.</p>
  */
-public interface ProviderInternal<T> extends Provider<T>, ValueSupplier, TaskDependencyContainer {
+public interface ProviderInternal<T> extends Provider<T>, ValueSupplier, TaskDependencyContainer, HasFinalizableValue {
     /**
      * Return the upper bound on the type of all values that this provider may produce, if known.
      *
@@ -117,6 +117,13 @@ public interface ProviderInternal<T> extends Provider<T>, ValueSupplier, TaskDep
      */
     @Nullable
     Class<T> getType();
+
+
+    @Override
+    default void implicitFinalizeValue() {
+        System.out.printf(">> Implicitly finalizing provider %s: %s%n", this.getClass().getSimpleName(), this);
+    }
+
 
     @Override
     <S> ProviderInternal<S> map(Transformer<? extends S, ? super T> transformer);


### PR DESCRIPTION
Goals:

1) Finalize all `Provider` and `FileCollection` instances, including `Configuration`. All `ProviderInternal` and `FileCollectionInternal` instances should implement the new `HasFinalizableValue` interface.
2) Instead of implicitly finalizing values, and then actually triggering the finalization via snapshotting inputs and outputs, finalize input and output properties explicitly right before snapshotting them. Only finalize properties that will be snapshot immediately.
3) Finalize inputs outside of the snapshotting build operation to avoid attributing long calculations to snapshotting.

For `Provider` and `FileCollection` instances that transform other `Provider` or `FileCollection` instances (like `MappingProvider` or `CompositeFileCollection`) it is enough to transitively finalize the delegate instance(s).

If the transforming instance can be configured, it should also implement `HasConfigurableValue` and prevent further configuration changes once finalization has been called.