### PR TITLE
Add a test fixture for Java toolchains

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/jvm/JavaToolchainFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/jvm/JavaToolchainFixture.groovy
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures.jvm
+
+import groovy.transform.SelfType
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.internal.jvm.Jvm
+import org.gradle.internal.jvm.inspection.JvmInstallationMetadata
+
+/**
+ * Introduces helper methods to write integration tests using Java toolchains.
+ */
+@SelfType(AbstractIntegrationSpec)
+trait JavaToolchainFixture {
+
+    /**
+     * Usage:
+     * <pre>
+     *     def jvm1 = Jvm.current()
+     *     def jvm2 = AvailableJavaHomes.getDifferentVersion(jvm1.javaVersion)
+     *
+     *     when:
+     *     withInstallations(jvm1, jvm2).run(":task")
+     * </pre>
+     */
+    AbstractIntegrationSpec withInstallations(Jvm jvm, Jvm... rest) {
+        def installationPaths = ([jvm] + rest.toList()).collect { it.javaHome.absolutePath }.join(",")
+        executer
+            .withArgument("-Porg.gradle.java.installations.paths=" + installationPaths)
+        this as AbstractIntegrationSpec
+    }
+
+    /**
+     * Usage:
+     * <pre>
+     *     def jdk1 = AvailableJavaHomes.getJvmInstallationMetadata(Jvm.current())
+     *     def jdk2 = AvailableJavaHomes.getJvmInstallationMetadata(AvailableJavaHomes.getDifferentVersion(jdk1.languageVersion))
+     *
+     *     when:
+     *     withInstallations(jdk1, jdk2).run(":task")
+     * </pre>
+     */
+    AbstractIntegrationSpec withInstallations(JvmInstallationMetadata jvmMetadata, JvmInstallationMetadata... rest) {
+        def installationPaths = ([jvmMetadata] + rest.toList()).collect { it.javaHome.toAbsolutePath().toString() }.join(",")
+        executer
+            .withArgument("-Porg.gradle.java.installations.paths=" + installationPaths)
+        this as AbstractIntegrationSpec
+    }
+}

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaExecToolchainIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaExecToolchainIntegrationTest.groovy
@@ -19,11 +19,12 @@ package org.gradle.api.tasks
 import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AvailableJavaHomes
+import org.gradle.integtests.fixtures.jvm.JavaToolchainFixture
 import org.gradle.internal.jvm.Jvm
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.internal.TextUtil
 
-class JavaExecToolchainIntegrationTest extends AbstractIntegrationSpec {
+class JavaExecToolchainIntegrationTest extends AbstractIntegrationSpec implements JavaToolchainFixture {
 
     def setup() {
         file("src/main/java/App.java") << """
@@ -227,12 +228,5 @@ class JavaExecToolchainIntegrationTest extends AbstractIntegrationSpec {
                 }
             }
         """
-    }
-
-    private withInstallations(Jvm... jvm) {
-        def installationPaths = jvm.collect { it.javaHome.absolutePath }.join(",")
-        executer
-            .withArgument("-Porg.gradle.java.installations.paths=" + installationPaths)
-        this
     }
 }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaExecToolchainIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaExecToolchainIntegrationTest.groovy
@@ -118,7 +118,7 @@ class JavaExecToolchainIntegrationTest extends AbstractIntegrationSpec implement
             configureExecutable(selectJdk(withExecutable))
         }
         if (withJavaExtension != null) {
-            configureJavaExtension(selectJdk(withJavaExtension))
+            configureJavaPluginToolchainVersion(selectJdk(withJavaExtension))
         }
 
         def targetJdk = selectJdk(target)
