### PR TITLE
Do not resolve output properties early

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/ResolvingValue.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/ResolvingValue.java
@@ -22,7 +22,7 @@ import javax.annotation.Nullable;
 import java.util.function.Function;
 
 /**
- * A {@link PropertyValue} backed by a fixed value.
+ * A {@link PropertyValue} that is calculated form another.
  */
 public class ResolvingValue implements PropertyValue {
     private final PropertyValue delegate;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/ResolvingValue.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/ResolvingValue.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks;
+
+import org.gradle.api.internal.tasks.properties.PropertyValue;
+
+import javax.annotation.Nullable;
+import java.util.function.Function;
+
+/**
+ * A {@link PropertyValue} backed by a fixed value.
+ */
+public class ResolvingValue implements PropertyValue {
+    private final PropertyValue delegate;
+    private final Function<Object, Object> resolver;
+
+    public ResolvingValue(PropertyValue delegate, Function<Object, Object> resolver) {
+        this.delegate = delegate;
+        this.resolver = resolver;
+    }
+
+    @Override
+    public TaskDependencyContainer getTaskDependencies() {
+        return delegate.getTaskDependencies();
+    }
+
+    @Override
+    public void maybeFinalizeValue() {
+        delegate.maybeFinalizeValue();
+    }
+
+    @Nullable
+    @Override
+    public Object call() {
+        return resolver.apply(delegate.call());
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecution.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecution.java
@@ -48,12 +48,12 @@ import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.exceptions.Contextual;
 import org.gradle.internal.exceptions.DefaultMultiCauseException;
 import org.gradle.internal.exceptions.MultiCauseException;
+import org.gradle.internal.execution.InputFingerprinter;
 import org.gradle.internal.execution.OutputSnapshotter;
 import org.gradle.internal.execution.UnitOfWork;
 import org.gradle.internal.execution.WorkValidationContext;
 import org.gradle.internal.execution.caching.CachingDisabledReason;
 import org.gradle.internal.execution.caching.CachingState;
-import org.gradle.internal.execution.InputFingerprinter;
 import org.gradle.internal.execution.history.ExecutionHistoryStore;
 import org.gradle.internal.execution.history.OverlappingOutputs;
 import org.gradle.internal.execution.history.changes.InputChangesInternal;
@@ -334,17 +334,14 @@ public class TaskExecution implements UnitOfWork {
     public void visitOutputs(File workspace, OutputVisitor visitor) {
         TaskProperties taskProperties = context.getTaskProperties();
         for (OutputFilePropertySpec property : taskProperties.getOutputFileProperties()) {
-            File outputFile = property.getOutputFile();
-            if (outputFile != null) {
-                try {
-                    visitor.visitOutputProperty(
-                        property.getPropertyName(),
-                        property.getOutputType(),
-                        new OutputFileValueSupplier(outputFile, property.getPropertyFiles())
-                    );
-                } catch (OutputSnapshotter.OutputFileSnapshottingException e) {
-                    throw decorateSnapshottingException("output", property.getPropertyName(), e.getCause());
-                }
+            try {
+                visitor.visitOutputProperty(
+                    property.getPropertyName(),
+                    property.getOutputType(),
+                    OutputFileValueSupplier.fromSupplier(property::getOutputFile, property.getPropertyFiles())
+                );
+            } catch (OutputSnapshotter.OutputFileSnapshottingException e) {
+                throw decorateSnapshottingException("output", property.getPropertyName(), e.getCause());
             }
         }
         for (File localStateRoot : taskProperties.getLocalStateFiles()) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultTaskProperties.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultTaskProperties.java
@@ -21,7 +21,7 @@ import org.gradle.api.NonNullApi;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.file.FileCollectionFactory;
-import org.gradle.api.internal.tasks.StaticValue;
+import org.gradle.api.internal.tasks.ResolvingValue;
 import org.gradle.api.internal.tasks.TaskPropertyUtils;
 import org.gradle.api.internal.tasks.TaskValidationContext;
 import org.gradle.api.tasks.FileNormalizer;
@@ -222,7 +222,7 @@ public class DefaultTaskProperties implements TaskProperties {
         public void visitUnpackedOutputFileProperty(String propertyName, boolean optional, PropertyValue value, OutputFilePropertySpec spec) {
             taskPropertySpecs.add(new DefaultValidatingProperty(
                 propertyName,
-                new StaticValue(spec.getOutputFile()),
+                new ResolvingValue(value, delegate -> spec.getOutputFile()),
                 optional,
                 ValidationActions.outputValidationActionFor(spec))
             );

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/FileParameterUtils.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/FileParameterUtils.java
@@ -18,32 +18,18 @@ package org.gradle.api.internal.tasks.properties;
 
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Sets;
-import org.gradle.api.InvalidUserDataException;
-import org.gradle.api.file.FileSystemLocationProperty;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileCollectionInternal;
-import org.gradle.api.internal.file.FileCollectionStructureVisitor;
-import org.gradle.api.internal.file.FileTreeInternal;
-import org.gradle.api.internal.file.collections.FileSystemMirroringFileTree;
-import org.gradle.api.internal.tasks.PropertyFileCollection;
-import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.FileNormalizer;
 import org.gradle.api.tasks.PathSensitivity;
-import org.gradle.api.tasks.util.PatternSet;
-import org.gradle.internal.file.TreeType;
 import org.gradle.internal.fingerprint.AbsolutePathInputNormalizer;
 import org.gradle.internal.fingerprint.IgnoredPathInputNormalizer;
 import org.gradle.internal.fingerprint.NameOnlyInputNormalizer;
 import org.gradle.internal.fingerprint.RelativePathInputNormalizer;
-import org.gradle.util.internal.DeferredUtil;
 
 import javax.annotation.Nullable;
-import java.io.File;
 import java.util.Iterator;
-import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
 
 public class FileParameterUtils {
 
@@ -97,89 +83,5 @@ public class FileParameterUtils {
         return inputFilePropertyType == InputFilePropertyType.DIRECTORY
             ? fileCollection.getAsFileTree()
             : fileCollection;
-    }
-
-    /**
-     * Resolves the given output file property to individual property specs.
-     *
-     * Especially, values of type {@link Map} are resolved.
-     */
-    public static void resolveOutputFilePropertySpecs(
-        String ownerDisplayName,
-        String propertyName,
-        PropertyValue value,
-        OutputFilePropertyType filePropertyType,
-        FileCollectionFactory fileCollectionFactory,
-        boolean locationOnly,
-        Consumer<OutputFilePropertySpec> consumer
-    ) {
-        Object unpackedValue = value.call();
-        unpackedValue = DeferredUtil.unpackNestableDeferred(unpackedValue);
-        if (locationOnly && unpackedValue instanceof FileSystemLocationProperty) {
-            unpackedValue = ((FileSystemLocationProperty<?>) unpackedValue).getLocationOnly();
-        }
-        if (unpackedValue instanceof Provider) {
-            unpackedValue = ((Provider<?>) unpackedValue).getOrNull();
-        }
-        if (unpackedValue == null) {
-            return;
-        }
-        // From here on, we already unpacked providers, so we can fail if any of the file collections contains a provider which is not present.
-        if (filePropertyType == OutputFilePropertyType.DIRECTORIES || filePropertyType == OutputFilePropertyType.FILES) {
-            resolveCompositeOutputFilePropertySpecs(ownerDisplayName, propertyName, unpackedValue, filePropertyType.getOutputType(), fileCollectionFactory, consumer);
-        } else {
-            FileCollectionInternal outputFiles = fileCollectionFactory.resolving(unpackedValue);
-            DefaultCacheableOutputFilePropertySpec filePropertySpec = new DefaultCacheableOutputFilePropertySpec(propertyName, null, outputFiles, filePropertyType.getOutputType());
-            consumer.accept(filePropertySpec);
-        }
-    }
-
-    private static void resolveCompositeOutputFilePropertySpecs(final String ownerDisplayName, final String propertyName, Object unpackedValue, final TreeType outputType, FileCollectionFactory fileCollectionFactory, Consumer<OutputFilePropertySpec> consumer) {
-        if (unpackedValue instanceof Map) {
-            for (Map.Entry<?, ?> entry : ((Map<?, ?>) unpackedValue).entrySet()) {
-                Object key = entry.getKey();
-                if (key == null) {
-                    throw new IllegalArgumentException(String.format("Mapped output property '%s' has null key", propertyName));
-                }
-                String id = key.toString();
-                FileCollectionInternal outputFiles = fileCollectionFactory.resolving(entry.getValue());
-                consumer.accept(new DefaultCacheableOutputFilePropertySpec(propertyName, "." + id, outputFiles, outputType));
-            }
-        } else {
-            FileCollectionInternal outputFileCollection = fileCollectionFactory.resolving(unpackedValue);
-            AtomicInteger index = new AtomicInteger();
-            outputFileCollection.visitStructure(new FileCollectionStructureVisitor() {
-                @Override
-                public void visitCollection(FileCollectionInternal.Source source, Iterable<File> contents) {
-                    for (File content : contents) {
-                        FileCollectionInternal outputFiles = fileCollectionFactory.fixed(content);
-                        consumer.accept(new DefaultCacheableOutputFilePropertySpec(propertyName, "$" + index.incrementAndGet(), outputFiles, outputType));
-                    }
-                }
-
-                @Override
-                public void visitFileTreeBackedByFile(File file, FileTreeInternal fileTree, FileSystemMirroringFileTree sourceTree) {
-                    failOnInvalidOutputType(fileTree);
-                }
-
-                @Override
-                public void visitFileTree(File root, PatternSet patterns, FileTreeInternal fileTree) {
-                    // We could support an unfiltered DirectoryFileTree here as a cacheable root,
-                    // but because @OutputDirectory also doesn't support it we choose not to.
-                    consumer.accept(new DirectoryTreeOutputFilePropertySpec(
-                        propertyName + "$" + index.incrementAndGet(),
-                        new PropertyFileCollection(ownerDisplayName, propertyName, "output", fileTree),
-                        root
-                    ));
-                }
-            });
-        }
-    }
-
-    private static void failOnInvalidOutputType(FileTreeInternal fileTree) {
-        throw new InvalidUserDataException(String.format(
-            "Only files and directories can be registered as outputs (was: %s)",
-            fileTree
-        ));
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/OutputFilePropertySpec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/OutputFilePropertySpec.java
@@ -18,11 +18,9 @@ package org.gradle.api.internal.tasks.properties;
 
 import org.gradle.internal.file.TreeType;
 
-import javax.annotation.Nullable;
 import java.io.File;
 
 public interface OutputFilePropertySpec extends FilePropertySpec {
     TreeType getOutputType();
-    @Nullable
     File getOutputFile();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/OutputUnpacker.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/OutputUnpacker.java
@@ -16,8 +16,24 @@
 
 package org.gradle.api.internal.tasks.properties;
 
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.file.FileSystemLocationProperty;
 import org.gradle.api.internal.file.FileCollectionFactory;
+import org.gradle.api.internal.file.FileCollectionInternal;
+import org.gradle.api.internal.file.FileCollectionStructureVisitor;
+import org.gradle.api.internal.file.FileTreeInternal;
+import org.gradle.api.internal.file.collections.FileSystemMirroringFileTree;
+import org.gradle.api.internal.tasks.PropertyFileCollection;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.internal.MutableBoolean;
+import org.gradle.internal.file.TreeType;
+import org.gradle.util.internal.DeferredUtil;
+
+import java.io.File;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 
 public class OutputUnpacker extends PropertyVisitor.Adapter {
 
@@ -64,7 +80,7 @@ public class OutputUnpacker extends PropertyVisitor.Adapter {
         if (finalizeBeforeUnpacking) {
             value.maybeFinalizeValue();
         }
-        FileParameterUtils.resolveOutputFilePropertySpecs(ownerDisplayName, propertyName, value, filePropertyType, fileCollectionFactory, locationOnly, spec -> {
+        resolveOutputFilePropertySpecs(ownerDisplayName, propertyName, value, filePropertyType, fileCollectionFactory, locationOnly, spec -> {
             hasSpecs.set(true);
             unpackedOutputConsumer.visitUnpackedOutputFileProperty(propertyName, optional, value, spec);
         });
@@ -75,5 +91,89 @@ public class OutputUnpacker extends PropertyVisitor.Adapter {
 
     public boolean hasDeclaredOutputs() {
         return hasDeclaredOutputs;
+    }
+
+    /**
+     * Resolves the given output file property to individual property specs.
+     *
+     * Especially, values of type {@link Map} are resolved.
+     */
+    private static void resolveOutputFilePropertySpecs(
+        String ownerDisplayName,
+        String propertyName,
+        PropertyValue value,
+        OutputFilePropertyType filePropertyType,
+        FileCollectionFactory fileCollectionFactory,
+        boolean locationOnly,
+        Consumer<OutputFilePropertySpec> consumer
+    ) {
+        Object unpackedValue = value.call();
+        unpackedValue = DeferredUtil.unpackNestableDeferred(unpackedValue);
+        if (locationOnly && unpackedValue instanceof FileSystemLocationProperty) {
+            unpackedValue = ((FileSystemLocationProperty<?>) unpackedValue).getLocationOnly();
+        }
+        if (unpackedValue instanceof Provider) {
+            unpackedValue = ((Provider<?>) unpackedValue).getOrNull();
+        }
+        if (unpackedValue == null) {
+            return;
+        }
+        // From here on, we already unpacked providers, so we can fail if any of the file collections contains a provider which is not present.
+        if (filePropertyType == OutputFilePropertyType.DIRECTORIES || filePropertyType == OutputFilePropertyType.FILES) {
+            resolveCompositeOutputFilePropertySpecs(ownerDisplayName, propertyName, unpackedValue, filePropertyType.getOutputType(), fileCollectionFactory, consumer);
+        } else {
+            FileCollectionInternal outputFiles = fileCollectionFactory.resolving(unpackedValue);
+            DefaultCacheableOutputFilePropertySpec filePropertySpec = new DefaultCacheableOutputFilePropertySpec(propertyName, null, outputFiles, filePropertyType.getOutputType());
+            consumer.accept(filePropertySpec);
+        }
+    }
+
+    private static void resolveCompositeOutputFilePropertySpecs(final String ownerDisplayName, final String propertyName, Object unpackedValue, final TreeType outputType, FileCollectionFactory fileCollectionFactory, Consumer<OutputFilePropertySpec> consumer) {
+        if (unpackedValue instanceof Map) {
+            for (Map.Entry<?, ?> entry : ((Map<?, ?>) unpackedValue).entrySet()) {
+                Object key = entry.getKey();
+                if (key == null) {
+                    throw new IllegalArgumentException(String.format("Mapped output property '%s' has null key", propertyName));
+                }
+                String id = key.toString();
+                FileCollectionInternal outputFiles = fileCollectionFactory.resolving(entry.getValue());
+                consumer.accept(new DefaultCacheableOutputFilePropertySpec(propertyName, "." + id, outputFiles, outputType));
+            }
+        } else {
+            FileCollectionInternal outputFileCollection = fileCollectionFactory.resolving(unpackedValue);
+            AtomicInteger index = new AtomicInteger();
+            outputFileCollection.visitStructure(new FileCollectionStructureVisitor() {
+                @Override
+                public void visitCollection(FileCollectionInternal.Source source, Iterable<File> contents) {
+                    for (File content : contents) {
+                        FileCollectionInternal outputFiles = fileCollectionFactory.fixed(content);
+                        consumer.accept(new DefaultCacheableOutputFilePropertySpec(propertyName, "$" + index.incrementAndGet(), outputFiles, outputType));
+                    }
+                }
+
+                @Override
+                public void visitFileTreeBackedByFile(File file, FileTreeInternal fileTree, FileSystemMirroringFileTree sourceTree) {
+                    failOnInvalidOutputType(fileTree);
+                }
+
+                @Override
+                public void visitFileTree(File root, PatternSet patterns, FileTreeInternal fileTree) {
+                    // We could support an unfiltered DirectoryFileTree here as a cacheable root,
+                    // but because @OutputDirectory also doesn't support it we choose not to.
+                    consumer.accept(new DirectoryTreeOutputFilePropertySpec(
+                        propertyName + "$" + index.incrementAndGet(),
+                        new PropertyFileCollection(ownerDisplayName, propertyName, "output", fileTree),
+                        root
+                    ));
+                }
+            });
+        }
+    }
+
+    private static void failOnInvalidOutputType(FileTreeInternal fileTree) {
+        throw new InvalidUserDataException(String.format(
+            "Only files and directories can be registered as outputs (was: %s)",
+            fileTree
+        ));
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNode.java
@@ -168,9 +168,7 @@ public class LocalTaskNode extends TaskNode {
         final MutationInfo mutations = getMutationInfo();
         outputFilePropertySpecs.forEach(spec -> {
             File outputLocation = spec.getOutputFile();
-            if (outputLocation != null) {
-                mutations.outputPaths.add(outputLocation.getAbsolutePath());
-            }
+            mutations.outputPaths.add(outputLocation.getAbsolutePath());
             mutations.hasOutputs = true;
         });
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactory.java
@@ -397,9 +397,9 @@ public class DefaultTransformerInvocationFactory implements TransformerInvocatio
             File outputDir = getOutputDir(workspace);
             File resultsFile = getResultsFile(workspace);
             visitor.visitOutputProperty(OUTPUT_DIRECTORY_PROPERTY_NAME, DIRECTORY,
-                new OutputFileValueSupplier(outputDir, fileCollectionFactory.fixed(outputDir)));
+                OutputFileValueSupplier.fromStatic(outputDir, fileCollectionFactory.fixed(outputDir)));
             visitor.visitOutputProperty(RESULTS_FILE_PROPERTY_NAME, FILE,
-                new OutputFileValueSupplier(resultsFile, fileCollectionFactory.fixed(resultsFile)));
+                OutputFileValueSupplier.fromStatic(resultsFile, fileCollectionFactory.fixed(resultsFile)));
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/DefaultDependenciesAccessors.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/DefaultDependenciesAccessors.java
@@ -337,7 +337,7 @@ public class DefaultDependenciesAccessors implements DependenciesAccessors {
 
         private void visitOutputDir(OutputVisitor visitor, File workspace, String propertyName) {
             File dir = new File(workspace, propertyName);
-            visitor.visitOutputProperty(propertyName, TreeType.DIRECTORY, new OutputFileValueSupplier(dir, fileCollectionFactory.fixed(dir)));
+            visitor.visitOutputProperty(propertyName, TreeType.DIRECTORY, OutputFileValueSupplier.fromStatic(dir, fileCollectionFactory.fixed(dir)));
         }
     }
 

--- a/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/UnitOfWorkBuilder.groovy
+++ b/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/UnitOfWorkBuilder.groovy
@@ -224,7 +224,7 @@ class UnitOfWorkBuilder {
             @Override
             void visitOutputs(File workspace, UnitOfWork.OutputVisitor visitor) {
                 outputs.forEach { name, spec ->
-                    visitor.visitOutputProperty(name, spec.treeType, new UnitOfWork.OutputFileValueSupplier(spec.root, TestFiles.fixed(spec.root)))
+                    visitor.visitOutputProperty(name, spec.treeType, UnitOfWork.OutputFileValueSupplier.fromStatic(spec.root, TestFiles.fixed(spec.root)))
                 }
             }
 

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/UnitOfWork.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/UnitOfWork.java
@@ -321,20 +321,36 @@ public interface UnitOfWork extends Describable {
         }
     }
 
-    class OutputFileValueSupplier implements FileValueSupplier {
-        private final File root;
+    abstract class OutputFileValueSupplier implements FileValueSupplier {
         private final FileCollection files;
 
-        public OutputFileValueSupplier(File root, FileCollection files) {
-            this.root = root;
+        public OutputFileValueSupplier(FileCollection files) {
             this.files = files;
+        }
+
+        public static OutputFileValueSupplier fromStatic(File root, FileCollection fileCollection) {
+            return new OutputFileValueSupplier(fileCollection) {
+                @Nonnull
+                @Override
+                public File getValue() {
+                    return root;
+                }
+            };
+        }
+
+        public static OutputFileValueSupplier fromSupplier(Supplier<File> root, FileCollection fileCollection) {
+            return new OutputFileValueSupplier(fileCollection) {
+                @Nonnull
+                @Override
+                public File getValue() {
+                    return root.get();
+                }
+            };
         }
 
         @Nonnull
         @Override
-        public File getValue() {
-            return root;
-        }
+        abstract public File getValue();
 
         @Override
         public FileCollection getFiles() {

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/impl/DefaultOutputSnapshotterTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/impl/DefaultOutputSnapshotterTest.groovy
@@ -46,7 +46,7 @@ class DefaultOutputSnapshotterTest extends Specification {
 
         then:
         1 * work.visitOutputs(workspace, _ as UnitOfWork.OutputVisitor) >> { File workspace, UnitOfWork.OutputVisitor outputVisitor ->
-            outputVisitor.visitOutputProperty("output", TreeType.FILE, new UnitOfWork.OutputFileValueSupplier(root, contents))
+            outputVisitor.visitOutputProperty("output", TreeType.FILE, UnitOfWork.OutputFileValueSupplier.fromStatic(root, contents))
         }
         1 * fileCollectionSnapshotter.snapshot(contents) >> Stub(FileCollectionSnapshotter.Result) {
             snapshot >> outputSnapshot
@@ -65,7 +65,7 @@ class DefaultOutputSnapshotterTest extends Specification {
 
         then:
         1 * work.visitOutputs(workspace, _ as UnitOfWork.OutputVisitor) >> { File workspace, UnitOfWork.OutputVisitor outputVisitor ->
-            outputVisitor.visitOutputProperty("output", TreeType.FILE, new UnitOfWork.OutputFileValueSupplier(root, contents))
+            outputVisitor.visitOutputProperty("output", TreeType.FILE, UnitOfWork.OutputFileValueSupplier.fromStatic(root, contents))
         }
         1 * fileCollectionSnapshotter.snapshot(contents) >> { throw failure }
         0 * _

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CaptureStateAfterExecutionStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CaptureStateAfterExecutionStepTest.groovy
@@ -194,7 +194,7 @@ class CaptureStateAfterExecutionStepTest extends StepSpec<InputChangesContext> {
 
         then:
         _ * work.visitOutputs(_ as File, _ as UnitOfWork.OutputVisitor) >> { File workspace, UnitOfWork.OutputVisitor visitor ->
-            visitor.visitOutputProperty("output", TreeType.DIRECTORY, new UnitOfWork.OutputFileValueSupplier(outputDir, Mock(FileCollection)))
+            visitor.visitOutputProperty("output", TreeType.DIRECTORY, UnitOfWork.OutputFileValueSupplier.fromStatic(outputDir, Mock(FileCollection)))
             visitor.visitDestroyable(destroyableDir)
             visitor.visitLocalState(localStateDir)
         }

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CleanupStaleOutputsStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CleanupStaleOutputsStepTest.groovy
@@ -52,7 +52,7 @@ class CleanupStaleOutputsStepTest extends StepSpec<WorkspaceContext> {
 
         _ * work.shouldCleanupStaleOutputs() >> true
         _ * work.visitOutputs(_) { UnitOfWork.OutputVisitor visitor ->
-            visitor.visitOutputProperty("output", TreeType.FILE, new UnitOfWork.OutputFileValueSupplier(target, TestFiles.fixed(target)))
+            visitor.visitOutputProperty("output", TreeType.FILE, UnitOfWork.OutputFileValueSupplier.fromStatic(target, TestFiles.fixed(target)))
         }
 
         _ * cleanupRegistry.isOutputOwnedByBuild(target) >> ownedByBuild

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CreateOutputsStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CreateOutputsStepTest.groovy
@@ -35,8 +35,8 @@ class CreateOutputsStepTest extends StepSpec<ChangingOutputsContext> {
 
         then:
         _ * work.visitOutputs(_ as File, _ as UnitOfWork.OutputVisitor) >> { File workspace, UnitOfWork.OutputVisitor visitor ->
-            visitor.visitOutputProperty("dir", TreeType.DIRECTORY, new UnitOfWork.OutputFileValueSupplier(outputDir, TestFiles.fixed(outputDir)))
-            visitor.visitOutputProperty("file", TreeType.FILE, new UnitOfWork.OutputFileValueSupplier(outputFile, TestFiles.fixed(outputFile)))
+            visitor.visitOutputProperty("dir", TreeType.DIRECTORY, UnitOfWork.OutputFileValueSupplier.fromStatic(outputDir, TestFiles.fixed(outputDir)))
+            visitor.visitOutputProperty("file", TreeType.FILE, UnitOfWork.OutputFileValueSupplier.fromStatic(outputFile, TestFiles.fixed(outputFile)))
             visitor.visitLocalState(localStateFile)
             visitor.visitDestroyable(destroyableFile)
         }

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/RemovePreviousOutputsStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/RemovePreviousOutputsStepTest.groovy
@@ -180,8 +180,8 @@ class RemovePreviousOutputsStepTest extends StepSpec<ChangingOutputsContext> imp
         _ * context.beforeExecutionState >> Optional.of(beforeExecutionState)
         1 * beforeExecutionState.detectedOverlappingOutputs >> Optional.of(new OverlappingOutputs("test", "/absolute/path"))
         _ * work.visitOutputs(_, _) >> { File workspace, OutputVisitor visitor ->
-            visitor.visitOutputProperty("dir", TreeType.DIRECTORY, new UnitOfWork.OutputFileValueSupplier(outputs.dir, TestFiles.fixed(outputs.dir)))
-            visitor.visitOutputProperty("file", TreeType.FILE, new UnitOfWork.OutputFileValueSupplier(outputs.file, TestFiles.fixed(outputs.file)))
+            visitor.visitOutputProperty("dir", TreeType.DIRECTORY, UnitOfWork.OutputFileValueSupplier.fromStatic(outputs.dir, TestFiles.fixed(outputs.dir)))
+            visitor.visitOutputProperty("file", TreeType.FILE, UnitOfWork.OutputFileValueSupplier.fromStatic(outputs.file, TestFiles.fixed(outputs.file)))
         }
         _ * context.previousExecutionState >> Optional.of(previousExecutionState)
         1 * previousExecutionState.outputFilesProducedByWork >> ImmutableSortedMap.of("dir", outputs.dirSnapshot, "file", outputs.fileSnapshot)
@@ -195,8 +195,8 @@ class RemovePreviousOutputsStepTest extends StepSpec<ChangingOutputsContext> imp
         _ * context.beforeExecutionState >> Optional.of(beforeExecutionState)
         1 * beforeExecutionState.detectedOverlappingOutputs >> Optional.empty()
         _ * work.visitOutputs(_, _) >> { File workspace, OutputVisitor visitor ->
-            visitor.visitOutputProperty("dir", TreeType.DIRECTORY, new UnitOfWork.OutputFileValueSupplier(outputs.dir, TestFiles.fixed(outputs.dir)))
-            visitor.visitOutputProperty("file", TreeType.FILE, new UnitOfWork.OutputFileValueSupplier(outputs.file, TestFiles.fixed(outputs.file)))
+            visitor.visitOutputProperty("dir", TreeType.DIRECTORY, UnitOfWork.OutputFileValueSupplier.fromStatic(outputs.dir, TestFiles.fixed(outputs.dir)))
+            visitor.visitOutputProperty("file", TreeType.FILE, UnitOfWork.OutputFileValueSupplier.fromStatic(outputs.file, TestFiles.fixed(outputs.file)))
         }
     }
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
@@ -173,8 +173,8 @@ class GenerateProjectAccessors(
     override fun visitOutputs(workspace: File, visitor: UnitOfWork.OutputVisitor) {
         val sourcesOutputDir = getSourcesOutputDir(workspace)
         val classesOutputDir = getClassesOutputDir(workspace)
-        visitor.visitOutputProperty(SOURCES_OUTPUT_PROPERTY, DIRECTORY, OutputFileValueSupplier(sourcesOutputDir, fileCollectionFactory.fixed(sourcesOutputDir)))
-        visitor.visitOutputProperty(CLASSES_OUTPUT_PROPERTY, DIRECTORY, OutputFileValueSupplier(classesOutputDir, fileCollectionFactory.fixed(classesOutputDir)))
+        visitor.visitOutputProperty(SOURCES_OUTPUT_PROPERTY, DIRECTORY, OutputFileValueSupplier.fromStatic(sourcesOutputDir, fileCollectionFactory.fixed(sourcesOutputDir)))
+        visitor.visitOutputProperty(CLASSES_OUTPUT_PROPERTY, DIRECTORY, OutputFileValueSupplier.fromStatic(classesOutputDir, fileCollectionFactory.fixed(classesOutputDir)))
     }
 }
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsClassPath.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsClassPath.kt
@@ -27,10 +27,10 @@ import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.classpath.DefaultClassPath
 import org.gradle.internal.execution.ExecutionEngine
+import org.gradle.internal.execution.InputFingerprinter
 import org.gradle.internal.execution.UnitOfWork
 import org.gradle.internal.execution.UnitOfWork.InputVisitor
 import org.gradle.internal.execution.UnitOfWork.OutputFileValueSupplier
-import org.gradle.internal.execution.InputFingerprinter
 import org.gradle.internal.file.TreeType.DIRECTORY
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher
@@ -167,8 +167,8 @@ class GeneratePluginAccessors(
     override fun visitOutputs(workspace: File, visitor: UnitOfWork.OutputVisitor) {
         val sourcesOutputDir = getSourcesOutputDir(workspace)
         val classesOutputDir = getClassesOutputDir(workspace)
-        visitor.visitOutputProperty(SOURCES_OUTPUT_PROPERTY, DIRECTORY, OutputFileValueSupplier(sourcesOutputDir, fileCollectionFactory.fixed(sourcesOutputDir)))
-        visitor.visitOutputProperty(CLASSES_OUTPUT_PROPERTY, DIRECTORY, OutputFileValueSupplier(classesOutputDir, fileCollectionFactory.fixed(classesOutputDir)))
+        visitor.visitOutputProperty(SOURCES_OUTPUT_PROPERTY, DIRECTORY, OutputFileValueSupplier.fromStatic(sourcesOutputDir, fileCollectionFactory.fixed(sourcesOutputDir)))
+        visitor.visitOutputProperty(CLASSES_OUTPUT_PROPERTY, DIRECTORY, OutputFileValueSupplier.fromStatic(classesOutputDir, fileCollectionFactory.fixed(classesOutputDir)))
     }
 }
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptEvaluator.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptEvaluator.kt
@@ -32,10 +32,10 @@ import org.gradle.internal.classpath.CachedClasspathTransformer.StandardTransfor
 import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.classpath.DefaultClassPath
 import org.gradle.internal.execution.ExecutionEngine
+import org.gradle.internal.execution.InputFingerprinter
 import org.gradle.internal.execution.UnitOfWork
 import org.gradle.internal.execution.UnitOfWork.InputVisitor
 import org.gradle.internal.execution.UnitOfWork.OutputFileValueSupplier
-import org.gradle.internal.execution.InputFingerprinter
 import org.gradle.internal.file.TreeType
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint
 import org.gradle.internal.hash.HashCode
@@ -355,7 +355,7 @@ class CompileKotlinScript(
         visitor.visitOutputProperty(
             "classesDir",
             TreeType.DIRECTORY,
-            OutputFileValueSupplier(classesDir, fileCollectionFactory.fixed(classesDir))
+            OutputFileValueSupplier.fromStatic(classesDir, fileCollectionFactory.fixed(classesDir))
         )
     }
 


### PR DESCRIPTION
Doing this allows two things:

1) we can pass around `OutputFilePropertySpec` instances without having to actually call the method associated with getting the value,
2) we can keep the same `PropertyValue` instance alive, and thus it can be finalized once and kept in a finalized state, instead of recreating a new `StaticValue` every time. This also keeps the task dependencies.