### PR TITLE
Track cross-project model access in `Project.getChildProjects` + Introduce `@ForExternalUse`

### DIFF
--- a/subprojects/architecture-test/src/test/java/org/gradle/architecture/test/ForExternalUseTest.java
+++ b/subprojects/architecture-test/src/test/java/org/gradle/architecture/test/ForExternalUseTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.architecture.test;
+
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+import org.gradle.internal.accesscontrol.AllowUsingApiForExternalUse;
+import org.gradle.internal.accesscontrol.ForExternalUse;
+
+import static com.tngtech.archunit.core.domain.properties.CanBeAnnotated.Predicates.annotatedWith;
+import static com.tngtech.archunit.lang.conditions.ArchConditions.beDeclaredInClassesThat;
+import static com.tngtech.archunit.lang.conditions.ArchConditions.beProtected;
+import static com.tngtech.archunit.lang.conditions.ArchConditions.bePublic;
+import static com.tngtech.archunit.lang.conditions.ArchPredicates.are;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.codeUnits;
+import static org.gradle.architecture.test.ArchUnitFixture.gradlePublicApi;
+
+@AnalyzeClasses(packages = "org.gradle")
+public class ForExternalUseTest {
+
+    @ArchTest
+    public static final ArchRule members_for_external_use_are_public_api =
+        codeUnits().that().areAnnotatedWith(ForExternalUse.class)
+            .should(beDeclaredInClassesThat(are(gradlePublicApi())))
+            .andShould(bePublic().or(beProtected()));
+
+    @ArchTest
+    public static final ArchRule members_for_external_use_are_not_used_internally =
+        codeUnits().that().areAnnotatedWith(ForExternalUse.class)
+            .should().onlyBeCalled().byCodeUnitsThat(
+                are(annotatedWith(ForExternalUse.class)
+                    .or(annotatedWith(AllowUsingApiForExternalUse.class)))
+            );
+}

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsAccessFromGroovyDslIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsAccessFromGroovyDslIntegrationTest.groovy
@@ -68,9 +68,10 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         }
 
         where:
-        block         | _
-        "allprojects" | _
-        "subprojects" | _
+        block                               | _
+        "allprojects"                       | _
+        "subprojects"                       | _
+        "configure(childProjects.values())" | _
     }
 
     def "reports problem when build script uses #property property to apply plugins to another project"() {
@@ -95,9 +96,10 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         }
 
         where:
-        property      | _
-        "allprojects" | _
-        "subprojects" | _
+        property                 | _
+        "allprojects"            | _
+        "subprojects"            | _
+        "childProjects.values()" | _
     }
 
     def "reports problem when build script uses project() block to apply plugins to another project"() {

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ProblemReportingCrossProjectModelAccess.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ProblemReportingCrossProjectModelAccess.kt
@@ -79,6 +79,7 @@ import org.gradle.configurationcache.problems.PropertyProblem
 import org.gradle.configurationcache.problems.StructuredMessage
 import org.gradle.configurationcache.problems.location
 import org.gradle.groovy.scripts.ScriptSource
+import org.gradle.internal.accesscontrol.AllowUsingApiForExternalUse
 import org.gradle.internal.logging.StandardOutputCapture
 import org.gradle.internal.metaobject.BeanDynamicObject
 import org.gradle.internal.metaobject.DynamicObject
@@ -276,6 +277,7 @@ class ProblemReportingCrossProjectModelAccess(
             delegate.status = status
         }
 
+        @AllowUsingApiForExternalUse
         override fun getChildProjects(): MutableMap<String, Project> {
             return delegate.childProjects
         }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ProblemReportingCrossProjectModelAccess.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ProblemReportingCrossProjectModelAccess.kt
@@ -280,6 +280,10 @@ class ProblemReportingCrossProjectModelAccess(
             return delegate.childProjects
         }
 
+        override fun getChildProjectsInternal(): MutableMap<String, Project> {
+            return delegate.childProjectsInternal
+        }
+
         override fun setProperty(name: String, value: Any?) {
             onAccess()
             delegate.setProperty(name, value)

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ProblemReportingCrossProjectModelAccess.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ProblemReportingCrossProjectModelAccess.kt
@@ -282,8 +282,8 @@ class ProblemReportingCrossProjectModelAccess(
             return delegate.childProjects
         }
 
-        override fun getChildProjectsInternal(): MutableMap<String, Project> {
-            return delegate.childProjectsInternal
+        override fun getChildProjectsUnchecked(): MutableMap<String, Project> {
+            return delegate.childProjectsUnchecked
         }
 
         override fun setProperty(name: String, value: Any?) {

--- a/subprojects/core-api/src/main/java/org/gradle/api/Project.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Project.java
@@ -1320,7 +1320,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      * <p>Adds an action to call immediately before this project is evaluated.</p>
      * <p>Passes the project to the action as a parameter. Actions passed to this
      * method execute in the same order they were passed.</p>
-     * 
+     *
      * <p>If the project has already been evaluated, the action never executes.</p>
      * <p>If you call this method within a <code>beforeEvaluate</code> action, the passed action never executes.</p>
      *
@@ -1334,7 +1334,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      * action as a parameter. Actions passed to this method execute in the same order they were passed.
      * A parent project may add an action to its child projects to further configure those projects based
      * on their state after their build files run.</p>
-     * 
+     *
      * <p>If the project has already been evaluated, this method fails.</p>
      * <p>If you call this method within an <code>afterEvaluate</code> action, the passed action executes after all
      * previously added <code>afterEvaluate</code> actions finish executing.</p>
@@ -1345,7 +1345,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
 
     /**
      * <p>Adds a closure to call immediately before this project is evaluated.</p>
-     * 
+     *
      * @see Project#beforeEvaluate(Action)
      *
      * @param closure The closure to call.
@@ -1354,7 +1354,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
 
     /**
      * <p>Adds a closure to call immediately after this project is evaluated.</p>
-     * 
+     *
      * @see Project#afterEvaluate(Action)
      *
      * @param closure The closure to call.

--- a/subprojects/core-api/src/main/java/org/gradle/api/Project.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Project.java
@@ -48,6 +48,7 @@ import org.gradle.api.resources.ResourceHandler;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.internal.HasInternalProtocol;
+import org.gradle.internal.accesscontrol.ForExternalUse;
 import org.gradle.normalization.InputNormalizationHandler;
 import org.gradle.process.ExecResult;
 import org.gradle.process.ExecSpec;
@@ -383,6 +384,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      * @return A map from child project name to child project. Returns an empty map if this project does not have
      *         any children.
      */
+    @ForExternalUse // See ProjectInternal#getChildProjects
     Map<String, Project> getChildProjects();
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/internal/accesscontrol/AllowUsingApiForExternalUse.java
+++ b/subprojects/core-api/src/main/java/org/gradle/internal/accesscontrol/AllowUsingApiForExternalUse.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.accesscontrol;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Suppresses the checks done for {@link ForExternalUse}, effectively allowing the code point
+ * marked by this annotation to use public API declarations that are meant for external use only in.
+ *
+ * @see ForExternalUse
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.CONSTRUCTOR})
+public @interface AllowUsingApiForExternalUse {
+}

--- a/subprojects/core-api/src/main/java/org/gradle/internal/accesscontrol/ForExternalUse.java
+++ b/subprojects/core-api/src/main/java/org/gradle/internal/accesscontrol/ForExternalUse.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.accesscontrol;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Designates a public API declaration that should not be used internally in the Gradle codebase.
+ * This is due to the contract of this public API that is stricter than what is expected in the Gradle internals.
+ * <p>
+ * For example, the implementation of such an API might add validations checking third-party
+ * plugins or build scripts for compliance with some limitations imposed by Gradle. In the internal
+ * code, one does not expect such limitations.
+ * <p>
+ * This annotations should only be applied to Gradle public API declarations.
+ *
+ * @see AllowUsingApiForExternalUse
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD})
+public @interface ForExternalUse {
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -497,7 +497,7 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
     }
 
     @Override