@@ -198,16 +198,6 @@ class JavaExecToolchainIntegrationTest extends AbstractIntegrationSpec implement
             task run(type: JavaExec) {
                 setJvmArgs(['-version'])
                 mainClass = 'None'
-            }
-        """
-    }
-
-    private TestFile configureJavaExtension(Jvm jdk) {
-        buildFile << """
-            java {
-                toolchain {
-                    languageVersion = JavaLanguageVersion.of(${jdk.javaVersion.majorVersion})
-                }
             }
         """
     }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.jvm.JavaToolchainBuildOperationsFixture
+import org.gradle.integtests.fixtures.jvm.JavaToolchainFixture
 import org.gradle.integtests.fixtures.versions.KotlinGradlePluginVersions
 import org.gradle.internal.jvm.Jvm
 import org.gradle.internal.jvm.inspection.JvmInstallationMetadata
@@ -29,7 +30,7 @@ import org.gradle.util.internal.TextUtil
 import org.gradle.util.internal.VersionNumber
 import spock.lang.Issue
 
-class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpec implements JavaToolchainBuildOperationsFixture {
+class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpec implements JavaToolchainFixture, JavaToolchainBuildOperationsFixture {
 
     static kgpLatestVersions = new KotlinGradlePluginVersions().latests.toList()
 
@@ -599,13 +600,6 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
                 }
             }
         """
