### PR TITLE
Allow reseting test framework to same value after setting options

### DIFF
--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
@@ -51,6 +51,15 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
         init(initialValue, initialValue);
     }
 
+    /**
+     * A simple getter that checks if this property has been finalized.
+     *
+     * @return {@code true} if this property has been finalized, {@code false} otherwise
+     */
+    public boolean isFinalized() {
+        return state instanceof FinalizedValue;
+    }
+
     @Override
     public boolean calculatePresence(ValueConsumer consumer) {
         beforeRead(producer, consumer);

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultPropertyTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultPropertyTest.groovy
@@ -21,7 +21,7 @@ import org.gradle.api.provider.Provider
 import org.gradle.internal.state.ManagedFactory
 import org.gradle.util.TestUtil
 
-class DefaultPropertyTest extends PropertySpec<String> {
+class DefaultPropertyTest extends AbstractPropertySpec<String> {
     DefaultProperty<String> property() {
         return propertyWithDefaultValue(String)
     }

--- a/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/AbstractPropertySpec.groovy
+++ b/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/AbstractPropertySpec.groovy
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider
+
+abstract class AbstractPropertySpec<T> extends PropertySpec<T> {
+    @Override
+    AbstractProperty<T, ? extends ValueSupplier> providerWithValue(T value) {
+        return propertyWithNoValue().value(value)
+    }
+
+    @Override
+    AbstractProperty<T, ? extends ValueSupplier> providerWithNoValue() {
+        return propertyWithNoValue()
+    }
+
+    @Override
+    abstract AbstractProperty<T, ? extends ValueSupplier> propertyWithNoValue()
+
+    AbstractProperty<T, ? extends ValueSupplier> propertyWithValue(T value) {
+        return propertyWithNoValue().value(value)
+    }
+
+    def "finalization checking works empty providers"() {
+        given:
+        def property = propertyWithNoValue()
+
+        expect:
+        !property.isPresent()
+        !property.isFinalized()
+    }
+
+    def "finalization checking works with simple values"() {
+        given:
+        def property = propertyWithValue(someValue())
+
+        expect:
+        property.isPresent()
+        !property.isFinalized()
+
+        when:
+        property.set(someOtherValue())
+
+        then:
+        !property.isFinalized()
+
+        when:
+        property.finalizeValue()
+
+        then:
+        property.isFinalized()
+    }
+
+    def "finalization checking works with providers"() {
+        given:
+        def property = propertyWithValue(someValue())
+
+        expect:
+        property.isPresent()
+        !property.isFinalized()
+
+        when:
+        property.set(providerWithValue(someOtherValue()))
+
+        then:
+        !property.isFinalized()
+
+        when:
+        property.finalizeValue()
+
+        then:
+        property.isFinalized()
+    }
+
+    def "finalization checking works with conventions"() {
+        given:
+        def property = propertyWithNoValue()
+        property.convention(someValue())
+
+        expect:
+        property.isPresent()
+        !property.isFinalized()
+
+        when:
+        property.finalizeValue()
+
+        then:
+        property.isFinalized()
+    }
+
+    def "finalization checking works with finalizeOnRead and isPresent"() {
+        given:
+        def property = propertyWithValue(someValue())
+        property.finalizeValueOnRead()
+
+        when:
+        property.isPresent()
+
+        then:
+        property.isFinalized()
+    }
+
+    def "finalization checking works with finalizeOnRead and get"() {
+        given:
+        def property = propertyWithValue(someValue())
+        property.finalizeValueOnRead()
+
+        when:
+        property.get()
+
+        then:
+        property.isFinalized()
+    }
+}

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestOptionsIntegrationSpec.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestOptionsIntegrationSpec.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.testing
 
-import org.gradle.api.tasks.testing.junitplatform.JUnitPlatformOptions
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.HtmlTestExecutionResult
 
@@ -379,8 +378,26 @@ public class SomeIntegTestClass {
                includeTags 'fast'
            }
         }
-        
-        assert integTest.options instanceof JUnitPlatformOptions 
+
+        assert integTest.options instanceof JUnitPlatformOptions
+        """.stripMargin()
+
+        expect:
+        succeeds "help"
+    }
+
+    def "can set built-in test task to use the same framework it was using after setting options"() {
+        given:
+        buildFile << """
+        test {
+           useJUnit()
+           options {
+               includeCategories 'fast'
+           }
+           useJUnit()
+        }
+
+        assert test.options instanceof JUnitOptions
         """.stripMargin()
 
         expect:

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskIntegrationTest.groovy
@@ -313,7 +313,7 @@ class TestTaskIntegrationTest extends JUnitMultiVersionIntegrationSpec {
         ignoreWhenJUnitPlatform()
 
         given:
-        testDirectory.file('src/test/java/MyTest.java') << junitJupiterStandaloneTestClass()
+        file('src/test/java/MyTest.java') << junitJupiterStandaloneTestClass()
 
         settingsFile << "rootProject.name = 'Sample'"
         buildFile << """apply plugin: 'java'

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskIntegrationTest.groovy
@@ -282,6 +282,35 @@ class TestTaskIntegrationTest extends JUnitMultiVersionIntegrationSpec {
         extraArgs << [[], ["--tests", "MyTest"]]
     }
 
+    def "test framework can be set to the same value (#frameworkName) twice"() {
+        ignoreWhenJUnitPlatform()
+
+        given:
+        file('src/test/java/MyTest.java') << (frameworkName == "JUnit" ? standaloneTestClass() : junitJupiterStandaloneTestClass())
+
+        settingsFile << "rootProject.name = 'Sample'"
+        buildFile << """apply plugin: 'java'
+
+            ${mavenCentralRepository()}
+            dependencies {
+                testImplementation $frameworkDeps
+            }
+
+            test {
+                $useMethod
+                $useMethod
+            }
+        """.stripIndent()
+
+        expect:
+        succeeds("test")
+
+        where:
+        frameworkName       | useMethod                 | frameworkDeps
+        "JUnit"             | "useJUnit()"              | "'junit:junit:${JUnitCoverage.NEWEST}'"
+        "JUnit Platform"    | "useJUnitPlatform()"      | "'org.junit.jupiter:junit-jupiter:${JUnitCoverage.LATEST_JUPITER_VERSION}'"
+    }
+
     def "options can be set prior to setting same test framework for the default test task"() {
         ignoreWhenJUnitPlatform()
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskIntegrationTest.groovy
@@ -282,11 +282,12 @@ class TestTaskIntegrationTest extends JUnitMultiVersionIntegrationSpec {
         extraArgs << [[], ["--tests", "MyTest"]]
     }
 
-    def "options cannot be set prior to setting same test framework"() {
+    def "options can be set prior to setting same test framework for the default test task"() {
         ignoreWhenJUnitPlatform()
 
         given:
         file('src/test/java/MyTest.java') << standaloneTestClass()
+        file("src/test/java/Slow.java") << """public interface Slow {}"""
 
         settingsFile << "rootProject.name = 'Sample'"
         buildFile << """apply plugin: 'java'
@@ -305,15 +306,14 @@ class TestTaskIntegrationTest extends JUnitMultiVersionIntegrationSpec {
         """.stripIndent()
 
         expect:
-        fails("test")
-        failure.assertHasCause("The value for task ':test' property 'testFrameworkProperty' is final and cannot be changed any further.")
+        succeeds("test")
     }
 
     def "options cannot be set prior to changing test framework for the default test task"() {
         ignoreWhenJUnitPlatform()
 
         given:
-        file('src/test/java/MyTest.java') << junitJupiterStandaloneTestClass()
+        testDirectory.file('src/test/java/MyTest.java') << junitJupiterStandaloneTestClass()
 
         settingsFile << "rootProject.name = 'Sample'"
         buildFile << """apply plugin: 'java'
@@ -337,6 +337,33 @@ class TestTaskIntegrationTest extends JUnitMultiVersionIntegrationSpec {
         expect:
         fails("test")
         failure.assertHasCause("The value for task ':test' property 'testFrameworkProperty' is final and cannot be changed any further.")
+    }
+
+    def "options can be set prior to setting same test framework for a custom test task"() {
+        ignoreWhenJUnitPlatform()
+
+        given:
+        file('src/test/java/MyTest.java') << standaloneTestClass()
+        file("src/test/java/Slow.java") << """public interface Slow {}"""
+
+        settingsFile << "rootProject.name = 'Sample'"
+        buildFile << """apply plugin: 'java'
+
+            ${mavenCentralRepository()}
+            dependencies {
+                testImplementation 'junit:junit:${JUnitCoverage.NEWEST}'
+            }
+
+            tasks.create('customTest', Test) {
+                options {
+                    excludeCategories = ["Slow"]
+                }
+                useJUnit()
+            }
+        """.stripIndent()
+
+        expect:
+        succeeds("customTest")
     }
 
     def "options cannot be set prior to changing test framework for a custom test task"() {

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -30,6 +30,7 @@ import org.gradle.api.file.FileTree;
 import org.gradle.api.file.FileTreeElement;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.classpath.ModuleRegistry;
+import org.gradle.api.internal.provider.DefaultProperty;
 import org.gradle.api.internal.tasks.testing.JvmTestExecutionSpec;
 import org.gradle.api.internal.tasks.testing.TestExecutableUtils;
 import org.gradle.api.internal.tasks.testing.TestExecuter;
@@ -1048,6 +1049,17 @@ public abstract class Test extends AbstractTestTask implements JavaForkOptions, 
     }
 
     void useTestFramework(TestFramework testFramework) {
+        if (((DefaultProperty<?>) this.testFramework).isFinalized()) {
+            Class<?> currentFramework = testFramework.getClass();
+            Class<?> newFramework = this.testFramework.get().getClass();
+            if (currentFramework == newFramework) {
+                // We are setting a finalized framework to its existing value, no-op so as not to trigger a failure here.
+                // We need to allow this especially for the default test task, so that existing builds that configure options and
+                // then call useJunit() afterwards don't fail
+                return;
+            }
+        }
+
         this.testFramework.set(testFramework);
     }
 

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -1050,8 +1050,8 @@ public abstract class Test extends AbstractTestTask implements JavaForkOptions, 
 
     void useTestFramework(TestFramework testFramework) {
         if (((DefaultProperty<?>) this.testFramework).isFinalized()) {
-            Class<?> currentFramework = testFramework.getClass();
-            Class<?> newFramework = this.testFramework.get().getClass();
+            Class<?> currentFramework = this.testFramework.get().getClass();
+            Class<?> newFramework = testFramework.getClass();
             if (currentFramework == newFramework) {
                 // We are setting a finalized framework to its existing value, no-op so as not to trigger a failure here.
                 // We need to allow this especially for the default test task, so that existing builds that configure options and


### PR DESCRIPTION
Prior to blocking a call to set the test framework on a Test task, check if the value is already finalized to the value and if so; allow it.

Needed to fix an Android Studio issues using Gradle 8.0 milestone 3.

- This also adds a isFinalized method to AbstractProperty to support this use case.
- Also expand and adjust some tests to now pass, and explicitly test the built-in test task and custom Test tasks outside of Test Suites.