-    public Map<String, Project> getChildProjectsInternal() {
+    public Map<String, Project> getChildProjectsUnchecked() {
         Map<String, Project> childProjects = Maps.newTreeMap();
         for (ProjectState project : owner.getChildProjects()) {
             childProjects.put(project.getName(), project.getMutableModel());
@@ -507,7 +507,7 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
 
     @Override
     public Map<String, Project> getChildProjects() {
-        return getChildProjectsInternal().entrySet().stream().collect(
+        return getChildProjectsUnchecked().entrySet().stream().collect(
             Collectors.toMap(
                 Map.Entry::getKey,
                 entry -> getCrossProjectModelAccess().access(this, (ProjectInternal) entry.getValue())

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -144,6 +144,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.util.Collections.singletonMap;
@@ -496,12 +497,22 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
     }
 
     @Override
-    public Map<String, Project> getChildProjects() {
+    public Map<String, Project> getChildProjectsInternal() {
         Map<String, Project> childProjects = Maps.newTreeMap();
         for (ProjectState project : owner.getChildProjects()) {
             childProjects.put(project.getName(), project.getMutableModel());
         }
         return childProjects;
+    }
+
+    @Override
+    public Map<String, Project> getChildProjects() {
+        return getChildProjectsInternal().entrySet().stream().collect(
+            Collectors.toMap(
+                Map.Entry::getKey,
+                entry -> getCrossProjectModelAccess().access(this, (ProjectInternal) entry.getValue())
+            )
+        );
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectHierarchyUtils.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectHierarchyUtils.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.project;
+
+import org.gradle.api.Project;
+
+import java.util.Collection;
+
+public class ProjectHierarchyUtils {
+    /**
+     * Gets the collection of the direct child projects from {@code thisProject}.
+     * This method is safe to use in the Gradle internal code, as it does not impose the contracts
+     * specific to the project public API.
+     *
+     * @param thisProject the project to get the children from. Expected to be {@link ProjectInternal}.
+     * @return the collection of the child projects
+     *
+     * @see Project#getChildProjects()
+     */
+    public static Collection<Project> getChildProjectsForInternalUse(Project thisProject) {
+        return ((ProjectInternal) thisProject).getChildProjectsInternal().values();
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectHierarchyUtils.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectHierarchyUtils.java
@@ -30,8 +30,9 @@ public class ProjectHierarchyUtils {
      * @return the collection of the child projects
      *
      * @see Project#getChildProjects()
+     * @see ProjectInternal#getChildProjectsUnchecked()
      */
     public static Collection<Project> getChildProjectsForInternalUse(Project thisProject) {
-        return ((ProjectInternal) thisProject).getChildProjectsInternal().values();
+        return ((ProjectInternal) thisProject).getChildProjectsUnchecked().values();
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
@@ -104,17 +104,32 @@ public interface ProjectInternal extends Project, ProjectIdentifier, HasScriptSe
 
     /**
      * Do not use this method to access the child projects in the Gradle codebase!
-     * The implementations may add check that enforce correct usage of the public API, such as
+     * The implementations may add checks that enforce correct usage of the public API, such as
      * cross-project model access checks, which are meant to report warnings on incorrect API usages
      * from third-party code. The internal usages won't pass these checks and will break.
      *
-     * @see ProjectInternal#getChildProjectsInternal()
+     * @see ProjectInternal#getChildProjectsUnchecked()
      * @see ProjectHierarchyUtils#getChildProjectsForInternalUse(Project)
      */
     @Override
     Map<String, Project> getChildProjects();
 
-    Map<String, Project> getChildProjectsInternal();
+    /**
+     * Returns a mapping of the direct child project names to the child project instances.
+     *
+     * Compared to {@link Project#getChildProjects()}, this method does not add any checks
+     * to the returned projects:
+     *
+     * <ul>
+     *     <li> With project isolation enabled, it does not add checks for cross-project model
+     *     access to the returned project instances. The returned project models can be accessed
+     *     without any limitations.
+     * </ul>
+     *
+     * This method is suitable for internal usages in the Gradle codebase.
+     * @return A map where the keys are the project names and the values are the child projects
+     */
+    Map<String, Project> getChildProjectsUnchecked();
 
     Set<? extends ProjectInternal> getAllprojects(ProjectInternal referrer);
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
@@ -49,6 +49,7 @@ import org.gradle.normalization.internal.InputNormalizationHandlerInternal;
 import org.gradle.util.Path;
 
 import javax.annotation.Nullable;
+import java.util.Map;
 import java.util.Set;
 
 @UsedByScanPlugin("scan, test-retry")
@@ -100,6 +101,20 @@ public interface ProjectInternal extends Project, ProjectIdentifier, HasScriptSe
     Set<? extends ProjectInternal> getSubprojects(ProjectInternal referrer);
 
     void subprojects(ProjectInternal referrer, Action<? super Project> configureAction);
+
+    /**
+     * Do not use this method to access the child projects in the Gradle codebase!
+     * The implementations may add check that enforce correct usage of the public API, such as
+     * cross-project model access checks, which are meant to report warnings on incorrect API usages
+     * from third-party code. The internal usages won't pass these checks and will break.
+     *
+     * @see ProjectInternal#getChildProjectsInternal()
+     * @see ProjectHierarchyUtils#getChildProjectsForInternalUse(Project)
+     */
+    @Override
+    Map<String, Project> getChildProjects();
+
+    Map<String, Project> getChildProjectsInternal();
 
     Set<? extends ProjectInternal> getAllprojects(ProjectInternal referrer);
 

--- a/subprojects/core/src/main/java/org/gradle/execution/TaskNameResolver.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/TaskNameResolver.java
@@ -21,6 +21,7 @@ import org.gradle.api.Project;
 import org.gradle.api.ProjectConfigurationException;
 import org.gradle.api.Task;
 import org.gradle.api.internal.TaskInternal;
+import org.gradle.api.internal.project.ProjectHierarchyUtils;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.tasks.TaskContainer;
 
@@ -120,7 +121,7 @@ public class TaskNameResolver {
     private void collectTaskNames(ProjectInternal project, Set<String> result) {
         discoverTasks(project);
         result.addAll(getTaskNames(project));
-        for (Project subProject : project.getChildProjects().values()) {
+        for (Project subProject : ProjectHierarchyUtils.getChildProjectsForInternalUse(project)) {
             collectTaskNames((ProjectInternal) subProject, result);
         }
     }
@@ -180,7 +181,7 @@ public class TaskNameResolver {
                     return;
                 }
             }
-            for (Project subProject : project.getChildProjects().values()) {
+            for (Project subProject : ProjectHierarchyUtils.getChildProjectsForInternalUse(project)) {
                 collect((ProjectInternal) subProject, tasks);
             }
         }

--- a/subprojects/core/src/main/java/org/gradle/execution/TaskNameResolver.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/TaskNameResolver.java
@@ -21,7 +21,6 @@ import org.gradle.api.Project;
 import org.gradle.api.ProjectConfigurationException;
 import org.gradle.api.Task;
 import org.gradle.api.internal.TaskInternal;
-import org.gradle.api.internal.project.ProjectHierarchyUtils;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.tasks.TaskContainer;
 
@@ -29,6 +28,8 @@ import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
+
+import static org.gradle.api.internal.project.ProjectHierarchyUtils.getChildProjectsForInternalUse;
 
 public class TaskNameResolver {
 
@@ -121,7 +122,7 @@ public class TaskNameResolver {
     private void collectTaskNames(ProjectInternal project, Set<String> result) {
         discoverTasks(project);
         result.addAll(getTaskNames(project));
-        for (Project subProject : ProjectHierarchyUtils.getChildProjectsForInternalUse(project)) {
+        for (Project subProject : getChildProjectsForInternalUse(project)) {
             collectTaskNames((ProjectInternal) subProject, result);
         }
     }
@@ -181,7 +182,7 @@ public class TaskNameResolver {
                     return;
                 }
             }
-            for (Project subProject : ProjectHierarchyUtils.getChildProjectsForInternalUse(project)) {
+            for (Project subProject : getChildProjectsForInternalUse(project)) {
                 collect((ProjectInternal) subProject, tasks);
             }
         }

--- a/subprojects/core/src/main/java/org/gradle/initialization/NotifyingBuildLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/NotifyingBuildLoader.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableSortedSet;
 import org.gradle.api.Project;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
+import org.gradle.api.internal.project.ProjectHierarchyUtils;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationDescriptor;
@@ -102,7 +103,7 @@ public class NotifyingBuildLoader implements BuildLoader {
             ((ProjectInternal) project).getIdentityPath().toString(),
             project.getProjectDir().getAbsolutePath(),
             project.getBuildFile().getAbsolutePath(),
-            convert(project.getChildProjects().values()));
+            convert(ProjectHierarchyUtils.getChildProjectsForInternalUse(project)));
     }
 
     private Set<LoadProjectsBuildOperationType.Result.Project> convert(Iterable<Project> children) {

--- a/subprojects/core/src/main/java/org/gradle/initialization/NotifyingBuildLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/NotifyingBuildLoader.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableSortedSet;
 import org.gradle.api.Project;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
-import org.gradle.api.internal.project.ProjectHierarchyUtils;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationDescriptor;
@@ -30,6 +29,8 @@ import org.gradle.internal.operations.RunnableBuildOperation;
 
 import java.util.Comparator;
 import java.util.Set;
+
+import static org.gradle.api.internal.project.ProjectHierarchyUtils.getChildProjectsForInternalUse;
 
 public class NotifyingBuildLoader implements BuildLoader {
 
@@ -103,7 +104,7 @@ public class NotifyingBuildLoader implements BuildLoader {
             ((ProjectInternal) project).getIdentityPath().toString(),
             project.getProjectDir().getAbsolutePath(),
             project.getBuildFile().getAbsolutePath(),
-            convert(ProjectHierarchyUtils.getChildProjectsForInternalUse(project)));
+            convert(getChildProjectsForInternalUse(project)));
     }
 
     private Set<LoadProjectsBuildOperationType.Result.Project> convert(Iterable<Project> children) {

--- a/subprojects/core/src/main/java/org/gradle/initialization/ProjectPropertySettingBuildLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/ProjectPropertySettingBuildLoader.java
@@ -19,6 +19,7 @@ package org.gradle.initialization;
 import org.gradle.api.Project;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
+import org.gradle.api.internal.project.ProjectHierarchyUtils;
 import org.gradle.api.internal.properties.GradleProperties;
 import org.gradle.internal.Pair;
 import org.gradle.internal.reflect.JavaPropertyReflectionUtil;
@@ -59,7 +60,7 @@ public class ProjectPropertySettingBuildLoader implements BuildLoader {
 
     private void setProjectProperties(Project project, CachingPropertyApplicator applicator) {
         addPropertiesToProject(project, applicator);
-        for (Project childProject : project.getChildProjects().values()) {
+        for (Project childProject : ProjectHierarchyUtils.getChildProjectsForInternalUse(project)) {
             setProjectProperties(childProject, applicator);
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/initialization/ProjectPropertySettingBuildLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/ProjectPropertySettingBuildLoader.java
@@ -19,7 +19,6 @@ package org.gradle.initialization;
 import org.gradle.api.Project;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
-import org.gradle.api.internal.project.ProjectHierarchyUtils;
 import org.gradle.api.internal.properties.GradleProperties;
 import org.gradle.internal.Pair;
 import org.gradle.internal.reflect.JavaPropertyReflectionUtil;
@@ -36,6 +35,7 @@ import java.util.Properties;
 
 import static com.google.common.collect.Maps.newHashMap;
 import static java.util.Collections.emptyMap;
+import static org.gradle.api.internal.project.ProjectHierarchyUtils.getChildProjectsForInternalUse;
 import static org.gradle.internal.Cast.uncheckedCast;
 
 public class ProjectPropertySettingBuildLoader implements BuildLoader {
@@ -60,7 +60,7 @@ public class ProjectPropertySettingBuildLoader implements BuildLoader {
 
     private void setProjectProperties(Project project, CachingPropertyApplicator applicator) {
         addPropertiesToProject(project, applicator);
-        for (Project childProject : ProjectHierarchyUtils.getChildProjectsForInternalUse(project)) {
+        for (Project childProject : getChildProjectsForInternalUse(project)) {
             setProjectProperties(childProject, applicator);
         }
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
@@ -454,9 +454,9 @@ class DefaultProjectTest extends Specification {
 
     def getChildProject() {
         expect:
-        project.childProjects.size() == 2
-        project.childProjects.child1.is(child1)
-        project.childProjects.child2.is(child2)
+        project.childProjectsInternal.size() == 2
+        project.childProjectsInternal.child1.is(child1)
+        project.childProjectsInternal.child2.is(child2)
     }
 
     def defaultTasks() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
@@ -454,9 +454,9 @@ class DefaultProjectTest extends Specification {
 
     def getChildProject() {
         expect:
-        project.childProjectsInternal.size() == 2
-        project.childProjectsInternal.child1.is(child1)
-        project.childProjectsInternal.child2.is(child2)
+        project.childProjectsUnchecked.size() == 2
+        project.childProjectsUnchecked.child1.is(child1)
+        project.childProjectsUnchecked.child2.is(child2)
     }
 
     def defaultTasks() {

--- a/subprojects/core/src/test/groovy/org/gradle/execution/TaskNameResolverTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/TaskNameResolverTest.groovy
@@ -68,10 +68,10 @@ class TaskNameResolverTest extends Specification {
         def childTasks = Mock(TaskContainerInternal)
         def childProject = Mock(ProjectInternal) {
             _ * getTasks() >> childTasks
-            _ * getChildProjects() >> [:]
+            _ * getChildProjectsInternal() >> [:]
         }
 
-        _ * project.childProjects >> [child: childProject]
+        _ * project.childProjectsInternal >> [child: childProject]
 
         when:
         def results = resolver.selectWithName('task', project, true)
@@ -104,10 +104,10 @@ class TaskNameResolverTest extends Specification {
         def childTasks = Mock(TaskContainerInternal)
         def childProject = Mock(ProjectInternal) {
             _ * getTasks() >> childTasks
-            _ * getChildProjects() >> [:]
+            _ * getChildProjectsInternal() >> [:]
         }
 
-        _ * project.childProjects >> [child: childProject]
+        _ * project.childProjectsInternal >> [child: childProject]
 
         when:
         def results = resolver.selectWithName('task', project, true)
@@ -136,9 +136,9 @@ class TaskNameResolverTest extends Specification {
         def childTasks = Mock(TaskContainerInternal)
         def childProject = Mock(ProjectInternal) {
             _ * getTasks() >> childTasks
-            _ * getChildProjects() >> [:]
+            _ * getChildProjectsInternal() >> [:]
         }
-        _ * project.childProjects >> [child: childProject]
+        _ * project.childProjectsInternal >> [child: childProject]
 
         when:
         def results = resolver.selectWithName('task', project, true)
@@ -197,9 +197,9 @@ class TaskNameResolverTest extends Specification {
         def childTasks = Mock(TaskContainerInternal)
         def childProject = Mock(ProjectInternal) {
             _ * getTasks() >> childTasks
-            _ * getChildProjects() >> [:]
+            _ * getChildProjectsInternal() >> [:]
         }
-        _ * project.childProjects >> [child: childProject]
+        _ * project.childProjectsInternal >> [child: childProject]
 
         when:
         def result = resolver.selectAll(project, true)
@@ -237,9 +237,9 @@ class TaskNameResolverTest extends Specification {
         def childTasks = Mock(TaskContainerInternal)
         def childProject = Mock(ProjectInternal) {
             _ * getTasks() >> childTasks
-            _ * getChildProjects() >> [:]
+            _ * getChildProjectsInternal() >> [:]
         }
-        _ * project.childProjects >> [child: childProject]
+        _ * project.childProjectsInternal >> [child: childProject]
 
         when:
         def result = resolver.selectAll(project, true)

--- a/subprojects/core/src/test/groovy/org/gradle/execution/TaskNameResolverTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/TaskNameResolverTest.groovy
@@ -68,10 +68,10 @@ class TaskNameResolverTest extends Specification {
         def childTasks = Mock(TaskContainerInternal)
         def childProject = Mock(ProjectInternal) {
             _ * getTasks() >> childTasks
-            _ * getChildProjectsInternal() >> [:]
+            _ * getChildProjectsUnchecked() >> [:]
         }
 
-        _ * project.childProjectsInternal >> [child: childProject]
+        _ * project.childProjectsUnchecked >> [child: childProject]
 
         when:
         def results = resolver.selectWithName('task', project, true)
@@ -104,10 +104,10 @@ class TaskNameResolverTest extends Specification {
         def childTasks = Mock(TaskContainerInternal)
         def childProject = Mock(ProjectInternal) {
             _ * getTasks() >> childTasks
-            _ * getChildProjectsInternal() >> [:]
+            _ * getChildProjectsUnchecked() >> [:]
         }
 
-        _ * project.childProjectsInternal >> [child: childProject]
+        _ * project.childProjectsUnchecked >> [child: childProject]
 
         when:
         def results = resolver.selectWithName('task', project, true)
@@ -136,9 +136,9 @@ class TaskNameResolverTest extends Specification {
         def childTasks = Mock(TaskContainerInternal)
         def childProject = Mock(ProjectInternal) {
             _ * getTasks() >> childTasks
-            _ * getChildProjectsInternal() >> [:]
+            _ * getChildProjectsUnchecked() >> [:]
         }
-        _ * project.childProjectsInternal >> [child: childProject]
+        _ * project.childProjectsUnchecked >> [child: childProject]
 
         when:
         def results = resolver.selectWithName('task', project, true)
@@ -197,9 +197,9 @@ class TaskNameResolverTest extends Specification {
         def childTasks = Mock(TaskContainerInternal)
         def childProject = Mock(ProjectInternal) {
             _ * getTasks() >> childTasks
-            _ * getChildProjectsInternal() >> [:]
+            _ * getChildProjectsUnchecked() >> [:]
         }
-        _ * project.childProjectsInternal >> [child: childProject]
+        _ * project.childProjectsUnchecked >> [child: childProject]
 
         when:
         def result = resolver.selectAll(project, true)
@@ -237,9 +237,9 @@ class TaskNameResolverTest extends Specification {
         def childTasks = Mock(TaskContainerInternal)
         def childProject = Mock(ProjectInternal) {
             _ * getTasks() >> childTasks
-            _ * getChildProjectsInternal() >> [:]
+            _ * getChildProjectsUnchecked() >> [:]
         }
-        _ * project.childProjectsInternal >> [child: childProject]
+        _ * project.childProjectsUnchecked >> [child: childProject]
 
         when:
         def result = resolver.selectAll(project, true)

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/InstantiatingBuildLoaderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/InstantiatingBuildLoaderTest.groovy
@@ -131,7 +131,7 @@ class InstantiatingBuildLoaderTest extends Specification {
         1 * gradle.setDefaultProject(childProject)
 
         and:
-        rootProject.childProjects['child'].is childProject
+        rootProject.childProjectsInternal['child'].is childProject
     }
 
     ProjectDescriptor descriptor(String name, ProjectDescriptor parent, File projectDir) {

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/InstantiatingBuildLoaderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/InstantiatingBuildLoaderTest.groovy
@@ -131,7 +131,7 @@ class InstantiatingBuildLoaderTest extends Specification {
         1 * gradle.setDefaultProject(childProject)
 
         and:
-        rootProject.childProjectsInternal['child'].is childProject
+        rootProject.childProjectsUnchecked['child'].is childProject
     }
 
     ProjectDescriptor descriptor(String name, ProjectDescriptor parent, File projectDir) {

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/ProjectPropertySettingBuildLoaderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/ProjectPropertySettingBuildLoaderTest.groovy
@@ -48,8 +48,8 @@ class ProjectPropertySettingBuildLoaderTest extends Specification {
 
     def setup() {
         _ * gradle.rootProject >> rootProject
-        _ * rootProject.childProjectsInternal >> [child: childProject]
-        _ * childProject.childProjectsInternal >> [:]
+        _ * rootProject.childProjectsUnchecked >> [child: childProject]
+        _ * childProject.childProjectsUnchecked >> [:]
         _ * rootProject.projectDir >> rootProjectDir
         _ * childProject.projectDir >> childProjectDir
         _ * rootProject.extensions >> rootExtension

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/ProjectPropertySettingBuildLoaderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/ProjectPropertySettingBuildLoaderTest.groovy
@@ -48,8 +48,8 @@ class ProjectPropertySettingBuildLoaderTest extends Specification {
 
     def setup() {
         _ * gradle.rootProject >> rootProject
-        _ * rootProject.childProjects >> [child: childProject]
-        _ * childProject.childProjects >> [:]
+        _ * rootProject.childProjectsInternal >> [child: childProject]
+        _ * childProject.childProjectsInternal >> [:]
         _ * rootProject.projectDir >> rootProjectDir
         _ * childProject.projectDir >> childProjectDir
         _ * rootProject.extensions >> rootExtension

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/plugins/HelpTasksPlugin.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/plugins/HelpTasksPlugin.java
@@ -23,7 +23,6 @@ import org.gradle.api.Project;
 import org.gradle.api.internal.component.BuildableJavaComponent;
 import org.gradle.api.internal.component.ComponentRegistry;
 import org.gradle.api.internal.plugins.DslObject;
-import org.gradle.api.internal.project.ProjectHierarchyUtils;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.diagnostics.BuildEnvironmentReportTask;
@@ -35,6 +34,8 @@ import org.gradle.api.tasks.diagnostics.PropertyReportTask;
 import org.gradle.api.tasks.diagnostics.ResolvableConfigurationsReportTask;
 import org.gradle.api.tasks.diagnostics.TaskReportTask;
 import org.gradle.configuration.Help;
+
+import static org.gradle.api.internal.project.ProjectHierarchyUtils.getChildProjectsForInternalUse;
 
 /**
  * Adds various reporting tasks that provide information about the project.
@@ -73,7 +74,7 @@ public class HelpTasksPlugin implements Plugin<Project> {
         String projectName = project.toString();
         tasks.register(ProjectInternal.HELP_TASK, Help.class, new HelpAction());
         tasks.register(ProjectInternal.PROJECTS_TASK, ProjectReportTask.class, new ProjectReportTaskAction(projectName));
-        tasks.register(ProjectInternal.TASKS_TASK, TaskReportTask.class, new TaskReportTaskAction(projectName, ProjectHierarchyUtils.getChildProjectsForInternalUse(project).isEmpty()));
+        tasks.register(ProjectInternal.TASKS_TASK, TaskReportTask.class, new TaskReportTaskAction(projectName, getChildProjectsForInternalUse(project).isEmpty()));
         tasks.register(PROPERTIES_TASK, PropertyReportTask.class, new PropertyReportTaskAction(projectName));
         tasks.register(DEPENDENCY_INSIGHT_TASK, DependencyInsightReportTask.class, new DependencyInsightReportTaskAction(projectName));
         tasks.register(DEPENDENCIES_TASK, DependencyReportTask.class, new DependencyReportTaskAction(projectName));

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/plugins/HelpTasksPlugin.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/plugins/HelpTasksPlugin.java
@@ -23,6 +23,7 @@ import org.gradle.api.Project;
 import org.gradle.api.internal.component.BuildableJavaComponent;
 import org.gradle.api.internal.component.ComponentRegistry;
 import org.gradle.api.internal.plugins.DslObject;
+import org.gradle.api.internal.project.ProjectHierarchyUtils;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.diagnostics.BuildEnvironmentReportTask;
@@ -72,7 +73,7 @@ public class HelpTasksPlugin implements Plugin<Project> {
         String projectName = project.toString();
         tasks.register(ProjectInternal.HELP_TASK, Help.class, new HelpAction());
         tasks.register(ProjectInternal.PROJECTS_TASK, ProjectReportTask.class, new ProjectReportTaskAction(projectName));
-        tasks.register(ProjectInternal.TASKS_TASK, TaskReportTask.class, new TaskReportTaskAction(projectName, project.getChildProjects().isEmpty()));
+        tasks.register(ProjectInternal.TASKS_TASK, TaskReportTask.class, new TaskReportTaskAction(projectName, ProjectHierarchyUtils.getChildProjectsForInternalUse(project).isEmpty()));
         tasks.register(PROPERTIES_TASK, PropertyReportTask.class, new PropertyReportTaskAction(projectName));
         tasks.register(DEPENDENCY_INSIGHT_TASK, DependencyInsightReportTask.class, new DependencyInsightReportTaskAction(projectName));
         tasks.register(DEPENDENCIES_TASK, DependencyReportTask.class, new DependencyReportTaskAction(projectName));

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/ProjectReportTask.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/ProjectReportTask.java
@@ -18,6 +18,7 @@ package org.gradle.api.tasks.diagnostics;
 import org.apache.commons.lang.StringUtils;
 import org.gradle.api.Incubating;
 import org.gradle.api.Project;
+import org.gradle.api.internal.project.ProjectHierarchyUtils;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.tasks.diagnostics.internal.ProjectDetails;
 import org.gradle.api.tasks.diagnostics.internal.TextReportRenderer;
@@ -102,7 +103,7 @@ public class ProjectReportTask extends AbstractProjectBasedReportTask<ProjectRep
     }
 
     private List<ProjectReportModel> calculateChildrenProjectsFor(Project project) {
-        List<Project> childProjects = CollectionUtils.sort(project.getChildProjects().values());
+        List<Project> childProjects = CollectionUtils.sort(ProjectHierarchyUtils.getChildProjectsForInternalUse(project));
         List<ProjectReportModel> children = new ArrayList<>(childProjects.size());
         for (Project childProject : childProjects) {
             children.add(calculateReportModelFor(childProject));

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/BuildInvocationsBuilder.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/BuildInvocationsBuilder.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Sets;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.internal.project.ProjectHierarchyUtils;
 import org.gradle.api.internal.project.ProjectTaskLister;
 import org.gradle.api.internal.tasks.PublicTaskSpecification;
 import org.gradle.plugins.ide.internal.tooling.model.DefaultBuildInvocations;
@@ -101,7 +102,7 @@ public class BuildInvocationsBuilder implements ToolingModelBuilder {
     }
 
     private void findTasks(Project project, Map<String, LaunchableGradleTaskSelector> taskSelectors, Collection<String> visibleTasks) {
-        for (Project child : project.getChildProjects().values()) {
+        for (Project child : ProjectHierarchyUtils.getChildProjectsForInternalUse(project)) {
             findTasks(child, taskSelectors, visibleTasks);
         }
 

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/BuildInvocationsBuilder.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/BuildInvocationsBuilder.java
@@ -23,7 +23,6 @@ import com.google.common.collect.Sets;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.internal.project.ProjectHierarchyUtils;
 import org.gradle.api.internal.project.ProjectTaskLister;
 import org.gradle.api.internal.tasks.PublicTaskSpecification;
 import org.gradle.plugins.ide.internal.tooling.model.DefaultBuildInvocations;
@@ -38,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.gradle.api.internal.project.ProjectHierarchyUtils.getChildProjectsForInternalUse;
 import static org.gradle.plugins.ide.internal.tooling.ToolingModelBuilderSupport.buildFromTask;
 
 public class BuildInvocationsBuilder implements ToolingModelBuilder {
@@ -102,7 +102,7 @@ public class BuildInvocationsBuilder implements ToolingModelBuilder {
     }
 
     private void findTasks(Project project, Map<String, LaunchableGradleTaskSelector> taskSelectors, Collection<String> visibleTasks) {
-        for (Project child : ProjectHierarchyUtils.getChildProjectsForInternalUse(project)) {
+        for (Project child : getChildProjectsForInternalUse(project)) {
             findTasks(child, taskSelectors, visibleTasks);
         }
 

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/EclipseModelBuilder.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/EclipseModelBuilder.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang.StringUtils;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.internal.GradleInternal;
+import org.gradle.api.internal.project.ProjectHierarchyUtils;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.invocation.Gradle;
@@ -186,7 +187,7 @@ public class EclipseModelBuilder implements ParameterizedToolingModelBuilder<Ecl
 
     private DefaultEclipseProject buildHierarchy(Project project) {
         List<DefaultEclipseProject> children = new ArrayList<>();
-        for (Project child : project.getChildProjects().values()) {
+        for (Project child : ProjectHierarchyUtils.getChildProjectsForInternalUse(project)) {
             children.add(buildHierarchy(child));
         }
 
@@ -241,7 +242,7 @@ public class EclipseModelBuilder implements ParameterizedToolingModelBuilder<Ecl
             populateEclipseProjectJdt(eclipseProject, eclipseModel.getJdt());
         });
 
-        for (Project childProject : project.getChildProjects().values()) {
+        for (Project childProject : ProjectHierarchyUtils.getChildProjectsForInternalUse(project)) {
             populate(childProject);
         }
     }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/EclipseModelBuilder.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/EclipseModelBuilder.java
@@ -23,7 +23,6 @@ import org.apache.commons.lang.StringUtils;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.internal.GradleInternal;
-import org.gradle.api.internal.project.ProjectHierarchyUtils;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.invocation.Gradle;
@@ -85,6 +84,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static org.gradle.api.internal.project.ProjectHierarchyUtils.getChildProjectsForInternalUse;
 
 public class EclipseModelBuilder implements ParameterizedToolingModelBuilder<EclipseRuntime> {
     private final GradleProjectBuilder gradleProjectBuilder;
@@ -187,7 +188,7 @@ public class EclipseModelBuilder implements ParameterizedToolingModelBuilder<Ecl
 
     private DefaultEclipseProject buildHierarchy(Project project) {
         List<DefaultEclipseProject> children = new ArrayList<>();
-        for (Project child : ProjectHierarchyUtils.getChildProjectsForInternalUse(project)) {
+        for (Project child : getChildProjectsForInternalUse(project)) {
             children.add(buildHierarchy(child));
         }
 
@@ -242,7 +243,7 @@ public class EclipseModelBuilder implements ParameterizedToolingModelBuilder<Ecl
             populateEclipseProjectJdt(eclipseProject, eclipseModel.getJdt());
         });
 
-        for (Project childProject : ProjectHierarchyUtils.getChildProjectsForInternalUse(project)) {
+        for (Project childProject : getChildProjectsForInternalUse(project)) {
             populate(childProject);
         }
     }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/GradleProjectBuilder.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/GradleProjectBuilder.java
@@ -18,6 +18,7 @@ package org.gradle.plugins.ide.internal.tooling;
 
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.internal.project.ProjectHierarchyUtils;
 import org.gradle.api.internal.tasks.TaskContainerInternal;
 import org.gradle.plugins.ide.internal.tooling.model.DefaultGradleProject;
 import org.gradle.plugins.ide.internal.tooling.model.LaunchableGradleProjectTask;
@@ -54,7 +55,7 @@ public class GradleProjectBuilder implements ToolingModelBuilder {
 
     private DefaultGradleProject buildHierarchy(Project project) {
         List<DefaultGradleProject> children = new ArrayList<DefaultGradleProject>();
-        for (Project child : project.getChildProjects().values()) {
+        for (Project child : ProjectHierarchyUtils.getChildProjectsForInternalUse(project)) {
             children.add(buildHierarchy(child));
         }
 

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/GradleProjectBuilder.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/GradleProjectBuilder.java
@@ -18,7 +18,6 @@ package org.gradle.plugins.ide.internal.tooling;
 
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.internal.project.ProjectHierarchyUtils;
 import org.gradle.api.internal.tasks.TaskContainerInternal;
 import org.gradle.plugins.ide.internal.tooling.model.DefaultGradleProject;
 import org.gradle.plugins.ide.internal.tooling.model.LaunchableGradleProjectTask;
@@ -32,6 +31,7 @@ import java.util.List;
 import java.util.SortedSet;
 import java.util.stream.Collectors;
 
+import static org.gradle.api.internal.project.ProjectHierarchyUtils.getChildProjectsForInternalUse;
 import static org.gradle.plugins.ide.internal.tooling.ToolingModelBuilderSupport.buildFromTask;
 
 /**
@@ -55,7 +55,7 @@ public class GradleProjectBuilder implements ToolingModelBuilder {
 
     private DefaultGradleProject buildHierarchy(Project project) {
         List<DefaultGradleProject> children = new ArrayList<DefaultGradleProject>();
-        for (Project child : ProjectHierarchyUtils.getChildProjectsForInternalUse(project)) {
+        for (Project child : getChildProjectsForInternalUse(project)) {
             children.add(buildHierarchy(child));
         }
 

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/RunBuildDependenciesTaskBuilder.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/RunBuildDependenciesTaskBuilder.java
@@ -36,6 +36,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.gradle.api.internal.project.ProjectHierarchyUtils.getChildProjectsForInternalUse;
+
 @NonNullApi
 public class RunBuildDependenciesTaskBuilder implements ParameterizedToolingModelBuilder<EclipseRuntime> {
     private Map<String, Boolean> projectOpenStatus;
@@ -81,7 +83,7 @@ public class RunBuildDependenciesTaskBuilder implements ParameterizedToolingMode
         EclipseModelBuilder.ClasspathElements elements = EclipseModelBuilder.gatherClasspathElements(projectOpenStatus, eclipseClasspath, false);
         List<TaskDependency> buildDependencies = new ArrayList<>(elements.getBuildDependencies());
 
-        for (Project childProject : project.getChildProjects().values()) {
+        for (Project childProject : getChildProjectsForInternalUse(project)) {
             buildDependencies.addAll(populate(childProject));
         }
         return buildDependencies;

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/ProjectDelegate.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/ProjectDelegate.kt
@@ -54,6 +54,7 @@ import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.resources.ResourceHandler
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.WorkResult
+import org.gradle.internal.accesscontrol.AllowUsingApiForExternalUse
 import org.gradle.normalization.InputNormalizationHandler
 import org.gradle.process.ExecResult
 import org.gradle.process.ExecSpec
@@ -356,6 +357,7 @@ abstract class ProjectDelegate : Project {
     override fun javaexec(action: Action<in JavaExecSpec>): ExecResult =
         delegate.javaexec(action)
 
+    @AllowUsingApiForExternalUse
     override fun getChildProjects(): MutableMap<String, Project> =
         delegate.childProjects
 


### PR DESCRIPTION
This is a partial fix for #21485 – the `Project.getChildProjects` part.

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation