### PR TITLE
Remove classesDirs dependency on DefaultSourceSetOutput

### DIFF
--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -105,7 +105,7 @@ In Gradle 8.0 and above, use the `AntlrSourceDirectorySet` source set extension 
 
 === Potential breaking changes
 
-=== Plugins, tasks and extension classes are now abstract
+==== Plugins, tasks and extension classes are now abstract
 
 Most public classes for plugins, tasks and extensions have been made abstract. This was done to make it easier to remove boilerplate from Gradle's implementation.
 
@@ -113,17 +113,17 @@ Plugins that are affected by this change should make their classes abstract as w
 Gradle uses runtime class decoration to implement abstract methods as long as the object is instantiated via `ObjectFactory` or some other automatic mechanism (like <<custom_gradle_types.adoc#managed_properties,managed properties>>).
 Those methods should never be directly implemented.
 
-=== Wrapper task configuration
+==== Wrapper task configuration
 If `gradle-wrapper.properties` contains the `distributionSha256Sum` property, you must specify a sum. You can specify a sum in the wrapped task configuration or with the `--gradle-distribution-sha256-sum` task option.
 
-=== Changes in the AbstractCodeQualityPlugin class
+==== Changes in the AbstractCodeQualityPlugin class
 
 The deprecated `AbstractCodeQualityPlugin.getJavaPluginConvention()` method was removed in Gradle 8.0. You should use `JavaPluginExtension` instead.
 
-=== Remove implicit `--add-opens` for Gradle workers
+==== Remove implicit `--add-opens` for Gradle workers
 Before Gradle 8.0, Gradle workers on JDK9+ automatically opened JDK modules `java.base/java.util` and `java.base/java.lang` by passing `--add-opens` CLI arguments. This enabled code executed in a Gradle worker to perform deep reflection on JDK internals without warning or failing. Workers no longer use these implicit arguments.
 
-This effects all internal Gradle workers, which are used for a variety of tasks:
+This affects all internal Gradle workers, which are used for a variety of tasks:
 
 - code-quality plugins (Checkstyle, CodeNarc, Pmd)
 - ScalaDoc
@@ -140,6 +140,44 @@ These errors can be resolved by updating the violating code or dependency. Updat
 - any Gradle plugins which use the worker API
 
 For some examples of possible error or warning outputs which may arise due to this change, see <<remove_test_add_opens>>.
+
+==== SourceSet classesDirs no longer depends upon the entire SourceSet as a task dependency
+
+Prior to Gradle 8.0, the task dependencies for `link:{groovyDslPath}/org.gradle.api.tasks.SourceSetOutput.html#org.gradle.api.tasks.SourceSetOutput:classesDirs[SourceSetOutput.classesDirs]`
+included tasks that did not produce class files. This meant that a task which
+depends on `classesDirs` would also depend on `classes`, `processResources`, and any other
+task dependency added to `link:{groovyDslPath}/org.gradle.api.tasks.SourceSetOutput.html[SourceSetOutput]`. This behavior was potentially an error because
+the `classesDirs` property did not contain the output for `processResources`.
+Since 8.0, this implicit dependency is removed. Now, depending on `classesDirs` only executes the
+tasks which directly produce files in the classes directories.
+
+Consider the following buildscript:
+```groovy
+plugins {
+    id 'java-library'
+}
+// Task lists all files in the given classFiles FileCollection
+tasks.register("listClassFiles", ListClassFiles) {
+    classFiles.from(java.sourceSets.main.output.classesDirs)
+}
+```
+
+Previously, the `listClassFiles` task depended on `compileJava`, `processResources`, and `classes`.
+Now, only `compileJava` is a task dependency of `listClassFiles`.
+
+If a task in your build relied on the previous behavior, you can instead use the entire
+`SourceSetOutput` as an input, which contains all classes and resources.
+
+If that is not feasible, you can restore the previous behavior by adding more task dependencies to `classesDirs`:
+```groovy
+java {
+    sourceSets {
+        main {
+            output.classesDirs.builtBy(output)
+        }
+    }
+}
+```
 
 ==== Minimal supported Kotlin Gradle Plugin version changed
 Gradle 7.x supports Kotlin Gradle Plugin 1.3.72 and above. Kotlin Gradle Plugin versions above 1.6.21 are not tested with Gradle 7.x.
@@ -205,7 +243,7 @@ The old format is still supported when resolving the `JavaVersion` from a string
 |===
 
 [[strict-kotlin-dsl-precompiled-scripts-accessors-by-default]]
-=== Precompiled script plugins use strict Kotlin DSL accessor generation by default
+==== Precompiled script plugins use strict Kotlin DSL accessor generation by default
 
 In precompiled script plugins, type safe Kotlin DSL accessor generation now fails the build if a plugin fails to apply.
 

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
@@ -19,7 +19,6 @@ package org.gradle.api.internal.file.collections;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.file.ConfigurableFileCollection;
-import org.gradle.api.internal.AbstractTaskDependencyContainerVisitingContext;
 import org.gradle.api.internal.file.CompositeFileCollection;
 import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.file.FileCollectionStructureVisitor;
@@ -46,7 +45,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 /**
@@ -69,7 +67,6 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
     private boolean disallowChanges;
     private boolean disallowUnsafeRead;
     private ValueCollector value = EMPTY_COLLECTOR;
-    private Predicate<Object> taskDependencyFilter = null;
 
     public DefaultConfigurableFileCollection(@Nullable String displayName, PathToFileResolver fileResolver, TaskDependencyFactory dependencyFactory, Factory<PatternSet> patternSetFactory, PropertyHost host) {
         super(patternSetFactory);
@@ -282,46 +279,10 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
         value.visitContents(visitor);
     }
 
-    /**
-     * Sets a filter which is applied to all build dependencies for this collection and any child file collections.
-     */
-    public DefaultConfigurableFileCollection setTaskDependencyFilter(@Nullable Predicate<Object> filter) {
-        this.taskDependencyFilter = filter;
-        return this;
-    }
-
     @Override
     public void visitDependencies(TaskDependencyResolveContext context) {
-        TaskDependencyResolveContext actual = context;
-        if (taskDependencyFilter != null) {
-            actual = new FilteringTaskDependencyResolveContext(context, taskDependencyFilter);
-        }
-
-        actual.add(buildDependency);
-        super.visitDependencies(actual);
-    }
-
-    /**
-     * A {@link TaskDependencyResolveContext} which wraps a delegate and only passes along dependencies which satisfy a given filter.
-     */
-    private static class FilteringTaskDependencyResolveContext extends AbstractTaskDependencyContainerVisitingContext {
-        private final Predicate<Object> filter;
-        public FilteringTaskDependencyResolveContext(TaskDependencyResolveContext delegate, Predicate<Object> filter) {
-            super(delegate);
-            this.filter = filter;
-        }
-
-        @Override
-        public void add(Object dependency) {
-            if (filter.test(dependency)) {
-                super.add(dependency);
-            }
-        }
-
-        @Override
-        public void visitFailure(Throwable failure) {
-            delegate.visitFailure(failure);
-        }
+        context.add(buildDependency);
+        super.visitDependencies(context);
     }
 
     private interface ValueCollector {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaPluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaPluginIntegrationTest.groovy
@@ -506,10 +506,8 @@ Artifacts
         result.assertTaskExecuted(":customCompile")
     }
 
-    // This is not intended behavior, though it remains due to backwards compatibility.
-    // There is no reason to run processResources if only the classes are needed.
     @Issue("https://github.com/gradle/gradle/issues/22484")
-    def "executing task which depends on source set classes builds resources"() {
+    def "executing task which depends on source set classes does not build resources"() {
         buildFile("""
             plugins {
                 id 'java'
@@ -538,6 +536,6 @@ Artifacts
         succeeds "bar"
 
         then:
-        result.assertTasksExecuted(":compileJava", ":foo", ":processResources", ":classes", ":bar")
+        result.assertTasksExecuted(":compileJava", ":bar")
     }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSetOutput.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSetOutput.java
@@ -16,17 +16,14 @@
 
 package org.gradle.api.internal.tasks;
 
-import org.gradle.api.Buildable;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.CompositeFileCollection;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.file.FileResolver;
-import org.gradle.api.internal.file.collections.DefaultConfigurableFileCollection;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSetOutput;
-import org.gradle.api.tasks.TaskDependency;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.internal.logging.text.TreeFormatter;
 
@@ -46,14 +43,12 @@ public abstract class DefaultSourceSetOutput extends CompositeFileCollection imp
     private final ConfigurableFileCollection dirs;
     private final ConfigurableFileCollection generatedSourcesDirs;
     private final FileResolver fileResolver;
-    private final FileCollectionFactory fileCollectionFactory;
 
     private DirectoryContribution resourcesContributor;
 
     @Inject
     public DefaultSourceSetOutput(String sourceSetDisplayName, FileResolver fileResolver, FileCollectionFactory fileCollectionFactory) {
         this.fileResolver = fileResolver;
-        this.fileCollectionFactory = fileCollectionFactory;
 
         this.classesDirs = fileCollectionFactory.configurableFiles(sourceSetDisplayName + " classesDirs");
 
@@ -63,10 +58,6 @@ public abstract class DefaultSourceSetOutput extends CompositeFileCollection imp
         this.dirs = fileCollectionFactory.configurableFiles(sourceSetDisplayName + " dirs");
 
         this.generatedSourcesDirs = fileCollectionFactory.configurableFiles(sourceSetDisplayName + " generatedSourcesDirs");
-
-        // Legacy behavior. We want to remove this eventually. Building classesDirs does not require
-        // building the entire source set.
-        classesDirs.builtBy(new LegacyBuildable(this));
     }
 
     @Override
@@ -91,28 +82,6 @@ public abstract class DefaultSourceSetOutput extends CompositeFileCollection imp
     @Override
     public ConfigurableFileCollection getClassesDirs() {
         return classesDirs;
-    }
-
-    /**
-     * Equivalent to {@link #getClassesDirs()} except it does not carry the dependency on {@code this}.
-     */
-    public FileCollection getClassesDirsInternal() {
-        String name = "legacy filtering wrapper for " + classesDirs;
-        return ((DefaultConfigurableFileCollection) fileCollectionFactory.configurableFiles(name))
-            .setTaskDependencyFilter(dependency -> !(dependency instanceof LegacyBuildable))
-            .from(classesDirs);
-    }
-
-    private static class LegacyBuildable implements Buildable {
-        private final Buildable delegate;
-        private LegacyBuildable(Buildable delegate) {
-            this.delegate = delegate;
-        }
-
-        @Override
-        public TaskDependency getBuildDependencies() {
-            return delegate.getBuildDependencies();
-        }
     }
 
     /**

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmPluginServices.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmPluginServices.java
@@ -194,7 +194,7 @@ public class DefaultJvmPluginServices implements JvmPluginServices {
         variant.setDescription("Directories containing compiled class files for " + sourceSet.getName() + ".");
         variant.getAttributes().attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objectFactory.named(LibraryElements.class, LibraryElements.CLASSES));
         variant.artifactsProvider(() ->  {
-            FileCollection classesDirs = ((DefaultSourceSetOutput) sourceSet.getOutput()).getClassesDirsInternal();
+            FileCollection classesDirs = sourceSet.getOutput().getClassesDirs();
             return classesDirs.getFiles().stream().map(file ->
                     new JvmPluginsHelper.ImmediateIntermediateJavaArtifact(ArtifactTypeDefinition.JVM_CLASS_DIRECTORY, classesDirs, file))
                 .collect(Collectors.toList());

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/jvm/internal/DefaultJvmPluginServicesTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/jvm/internal/DefaultJvmPluginServicesTest.groovy
@@ -180,7 +180,7 @@ class DefaultJvmPluginServicesTest extends AbstractJvmPluginServicesTest {
         }
         1 * variant.setDescription(_)
         _ * sourceSet.getOutput() >> output
-        1 * output.getClassesDirsInternal() >> classes
+        1 * output.getClassesDirs() >> classes
         1 * sourceSet.getName()
         0 * _
     }


### PR DESCRIPTION
Removes the dependency on the parent SourceSetOutput from the child classesDirs.

These changes bring to light a potential missing API in `SourceSetOutput`. Users cannot directly add files to `classesDirs`, since it is not a `ConfigurableFileCollection` in the API, even though internally it is implemented as a `CFC` and we use it as such internally. 