### PR TITLE
Reset performance baseline to accommodate changes done when replacing compression libraries 

### DIFF
--- a/.teamcity/performance-tests-ci.json
+++ b/.teamcity/performance-tests-ci.json
@@ -336,6 +336,14 @@
       }
     } ]
   }, {
+    "testId" : "org.gradle.performance.regression.corefeature.ArchiveTreePerformanceTest.visiting tar trees",
+    "groups" : [ {
+      "testProject" : "archivePerformanceProject",
+      "coverage" : {
+        "per_day" : [ "linux" ]
+      }
+    } ]
+  }, {
     "testId" : "org.gradle.performance.regression.corefeature.ArchiveTreePerformanceTest.visiting zip trees",
     "groups" : [ {
       "testProject" : "archivePerformanceProject",
@@ -756,6 +764,11 @@
       }
     }, {
       "testProject" : "largeMonolithicGroovyProject",
+      "coverage" : {
+        "per_commit" : [ "linux" ]
+      }
+    }, {
+      "testProject" : "largeMonolithicJavaProject",
       "coverage" : {
         "per_commit" : [ "linux" ]
       }

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,4 +26,4 @@ systemProp.gradle.internal.testdistribution.queryResponseTimeout=PT20S
 systemProp.org.gradle.kotlin.dsl.precompiled.accessors.strict=true
 
 # Default performance baseline
-defaultPerformanceBaselines=8.0-commit-6d0169890d7
+defaultPerformanceBaselines=8.0-commit-464b7dbb21b

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ArchiveTreePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ArchiveTreePerformanceTest.groovy
@@ -40,7 +40,9 @@ class ArchiveTreePerformanceTest extends AbstractCrossVersionPerformanceTest {
         result.assertCurrentVersionHasNotRegressed()
     }
 
-    @RunFor([]) //TODO (#19570), re-enable: @Scenario(type = PER_DAY, operatingSystems = [LINUX], testProjects = ["archivePerformanceProject"])
+    @RunFor(
+        @Scenario(type = PER_DAY, operatingSystems = [LINUX], testProjects = ["archivePerformanceProject"])
+    )
     def "visiting tar trees"() {
         given:
         runner.tasksToRun = ['visitTar']

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaIncrementalExecutionPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaIncrementalExecutionPerformanceTest.groovy
@@ -49,7 +49,7 @@ class JavaIncrementalExecutionPerformanceTest extends AbstractIncrementalExecuti
     }
 
     @RunFor([
-        @Scenario(type = PER_COMMIT, operatingSystems = LINUX, testProjects = ["largeGroovyMultiProject", "largeMonolithicGroovyProject"], iterationMatcher = "assemble for non-abi change"),
+        @Scenario(type = PER_COMMIT, operatingSystems = LINUX, testProjects = ["largeGroovyMultiProject", "largeMonolithicJavaProject", "largeMonolithicGroovyProject"], iterationMatcher = "assemble for non-abi change"),
         @Scenario(type = PER_COMMIT, operatingSystems = [LINUX, WINDOWS, MAC_OS], testProjects = "largeJavaMultiProject")
     ])
     def "assemble for non-abi change#configurationCaching"() {


### PR DESCRIPTION
Accept performance regression introduced in https://github.com/gradle/gradle/pull/19570 . Reasons behind the decision:
* There is one ~4% performance regression on visiting TAR trees. 
* The is one ~12% performance improvement on visiting ZIP trees. 
* Both are visible on very synthetic test scenarios. 
* The impact on real world scenarios is unclear but the results mostly show small improvements here and there.
* The somewhat faster handling of ZIP archives might help in more realistic scenarios.

There is also another performance test scenario which failed when making this change: assemble for abi change | largeMonolithicJavaProject | JavaIncrementalExecutionPerformanceTest. We have looked at that and seem like it was already on the verge of failing (for a while), plus it's about a single project build, so we decided to ignore it.

Re-enable performance tests disabled in the above-mentioned PR.

Reset the performance baseline to the merge commit of the above-mentioned PR.
