### PR TITLE
Filter legacy source set dependency for classes dirs

### DIFF
--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.file.collections;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.internal.AbstractTaskDependencyContainerVisitingContext;
 import org.gradle.api.internal.file.CompositeFileCollection;
 import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.file.FileCollectionStructureVisitor;
@@ -45,6 +46,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 /**
@@ -67,6 +69,7 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
     private boolean disallowChanges;
     private boolean disallowUnsafeRead;
     private ValueCollector value = EMPTY_COLLECTOR;
+    private Predicate<Object> taskDependencyFilter = null;
 
     public DefaultConfigurableFileCollection(@Nullable String displayName, PathToFileResolver fileResolver, TaskDependencyFactory dependencyFactory, Factory<PatternSet> patternSetFactory, PropertyHost host) {
         super(patternSetFactory);
@@ -284,10 +287,46 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
         value.visitContents(visitor);
     }
 
+    /**
+     * Sets a filter which is applied to all build dependencies for this collection and any child file collections.
+     */
+    public DefaultConfigurableFileCollection setTaskDependencyFilter(@Nullable Predicate<Object> filter) {
+        this.taskDependencyFilter = filter;
+        return this;
+    }
+
     @Override
     public void visitDependencies(TaskDependencyResolveContext context) {
-        context.add(buildDependency);
-        super.visitDependencies(context);
+        TaskDependencyResolveContext actual = context;
+        if (taskDependencyFilter != null) {
+            actual = new FilteringTaskDependencyResolveContext(context, taskDependencyFilter);
+        }
+
+        actual.add(buildDependency);
+        super.visitDependencies(actual);
+    }
+
+    /**
+     * A {@link TaskDependencyResolveContext} which wraps a delegate and only passes along dependencies which satisfy a given filter.
+     */
+    private static class FilteringTaskDependencyResolveContext extends AbstractTaskDependencyContainerVisitingContext {
+        private final Predicate<Object> filter;
+        public FilteringTaskDependencyResolveContext(TaskDependencyResolveContext delegate, Predicate<Object> filter) {
+            super(delegate);
+            this.filter = filter;
+        }
+
+        @Override
+        public void add(Object dependency) {
+            if (filter.test(dependency)) {
+                super.add(dependency);
+            }
+        }
+
+        @Override
+        public void visitFailure(Throwable failure) {
+            delegate.visitFailure(failure);
+        }
     }
 
     private interface ValueCollector {

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/AbstractTaskDependencyContainerVisitingContext.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/AbstractTaskDependencyContainerVisitingContext.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal;
+
+import org.gradle.api.Task;
+import org.gradle.api.internal.tasks.AbstractTaskDependencyResolveContext;
+import org.gradle.api.internal.tasks.TaskDependencyContainer;
+import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
+
+import javax.annotation.Nullable;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * A {@link TaskDependencyResolveContext} which visits incoming dependencies if they are {@link TaskDependencyContainer} instances.
+ */
+public abstract class AbstractTaskDependencyContainerVisitingContext extends AbstractTaskDependencyResolveContext {
+    private final Set<Object> seen = new HashSet<>();
+    protected final TaskDependencyResolveContext delegate;
+
+    public AbstractTaskDependencyContainerVisitingContext(TaskDependencyResolveContext context) {
+        this.delegate = context;
+    }
+
+    @Override
+    public void add(Object dep) {
+        if (!seen.add(dep)) {
+            return;
+        }
+        if (dep instanceof TaskDependencyContainer) {
+            TaskDependencyContainer container = (TaskDependencyContainer) dep;
+            container.visitDependencies(this);
+        } else {
+            delegate.add(dep);
+        }
+    }
+
+    @Nullable
+    @Override
+    public Task getTask() {
+        return delegate.getTask();
+    }
+}

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/tasks/FailureCollectingTaskDependencyResolveContext.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/tasks/FailureCollectingTaskDependencyResolveContext.java
@@ -16,19 +16,16 @@
 
 package org.gradle.api.internal.tasks;
 
-import org.gradle.api.Task;
+import org.gradle.api.internal.AbstractTaskDependencyContainerVisitingContext;
 
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-public class FailureCollectingTaskDependencyResolveContext implements TaskDependencyResolveContext {
-    private final Set<Object> seen = new HashSet<Object>();
-    private final TaskDependencyResolveContext context;
+public class FailureCollectingTaskDependencyResolveContext extends AbstractTaskDependencyContainerVisitingContext {
     private final Set<Throwable> failures = new LinkedHashSet<Throwable>();
 
-    public FailureCollectingTaskDependencyResolveContext(TaskDependencyResolveContext context) {
-        this.context = context;
+    public FailureCollectingTaskDependencyResolveContext(TaskDependencyResolveContext delegate) {
+        super(delegate);
     }
 
     public Set<Throwable> getFailures() {
@@ -36,25 +33,7 @@ public class FailureCollectingTaskDependencyResolveContext implements TaskDepend
     }
 
     @Override
-    public void add(Object dep) {
-        if (!seen.add(dep)) {
-            return;
-        }
-        if (dep instanceof TaskDependencyContainer) {
-            TaskDependencyContainer container = (TaskDependencyContainer) dep;
-            container.visitDependencies(this);
-        } else {
-            context.add(dep);
-        }
-    }
-
-    @Override
     public void visitFailure(Throwable failure) {
         failures.add(failure);
-    }
-
-    @Override
-    public Task getTask() {
-        return context.getTask();
     }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmPluginServices.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmPluginServices.java
@@ -194,7 +194,7 @@ public class DefaultJvmPluginServices implements JvmPluginServices {
         variant.setDescription("Directories containing compiled class files for " + sourceSet.getName() + ".");
         variant.getAttributes().attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objectFactory.named(LibraryElements.class, LibraryElements.CLASSES));
         variant.artifactsProvider(() ->  {
-            FileCollection classesDirs = sourceSet.getOutput().getClassesDirs();
+            FileCollection classesDirs = ((DefaultSourceSetOutput) sourceSet.getOutput()).getClassesDirsInternal();
             return classesDirs.getFiles().stream().map(file ->
                     new JvmPluginsHelper.ImmediateIntermediateJavaArtifact(ArtifactTypeDefinition.JVM_CLASS_DIRECTORY, classesDirs, file))
                 .collect(Collectors.toList());

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
@@ -218,7 +218,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         mainSourceSet.annotationProcessorPath.is(project.configurations.annotationProcessor)
         mainSourceSet.java.destinationDirectory.set(new File(project.buildDir, 'classes/java/main'))
         mainSourceSet.output.resourcesDir == new File(project.buildDir, 'resources/main')
-        mainSourceSet.getOutput().getBuildDependencies().getDependencies(null)*.name == [ JavaPlugin.CLASSES_TASK_NAME, JavaPlugin.COMPILE_JAVA_TASK_NAME ]
+        mainSourceSet.getOutput().getBuildDependencies().getDependencies(null)*.name as Set == [ JavaPlugin.CLASSES_TASK_NAME, JavaPlugin.COMPILE_JAVA_TASK_NAME ] as Set
         mainSourceSet.output.generatedSourcesDirs.files == toLinkedSet(new File(project.buildDir, 'generated/sources/annotationProcessor/java/main'))
         mainSourceSet.output.generatedSourcesDirs.buildDependencies.getDependencies(null)*.name == [ JavaPlugin.COMPILE_JAVA_TASK_NAME ]
         mainSourceSet.runtimeClasspath.sourceCollections.contains(project.configurations.runtimeClasspath)
@@ -235,7 +235,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         testSourceSet.annotationProcessorPath.is(project.configurations.testAnnotationProcessor)
         testSourceSet.java.destinationDirectory.set(new File(project.buildDir, 'classes/java/test'))
         testSourceSet.output.resourcesDir == new File(project.buildDir, 'resources/test')
-        testSourceSet.getOutput().getBuildDependencies().getDependencies(null)*.name == [ JavaPlugin.TEST_CLASSES_TASK_NAME, JavaPlugin.COMPILE_TEST_JAVA_TASK_NAME ]
+        testSourceSet.getOutput().getBuildDependencies().getDependencies(null)*.name as Set == [ JavaPlugin.TEST_CLASSES_TASK_NAME, JavaPlugin.COMPILE_TEST_JAVA_TASK_NAME ] as Set
         testSourceSet.output.generatedSourcesDirs.files == toLinkedSet(new File(project.buildDir, 'generated/sources/annotationProcessor/java/test'))
         testSourceSet.output.generatedSourcesDirs.buildDependencies.getDependencies(null)*.name == [ JavaPlugin.COMPILE_TEST_JAVA_TASK_NAME ]
         testSourceSet.runtimeClasspath.sourceCollections.contains(project.configurations.testRuntimeClasspath)
@@ -256,7 +256,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         set.compileClasspath.is(project.configurations.customCompileClasspath)
         set.annotationProcessorPath.is(project.configurations.customAnnotationProcessor)
         set.java.destinationDirectory.set(new File(project.buildDir, 'classes/java/custom'))
-        set.getOutput().getBuildDependencies().getDependencies(null)*.name == [ 'customClasses', 'compileCustomJava' ]
+        set.getOutput().getBuildDependencies().getDependencies(null)*.name as Set == [ 'customClasses', 'compileCustomJava' ] as Set
         set.output.generatedSourcesDirs.files == toLinkedSet(new File(project.buildDir, 'generated/sources/annotationProcessor/java/custom'))
         set.output.generatedSourcesDirs.buildDependencies.getDependencies(null)*.name == [ 'compileCustomJava' ]
         assertThat(set.runtimeClasspath, sameCollection(set.output + project.configurations.customRuntimeClasspath))

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/jvm/internal/DefaultJvmPluginServicesTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/jvm/internal/DefaultJvmPluginServicesTest.groovy
@@ -177,7 +177,7 @@ class DefaultJvmPluginServicesTest extends AbstractJvmPluginServicesTest {
         }
         1 * variant.setDescription(_)
         _ * sourceSet.getOutput() >> output
-        1 * output.getClassesDirs() >> classes
+        1 * output.getClassesDirsInternal() >> classes
         1 * sourceSet.getName()
         0 * _
     }


### PR DESCRIPTION
Create 'getClassesDirsInternal' which does not carry a dependency on the source set. We use it internally to avoid triggering :classes and :processResources when just building the classes.

Fixes: #22484

Reverts change from: https://github.com/gradle/gradle/commit/4d1aadc0ee64586d397491c3bab0fe6587f37e48
