### PR TITLE
Remove the CACHE_MISS condition on m1 mac

### DIFF
--- a/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.cache-miss-monitor.gradle.kts
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.cache-miss-monitor.gradle.kts
@@ -61,10 +61,7 @@ fun Task.isCompileCacheMissMonitoredTask() = isMonitoredCompileTask() && !projec
 
 fun Project.isAsciidoctorCacheMissTask() = isMonitoredAsciidoctorTask() && !isExpectedAsciidoctorCacheMiss()
 
-fun Task.isMonitoredCompileTask() = (this is AbstractCompile || this.isClasspathManifest()) && !isKotlinJsIrLink() && !isOnM1Mac()
-
-// vendor is an input of GroovyCompile, so GroovyCompile on M1 mac is definitely a cache miss
-fun Task.isOnM1Mac() = OperatingSystem.current().isMacOsX && System.getProperty("os.arch") == "aarch64"
+fun Task.isMonitoredCompileTask() = (this is AbstractCompile || this.isClasspathManifest()) && !isKotlinJsIrLink() 
 
 fun Task.isClasspathManifest() = this.javaClass.simpleName.startsWith("ClasspathManifest")
 


### PR DESCRIPTION
Because we use same vendor on M1 mac now.
