### PR TITLE
Add dependency from classesDirs to DefaultSourceSetOutput

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildPluginDevelopmentIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildPluginDevelopmentIntegrationTest.groovy
@@ -458,12 +458,14 @@ class CompositeBuildPluginDevelopmentIntegrationTest extends AbstractCompositeBu
         then:
         failure.assertHasCause("""
 Circular dependency between the following tasks:
-:pluginDependencyA:compileJava
-\\--- :pluginDependencyB:jar
-     +--- :pluginDependencyB:classes
-     |    \\--- :pluginDependencyB:compileJava
-     |         \\--- :pluginDependencyA:compileJava (*)
-     \\--- :pluginDependencyB:compileJava (*)
+:pluginDependencyA:classes
+\\--- :pluginDependencyA:compileJava
+     \\--- :pluginDependencyB:jar
+          +--- :pluginDependencyB:classes
+          |    \\--- :pluginDependencyB:compileJava
+          |         +--- :pluginDependencyA:classes (*)
+          |         \\--- :pluginDependencyA:compileJava (*)
+          \\--- :pluginDependencyB:compileJava (*)
 
 (*) - details omitted (listed previously)
 """.trim())

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/CalculateTaskGraphBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/CalculateTaskGraphBuildOperationIntegrationTest.groovy
@@ -143,7 +143,7 @@ class CalculateTaskGraphBuildOperationIntegrationTest extends AbstractIntegratio
         taskGraphCalculations[1].details.buildPath == ":"
         taskGraphCalculations[1].result.requestedTaskPaths == [":build"]
         taskGraphCalculations[2].details.buildPath == ":b"
-        taskGraphCalculations[2].result.requestedTaskPaths == [":compileJava", ":jar"]
+        taskGraphCalculations[2].result.requestedTaskPaths == [":classes", ":compileJava", ":jar"]
     }
 
     def "exposes task plan details"() {
@@ -194,15 +194,15 @@ class CalculateTaskGraphBuildOperationIntegrationTest extends AbstractIntegratio
         with(operations[0].result.taskPlan) {
             task.taskPath == [":compileJava", ":processResources", ":classes", ":independentTask", ":anotherTask", ":otherTask", ":someTask", ":lastTask"]
             task.buildPath == [":", ":", ":", ":", ":", ":", ":", ":"]
-            dependencies.taskPath.collect { it.sort() } == [[":compileJava"], [], [":compileJava", ":processResources"], [], [], [], [":anotherTask", ":otherTask"], []]
-            dependencies.buildPath == [[":included-build"], [], [":", ":"], [], [], [], [":", ":"], []]
+            dependencies.taskPath.collect { it.sort() } == [[":classes", ":compileJava"], [], [":compileJava", ":processResources"], [], [], [], [":anotherTask", ":otherTask"], []]
+            dependencies.buildPath == [[":included-build", ":included-build"], [], [":", ":"], [], [], [], [":", ":"], []]
             finalizedBy.taskPath == [[], [], [], [], [], [], [":lastTask"], []]
             mustRunAfter.taskPath == [[], [], [], [], [], [], [":firstTask"], []]
             shouldRunAfter.taskPath == [[], [], [], [], [], [], [":secondTask"], []]
         }
         with(operations[1].result.taskPlan) {
-            task.taskPath == [':compileJava']
-            task.buildPath == [':included-build']
+            task.taskPath == [':compileJava', ":processResources", ":classes"]
+            task.buildPath == [':included-build', ':included-build', ':included-build']
         }
     }
 
@@ -312,7 +312,7 @@ class CalculateTaskGraphBuildOperationIntegrationTest extends AbstractIntegratio
         then:
         with(operations()[0].result.taskPlan) {
             task.taskPath == [":producer:compileJava", ":producer:processResources", ":producer:classes", ":producer:jar", ":compileJava", ":processResources", ":classes", ":jar", ":startScripts", ":distZip"]
-            dependencies.taskPath.collect { it.sort() } == [[], [], [":producer:compileJava", ":producer:processResources"], [":producer:classes", ":producer:compileJava"], [":producer:compileJava"], [], [":compileJava", ":processResources"], [":classes", ":compileJava"], [":jar", ":producer:jar"], [":jar", ":producer:jar", ":startScripts"]]
+            dependencies.taskPath.collect { it.sort() } == [[], [], [":producer:compileJava", ":producer:processResources"], [":producer:classes", ":producer:compileJava"], [":producer:classes", ":producer:compileJava"], [], [":compileJava", ":processResources"], [":classes", ":compileJava"], [":jar", ":producer:jar"], [":jar", ":producer:jar", ":startScripts"]]
         }
     }
 

