### PR TITLE
Use `promoteFinalRelease` task in backport release

### DIFF
--- a/.teamcity/src/main/kotlin/common/VersionedSettingsBranch.kt
+++ b/.teamcity/src/main/kotlin/common/VersionedSettingsBranch.kt
@@ -39,6 +39,12 @@ data class VersionedSettingsBranch(val branchName: String, val enableTriggers: B
     fun promoteNightlyTaskName() = nightlyTaskName("promote")
     fun prepNightlyTaskName() = nightlyTaskName("prep")
 
+    fun promoteFinalReleaseTaskName(): String = when {
+        isMaster -> throw UnsupportedOperationException("No final release job on master branch")
+        isRelease -> "promoteFinalRelease"
+        else -> "promoteFinalBackportRelease"
+    }
+
     private fun nightlyTaskName(prefix: String): String = when {
         isMaster -> "${prefix}Nightly"
         isRelease -> "${prefix}ReleaseNightly"

--- a/.teamcity/src/main/kotlin/promotion/PublishRelease.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishRelease.kt
@@ -73,7 +73,7 @@ abstract class PublishRelease(
 class PublishFinalRelease(branch: VersionedSettingsBranch) : PublishRelease(
     promotedBranch = branch.branchName,
     prepTask = "prepFinalRelease",
-    promoteTask = "promoteFinalRelease",
+    promoteTask = branch.promoteFinalReleaseTaskName(),
     requiredConfirmationCode = "final",
     init = {
         id("Promotion_FinalRelease")


### PR DESCRIPTION
For backport release (e.g. `release6x`), we should use `promoteBackportRelease` task instead of `promoteFinalRelease`.