-    }
-
-    private withInstallations(JvmInstallationMetadata... jdkMetadata) {
-        def installationPaths = jdkMetadata.collect { it.javaHome.toAbsolutePath().toString() }.join(",")
-        executer
-            .withArgument("-Porg.gradle.java.installations.paths=" + installationPaths)
-        this
     }
 
     private static String latestStableKotlinPluginVersion(String major) {

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
@@ -56,11 +56,11 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
             jdkMetadata = AvailableJavaHomes.getJvmInstallationMetadata(AvailableJavaHomes.differentJdk)
 
             if (configureToolchain == "with java plugin") {
-                configureToolchainViaJavaPlugin(jdkMetadata)
+                configureJavaPluginToolchainVersion(jdkMetadata)
             } else if (configureToolchain == "with per task") {
                 configureToolchainPerTask(jdkMetadata)
             } else if (configureToolchain == "with java plugin and per task") {
-                configureToolchainViaJavaPlugin(AvailableJavaHomes.getJvmInstallationMetadata(Jvm.current()))
+                configureJavaPluginToolchainVersion(AvailableJavaHomes.getJvmInstallationMetadata(Jvm.current()))
                 configureToolchainPerTask(jdkMetadata)
             } else {
                 throw new IllegalArgumentException("Unknown configureToolchain: " + configureToolchain)
@@ -357,7 +357,7 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
         def minJdk = [jdkMetadata1, jdkMetadata2].min { it.languageVersion }
         def maxJdk = [jdkMetadata1, jdkMetadata2].max { it.languageVersion }
 
-        configureToolchainViaJavaPlugin(minJdk)
+        configureJavaPluginToolchainVersion(minJdk)
 
         buildFile << """
             def javaExecutable = javaToolchains.launcherFor {
@@ -479,7 +479,7 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
 
         JvmInstallationMetadata jdkMetadata = AvailableJavaHomes.getJvmInstallationMetadata(AvailableJavaHomes.differentJdk)
 
-        configureToolchainViaJavaPlugin(jdkMetadata)
+        configureJavaPluginToolchainVersion(jdkMetadata)
 
         file("src/main/java/Foo.java") << """
             public class Foo extends Oops {}
@@ -500,7 +500,7 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
 
         JvmInstallationMetadata jdkMetadata = AvailableJavaHomes.getJvmInstallationMetadata(AvailableJavaHomes.differentJdk)
 
-        configureToolchainViaJavaPlugin(jdkMetadata)
+        configureJavaPluginToolchainVersion(jdkMetadata)
 
         file("src/test/java/FooTest.java") << """
             public class FooTest {
@@ -523,7 +523,7 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
 
         JvmInstallationMetadata jdkMetadata = AvailableJavaHomes.getJvmInstallationMetadata(AvailableJavaHomes.differentJdk)
 
-        configureToolchainViaJavaPlugin(jdkMetadata)
+        configureJavaPluginToolchainVersion(jdkMetadata)
 
         file("src/main/java/Foo.java") << """
             /**
@@ -586,16 +586,6 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
 
             javadoc {
                 javadocTool = javaToolchains.javadocToolFor {
-                    languageVersion = JavaLanguageVersion.of(${jdkMetadata.languageVersion.majorVersion})
-                }
-            }
-        """
-    }
-
-    private TestFile configureToolchainViaJavaPlugin(JvmInstallationMetadata jdkMetadata) {
-        buildFile << """
-            java {
-                toolchain {
                     languageVersion = JavaLanguageVersion.of(${jdkMetadata.languageVersion.majorVersion})
                 }
             }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileToolchainIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileToolchainIntegrationTest.groovy
@@ -134,7 +134,7 @@ class JavaCompileToolchainIntegrationTest extends AbstractIntegrationSpec implem
             configureForkOptionsExecutable(selectJdk(withExecutable))
         }
         if (withJavaExtension != null) {
-            configureJavaExtension(selectJdk(withJavaExtension))
+            configureJavaPluginToolchainVersion(selectJdk(withJavaExtension))
         }
 
         def targetJdk = selectJdk(target)
@@ -658,16 +658,6 @@ class JavaCompileToolchainIntegrationTest extends AbstractIntegrationSpec implem
         javaVersion             | deprecationMessage
         JavaVersion.VERSION_1_8 | "[deprecation] foo() in com.example.Foo has been deprecated"
         JavaVersion.current()   | "[deprecation] foo() in Foo has been deprecated"
-    }
-
-    private TestFile configureJavaExtension(Jvm jdk) {
-        buildFile << """
-            java {
-                toolchain {
-                    languageVersion = JavaLanguageVersion.of(${jdk.javaVersion.majorVersion})
-                }
-            }
-        """
     }
 
     private TestFile configureForkOptionsExecutable(Jvm jdk) {

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileToolchainIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileToolchainIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import org.gradle.integtests.fixtures.jvm.JavaToolchainFixture
 import org.gradle.internal.jvm.Jvm
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.internal.os.OperatingSystem
@@ -30,7 +31,7 @@ import spock.lang.Issue
 
 import static org.junit.Assume.assumeNotNull
 
-class JavaCompileToolchainIntegrationTest extends AbstractIntegrationSpec {
+class JavaCompileToolchainIntegrationTest extends AbstractIntegrationSpec implements JavaToolchainFixture {
 
     def setup() {
         file("src/main/java/Foo.java") << "public class Foo {}"
@@ -696,12 +697,4 @@ class JavaCompileToolchainIntegrationTest extends AbstractIntegrationSpec {
             }
         """
     }
-
-    private withInstallations(Jvm... jvm) {
-        def installationPaths = jvm.collect { it.javaHome.absolutePath }.join(",")
-        executer
-            .withArgument("-Porg.gradle.java.installations.paths=" + installationPaths)
-        this
-    }
-
 }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/javadoc/JavadocToolchainIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/javadoc/JavadocToolchainIntegrationTest.groovy
@@ -127,7 +127,7 @@ class JavadocToolchainIntegrationTest extends AbstractIntegrationSpec implements
             configureExecutable(selectJdk(withExecutable))
         }
         if (withJavaExtension != null) {
-            configureJavaExtension(selectJdk(withJavaExtension))
+            configureJavaPluginToolchainVersion(selectJdk(withJavaExtension))
         }
 
         def targetJdk = selectJdk(target)
@@ -206,16 +206,6 @@ class JavadocToolchainIntegrationTest extends AbstractIntegrationSpec implements
 
             javadoc {
                 options.jFlags("-version")
-            }
-        """
-    }
-
-    private TestFile configureJavaExtension(Jvm jdk) {
-        buildFile << """
-            java {
-                toolchain {
-                    languageVersion = JavaLanguageVersion.of(${jdk.javaVersion.majorVersion})
-                }
             }
         """
     }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/javadoc/JavadocToolchainIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/javadoc/JavadocToolchainIntegrationTest.groovy
@@ -18,11 +18,12 @@ package org.gradle.api.tasks.javadoc
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AvailableJavaHomes
+import org.gradle.integtests.fixtures.jvm.JavaToolchainFixture
 import org.gradle.internal.jvm.Jvm
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.internal.TextUtil
 
-class JavadocToolchainIntegrationTest extends AbstractIntegrationSpec {
+class JavadocToolchainIntegrationTest extends AbstractIntegrationSpec implements JavaToolchainFixture {
 
     def setup() {
         file("src/main/java/Lib.java") << """
@@ -235,11 +236,5 @@ class JavadocToolchainIntegrationTest extends AbstractIntegrationSpec {
                 }
             }
         """
-    }
-
-    private withInstallations(Jvm... jvm) {
-        def installationPaths = jvm.collect { it.javaHome.absolutePath }.join(",")
-        executer.withArgument("-Porg.gradle.java.installations.paths=" + installationPaths)
-        this
     }
 }

--- a/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainIntegrationTest.groovy
+++ b/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainIntegrationTest.groovy
@@ -19,10 +19,10 @@ package org.gradle.jvm.toolchain
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AvailableJavaHomes
+import org.gradle.integtests.fixtures.jvm.JavaToolchainFixture
 import org.gradle.internal.jvm.Jvm
-import org.gradle.internal.jvm.inspection.JvmInstallationMetadata
 
-class JavaToolchainIntegrationTest extends AbstractIntegrationSpec {
+class JavaToolchainIntegrationTest extends AbstractIntegrationSpec implements JavaToolchainFixture {
 
     def "fails when using an invalid toolchain spec when #description"() {
         buildScript """
@@ -159,12 +159,5 @@ class JavaToolchainIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         failure.assertHasCause("The value for property 'languageVersion' is final and cannot be changed any further")
-    }
-
-    private withInstallations(JvmInstallationMetadata... jdkMetadata) {
-        def installationPaths = jdkMetadata.collect { it.javaHome.toAbsolutePath().toString() }.join(",")
-        executer
-            .withArgument("-Porg.gradle.java.installations.paths=" + installationPaths)
-        this
     }
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaBasePluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaBasePluginIntegrationTest.groovy
@@ -19,10 +19,11 @@ package org.gradle.api.plugins
 import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AvailableJavaHomes
+import org.gradle.integtests.fixtures.jvm.JavaToolchainFixture
 import org.gradle.internal.jvm.Jvm
 import org.gradle.util.internal.TextUtil
 
-class JavaBasePluginIntegrationTest extends AbstractIntegrationSpec {
+class JavaBasePluginIntegrationTest extends AbstractIntegrationSpec implements JavaToolchainFixture {
 
     def "can define and build a source set with implementation dependencies"() {
         settingsFile << """
@@ -158,13 +159,6 @@ class JavaBasePluginIntegrationTest extends AbstractIntegrationSpec {
         null       | null        | null            | "9"        | "11"          | "9"                  | "9"
         null       | null        | null            | null       | "11"          | "11"                 | "11"
         null       | null        | null            | null       | null          | currentJavaVersion() | currentJavaVersion()
-    }
-
-    private withInstallations(Jvm... jvm) {
-        def installationPaths = jvm.collect { it.javaHome.absolutePath }.join(",")
-        executer
-            .withArgument("-Porg.gradle.java.installations.paths=" + installationPaths)
-        this
     }
 
     private static String currentJavaVersion() {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/AbstractToolchainGroovyCompileIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/AbstractToolchainGroovyCompileIntegrationTest.groovy
@@ -16,12 +16,13 @@
 
 package org.gradle.groovy.compile
 
+import org.gradle.integtests.fixtures.jvm.JavaToolchainFixture
 import org.gradle.internal.jvm.Jvm
 import org.gradle.testing.fixture.GroovyCoverage
 import org.junit.Assume
 
 
-abstract class AbstractToolchainGroovyCompileIntegrationTest extends ApiGroovyCompilerIntegrationSpec {
+abstract class AbstractToolchainGroovyCompileIntegrationTest extends ApiGroovyCompilerIntegrationSpec implements JavaToolchainFixture {
 
     Jvm jdk
 
@@ -31,7 +32,7 @@ abstract class AbstractToolchainGroovyCompileIntegrationTest extends ApiGroovyCo
         Assume.assumeTrue(GroovyCoverage.supportsJavaVersion(version, jdk.javaVersion))
 
         executer.beforeExecute {
-            withArgument("-Porg.gradle.java.installations.paths=${jdk.javaHome.absolutePath}")
+            withInstallations(jdk)
         }
     }
 
@@ -39,13 +40,7 @@ abstract class AbstractToolchainGroovyCompileIntegrationTest extends ApiGroovyCo
 
     @Override
     String compilerConfiguration() {
-        """
-            java {
-                toolchain {
-                    languageVersion = JavaLanguageVersion.of(${jdk.javaVersion.majorVersion})
-                }
-            }
-        """
+        javaPluginToolchainVersion(jdk)
     }
 
     @Override

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/AbstractToolchainZincScalaCompileIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/AbstractToolchainZincScalaCompileIntegrationTest.groovy
@@ -18,10 +18,11 @@ package org.gradle.scala.compile
 
 import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.ScalaCoverage
+import org.gradle.integtests.fixtures.jvm.JavaToolchainFixture
 import org.gradle.internal.jvm.Jvm
 import org.junit.Assume
 
-abstract class AbstractToolchainZincScalaCompileIntegrationTest extends BasicZincScalaCompilerIntegrationTest {
+abstract class AbstractToolchainZincScalaCompileIntegrationTest extends BasicZincScalaCompilerIntegrationTest implements JavaToolchainFixture {
 
     Jvm jdk
 
@@ -30,15 +31,10 @@ abstract class AbstractToolchainZincScalaCompileIntegrationTest extends BasicZin
         Assume.assumeNotNull(jdk)
         Assume.assumeTrue(ScalaCoverage.SCALA_VERSION_TO_MAX_JAVA_VERSION.getOrDefault(version, JavaVersion.VERSION_1_8).isCompatibleWith(jdk.javaVersion))
         executer.beforeExecute {
-            withArgument("-Porg.gradle.java.installations.paths=${jdk.javaHome.absolutePath}")
+            withInstallations(jdk)
         }
-        buildFile << """
-    java {
-        toolchain {
-            languageVersion = JavaLanguageVersion.of(${jdk.javaVersion.majorVersion})
-        }
-    }
-"""
+
+        configureJavaPluginToolchainVersion(jdk)
     }
 
     abstract Jvm computeJdkForTest()

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/UpToDateScalaCompileIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/UpToDateScalaCompileIntegrationTest.groovy
@@ -20,13 +20,13 @@ import org.gradle.api.plugins.scala.ScalaBasePlugin
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.integtests.fixtures.jvm.JavaToolchainBuildOperationsFixture
-import org.gradle.internal.jvm.inspection.JvmInstallationMetadata
+import org.gradle.integtests.fixtures.jvm.JavaToolchainFixture
 import org.gradle.util.Requires
 
 import static org.gradle.api.JavaVersion.VERSION_11
 import static org.gradle.api.JavaVersion.VERSION_1_8
 
-class UpToDateScalaCompileIntegrationTest extends AbstractIntegrationSpec implements JavaToolchainBuildOperationsFixture {
+class UpToDateScalaCompileIntegrationTest extends AbstractIntegrationSpec implements JavaToolchainFixture, JavaToolchainBuildOperationsFixture {
 
     def setup() {
         file('src/main/scala/Person.scala') << "class Person(name: String)"
@@ -211,12 +211,5 @@ class UpToDateScalaCompileIntegrationTest extends AbstractIntegrationSpec implem
         then:
         skipped ":compileScala"
         assertToolchainUsages(events, jdkMetadata, "JavaLauncher")
-    }
-
-    private withInstallations(JvmInstallationMetadata... jdkMetadata) {
-        def installationPaths = jdkMetadata.collect { it.javaHome.toAbsolutePath().toString() }.join(",")
-        executer
-            .withArgument("-Porg.gradle.java.installations.paths=" + installationPaths)
-        this
     }
 }

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/scaladoc/ScalaDocIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/scaladoc/ScalaDocIntegrationTest.groovy
@@ -20,17 +20,16 @@ import org.gradle.api.plugins.scala.ScalaPlugin
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
-import org.gradle.internal.jvm.inspection.JvmInstallationMetadata
+import org.gradle.integtests.fixtures.jvm.JavaToolchainFixture
 import org.gradle.scala.ScalaCompilationFixture
 
 import static org.gradle.api.JavaVersion.VERSION_11
 import static org.gradle.api.JavaVersion.VERSION_1_8
 
-class ScalaDocIntegrationTest extends AbstractIntegrationSpec implements DirectoryBuildCacheFixture {
+class ScalaDocIntegrationTest extends AbstractIntegrationSpec implements DirectoryBuildCacheFixture, JavaToolchainFixture {
 
     String scaladoc = ":${ScalaPlugin.SCALA_DOC_TASK_NAME}"
     ScalaCompilationFixture classes = new ScalaCompilationFixture(testDirectory)
-
 
     def "changing the Scala version makes Scaladoc out of date"() {
         classes.baseline()
@@ -218,12 +217,5 @@ scaladoc {
         withInstallations(jdk8, jdk11).run scaladoc, '-Pchanged', '--info'
         then:
         skipped scaladoc
-    }
-
-    private withInstallations(JvmInstallationMetadata... jdkMetadata) {
-        def installationPaths = jdkMetadata.collect { it.javaHome.toAbsolutePath().toString() }.join(",")
-        executer
-            .withArgument("-Porg.gradle.java.installations.paths=" + installationPaths)
-        this
     }
 }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskToolchainIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskToolchainIntegrationTest.groovy
@@ -94,7 +94,7 @@ class TestTaskToolchainIntegrationTest extends AbstractIntegrationSpec implement
             configureExecutable(selectJdk(withExecutable))
         }
         if (withJavaExtension != null) {
-            configureJavaExtension(selectJdk(withJavaExtension))
+            configureJavaPluginToolchainVersion(selectJdk(withJavaExtension))
         }
 
         def targetJdk = selectJdk(target)
@@ -203,16 +203,6 @@ class TestTaskToolchainIntegrationTest extends AbstractIntegrationSpec implement
             }
 
             test.dependsOn compileJava
-        """
-    }
-
-    private TestFile configureJavaExtension(Jvm jdk) {
-        buildFile << """
-            java {
-                toolchain {
-                    languageVersion = JavaLanguageVersion.of(${jdk.javaVersion.majorVersion})
-                }
-            }
         """
     }
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskToolchainIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskToolchainIntegrationTest.groovy
@@ -19,11 +19,12 @@ package org.gradle.testing
 import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AvailableJavaHomes
+import org.gradle.integtests.fixtures.jvm.JavaToolchainFixture
 import org.gradle.internal.jvm.Jvm
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.internal.TextUtil
 
-class TestTaskToolchainIntegrationTest extends AbstractIntegrationSpec {
+class TestTaskToolchainIntegrationTest extends AbstractIntegrationSpec implements JavaToolchainFixture {
 
     def setup() {
         file("src/test/java/ToolchainTest.java") << """
@@ -232,12 +233,4 @@ class TestTaskToolchainIntegrationTest extends AbstractIntegrationSpec {
             }
         """
     }
-
-    private withInstallations(Jvm... jvm) {
-        def installationPaths = jvm.collect { it.javaHome.absolutePath }.join(",")
-        executer
-            .withArgument("-Porg.gradle.java.installations.paths=" + installationPaths)
-        this
-    }
-
 }


### PR DESCRIPTION
Follow-up for #22108

Introducing a test fixture `JavaToolchainFixture` and extracting common toolchain-related test and build configuration logic there.