### PR TITLE
added publishToMavenLocal behaviour in docs

### DIFF
--- a/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_maven.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_maven.adoc
@@ -260,7 +260,8 @@ WARNING: Note that the Signing plugin is not yet compatible with the <<configura
 
 [TIP]
 ====
-`publishToMavenLocal` do not create checksum files to _$USER_HOME/.m2/repository_ since it works in Maven itself. If you want to validate locally, please validate checksum files `<project directory>/build` directory, which `publish` task generates.
+`publishToMavenLocal` does not create checksum files in `$USER_HOME/.m2/repository`.
+Instead, `publishToMavenLocal` creates checksum files in the `<project directory>/build` directory during the `publish` task.
 ====
 
 [[publishing_maven:deferred_configuration]]

--- a/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_maven.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_maven.adoc
@@ -258,6 +258,11 @@ The <<signing_plugin.adoc#signing_plugin, Signing Plugin>> is used to generate a
 
 WARNING: Note that the Signing plugin is not yet compatible with the <<configuration_cache.adoc#config_cache:plugins:core,configuration cache>>.
 
+[TIP]
+====
+`publishToMavenLocal` do not create checksum files to _$USER_HOME/.m2/repository_ since it works in Maven itself. If you want to validate locally, please validate checksum files `<project directory>/build` directory, which `publish` task generates.
+====
+
 [[publishing_maven:deferred_configuration]]
 == Removal of deferred configuration behavior
 

--- a/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_maven.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_maven.adoc
@@ -260,8 +260,7 @@ WARNING: Note that the Signing plugin is not yet compatible with the <<configura
 
 [TIP]
 ====
-`publishToMavenLocal` does not create checksum files in `$USER_HOME/.m2/repository`.
-Instead, `publishToMavenLocal` creates checksum files in the `<project directory>/build` directory during the `publish` task.
+`publishToMavenLocal` does not create checksum files in `$USER_HOME/.m2/repository`. If you want to verify that the checksum files are created correctly, or use them for later publishing, consider configuring a <<declaring_repositories.adoc#sec:maven_repo,custom Maven repository>> with a `file://` URL and using that as the publishing target instead.
 ====
 
 [[publishing_maven:deferred_configuration]]


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #22482

### Context
added publishToMavenLocal behaviour in docs

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
