### PR TITLE
Fix org.gradle.java.installations.paths to be referred to as a Gradle property

### DIFF
--- a/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
@@ -281,7 +281,7 @@ gradle -q javaToolchains
      | Vendor:             AdoptOpenJDK
      | Architecture:       x86_64
      | Is JDK:             false
-     | Detected by:        system property 'org.gradle.java.installations.paths'
+     | Detected by:        Gradle property 'org.gradle.java.installations.paths'
 
  + Microsoft JDK 16.0.2+7
      | Location:           /Users/username/.sdkman/candidates/java/16.0.2.7.1-ms
@@ -322,17 +322,18 @@ In order to disable auto-provisioning, you can use the `org.gradle.java.installa
 == Custom toolchain locations
 
 If auto-detecting local toolchains is not sufficient or disabled, there are additional ways you can let Gradle know about installed toolchains.
+To let Gradle know which directories to look at when detecting JVMs, use one of the following Gradle properties in `gradle.properties`.
 
 If your setup already provides environment variables pointing to installed JVMs, you can also let Gradle know about which environment variables to take into account.
-Assuming the environment variables `JDK8` and `JRE17` point to valid java installations, the following instructs Gradle to resolve those environment variables and consider those installations when looking for a matching toolchain.
+Assuming the environment variables `JDK8` and `JRE17` point to valid java installations, setting the `org.gradle.java.installations.fromEnv` Gradle property instructs
+Gradle to resolve those environment variables and consider those installations when looking for a matching toolchain:
 
 ----
 org.gradle.java.installations.fromEnv=JDK8,JRE17
 ----
 
-Additionally, you can provide a comma-separated list of paths to specific installations using the `org.gradle.java.installations.paths` property.
-For example, using the following in your `gradle.properties` will let Gradle know which directories to look at when detecting toolchains.
-Gradle will treat these directories as possible installations but will not descend into any nested directories.
+Additionally, you can provide a comma-separated list of paths to specific installations using the `org.gradle.java.installations.paths` Gradle property.
+Gradle will treat these directories as possible installations but will not descend into any nested directories:
 
 ----
 org.gradle.java.installations.paths=/custom/path/jdk1.8,/shared/jre11

--- a/subprojects/jvm-services/src/integTest/groovy/org/gradle/jvm/toolchain/InvalidJvmInstallationReportingIntegrationTest.groovy
+++ b/subprojects/jvm-services/src/integTest/groovy/org/gradle/jvm/toolchain/InvalidJvmInstallationReportingIntegrationTest.groovy
@@ -72,7 +72,7 @@ class InvalidJvmInstallationReportingIntegrationTest extends AbstractIntegration
         results.size() == 2
         results.every { result ->
             def expectedErrorMessages = [invalidJdkHome1, invalidJdkHome2].collect {
-                "Invalid Java installation found at '${it.canonicalPath}' (system property 'org.gradle.java.installations.paths'). " +
+                "Invalid Java installation found at '${it.canonicalPath}' (Gradle property 'org.gradle.java.installations.paths'). " +
                     "It will be re-checked in the next build. This might have performance impact if it keeps failing. " +
                     "Run the 'javaToolchains' task for more details."
             }

--- a/subprojects/jvm-services/src/integTest/groovy/org/gradle/jvm/toolchain/JavaInstallationRegistryIntegrationTest.groovy
+++ b/subprojects/jvm-services/src/integTest/groovy/org/gradle/jvm/toolchain/JavaInstallationRegistryIntegrationTest.groovy
@@ -82,7 +82,7 @@ class JavaInstallationRegistryIntegrationTest extends AbstractIntegrationSpec {
             .withTasks("show")
             .run()
         then:
-        outputContains("${File.separator}unknown${File.separator}path' (system property 'org.gradle.java.installations.paths') used for java installations does not exist")
+        outputContains("${File.separator}unknown${File.separator}path' (Gradle property 'org.gradle.java.installations.paths') used for java installations does not exist")
         outputContains("${File.separator}unknown${File.separator}env' (environment variable 'JDK1') used for java installations does not exist")
         outputContains(firstJavaHome)
         outputContains(secondJavaHome)
@@ -95,7 +95,7 @@ class JavaInstallationRegistryIntegrationTest extends AbstractIntegrationSpec {
             .withTasks("show")
             .run()
         then:
-        outputContains("${File.separator}other${File.separator}path' (system property 'org.gradle.java.installations.paths') used for java installations does not exist")
+        outputContains("${File.separator}other${File.separator}path' (Gradle property 'org.gradle.java.installations.paths') used for java installations does not exist")
         outputContains("${File.separator}unknown${File.separator}env' (environment variable 'JDK1') used for java installations does not exist")
         outputContains(firstJavaHome)
         outputContains(secondJavaHome)

--- a/subprojects/jvm-services/src/main/java/org/gradle/jvm/toolchain/internal/LocationListInstallationSupplier.java
+++ b/subprojects/jvm-services/src/main/java/org/gradle/jvm/toolchain/internal/LocationListInstallationSupplier.java
@@ -48,7 +48,7 @@ public class LocationListInstallationSupplier implements InstallationSupplier {
     private Set<InstallationLocation> asInstallations(String listOfDirectories) {
         return Arrays.stream(listOfDirectories.split(","))
             .filter(path -> !path.trim().isEmpty())
-            .map(path -> new InstallationLocation(fileResolver.resolve(path), "system property '" + JAVA_INSTALLATIONS_PATHS_PROPERTY + "'"))
+            .map(path -> new InstallationLocation(fileResolver.resolve(path), "Gradle property '" + JAVA_INSTALLATIONS_PATHS_PROPERTY + "'"))
             .collect(Collectors.toSet());
     }
 

--- a/subprojects/jvm-services/src/test/groovy/org/gradle/jvm/toolchain/internal/LocationListInstallationSupplierTest.groovy
+++ b/subprojects/jvm-services/src/test/groovy/org/gradle/jvm/toolchain/internal/LocationListInstallationSupplierTest.groovy
@@ -54,7 +54,7 @@ class LocationListInstallationSupplierTest extends Specification {
 
         then:
         directories*.location == [new File("/foo/bar")]
-        directories*.source == ["system property 'org.gradle.java.installations.paths'"]
+        directories*.source == ["Gradle property 'org.gradle.java.installations.paths'"]
     }
 
     def "supplies multiple installations for multiple paths"() {


### PR DESCRIPTION
### Context

I was trying to set `org.gradle.java.installations.paths` as a systemn property via the `-D` command line option, which did not work. I realized that despite the output of `./gradlew -q javaToolchains` which says `Detected by:        system property 'org.gradle.java.installations.paths'` befopre this change, I have to use `-P` instead to make `org.gradle.java.installations.paths` a Gradle project property.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
