### PR TITLE
Use "normal" as display type of performance baselines parameter

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
@@ -59,7 +59,7 @@ class PerformanceTest(
             text(
                 "performance.baselines",
                 type.defaultBaselines,
-                display = ParameterDisplay.PROMPT,
+                display = ParameterDisplay.NORMAL,
                 allowEmpty = true,
                 description = "The baselines you want to run performance tests against. Empty means default baseline."
             )

--- a/.teamcity/src/main/kotlin/configurations/PerformanceTestsPass.kt
+++ b/.teamcity/src/main/kotlin/configurations/PerformanceTestsPass.kt
@@ -39,7 +39,7 @@ class PerformanceTestsPass(model: CIBuildModel, performanceTestProject: Performa
             text(
                 "reverse.dep.*.performance.baselines",
                 type.defaultBaselines,
-                display = ParameterDisplay.PROMPT,
+                display = ParameterDisplay.NORMAL,
                 allowEmpty = true,
                 description = "The baselines you want to run performance tests against. Empty means default baseline."
             )


### PR DESCRIPTION
From @alllex 

> Is it possible to remove the this-is-required-parameter asterisk for the performance.baselines parameter when configuring AdHoc performance scenarios?
> The comment says that the field can be empty and it actually works, but the red asterisk makes it very confusing. 

![image](https://user-images.githubusercontent.com/12689835/198162269-5e70b14d-9528-41e8-bacf-a47ddb42c6bf.png)

With this change, when clicking "Run" button, there will be no popup - if people want to specify another baseline version, then must run a custom build.