### PR TITLE
Avoid setting release flag for Java compiler when toolchains are used

### DIFF
--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -292,23 +292,23 @@ public class JavaCompile extends AbstractCompile implements HasCompileOptions {
                 spec.setRelease(compileOptions.getRelease().get());
             } else {
                 boolean isSourceOrTargetConfigured = false;
+                // Using call to super to avoid convention mapping and determine whether a value was actually set by the user
                 if (super.getSourceCompatibility() != null) {
+                    // Using a non-super getter to get an actual value
                     spec.setSourceCompatibility(getSourceCompatibility());
                     isSourceOrTargetConfigured = true;
                 }
+                // Using call to super to avoid convention mapping and determine whether a value was actually set by the user
                 if (super.getTargetCompatibility() != null) {
+                    // Using a non-super getter to get an actual value
                     spec.setTargetCompatibility(getTargetCompatibility());
                     isSourceOrTargetConfigured = true;
                 }
                 if (!isSourceOrTargetConfigured) {
                     JavaLanguageVersion languageVersion = toolchain.getLanguageVersion();
-                    if (languageVersion.canCompileOrRun(10)) {
-                        spec.setRelease(languageVersion.asInt());
-                    } else {
-                        String version = languageVersion.toString();
-                        spec.setSourceCompatibility(version);
-                        spec.setTargetCompatibility(version);
-                    }
+                    String version = languageVersion.toString();
+                    spec.setSourceCompatibility(version);
+                    spec.setTargetCompatibility(version);
                 }
             }
         } else if (compileOptions.getRelease().isPresent()) {

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/tasks/compile/JavaCompileTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/tasks/compile/JavaCompileTest.groovy
@@ -27,7 +27,6 @@ import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 import spock.lang.Issue
 
-@SuppressWarnings('GrDeprecatedAPIUsage')
 class JavaCompileTest extends AbstractProjectBuilderSpec {
 
     def "disallow using custom java_home with compiler present"() {
@@ -126,7 +125,7 @@ class JavaCompileTest extends AbstractProjectBuilderSpec {
 
     def "spec is configured using the toolchain compiler in-process using the current jvm as toolchain and sets release"() {
         def javaCompile = project.tasks.create("compileJava", JavaCompile)
-        javaCompile.destinationDirectory = new File("tmp")
+        javaCompile.destinationDirectory.set(new File("tmp"))
         def javaHome = Jvm.current().javaHome
         def metadata = Mock(JavaInstallationMetadata)
         def compiler = Mock(JavaCompiler)
@@ -140,9 +139,9 @@ class JavaCompileTest extends AbstractProjectBuilderSpec {
         def spec = javaCompile.createSpec()
 
         then:
-        spec.getSourceCompatibility() == null
-        spec.getTargetCompatibility() == null
-        spec.release == 12
+        spec.getSourceCompatibility() == "12"
+        spec.getTargetCompatibility() == "12"
+        spec.release == null
         spec.compileOptions.forkOptions.javaHome == null
         (spec as ForkingJavaCompileSpec).javaHome == javaHome
     }
@@ -150,7 +149,7 @@ class JavaCompileTest extends AbstractProjectBuilderSpec {
     @Issue('https://bugs.openjdk.java.net/browse/JDK-8139607')
     def "spec is configured using the toolchain compiler in-process using the current jvm as toolchain and does not set release for Java 9"() {
         def javaCompile = project.tasks.create("compileJava", JavaCompile)
-        javaCompile.destinationDirectory = new File("tmp")
+        javaCompile.destinationDirectory.set(new File("tmp"))
         def javaHome = Jvm.current().javaHome
         def metadata = Mock(JavaInstallationMetadata)
         def compiler = Mock(JavaCompiler)
@@ -173,7 +172,7 @@ class JavaCompileTest extends AbstractProjectBuilderSpec {
 
     def "spec is configured using the toolchain compiler in-process using the current jvm as toolchain and set source and target compatibility"() {
         def javaCompile = project.tasks.create("compileJava", JavaCompile)
-        javaCompile.destinationDirectory = new File("tmp")
+        javaCompile.destinationDirectory.set(new File("tmp"))
         def javaHome = Jvm.current().javaHome
         def metadata = Mock(JavaInstallationMetadata)
         def compiler = Mock(JavaCompiler)
@@ -204,7 +203,7 @@ class JavaCompileTest extends AbstractProjectBuilderSpec {
 
     def "command line compiler spec is selected when forking and executable is set"() {
         def javaCompile = project.tasks.create("compileJava", JavaCompile)
-        javaCompile.destinationDirectory = new File("tmp")
+        javaCompile.destinationDirectory.set(new File("tmp"))
         def executable = Jvm.current().javacExecutable.absolutePath
 
         when:
@@ -219,7 +218,7 @@ class JavaCompileTest extends AbstractProjectBuilderSpec {
 
     def "command line compiler spec is selected when forking and java home is set"() {
         def javaCompile = project.tasks.create("compileJava", JavaCompile)
-        javaCompile.destinationDirectory = new File("tmp")
+        javaCompile.destinationDirectory.set(new File("tmp"))
         def jvm = Jvm.current()
         def javaHome = jvm.javaHome
 
@@ -235,7 +234,7 @@ class JavaCompileTest extends AbstractProjectBuilderSpec {
 
     def "java home takes precedence over executable when forking"() {
         def javaCompile = project.tasks.create("compileJava", JavaCompile)
-        javaCompile.destinationDirectory = new File("tmp")
+        javaCompile.destinationDirectory.set(new File("tmp"))
         def jvm = Jvm.current()
         def javaHome = jvm.javaHome
 

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaBasePluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaBasePluginIntegrationTest.groovy
@@ -19,10 +19,11 @@ package org.gradle.api.plugins
 import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AvailableJavaHomes
-import spock.lang.IgnoreIf
+import org.gradle.util.internal.TextUtil
 
 
 class JavaBasePluginIntegrationTest extends AbstractIntegrationSpec {
+
     def "can define and build a source set with implementation dependencies"() {
         settingsFile << """
             include 'main', 'tests'
@@ -51,7 +52,6 @@ class JavaBasePluginIntegrationTest extends AbstractIntegrationSpec {
         file("tests/build/classes/java/unitTest").assertHasDescendants("Test.class")
     }
 
-    @IgnoreIf({ AvailableJavaHomes.getJdk(JavaVersion.VERSION_1_8) == null })
     def "can configure source and target Java versions"() {
         def jdk = AvailableJavaHomes.getJdk(JavaVersion.VERSION_1_8)
         buildFile << """
@@ -60,12 +60,12 @@ class JavaBasePluginIntegrationTest extends AbstractIntegrationSpec {
                 sourceCompatibility = JavaVersion.VERSION_1_7
                 targetCompatibility = JavaVersion.VERSION_1_8
             }
-            sourceSets { 
-                unitTest { } 
+            sourceSets {
+                unitTest { }
             }
             compileUnitTestJava {
                 options.fork = true
-                options.forkOptions.javaHome = file('${jdk.javaHome.toURI()}')
+                options.forkOptions.javaHome = file("${TextUtil.normaliseFileSeparators(jdk.javaHome.toString())}")
             }
             compileUnitTestJava.doFirst {
                 assert sourceCompatibility == "1.7"

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/BasicJavaCompilerIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/BasicJavaCompilerIntegrationSpec.groovy
@@ -26,12 +26,15 @@ import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 
 abstract class BasicJavaCompilerIntegrationSpec extends AbstractIntegrationSpec {
+
+    abstract String compilerConfiguration()
+
+    abstract String logStatement()
+
     def setup() {
         executer.withArguments("-i")
         buildFile << buildScript()
-        buildFile << """
-    ${compilerConfiguration()}
-"""
+        buildFile << compilerConfiguration()
     }
 
     def compileGoodCode() {
@@ -410,10 +413,6 @@ dependencies {
 }
 """
     }
-
-    abstract compilerConfiguration()
-
-    abstract logStatement()
 
     def goodCode() {
         file("src/main/java/compile/test/Person.java") << '''

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/CommandLineJavaCompilerForExecutableIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/CommandLineJavaCompilerForExecutableIntegrationTest.groovy
@@ -19,24 +19,22 @@ package org.gradle.java.compile
 
 import org.gradle.internal.jvm.Jvm
 
-import spock.lang.IgnoreIf
 import org.gradle.util.internal.TextUtil
 
-@IgnoreIf({ !Jvm.current().getExecutable("javac").exists() })
 class CommandLineJavaCompilerForExecutableIntegrationTest extends JavaCompilerIntegrationSpec {
 
-    def compilerConfiguration() {
-        def executable = TextUtil.escapeString(Jvm.current().getExecutable("javac"))
-
+    @Override
+    String compilerConfiguration() {
         """
-compileJava.options.with {
-    fork = true
-    forkOptions.executable = "$executable"
-}
-"""
+            compileJava.options.with {
+                fork = true
+                forkOptions.executable = "${TextUtil.normaliseFileSeparators(Jvm.current().getExecutable("javac").absolutePath)}"
+            }
+        """
     }
 
-    def logStatement() {
+    @Override
+    String logStatement() {
         "Compiling with Java command line compiler"
     }
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/CommandLineJavaCompilerIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/CommandLineJavaCompilerIntegrationTest.groovy
@@ -19,22 +19,21 @@ package org.gradle.java.compile
 
 import org.gradle.internal.jvm.Jvm
 import org.gradle.util.internal.TextUtil
-import spock.lang.IgnoreIf
 
-@IgnoreIf({ !Jvm.current().getExecutable("javac").exists() })
 class CommandLineJavaCompilerIntegrationTest extends JavaCompilerIntegrationSpec {
-    def compilerConfiguration() {
-        def javaHome = TextUtil.escapeString(Jvm.current().getJavaHome().getAbsolutePath())
 
+    @Override
+    String compilerConfiguration() {
         """
-compileJava.options.with {
-    fork = true
-    forkOptions.javaHome = file("$javaHome")
-}
-"""
+            compileJava.options.with {
+                fork = true
+                forkOptions.javaHome = file("${TextUtil.normaliseFileSeparators(Jvm.current().javaHome.toString())}")
+            }
+        """
     }
 
-    def logStatement() {
+    @Override
+    String logStatement() {
         "Compiling with Java command line compiler"
     }
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/InProcessJavaCompilerIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/InProcessJavaCompilerIntegrationTest.groovy
@@ -16,15 +16,18 @@
 package org.gradle.java.compile
 
 class InProcessJavaCompilerIntegrationTest extends JavaCompilerIntegrationSpec {
-    def compilerConfiguration() {
-        '''
-compileJava.options.with {
-    fork = false
-}
-'''
+
+    @Override
+    String compilerConfiguration() {
+        """
+            compileJava.options.with {
+                fork = false
+            }
+        """
     }
 
-    def logStatement() {
+    @Override
+    String logStatement() {
         "Java compiler API"
     }
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/JavaCompilerIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/JavaCompilerIntegrationSpec.groovy
@@ -18,12 +18,13 @@ package org.gradle.java.compile
 import spock.lang.Issue
 
 abstract class JavaCompilerIntegrationSpec extends BasicJavaCompilerIntegrationSpec {
+
     def setup() {
         buildFile << """
-        tasks.withType(JavaCompile) {
-            options.compilerArgs << '-Xlint:all' << '-Werror'
-        }
-"""
+            tasks.withType(JavaCompile) {
+                options.compilerArgs << '-Xlint:all' << '-Werror'
+            }
+        """
     }
 
     def compileWithLongClasspath() {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/daemon/DaemonJavaCompilerIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/daemon/DaemonJavaCompilerIntegrationTest.groovy
@@ -24,6 +24,24 @@ import spock.lang.Issue
 
 class DaemonJavaCompilerIntegrationTest extends JavaCompilerIntegrationSpec {
 
+    @Override
+    String compilerConfiguration() {
+        """
+            tasks.withType(JavaCompile) {
+                options.fork = true
+            }
+        """
+    }
+
+    @Override
+    String logStatement() {
+        "compiler daemon"
+    }
+
+    def setup() {
+        executer.withArguments("-d")
+    }
+
     def "respects fork options settings"() {
         goodCode()
         buildFile << """
@@ -78,15 +96,4 @@ class DaemonJavaCompilerIntegrationTest extends JavaCompilerIntegrationSpec {
         succeeds "compileJava"
     }
 
-    def setup() {
-        executer.withArguments("-d")
-    }
-
-    def compilerConfiguration() {
-        "tasks.withType(JavaCompile) { options.fork = true }"
-    }
-
-    def logStatement() {
-        "compiler daemon"
-    }
 }


### PR DESCRIPTION
Currently, when toolchain is configured for the `JavaCompile` task, the logic that configures the actual underlying Java compiler may decide to pass `release` flag instead of setting `sourceCompatibility` and `targetCompatibility`. More precisely, the `release` flag is set for Java 10+ toolchains.

This can lead to various problems due to `release` flag of the Java compiler being incompatible with other compiler options such as `--add-exports` or required to be used in combination with other flags such as `--enable-preview`.

This PR changes this behavior to always setting only `sourceCompatibility` and `targetCompatibility` when those are derived from a toolchain.

Fixes https://github.com/gradle/gradle/issues/18824