### PR TITLE
Handle repository names invalid as identities

### DIFF
--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishHttpIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishHttpIntegTest.groovy
@@ -218,7 +218,7 @@ class MavenPublishHttpIntegTest extends AbstractMavenPublishIntegTest {
         given:
         redirectServer.start()
 
-        buildFile.text = publicationBuild(version, group, new URI("${redirectServer.uri}/repo"), "credentials(PasswordCredentials)")
+        buildFile.text = publicationBuild(version, group, new URI("${redirectServer.uri}/repo"))
         PasswordCredentials credentials = new DefaultPasswordCredentials('username', 'password')
         configureRepositoryCredentials(credentials.username, credentials.password)
 
@@ -310,7 +310,7 @@ class MavenPublishHttpIntegTest extends AbstractMavenPublishIntegTest {
 
     def "can publish to authenticated repository using credentials Provider with inferred identity"() {
         given:
-        buildFile << publicationBuild(version, group, mavenRemoteRepo.uri, "credentials(PasswordCredentials)")
+        buildFile << publicationBuild(version, group, mavenRemoteRepo.uri)
         server.authenticationScheme = AuthScheme.BASIC
         PasswordCredentials credentials = new DefaultPasswordCredentials('username', 'password')
         expectPublishModuleWithCredentials(module, credentials)
@@ -322,16 +322,56 @@ class MavenPublishHttpIntegTest extends AbstractMavenPublishIntegTest {
         succeeds 'publish'
     }
 
-    @UnsupportedWithConfigurationCache
+    /**
+     * @see org.gradle.configurationcache.ConfigurationCachePublishingIntegrationTest
+     */
+    @UnsupportedWithConfigurationCache(because="Unsafe/inline credentials not supported with CC")
+    def "cannot publish to authenticated repository using credentials Provider with inferred identity if repo has incompatible name"() {
+        given:
+        buildFile << publicationBuild(version, group, mavenRemoteRepo.uri, "incompatible_repo_name")
+        server.authenticationScheme = AuthScheme.BASIC
+
+        when:
+        fails 'publish'
+
+        then:
+        failure.assertHasDescription("Execution failed for task ':publishMavenPublicationToIncompatible_repo_nameRepository'.")
+        failure.assertHasCause("Identity may contain only letters and digits, received: incompatible_repo_name")
+    }
+
+    @UnsupportedWithConfigurationCache(because="Unsafe/inline credentials not supported with CC")
     def "can publish to authenticated repository using inlined credentials"() {
         given:
         PasswordCredentials credentials = new DefaultPasswordCredentials('username', 'password')
-        buildFile << publicationBuild(version, group, mavenRemoteRepo.uri, """
+        buildFile << publicationBuild(version, group, mavenRemoteRepo.uri, "mavenRepo","""
             credentials {
                 username '${credentials.username}'
                 password '${credentials.password}'
             }
         """)
+        server.authenticationScheme = AuthScheme.BASIC
+        expectPublishModuleWithCredentials(module, credentials)
+
+        when:
+        succeeds 'publish'
+
+        then:
+        module.assertPublishedAsJavaModule()
+    }
+
+    @UnsupportedWithConfigurationCache(because="Unsafe/inline credentials not supported with CC")
+    def "can publish to authenticated repository with name not valid as identity as long as one uses inlined credentials "() {
+        given:
+        PasswordCredentials credentials = new DefaultPasswordCredentials('username', 'password')
+
+        def repositoryName = "maven-repo-invalid-as-identity"
+        buildFile << publicationBuild(version, group, mavenRemoteRepo.uri, repositoryName,"""
+            credentials {
+                username '${credentials.username}'
+                password '${credentials.password}'
+            }
+        """)
+
         server.authenticationScheme = AuthScheme.BASIC
         expectPublishModuleWithCredentials(module, credentials)
 
@@ -385,14 +425,14 @@ class MavenPublishHttpIntegTest extends AbstractMavenPublishIntegTest {
     }
 
     private static String publicationBuildWithoutCredentials(String version, String group, URI uri) {
-        return publicationBuild(version, group, uri, '')
+        return publicationBuild(version, group, uri, "maven", '')
     }
 
     private static String publicationBuildWithCredentialsProvider(String version, String group, URI uri, Class<? extends Credentials> credentialsType = PasswordCredentials.class) {
-        return publicationBuild(version, group, uri, "credentials(${credentialsType.simpleName})")
+        return publicationBuild(version, group, uri, "maven", "credentials(${credentialsType.simpleName})")
     }
 
-    private static String publicationBuild(String version, String group, URI uri, String credentialsBlock) {
+    private static String publicationBuild(String version, String group, URI uri, String repoName = "maven", String credentialsBlock = "credentials(PasswordCredentials)") {
         return """
             plugins {
                 id 'java'
@@ -404,6 +444,7 @@ class MavenPublishHttpIntegTest extends AbstractMavenPublishIntegTest {
             publishing {
                 repositories {
                     maven {
+                        name "$repoName"
                         url "$uri"
                         ${credentialsBlock}
                     }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/PublishToMavenRepository.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/PublishToMavenRepository.java
@@ -133,7 +133,14 @@ public class PublishToMavenRepository extends AbstractPublishToMaven {
         ProviderFactory providerFactory = getServices().get(ProviderFactory.class);
         Credentials referenceCredentials;
         try {
-            Provider<? extends Credentials> credentialsProvider = providerFactory.credentials(toCheck.getClass(), identity);
+            Provider<? extends Credentials> credentialsProvider;
+            try {
+                credentialsProvider = providerFactory.credentials(toCheck.getClass(), identity);
+            } catch (IllegalArgumentException e) {
+                // some possibilities are invalid repository names and invalid credential types
+                // either way, this is not the place to validate that
+                return false;
+            }
             referenceCredentials = credentialsProvider.get();
         } catch (MissingValueException e) {
             return false;


### PR DESCRIPTION
For credentials provided using credential providers, the repository name is used as the identity of the provider. Credential provider identities must be made exclusively of letters and digits. So, when using credential providers with repositories, the repository name must also be valid provider identity.

However, for inlined/unsafe credentials, since providers are not used, we should not impose such limitations.

Issue: #22582

The only change to production code is here: https://github.com/gradle/gradle/pull/22603/files#diff-fd396a32e765394411385b16ada52bcfd99d3dedea41216a77d9500da458d1acR136