### PR TITLE
Add test worker distribution dependencies to application classpath

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/FilteringClassLoader.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/FilteringClassLoader.java
@@ -109,7 +109,7 @@ public class FilteringClassLoader extends ClassLoader implements ClassLoaderHier
     @Override
     protected Package getPackage(String name) {
         Package p = super.getPackage(name);
-        if (p == null || !allowed(p)) {
+        if (p == null || !isPackageAllowed(p.getName())) {
             return null;
         }
         return p;
@@ -119,7 +119,7 @@ public class FilteringClassLoader extends ClassLoader implements ClassLoaderHier
     protected Package[] getPackages() {
         List<Package> packages = new ArrayList<Package>();
         for (Package p : super.getPackages()) {
-            if (allowed(p)) {
+            if (isPackageAllowed(p.getName())) {
                 packages.add(p);
             }
         }
@@ -128,7 +128,7 @@ public class FilteringClassLoader extends ClassLoader implements ClassLoaderHier
 
     @Override
     public URL getResource(String name) {
-        if (allowed(name)) {
+        if (isResourceAllowed(name)) {
             return super.getResource(name);
         }
         return EXT_CLASS_LOADER.getResource(name);
@@ -136,7 +136,7 @@ public class FilteringClassLoader extends ClassLoader implements ClassLoaderHier
 
     @Override
     public Enumeration<URL> getResources(String name) throws IOException {
-        if (allowed(name)) {
+        if (isResourceAllowed(name)) {
             return super.getResources(name);
         }
         return EXT_CLASS_LOADER.getResources(name);
@@ -147,13 +147,12 @@ public class FilteringClassLoader extends ClassLoader implements ClassLoaderHier
         return FilteringClassLoader.class.getSimpleName() + "(" + getParent() + ")";
     }
 
-    private boolean allowed(String resourceName) {
+    private boolean isResourceAllowed(String resourceName) {
         return resourceNames.contains(resourceName)
             || resourcePrefixes.find(resourceName);
     }
 
-    private boolean allowed(Package pkg) {
-        String packageName = pkg.getName();
+    private boolean isPackageAllowed(String packageName) {
         if (disallowedPackagePrefixes.find(packageName)) {
             return false;
         }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/WorkerProcessSettings.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/WorkerProcessSettings.java
@@ -47,6 +47,13 @@ public interface WorkerProcessSettings {
 
     WorkerProcessSettings sharedPackages(Iterable<String> packages);
 
+    /**
+     * The packages which are allowed to leak from the application classpath into the implementation classpath.
+     * These packages affect both classes and resources.
+     * Subpackages of the provided packages are also shared with the implementation classpath.
+     *
+     * @return The list of packages which are shared from the application to the implementation classpath.
+     */
     Set<String> getSharedPackages();
 
     JavaExecHandleBuilder getJavaCommand();

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/ForkingTestClassProcessor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/ForkingTestClassProcessor.java
@@ -35,7 +35,6 @@ import org.gradle.util.internal.CollectionUtils;
 
 import java.io.File;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -46,8 +45,6 @@ public class ForkingTestClassProcessor implements TestClassProcessor {
     private final JavaForkOptions options;
     private final Iterable<File> classPath;
     private final Iterable<File> modulePath;
-    private final List<String> testWorkerImplementationClasses;
-    private final List<String> testWorkerImplementationModules;
     private final Action<WorkerProcessBuilder> buildConfigAction;
     private final ModuleRegistry moduleRegistry;
     private final Lock lock = new ReentrantLock();
@@ -60,9 +57,15 @@ public class ForkingTestClassProcessor implements TestClassProcessor {
     private boolean stoppedNow;
 
     public ForkingTestClassProcessor(
-        WorkerThreadRegistry workerThreadRegistry, WorkerProcessFactory workerFactory, WorkerTestClassProcessorFactory processorFactory, JavaForkOptions options,
-        Iterable<File> classPath, Iterable<File> modulePath, List<String> testWorkerImplementationClasses, List<String> testWorkerImplementationModules,
-        Action<WorkerProcessBuilder> buildConfigAction, ModuleRegistry moduleRegistry, DocumentationRegistry documentationRegistry
+        WorkerThreadRegistry workerThreadRegistry,
+        WorkerProcessFactory workerFactory,
+        WorkerTestClassProcessorFactory processorFactory,
+        JavaForkOptions options,
+        Iterable<File> classPath,
+        Iterable<File> modulePath,
+        Action<WorkerProcessBuilder> buildConfigAction,
+        ModuleRegistry moduleRegistry,
+        DocumentationRegistry documentationRegistry
     ) {
         this.workerThreadRegistry = workerThreadRegistry;
         this.workerFactory = workerFactory;
@@ -70,8 +73,6 @@ public class ForkingTestClassProcessor implements TestClassProcessor {
         this.options = options;
         this.classPath = classPath;
         this.modulePath = modulePath;
-        this.testWorkerImplementationClasses = testWorkerImplementationClasses;
-        this.testWorkerImplementationModules = testWorkerImplementationModules;
         this.buildConfigAction = buildConfigAction;
         this.moduleRegistry = moduleRegistry;
         this.documentationRegistry = documentationRegistry;
@@ -111,7 +112,6 @@ public class ForkingTestClassProcessor implements TestClassProcessor {
         WorkerProcessBuilder builder = workerFactory.create(new TestWorker(processorFactory));
         builder.setBaseName("Gradle Test Executor");
         builder.setImplementationClasspath(getTestWorkerImplementationClasspath());
-        builder.setImplementationModulePath(getTestWorkerImplementationModulePath());
         builder.applicationClasspath(classPath);
         builder.applicationModulePath(modulePath);
         options.copyTo(builder.getJavaCommand());
@@ -131,11 +131,6 @@ public class ForkingTestClassProcessor implements TestClassProcessor {
     }
 
     List<URL> getTestWorkerImplementationClasspath() {
-        List<URL> workerImplementationClasses = new ArrayList<URL>();
-        for (String moduleName : testWorkerImplementationClasses) {
-            workerImplementationClasses.addAll(moduleRegistry.getExternalModule(moduleName).getImplementationClasspath().getAsURLs());
-        }
-
         return CollectionUtils.flattenCollections(URL.class,
             moduleRegistry.getModule("gradle-core-api").getImplementationClasspath().getAsURLs(),
             moduleRegistry.getModule("gradle-worker-processes").getImplementationClasspath().getAsURLs(),
@@ -161,17 +156,8 @@ public class ForkingTestClassProcessor implements TestClassProcessor {
             moduleRegistry.getExternalModule("native-platform").getImplementationClasspath().getAsURLs(),
             moduleRegistry.getExternalModule("kryo").getImplementationClasspath().getAsURLs(),
             moduleRegistry.getExternalModule("commons-lang").getImplementationClasspath().getAsURLs(),
-            moduleRegistry.getExternalModule("javax.inject").getImplementationClasspath().getAsURLs(),
-            workerImplementationClasses
+            moduleRegistry.getExternalModule("javax.inject").getImplementationClasspath().getAsURLs()
         );
-    }
-
-    List<URL> getTestWorkerImplementationModulePath() {
-        List<URL> modules = new ArrayList<URL>();
-        for (String moduleName : testWorkerImplementationModules) {
-            modules.addAll(moduleRegistry.getExternalModule(moduleName).getImplementationClasspath().getAsURLs());
-        }
-        return modules;
     }
 
     @Override

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/worker/ForkingTestClassProcessorTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/worker/ForkingTestClassProcessorTest.groovy
@@ -46,11 +46,8 @@ class ForkingTestClassProcessorTest extends Specification {
     WorkerProcessFactory workerProcessFactory = Stub(WorkerProcessFactory)
     JavaForkOptions options = Stub(JavaForkOptions)
 
-    List<String> testWorkerImplementationClasses = []
-    List<String> testWorkerImplementationModules = []
-
     @Subject
-        processor = Spy(ForkingTestClassProcessor, constructorArgs: [workerLeaseRegistry, workerProcessFactory, Mock(WorkerTestClassProcessorFactory), options, [new File("classpath.jar")], [], testWorkerImplementationClasses, testWorkerImplementationModules, Mock(Action), moduleRegistry, documentationRegistry])
+        processor = Spy(ForkingTestClassProcessor, constructorArgs: [workerLeaseRegistry, workerProcessFactory, Mock(WorkerTestClassProcessorFactory), options, [new File("classpath.jar")], [], Mock(Action), moduleRegistry, documentationRegistry])
 
     def setup() {
         workerProcessBuilder.build() >> workerProcess
@@ -87,37 +84,6 @@ class ForkingTestClassProcessorTest extends Specification {
         19 * moduleRegistry.getModule(_) >> { module(it[0]) }
         6 * moduleRegistry.getExternalModule(_) >> { module(it[0]) }
         1 * workerProcessBuilder.setImplementationClasspath(_) >> { assert it[0].size() == 25 }
-        1 * workerProcessBuilder.setImplementationModulePath(_) >> { assert it[0].size() == 0 }
-    }
-
-    def "can provide jars for implementation classpath"() {
-        setup:
-        testWorkerImplementationClasses.addAll("junit")
-        1 * workerProcess.getConnection() >> Stub(ObjectConnection) { addOutgoing(_) >> Stub(RemoteTestClassProcessor) }
-
-        when:
-        processor.forkProcess()
-
-        then:
-        19 * moduleRegistry.getModule(_) >> { module(it[0]) }
-        7 * moduleRegistry.getExternalModule(_) >> { module(it[0]) }
-        1 * workerProcessBuilder.setImplementationClasspath(_) >> { assert it[0].size() == 26 }
-        1 * workerProcessBuilder.setImplementationModulePath(_) >> { assert it[0].size() == 0 }
-    }
-
-    def "can provide modules for implementation module path if process runs as module"() {
-        setup:
-        testWorkerImplementationModules.addAll("junit-platform-engine", "junit-platform-launcher", "junit-platform-commons")
-        1 * workerProcess.getConnection() >> Stub(ObjectConnection) { addOutgoing(_) >> Stub(RemoteTestClassProcessor) }
-
-        when:
-        processor.forkProcess()
-
-        then:
-        19 * moduleRegistry.getModule(_) >> { module(it[0]) }
-        9 * moduleRegistry.getExternalModule(_) >> { module(it[0]) }
-        1 * workerProcessBuilder.setImplementationClasspath(_) >> { assert it[0].size() == 25 }
-        1 * workerProcessBuilder.setImplementationModulePath(_) >> { assert it[0].size() == 3 }
     }
 
     def "stopNow does nothing when no remote processor"() {
@@ -130,7 +96,7 @@ class ForkingTestClassProcessorTest extends Specification {
     }
 
     def "stopNow propagates to worker process"() {
-        ForkingTestClassProcessor processor = new ForkingTestClassProcessor(workerLeaseRegistry, workerProcessFactory, Mock(WorkerTestClassProcessorFactory), options, [new File("classpath.jar")], [], [], [], Mock(Action), Stub(ModuleRegistry), documentationRegistry)
+        ForkingTestClassProcessor processor = new ForkingTestClassProcessor(workerLeaseRegistry, workerProcessFactory, Mock(WorkerTestClassProcessorFactory), options, [new File("classpath.jar")], [], Mock(Action), Stub(ModuleRegistry), documentationRegistry)
 
         setup:
         1 * workerProcess.getConnection() >> Stub(ObjectConnection) { addOutgoing(_) >> Stub(RemoteTestClassProcessor) }
@@ -144,7 +110,7 @@ class ForkingTestClassProcessorTest extends Specification {
     }
 
     def "no exception when stop after stopNow"() {
-        ForkingTestClassProcessor processor = new ForkingTestClassProcessor(workerLeaseRegistry, workerProcessFactory, Mock(WorkerTestClassProcessorFactory), options, [new File("classpath.jar")], [], [], [], Mock(Action), Stub(ModuleRegistry), documentationRegistry)
+        ForkingTestClassProcessor processor = new ForkingTestClassProcessor(workerLeaseRegistry, workerProcessFactory, Mock(WorkerTestClassProcessorFactory), options, [new File("classpath.jar")], [], Mock(Action), Stub(ModuleRegistry), documentationRegistry)
 
         setup:
         1 * workerProcess.getConnection() >> Stub(ObjectConnection) { addOutgoing(_) >> Stub(RemoteTestClassProcessor) }

--- a/subprojects/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junit/IgnoredTestDescriptorProvider.java
+++ b/subprojects/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junit/IgnoredTestDescriptorProvider.java
@@ -49,6 +49,8 @@ public class IgnoredTestDescriptorProvider {
             return runner;
         } catch (NoClassDefFoundError e) {
             return getRunnerLegacy(testClass);
+        } catch (NoSuchMethodError e) {
+            return getRunnerLegacy(testClass);
         }
     }
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformLauncherSessionListenerIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformLauncherSessionListenerIntegrationTest.groovy
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing.junitplatform
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Issue
+
+/**
+ * Tests JUnitPlatform integrations with {@code LauncherSessionListener}.
+ */
+class JUnitPlatformLauncherSessionListenerIntegrationTest extends AbstractIntegrationSpec {
+    /**
+     * @see <a href=https://github.com/JetBrains/intellij-community/commit/d41841670c8a98c0464ef25ef490c79b5bafe8a9">The IntelliJ commit</a>
+     * which introduced a {@code LauncherSessionListener} onto the test classpath when using the {@code org.jetbrains.intellij} plugin.
+     */
+    @Issue("https://github.com/gradle/gradle/issues/22333")
+    def "LauncherSessionListeners are automatically loaded from the test classpath when listener does not provide junit platform launcher dependency"() {
+        settingsFile << "include 'other'"
+        file("other/build.gradle") << """
+            plugins {
+                id 'java'
+            }
+
+            ${mavenCentralRepository()}
+
+            dependencies {
+                compileOnly 'org.junit.platform:junit-platform-launcher:1.9.1'
+            }
+        """
+        file("other/src/main/java/com/example/MyLauncherSessionListener.java") << """
+            package com.example;
+            import org.junit.platform.launcher.LauncherSession;
+            import org.junit.platform.launcher.LauncherSessionListener;
+            public class MyLauncherSessionListener implements LauncherSessionListener {
+                public void launcherSessionOpened(LauncherSession session) {
+                    System.out.println("Session opened");
+                }
+                public void launcherSessionClosed(LauncherSession session) {
+                    System.out.println("Session closed");
+                }
+            }
+        """
+        file("other/src/main/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener") << """
+            com.example.MyLauncherSessionListener
+        """
+
+        buildFile << """
+            plugins {
+                id 'java'
+            }
+
+            ${mavenCentralRepository()}
+
+            dependencies {
+                testImplementation project(':other')
+                testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.1'
+            }
+
+            test {
+                useJUnitPlatform()
+                testLogging.showStandardStreams = true
+            }
+        """
+        file("src/test/java/com/example/MyTest.java") << "package com.example; public class MyTest {} "
+
+        when:
+        succeeds "test"
+
+        then:
+        outputContains("Session opened")
+        outputContains("Session closed")
+
+        when:
+        succeeds "dependencies", "--configuration", "testRuntimeClasspath"
+
+        then:
+        // Sanity check in case future versions for some reason include a launcher
+        outputDoesNotContain("junit-platform-launcher")
+    }
+}

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/DefaultDistributionModule.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/DefaultDistributionModule.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.testing;
+
+import java.util.regex.Pattern;
+
+/**
+ * Default implementation of {@link DistributionModule}.
+ */
+public class DefaultDistributionModule implements DistributionModule {
+    private final String moduleName;
+    private final Pattern fileNameMatcher;
+
+    public DefaultDistributionModule(String moduleName, Pattern fileNameMatcher) {
+        this.moduleName = moduleName;
+        this.fileNameMatcher = fileNameMatcher;
+    }
+
+    @Override
+    public String getModuleName() {
+        return moduleName;
+    }
+
+    @Override
+    public Pattern getFileNameMatcher() {
+        return fileNameMatcher;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        DefaultDistributionModule that = (DefaultDistributionModule) o;
+
+        if (!moduleName.equals(that.moduleName)) {
+            return false;
+        }
+        return fileNameMatcher.equals(that.fileNameMatcher);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = moduleName.hashCode();
+        result = 31 * result + fileNameMatcher.hashCode();
+        return result;
+    }
+}

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/DistributionModule.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/DistributionModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 the original author or authors.
+ * Copyright 2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,20 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.api.internal.tasks.testing.detection;
 
-import org.gradle.api.internal.file.RelativeFile;
-import org.gradle.api.internal.tasks.testing.TestClassProcessor;
+package org.gradle.api.internal.tasks.testing;
 
-import java.io.File;
-import java.util.List;
+import java.util.regex.Pattern;
 
-public interface TestFrameworkDetector {
-    void startDetection(TestClassProcessor testClassProcessor);
+/**
+ * A third-party module which may be loaded from the Gradle distribution.
+ */
+public interface DistributionModule {
+    /**
+     * The name of the module to load.
+     */
+    String getModuleName();
 
-    boolean processTestClass(RelativeFile testClassFile);
-
-    void setTestClasses(List<File> testClasses);
-
-    void setTestClasspath(List<File> classpath);
+    /**
+     * A pattern which matches jars provided by the module. Used to determine
+     * if this module already exists on the classpath.
+     */
+    Pattern getFileNameMatcher();
 }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/JvmTestExecutionSpec.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/JvmTestExecutionSpec.java
@@ -40,14 +40,20 @@ public class JvmTestExecutionSpec implements TestExecutionSpec {
     private final JavaForkOptions javaForkOptions;
     private final int maxParallelForks;
     private final Set<String> previousFailedTestClasses;
+    private final boolean testIsModule;
 
+    @SuppressWarnings("unused")
     @UsedByScanPlugin("test-retry <= 1.1.3")
     public JvmTestExecutionSpec(TestFramework testFramework, Iterable<? extends File> classpath, FileTree candidateClassFiles, boolean scanForTestClasses, FileCollection testClassesDirs, String path, Path identityPath, long forkEvery, JavaForkOptions javaForkOptions, int maxParallelForks, Set<String> previousFailedTestClasses) {
         this(testFramework, classpath, Collections.<File>emptyList(), candidateClassFiles, scanForTestClasses, testClassesDirs, path, identityPath, forkEvery, javaForkOptions, maxParallelForks, previousFailedTestClasses);
     }
 
-    @UsedByScanPlugin("test-retry")
+    @UsedByScanPlugin("test-retry <= 1.4.1")
     public JvmTestExecutionSpec(TestFramework testFramework, Iterable<? extends File> classpath, Iterable<? extends File>  modulePath, FileTree candidateClassFiles, boolean scanForTestClasses, FileCollection testClassesDirs, String path, Path identityPath, long forkEvery, JavaForkOptions javaForkOptions, int maxParallelForks, Set<String> previousFailedTestClasses) {
+        this(testFramework, classpath, modulePath, candidateClassFiles, scanForTestClasses, testClassesDirs, path, identityPath, forkEvery, javaForkOptions, maxParallelForks, previousFailedTestClasses, false);
+    }
+
+    public JvmTestExecutionSpec(TestFramework testFramework, Iterable<? extends File> classpath, Iterable<? extends File>  modulePath, FileTree candidateClassFiles, boolean scanForTestClasses, FileCollection testClassesDirs, String path, Path identityPath, long forkEvery, JavaForkOptions javaForkOptions, int maxParallelForks, Set<String> previousFailedTestClasses, boolean testIsModule) {
         this.testFramework = testFramework;
         this.classpath = classpath;
         this.modulePath = modulePath;
@@ -60,6 +66,16 @@ public class JvmTestExecutionSpec implements TestExecutionSpec {
         this.javaForkOptions = javaForkOptions;
         this.maxParallelForks = maxParallelForks;
         this.previousFailedTestClasses = previousFailedTestClasses;
+        this.testIsModule = testIsModule;
+    }
+
+    @SuppressWarnings("unused")
+    @UsedByScanPlugin("test-retry")
+    public JvmTestExecutionSpec copyWithTestFramework(TestFramework testFramework) {
+        return new JvmTestExecutionSpec(testFramework, this.classpath, this.modulePath, this.candidateClassFiles,
+            this.scanForTestClasses, this.testClassesDirs, this.path, this.identityPath, this.forkEvery,
+            this.javaForkOptions, this.maxParallelForks, this.previousFailedTestClasses, this.testIsModule
+        );
     }
 
     public TestFramework getTestFramework() {
@@ -110,5 +126,9 @@ public class JvmTestExecutionSpec implements TestExecutionSpec {
 
     public Set<String> getPreviousFailedTestClasses() {
         return previousFailedTestClasses;
+    }
+
+    public boolean getTestIsModule() {
+        return testIsModule;
     }
 }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/TestFramework.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/TestFramework.java
@@ -26,8 +26,7 @@ import org.gradle.internal.scan.UsedByScanPlugin;
 import org.gradle.process.internal.worker.WorkerProcessBuilder;
 
 import java.io.Closeable;
-import java.util.Set;
-import java.util.regex.Pattern;
+import java.util.List;
 
 @UsedByScanPlugin("test-retry")
 public interface TestFramework extends Closeable {
@@ -74,7 +73,7 @@ public interface TestFramework extends Closeable {
      * @see #getUseDistributionDependencies()
      */
     @Internal
-    Set<? extends DistributionModule> getTestWorkerApplicationClasses();
+    List<? extends DistributionModule> getTestWorkerApplicationClasses();
 
     /**
      * Returns a list of modules the test worker requires on the modulepath if it runs as a module.
@@ -83,7 +82,7 @@ public interface TestFramework extends Closeable {
      * @see #getUseDistributionDependencies()
      */
     @Internal
-    Set<? extends DistributionModule> getTestWorkerApplicationModules();
+    List<? extends DistributionModule> getTestWorkerApplicationModules();
 
     /**
      * Whether the legacy behavior of loading test framework dependencies from the Gradle distribution
@@ -99,63 +98,4 @@ public interface TestFramework extends Closeable {
     @Internal
     boolean getUseDistributionDependencies();
 
-    /**
-     * A third-party module which may be loaded from the Gradle distribution.
-     */
-    interface DistributionModule {
-        /**
-         * The name of the module to load.
-         */
-        String getModuleName();
-
-        /**
-         * A pattern which matches jars provided by the module. Used to determine
-         * if this module already exists on the classpath.
-         */
-        Pattern getFileNameMatcher();
-    }
-
-    class DefaultDistributionModule implements DistributionModule {
-        private final String moduleName;
-        private final Pattern fileNameMatcher;
-
-        public DefaultDistributionModule(String moduleName, Pattern fileNameMatcher) {
-            this.moduleName = moduleName;
-            this.fileNameMatcher = fileNameMatcher;
-        }
-
-        @Override
-        public String getModuleName() {
-            return moduleName;
-        }
-
-        @Override
-        public Pattern getFileNameMatcher() {
-            return fileNameMatcher;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-
-            DefaultDistributionModule that = (DefaultDistributionModule) o;
-
-            if (!moduleName.equals(that.moduleName)) {
-                return false;
-            }
-            return fileNameMatcher.equals(that.fileNameMatcher);
-        }
-
-        @Override
-        public int hashCode() {
-            int result = moduleName.hashCode();
-            result = 31 * result + fileNameMatcher.hashCode();
-            return result;
-        }
-    }
 }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/detection/AbstractTestFrameworkDetector.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/detection/AbstractTestFrameworkDetector.java
@@ -37,7 +37,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static org.gradle.internal.FileUtils.hasExtension;
 
@@ -50,8 +49,8 @@ public abstract class AbstractTestFrameworkDetector<T extends TestClassVisitor> 
     private final Map<File, Boolean> superClasses;
     private TestClassProcessor testClassProcessor;
 
-    private Set<File> testClassesDirectories;
-    private Set<File> testClasspath;
+    private List<File> testClassesDirectories;
+    private List<File> testClasspath;
 
     protected AbstractTestFrameworkDetector(ClassFileExtractionManager classFileExtractionManager) {
         assert classFileExtractionManager != null;
@@ -108,12 +107,12 @@ public abstract class AbstractTestFrameworkDetector<T extends TestClassVisitor> 
     }
 
     @Override
-    public void setTestClasses(Set<File> testClassesDirectories) {
+    public void setTestClasses(List<File> testClassesDirectories) {
         this.testClassesDirectories = testClassesDirectories;
     }
 
     @Override
-    public void setTestClasspath(Set<File> testClasspath) {
+    public void setTestClasspath(List<File> testClasspath) {
         this.testClasspath = testClasspath;
     }
 

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/detection/DefaultTestExecuter.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/detection/DefaultTestExecuter.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.tasks.testing.detection;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.internal.DocumentationRegistry;
@@ -203,6 +204,19 @@ public class DefaultTestExecuter implements TestExecuter<JvmTestExecutionSpec> {
             // load all of our modules so that we don't get version mismatches between our
             // own dependencies. (Eg junit-platform-launcher-1.9.0 and junit-platform-commons-1.6.0)
             toLoad = additionalModules;
+            LOGGER.info("Loading all additional modules from the distribution since the application classpath does " +
+                "not contain all requested modules. This may lead to duplicate test framework implementation classes " +
+                "on the classpath. To resolve this, either declare all requested modules explicitly as test dependencies, " +
+                "use test suites, or remove any already declared dependencies");
+        }
+
+        if (LOGGER.isDebugEnabled() && !toLoad.isEmpty()) {
+            ArrayList<String> names = new ArrayList<String>();
+            for (DistributionModule module : additionalModules) {
+                names.add(module.getModuleName());
+            }
+
+            LOGGER.debug("Loaded additional modules from the Gradle distribution: " + Joiner.on(",").join(names));
         }
 
         // For any modules not provided by the test, load them from the distribution.

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestFramework.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestFramework.java
@@ -31,10 +31,14 @@ import org.gradle.process.internal.worker.WorkerProcessBuilder;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
-import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
 
 @UsedByScanPlugin("test-retry")
 public class JUnitTestFramework implements TestFramework {
+    private static final Set<? extends DistributionModule> DISTRIBUTION_CLASSES = Collections.singleton(
+        new DefaultDistributionModule("junit", Pattern.compile("junit-4.*\\.jar")));
+
     private JUnitOptions options;
     private JUnitDetector detector;
     private final DefaultTestFilter filter;
@@ -88,17 +92,17 @@ public class JUnitTestFramework implements TestFramework {
     }
 
     @Override
-    public List<String> getTestWorkerImplementationClasses() {
-        return Collections.singletonList("junit");
+    public Set<? extends DistributionModule> getTestWorkerApplicationClasses() {
+        return DISTRIBUTION_CLASSES;
     }
 
     @Override
-    public List<String> getTestWorkerImplementationModules() {
-        return Collections.emptyList();
+    public Set<? extends DistributionModule> getTestWorkerApplicationModules() {
+        return Collections.emptySet();
     }
 
     @Override
-    public boolean getUseImplementationDependencies() {
+    public boolean getUseDistributionDependencies() {
         return useImplementationDependencies;
     }
 

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestFramework.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestFramework.java
@@ -17,6 +17,8 @@
 package org.gradle.api.internal.tasks.testing.junit;
 
 import org.gradle.api.Action;
+import org.gradle.api.internal.tasks.testing.DefaultDistributionModule;
+import org.gradle.api.internal.tasks.testing.DistributionModule;
 import org.gradle.api.internal.tasks.testing.TestFramework;
 import org.gradle.api.internal.tasks.testing.WorkerTestClassProcessorFactory;
 import org.gradle.api.internal.tasks.testing.detection.ClassFileExtractionManager;
@@ -31,12 +33,12 @@ import org.gradle.process.internal.worker.WorkerProcessBuilder;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
-import java.util.Set;
+import java.util.List;
 import java.util.regex.Pattern;
 
 @UsedByScanPlugin("test-retry")
 public class JUnitTestFramework implements TestFramework {
-    private static final Set<? extends DistributionModule> DISTRIBUTION_CLASSES = Collections.singleton(
+    private static final List<? extends DistributionModule> DISTRIBUTION_CLASSES = Collections.singletonList(
         new DefaultDistributionModule("junit", Pattern.compile("junit-4.*\\.jar")));
 
     private JUnitOptions options;
@@ -92,13 +94,13 @@ public class JUnitTestFramework implements TestFramework {
     }
 
     @Override
-    public Set<? extends DistributionModule> getTestWorkerApplicationClasses() {
+    public List<? extends DistributionModule> getTestWorkerApplicationClasses() {
         return DISTRIBUTION_CLASSES;
     }
 
     @Override
-    public Set<? extends DistributionModule> getTestWorkerApplicationModules() {
-        return Collections.emptySet();
+    public List<? extends DistributionModule> getTestWorkerApplicationModules() {
+        return Collections.emptyList();
     }
 
     @Override

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestFramework.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestFramework.java
@@ -16,9 +16,11 @@
 
 package org.gradle.api.internal.tasks.testing.junitplatform;
 
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.Action;
 import org.gradle.api.JavaVersion;
+import org.gradle.api.internal.tasks.testing.DefaultDistributionModule;
+import org.gradle.api.internal.tasks.testing.DistributionModule;
 import org.gradle.api.internal.tasks.testing.TestFramework;
 import org.gradle.api.internal.tasks.testing.WorkerTestClassProcessorFactory;
 import org.gradle.api.internal.tasks.testing.detection.TestFrameworkDetector;
@@ -32,12 +34,12 @@ import org.gradle.process.internal.worker.WorkerProcessBuilder;
 import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Collections;
-import java.util.Set;
+import java.util.List;
 import java.util.regex.Pattern;
 
 @UsedByScanPlugin("test-retry")
 public class JUnitPlatformTestFramework implements TestFramework {
-    private static final Set<? extends DistributionModule> DISTRIBUTION_MODULES = ImmutableSet.of(
+    private static final List<? extends DistributionModule> DISTRIBUTION_MODULES = ImmutableList.of(
         new DefaultDistributionModule("junit-platform-engine", Pattern.compile("junit-platform-engine-1.*\\.jar")),
         new DefaultDistributionModule("junit-platform-launcher", Pattern.compile("junit-platform-launcher-1.*\\.jar")),
         new DefaultDistributionModule("junit-platform-commons", Pattern.compile("junit-platform-commons-1.*\\.jar"))
@@ -103,12 +105,12 @@ public class JUnitPlatformTestFramework implements TestFramework {
     }
 
     @Override
-    public Set<? extends DistributionModule> getTestWorkerApplicationClasses() {
-        return Collections.emptySet();
+    public List<? extends DistributionModule> getTestWorkerApplicationClasses() {
+        return Collections.emptyList();
     }
 
     @Override
-    public Set<? extends DistributionModule> getTestWorkerApplicationModules() {
+    public List<? extends DistributionModule> getTestWorkerApplicationModules() {
         return DISTRIBUTION_MODULES;
     }
 

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestFramework.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestFramework.java
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.tasks.testing.junitplatform;
 
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import org.gradle.api.Action;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.internal.tasks.testing.TestFramework;
@@ -32,10 +32,17 @@ import org.gradle.process.internal.worker.WorkerProcessBuilder;
 import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Collections;
-import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
 
 @UsedByScanPlugin("test-retry")
 public class JUnitPlatformTestFramework implements TestFramework {
+    private static final Set<? extends DistributionModule> DISTRIBUTION_MODULES = ImmutableSet.of(
+        new DefaultDistributionModule("junit-platform-engine", Pattern.compile("junit-platform-engine-1.*\\.jar")),
+        new DefaultDistributionModule("junit-platform-launcher", Pattern.compile("junit-platform-launcher-1.*\\.jar")),
+        new DefaultDistributionModule("junit-platform-commons", Pattern.compile("junit-platform-commons-1.*\\.jar"))
+    );
+
     private final JUnitPlatformOptions options;
     private final DefaultTestFilter filter;
     private final boolean useImplementationDependencies;
@@ -96,17 +103,17 @@ public class JUnitPlatformTestFramework implements TestFramework {
     }
 
     @Override
-    public List<String> getTestWorkerImplementationClasses() {
-        return Collections.emptyList();
+    public Set<? extends DistributionModule> getTestWorkerApplicationClasses() {
+        return Collections.emptySet();
     }
 
     @Override
-    public List<String> getTestWorkerImplementationModules() {
-        return ImmutableList.of("junit-platform-engine", "junit-platform-launcher", "junit-platform-commons");
+    public Set<? extends DistributionModule> getTestWorkerApplicationModules() {
+        return DISTRIBUTION_MODULES;
     }
 
     @Override
-    public boolean getUseImplementationDependencies() {
+    public boolean getUseDistributionDependencies() {
         return useImplementationDependencies;
     }
 

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGTestFramework.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGTestFramework.java
@@ -21,6 +21,7 @@ import org.gradle.api.GradleException;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.plugins.DslObject;
+import org.gradle.api.internal.tasks.testing.DistributionModule;
 import org.gradle.api.internal.tasks.testing.TestClassLoaderFactory;
 import org.gradle.api.internal.tasks.testing.TestFramework;
 import org.gradle.api.internal.tasks.testing.WorkerTestClassProcessorFactory;
@@ -39,7 +40,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.Callable;
 
 @UsedByScanPlugin("test-retry")
@@ -203,13 +203,13 @@ public class TestNGTestFramework implements TestFramework {
     }
 
     @Override
-    public Set<? extends DistributionModule> getTestWorkerApplicationClasses() {
-        return Collections.emptySet();
+    public List<? extends DistributionModule> getTestWorkerApplicationClasses() {
+        return Collections.emptyList();
     }
 
     @Override
-    public Set<? extends DistributionModule> getTestWorkerApplicationModules() {
-        return Collections.emptySet();
+    public List<? extends DistributionModule> getTestWorkerApplicationModules() {
+        return Collections.emptyList();
     }
 
     @Override

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGTestFramework.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGTestFramework.java
@@ -39,6 +39,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Callable;
 
 @UsedByScanPlugin("test-retry")
@@ -202,17 +203,17 @@ public class TestNGTestFramework implements TestFramework {
     }
 
     @Override
-    public List<String> getTestWorkerImplementationClasses() {
-        return Collections.emptyList();
+    public Set<? extends DistributionModule> getTestWorkerApplicationClasses() {
+        return Collections.emptySet();
     }
 
     @Override
-    public List<String> getTestWorkerImplementationModules() {
-        return Collections.emptyList();
+    public Set<? extends DistributionModule> getTestWorkerApplicationModules() {
+        return Collections.emptySet();
     }
 
     @Override
-    public boolean getUseImplementationDependencies() {
+    public boolean getUseDistributionDependencies() {
         // We have no (default) implementation dependencies (see above).
         // The user must add their TestNG dependency to the test's runtimeClasspath themselves
         // or preferably use test suites where the dependencies are automatically managed.

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -634,7 +634,7 @@ public abstract class Test extends AbstractTestTask implements JavaForkOptions, 
         boolean testIsModule = javaModuleDetector.isModule(modularity.getInferModulePath().get(), getTestClassesDirs());
         FileCollection classpath = javaModuleDetector.inferClasspath(testIsModule, stableClasspath);
         FileCollection modulePath = javaModuleDetector.inferModulePath(testIsModule, stableClasspath);
-        return new JvmTestExecutionSpec(getTestFramework(), classpath, modulePath, getCandidateClassFiles(), isScanForTestClasses(), getTestClassesDirs(), getPath(), getIdentityPath(), getForkEvery(), javaForkOptions, getMaxParallelForks(), getPreviousFailedTestClasses());
+        return new JvmTestExecutionSpec(getTestFramework(), classpath, modulePath, getCandidateClassFiles(), isScanForTestClasses(), getTestClassesDirs(), getPath(), getIdentityPath(), getForkEvery(), javaForkOptions, getMaxParallelForks(), getPreviousFailedTestClasses(), testIsModule);
     }
 
     private void validateExecutableMatchesToolchain() {


### PR DESCRIPTION
When the junit platform launcher auto-loads `LauncherSessionListener` implementations, it does so in the context of the application classloader. If the classloader does not have junit platform launcher, it fails to load `LauncherSessionListener` even if the the implementation classpath does have the launcher classes.

The resolution is to place test framework dependencies on the application classpath if they are loaded from the distribution. This is also more consistent with the way test suites configures these dependencies. 

Breaks compatibility with the test-retry plugin. But adds a new method which will avoid needing to break compatibility in the future. 

Fixes https://github.com/gradle/gradle/issues/22333
