### PR TITLE
Improve deprecation nagger short form

### DIFF
--- a/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
@@ -205,7 +205,7 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
         output.contains('build.gradle:2)') == withFullStacktrace
         output.count(PLUGIN_DEPRECATION_MESSAGE) == 1
 
-        withFullStacktrace ? (output.count('\tat') > 1) : (output.count('\tat') == 1)
+        withFullStacktrace ? (output.count('\tat') > 2) : (output.count('\tat') == 2)
         withFullStacktrace == !output.contains(RUN_WITH_STACKTRACE)
 
         where:
@@ -239,7 +239,7 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
         output.contains('build.gradle:2)') == withFullStacktrace
         output.count(PLUGIN_DEPRECATION_MESSAGE) == 1
 
-        withFullStacktrace ? (output.count('\tat') > 1) : (output.count('\tat') == 1)
+        withFullStacktrace ? (output.count('\tat') > 2) : (output.count('\tat') == 2)
         withFullStacktrace == !output.contains(RUN_WITH_STACKTRACE)
 
         where:
@@ -248,13 +248,13 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
         'with full stacktrace'    | true
     }
 
-    boolean assertFullStacktraceResult(boolean fullStacktraceEnabled, int warningsCountInConsole) {
+    void assertFullStacktraceResult(boolean fullStacktraceEnabled, int warningsCountInConsole) {
         if (warningsCountInConsole == 0) {
-            output.count('\tat') == 0 && output.count(RUN_WITH_STACKTRACE) == 0
+            assert output.count('\tat') == 0 && output.count(RUN_WITH_STACKTRACE) == 0
         } else if (fullStacktraceEnabled) {
-            output.count('\tat') > 3 && output.count(RUN_WITH_STACKTRACE) == 0
+            assert output.count('\tat') > 7 && output.count(RUN_WITH_STACKTRACE) == 0
         } else {
-            output.count('\tat') == 3 && output.count(RUN_WITH_STACKTRACE) == 3
+            assert output.count('\tat') == 7 && output.count(RUN_WITH_STACKTRACE) == 4
         }
     }
 

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/deprecation/DeprecationMessagesTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/deprecation/DeprecationMessagesTest.groovy
@@ -24,6 +24,7 @@ import org.gradle.internal.logging.CollectingTestOutputEventListener
 import org.gradle.internal.logging.ConfigureLogging
 import org.gradle.internal.operations.BuildOperationProgressEventEmitter
 import org.gradle.util.GradleVersion
+import org.gradle.util.TextUtil
 import org.junit.Rule
 import spock.lang.Specification
 
@@ -355,6 +356,6 @@ class DeprecationMessagesTest extends Specification {
     private void expectMessage(String expectedMessage) {
         def events = outputEventListener.events
         events.size() == 1
-        assert events[0].message == expectedMessage
+        assert events[0].message.startsWith(TextUtil.toPlatformLineSeparators("$expectedMessage\n"))
     }
 }


### PR DESCRIPTION
Fixes: #1269 (which was closed as duplicate of a ticket that was related but not at all the same)

### Context
Without this PR you do not get any information where
a deprecation warning originates from
if it is not from some Gradle script.

And even if it originates from some Gradle script,
the real culprit could be some plugin which is not easily recognizable instantly.

With this commit, the first non-system and non-script stacktrace element
before the first script element (which includes no script element)
for a deprecation finding is output in the short form
to instantly see where in a 3rd party component (plugin) the finding occurred.

Example before:
```
$ ./gradlew foo
> Task :foo
Invocation of Task.project at execution time has been deprecated. This will fail with an error in Gradle 8.0. Consult the upgrading guide for further information: https://docs.gradle.org/7.5.1/userguide/upgrading_version_7.html#task_project

BUILD SUCCESSFUL in 13s
```

Example after:
```
$ ../gradle/build/install/bin/gradle foo
> Task :foo
Invocation of Task.project at execution time has been deprecated. This will fail with an error in Gradle 8.0. Consult the upgrading guide for further information: https://docs.gradle.org/8.0-20221022195010+0000/userguide/upgrading_version_7.html#task_project
        at FooTask.foo(FooTask.kt:7)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)

BUILD SUCCESSFUL in 6m 54s
```

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- n/a Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
