### PR TITLE
Don't run Gradleception on shared host

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/Gradleception.kt
+++ b/.teamcity/src/main/kotlin/configurations/Gradleception.kt
@@ -5,6 +5,7 @@ import common.customGradle
 import common.dependsOn
 import common.gradleWrapper
 import common.requiresNotEc2Agent
+import common.requiresNotSharedHost
 import common.skipConditionally
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
 import jetbrains.buildServer.configs.kotlin.v2019_2.RelativeId
@@ -25,6 +26,7 @@ class Gradleception(model: CIBuildModel, stage: Stage, bundleGroovy4: Boolean = 
     requirements {
         // Gradleception is a heavy build which runs ~40m on EC2 agents but only ~20m on Hetzner agents
         requiresNotEc2Agent()
+        requiresNotSharedHost()
     }
 
     features {


### PR DESCRIPTION
Sometimes Gradleception can be as slow as 40m if the agent is under heavy workload. Let's not run it on shared host.