--- a/subprojects/docs/src/samples/build-organization/composite-builds/basic/tests/compositeRootProject.out
+++ b/subprojects/docs/src/samples/build-organization/composite-builds/basic/tests/compositeRootProject.out
@@ -1,11 +1,11 @@
 > Task :my-app:app:processResources NO-SOURCE
 > Task :my-utils:string-utils:compileJava
-> Task :my-utils:number-utils:compileJava
 > Task :my-utils:string-utils:processResources NO-SOURCE
 > Task :my-utils:string-utils:classes
-> Task :my-utils:string-utils:jar
+> Task :my-utils:number-utils:compileJava
 > Task :my-utils:number-utils:processResources NO-SOURCE
 > Task :my-utils:number-utils:classes
+> Task :my-utils:string-utils:jar
 > Task :my-utils:number-utils:jar
 > Task :my-app:app:compileJava
 > Task :my-app:app:classes

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/JavaProjectIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/JavaProjectIntegrationTest.groovy
@@ -250,7 +250,7 @@ class JavaProjectIntegrationTest extends AbstractIntegrationTest {
         """
 
         def result = inTestDirectory().withTasks("a:classes").run()
-        result.assertTasksExecuted(":b:compileJava", ":a:compileJava", ":a:processResources", ":a:classes")
+        result.assertTasksExecuted(":b:compileJava", ":a:compileJava", ":a:processResources", ":a:classes", ":b:classes", ":b:processResources")
     }
 
 }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
@@ -429,11 +429,13 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         executedAndNotSkipped ":b:$executed"
-        notExecuted ":b:$notExec"
+        if (notExec != null) {
+            notExecuted ":b:$notExec"
+        }
 
         where:
         scenario              | token       | expectedDirName     | executed           | notExec
-        'class directory'     | 'CLASSES'   | 'classes/java/main' | 'compileJava'      | 'processResources'
+        'class directory'     | 'CLASSES'   | 'classes/java/main' | 'compileJava'      | null // Ideally, processResources would not be executed here.
         'resources directory' | 'RESOURCES' | 'resources/main'    | 'processResources' | 'compileJava'
     }
 

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/GroovyJavaLibraryInteractionIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/GroovyJavaLibraryInteractionIntegrationTest.groovy
@@ -71,7 +71,7 @@ class GroovyJavaLibraryInteractionIntegrationTest extends AbstractDependencyReso
             jar.hasDescendants("Dummy.class", "GroovyClass.class")
         } else {
             executedAndNotSkipped(":groovyLib:compileJava", ":groovyLib:compileGroovy")
-            notExecuted(":groovyLib:classes", ":groovyLib:jar")
+            notExecuted(":groovyLib:jar")
         }
 
         then:
@@ -163,7 +163,7 @@ class GroovyJavaLibraryInteractionIntegrationTest extends AbstractDependencyReso
         succeeds 'javaLib:checkDeps'
 
         executedAndNotSkipped(":groovyLib:compileJava", ":groovyLib:compileGroovy")
-        notExecuted(":groovyLib:classes", ":groovyLib:jar")
+        notExecuted(":groovyLib:jar")
 
         then:
         resolve.expectGraph {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaApplicationOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaApplicationOutgoingVariantsIntegrationTest.groovy
@@ -122,7 +122,7 @@ project(':consumer') {
         resolve()
 
         then:
-        result.assertTasksExecuted(":other-java:compileJava", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
+        result.assertTasksExecuted(":other-java:compileJava", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve", ":other-java:classes", ":other-java:processResources")
         assertResolveOutput("""
             files: [java.jar]
             java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-api}
