### PR TITLE
Use `promoteFinalRelease` task in backport release

### DIFF
--- a/.teamcity/src/main/kotlin/common/VersionedSettingsBranch.kt
+++ b/.teamcity/src/main/kotlin/common/VersionedSettingsBranch.kt
@@ -44,6 +44,12 @@ data class VersionedSettingsBranch(val branchName: String, val enableTriggers: B
         else -> "promoteMilestone"
     }
 
+    fun promoteFinalReleaseTaskName(): String = when {
+        isMaster -> throw UnsupportedOperationException()
+        isRelease -> "promoteFinalRelease"
+        else -> "promoteFinalBackportRelease"
+    }
+
     private fun nightlyTaskName(prefix: String): String = when {
         isMaster -> "${prefix}Nightly"
         isRelease -> "${prefix}ReleaseNightly"

--- a/.teamcity/src/main/kotlin/promotion/PublishRelease.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishRelease.kt
@@ -73,7 +73,7 @@ abstract class PublishRelease(
 class PublishFinalRelease(branch: VersionedSettingsBranch) : PublishRelease(
     promotedBranch = branch.branchName,
     prepTask = "prepFinalRelease",
-    promoteTask = "promoteFinalRelease",
+    promoteTask = branch.promoteFinalReleaseTaskName(),
     requiredConfirmationCode = "final",
     init = {
         id("Promotion_FinalRelease")


### PR DESCRIPTION
For backport release (e.g. `release6x`), we should use `promoteBackportRelease` task instead of `promoteFinalRelease`.

This PR is targeting `master` because we want to sync the promotion code across all branches. It will be cherry-picked to `release` and `release6x`.