### PR TITLE
WIP: Merge daemon defaults with user-supplied jvmargs

### DIFF
--- a/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
@@ -397,7 +397,7 @@ performanceTest.registerTestProject("bigSwiftApp", BuildBuilderGenerator) {
 performanceTest.registerAndroidTestProject("largeAndroidBuild", RemoteProject) {
     remoteUri = 'https://github.com/gradle/perf-android-large.git'
     // From android-73 branch
-    ref = "54eef7cc87e9eb1e89fce0d2de8d12e60c694080"
+    ref = "dc1eb950422d1e5ca74554b9335d65f802579621"
 }
 
 performanceTest.registerAndroidTestProject("largeAndroidBuild2", RemoteProject) {

--- a/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
@@ -409,7 +409,7 @@ performanceTest.registerAndroidTestProject("largeAndroidBuild2", RemoteProject) 
 performanceTest.registerAndroidTestProject("santaTrackerAndroidBuild", RemoteProject) {
     remoteUri = 'https://github.com/gradle/santa-tracker-android.git'
     // Pinned from main branch
-    ref = '622fc64b7c39cb84e94174be3df9a54393348b45'
+    ref = '7fcf70588083230c82c43c9f17733ff289c71819'
     doLast {
         addGoogleServicesJson(outputDirectory)
     }

--- a/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
@@ -397,7 +397,7 @@ performanceTest.registerTestProject("bigSwiftApp", BuildBuilderGenerator) {
 performanceTest.registerAndroidTestProject("largeAndroidBuild", RemoteProject) {
     remoteUri = 'https://github.com/gradle/perf-android-large.git'
     // From android-73 branch
-    ref = "dc1eb950422d1e5ca74554b9335d65f802579621"
+    ref = "54eef7cc87e9eb1e89fce0d2de8d12e60c694080"
 }
 
 performanceTest.registerAndroidTestProject("largeAndroidBuild2", RemoteProject) {

--- a/subprojects/base-services/src/main/java/org/gradle/internal/jvm/JpmsConfiguration.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/jvm/JpmsConfiguration.java
@@ -19,7 +19,9 @@ package org.gradle.internal.jvm;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * These JVM arguments should be passed to any Gradle process that will be running on Java 9+
@@ -39,7 +41,7 @@ public class JpmsConfiguration {
     public static final List<String> GRADLE_DAEMON_JPMS_ARGS;
 
     static {
-        List<String> gradleDaemonJvmArgs = new ArrayList<String>();
+        Set<String> gradleDaemonJvmArgs = new LinkedHashSet<String>();
         gradleDaemonJvmArgs.addAll(GROOVY_JPMS_ARGS);
 
         List<String> configurationCacheJpmsArgs = Collections.unmodifiableList(Arrays.asList(
@@ -50,6 +52,6 @@ public class JpmsConfiguration {
         ));
         gradleDaemonJvmArgs.addAll(configurationCacheJpmsArgs);
 
-        GRADLE_DAEMON_JPMS_ARGS = Collections.unmodifiableList(gradleDaemonJvmArgs);
+        GRADLE_DAEMON_JPMS_ARGS = Collections.unmodifiableList(new ArrayList<String>(gradleDaemonJvmArgs));
     }
 }

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -252,6 +252,14 @@ If `gradle-wrapper.properties` contains the `distributionSha256Sum` property, yo
 
 The deprecated `AbstractCodeQualityPlugin.getJavaPluginConvention()` method was removed in Gradle 8.0. You should use `JavaPluginExtension` instead.
 
+==== User provided daemon JVM arguments are merged with defaults
+
+Prior to 8.0, setting `org.gradle.jvmargs` would overwrite all default daemon JVM args, however now Gradle's default JVM arguments are merged with the arguments provided by this property. In some cases, this may cause builds which set `org.gradle.jvmargs` to have different memory configuration in Gradle 7.6.
+
+As it was before, the default daemon JVM args are `-Xms256m -Xmx512m -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError`. Previously, if `org.gradle.jvmargs` is set to `-DsomeProperty=123`, the existing behavior would be to resolve the daemon arguments to `-DsomeProperty=123` while the new behavior would resolve to `-DsomeProperty=123 -Xms256m -Xmx512m -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError`.
+
+Since the JVM's default memory arguments are more generous than Gradle's default daemon JVM arguments, this change can cause existing builds to fail with an `OutOfMemoryError` if the build uses more memory than is explicitly set in `org.gradle.jvmargs`.
+
 ==== Remove implicit `--add-opens` for Gradle workers
 Before Gradle 8.0, Gradle workers on JDK9+ automatically opened JDK modules `java.base/java.util` and `java.base/java.lang` by passing `--add-opens` CLI arguments. This enabled code executed in a Gradle worker to perform deep reflection on JDK internals without warning or failing. Workers no longer use these implicit arguments.
 

--- a/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
@@ -101,7 +101,7 @@ _A reasonable default is derived from your environment (`JAVA_HOME` or the path 
 
 `org.gradle.jvmargs=(JVM arguments)`::
 Specifies the JVM arguments used for the Gradle Daemon. The setting is particularly useful for <<#sec:configuring_jvm_memory,configuring JVM memory settings>> for build performance. This does not affect the JVM settings for the Gradle client VM.
-_The default is `-Xmx512m "-XX:MaxMetaspaceSize=256m"`._
+_The default is `-Xms256m -Xmx512m -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError`._
 
 `org.gradle.logging.level=(quiet,warn,lifecycle,info,debug)`::
 When set to quiet, warn, lifecycle, info, or debug, Gradle will use this log level. The values are not case sensitive. See <<logging.adoc#sec:choosing_a_log_level,Choosing a log level>>.
@@ -339,7 +339,7 @@ You should check for existence of optional project properties before you access 
 
 You can adjust JVM options for Gradle in the following ways:
 
-The `org.gradle.jvmargs` Gradle property controls the VM running the build. It defaults to `-Xmx512m "-XX:MaxMetaspaceSize=256m"`
+The `org.gradle.jvmargs` Gradle property controls the VM running the build. It defaults to `-Xms256m -Xmx512m -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError`
 
 .Changing JVM settings for the build VM
 ====

--- a/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
@@ -101,7 +101,7 @@ _A reasonable default is derived from your environment (`JAVA_HOME` or the path 
 
 `org.gradle.jvmargs=(JVM arguments)`::
 Specifies JVM arguments to be used for the Gradle Daemon. The setting is particularly useful for <<#sec:configuring_jvm_memory,configuring JVM memory settings>> for build performance. This does not affect the JVM settings for the Gradle client VM.
-Supplied values are merged with the defaults, with the exception of <<#sec:configuring_jvm_memory,JVM memory settings>>.
+Supplied values are merged with the defaults, with special handling for <<#sec:configuring_jvm_memory,JVM memory settings>> (see link).
 _The default values are `-Xms256m -Xmx512m -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError`._
 
 `org.gradle.logging.level=(quiet,warn,lifecycle,info,debug)`::
@@ -342,7 +342,7 @@ You can adjust JVM options for Gradle in the following ways:
 
 The `org.gradle.jvmargs` Gradle property specifies arguments for the JVM running the build. The default values are `-Xms256m -Xmx512m -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError`.
 
-JVM arguments provided via `org.gradle.jvmargs` are combined with the defaults, with the exception of `-Xms` and `-Xmx`: setting either these values will remove the default for the other.
+JVM arguments provided via `org.gradle.jvmargs` are combined with the defaults, with special handling for `-Xms` and `-Xmx`: setting either these values will remove the default for the other.
 This avoids the case where a default value is incompatible with a user-supplied value, such as having a minimum memory setting higher than the maximum.
 
 .Changing JVM memory settings for the build VM

--- a/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
@@ -100,8 +100,9 @@ Specifies the Java home for the Gradle build process. The value can be set to ei
 _A reasonable default is derived from your environment (`JAVA_HOME` or the path to `java`) if the setting is unspecified._
 
 `org.gradle.jvmargs=(JVM arguments)`::
-Specifies the JVM arguments used for the Gradle Daemon. The setting is particularly useful for <<#sec:configuring_jvm_memory,configuring JVM memory settings>> for build performance. This does not affect the JVM settings for the Gradle client VM.
-_The default is `-Xms256m -Xmx512m -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError`._
+Specifies JVM arguments to be used for the Gradle Daemon. The setting is particularly useful for <<#sec:configuring_jvm_memory,configuring JVM memory settings>> for build performance. This does not affect the JVM settings for the Gradle client VM.
+Supplied values are merged with the defaults, with the exception of <<#sec:configuring_jvm_memory,JVM memory settings>>.
+_The default values are `-Xms256m -Xmx512m -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError`._
 
 `org.gradle.logging.level=(quiet,warn,lifecycle,info,debug)`::
 When set to quiet, warn, lifecycle, info, or debug, Gradle will use this log level. The values are not case sensitive. See <<logging.adoc#sec:choosing_a_log_level,Choosing a log level>>.
@@ -339,12 +340,15 @@ You should check for existence of optional project properties before you access 
 
 You can adjust JVM options for Gradle in the following ways:
 
-The `org.gradle.jvmargs` Gradle property controls the VM running the build. It defaults to `-Xms256m -Xmx512m -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError`
+The `org.gradle.jvmargs` Gradle property specifies arguments for the JVM running the build. The default values are `-Xms256m -Xmx512m -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError`.
 
-.Changing JVM settings for the build VM
+JVM arguments provided via `org.gradle.jvmargs` are combined with the defaults, with the exception of `-Xms` and `-Xmx`: setting either these values will remove the default for the other.
+This avoids the case where a default value is incompatible with a user-supplied value, such as having a minimum memory setting higher than the maximum.
+
+.Changing JVM memory settings for the build VM
 ====
 ----
-org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xms256m -Xmx2g
 ----
 ====
 

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonJvmSettingsIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonJvmSettingsIntegrationTest.groovy
@@ -45,7 +45,7 @@ assert java.lang.management.ManagementFactory.runtimeMXBean.inputArguments.conta
 
         file('build.gradle') << """
             assert java.lang.management.ManagementFactory.runtimeMXBean.inputArguments.contains('-Xmx1024m')
-            assert java.lang.management.ManagementFactory.runtimeMXBean.inputArguments.count { !it.startsWith('--add-opens=') && !it.startsWith('-D') } == 1
+            assert java.lang.management.ManagementFactory.runtimeMXBean.inputArguments.count { !it.startsWith('--add-opens=') && !it.startsWith('-D') && !it.startsWith('-XX') } == 1
         """
 
         when:

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/client/DaemonStopClient.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/client/DaemonStopClient.java
@@ -49,7 +49,7 @@ import java.util.concurrent.TimeUnit;
  * </ul>
  */
 public class DaemonStopClient {
-    private static final Logger LOGGER = Logging.getLogger(DaemonClient.class);
+    private static final Logger LOGGER = Logging.getLogger(DaemonStopClient.class);
     private static final int STOP_TIMEOUT_SECONDS = 30;
     private final DaemonConnector connector;
     private final IdGenerator<UUID> idGenerator;

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java
@@ -126,10 +126,6 @@ public class DaemonParameters {
     }
 
     public void applyDefaultsFor(JavaVersion javaVersion) {
-        if (javaVersion.compareTo(JavaVersion.VERSION_1_8) < 0) {
-            throw new IllegalStateException("Running daemon on JDK < 8 is not supported");
-        }
-
         if (javaVersion.compareTo(JavaVersion.VERSION_1_9) >= 0) {
             Set<String> jpmsArgs = new LinkedHashSet<>(ALLOW_ENVIRONMENT_VARIABLE_OVERWRITE);
             jpmsArgs.addAll(JpmsConfiguration.GRADLE_DAEMON_JPMS_ARGS);

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java
@@ -127,8 +127,8 @@ public class DaemonParameters {
 
     public void applyDefaultsFor(JavaVersion javaVersion) {
         if (javaVersion.compareTo(JavaVersion.VERSION_1_9) >= 0) {
-            Set<String> jpmsArgs = new LinkedHashSet<>(ALLOW_ENVIRONMENT_VARIABLE_OVERWRITE);
-            jpmsArgs.addAll(JpmsConfiguration.GRADLE_DAEMON_JPMS_ARGS);
+            Set<String> jpmsArgs = new LinkedHashSet<>(JpmsConfiguration.GRADLE_DAEMON_JPMS_ARGS);
+            jpmsArgs.addAll(ALLOW_ENVIRONMENT_VARIABLE_OVERWRITE);
             jvmOptions.jvmArgs(jpmsArgs);
         }
 

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/configuration/BuildProcessTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/configuration/BuildProcessTest.groovy
@@ -42,7 +42,7 @@ class BuildProcessTest extends Specification {
         def currentJvmOptions = new JvmOptions(fileCollectionFactory)
         currentJvmOptions.minHeapSize = "16m"
         currentJvmOptions.maxHeapSize = "256m"
-        currentJvmOptions.jvmArgs("-XX:MaxPermSize=256m", "-XX:+HeapDumpOnOutOfMemoryError")
+        currentJvmOptions.jvmArgs("-XX:MaxMetaspaceSize=256m", "-XX:+HeapDumpOnOutOfMemoryError")
 
         when:
         def buildProcess = new BuildProcess(currentJvm, currentJvmOptions)
@@ -56,7 +56,7 @@ class BuildProcessTest extends Specification {
         def currentJvmOptions = new JvmOptions(fileCollectionFactory)
         currentJvmOptions.minHeapSize = "16m"
         currentJvmOptions.maxHeapSize = "1024m"
-        currentJvmOptions.jvmArgs("-XX:MaxPermSize=256m", "-XX:+HeapDumpOnOutOfMemoryError")
+        currentJvmOptions.jvmArgs("-XX:MaxMetaspaceSize=256m", "-XX:+HeapDumpOnOutOfMemoryError")
 
         when:
         def buildProcess = new BuildProcess(currentJvm, currentJvmOptions)
@@ -80,7 +80,7 @@ class BuildProcessTest extends Specification {
         def currentJvmOptions = new JvmOptions(fileCollectionFactory)
         currentJvmOptions.setAllJvmArgs(["-Dfile.encoding=$notDefaultEncoding", "-Xmx100m", "-XX:SomethingElse"])
         // Default jvm options: these will be implicit in the request
-        currentJvmOptions.jvmArgs("-XX:MaxPermSize=256m", "-XX:+HeapDumpOnOutOfMemoryError")
+        currentJvmOptions.jvmArgs("-XX:MaxMetaspaceSize=256m", "-XX:+HeapDumpOnOutOfMemoryError")
 
         when:
         def buildProcess = new BuildProcess(currentJvm, currentJvmOptions)
@@ -98,7 +98,7 @@ class BuildProcessTest extends Specification {
         def currentJvmOptions = new JvmOptions(fileCollectionFactory)
         currentJvmOptions.minHeapSize = "16m"
         currentJvmOptions.maxHeapSize = "1024m"
-        currentJvmOptions.jvmArgs("-XX:MaxPermSize=256m", "-XX:+HeapDumpOnOutOfMemoryError")
+        currentJvmOptions.jvmArgs("-XX:MaxMetaspaceSize=256m", "-XX:+HeapDumpOnOutOfMemoryError")
         def emptyRequest = buildParameters([])
 
         when:
@@ -113,7 +113,7 @@ class BuildProcessTest extends Specification {
         def currentJvmOptions = new JvmOptions(fileCollectionFactory)
         currentJvmOptions.minHeapSize = "64m"
         currentJvmOptions.maxHeapSize = "64m"
-        currentJvmOptions.jvmArgs("-XX:MaxPermSize=256m", "-XX:+HeapDumpOnOutOfMemoryError")
+        currentJvmOptions.jvmArgs("-XX:MaxMetaspaceSize=256m", "-XX:+HeapDumpOnOutOfMemoryError")
         def defaultRequest = buildParameters(null as Iterable)
 
         when:
@@ -133,7 +133,7 @@ class BuildProcessTest extends Specification {
         def buildProcess = new BuildProcess(currentJvm, new JvmOptions(fileCollectionFactory))
 
         then:
-        requestWithDefaults.getEffectiveJvmArgs().containsAll("-Xmx512m", "-Xms256m", "-XX:MaxPermSize=256m", "-XX:+HeapDumpOnOutOfMemoryError")
+        requestWithDefaults.getEffectiveJvmArgs().containsAll("-Xmx512m", "-Xms256m", "-XX:MaxMetaspaceSize=256m", "-XX:+HeapDumpOnOutOfMemoryError")
         buildProcess.configureForBuild(requestWithDefaults)
     }
 
@@ -142,7 +142,7 @@ class BuildProcessTest extends Specification {
         def currentJvmOptions = new JvmOptions(fileCollectionFactory)
         currentJvmOptions.minHeapSize = "16m"
         currentJvmOptions.maxHeapSize = "1024m"
-        currentJvmOptions.jvmArgs("-XX:MaxPermSize=256m", "-XX:+HeapDumpOnOutOfMemoryError")
+        currentJvmOptions.jvmArgs("-XX:MaxMetaspaceSize=256m", "-XX:+HeapDumpOnOutOfMemoryError")
         def requestWithMutableArgument = buildParameters(["-Dfoo=bar"])
 
         when:
@@ -156,7 +156,7 @@ class BuildProcessTest extends Specification {
         given:
         def currentJvmOptions = new JvmOptions(fileCollectionFactory)
         currentJvmOptions.setAllJvmArgs(["-Xmx100m", "-XX:SomethingElse", "-Dfoo=bar", "-Dbaz"])
-        currentJvmOptions.jvmArgs("-XX:MaxPermSize=256m", "-XX:+HeapDumpOnOutOfMemoryError")
+        currentJvmOptions.jvmArgs("-XX:MaxMetaspaceSize=256m", "-XX:+HeapDumpOnOutOfMemoryError")
 
         when:
         def buildProcess = new BuildProcess(currentJvm, currentJvmOptions)
@@ -228,7 +228,7 @@ class BuildProcessTest extends Specification {
 
     def "user-defined vm args that correspond to daemon default are considered during matching"() {
         given:
-        def parametersWithDefaults = buildParameters(["-Xmx512m", "-Xms256m", "-XX:MaxPermSize=256m", "-XX:+HeapDumpOnOutOfMemoryError"])
+        def parametersWithDefaults = buildParameters(["-Xmx512m", "-Xms256m", "-XX:MaxMetaspaceSize=256m", "-XX:+HeapDumpOnOutOfMemoryError"])
 
         when:
         def buildProcess = new BuildProcess(currentJvm, new JvmOptions(fileCollectionFactory))
@@ -254,7 +254,7 @@ class BuildProcessTest extends Specification {
         if (jvmArgs != null) {
             parameters.setJvmArgs(jvmArgs)
         }
-        parameters.applyDefaultsFor(JavaVersion.VERSION_1_7)
+        parameters.applyDefaultsFor(JavaVersion.VERSION_1_8)
         return parameters
     }
 }

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/configuration/DaemonParametersTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/configuration/DaemonParametersTest.groovy
@@ -88,7 +88,7 @@ class DaemonParametersTest extends Specification {
     }
 
     private void assertContainsJPMSDefaults(def jvmArgs) {
-        assert Collections.indexOfSubList(jvmArgs, ["--add-opens", "java.base/java.util=ALL-UNNAMED"]) >= 0
+        assert Collections.indexOfSubList(jvmArgs, ["--add-opens=java.base/java.util=ALL-UNNAMED"]) >= 0
         assert Collections.indexOfSubList(jvmArgs, JpmsConfiguration.GRADLE_DAEMON_JPMS_ARGS) >= 0
     }
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractAndroidSantaTrackerSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractAndroidSantaTrackerSmokeTest.groovy
@@ -87,8 +87,7 @@ class AbstractAndroidSantaTrackerSmokeTest extends AbstractSmokeTest {
             .withTestKitDir(homeDir)
             .forwardOutput()
         if (JavaVersion.current().isJava9Compatible()) {
-            runner.withJvmArguments(
-                "-Xmx8g", "-XX:MaxMetaspaceSize=1024m", "-XX:+HeapDumpOnOutOfMemoryError",
+            runner.withJvmArguments(EXTRA_MEMORY_JVM_ARGS + [
                 "--add-opens", "jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
                 "--add-opens", "jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
                 "--add-opens", "jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
@@ -97,7 +96,7 @@ class AbstractAndroidSantaTrackerSmokeTest extends AbstractSmokeTest {
                 "--add-opens", "jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
                 "--add-opens", "jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
                 "--add-opens", "jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED"
-            )
+            ])
         }
         if (AGP_VERSIONS.isAgpNightly(agpVersion)) {
             def init = AGP_VERSIONS.createAgpNightlyRepositoryInitScript()

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -52,6 +52,8 @@ abstract class AbstractSmokeTest extends Specification {
     protected static final KotlinGradlePluginVersions KOTLIN_VERSIONS = new KotlinGradlePluginVersions()
     protected static final String KGP_NO_CC_ITERATION_MATCHER = ".*(kotlin=1\\.3\\.|kotlin=1\\.4\\.[01]).*"
 
+    protected static final List<String> EXTRA_MEMORY_JVM_ARGS = ["-Xmx8g", "-XX:MaxMetaspaceSize=1024m", "-XX:+HeapDumpOnOutOfMemoryError"]
+
     static class TestedVersions {
         /**
          * May also need to update
@@ -265,7 +267,7 @@ abstract class AbstractSmokeTest extends Specification {
             .withArguments(
                 tasks.toList() + outputParameters() + repoMirrorParameters() + configurationCacheParameters() + toolchainParameters()
             ) as DefaultGradleRunner
-        gradleRunner.withJvmArguments(["-Xmx8g", "-XX:MaxMetaspaceSize=1024m", "-XX:+HeapDumpOnOutOfMemoryError"])
+        gradleRunner.withJvmArguments(EXTRA_MEMORY_JVM_ARGS)
         return new SmokeTestGradleRunner(gradleRunner)
     }
 
@@ -350,9 +352,9 @@ abstract class AbstractSmokeTest extends Specification {
             extraArgs += ["-I", init.canonicalPath]
         }
         if (agpVersion.startsWith("7.2") && JavaVersion.current().java9Compatible) {
-            runner = runner.withJvmArguments('--add-opens', 'java.logging/java.util.logging=ALL-UNNAMED')
+            runner = runner.withJvmArguments(EXTRA_MEMORY_JVM_ARGS + ['--add-opens', 'java.logging/java.util.logging=ALL-UNNAMED'])
         }
-        return runner.withArguments([runner.arguments, extraArgs].flatten())
+        return runner.withArguments(runner.arguments + extraArgs)
     }
 
     protected void replaceVariablesInBuildFile(Map binding) {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyGradleModuleMetadataSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyGradleModuleMetadataSmokeTest.groovy
@@ -123,9 +123,11 @@ class ThirdPartyGradleModuleMetadataSmokeTest extends AbstractSmokeTest {
     private static SmokeTestGradleRunner setIllegalAccessPermitForJDK16KotlinCompilerDaemonOptions(SmokeTestGradleRunner runner) {
         if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16)) {
             // https://youtrack.jetbrains.com/issue/KT-44266#focus=Comments-27-4639508.0-0
-            runner.withJvmArguments("-Dkotlin.daemon.jvm.options=" +
+            runner.withJvmArguments(EXTRA_MEMORY_JVM_ARGS + [
+                "-Dkotlin.daemon.jvm.options=" +
                 "--add-exports=java.base/sun.nio.ch=ALL-UNNAMED," +
-                "--add-opens=java.base/java.util=ALL-UNNAMED")
+                "--add-opens=java.base/java.util=ALL-UNNAMED"
+            ])
         }
         return runner
     }
@@ -150,7 +152,7 @@ class ThirdPartyGradleModuleMetadataSmokeTest extends AbstractSmokeTest {
             .withProjectDir(new File(testProjectDir, 'consumer'))
             .forwardOutput()
         if (JavaVersion.current().isJava9Compatible()) {
-            runner.withJvmArguments("--add-opens", "java.base/java.io=ALL-UNNAMED")
+            runner.withJvmArguments(EXTRA_MEMORY_JVM_ARGS + ["--add-opens", "java.base/java.io=ALL-UNNAMED"])
         }
         return runner.build()
     }


### PR DESCRIPTION
WIP: Don't throw away daemon defaults when the user adds their own args. 

Currently we're running into an issue where existing builds which use a lot of memory run into metaspace OOMs after this change since the defaults now bound the metaspace. Previously users would set the max heap size, which would wipe away the default upper bound on metaspace size. 

This PR is a rebased copy of: https://github.com/gradle/gradle/pull/20054
See the linked PR for more details