### PR TITLE
Remove harmless extra output in ToolingApiLoggingCrossVersionSpec

### DIFF
--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/m8/ToolingApiLoggingCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/m8/ToolingApiLoggingCrossVersionSpec.groovy
@@ -168,6 +168,7 @@ project.logger.debug("debug logging");
     String normaliseOutput(String output) {
         // Must replace both build result formats for cross compat
         return output
+            .replaceAll(/Unable to list file systems to check whether they can be watched.*\n/, '')
             .replaceFirst(/Support for .* was deprecated.*\n/, '')
             .replaceFirst(/ in [ \dms]+/, " in 0ms")
             .replaceFirst("Total time: .+ secs", "Total time: 0 secs")


### PR DESCRIPTION
When scheduled on TD remote executors, there is an extra harmless warning line breaking the output assertion.