### PR TITLE
Show all deprecation instances (#16688)

### DIFF
--- a/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
@@ -87,27 +87,27 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
         if (fullStacktraceEnabled) {
             executer.withFullDeprecationStackTraceEnabled()
         }
-        if (warningsCountInConsole > 0) {
-            executer.expectDeprecationWarnings(warningsCountInConsole)
+        if (warningsCount > 0) {
+            executer.expectDeprecationWarnings(warningsCount)
         }
         executer.withWarningMode(warnings)
         warnings == WarningMode.Fail ? fails('deprecated', 'broken') : succeeds('deprecated', 'broken')
 
         then:
-        output.contains('build.gradle:2)') == warningsCountInConsole > 0
-        output.contains('build.gradle:4)') == warningsCountInConsole > 0
-        output.contains('build.gradle:9)') == warningsCountInConsole > 0
+        output.contains('build.gradle:2)') == warningsCount > 0
+        output.contains('build.gradle:4)') == warningsCount > 0
+        output.contains('build.gradle:9)') == warningsCount > 0
 
         and:
-        output.contains(PLUGIN_DEPRECATION_MESSAGE) == warningsCountInConsole > 0
-        output.contains('The DeprecatedTask.someFeature() method has been deprecated') == warningsCountInConsole > 0
-        output.contains('The DeprecatedTask.otherFeature() method has been deprecated') == warningsCountInConsole > 0
-        output.contains('The deprecated task has been deprecated') == warningsCountInConsole > 0
+        output.contains(PLUGIN_DEPRECATION_MESSAGE) == warningsCount > 0
+        output.contains('The DeprecatedTask.someFeature() method has been deprecated') == warningsCount > 0
+        output.contains('The DeprecatedTask.otherFeature() method has been deprecated') == warningsCount > 0
+        output.contains('The deprecated task has been deprecated') == warningsCount > 0
 
         and:
-        output.contains(LoggingDeprecatedFeatureHandler.WARNING_SUMMARY) == (warningsCountInSummary > 0)
-        output.contains("You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.") == (warningsCountInSummary > 0)
-        output.contains(LoggingDeprecatedFeatureHandler.WARNING_LOGGING_DOCS_MESSAGE) == (warningsCountInSummary > 0)
+        output.contains(LoggingDeprecatedFeatureHandler.WARNING_SUMMARY) == warningsSummary
+        output.contains("You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.") == warningsSummary
+        output.contains(LoggingDeprecatedFeatureHandler.WARNING_LOGGING_DOCS_MESSAGE) == warningsSummary
 
         and: "system stack frames are filtered"
         !output.contains('jdk.internal.')
@@ -117,7 +117,7 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
         !output.contains('org.gradle.kotlin.dsl.execution.')
 
         and:
-        assertFullStacktraceResult(fullStacktraceEnabled, warningsCountInConsole)
+        assertFullStacktraceResult(fullStacktraceEnabled, warningsCount)
 
         and:
         if (warnings == WarningMode.Fail) {
@@ -125,15 +125,15 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
         }
 
         where:
-        scenario                                        | warnings            | warningsCountInConsole | warningsCountInSummary | fullStacktraceEnabled
-        'without stacktrace and --warning-mode=all'     | WarningMode.All     | 4                      | 0                      | false
-        'with stacktrace and --warning-mode=all'        | WarningMode.All     | 4                      | 0                      | true
-        'without stacktrace and --warning-mode=no'      | WarningMode.None    | 0                      | 0                      | false
-        'with stacktrace and --warning-mode=no'         | WarningMode.None    | 0                      | 0                      | true
-        'without stacktrace and --warning-mode=summary' | WarningMode.Summary | 0                      | 4                      | false
-        'with stacktrace and --warning-mode=summary'    | WarningMode.Summary | 0                      | 4                      | true
-        'without stacktrace and --warning-mode=fail'    | WarningMode.Fail    | 4                      | 0                      | false
-        'with stacktrace and --warning-mode=fail'       | WarningMode.Fail    | 4                      | 0                      | true
+        scenario                                        | warnings            | warningsCount | warningsSummary | fullStacktraceEnabled
+        'without stacktrace and --warning-mode=all'     | WarningMode.All     | 5             | false           | false
+        'with stacktrace and --warning-mode=all'        | WarningMode.All     | 5             | false           | true
+        'without stacktrace and --warning-mode=no'      | WarningMode.None    | 0             | false           | false
+        'with stacktrace and --warning-mode=no'         | WarningMode.None    | 0             | false           | true
+        'without stacktrace and --warning-mode=summary' | WarningMode.Summary | 0             | true            | false
+        'with stacktrace and --warning-mode=summary'    | WarningMode.Summary | 0             | true            | true
+        'without stacktrace and --warning-mode=fail'    | WarningMode.Fail    | 5             | false           | false
+        'with stacktrace and --warning-mode=fail'       | WarningMode.Fail    | 5             | false           | true
     }
 
     def 'build error and deprecation failure combined'() {
@@ -248,13 +248,13 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
         'with full stacktrace'    | true
     }
 
-    boolean assertFullStacktraceResult(boolean fullStacktraceEnabled, int warningsCountInConsole) {
-        if (warningsCountInConsole == 0) {
-            output.count('\tat') == 0 && output.count(RUN_WITH_STACKTRACE) == 0
+    void assertFullStacktraceResult(boolean fullStacktraceEnabled, int warningsCount) {
+        if (warningsCount == 0) {
+            assert output.count('\tat') == 0 && output.count(RUN_WITH_STACKTRACE) == 0
         } else if (fullStacktraceEnabled) {
-            output.count('\tat') > 3 && output.count(RUN_WITH_STACKTRACE) == 0
+            assert output.count('\tat') > 4 && output.count(RUN_WITH_STACKTRACE) == 0
         } else {
-            output.count('\tat') == 3 && output.count(RUN_WITH_STACKTRACE) == 3
+            assert output.count('\tat') == 4 && output.count(RUN_WITH_STACKTRACE) == 4
         }
     }
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ArtifactoryAndDockerSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ArtifactoryAndDockerSmokeTest.groovy
@@ -114,13 +114,15 @@ class ArtifactoryAndDockerSmokeTest extends AbstractPluginValidatingSmokeTest {
         """
 
         then:
-        runner('artifactoryPublish')
-            .expectLegacyDeprecationWarning(
+        def runner = runner('artifactoryPublish')
+        3.times {
+            runner.expectLegacyDeprecationWarning(
                 "The org.gradle.util.ConfigureUtil type has been deprecated. " +
                     "This is scheduled to be removed in Gradle 9.0. " +
                     "Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_7.html#org_gradle_util_reports_deprecations"
             )
-            .build()
+        }
+        runner.build()
     }
 
     @Override


### PR DESCRIPTION
Fixes #16688

### Context
Without this PR only the first finding of a concrete deprecation
warning is shown. This means you can only fix one after the other and
also only see own violations if all plugins were fixed.

With this PR all instances of a deprecation warning are shown
as long as they come from different locations.
The printed stack information is simply included in the
message deduplication that previously only contained the message itself.

Example before:
```
$ ./gradlew foo foo2 bar baz
> Task :foo
Invocation of Task.project at execution time has been deprecated. This will fail with an error in Gradle 8.0. Consult the upgrading guide for further information: https://docs.gradle.org/7.5.1/userguide/upgrading_version_7.html#task_project
        at FooTask.foo(FooTask.kt:7)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)

> Task :foo2
> Task :bar
> Task :baz

BUILD SUCCESSFUL in 1m 37s
```

Example after:
```
$ ../gradle/build/install/bin/gradle foo foo2 bar baz
> Task :foo
Invocation of Task.project at execution time has been deprecated. This will fail with an error in Gradle 8.0. Consult the upgrading guide for further information: https://docs.gradle.org/8.0-20221023202731+0000/userguide/upgrading_version_7.html#task_project
        at FooTask.foo(FooTask.kt:7)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)

> Task :foo2

> Task :bar
Invocation of Task.project at execution time has been deprecated. This will fail with an error in Gradle 8.0. Consult the upgrading guide for further information: https://docs.gradle.org/8.0-20221023202731+0000/userguide/upgrading_version_7.html#task_project
        at BarTask.bar(BarTask.kt:7)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)

> Task :baz
Invocation of Task.project at execution time has been deprecated. This will fail with an error in Gradle 8.0. Consult the upgrading guide for further information: https://docs.gradle.org/8.0-20221023202731+0000/userguide/upgrading_version_7.html#task_project
        at Foo_gradle$1$1.execute(foo.gradle.kts:18)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)

BUILD SUCCESSFUL in 2m 19s
```

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- n/a Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [ ] Recognize contributor in release notes