@@ -195,7 +195,7 @@ project(':consumer') {
         resolve()
 
         then:
-        result.assertTasksExecuted(":other-java:compileJava", ":java:compileJava", ":consumer:resolve")
+        result.assertTasksExecuted(":other-java:compileJava", ":java:compileJava", ":consumer:resolve", ":java:classes", ":java:processResources", ":other-java:classes", ":other-java:processResources")
         assertResolveOutput("""
             files: [main, file-dep.jar, main, implementation-1.0.jar, runtime-only-1.0.jar]
             main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=classes, org.gradle.usage=java-runtime}

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryCompilationIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryCompilationIntegrationTest.groovy
@@ -153,7 +153,7 @@ class JavaLibraryCompilationIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         executedAndNotSkipped ':b:compileJava'
-        notExecuted ':b:processResources', ':b:classes', ':b:jar'
+        notExecuted ':b:jar'
     }
 
     def "uses the API of a library when compiling a custom source set against it [compileClasspathPackaging=#compileClasspathPackaging]"() {
@@ -243,7 +243,7 @@ class JavaLibraryCompilationIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         executedAndNotSkipped ':b:compileJava'
-        notExecuted ':b:processResources', ':b:classes', ':b:jar'
+        notExecuted ':b:jar'
     }
 
     def "recompiles consumer if API dependency of producer changed [compileClasspathPackaging=#compileClasspathPackaging]"() {
@@ -420,20 +420,21 @@ class JavaLibraryCompilationIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         executedAndNotSkipped ":b:$executed"
-        notExecuted ":b:$notExec"
+        if (notExec != null) {
+            notExecuted ":b:$notExec"
+        }
 
         where:
         scenario              | token       | expectedDirName     | executed           | notExec
-        'class directory'     | 'CLASSES'   | 'classes/java/main' | 'compileJava'      | 'processResources'
+        'class directory'     | 'CLASSES'   | 'classes/java/main' | 'compileJava'      | null
         'resources directory' | 'RESOURCES' | 'resources/main'    | 'processResources' | 'compileJava'
     }
 
     private void packagingTasks(boolean expectExecuted) {
-        def tasks = [':b:processResources', ':b:classes', ':b:jar']
         if (expectExecuted) {
-            executed(*tasks)
+            executed(':b:processResources', ':b:classes', ':b:jar')
         } else {
-            notExecuted(*tasks)
+            notExecuted(':b:jar')
         }
     }
 

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryDocumentationIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryDocumentationIntegrationTest.groovy
@@ -176,7 +176,7 @@ class JavaLibraryDocumentationIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         // requires 'c' to do compileJava for the classpath of the javadoc task of 'b'
-        result.assertTasksExecuted(':a:collectJavadoc', ':a:javadoc', ':a:javadocJar', ':a:classes', ':a:compileJava', ':a:processResources', ':b:javadoc', ':b:javadocJar', ':b:classes', ':b:compileJava', ':b:processResources', ':c:compileJava')
+        result.assertTasksExecuted(':a:collectJavadoc', ':a:javadoc', ':a:javadocJar', ':a:classes', ':a:compileJava', ':a:processResources', ':b:javadoc', ':b:javadocJar', ':b:classes', ':b:compileJava', ':b:processResources', ':c:compileJava', ":c:classes", ":c:processResources")
         output('javadocs') == ['a-javadoc.jar', 'b-javadoc.jar'] as Set
         jar('javadocs/a-javadoc.jar').assertContainsFile('ToolImpl.html')
         jar('javadocs/b-javadoc.jar').assertContainsFile('Tool.html')

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryOutgoingVariantsIntegrationTest.groovy
@@ -128,7 +128,7 @@ project(':consumer') {
         resolve()
 
         then:
-        result.assertTasksExecuted(":other-java:compileJava", ":java:compileJava", ":consumer:resolve")
+        result.assertTasksExecuted(":other-java:compileJava", ":java:compileJava", ":consumer:resolve", ":java:classes", ":java:processResources", ":other-java:classes", ":other-java:processResources")
         assertResolveOutput("""
             files: [main, api-1.0.jar, compile-only-api-1.0.jar]
             main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=classes, org.gradle.usage=java-api}
@@ -205,7 +205,7 @@ project(':consumer') {
         resolve()
 
         then:
-        result.assertTasksExecuted(":other-java:compileJava", ":java:compileJava", ":consumer:resolve")
+        result.assertTasksExecuted(":other-java:compileJava", ":java:compileJava", ":consumer:resolve", ":java:classes", ":java:processResources", ":other-java:classes", ":other-java:processResources")
         assertResolveOutput("""
             files: [main, file-dep.jar, api-1.0.jar, main, implementation-1.0.jar, runtime-only-1.0.jar]
             main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=classes, org.gradle.usage=java-runtime}

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaProjectOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaProjectOutgoingVariantsIntegrationTest.groovy
@@ -218,7 +218,7 @@ project(':consumer') {
         resolve()
 
         then:
-        result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":consumer:resolve")
+        result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":consumer:resolve", ":java:classes", ":java:processResources")
         assertResolveOutput("""
             files: [main, file-dep.jar, main, implementation-1.0.jar, runtime-only-1.0.jar]
             main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=classes, org.gradle.usage=java-runtime}

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSetOutput.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSetOutput.java
@@ -49,6 +49,8 @@ public class DefaultSourceSetOutput extends CompositeFileCollection implements S
         this.fileResolver = fileResolver;
 
         this.classesDirs = fileCollectionFactory.configurableFiles(sourceSetDisplayName + " classesDirs");
+        // TODO: This should be more specific to just the tasks that create the class files?
+        classesDirs.builtBy(this);
 
         this.outputDirectories = fileCollectionFactory.configurableFiles(sourceSetDisplayName + " classes");
         outputDirectories.from(classesDirs, (Callable<File>) this::getResourcesDir);

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaLibraryPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaLibraryPluginTest.groovy
@@ -190,13 +190,15 @@ class JavaLibraryPluginTest extends AbstractProjectBuilderSpec {
         def task = project.tasks.compileJava
 
         then:
-        task.taskDependencies.getDependencies(task)*.path as Set == [":common:$producingTask", ":tools:$producingTask"] as Set<String>
+        task.taskDependencies.getDependencies(task)*.path as Set ==
+            ([":common:$producingTask", ":tools:$producingTask"] + (producingTask == 'compileJava' ? [":common:classes", ":tools:classes"] : [])) as Set<String>
 
         when:
         task = commonProject.tasks.compileJava
 
         then:
-        task.taskDependencies.getDependencies(task)*.path as Set == [":tools:$producingTask", ":internal:$producingTask"] as Set<String>
+        task.taskDependencies.getDependencies(task)*.path as Set ==
+            ([":internal:$producingTask", ":tools:$producingTask"] + (producingTask == 'compileJava' ? [":internal:classes", ":tools:classes"] : [])) as Set<String>
 
         cleanup:
         System.setProperty(JavaBasePlugin.COMPILE_CLASSPATH_PACKAGING_SYSTEM_PROPERTY, "")

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
@@ -218,7 +218,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         mainSourceSet.annotationProcessorPath.is(project.configurations.annotationProcessor)
         mainSourceSet.java.destinationDirectory.set(new File(project.buildDir, 'classes/java/main'))
         mainSourceSet.output.resourcesDir == new File(project.buildDir, 'resources/main')
-        mainSourceSet.getOutput().getBuildDependencies().getDependencies(null)*.name == [ JavaPlugin.CLASSES_TASK_NAME, JavaPlugin.COMPILE_JAVA_TASK_NAME ]
+        mainSourceSet.getOutput().getBuildDependencies().getDependencies(null)*.name as Set == [ JavaPlugin.CLASSES_TASK_NAME, JavaPlugin.COMPILE_JAVA_TASK_NAME ] as Set
         mainSourceSet.output.generatedSourcesDirs.files == toLinkedSet(new File(project.buildDir, 'generated/sources/annotationProcessor/java/main'))
         mainSourceSet.output.generatedSourcesDirs.buildDependencies.getDependencies(null)*.name == [ JavaPlugin.COMPILE_JAVA_TASK_NAME ]
         mainSourceSet.runtimeClasspath.sourceCollections.contains(project.configurations.runtimeClasspath)
@@ -235,7 +235,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         testSourceSet.annotationProcessorPath.is(project.configurations.testAnnotationProcessor)
         testSourceSet.java.destinationDirectory.set(new File(project.buildDir, 'classes/java/test'))
         testSourceSet.output.resourcesDir == new File(project.buildDir, 'resources/test')
-        testSourceSet.getOutput().getBuildDependencies().getDependencies(null)*.name == [ JavaPlugin.TEST_CLASSES_TASK_NAME, JavaPlugin.COMPILE_TEST_JAVA_TASK_NAME ]
+        testSourceSet.getOutput().getBuildDependencies().getDependencies(null)*.name as Set == [ JavaPlugin.TEST_CLASSES_TASK_NAME, JavaPlugin.COMPILE_TEST_JAVA_TASK_NAME ] as Set
         testSourceSet.output.generatedSourcesDirs.files == toLinkedSet(new File(project.buildDir, 'generated/sources/annotationProcessor/java/test'))
         testSourceSet.output.generatedSourcesDirs.buildDependencies.getDependencies(null)*.name == [ JavaPlugin.COMPILE_TEST_JAVA_TASK_NAME ]
         testSourceSet.runtimeClasspath.sourceCollections.contains(project.configurations.testRuntimeClasspath)
@@ -256,7 +256,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         set.compileClasspath.is(project.configurations.customCompileClasspath)
         set.annotationProcessorPath.is(project.configurations.customAnnotationProcessor)
         set.java.destinationDirectory.set(new File(project.buildDir, 'classes/java/custom'))
-        set.getOutput().getBuildDependencies().getDependencies(null)*.name == [ 'customClasses', 'compileCustomJava' ]
+        set.getOutput().getBuildDependencies().getDependencies(null)*.name as Set == [ 'customClasses', 'compileCustomJava' ] as Set
         set.output.generatedSourcesDirs.files == toLinkedSet(new File(project.buildDir, 'generated/sources/annotationProcessor/java/custom'))
         set.output.generatedSourcesDirs.buildDependencies.getDependencies(null)*.name == [ 'compileCustomJava' ]
         assertThat(set.runtimeClasspath, sameCollection(set.output + project.configurations.customRuntimeClasspath))

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/ScalaCompileWithJavaLibraryIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/ScalaCompileWithJavaLibraryIntegrationTest.groovy
@@ -35,7 +35,7 @@ class ScalaCompileWithJavaLibraryIntegrationTest extends AbstractIntegrationSpec
 
         then:
         executedAndNotSkipped(":lib:compileScala")
-        notExecuted(":lib:processResources", ":lib:jar")
+        notExecuted(":lib:jar")
     }
 
     def "scala and java source directory compilation order can be reversed (task configuration #configurationStyle)"() {

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r73/DependencyArtifactDownloadProgressEventCrossVersionTest.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r73/DependencyArtifactDownloadProgressEventCrossVersionTest.groovy
@@ -23,6 +23,7 @@ import org.gradle.integtests.tooling.fixture.ToolingApiVersion
 import org.gradle.tooling.BuildException
 import org.gradle.tooling.ProjectConnection
 import org.gradle.tooling.events.OperationType
+import org.gradle.util.GradleVersion
 
 @ToolingApiVersion(">=7.3")
 @TargetGradleVersion(">=7.3")
@@ -128,10 +129,14 @@ class DependencyArtifactDownloadProgressEventCrossVersionTest extends AbstractHt
             build.addProgressListener(events, OperationType.FILE_DOWNLOAD, OperationType.TASK)
                 .run()
         }
-
         then:
-        events.operations.size() == 12
-        events.trees.size() == 4
+        if (targetVersion >= GradleVersion.version('7.5.1')) {
+            assert events.operations.size() == 12
+            assert events.trees.size() == 4
+        } else {
+            assert events.operations.size() == 10
+            assert events.trees.size() == 2
+        }
         events.operation("Task :a:compileJava")
         def task = events.operation("Task :resolve")
         task.child("Download ${modules.projectB.pom.uri}").assertIsDownload(modules.projectB.pom)

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r73/DependencyArtifactDownloadProgressEventCrossVersionTest.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r73/DependencyArtifactDownloadProgressEventCrossVersionTest.groovy
@@ -130,8 +130,8 @@ class DependencyArtifactDownloadProgressEventCrossVersionTest extends AbstractHt
         }
 
         then:
-        events.operations.size() == 10
-        events.trees.size() == 2
+        events.operations.size() == 12
+        events.trees.size() == 4
         events.operation("Task :a:compileJava")
         def task = events.operation("Task :resolve")
         task.child("Download ${modules.projectB.pom.uri}").assertIsDownload(modules.projectB.pom)


### PR DESCRIPTION
We removed this dependency in an earlier change, though it caused a regression where 'classes' no longer depends upon 'processResources'. While this behavior is not strictly necessary, we add it back for backwards compatibility.

Fixes: #22484

Reverts change from: https://github.com/gradle/gradle/commit/4d1aadc0ee64586d397491c3bab0fe6587f37e48

