### PR TITLE
Deprecate UsageContext

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/component/ComponentWithVariants.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/component/ComponentWithVariants.java
@@ -18,6 +18,32 @@ package org.gradle.api.component;
 
 import java.util.Set;
 
+// getVariants() returns a list of child components.
+// This should be called something more like ComponentWithChildren.
+//
+// When publishing GMM, we will publish all variants of all child components as a "RemoteVariant"
+// RemoteVariants are "available-at" variants.
+
+// Presumably this is so you can have different dependencies for different variants,
+// and publish them to different maven coordinates, while also having a parent component
+// which can reference back to them.
+
+/*
+
+If I had a component C with variants A and B, each with different artifacts, I cannot publish this to a maven repository.
+Maven can use scopes to have different dependencies at compile vs runtime, but runtime and compile time must share an artifact.
+To publish a component with different variants/artifacts, we spread our multi-variant component over many Maven components.
+In a way, each Maven component is acting like a variant. It has an artifact and a dependency set. It also has coordinates -- something a variant does not have.
+
+Kotlin MPP must use this to publish binaries from each target.
+
+Kotlin needs an API to publish components with multiple
+
+
+
+ */
+
+
 /**
  * Represents a {@link SoftwareComponent} that provides one or more mutually exclusive children, or variants.
  *

--- a/subprojects/core-api/src/main/java/org/gradle/api/component/ComponentWithVariants.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/component/ComponentWithVariants.java
@@ -21,7 +21,7 @@ import java.util.Set;
 // getVariants() returns a list of child components.
 // This should be called something more like ComponentWithChildren.
 //
-// When publishing GMM, we will publish all variants of all child components as a "RemoteVariant"
+// When publishing GMM, we will publish all variants of all child components each as a "RemoteVariant"
 // RemoteVariants are "available-at" variants.
 
 // Presumably this is so you can have different dependencies for different variants,
@@ -37,7 +37,7 @@ In a way, each Maven component is acting like a variant. It has an artifact and 
 
 Kotlin MPP must use this to publish binaries from each target.
 
-Kotlin needs an API to publish components with multiple
+Users need an API to publish components with multiple different targets or artifacts.
 
 
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/component/AbstractSoftwareComponentVariant.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/component/AbstractSoftwareComponentVariant.java
@@ -13,20 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.api.plugins.internal;
+package org.gradle.api.internal.component;
 
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.component.SoftwareComponentVariant;
-import org.gradle.api.internal.attributes.ImmutableAttributes;
 
 import java.util.Set;
 
 public abstract class AbstractSoftwareComponentVariant implements SoftwareComponentVariant {
-    private final ImmutableAttributes attributes;
-    private final Set<PublishArtifact> artifacts;
+    private final AttributeContainer attributes;
+    private final Set<? extends PublishArtifact> artifacts;
 
-    public AbstractSoftwareComponentVariant(ImmutableAttributes attributes, Set<PublishArtifact> artifacts) {
+    public AbstractSoftwareComponentVariant(AttributeContainer attributes, Set<? extends PublishArtifact> artifacts) {
         this.attributes = attributes;
         this.artifacts = artifacts;
     }
@@ -37,7 +36,7 @@ public abstract class AbstractSoftwareComponentVariant implements SoftwareCompon
     }
 
     @Override
-    public Set<PublishArtifact> getArtifacts() {
+    public Set<? extends PublishArtifact> getArtifacts() {
         return artifacts;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/component/DefaultSoftwareComponentPublications.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/component/DefaultSoftwareComponentPublications.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,25 +16,23 @@
 
 package org.gradle.api.internal.component;
 
-import org.gradle.api.attributes.Usage;
 import org.gradle.api.component.SoftwareComponentVariant;
 
-/**
- * Currently used by the Kotlin multiplatform plugins.
- *
- * @deprecated Use {@link SoftwareComponentVariant}. This class is scheduled for removal in Gradle 9.0.
- */
-@Deprecated
-public interface UsageContext extends SoftwareComponentVariant {
+import java.util.Set;
 
-    /**
-     * Currently used by the Kotlin multiplatform plugins.
-     *
-     * @deprecated This class is scheduled for removal in Gradle 9.0.
-     */
-    @Deprecated
-    default Usage getUsage(){
-        throw new UnsupportedOperationException("This method has been deprecated, should never be called");
+/**
+ * Default implementation of {@link SoftwareComponentPublications}.
+ */
+public class DefaultSoftwareComponentPublications implements SoftwareComponentPublications {
+
+    private final Set<? extends SoftwareComponentVariant> variants;
+
+    public DefaultSoftwareComponentPublications(Set<? extends SoftwareComponentVariant> variants) {
+        this.variants = variants;
     }
 
+    @Override
+    public Set<? extends SoftwareComponentVariant> getVariants() {
+        return variants;
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/component/DefaultSoftwareComponentVariant.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/component/DefaultSoftwareComponentVariant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,51 +14,49 @@
  * limitations under the License.
  */
 
-package org.gradle.language.cpp.internal;
+package org.gradle.api.internal.component;
 
-import org.gradle.api.Named;
-import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.DependencyConstraint;
 import org.gradle.api.artifacts.ExcludeRule;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.capabilities.Capability;
-import org.gradle.api.component.SoftwareComponentVariant;
-import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
-import org.gradle.api.plugins.internal.AbstractSoftwareComponentVariant;
-import org.gradle.internal.Cast;
 
 import java.util.Collections;
 import java.util.Set;
 
-public class DefaultSoftwareComponentVariant extends AbstractSoftwareComponentVariant implements Named {
+public class DefaultSoftwareComponentVariant extends AbstractSoftwareComponentVariant {
     private final String name;
     private final Set<? extends ModuleDependency> dependencies;
     private final Set<? extends DependencyConstraint> dependencyConstraints;
+    private final Set<? extends Capability> capabilities;
     private final Set<ExcludeRule> globalExcludes;
 
-    public DefaultSoftwareComponentVariant(SoftwareComponentVariant base, Set<? extends PublishArtifact> artifacts, Configuration configuration) {
-        this(base.getName(), base.getAttributes(), artifacts, configuration);
-    }
-
     public DefaultSoftwareComponentVariant(String name, AttributeContainer attributes) {
-        this(name, attributes, null, null);
+        this(name, attributes, Collections.emptySet());
     }
 
-    public DefaultSoftwareComponentVariant(String name, AttributeContainer attributes, Set<? extends PublishArtifact> artifacts, Configuration configuration) {
-        super(((AttributeContainerInternal)attributes).asImmutable(), Cast.uncheckedCast(artifacts));
+    public DefaultSoftwareComponentVariant(String name, AttributeContainer attributes, Set<? extends PublishArtifact> artifacts) {
+        this(name, attributes, artifacts, Collections.emptySet(), Collections.emptySet(), Collections.emptySet(), Collections.emptySet());
+    }
+
+    public DefaultSoftwareComponentVariant(
+        String name,
+        AttributeContainer attributes,
+        Set<? extends PublishArtifact> artifacts,
+        Set<? extends ModuleDependency> dependencies,
+        Set<? extends DependencyConstraint> dependencyConstraints,
+        Set<? extends Capability> capabilities,
+        Set<ExcludeRule> globalExcludes
+    ) {
+        super(((AttributeContainerInternal)attributes).asImmutable(), artifacts);
         this.name = name;
-        if (configuration != null) {
-            this.dependencies = configuration.getAllDependencies().withType(ModuleDependency.class);
-            this.dependencyConstraints = configuration.getAllDependencyConstraints();
-            this.globalExcludes = ((ConfigurationInternal) configuration).getAllExcludeRules();
-        } else {
-            this.dependencies = null;
-            this.dependencyConstraints = null;
-            this.globalExcludes = Collections.emptySet();
-        }
+        this.dependencies = dependencies;
+        this.dependencyConstraints = dependencyConstraints;
+        this.capabilities = capabilities;
+        this.globalExcludes = globalExcludes;
     }
 
     @Override
@@ -80,7 +78,7 @@ public class DefaultSoftwareComponentVariant extends AbstractSoftwareComponentVa
 
     @Override
     public Set<? extends Capability> getCapabilities() {
-        return Collections.emptySet();
+        return capabilities;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/component/DelegatingSoftwareComponentVariant.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/component/DelegatingSoftwareComponentVariant.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.component;
+
+import org.gradle.api.artifacts.DependencyConstraint;
+import org.gradle.api.artifacts.ExcludeRule;
+import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.artifacts.PublishArtifact;
+import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.capabilities.Capability;
+import org.gradle.api.component.SoftwareComponentVariant;
+
+import java.util.Set;
+
+/**
+ * A {@link SoftwareComponentVariant} which delegates all methods to a provided delegate instance.
+ */
+public abstract class DelegatingSoftwareComponentVariant implements SoftwareComponentVariant {
+
+    private final SoftwareComponentVariant delegate;
+
+    public DelegatingSoftwareComponentVariant(SoftwareComponentVariant delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public String getName() {
+        return delegate.getName();
+    }
+
+    @Override
+    public AttributeContainer getAttributes() {
+        return delegate.getAttributes();
+    }
+
+    @Override
+    public Set<? extends PublishArtifact> getArtifacts() {
+        return delegate.getArtifacts();
+    }
+
+    @Override
+    public Set<? extends ModuleDependency> getDependencies() {
+        return delegate.getDependencies();
+    }
+
+    @Override
+    public Set<? extends DependencyConstraint> getDependencyConstraints() {
+        return delegate.getDependencyConstraints();
+    }
+
+    @Override
+    public Set<? extends Capability> getCapabilities() {
+        return delegate.getCapabilities();
+    }
+
+    @Override
+    public Set<ExcludeRule> getGlobalExcludes() {
+        return delegate.getGlobalExcludes();
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/component/IvyPublishingAwareVariant.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/component/IvyPublishingAwareVariant.java
@@ -13,23 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.gradle.api.internal.component;
 
-public interface MavenPublishingAwareContext extends UsageContext {
-    ScopeMapping getScopeMapping();
+import org.gradle.api.component.SoftwareComponentVariant;
 
-    // Order is important!
-    enum ScopeMapping {
-        compile,
-        runtime,
-        compile_optional,
-        runtime_optional;
+public interface IvyPublishingAwareVariant extends SoftwareComponentVariant {
 
-        public static ScopeMapping of(String scope, boolean optional) {
-            if (optional) {
-                scope += "_optional";
-            }
-            return ScopeMapping.valueOf(scope);
-        }
-    }
+    boolean isOptional();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/component/MavenPublishingAwareVariant.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/component/MavenPublishingAwareVariant.java
@@ -13,10 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.gradle.api.internal.component;
 
-public interface IvyPublishingAwareContext extends UsageContext {
+import org.gradle.api.component.SoftwareComponentVariant;
 
-    boolean isOptional();
+public interface MavenPublishingAwareVariant extends SoftwareComponentVariant {
+    ScopeMapping getScopeMapping();
+
+    // Order is important!
+    enum ScopeMapping {
+        compile,
+        runtime,
+        compile_optional,
+        runtime_optional;
+
+        public static ScopeMapping of(String scope, boolean optional) {
+            if (optional) {
+                scope += "_optional";
+            }
+            return ScopeMapping.valueOf(scope);
+        }
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/component/SoftwareComponentInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/component/SoftwareComponentInternal.java
@@ -29,24 +29,19 @@ import java.util.stream.Collectors;
  */
 public interface SoftwareComponentInternal extends SoftwareComponent {
 
-    // TODO: Should we name this `getVariants`? `ComponentWithVariants` already defines a `getVariants` which
-    // returns a different type. There are existing classes (internally and in KGP) which implement both this class and
-    // `ComponentWithVariants`.
-    default Set<? extends SoftwareComponentVariant> getAllVariants() {
-        // TODO Gradle 8.1: Add a deprecation nag here. Subclasses should implement this method
-        // instead of getUsages. In 9.0, we'll remove the default implementation.
-        return Collections.unmodifiableSet(getUsages());
+    default SoftwareComponentPublications getOutgoing() {
+        return new DefaultSoftwareComponentPublications(Collections.unmodifiableSet(getUsages()));
     }
 
     /**
-     * Currently used by the kotlin plugins.
+     * Currently used by the kotlin multiplatform plugins.
      *
-     * @deprecated Use {@link #getAllVariants()}. This method is scheduled for removal in Gradle 9.0.
+     * @deprecated Use {@link #getOutgoing()} ()}. This method is scheduled for removal in Gradle 9.0.
      */
     @Deprecated
     default Set<? extends UsageContext> getUsages() {
         // TODO Gradle 8.1: Add a deprecation nag here.
-        return getAllVariants().stream().map(UsageContextShim::new).collect(Collectors.toSet());
+        return getOutgoing().getVariants().stream().map(UsageContextShim::new).collect(Collectors.toSet());
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/internal/component/SoftwareComponentInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/component/SoftwareComponentInternal.java
@@ -17,12 +17,30 @@
 package org.gradle.api.internal.component;
 
 import org.gradle.api.component.SoftwareComponent;
+import org.gradle.api.component.SoftwareComponentVariant;
 
+import java.util.Collections;
 import java.util.Set;
 
 /**
  * This will be replaced by {@link org.gradle.api.component.ComponentWithVariants} and other public APIs.
  */
 public interface SoftwareComponentInternal extends SoftwareComponent {
-    Set<? extends UsageContext> getUsages();
+
+    // TODO: Should we name this `getVariants`? `ComponentWithVariants` already defines a `getVariants` which
+    // returns a different type. There are existing classes (in KGP) which implement both this class and
+    // `ComponentWithVariants`.
+    default Set<SoftwareComponentVariant> getAllVariants() {
+        return Collections.unmodifiableSet(getUsages());
+    }
+
+    /**
+     * Currently used by the kotlin plugins.
+     *
+     * @deprecated Use {@link #getAllVariants()}. This method is scheduled for removal in Gradle 9.0.
+     */
+    @Deprecated
+    default Set<? extends UsageContext> getUsages() {
+        throw new UnsupportedOperationException("getUsages() is deprecated. Call getAllVariants() instead.");
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/component/SoftwareComponentInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/component/SoftwareComponentInternal.java
@@ -19,7 +19,6 @@ package org.gradle.api.internal.component;
 import org.gradle.api.component.SoftwareComponent;
 import org.gradle.api.component.SoftwareComponentVariant;
 
-import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -30,7 +29,11 @@ import java.util.stream.Collectors;
 public interface SoftwareComponentInternal extends SoftwareComponent {
 
     default SoftwareComponentPublications getOutgoing() {
-        return new DefaultSoftwareComponentPublications(Collections.unmodifiableSet(getUsages()));
+        return new DefaultSoftwareComponentPublications(
+            getUsages().stream()
+                .map(x -> x instanceof UsageContextShim ? ((UsageContextShim) x).variant : x)
+                .collect(Collectors.toSet())
+        );
     }
 
     /**
@@ -51,8 +54,10 @@ public interface SoftwareComponentInternal extends SoftwareComponent {
      */
     @SuppressWarnings("deprecation")
     class UsageContextShim extends DelegatingSoftwareComponentVariant implements UsageContext {
+        private final SoftwareComponentVariant variant;
         private UsageContextShim(SoftwareComponentVariant variant) {
             super(variant);
+            this.variant = variant;
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/component/SoftwareComponentInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/component/SoftwareComponentInternal.java
@@ -32,7 +32,7 @@ public interface SoftwareComponentInternal extends SoftwareComponent {
     // TODO: Should we name this `getVariants`? `ComponentWithVariants` already defines a `getVariants` which
     // returns a different type. There are existing classes (internally and in KGP) which implement both this class and
     // `ComponentWithVariants`.
-    default Set<SoftwareComponentVariant> getAllVariants() {
+    default Set<? extends SoftwareComponentVariant> getAllVariants() {
         // TODO Gradle 8.1: Add a deprecation nag here. Subclasses should implement this method
         // instead of getUsages. In 9.0, we'll remove the default implementation.
         return Collections.unmodifiableSet(getUsages());
@@ -55,17 +55,9 @@ public interface SoftwareComponentInternal extends SoftwareComponent {
      * should be removed once the above method is removed.
      */
     @SuppressWarnings("deprecation")
-    class UsageContextShim extends DefaultSoftwareComponentVariant implements UsageContext {
+    class UsageContextShim extends DelegatingSoftwareComponentVariant implements UsageContext {
         private UsageContextShim(SoftwareComponentVariant variant) {
-            super(
-                variant.getName(),
-                variant.getAttributes(),
-                variant.getArtifacts(),
-                variant.getDependencies(),
-                variant.getDependencyConstraints(),
-                variant.getCapabilities(),
-                variant.getGlobalExcludes()
-            );
+            super(variant);
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/component/SoftwareComponentPublications.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/component/SoftwareComponentPublications.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,25 +16,17 @@
 
 package org.gradle.api.internal.component;
 
-import org.gradle.api.attributes.Usage;
 import org.gradle.api.component.SoftwareComponentVariant;
 
+import java.util.Set;
+
 /**
- * Currently used by the Kotlin multiplatform plugins.
- *
- * @deprecated Use {@link SoftwareComponentVariant}. This class is scheduled for removal in Gradle 9.0.
+ * Represents the outgoing view of a software component -- the view which external consumers interact with.
  */
-@Deprecated
-public interface UsageContext extends SoftwareComponentVariant {
+public interface SoftwareComponentPublications {
 
     /**
-     * Currently used by the Kotlin multiplatform plugins.
-     *
-     * @deprecated This class is scheduled for removal in Gradle 9.0.
+     * @return All variants for this component.
      */
-    @Deprecated
-    default Usage getUsage(){
-        throw new UnsupportedOperationException("This method has been deprecated, should never be called");
-    }
-
+    Set<? extends SoftwareComponentVariant> getVariants();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/component/UsageContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/component/UsageContext.java
@@ -19,7 +19,22 @@ package org.gradle.api.internal.component;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.component.SoftwareComponentVariant;
 
+/**
+ * Currently used by the kotlin plugins.
+ *
+ * @deprecated Use {@link SoftwareComponentVariant}. This class is scheduled for removal in Gradle 9.0.
+ */
+@Deprecated
 public interface UsageContext extends SoftwareComponentVariant {
+
+    /**
+     * Currently used by the kotlin plugins.
+     *
+     * @deprecated This class is scheduled for removal in Gradle 9.0.
+     */
     @Deprecated
-    Usage getUsage(); // kept for backwards compatibility of plugins (like kotlin-multiplatform) using internal APIs
+    default Usage getUsage(){
+        throw new UnsupportedOperationException("This method has been deprecated, should never be called");
+    }
+
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
@@ -32,6 +32,7 @@ import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.component.SoftwareComponent;
+import org.gradle.api.component.SoftwareComponentVariant;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
@@ -40,9 +41,8 @@ import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDepende
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
-import org.gradle.api.internal.component.IvyPublishingAwareContext;
+import org.gradle.api.internal.component.IvyPublishingAwareVariant;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
-import org.gradle.api.internal.component.UsageContext;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
@@ -274,24 +274,24 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
         PublicationErrorChecker.checkForUnpublishableAttributes(component, documentationRegistry);
 
         PublicationWarningsCollector publicationWarningsCollector = new PublicationWarningsCollector(LOG, UNSUPPORTED_FEATURE, "", PUBLICATION_WARNING_FOOTER, "suppressIvyMetadataWarningsFor");
-        Set<? extends UsageContext> usageContexts = component.getUsages();
+        Set<? extends SoftwareComponentVariant> variants = component.getAllVariants();
 
-        populateConfigurations(usageContexts);
-        populateArtifacts(usageContexts);
-        populateDependencies(usageContexts, publicationWarningsCollector);
-        populateGlobalExcludes(usageContexts);
+        populateConfigurations(variants);
+        populateArtifacts(variants);
+        populateDependencies(variants, publicationWarningsCollector);
+        populateGlobalExcludes(variants);
 
         if (!silenceAllPublicationWarnings) {
             publicationWarningsCollector.complete(getDisplayName() + " ivy metadata", silencedVariants);
         }
     }
 
-    private void populateConfigurations(Set<? extends UsageContext> usageContexts) {
+    private void populateConfigurations(Set<? extends SoftwareComponentVariant> variants) {
         IvyConfiguration defaultConfiguration = configurations.maybeCreate("default");
-        for (UsageContext usageContext : usageContexts) {
-            String conf = mapUsageNameToIvyConfiguration(usageContext.getName());
+        for (SoftwareComponentVariant variant : variants) {
+            String conf = mapVariantNameToIvyConfiguration(variant.getName());
             configurations.maybeCreate(conf);
-            if (defaultShouldExtend(usageContext)) {
+            if (defaultShouldExtend(variant)) {
                 defaultConfiguration.extend(conf);
             }
         }
@@ -299,36 +299,36 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
 
     /**
      * In general, default extends all configurations such that you get 'everything' when depending on default.
-     * If a usage is optional, however it is not included.
-     * If a usage represents the Java API variant, it is also not included, because the Java Runtime variant already includes everything
+     * If a variant is optional, however it is not included.
+     * If a variant represents the Java API variant, it is also not included, because the Java Runtime variant already includes everything
      * (including both also works but would lead to some duplication, that might break backwards compatibility in certain cases).
      */
-    private static boolean defaultShouldExtend(UsageContext usageContext) {
-        if (!(usageContext instanceof IvyPublishingAwareContext)) {
+    private static boolean defaultShouldExtend(SoftwareComponentVariant variant) {
+        if (!(variant instanceof IvyPublishingAwareVariant)) {
             return true;
         }
-        if (((IvyPublishingAwareContext) usageContext).isOptional()) {
+        if (((IvyPublishingAwareVariant) variant).isOptional()) {
             return false;
         }
-        return !isJavaApiVariant(usageContext.getName());
+        return !isJavaApiVariant(variant.getName());
     }
 
-    private static boolean isJavaRuntimeVariant(String usageName) {
-        return RUNTIME_VARIANT.equals(usageName) || RUNTIME_ELEMENTS_VARIANT.equals(usageName);
+    private static boolean isJavaRuntimeVariant(String variantName) {
+        return RUNTIME_VARIANT.equals(variantName) || RUNTIME_ELEMENTS_VARIANT.equals(variantName);
     }
 
-    private static boolean isJavaApiVariant(String usageName) {
-        return API_VARIANT.equals(usageName) || API_ELEMENTS_VARIANT.equals(usageName);
+    private static boolean isJavaApiVariant(String variantName) {
+        return API_VARIANT.equals(variantName) || API_ELEMENTS_VARIANT.equals(variantName);
     }
 
-    private void populateArtifacts(Set<? extends UsageContext> usageContexts) {
+    private void populateArtifacts(Set<? extends SoftwareComponentVariant> variants) {
         if (artifactsOverridden) {
             return;
         }
         Map<String, IvyArtifact> seenArtifacts = Maps.newHashMap();
-        for (UsageContext usageContext : usageContexts) {
-            String conf = mapUsageNameToIvyConfiguration(usageContext.getName());
-            for (PublishArtifact publishArtifact : usageContext.getArtifacts()) {
+        for (SoftwareComponentVariant variant : variants) {
+            String conf = mapVariantNameToIvyConfiguration(variant.getName());
+            for (PublishArtifact publishArtifact : variant.getArtifacts()) {
                 String key = artifactKey(publishArtifact);
                 IvyArtifact ivyArtifact = seenArtifacts.get(key);
                 if (ivyArtifact == null) {
@@ -346,11 +346,11 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
         return publishArtifact.getName() + ":" + publishArtifact.getType() + ":" + publishArtifact.getExtension() + ":" + publishArtifact.getClassifier();
     }
 
-    private void populateDependencies(Set<? extends UsageContext> usageContexts, PublicationWarningsCollector publicationWarningsCollector) {
-        for (UsageContext usageContext : usageContexts) {
-            publicationWarningsCollector.newContext(usageContext.getName());
-            for (ModuleDependency dependency : usageContext.getDependencies()) {
-                String confMapping = confMappingFor(usageContext, dependency);
+    private void populateDependencies(Set<? extends SoftwareComponentVariant> variants, PublicationWarningsCollector publicationWarningsCollector) {
+        for (SoftwareComponentVariant variant : variants) {
+            publicationWarningsCollector.newContext(variant.getName());
+            for (ModuleDependency dependency : variant.getDependencies()) {
+                String confMapping = confMappingFor(variant, dependency);
                 if (!dependency.getAttributes().isEmpty()) {
                     publicationWarningsCollector.addUnsupported(String.format("%s:%s:%s declared with Gradle attributes", dependency.getGroup(), dependency.getName(), dependency.getVersion()));
                 }
@@ -364,17 +364,17 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
                     if (!versionMappingInUse && externalDependency.getVersion() == null) {
                         publicationWarningsCollector.addUnsupported(String.format("%s:%s declared without version", externalDependency.getGroup(), externalDependency.getName()));
                     }
-                    addExternalDependency(externalDependency, confMapping, ((AttributeContainerInternal) usageContext.getAttributes()).asImmutable());
+                    addExternalDependency(externalDependency, confMapping, ((AttributeContainerInternal) variant.getAttributes()).asImmutable());
                 }
             }
 
-            if (!usageContext.getDependencyConstraints().isEmpty()) {
-                for (DependencyConstraint constraint : usageContext.getDependencyConstraints()) {
+            if (!variant.getDependencyConstraints().isEmpty()) {
+                for (DependencyConstraint constraint : variant.getDependencyConstraints()) {
                     publicationWarningsCollector.addUnsupported(String.format("%s:%s:%s declared as a dependency constraint", constraint.getGroup(), constraint.getName(), constraint.getVersion()));
                 }
             }
-            if (!usageContext.getCapabilities().isEmpty()) {
-                for (Capability capability : usageContext.getCapabilities()) {
+            if (!variant.getCapabilities().isEmpty()) {
+                for (Capability capability : variant.getCapabilities()) {
                     publicationWarningsCollector.addVariantUnsupported(String.format("Declares capability %s:%s:%s which cannot be mapped to Ivy", capability.getGroup(), capability.getName(), capability.getVersion()));
                 }
             }
@@ -382,24 +382,24 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
         }
     }
 
-    private void populateGlobalExcludes(Set<? extends UsageContext> usageContexts) {
-        for (UsageContext usageContext : usageContexts) {
-            String conf = mapUsageNameToIvyConfiguration(usageContext.getName());
-            for (ExcludeRule excludeRule : usageContext.getGlobalExcludes()) {
+    private void populateGlobalExcludes(Set<? extends SoftwareComponentVariant> variants) {
+        for (SoftwareComponentVariant variant : variants) {
+            String conf = mapVariantNameToIvyConfiguration(variant.getName());
+            for (ExcludeRule excludeRule : variant.getGlobalExcludes()) {
                 globalExcludes.add(new DefaultIvyExcludeRule(excludeRule, conf));
             }
         }
     }
 
-    private static String confMappingFor(UsageContext usageContext, ModuleDependency dependency) {
-        String conf = mapUsageNameToIvyConfiguration(usageContext.getName());
-        String confMappingTarget = mapUsageNameToIvyConfiguration(dependency.getTargetConfiguration());
+    private static String confMappingFor(SoftwareComponentVariant variant, ModuleDependency dependency) {
+        String conf = mapVariantNameToIvyConfiguration(variant.getName());
+        String confMappingTarget = mapVariantNameToIvyConfiguration(dependency.getTargetConfiguration());
 
         // If the following code is activated implementation/runtime separation will be published to ivy. This however is a breaking change.
         //
         // if (confMappingTarget == null) {
-        //     if (usageContext instanceof MavenPublishingAwareContext) {
-        //         MavenPublishingAwareContext.ScopeMapping mapping = ((MavenPublishingAwareContext) usageContext).getScopeMapping();
+        //     if (variant instanceof MavenPublishingAwareContext) {
+        //         MavenPublishingAwareContext.ScopeMapping mapping = ((MavenPublishingAwareContext) variant).getScopeMapping();
         //         if (mapping == runtime || mapping == runtime_optional) {
         //             confMappingTarget = "runtime";
         //         }
@@ -416,17 +416,17 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
     }
 
     /**
-     * The usage name usually corresponds to the name of the Gradle configuration on which the variant represented by the usage is based on.
+     * The variant name usually corresponds to the name of the Gradle configuration on which the variant is based on.
      * For backward compatibility, the 'apiElements' and 'runtimeElements' configurations/variants of the Java ecosystem are named 'compile' and 'runtime' in the publication.
      */
-    private static String mapUsageNameToIvyConfiguration(String usageName) {
-        if (isJavaApiVariant(usageName)) {
+    private static String mapVariantNameToIvyConfiguration(String variantName) {
+        if (isJavaApiVariant(variantName)) {
             return "compile";
         }
-        if (isJavaRuntimeVariant(usageName)) {
+        if (isJavaRuntimeVariant(variantName)) {
             return "runtime";
         }
-        return usageName;
+        return variantName;
     }
 
     private void addProjectDependency(ProjectDependency dependency, String confMapping) {

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
@@ -274,7 +274,7 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
         PublicationErrorChecker.checkForUnpublishableAttributes(component, documentationRegistry);
 
         PublicationWarningsCollector publicationWarningsCollector = new PublicationWarningsCollector(LOG, UNSUPPORTED_FEATURE, "", PUBLICATION_WARNING_FOOTER, "suppressIvyMetadataWarningsFor");
-        Set<? extends SoftwareComponentVariant> variants = component.getAllVariants();
+        Set<? extends SoftwareComponentVariant> variants = component.getOutgoing().getVariants();
 
         populateConfigurations(variants);
         populateArtifacts(variants);

--- a/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
+++ b/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
@@ -35,6 +35,7 @@ import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyPublicationResolver
 import org.gradle.api.internal.attributes.ImmutableAttributes
+import org.gradle.api.internal.component.DefaultSoftwareComponentPublications
 import org.gradle.api.internal.component.SoftwareComponentInternal
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.publish.internal.PublicationInternal
@@ -421,7 +422,7 @@ class DefaultIvyPublicationTest extends Specification {
             getAttributes() >> ImmutableAttributes.EMPTY
         }
         def component = Stub(SoftwareComponentInternal) {
-            getAllVariants() >> [variant]
+            getOutgoing() >> new DefaultSoftwareComponentPublications([variant] as Set)
         }
         return component
     }

--- a/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
+++ b/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
@@ -27,6 +27,7 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.artifacts.PublishArtifact
 import org.gradle.api.component.ComponentWithVariants
+import org.gradle.api.component.SoftwareComponentVariant
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.DocumentationRegistry
@@ -35,7 +36,6 @@ import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyPublicationResolver
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.component.SoftwareComponentInternal
-import org.gradle.api.internal.component.UsageContext
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.publish.internal.PublicationInternal
 import org.gradle.api.publish.internal.versionmapping.VersionMappingStrategyInternal
@@ -414,14 +414,14 @@ class DefaultIvyPublicationTest extends Specification {
     }
 
     def createComponent(def artifacts, def dependencies) {
-        def usage = Stub(UsageContext) {
+        def variant = Stub(SoftwareComponentVariant) {
             getName() >> 'runtime'
             getArtifacts() >> artifacts
             getDependencies() >> dependencies
             getAttributes() >> ImmutableAttributes.EMPTY
         }
         def component = Stub(SoftwareComponentInternal) {
-            getUsages() >> [usage]
+            getAllVariants() >> [variant]
         }
         return component
     }

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppExecutable.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppExecutable.java
@@ -128,7 +128,7 @@ public class DefaultCppExecutable extends DefaultCppBinary implements CppExecuta
     }
 
     @Override
-    public Set<SoftwareComponentVariant> getAllVariants() {
+    public Set<? extends SoftwareComponentVariant> getAllVariants() {
         Configuration runtimeElements = runtimeElementsProperty.get();
         return Collections.singleton(new ConfigurationSoftwareComponentVariant(getIdentity().getRuntimeVariant(), runtimeElements.getAllArtifacts(), runtimeElements));
     }

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppExecutable.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppExecutable.java
@@ -29,6 +29,7 @@ import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.plugins.internal.ConfigurationSoftwareComponentVariant;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.language.cpp.CppExecutable;
@@ -129,7 +130,7 @@ public class DefaultCppExecutable extends DefaultCppBinary implements CppExecuta
     @Override
     public Set<SoftwareComponentVariant> getAllVariants() {
         Configuration runtimeElements = runtimeElementsProperty.get();
-        return Collections.singleton(new DefaultSoftwareComponentVariant(getIdentity().getRuntimeVariant(), runtimeElements.getAllArtifacts(), runtimeElements));
+        return Collections.singleton(new ConfigurationSoftwareComponentVariant(getIdentity().getRuntimeVariant(), runtimeElements.getAllArtifacts(), runtimeElements));
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppExecutable.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppExecutable.java
@@ -21,13 +21,14 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
-import org.gradle.api.component.SoftwareComponentVariant;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.internal.component.DefaultSoftwareComponentPublications;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
+import org.gradle.api.internal.component.SoftwareComponentPublications;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.internal.ConfigurationSoftwareComponentVariant;
 import org.gradle.api.provider.Property;
@@ -46,7 +47,6 @@ import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.util.Collections;
-import java.util.Set;
 
 public class DefaultCppExecutable extends DefaultCppBinary implements CppExecutable, ConfigurableComponentWithExecutable, ConfigurableComponentWithRuntimeUsage, SoftwareComponentInternal {
     private final RegularFileProperty executableFile;
@@ -128,9 +128,10 @@ public class DefaultCppExecutable extends DefaultCppBinary implements CppExecuta
     }
 
     @Override
-    public Set<? extends SoftwareComponentVariant> getAllVariants() {
+    public SoftwareComponentPublications getOutgoing() {
         Configuration runtimeElements = runtimeElementsProperty.get();
-        return Collections.singleton(new ConfigurationSoftwareComponentVariant(getIdentity().getRuntimeVariant(), runtimeElements.getAllArtifacts(), runtimeElements));
+        return new DefaultSoftwareComponentPublications(Collections.singleton(
+            new ConfigurationSoftwareComponentVariant(getIdentity().getRuntimeVariant(), runtimeElements.getAllArtifacts(), runtimeElements)));
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppExecutable.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppExecutable.java
@@ -21,13 +21,13 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.component.SoftwareComponentVariant;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
-import org.gradle.api.internal.component.UsageContext;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
@@ -127,14 +127,14 @@ public class DefaultCppExecutable extends DefaultCppBinary implements CppExecuta
     }
 
     @Override
-    public Set<? extends UsageContext> getUsages() {
+    public Set<SoftwareComponentVariant> getAllVariants() {
         Configuration runtimeElements = runtimeElementsProperty.get();
-        return Collections.singleton(new DefaultUsageContext(getIdentity().getRuntimeUsageContext(), runtimeElements.getAllArtifacts(), runtimeElements));
+        return Collections.singleton(new DefaultSoftwareComponentVariant(getIdentity().getRuntimeVariant(), runtimeElements.getAllArtifacts(), runtimeElements));
     }
 
     @Override
     public AttributeContainer getRuntimeAttributes() {
-        return getIdentity().getRuntimeUsageContext().getAttributes();
+        return getIdentity().getRuntimeVariant().getAttributes();
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppSharedLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppSharedLibrary.java
@@ -22,11 +22,12 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
-import org.gradle.api.component.SoftwareComponentVariant;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.internal.component.DefaultSoftwareComponentPublications;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
+import org.gradle.api.internal.component.SoftwareComponentPublications;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.internal.ConfigurationSoftwareComponentVariant;
 import org.gradle.api.provider.Property;
@@ -44,7 +45,6 @@ import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
-import java.util.Set;
 
 public class DefaultCppSharedLibrary extends DefaultCppBinary implements CppSharedLibrary, ConfigurableComponentWithSharedLibrary, ConfigurableComponentWithLinkUsage, ConfigurableComponentWithRuntimeUsage, SoftwareComponentInternal {
     private final RegularFileProperty linkFile;
@@ -114,13 +114,13 @@ public class DefaultCppSharedLibrary extends DefaultCppBinary implements CppShar
     }
 
     @Override
-    public Set<? extends SoftwareComponentVariant> getAllVariants() {
+    public SoftwareComponentPublications getOutgoing() {
         Configuration linkElements = getLinkElements().get();
         Configuration runtimeElements = getRuntimeElements().get();
-        return Sets.newHashSet(
+        return new DefaultSoftwareComponentPublications(Sets.newHashSet(
             new ConfigurationSoftwareComponentVariant(getIdentity().getLinkVariant(), linkElements.getAllArtifacts(), linkElements),
             new ConfigurationSoftwareComponentVariant(getIdentity().getRuntimeVariant(), runtimeElements.getAllArtifacts(), runtimeElements)
-        );
+        ));
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppSharedLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppSharedLibrary.java
@@ -28,6 +28,7 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.plugins.internal.ConfigurationSoftwareComponentVariant;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.language.cpp.CppPlatform;
@@ -117,8 +118,8 @@ public class DefaultCppSharedLibrary extends DefaultCppBinary implements CppShar
         Configuration linkElements = getLinkElements().get();
         Configuration runtimeElements = getRuntimeElements().get();
         return Sets.newHashSet(
-            new DefaultSoftwareComponentVariant(getIdentity().getLinkVariant(), linkElements.getAllArtifacts(), linkElements),
-            new DefaultSoftwareComponentVariant(getIdentity().getRuntimeVariant(), runtimeElements.getAllArtifacts(), runtimeElements)
+            new ConfigurationSoftwareComponentVariant(getIdentity().getLinkVariant(), linkElements.getAllArtifacts(), linkElements),
+            new ConfigurationSoftwareComponentVariant(getIdentity().getRuntimeVariant(), runtimeElements.getAllArtifacts(), runtimeElements)
         );
     }
 

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppSharedLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppSharedLibrary.java
@@ -22,11 +22,11 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.component.SoftwareComponentVariant;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
-import org.gradle.api.internal.component.UsageContext;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
@@ -113,23 +113,23 @@ public class DefaultCppSharedLibrary extends DefaultCppBinary implements CppShar
     }
 
     @Override
-    public Set<? extends UsageContext> getUsages() {
+    public Set<SoftwareComponentVariant> getAllVariants() {
         Configuration linkElements = getLinkElements().get();
         Configuration runtimeElements = getRuntimeElements().get();
         return Sets.newHashSet(
-            new DefaultUsageContext(getIdentity().getLinkUsageContext(), linkElements.getAllArtifacts(), linkElements),
-            new DefaultUsageContext(getIdentity().getRuntimeUsageContext(), runtimeElements.getAllArtifacts(), runtimeElements)
+            new DefaultSoftwareComponentVariant(getIdentity().getLinkVariant(), linkElements.getAllArtifacts(), linkElements),
+            new DefaultSoftwareComponentVariant(getIdentity().getRuntimeVariant(), runtimeElements.getAllArtifacts(), runtimeElements)
         );
     }
 
     @Override
     public AttributeContainer getLinkAttributes() {
-        return getIdentity().getLinkUsageContext().getAttributes();
+        return getIdentity().getLinkVariant().getAttributes();
     }
 
     @Override
     public AttributeContainer getRuntimeAttributes() {
-        return getIdentity().getRuntimeUsageContext().getAttributes();
+        return getIdentity().getRuntimeVariant().getAttributes();
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppSharedLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppSharedLibrary.java
@@ -114,7 +114,7 @@ public class DefaultCppSharedLibrary extends DefaultCppBinary implements CppShar
     }
 
     @Override
-    public Set<SoftwareComponentVariant> getAllVariants() {
+    public Set<? extends SoftwareComponentVariant> getAllVariants() {
         Configuration linkElements = getLinkElements().get();
         Configuration runtimeElements = getRuntimeElements().get();
         return Sets.newHashSet(

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppStaticLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppStaticLibrary.java
@@ -30,6 +30,7 @@ import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.plugins.internal.ConfigurationSoftwareComponentVariant;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.language.cpp.CppPlatform;
@@ -118,8 +119,8 @@ public class DefaultCppStaticLibrary extends DefaultCppBinary implements CppStat
         Configuration runtimeElements = getRuntimeElements().get();
         // TODO: Does a static library really have any runtime elements?
         return Sets.newHashSet(
-            new DefaultSoftwareComponentVariant(getIdentity().getLinkVariant(), linkElements.getAllArtifacts(), linkElements),
-            new DefaultSoftwareComponentVariant(getIdentity().getRuntimeVariant(), runtimeElements.getAllArtifacts(), runtimeElements)
+            new ConfigurationSoftwareComponentVariant(getIdentity().getLinkVariant(), linkElements.getAllArtifacts(), linkElements),
+            new ConfigurationSoftwareComponentVariant(getIdentity().getRuntimeVariant(), runtimeElements.getAllArtifacts(), runtimeElements)
         );
     }
 

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppStaticLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppStaticLibrary.java
@@ -22,12 +22,12 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.component.SoftwareComponentVariant;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
-import org.gradle.api.internal.component.UsageContext;
 import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
@@ -113,24 +113,24 @@ public class DefaultCppStaticLibrary extends DefaultCppBinary implements CppStat
     }
 
     @Override
-    public Set<? extends UsageContext> getUsages() {
+    public Set<SoftwareComponentVariant> getAllVariants() {
         Configuration linkElements = getLinkElements().get();
         Configuration runtimeElements = getRuntimeElements().get();
         // TODO: Does a static library really have any runtime elements?
         return Sets.newHashSet(
-            new DefaultUsageContext(getIdentity().getLinkUsageContext(), linkElements.getAllArtifacts(), linkElements),
-            new DefaultUsageContext(getIdentity().getRuntimeUsageContext(), runtimeElements.getAllArtifacts(), runtimeElements)
+            new DefaultSoftwareComponentVariant(getIdentity().getLinkVariant(), linkElements.getAllArtifacts(), linkElements),
+            new DefaultSoftwareComponentVariant(getIdentity().getRuntimeVariant(), runtimeElements.getAllArtifacts(), runtimeElements)
         );
     }
 
     @Override
     public AttributeContainer getLinkAttributes() {
-        return getIdentity().getLinkUsageContext().getAttributes();
+        return getIdentity().getLinkVariant().getAttributes();
     }
 
     @Override
     public AttributeContainer getRuntimeAttributes() {
-        return getIdentity().getRuntimeUsageContext().getAttributes();
+        return getIdentity().getRuntimeVariant().getAttributes();
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppStaticLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppStaticLibrary.java
@@ -22,12 +22,13 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
-import org.gradle.api.component.SoftwareComponentVariant;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.internal.component.DefaultSoftwareComponentPublications;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
+import org.gradle.api.internal.component.SoftwareComponentPublications;
 import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.internal.ConfigurationSoftwareComponentVariant;
@@ -46,7 +47,6 @@ import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
-import java.util.Set;
 
 public class DefaultCppStaticLibrary extends DefaultCppBinary implements CppStaticLibrary, ConfigurableComponentWithStaticLibrary, ConfigurableComponentWithLinkUsage, ConfigurableComponentWithRuntimeUsage, SoftwareComponentInternal {
     private final RegularFileProperty linkFile;
@@ -114,14 +114,14 @@ public class DefaultCppStaticLibrary extends DefaultCppBinary implements CppStat
     }
 
     @Override
-    public Set<? extends SoftwareComponentVariant> getAllVariants() {
+    public SoftwareComponentPublications getOutgoing() {
         Configuration linkElements = getLinkElements().get();
         Configuration runtimeElements = getRuntimeElements().get();
         // TODO: Does a static library really have any runtime elements?
-        return Sets.newHashSet(
+        return new DefaultSoftwareComponentPublications(Sets.newHashSet(
             new ConfigurationSoftwareComponentVariant(getIdentity().getLinkVariant(), linkElements.getAllArtifacts(), linkElements),
             new ConfigurationSoftwareComponentVariant(getIdentity().getRuntimeVariant(), runtimeElements.getAllArtifacts(), runtimeElements)
-        );
+        ));
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppStaticLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppStaticLibrary.java
@@ -114,7 +114,7 @@ public class DefaultCppStaticLibrary extends DefaultCppBinary implements CppStat
     }
 
     @Override
-    public Set<SoftwareComponentVariant> getAllVariants() {
+    public Set<? extends SoftwareComponentVariant> getAllVariants() {
         Configuration linkElements = getLinkElements().get();
         Configuration runtimeElements = getRuntimeElements().get();
         // TODO: Does a static library really have any runtime elements?

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultSoftwareComponentVariant.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultSoftwareComponentVariant.java
@@ -24,30 +24,30 @@ import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.capabilities.Capability;
+import org.gradle.api.component.SoftwareComponentVariant;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
-import org.gradle.api.internal.component.UsageContext;
-import org.gradle.api.plugins.internal.AbstractUsageContext;
+import org.gradle.api.plugins.internal.AbstractSoftwareComponentVariant;
 import org.gradle.internal.Cast;
 
 import java.util.Collections;
 import java.util.Set;
 
-public class DefaultUsageContext extends AbstractUsageContext implements Named {
+public class DefaultSoftwareComponentVariant extends AbstractSoftwareComponentVariant implements Named {
     private final String name;
     private final Set<? extends ModuleDependency> dependencies;
     private final Set<? extends DependencyConstraint> dependencyConstraints;
     private final Set<ExcludeRule> globalExcludes;
 
-    public DefaultUsageContext(UsageContext usageContext, Set<? extends PublishArtifact> artifacts, Configuration configuration) {
-        this(usageContext.getName(), usageContext.getAttributes(), artifacts, configuration);
+    public DefaultSoftwareComponentVariant(SoftwareComponentVariant base, Set<? extends PublishArtifact> artifacts, Configuration configuration) {
+        this(base.getName(), base.getAttributes(), artifacts, configuration);
     }
 
-    public DefaultUsageContext(String name, AttributeContainer attributes) {
+    public DefaultSoftwareComponentVariant(String name, AttributeContainer attributes) {
         this(name, attributes, null, null);
     }
 
-    public DefaultUsageContext(String name, AttributeContainer attributes, Set<? extends PublishArtifact> artifacts, Configuration configuration) {
+    public DefaultSoftwareComponentVariant(String name, AttributeContainer attributes, Set<? extends PublishArtifact> artifacts, Configuration configuration) {
         super(((AttributeContainerInternal)attributes).asImmutable(), Cast.uncheckedCast(artifacts));
         this.name = name;
         if (configuration != null) {

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/MainExecutableVariant.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/MainExecutableVariant.java
@@ -20,8 +20,9 @@ import com.google.common.collect.ImmutableSet;
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.component.ComponentWithVariants;
 import org.gradle.api.component.SoftwareComponent;
-import org.gradle.api.component.SoftwareComponentVariant;
+import org.gradle.api.internal.component.DefaultSoftwareComponentPublications;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
+import org.gradle.api.internal.component.SoftwareComponentPublications;
 import org.gradle.api.model.ObjectFactory;
 
 import java.util.Set;
@@ -48,7 +49,7 @@ public class MainExecutableVariant implements SoftwareComponentInternal, Compone
     }
 
     @Override
-    public Set<? extends SoftwareComponentVariant> getAllVariants() {
-        return ImmutableSet.of();
+    public SoftwareComponentPublications getOutgoing() {
+        return new DefaultSoftwareComponentPublications(ImmutableSet.of());
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/MainExecutableVariant.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/MainExecutableVariant.java
@@ -20,8 +20,8 @@ import com.google.common.collect.ImmutableSet;
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.component.ComponentWithVariants;
 import org.gradle.api.component.SoftwareComponent;
+import org.gradle.api.component.SoftwareComponentVariant;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
-import org.gradle.api.internal.component.UsageContext;
 import org.gradle.api.model.ObjectFactory;
 
 import java.util.Set;
@@ -48,7 +48,7 @@ public class MainExecutableVariant implements SoftwareComponentInternal, Compone
     }
 
     @Override
-    public Set<? extends UsageContext> getUsages() {
+    public Set<SoftwareComponentVariant> getAllVariants() {
         return ImmutableSet.of();
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/MainExecutableVariant.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/MainExecutableVariant.java
@@ -48,7 +48,7 @@ public class MainExecutableVariant implements SoftwareComponentInternal, Compone
     }
 
     @Override
-    public Set<SoftwareComponentVariant> getAllVariants() {
+    public Set<? extends SoftwareComponentVariant> getAllVariants() {
         return ImmutableSet.of();
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/MainLibraryVariant.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/MainLibraryVariant.java
@@ -24,8 +24,9 @@ import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.component.ComponentWithVariants;
 import org.gradle.api.component.SoftwareComponent;
-import org.gradle.api.component.SoftwareComponentVariant;
+import org.gradle.api.internal.component.DefaultSoftwareComponentPublications;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
+import org.gradle.api.internal.component.SoftwareComponentPublications;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.internal.ConfigurationSoftwareComponentVariant;
 
@@ -54,8 +55,9 @@ public class MainLibraryVariant implements ComponentWithVariants, SoftwareCompon
     }
 
     @Override
-    public Set<? extends SoftwareComponentVariant> getAllVariants() {
-        return ImmutableSet.of(new ConfigurationSoftwareComponentVariant(name, dependencies, attributeContainer, artifacts));
+    public SoftwareComponentPublications getOutgoing() {
+        return new DefaultSoftwareComponentPublications(ImmutableSet.of(
+            new ConfigurationSoftwareComponentVariant(name, dependencies, attributeContainer, artifacts)));
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/MainLibraryVariant.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/MainLibraryVariant.java
@@ -54,7 +54,7 @@ public class MainLibraryVariant implements ComponentWithVariants, SoftwareCompon
     }
 
     @Override
-    public Set<SoftwareComponentVariant> getAllVariants() {
+    public Set<? extends SoftwareComponentVariant> getAllVariants() {
         return ImmutableSet.of(new ConfigurationSoftwareComponentVariant(name, dependencies, attributeContainer, artifacts));
     }
 

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/MainLibraryVariant.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/MainLibraryVariant.java
@@ -24,8 +24,8 @@ import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.component.ComponentWithVariants;
 import org.gradle.api.component.SoftwareComponent;
+import org.gradle.api.component.SoftwareComponentVariant;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
-import org.gradle.api.internal.component.UsageContext;
 import org.gradle.api.model.ObjectFactory;
 
 import java.util.LinkedHashSet;
@@ -53,8 +53,8 @@ public class MainLibraryVariant implements ComponentWithVariants, SoftwareCompon
     }
 
     @Override
-    public Set<? extends UsageContext> getUsages() {
-        return ImmutableSet.of(new DefaultUsageContext(name, attributeContainer, artifacts, dependencies));
+    public Set<SoftwareComponentVariant> getAllVariants() {
+        return ImmutableSet.of(new DefaultSoftwareComponentVariant(name, attributeContainer, artifacts, dependencies));
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/MainLibraryVariant.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/MainLibraryVariant.java
@@ -27,6 +27,7 @@ import org.gradle.api.component.SoftwareComponent;
 import org.gradle.api.component.SoftwareComponentVariant;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.plugins.internal.ConfigurationSoftwareComponentVariant;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -54,7 +55,7 @@ public class MainLibraryVariant implements ComponentWithVariants, SoftwareCompon
 
     @Override
     public Set<SoftwareComponentVariant> getAllVariants() {
-        return ImmutableSet.of(new DefaultSoftwareComponentVariant(name, attributeContainer, artifacts, dependencies));
+        return ImmutableSet.of(new ConfigurationSoftwareComponentVariant(name, dependencies, attributeContainer, artifacts));
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/NativeVariantIdentity.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/NativeVariantIdentity.java
@@ -19,9 +19,9 @@ package org.gradle.language.cpp.internal;
 import com.google.common.collect.Sets;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.component.ComponentWithCoordinates;
+import org.gradle.api.component.SoftwareComponentVariant;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
-import org.gradle.api.internal.component.UsageContext;
 import org.gradle.api.provider.Provider;
 import org.gradle.nativeplatform.Linkage;
 import org.gradle.nativeplatform.TargetMachine;
@@ -37,16 +37,16 @@ public class NativeVariantIdentity implements SoftwareComponentInternal, Compone
     private final boolean debuggable;
     private final boolean optimized;
     private final TargetMachine targetMachine;
-    private final UsageContext linkUsage;
-    private final UsageContext runtimeUsage;
+    private final SoftwareComponentVariant linkVariant;
+    private final SoftwareComponentVariant runtimeVariant;
     private final Linkage linkage;
-    private final Set<UsageContext> usageContexts;
+    private final Set<SoftwareComponentVariant> variants;
 
-    public NativeVariantIdentity(String name, Provider<String> baseName, Provider<String> group, Provider<String> version, boolean debuggable, boolean optimized, TargetMachine targetMachine, UsageContext linkUsage, UsageContext runtimeUsage) {
-        this(name, baseName, group, version, debuggable, optimized, targetMachine, linkUsage, runtimeUsage, null);
+    public NativeVariantIdentity(String name, Provider<String> baseName, Provider<String> group, Provider<String> version, boolean debuggable, boolean optimized, TargetMachine targetMachine, SoftwareComponentVariant linkVariant, SoftwareComponentVariant runtimeVariant) {
+        this(name, baseName, group, version, debuggable, optimized, targetMachine, linkVariant, runtimeVariant, null);
     }
 
-    public NativeVariantIdentity(String name, Provider<String> baseName, Provider<String> group, Provider<String> version, boolean debuggable, boolean optimized, TargetMachine targetMachine, UsageContext linkUsage, UsageContext runtimeUsage, Linkage linkage) {
+    public NativeVariantIdentity(String name, Provider<String> baseName, Provider<String> group, Provider<String> version, boolean debuggable, boolean optimized, TargetMachine targetMachine, SoftwareComponentVariant linkVariant, SoftwareComponentVariant runtimeVariant, Linkage linkage) {
         this.name = name;
         this.baseName = baseName;
         this.group = group;
@@ -54,15 +54,15 @@ public class NativeVariantIdentity implements SoftwareComponentInternal, Compone
         this.debuggable = debuggable;
         this.optimized = optimized;
         this.targetMachine = targetMachine;
-        this.linkUsage = linkUsage;
-        this.runtimeUsage = runtimeUsage;
+        this.linkVariant = linkVariant;
+        this.runtimeVariant = runtimeVariant;
         this.linkage = linkage;
-        this.usageContexts = Sets.newLinkedHashSet();
-        if (linkUsage!=null) {
-            usageContexts.add(linkUsage);
+        this.variants = Sets.newLinkedHashSet();
+        if (linkVariant != null) {
+            variants.add(linkVariant);
         }
-        if (runtimeUsage!=null) {
-            usageContexts.add(runtimeUsage);
+        if (runtimeVariant !=null) {
+            variants.add(runtimeVariant);
         }
     }
 
@@ -88,8 +88,8 @@ public class NativeVariantIdentity implements SoftwareComponentInternal, Compone
     }
 
     @Override
-    public Set<? extends UsageContext> getUsages() {
-        return usageContexts;
+    public Set<SoftwareComponentVariant> getAllVariants() {
+        return variants;
     }
 
     @Override
@@ -97,11 +97,11 @@ public class NativeVariantIdentity implements SoftwareComponentInternal, Compone
         return name;
     }
 
-    public UsageContext getRuntimeUsageContext() {
-        return runtimeUsage;
+    public SoftwareComponentVariant getRuntimeVariant() {
+        return runtimeVariant;
     }
 
-    public UsageContext getLinkUsageContext() {
-        return linkUsage;
+    public SoftwareComponentVariant getLinkVariant() {
+        return linkVariant;
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/NativeVariantIdentity.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/NativeVariantIdentity.java
@@ -88,7 +88,7 @@ public class NativeVariantIdentity implements SoftwareComponentInternal, Compone
     }
 
     @Override
-    public Set<SoftwareComponentVariant> getAllVariants() {
+    public Set<? extends SoftwareComponentVariant> getAllVariants() {
         return variants;
     }
 

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/NativeVariantIdentity.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/NativeVariantIdentity.java
@@ -21,7 +21,9 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.component.ComponentWithCoordinates;
 import org.gradle.api.component.SoftwareComponentVariant;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
+import org.gradle.api.internal.component.DefaultSoftwareComponentPublications;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
+import org.gradle.api.internal.component.SoftwareComponentPublications;
 import org.gradle.api.provider.Provider;
 import org.gradle.nativeplatform.Linkage;
 import org.gradle.nativeplatform.TargetMachine;
@@ -88,8 +90,8 @@ public class NativeVariantIdentity implements SoftwareComponentInternal, Compone
     }
 
     @Override
-    public Set<? extends SoftwareComponentVariant> getAllVariants() {
-        return variants;
+    public SoftwareComponentPublications getOutgoing() {
+        return new DefaultSoftwareComponentPublications(variants);
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/Dimensions.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/Dimensions.java
@@ -26,7 +26,7 @@ import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.SetProperty;
-import org.gradle.language.cpp.internal.DefaultSoftwareComponentVariant;
+import org.gradle.api.internal.component.DefaultSoftwareComponentVariant;
 import org.gradle.language.cpp.internal.NativeVariantIdentity;
 import org.gradle.nativeplatform.Linkage;
 import org.gradle.nativeplatform.MachineArchitecture;

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/Dimensions.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/Dimensions.java
@@ -26,7 +26,7 @@ import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.SetProperty;
-import org.gradle.language.cpp.internal.DefaultUsageContext;
+import org.gradle.language.cpp.internal.DefaultSoftwareComponentVariant;
 import org.gradle.language.cpp.internal.NativeVariantIdentity;
 import org.gradle.nativeplatform.Linkage;
 import org.gradle.nativeplatform.MachineArchitecture;
@@ -143,15 +143,15 @@ public class Dimensions {
                     addCommonAttributes(buildType, targetMachine, runtimeAttributes);
                     runtimeAttributes.attribute(LINKAGE_ATTRIBUTE, linkage);
 
-                    DefaultUsageContext runtimeUsageContext = new DefaultUsageContext(variantName + "Runtime", runtimeAttributes);
+                    DefaultSoftwareComponentVariant runtimeVariant = new DefaultSoftwareComponentVariant(variantName + "Runtime", runtimeAttributes);
 
                     AttributeContainer linkAttributes = attributesFactory.mutable();
                     linkAttributes.attribute(Usage.USAGE_ATTRIBUTE, linkUsage);
                     addCommonAttributes(buildType, targetMachine, linkAttributes);
                     linkAttributes.attribute(LINKAGE_ATTRIBUTE, linkage);
-                    DefaultUsageContext linkUsageContext = new DefaultUsageContext(variantName + "Link", linkAttributes);
+                    DefaultSoftwareComponentVariant linkVariant = new DefaultSoftwareComponentVariant(variantName + "Link", linkAttributes);
 
-                    NativeVariantIdentity variantIdentity = new NativeVariantIdentity(variantName, baseName, group, version, buildType.isDebuggable(), buildType.isOptimized(), targetMachine, linkUsageContext, runtimeUsageContext, linkage);
+                    NativeVariantIdentity variantIdentity = new NativeVariantIdentity(variantName, baseName, group, version, buildType.isDebuggable(), buildType.isOptimized(), targetMachine, linkVariant, runtimeVariant, linkage);
 
                     action.execute(variantIdentity);
                 }
@@ -180,11 +180,11 @@ public class Dimensions {
                 runtimeAttributes.attribute(Usage.USAGE_ATTRIBUTE, runtimeUsage);
                 addCommonAttributes(buildType, targetMachine, runtimeAttributes);
 
-                DefaultUsageContext runtimeUsageContext = new DefaultUsageContext(variantName + "Runtime", runtimeAttributes);
+                DefaultSoftwareComponentVariant runtimeVariant = new DefaultSoftwareComponentVariant(variantName + "Runtime", runtimeAttributes);
 
-                DefaultUsageContext linkUsageContext = null;
+                DefaultSoftwareComponentVariant linkVariant = null;
 
-                NativeVariantIdentity variantIdentity = new NativeVariantIdentity(variantName, baseName, group, version, buildType.isDebuggable(), buildType.isOptimized(), targetMachine, linkUsageContext, runtimeUsageContext, null);
+                NativeVariantIdentity variantIdentity = new NativeVariantIdentity(variantName, baseName, group, version, buildType.isDebuggable(), buildType.isOptimized(), targetMachine, linkVariant, runtimeVariant, null);
 
                 action.execute(variantIdentity);
             }

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftExecutable.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftExecutable.java
@@ -20,18 +20,18 @@ import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.component.SoftwareComponentVariant;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
-import org.gradle.api.internal.component.UsageContext;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
-import org.gradle.language.cpp.internal.DefaultUsageContext;
+import org.gradle.language.cpp.internal.DefaultSoftwareComponentVariant;
 import org.gradle.language.cpp.internal.NativeVariantIdentity;
 import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithExecutable;
 import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithRuntimeUsage;
@@ -129,13 +129,13 @@ public class DefaultSwiftExecutable extends DefaultSwiftBinary implements SwiftE
     }
 
     @Override
-    public Set<? extends UsageContext> getUsages() {
+    public Set<SoftwareComponentVariant> getAllVariants() {
         Configuration runtimeElements = runtimeElementsProperty.get();
-        return Collections.singleton(new DefaultUsageContext(getIdentity().getRuntimeUsageContext(), runtimeElements.getAllArtifacts(), runtimeElements));
+        return Collections.singleton(new DefaultSoftwareComponentVariant(getIdentity().getRuntimeVariant(), runtimeElements.getAllArtifacts(), runtimeElements));
     }
 
     @Override
     public AttributeContainer getRuntimeAttributes() {
-        return getIdentity().getRuntimeUsageContext().getAttributes();
+        return getIdentity().getRuntimeVariant().getAttributes();
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftExecutable.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftExecutable.java
@@ -29,9 +29,9 @@ import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.plugins.internal.ConfigurationSoftwareComponentVariant;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
-import org.gradle.language.cpp.internal.DefaultSoftwareComponentVariant;
 import org.gradle.language.cpp.internal.NativeVariantIdentity;
 import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithExecutable;
 import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithRuntimeUsage;
@@ -131,7 +131,7 @@ public class DefaultSwiftExecutable extends DefaultSwiftBinary implements SwiftE
     @Override
     public Set<SoftwareComponentVariant> getAllVariants() {
         Configuration runtimeElements = runtimeElementsProperty.get();
-        return Collections.singleton(new DefaultSoftwareComponentVariant(getIdentity().getRuntimeVariant(), runtimeElements.getAllArtifacts(), runtimeElements));
+        return Collections.singleton(new ConfigurationSoftwareComponentVariant(getIdentity().getRuntimeVariant(), runtimeElements.getAllArtifacts(), runtimeElements));
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftExecutable.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftExecutable.java
@@ -129,7 +129,7 @@ public class DefaultSwiftExecutable extends DefaultSwiftBinary implements SwiftE
     }
 
     @Override
-    public Set<SoftwareComponentVariant> getAllVariants() {
+    public Set<? extends SoftwareComponentVariant> getAllVariants() {
         Configuration runtimeElements = runtimeElementsProperty.get();
         return Collections.singleton(new ConfigurationSoftwareComponentVariant(getIdentity().getRuntimeVariant(), runtimeElements.getAllArtifacts(), runtimeElements));
     }

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftExecutable.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftExecutable.java
@@ -20,13 +20,14 @@ import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.attributes.AttributeContainer;
-import org.gradle.api.component.SoftwareComponentVariant;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.internal.component.DefaultSoftwareComponentPublications;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
+import org.gradle.api.internal.component.SoftwareComponentPublications;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.internal.ConfigurationSoftwareComponentVariant;
@@ -47,7 +48,6 @@ import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.util.Collections;
-import java.util.Set;
 
 public class DefaultSwiftExecutable extends DefaultSwiftBinary implements SwiftExecutable, ConfigurableComponentWithExecutable, ConfigurableComponentWithRuntimeUsage, SoftwareComponentInternal {
     private final RegularFileProperty executableFile;
@@ -129,9 +129,10 @@ public class DefaultSwiftExecutable extends DefaultSwiftBinary implements SwiftE
     }
 
     @Override
-    public Set<? extends SoftwareComponentVariant> getAllVariants() {
+    public SoftwareComponentPublications getOutgoing() {
         Configuration runtimeElements = runtimeElementsProperty.get();
-        return Collections.singleton(new ConfigurationSoftwareComponentVariant(getIdentity().getRuntimeVariant(), runtimeElements.getAllArtifacts(), runtimeElements));
+        return new DefaultSoftwareComponentPublications(Collections.singleton(
+            new ConfigurationSoftwareComponentVariant(getIdentity().getRuntimeVariant(), runtimeElements.getAllArtifacts(), runtimeElements)));
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftSharedLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftSharedLibrary.java
@@ -28,9 +28,9 @@ import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.plugins.internal.ConfigurationSoftwareComponentVariant;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
-import org.gradle.language.cpp.internal.DefaultSoftwareComponentVariant;
 import org.gradle.language.cpp.internal.NativeVariantIdentity;
 import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithLinkUsage;
 import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithRuntimeUsage;
@@ -129,8 +129,8 @@ public class DefaultSwiftSharedLibrary extends DefaultSwiftBinary implements Swi
         Configuration linkElements = getLinkElements().get();
         Configuration runtimeElements = getRuntimeElements().get();
         return Sets.newHashSet(
-            new DefaultSoftwareComponentVariant(getIdentity().getLinkVariant(), linkElements.getAllArtifacts(), linkElements),
-            new DefaultSoftwareComponentVariant(getIdentity().getRuntimeVariant(), runtimeElements.getAllArtifacts(), runtimeElements)
+            new ConfigurationSoftwareComponentVariant(getIdentity().getLinkVariant(), linkElements.getAllArtifacts(), linkElements),
+            new ConfigurationSoftwareComponentVariant(getIdentity().getRuntimeVariant(), runtimeElements.getAllArtifacts(), runtimeElements)
         );
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftSharedLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftSharedLibrary.java
@@ -125,7 +125,7 @@ public class DefaultSwiftSharedLibrary extends DefaultSwiftBinary implements Swi
     }
 
     @Override
-    public Set<SoftwareComponentVariant> getAllVariants() {
+    public Set<? extends SoftwareComponentVariant> getAllVariants() {
         Configuration linkElements = getLinkElements().get();
         Configuration runtimeElements = getRuntimeElements().get();
         return Sets.newHashSet(

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftSharedLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftSharedLibrary.java
@@ -21,11 +21,12 @@ import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.attributes.AttributeContainer;
-import org.gradle.api.component.SoftwareComponentVariant;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.internal.component.DefaultSoftwareComponentPublications;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
+import org.gradle.api.internal.component.SoftwareComponentPublications;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.internal.ConfigurationSoftwareComponentVariant;
@@ -45,7 +46,6 @@ import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
-import java.util.Set;
 
 public class DefaultSwiftSharedLibrary extends DefaultSwiftBinary implements SwiftSharedLibrary, ConfigurableComponentWithSharedLibrary, ConfigurableComponentWithLinkUsage, ConfigurableComponentWithRuntimeUsage, SoftwareComponentInternal {
     private final RegularFileProperty linkFile;
@@ -125,12 +125,12 @@ public class DefaultSwiftSharedLibrary extends DefaultSwiftBinary implements Swi
     }
 
     @Override
-    public Set<? extends SoftwareComponentVariant> getAllVariants() {
+    public SoftwareComponentPublications getOutgoing() {
         Configuration linkElements = getLinkElements().get();
         Configuration runtimeElements = getRuntimeElements().get();
-        return Sets.newHashSet(
+        return new DefaultSoftwareComponentPublications(Sets.newHashSet(
             new ConfigurationSoftwareComponentVariant(getIdentity().getLinkVariant(), linkElements.getAllArtifacts(), linkElements),
             new ConfigurationSoftwareComponentVariant(getIdentity().getRuntimeVariant(), runtimeElements.getAllArtifacts(), runtimeElements)
-        );
+        ));
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftSharedLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftSharedLibrary.java
@@ -21,16 +21,16 @@ import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.component.SoftwareComponentVariant;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
-import org.gradle.api.internal.component.UsageContext;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
-import org.gradle.language.cpp.internal.DefaultUsageContext;
+import org.gradle.language.cpp.internal.DefaultSoftwareComponentVariant;
 import org.gradle.language.cpp.internal.NativeVariantIdentity;
 import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithLinkUsage;
 import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithRuntimeUsage;
@@ -116,21 +116,21 @@ public class DefaultSwiftSharedLibrary extends DefaultSwiftBinary implements Swi
 
     @Override
     public AttributeContainer getLinkAttributes() {
-        return getIdentity().getLinkUsageContext().getAttributes();
+        return getIdentity().getLinkVariant().getAttributes();
     }
 
     @Override
     public AttributeContainer getRuntimeAttributes() {
-        return getIdentity().getRuntimeUsageContext().getAttributes();
+        return getIdentity().getRuntimeVariant().getAttributes();
     }
 
     @Override
-    public Set<? extends UsageContext> getUsages() {
+    public Set<SoftwareComponentVariant> getAllVariants() {
         Configuration linkElements = getLinkElements().get();
         Configuration runtimeElements = getRuntimeElements().get();
         return Sets.newHashSet(
-            new DefaultUsageContext(getIdentity().getLinkUsageContext(), linkElements.getAllArtifacts(), linkElements),
-            new DefaultUsageContext(getIdentity().getRuntimeUsageContext(), runtimeElements.getAllArtifacts(), runtimeElements)
+            new DefaultSoftwareComponentVariant(getIdentity().getLinkVariant(), linkElements.getAllArtifacts(), linkElements),
+            new DefaultSoftwareComponentVariant(getIdentity().getRuntimeVariant(), runtimeElements.getAllArtifacts(), runtimeElements)
         );
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftStaticLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftStaticLibrary.java
@@ -21,12 +21,13 @@ import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.attributes.AttributeContainer;
-import org.gradle.api.component.SoftwareComponentVariant;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.internal.component.DefaultSoftwareComponentPublications;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
+import org.gradle.api.internal.component.SoftwareComponentPublications;
 import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.model.ObjectFactory;
@@ -47,7 +48,6 @@ import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
-import java.util.Set;
 
 public class DefaultSwiftStaticLibrary extends DefaultSwiftBinary implements SwiftStaticLibrary, ConfigurableComponentWithStaticLibrary, ConfigurableComponentWithLinkUsage, ConfigurableComponentWithRuntimeUsage, SoftwareComponentInternal {
     private final RegularFileProperty linkFile;
@@ -125,13 +125,13 @@ public class DefaultSwiftStaticLibrary extends DefaultSwiftBinary implements Swi
     }
 
     @Override
-    public Set<? extends SoftwareComponentVariant> getAllVariants() {
+    public SoftwareComponentPublications getOutgoing() {
         Configuration linkElements = getLinkElements().get();
         Configuration runtimeElements = getRuntimeElements().get();
-        return Sets.newHashSet(
-                // TODO: Does a static library have runtime elements?
-                new ConfigurationSoftwareComponentVariant(getIdentity().getLinkVariant(), linkElements.getAllArtifacts(), linkElements),
-                new ConfigurationSoftwareComponentVariant(getIdentity().getRuntimeVariant(), runtimeElements.getAllArtifacts(), runtimeElements)
-        );
+        return new DefaultSoftwareComponentPublications(Sets.newHashSet(
+            // TODO: Does a static library have runtime elements?
+            new ConfigurationSoftwareComponentVariant(getIdentity().getLinkVariant(), linkElements.getAllArtifacts(), linkElements),
+            new ConfigurationSoftwareComponentVariant(getIdentity().getRuntimeVariant(), runtimeElements.getAllArtifacts(), runtimeElements)
+        ));
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftStaticLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftStaticLibrary.java
@@ -125,7 +125,7 @@ public class DefaultSwiftStaticLibrary extends DefaultSwiftBinary implements Swi
     }
 
     @Override
-    public Set<SoftwareComponentVariant> getAllVariants() {
+    public Set<? extends SoftwareComponentVariant> getAllVariants() {
         Configuration linkElements = getLinkElements().get();
         Configuration runtimeElements = getRuntimeElements().get();
         return Sets.newHashSet(

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftStaticLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftStaticLibrary.java
@@ -21,18 +21,18 @@ import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.component.SoftwareComponentVariant;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
-import org.gradle.api.internal.component.UsageContext;
 import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
-import org.gradle.language.cpp.internal.DefaultUsageContext;
+import org.gradle.language.cpp.internal.DefaultSoftwareComponentVariant;
 import org.gradle.language.cpp.internal.NativeVariantIdentity;
 import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithLinkUsage;
 import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithRuntimeUsage;
@@ -116,22 +116,22 @@ public class DefaultSwiftStaticLibrary extends DefaultSwiftBinary implements Swi
 
     @Override
     public AttributeContainer getLinkAttributes() {
-        return getIdentity().getLinkUsageContext().getAttributes();
+        return getIdentity().getLinkVariant().getAttributes();
     }
 
     @Override
     public AttributeContainer getRuntimeAttributes() {
-        return getIdentity().getRuntimeUsageContext().getAttributes();
+        return getIdentity().getRuntimeVariant().getAttributes();
     }
 
     @Override
-    public Set<? extends UsageContext> getUsages() {
+    public Set<SoftwareComponentVariant> getAllVariants() {
         Configuration linkElements = getLinkElements().get();
         Configuration runtimeElements = getRuntimeElements().get();
         return Sets.newHashSet(
                 // TODO: Does a static library have runtime elements?
-                new DefaultUsageContext(getIdentity().getLinkUsageContext(), linkElements.getAllArtifacts(), linkElements),
-                new DefaultUsageContext(getIdentity().getRuntimeUsageContext(), runtimeElements.getAllArtifacts(), runtimeElements)
+                new DefaultSoftwareComponentVariant(getIdentity().getLinkVariant(), linkElements.getAllArtifacts(), linkElements),
+                new DefaultSoftwareComponentVariant(getIdentity().getRuntimeVariant(), runtimeElements.getAllArtifacts(), runtimeElements)
         );
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftStaticLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftStaticLibrary.java
@@ -30,9 +30,9 @@ import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.plugins.internal.ConfigurationSoftwareComponentVariant;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
-import org.gradle.language.cpp.internal.DefaultSoftwareComponentVariant;
 import org.gradle.language.cpp.internal.NativeVariantIdentity;
 import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithLinkUsage;
 import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithRuntimeUsage;
@@ -130,8 +130,8 @@ public class DefaultSwiftStaticLibrary extends DefaultSwiftBinary implements Swi
         Configuration runtimeElements = getRuntimeElements().get();
         return Sets.newHashSet(
                 // TODO: Does a static library have runtime elements?
-                new DefaultSoftwareComponentVariant(getIdentity().getLinkVariant(), linkElements.getAllArtifacts(), linkElements),
-                new DefaultSoftwareComponentVariant(getIdentity().getRuntimeVariant(), runtimeElements.getAllArtifacts(), runtimeElements)
+                new ConfigurationSoftwareComponentVariant(getIdentity().getLinkVariant(), linkElements.getAllArtifacts(), linkElements),
+                new ConfigurationSoftwareComponentVariant(getIdentity().getRuntimeVariant(), runtimeElements.getAllArtifacts(), runtimeElements)
         );
     }
 }

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/plugins/NativeBasePluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/plugins/NativeBasePluginTest.groovy
@@ -25,6 +25,7 @@ import org.gradle.api.component.SoftwareComponentVariant
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal
+import org.gradle.api.internal.component.DefaultSoftwareComponentPublications
 import org.gradle.api.internal.component.SoftwareComponentInternal
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.provider.Providers
@@ -417,7 +418,7 @@ class NativeBasePluginTest extends Specification {
         componentVariant1.artifacts >> [artifact1]
         def variant1 = Stub(PublishableVariant)
         variant1.name >> "debug"
-        variant1.allVariants >> [componentVariant1]
+        variant1.outgoing >> new DefaultSoftwareComponentPublications([componentVariant1] as Set)
         variant1.getCoordinates() >> new DefaultModuleVersionIdentifier("my.group", "test_app_debug", "1.2")
 
         def componentVariant2 = Stub(SoftwareComponentVariant)
@@ -426,7 +427,7 @@ class NativeBasePluginTest extends Specification {
         componentVariant2.artifacts >> [artifact2]
         def variant2 = Stub(PublishableVariant)
         variant2.name >> "release"
-        variant2.allVariants >> [componentVariant2]
+        variant2.outgoing >> new DefaultSoftwareComponentPublications([componentVariant2] as Set)
         variant2.getCoordinates() >> new DefaultModuleVersionIdentifier("my.group", "test_app_release", "1.2")
 
         def doNotPublish = Stub(SoftwareComponentInternal)

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/plugins/NativeBasePluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/plugins/NativeBasePluginTest.groovy
@@ -21,11 +21,11 @@ import org.gradle.api.artifacts.PublishArtifact
 import org.gradle.api.component.ComponentWithVariants
 import org.gradle.api.component.PublishableComponent
 import org.gradle.api.component.SoftwareComponent
+import org.gradle.api.component.SoftwareComponentVariant
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal
 import org.gradle.api.internal.component.SoftwareComponentInternal
-import org.gradle.api.internal.component.UsageContext
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.provider.Providers
 import org.gradle.api.publish.maven.plugins.MavenPublishPlugin
@@ -411,22 +411,22 @@ class NativeBasePluginTest extends Specification {
     }
 
     def "adds Maven publications for component with main publication"() {
-        def usage1 = Stub(UsageContext)
+        def componentVariant1 = Stub(SoftwareComponentVariant)
         def artifact1 = Stub(PublishArtifact)
         artifact1.getFile() >> projectDir.file("artifact1")
-        usage1.artifacts >> [artifact1]
+        componentVariant1.artifacts >> [artifact1]
         def variant1 = Stub(PublishableVariant)
         variant1.name >> "debug"
-        variant1.usages >> [usage1]
+        variant1.allVariants >> [componentVariant1]
         variant1.getCoordinates() >> new DefaultModuleVersionIdentifier("my.group", "test_app_debug", "1.2")
 
-        def usage2 = Stub(UsageContext)
+        def componentVariant2 = Stub(SoftwareComponentVariant)
         def artifact2 = Stub(PublishArtifact)
         artifact2.getFile() >> projectDir.file("artifact1")
-        usage2.artifacts >> [artifact2]
+        componentVariant2.artifacts >> [artifact2]
         def variant2 = Stub(PublishableVariant)
         variant2.name >> "release"
-        variant2.usages >> [usage2]
+        variant2.allVariants >> [componentVariant2]
         variant2.getCoordinates() >> new DefaultModuleVersionIdentifier("my.group", "test_app_release", "1.2")
 
         def doNotPublish = Stub(SoftwareComponentInternal)

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftLibraryTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftLibraryTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.language.swift.internal
 
-import org.gradle.language.cpp.internal.DefaultSoftwareComponentVariant
+import org.gradle.api.internal.component.DefaultSoftwareComponentVariant
 import org.gradle.language.cpp.internal.NativeVariantIdentity
 import org.gradle.language.swift.SwiftPlatform
 import org.gradle.nativeplatform.MachineArchitecture

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftLibraryTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftLibraryTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.language.swift.internal
 
-import org.gradle.language.cpp.internal.DefaultUsageContext
+import org.gradle.language.cpp.internal.DefaultSoftwareComponentVariant
 import org.gradle.language.cpp.internal.NativeVariantIdentity
 import org.gradle.language.swift.SwiftPlatform
 import org.gradle.nativeplatform.MachineArchitecture
@@ -110,8 +110,8 @@ class DefaultSwiftLibraryTest extends Specification {
 
     private NativeVariantIdentity getIdentity() {
         return new NativeVariantIdentity("test", null, null, null, true, false, targetMachine(OperatingSystemFamily.WINDOWS, MachineArchitecture.X86_64),
-            new DefaultUsageContext("test", AttributeTestUtil.attributesFactory().mutable()),
-            new DefaultUsageContext("test", AttributeTestUtil.attributesFactory().mutable())
+            new DefaultSoftwareComponentVariant("test", AttributeTestUtil.attributesFactory().mutable()),
+            new DefaultSoftwareComponentVariant("test", AttributeTestUtil.attributesFactory().mutable())
         )
     }
 

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -419,7 +419,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
             ? Comparator.comparing(x -> ((MavenPublishingAwareVariant) x).getScopeMapping())
             : (u1, u2) -> VARIANT_ORDERING.compare(u1.getName(), u2.getName());
 
-        return this.component.getAllVariants().stream().sorted(comparator).collect(Collectors.toList());
+        return this.component.getOutgoing().getVariants().stream().sorted(comparator).collect(Collectors.toList());
     }
 
     private Set<MavenDependencyInternal> dependenciesFor(SoftwareComponentVariant variant) {

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -19,7 +19,6 @@ package org.gradle.api.publish.maven.internal.publication;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Objects;
 import com.google.common.base.Strings;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.gradle.api.Action;
 import org.gradle.api.DomainObjectCollection;
@@ -37,6 +36,7 @@ import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.component.AdhocComponentWithVariants;
 import org.gradle.api.component.SoftwareComponent;
+import org.gradle.api.component.SoftwareComponentVariant;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.CompositeDomainObjectSet;
 import org.gradle.api.internal.DocumentationRegistry;
@@ -51,9 +51,8 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.MavenVer
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyPublicationResolver;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
-import org.gradle.api.internal.component.MavenPublishingAwareContext;
+import org.gradle.api.internal.component.MavenPublishingAwareVariant;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
-import org.gradle.api.internal.component.UsageContext;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
@@ -102,6 +101,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toMap;
 
@@ -305,20 +305,20 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
         Set<ArtifactKey> seenArtifacts = Sets.newHashSet();
         Set<PublishedDependency> seenDependencies = Sets.newHashSet();
         Set<DependencyConstraint> seenConstraints = Sets.newHashSet();
-        for (UsageContext usageContext : getSortedUsageContexts()) {
-            // TODO Need a smarter way to map usage to artifact classifier
-            for (PublishArtifact publishArtifact : usageContext.getArtifacts()) {
+        for (SoftwareComponentVariant variant : getSortedVariants()) {
+            // TODO Need a smarter way to map variant to artifact classifier
+            for (PublishArtifact publishArtifact : variant.getArtifacts()) {
                 ArtifactKey key = new ArtifactKey(publishArtifact.getFile(), publishArtifact.getClassifier(), publishArtifact.getExtension());
                 if (!artifactsOverridden && seenArtifacts.add(key)) {
                     artifact(publishArtifact);
                 }
             }
 
-            Set<ExcludeRule> globalExcludes = usageContext.getGlobalExcludes();
+            Set<ExcludeRule> globalExcludes = variant.getGlobalExcludes();
 
-            publicationWarningsCollector.newContext(usageContext.getName());
-            Set<MavenDependencyInternal> dependencies = dependenciesFor(usageContext);
-            for (ModuleDependency dependency : usageContext.getDependencies()) {
+            publicationWarningsCollector.newContext(variant.getName());
+            Set<MavenDependencyInternal> dependencies = dependenciesFor(variant);
+            for (ModuleDependency dependency : variant.getDependencies()) {
                 if (seenDependencies.add(PublishedDependency.of(dependency))) {
                     if (isDependencyWithDefaultArtifact(dependency) && dependencyMatchesProject(dependency)) {
                         // We skip all self referencing dependency declarations, unless they have custom artifact information
@@ -348,8 +348,8 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
                     }
                 }
             }
-            Set<MavenDependency> dependencyConstraints = dependencyConstraintsFor(usageContext);
-            for (DependencyConstraint dependency : usageContext.getDependencyConstraints()) {
+            Set<MavenDependency> dependencyConstraints = dependencyConstraintsFor(variant);
+            for (DependencyConstraint dependency : variant.getDependencyConstraints()) {
                 if (seenConstraints.add(dependency)) {
                     if (dependency instanceof DefaultProjectDependencyConstraint) {
                         addDependencyConstraint((DefaultProjectDependencyConstraint) dependency, dependencyConstraints);
@@ -361,8 +361,8 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
                     }
                 }
             }
-            if (!usageContext.getCapabilities().isEmpty()) {
-                for (Capability capability : usageContext.getCapabilities()) {
+            if (!variant.getCapabilities().isEmpty()) {
+                for (Capability capability : variant.getCapabilities()) {
                     if (isNotDefaultCapability(capability)) {
                         publicationWarningsCollector.addVariantUnsupported(String.format("Declares capability %s:%s:%s which cannot be mapped to Maven", capability.getGroup(), capability.getName(), capability.getVersion()));
                     }
@@ -414,19 +414,17 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
         importDependencyConstraints.add(new DefaultMavenDependency(dependency.getGroup(), dependency.getName(), dependency.getVersion(), "pom"));
     }
 
-    private List<UsageContext> getSortedUsageContexts() {
-        List<UsageContext> usageContexts = Lists.newArrayList(this.component.getUsages());
-        if (component instanceof AdhocComponentWithVariants) {
-            Collections.sort(Cast.uncheckedCast(usageContexts), Comparator.comparing(MavenPublishingAwareContext::getScopeMapping));
-        } else {
-            Collections.sort(usageContexts, (u1, u2) -> VARIANT_ORDERING.compare(u1.getName(), u2.getName()));
-        }
-        return usageContexts;
+    private List<SoftwareComponentVariant> getSortedVariants() {
+        Comparator<SoftwareComponentVariant> comparator = component instanceof AdhocComponentWithVariants
+            ? Comparator.comparing(x -> ((MavenPublishingAwareVariant) x).getScopeMapping())
+            : (u1, u2) -> VARIANT_ORDERING.compare(u1.getName(), u2.getName());
+
+        return this.component.getAllVariants().stream().sorted(comparator).collect(Collectors.toList());
     }
 
-    private Set<MavenDependencyInternal> dependenciesFor(UsageContext usage) {
-        if (usage instanceof MavenPublishingAwareContext) {
-            MavenPublishingAwareContext.ScopeMapping mapping = ((MavenPublishingAwareContext) usage).getScopeMapping();
+    private Set<MavenDependencyInternal> dependenciesFor(SoftwareComponentVariant variant) {
+        if (variant instanceof MavenPublishingAwareVariant) {
+            MavenPublishingAwareVariant.ScopeMapping mapping = ((MavenPublishingAwareVariant) variant).getScopeMapping();
             switch (mapping) {
                 case compile:
                     return apiDependencies;
@@ -439,16 +437,16 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
             }
         }
         // legacy mode for internal APIs
-        String name = usage.getName();
+        String name = variant.getName();
         if (API_VARIANT.equals(name) || API_ELEMENTS_VARIANT.equals(name)) {
             return apiDependencies;
         }
         return runtimeDependencies;
     }
 
-    private Set<MavenDependency> dependencyConstraintsFor(UsageContext usage) {
-        if (usage instanceof MavenPublishingAwareContext) {
-            MavenPublishingAwareContext.ScopeMapping mapping = ((MavenPublishingAwareContext) usage).getScopeMapping();
+    private Set<MavenDependency> dependencyConstraintsFor(SoftwareComponentVariant variant) {
+        if (variant instanceof MavenPublishingAwareVariant) {
+            MavenPublishingAwareVariant.ScopeMapping mapping = ((MavenPublishingAwareVariant) variant).getScopeMapping();
             switch (mapping) {
                 case compile:
                 case compile_optional:
@@ -459,7 +457,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
             }
         }
         // legacy mode
-        String name = usage.getName();
+        String name = variant.getName();
         if (API_VARIANT.equals(name) || API_ELEMENTS_VARIANT.equals(name)) {
             return apiDependencyConstraints;
         }

--- a/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
@@ -35,6 +35,7 @@ import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyPublicationResolver
 import org.gradle.api.internal.attributes.ImmutableAttributes
+import org.gradle.api.internal.component.DefaultSoftwareComponentPublications
 import org.gradle.api.internal.component.SoftwareComponentInternal
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.publish.internal.PublicationArtifactInternal
@@ -228,7 +229,7 @@ class DefaultMavenPublicationTest extends Specification {
         def variant2 = Stub(SoftwareComponentVariant) { getName() >> 'runtime' }
         variant2.artifacts >> [artifact2]
         def component = Stub(SoftwareComponentInternal)
-        component.allVariants >> [variant1, variant2]
+        component.outgoing >> new DefaultSoftwareComponentPublications([variant1, variant2] as Set)
         def mavenArtifact = Mock(MavenArtifact)
         mavenArtifact.file >> artifactFile
         notationParser.parseNotation(artifact1) >> mavenArtifact
@@ -600,7 +601,7 @@ class DefaultMavenPublicationTest extends Specification {
             getDependencies() >> dependencies
         }
         def component = Stub(SoftwareComponentInternal) {
-            getAllVariants() >> [variant]
+            getOutgoing() >> new DefaultSoftwareComponentPublications([variant] as Set)
         }
         return component
     }

--- a/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
@@ -27,6 +27,7 @@ import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.artifacts.PublishArtifact
 import org.gradle.api.attributes.Category
 import org.gradle.api.component.ComponentWithVariants
+import org.gradle.api.component.SoftwareComponentVariant
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.DocumentationRegistry
@@ -35,7 +36,6 @@ import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyPublicationResolver
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.component.SoftwareComponentInternal
-import org.gradle.api.internal.component.UsageContext
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.publish.internal.PublicationArtifactInternal
 import org.gradle.api.publish.internal.PublicationInternal
@@ -223,12 +223,12 @@ class DefaultMavenPublicationTest extends Specification {
         artifact2.file >> artifactFile
         artifact2.classifier >> ""
         artifact2.extension >> "jar"
-        def usage1 = Stub(UsageContext) { getName() >> 'api' }
-        usage1.artifacts >> [artifact1]
-        def usage2 = Stub(UsageContext) { getName() >> 'runtime' }
-        usage2.artifacts >> [artifact2]
+        def variant1 = Stub(SoftwareComponentVariant) { getName() >> 'api' }
+        variant1.artifacts >> [artifact1]
+        def variant2 = Stub(SoftwareComponentVariant) { getName() >> 'runtime' }
+        variant2.artifacts >> [artifact2]
         def component = Stub(SoftwareComponentInternal)
-        component.usages >> [usage1, usage2]
+        component.allVariants >> [variant1, variant2]
         def mavenArtifact = Mock(MavenArtifact)
         mavenArtifact.file >> artifactFile
         notationParser.parseNotation(artifact1) >> mavenArtifact
@@ -594,13 +594,13 @@ class DefaultMavenPublicationTest extends Specification {
     }
 
     def createComponent(def artifacts, def dependencies, def scope) {
-        def usage = Stub(UsageContext) {
+        def variant = Stub(SoftwareComponentVariant) {
             getName() >> scope
             getArtifacts() >> artifacts
             getDependencies() >> dependencies
         }
         def component = Stub(SoftwareComponentInternal) {
-            getUsages() >> [usage]
+            getAllVariants() >> [variant]
         }
         return component
     }

--- a/subprojects/platform-base/src/main/java/org/gradle/api/internal/java/usagecontext/FeatureConfigurationVariant.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/api/internal/java/usagecontext/FeatureConfigurationVariant.java
@@ -18,16 +18,16 @@ package org.gradle.api.internal.java.usagecontext;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationVariant;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
-import org.gradle.api.internal.component.IvyPublishingAwareContext;
-import org.gradle.api.internal.component.MavenPublishingAwareContext;
-import org.gradle.api.plugins.internal.AbstractConfigurationUsageContext;
+import org.gradle.api.internal.component.IvyPublishingAwareVariant;
+import org.gradle.api.internal.component.MavenPublishingAwareVariant;
+import org.gradle.api.plugins.internal.AbstractConfigurationVariant;
 
-public class FeatureConfigurationUsageContext extends AbstractConfigurationUsageContext implements MavenPublishingAwareContext, IvyPublishingAwareContext {
+public class FeatureConfigurationVariant extends AbstractConfigurationVariant implements MavenPublishingAwareVariant, IvyPublishingAwareVariant {
     private final Configuration configuration;
     private final ScopeMapping scopeMapping;
     private final boolean optional;
 
-    public FeatureConfigurationUsageContext(String name, Configuration configuration, ConfigurationVariant variant, String mavenScope, boolean optional) {
+    public FeatureConfigurationVariant(String name, Configuration configuration, ConfigurationVariant variant, String mavenScope, boolean optional) {
         super(name, ((AttributeContainerInternal)variant.getAttributes()).asImmutable(), variant.getArtifacts());
         this.configuration = configuration;
         this.scopeMapping = ScopeMapping.of(mavenScope, optional);

--- a/subprojects/platform-base/src/main/java/org/gradle/api/internal/java/usagecontext/FeatureConfigurationVariant.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/api/internal/java/usagecontext/FeatureConfigurationVariant.java
@@ -20,23 +20,16 @@ import org.gradle.api.artifacts.ConfigurationVariant;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.component.IvyPublishingAwareVariant;
 import org.gradle.api.internal.component.MavenPublishingAwareVariant;
-import org.gradle.api.plugins.internal.AbstractConfigurationVariant;
+import org.gradle.api.plugins.internal.ConfigurationSoftwareComponentVariant;
 
-public class FeatureConfigurationVariant extends AbstractConfigurationVariant implements MavenPublishingAwareVariant, IvyPublishingAwareVariant {
-    private final Configuration configuration;
+public class FeatureConfigurationVariant extends ConfigurationSoftwareComponentVariant implements MavenPublishingAwareVariant, IvyPublishingAwareVariant {
     private final ScopeMapping scopeMapping;
     private final boolean optional;
 
     public FeatureConfigurationVariant(String name, Configuration configuration, ConfigurationVariant variant, String mavenScope, boolean optional) {
-        super(name, ((AttributeContainerInternal)variant.getAttributes()).asImmutable(), variant.getArtifacts());
-        this.configuration = configuration;
+        super(name, configuration, ((AttributeContainerInternal)variant.getAttributes()).asImmutable(), variant.getArtifacts());
         this.scopeMapping = ScopeMapping.of(mavenScope, optional);
         this.optional = optional;
-    }
-
-    @Override
-    protected Configuration getConfiguration() {
-        return configuration;
     }
 
     @Override

--- a/subprojects/platform-base/src/main/java/org/gradle/api/plugins/internal/AbstractConfigurationVariant.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/api/plugins/internal/AbstractConfigurationVariant.java
@@ -30,14 +30,14 @@ import org.gradle.api.internal.attributes.ImmutableAttributes;
 
 import java.util.Set;
 
-public abstract class AbstractConfigurationUsageContext extends AbstractUsageContext {
+public abstract class AbstractConfigurationVariant extends AbstractSoftwareComponentVariant {
     protected final String name;
     private DomainObjectSet<ModuleDependency> dependencies;
     private DomainObjectSet<DependencyConstraint> dependencyConstraints;
     private Set<? extends Capability> capabilities;
     private Set<ExcludeRule> excludeRules;
 
-    public AbstractConfigurationUsageContext(String name, ImmutableAttributes attributes, Set<PublishArtifact> artifacts) {
+    public AbstractConfigurationVariant(String name, ImmutableAttributes attributes, Set<PublishArtifact> artifacts) {
         super(attributes, artifacts);
         this.name = name;
     }

--- a/subprojects/platform-base/src/main/java/org/gradle/api/plugins/internal/AbstractSoftwareComponentVariant.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/api/plugins/internal/AbstractSoftwareComponentVariant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,24 +17,18 @@ package org.gradle.api.plugins.internal;
 
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.attributes.AttributeContainer;
-import org.gradle.api.attributes.Usage;
+import org.gradle.api.component.SoftwareComponentVariant;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
-import org.gradle.api.internal.component.UsageContext;
 
 import java.util.Set;
 
-public abstract class AbstractUsageContext implements UsageContext {
+public abstract class AbstractSoftwareComponentVariant implements SoftwareComponentVariant {
     private final ImmutableAttributes attributes;
     private final Set<PublishArtifact> artifacts;
 
-    public AbstractUsageContext(ImmutableAttributes attributes, Set<PublishArtifact> artifacts) {
+    public AbstractSoftwareComponentVariant(ImmutableAttributes attributes, Set<PublishArtifact> artifacts) {
         this.attributes = attributes;
         this.artifacts = artifacts;
-    }
-
-    @Override
-    public Usage getUsage() {
-        throw new UnsupportedOperationException("This method has been deprecated, should never be called");
     }
 
     @Override

--- a/subprojects/platform-base/src/main/java/org/gradle/api/plugins/internal/ConfigurationSoftwareComponentVariant.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/api/plugins/internal/ConfigurationSoftwareComponentVariant.java
@@ -23,22 +23,31 @@ import org.gradle.api.artifacts.DependencyConstraint;
 import org.gradle.api.artifacts.ExcludeRule;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.PublishArtifact;
+import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.capabilities.Capability;
+import org.gradle.api.component.SoftwareComponentVariant;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.artifacts.configurations.Configurations;
-import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.component.AbstractSoftwareComponentVariant;
 
 import java.util.Set;
 
-public abstract class AbstractConfigurationVariant extends AbstractSoftwareComponentVariant {
+public class ConfigurationSoftwareComponentVariant extends AbstractSoftwareComponentVariant {
     protected final String name;
+    private final Configuration configuration;
     private DomainObjectSet<ModuleDependency> dependencies;
     private DomainObjectSet<DependencyConstraint> dependencyConstraints;
     private Set<? extends Capability> capabilities;
     private Set<ExcludeRule> excludeRules;
 
-    public AbstractConfigurationVariant(String name, ImmutableAttributes attributes, Set<PublishArtifact> artifacts) {
-        super(attributes, artifacts);
+    public ConfigurationSoftwareComponentVariant(SoftwareComponentVariant base, Set<? extends PublishArtifact> artifacts, Configuration configuration) {
+        this(base.getName(), configuration, base.getAttributes(), artifacts);
+    }
+
+    public ConfigurationSoftwareComponentVariant(String name, Configuration configuration, AttributeContainer attributes, Set<? extends PublishArtifact> artifacts) {
+        super(((AttributeContainerInternal) attributes).asImmutable(), artifacts);
+        this.configuration = configuration;
         this.name = name;
     }
 
@@ -81,5 +90,7 @@ public abstract class AbstractConfigurationVariant extends AbstractSoftwareCompo
         return excludeRules;
     }
 
-    protected abstract Configuration getConfiguration();
+    protected Configuration getConfiguration() {
+        return configuration;
+    }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/java/WebApplication.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/java/WebApplication.java
@@ -40,7 +40,7 @@ public class WebApplication implements SoftwareComponentInternal {
     }
 
     @Override
-    public Set<SoftwareComponentVariant> getAllVariants() {
+    public Set<? extends SoftwareComponentVariant> getAllVariants() {
         return Collections.singleton(variant);
     }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/java/WebApplication.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/java/WebApplication.java
@@ -22,17 +22,17 @@ import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.capabilities.Capability;
+import org.gradle.api.component.SoftwareComponentVariant;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
-import org.gradle.api.internal.component.UsageContext;
-import org.gradle.api.plugins.internal.AbstractUsageContext;
+import org.gradle.api.plugins.internal.AbstractSoftwareComponentVariant;
 
 import javax.inject.Inject;
 import java.util.Collections;
 import java.util.Set;
 
 public class WebApplication implements SoftwareComponentInternal {
-    private final UsageContext webArchiveUsage;
+    private final SoftwareComponentVariant variant;
     private final PublishArtifact warArtifact;
     private final String variantName;
 
@@ -40,7 +40,7 @@ public class WebApplication implements SoftwareComponentInternal {
     public WebApplication(PublishArtifact warArtifact, String variantName, AttributeContainer attributes) {
         this.warArtifact = warArtifact;
         this.variantName = variantName;
-        this.webArchiveUsage = new WebArchiveUsageContext(attributes);
+        this.variant = new WebArchiveVariant(attributes);
     }
 
     @Override
@@ -49,12 +49,12 @@ public class WebApplication implements SoftwareComponentInternal {
     }
 
     @Override
-    public Set<UsageContext> getUsages() {
-        return Collections.singleton(webArchiveUsage);
+    public Set<SoftwareComponentVariant> getAllVariants() {
+        return Collections.singleton(variant);
     }
 
-    private class WebArchiveUsageContext extends AbstractUsageContext {
-        public WebArchiveUsageContext(AttributeContainer attributes) {
+    private class WebArchiveVariant extends AbstractSoftwareComponentVariant {
+        public WebArchiveVariant(AttributeContainer attributes) {
             super(((AttributeContainerInternal)attributes).asImmutable(), Collections.singleton(warArtifact));
         }
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/java/WebApplication.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/java/WebApplication.java
@@ -16,16 +16,11 @@
 
 package org.gradle.api.internal.java;
 
-import org.gradle.api.artifacts.DependencyConstraint;
-import org.gradle.api.artifacts.ExcludeRule;
-import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.attributes.AttributeContainer;
-import org.gradle.api.capabilities.Capability;
 import org.gradle.api.component.SoftwareComponentVariant;
-import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
-import org.gradle.api.plugins.internal.AbstractSoftwareComponentVariant;
+import org.gradle.api.internal.component.DefaultSoftwareComponentVariant;
 
 import javax.inject.Inject;
 import java.util.Collections;
@@ -33,14 +28,10 @@ import java.util.Set;
 
 public class WebApplication implements SoftwareComponentInternal {
     private final SoftwareComponentVariant variant;
-    private final PublishArtifact warArtifact;
-    private final String variantName;
 
     @Inject
     public WebApplication(PublishArtifact warArtifact, String variantName, AttributeContainer attributes) {
-        this.warArtifact = warArtifact;
-        this.variantName = variantName;
-        this.variant = new WebArchiveVariant(attributes);
+        this.variant = new DefaultSoftwareComponentVariant(variantName, attributes, Collections.singleton(warArtifact));
     }
 
     @Override
@@ -51,36 +42,5 @@ public class WebApplication implements SoftwareComponentInternal {
     @Override
     public Set<SoftwareComponentVariant> getAllVariants() {
         return Collections.singleton(variant);
-    }
-
-    private class WebArchiveVariant extends AbstractSoftwareComponentVariant {
-        public WebArchiveVariant(AttributeContainer attributes) {
-            super(((AttributeContainerInternal)attributes).asImmutable(), Collections.singleton(warArtifact));
-        }
-
-        @Override
-        public String getName() {
-            return variantName;
-        }
-
-        @Override
-        public Set<ModuleDependency> getDependencies() {
-            return Collections.emptySet();
-        }
-
-        @Override
-        public Set<? extends DependencyConstraint> getDependencyConstraints() {
-            return Collections.emptySet();
-        }
-
-        @Override
-        public Set<? extends Capability> getCapabilities() {
-            return Collections.emptySet();
-        }
-
-        @Override
-        public Set<ExcludeRule> getGlobalExcludes() {
-            return Collections.emptySet();
-        }
     }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/java/WebApplication.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/java/WebApplication.java
@@ -19,12 +19,13 @@ package org.gradle.api.internal.java;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.component.SoftwareComponentVariant;
-import org.gradle.api.internal.component.SoftwareComponentInternal;
+import org.gradle.api.internal.component.DefaultSoftwareComponentPublications;
 import org.gradle.api.internal.component.DefaultSoftwareComponentVariant;
+import org.gradle.api.internal.component.SoftwareComponentInternal;
+import org.gradle.api.internal.component.SoftwareComponentPublications;
 
 import javax.inject.Inject;
 import java.util.Collections;
-import java.util.Set;
 
 public class WebApplication implements SoftwareComponentInternal {
     private final SoftwareComponentVariant variant;
@@ -40,7 +41,7 @@ public class WebApplication implements SoftwareComponentInternal {
     }
 
     @Override
-    public Set<? extends SoftwareComponentVariant> getAllVariants() {
-        return Collections.singleton(variant);
+    public SoftwareComponentPublications getOutgoing() {
+        return new DefaultSoftwareComponentPublications(Collections.singleton(variant));
     }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/java/usagecontext/ConfigurationVariantMapping.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/java/usagecontext/ConfigurationVariantMapping.java
@@ -27,8 +27,8 @@ import org.gradle.api.artifacts.ConfigurationVariant;
 import org.gradle.api.artifacts.PublishArtifactSet;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.component.ConfigurationVariantDetails;
+import org.gradle.api.component.SoftwareComponentVariant;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
-import org.gradle.api.internal.component.UsageContext;
 import org.gradle.internal.Actions;
 import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.reflect.Instantiator;
@@ -57,7 +57,7 @@ public class ConfigurationVariantMapping {
         this.action = Actions.composite(this.action, action);
     }
 
-    public void collectUsageContexts(final ImmutableCollection.Builder<UsageContext> outgoing) {
+    public void collectVariants(final ImmutableCollection.Builder<SoftwareComponentVariant> outgoing) {
         if (!outgoingConfiguration.isTransitive()) {
             DeprecationLogger.warnOfChangedBehaviour("Publication ignores 'transitive = false' at configuration level", "Consider using 'transitive = false' at the dependency level if you need this to be published.")
                 .withUserManual("publishing_ivy", "configurations_marked_as_non_transitive")
@@ -69,7 +69,7 @@ public class ConfigurationVariantMapping {
         action.execute(details);
         String outgoingConfigurationName = outgoingConfiguration.getName();
         if (details.shouldPublish()) {
-            registerUsageContext(outgoing, seen, defaultConfigurationVariant, outgoingConfigurationName, details.getMavenScope(), details.isOptional());
+            registerVariant(outgoing, seen, defaultConfigurationVariant, outgoingConfigurationName, details.getMavenScope(), details.isOptional());
         }
         NamedDomainObjectContainer<ConfigurationVariant> extraVariants = outgoingConfiguration.getOutgoing().getVariants();
         for (ConfigurationVariant variant : extraVariants) {
@@ -77,14 +77,14 @@ public class ConfigurationVariantMapping {
             action.execute(details);
             if (details.shouldPublish()) {
                 String name = outgoingConfigurationName + StringUtils.capitalize(variant.getName());
-                registerUsageContext(outgoing, seen, variant, name, details.getMavenScope(), details.isOptional());
+                registerVariant(outgoing, seen, variant, name, details.getMavenScope(), details.isOptional());
             }
         }
     }
 
-    private void registerUsageContext(ImmutableCollection.Builder<UsageContext> outgoing, Set<String> seen, ConfigurationVariant variant, String name, String scope, boolean optional) {
+    private void registerVariant(ImmutableCollection.Builder<SoftwareComponentVariant> outgoing, Set<String> seen, ConfigurationVariant variant, String name, String scope, boolean optional) {
         assertNoDuplicateVariant(name, seen);
-        outgoing.add(new FeatureConfigurationUsageContext(name, outgoingConfiguration, variant, scope, optional));
+        outgoing.add(new FeatureConfigurationVariant(name, outgoingConfiguration, variant, scope, optional));
     }
 
     static class DefaultConfigurationVariant implements ConfigurationVariant {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultAdhocSoftwareComponent.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultAdhocSoftwareComponent.java
@@ -18,7 +18,6 @@ package org.gradle.api.plugins.internal;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import org.gradle.api.Action;
-import org.gradle.api.GradleException;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.component.AdhocComponentWithVariants;
@@ -49,11 +48,7 @@ public class DefaultAdhocSoftwareComponent implements AdhocComponentWithVariants
 
     @Override
     public void addVariantsFromConfiguration(Configuration outgoingConfiguration, Action<? super ConfigurationVariantDetails> spec) {
-        ConfigurationVariantMapping mapping = new ConfigurationVariantMapping((ConfigurationInternal) outgoingConfiguration, spec, instantiator);
-        if (variants.put(outgoingConfiguration, mapping) != null) {
-            throw new GradleException("Mapping for configuration '" + outgoingConfiguration.getName() +
-                "' already exists. Use 'withVariantsFromConfiguration' to modify this configuration's variants");
-        }
+        variants.put(outgoingConfiguration, new ConfigurationVariantMapping((ConfigurationInternal) outgoingConfiguration, spec, instantiator));
     }
 
     @Override

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultAdhocSoftwareComponent.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultAdhocSoftwareComponent.java
@@ -24,12 +24,13 @@ import org.gradle.api.component.AdhocComponentWithVariants;
 import org.gradle.api.component.ConfigurationVariantDetails;
 import org.gradle.api.component.SoftwareComponentVariant;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
+import org.gradle.api.internal.component.DefaultSoftwareComponentPublications;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
+import org.gradle.api.internal.component.SoftwareComponentPublications;
 import org.gradle.api.internal.java.usagecontext.ConfigurationVariantMapping;
 import org.gradle.internal.reflect.Instantiator;
 
 import java.util.Map;
-import java.util.Set;
 
 public class DefaultAdhocSoftwareComponent implements AdhocComponentWithVariants, SoftwareComponentInternal {
     private final String componentName;
@@ -60,11 +61,11 @@ public class DefaultAdhocSoftwareComponent implements AdhocComponentWithVariants
     }
 
     @Override
-    public Set<? extends SoftwareComponentVariant> getAllVariants() {
+    public SoftwareComponentPublications getOutgoing() {
         ImmutableSet.Builder<SoftwareComponentVariant> builder = new ImmutableSet.Builder<>();
         for (ConfigurationVariantMapping variant : variants.values()) {
             variant.collectVariants(builder);
         }
-        return builder.build();
+        return new DefaultSoftwareComponentPublications(builder.build());
     }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultAdhocSoftwareComponent.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultAdhocSoftwareComponent.java
@@ -60,7 +60,7 @@ public class DefaultAdhocSoftwareComponent implements AdhocComponentWithVariants
     }
 
     @Override
-    public Set<SoftwareComponentVariant> getAllVariants() {
+    public Set<? extends SoftwareComponentVariant> getAllVariants() {
         ImmutableSet.Builder<SoftwareComponentVariant> builder = new ImmutableSet.Builder<>();
         for (ConfigurationVariantMapping variant : variants.values()) {
             variant.collectVariants(builder);

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaLibraryPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaLibraryPluginTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.plugins
 
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.ModuleDependency
+import org.gradle.api.plugins.internal.DefaultAdhocSoftwareComponent
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 import org.gradle.util.TestUtil
 
@@ -217,22 +218,22 @@ class JavaLibraryPluginTest extends AbstractProjectBuilderSpec {
 
         when:
         def jarTask = project.tasks.getByName(JavaPlugin.JAR_TASK_NAME)
-        def javaLibrary = project.components.getByName("java")
-        def runtimeUsage = javaLibrary.usages.find { it.name == 'runtimeElements' }
-        def apiUsage = javaLibrary.usages.find { it.name == 'apiElements' }
+        DefaultAdhocSoftwareComponent javaLibrary = project.components.getByName("java")
+        def runtimeVariant = javaLibrary.allVariants.find { it.name == 'runtimeElements' }
+        def apiVariant = javaLibrary.allVariants.find { it.name == 'apiElements' }
 
         then:
-        runtimeUsage.artifacts.collect {it.file} == [jarTask.archiveFile.get().asFile]
-        runtimeUsage.dependencies.size() == 2
-        runtimeUsage.dependencies == project.configurations.getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME).allDependencies.withType(ModuleDependency)
-        runtimeUsage.dependencyConstraints.size() == 2
-        runtimeUsage.dependencyConstraints == project.configurations.getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME).allDependencyConstraints
+        runtimeVariant.artifacts.collect {it.file} == [jarTask.archiveFile.get().asFile]
+        runtimeVariant.dependencies.size() == 2
+        runtimeVariant.dependencies == project.configurations.getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME).allDependencies.withType(ModuleDependency)
+        runtimeVariant.dependencyConstraints.size() == 2
+        runtimeVariant.dependencyConstraints == project.configurations.getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME).allDependencyConstraints
 
-        apiUsage.artifacts.collect {it.file} == [jarTask.archiveFile.get().asFile]
-        apiUsage.dependencies.size() == 1
-        apiUsage.dependencies == project.configurations.getByName(JavaPlugin.API_CONFIGURATION_NAME).allDependencies.withType(ModuleDependency)
-        apiUsage.dependencyConstraints.size() == 1
-        apiUsage.dependencyConstraints == project.configurations.getByName(JavaPlugin.API_CONFIGURATION_NAME).allDependencyConstraints
+        apiVariant.artifacts.collect {it.file} == [jarTask.archiveFile.get().asFile]
+        apiVariant.dependencies.size() == 1
+        apiVariant.dependencies == project.configurations.getByName(JavaPlugin.API_CONFIGURATION_NAME).allDependencies.withType(ModuleDependency)
+        apiVariant.dependencyConstraints.size() == 1
+        apiVariant.dependencyConstraints == project.configurations.getByName(JavaPlugin.API_CONFIGURATION_NAME).allDependencyConstraints
     }
 
 }

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaLibraryPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaLibraryPluginTest.groovy
@@ -219,8 +219,8 @@ class JavaLibraryPluginTest extends AbstractProjectBuilderSpec {
         when:
         def jarTask = project.tasks.getByName(JavaPlugin.JAR_TASK_NAME)
         DefaultAdhocSoftwareComponent javaLibrary = project.components.getByName("java")
-        def runtimeVariant = javaLibrary.allVariants.find { it.name == 'runtimeElements' }
-        def apiVariant = javaLibrary.allVariants.find { it.name == 'apiElements' }
+        def runtimeVariant = javaLibrary.outgoing.variants.find { it.name == 'runtimeElements' }
+        def apiVariant = javaLibrary.outgoing.variants.find { it.name == 'apiElements' }
 
         then:
         runtimeVariant.artifacts.collect {it.file} == [jarTask.archiveFile.get().asFile]

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPlatformPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPlatformPluginTest.groovy
@@ -116,8 +116,8 @@ class JavaPlatformPluginTest extends AbstractProjectBuilderSpec {
 
         when:
         DefaultAdhocSoftwareComponent javaPlatform = project.components.getByName("javaPlatform")
-        SoftwareComponentVariant apiVariant = javaPlatform.allVariants[0]
-        SoftwareComponentVariant runtimeVariant = javaPlatform.allVariants[1]
+        SoftwareComponentVariant apiVariant = javaPlatform.outgoing.variants[0]
+        SoftwareComponentVariant runtimeVariant = javaPlatform.outgoing.variants[1]
 
         then:
         runtimeVariant.dependencies.size() == 2

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPlatformPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPlatformPluginTest.groovy
@@ -21,7 +21,8 @@ import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.attributes.Category
 import org.gradle.api.attributes.LibraryElements
 import org.gradle.api.attributes.Usage
-import org.gradle.api.internal.component.UsageContext
+import org.gradle.api.component.SoftwareComponentVariant
+import org.gradle.api.plugins.internal.DefaultAdhocSoftwareComponent
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 import spock.lang.Unroll
 
@@ -114,26 +115,26 @@ class JavaPlatformPluginTest extends AbstractProjectBuilderSpec {
         project.dependencies.constraints.add(JavaPlatformPlugin.RUNTIME_CONFIGURATION_NAME, "org:runtime2:2.0")
 
         when:
-        def javaPlatform = project.components.getByName("javaPlatform")
-        UsageContext apiUsage = javaPlatform.usages[0]
-        UsageContext runtimeUsage = javaPlatform.usages[1]
+        DefaultAdhocSoftwareComponent javaPlatform = project.components.getByName("javaPlatform")
+        SoftwareComponentVariant apiVariant = javaPlatform.allVariants[0]
+        SoftwareComponentVariant runtimeVariant = javaPlatform.allVariants[1]
 
         then:
-        runtimeUsage.dependencies.size() == 2
-        runtimeUsage.dependencies == project.configurations.getByName(JavaPlatformPlugin.RUNTIME_CONFIGURATION_NAME).allDependencies.withType(ModuleDependency)
-        runtimeUsage.dependencyConstraints.size() == 2
-        runtimeUsage.dependencyConstraints == project.configurations.getByName(JavaPlatformPlugin.RUNTIME_CONFIGURATION_NAME).allDependencyConstraints
-        runtimeUsage.attributes.keySet() == [Usage.USAGE_ATTRIBUTE, Category.CATEGORY_ATTRIBUTE] as Set
-        runtimeUsage.attributes.getAttribute(Usage.USAGE_ATTRIBUTE).name == Usage.JAVA_RUNTIME
-        runtimeUsage.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE).name == Category.REGULAR_PLATFORM
+        runtimeVariant.dependencies.size() == 2
+        runtimeVariant.dependencies == project.configurations.getByName(JavaPlatformPlugin.RUNTIME_CONFIGURATION_NAME).allDependencies.withType(ModuleDependency)
+        runtimeVariant.dependencyConstraints.size() == 2
+        runtimeVariant.dependencyConstraints == project.configurations.getByName(JavaPlatformPlugin.RUNTIME_CONFIGURATION_NAME).allDependencyConstraints
+        runtimeVariant.attributes.keySet() == [Usage.USAGE_ATTRIBUTE, Category.CATEGORY_ATTRIBUTE] as Set
+        runtimeVariant.attributes.getAttribute(Usage.USAGE_ATTRIBUTE).name == Usage.JAVA_RUNTIME
+        runtimeVariant.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE).name == Category.REGULAR_PLATFORM
 
-        apiUsage.dependencies.size() == 1
-        apiUsage.dependencies == project.configurations.getByName(JavaPlatformPlugin.API_CONFIGURATION_NAME).allDependencies.withType(ModuleDependency)
-        apiUsage.dependencyConstraints.size() == 1
-        apiUsage.dependencyConstraints == project.configurations.getByName(JavaPlatformPlugin.API_CONFIGURATION_NAME).allDependencyConstraints
-        apiUsage.attributes.keySet() == [Usage.USAGE_ATTRIBUTE, Category.CATEGORY_ATTRIBUTE] as Set
-        apiUsage.attributes.getAttribute(Usage.USAGE_ATTRIBUTE).name == Usage.JAVA_API
-        apiUsage.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE).name == Category.REGULAR_PLATFORM
+        apiVariant.dependencies.size() == 1
+        apiVariant.dependencies == project.configurations.getByName(JavaPlatformPlugin.API_CONFIGURATION_NAME).allDependencies.withType(ModuleDependency)
+        apiVariant.dependencyConstraints.size() == 1
+        apiVariant.dependencyConstraints == project.configurations.getByName(JavaPlatformPlugin.API_CONFIGURATION_NAME).allDependencyConstraints
+        apiVariant.attributes.keySet() == [Usage.USAGE_ATTRIBUTE, Category.CATEGORY_ATTRIBUTE] as Set
+        apiVariant.attributes.getAttribute(Usage.USAGE_ATTRIBUTE).name == Usage.JAVA_API
+        apiVariant.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE).name == Category.REGULAR_PLATFORM
     }
 
     @Unroll("cannot add a dependency to the #configuration configuration by default")

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.plugins
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.Dependency
+import org.gradle.api.plugins.internal.DefaultAdhocSoftwareComponent
 import org.gradle.api.reporting.ReportingExtension
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.SourceSet
@@ -196,10 +197,10 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
 
         when:
         def jarTask = project.tasks.getByName(JavaPlugin.JAR_TASK_NAME)
-        def javaLibrary = project.components.getByName("java")
+        DefaultAdhocSoftwareComponent javaLibrary = project.components.getByName("java")
 
         then:
-        def runtime = javaLibrary.usages.find { it.name == 'runtimeElements' }
+        def runtime = javaLibrary.allVariants.find { it.name == 'runtimeElements' }
         runtime.artifacts.collect {it.file} == [jarTask.archiveFile.get().asFile]
         runtime.dependencies == project.configurations.getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME).allDependencies
     }

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
@@ -200,7 +200,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         DefaultAdhocSoftwareComponent javaLibrary = project.components.getByName("java")
 
         then:
-        def runtime = javaLibrary.allVariants.find { it.name == 'runtimeElements' }
+        def runtime = javaLibrary.outgoing.variants.find { it.name == 'runtimeElements' }
         runtime.artifacts.collect {it.file} == [jarTask.archiveFile.get().asFile]
         runtime.dependencies == project.configurations.getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME).allDependencies
     }

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/metadata/ModuleMetadataSpecBuilder.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/metadata/ModuleMetadataSpecBuilder.java
@@ -33,6 +33,7 @@ import org.gradle.api.capabilities.Capability;
 import org.gradle.api.component.ComponentWithCoordinates;
 import org.gradle.api.component.ComponentWithVariants;
 import org.gradle.api.component.SoftwareComponent;
+import org.gradle.api.component.SoftwareComponentVariant;
 import org.gradle.api.internal.artifacts.DefaultExcludeRule;
 import org.gradle.api.internal.artifacts.ImmutableVersionConstraint;
 import org.gradle.api.internal.artifacts.PublishArtifactInternal;
@@ -42,7 +43,6 @@ import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDepende
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
-import org.gradle.api.internal.component.UsageContext;
 import org.gradle.api.publish.internal.PublicationInternal;
 import org.gradle.api.publish.internal.versionmapping.VariantVersionMappingStrategyInternal;
 import org.gradle.api.publish.internal.versionmapping.VersionMappingStrategyInternal;
@@ -120,7 +120,7 @@ class ModuleMetadataSpecBuilder {
 
     private List<ModuleMetadataSpec.Variant> variants() {
         ArrayList<ModuleMetadataSpec.Variant> variants = new ArrayList<>();
-        for (UsageContext variant : component.getUsages()) {
+        for (SoftwareComponentVariant variant : component.getAllVariants()) {
             checkVariant(variant);
             variants.add(
                 new ModuleMetadataSpec.LocalVariant(
@@ -138,7 +138,7 @@ class ModuleMetadataSpecBuilder {
                 ModuleVersionIdentifier childCoordinates = coordinatesOf(childComponent);
                 assert childCoordinates != null;
                 if (childComponent instanceof SoftwareComponentInternal) {
-                    for (UsageContext variant : ((SoftwareComponentInternal) childComponent).getUsages()) {
+                    for (SoftwareComponentVariant variant : ((SoftwareComponentInternal) childComponent).getAllVariants()) {
                         checkVariant(variant);
                         variants.add(
                             new ModuleMetadataSpec.RemoteVariant(
@@ -155,7 +155,7 @@ class ModuleMetadataSpecBuilder {
         return variants;
     }
 
-    private List<ModuleMetadataSpec.Artifact> artifactsOf(UsageContext variant) {
+    private List<ModuleMetadataSpec.Artifact> artifactsOf(SoftwareComponentVariant variant) {
         if (variant.getArtifacts().isEmpty()) {
             return emptyList();
         }
@@ -341,7 +341,7 @@ class ModuleMetadataSpecBuilder {
         );
     }
 
-    private List<ModuleMetadataSpec.Dependency> dependenciesOf(UsageContext variant) {
+    private List<ModuleMetadataSpec.Dependency> dependenciesOf(SoftwareComponentVariant variant) {
         if (variant.getDependencies().isEmpty()) {
             return emptyList();
         }
@@ -374,7 +374,7 @@ class ModuleMetadataSpecBuilder {
         return dependencies;
     }
 
-    private List<ModuleMetadataSpec.DependencyConstraint> dependencyConstraintsFor(UsageContext variant) {
+    private List<ModuleMetadataSpec.DependencyConstraint> dependencyConstraintsFor(SoftwareComponentVariant variant) {
         if (variant.getDependencyConstraints().isEmpty()) {
             return emptyList();
         }
@@ -486,11 +486,11 @@ class ModuleMetadataSpecBuilder {
         }
     }
 
-    private void checkVariant(UsageContext usageContext) {
+    private void checkVariant(SoftwareComponentVariant variant) {
         checker.registerVariant(
-            usageContext.getName(),
-            usageContext.getAttributes(),
-            usageContext.getCapabilities()
+            variant.getName(),
+            variant.getAttributes(),
+            variant.getCapabilities()
         );
     }
 
@@ -529,14 +529,14 @@ class ModuleMetadataSpecBuilder {
         return projectDependencyResolver.resolve(ModuleVersionIdentifier.class, projectDependency);
     }
 
-    private VariantVersionMappingStrategyInternal versionMappingStrategyFor(UsageContext variant) {
+    private VariantVersionMappingStrategyInternal versionMappingStrategyFor(SoftwareComponentVariant variant) {
         VersionMappingStrategyInternal versionMappingStrategy = publication.getVersionMappingStrategy();
         return versionMappingStrategy != null
             ? versionMappingStrategy.findStrategyForVariant(immutableAttributesOf(variant))
             : null;
     }
 
-    private ImmutableAttributes immutableAttributesOf(UsageContext variant) {
+    private ImmutableAttributes immutableAttributesOf(SoftwareComponentVariant variant) {
         return ((AttributeContainerInternal) variant.getAttributes()).asImmutable();
     }
 

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/metadata/ModuleMetadataSpecBuilder.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/metadata/ModuleMetadataSpecBuilder.java
@@ -120,7 +120,7 @@ class ModuleMetadataSpecBuilder {
 
     private List<ModuleMetadataSpec.Variant> variants() {
         ArrayList<ModuleMetadataSpec.Variant> variants = new ArrayList<>();
-        for (SoftwareComponentVariant variant : component.getAllVariants()) {
+        for (SoftwareComponentVariant variant : component.getOutgoing().getVariants()) {
             checkVariant(variant);
             variants.add(
                 new ModuleMetadataSpec.LocalVariant(
@@ -138,7 +138,7 @@ class ModuleMetadataSpecBuilder {
                 ModuleVersionIdentifier childCoordinates = coordinatesOf(childComponent);
                 assert childCoordinates != null;
                 if (childComponent instanceof SoftwareComponentInternal) {
-                    for (SoftwareComponentVariant variant : ((SoftwareComponentInternal) childComponent).getAllVariants()) {
+                    for (SoftwareComponentVariant variant : ((SoftwareComponentInternal) childComponent).getOutgoing().getVariants()) {
                         checkVariant(variant);
                         variants.add(
                             new ModuleMetadataSpec.RemoteVariant(

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/validation/PublicationErrorChecker.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/validation/PublicationErrorChecker.java
@@ -37,7 +37,7 @@ public abstract class PublicationErrorChecker {
      * @throws PublishException if the component uses attributes invalid for publication
      */
     public static void checkForUnpublishableAttributes(SoftwareComponentInternal component, DocumentationRegistry documentationRegistry) {
-        for (final SoftwareComponentVariant variant : component.getAllVariants()) {
+        for (final SoftwareComponentVariant variant : component.getOutgoing().getVariants()) {
             Optional<Attribute<?>> category = variant.getAttributes().keySet().stream()
                 .filter(a -> Category.CATEGORY_ATTRIBUTE.getName().equals(a.getName()))
                 .findFirst();

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/validation/PublicationErrorChecker.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/validation/PublicationErrorChecker.java
@@ -19,9 +19,9 @@ package org.gradle.api.publish.internal.validation;
 import org.gradle.api.artifacts.PublishException;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.Category;
+import org.gradle.api.component.SoftwareComponentVariant;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
-import org.gradle.api.internal.component.UsageContext;
 
 import java.util.Optional;
 
@@ -37,15 +37,15 @@ public abstract class PublicationErrorChecker {
      * @throws PublishException if the component uses attributes invalid for publication
      */
     public static void checkForUnpublishableAttributes(SoftwareComponentInternal component, DocumentationRegistry documentationRegistry) {
-        for (final UsageContext usageContext : component.getUsages()) {
-            Optional<Attribute<?>> category = usageContext.getAttributes().keySet().stream()
+        for (final SoftwareComponentVariant variant : component.getAllVariants()) {
+            Optional<Attribute<?>> category = variant.getAttributes().keySet().stream()
                 .filter(a -> Category.CATEGORY_ATTRIBUTE.getName().equals(a.getName()))
                 .findFirst();
 
             category.ifPresent(c -> {
-                Object value = usageContext.getAttributes().getAttribute(c);
+                Object value = variant.getAttributes().getAttribute(c);
                 if (value != null && Category.VERIFICATION.equals(value.toString())) {
-                    throw new PublishException("Cannot publish module metadata for component '" + component.getName() + "' which would include a variant '" + usageContext.getName() + "' that contains a '" + Category.CATEGORY_ATTRIBUTE.getName() + "' attribute with a value of '" + Category.VERIFICATION + "'.  This attribute is reserved for test verification output and is not publishable.  See: " + documentationRegistry.getDocumentationFor("variant_attributes.html", "sec:verification_category"));
+                    throw new PublishException("Cannot publish module metadata for component '" + component.getName() + "' which would include a variant '" + variant.getName() + "' that contains a '" + Category.CATEGORY_ATTRIBUTE.getName() + "' attribute with a value of '" + Category.VERIFICATION + "'.  This attribute is reserved for test verification output and is not publishable.  See: " + documentationRegistry.getDocumentationFor("variant_attributes.html", "sec:verification_category"));
                 }
             });
         }

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/tasks/GenerateModuleMetadata.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/tasks/GenerateModuleMetadata.java
@@ -317,7 +317,7 @@ public abstract class GenerateModuleMetadata extends DefaultTask {
         }
 
         private void forEachArtifactOf(SoftwareComponentInternal component, Action<PublishArtifact> action) {
-            for (SoftwareComponentVariant variant : component.getAllVariants()) {
+            for (SoftwareComponentVariant variant : component.getOutgoing().getVariants()) {
                 for (PublishArtifact publishArtifact : variant.getArtifacts()) {
                     action.execute(publishArtifact);
                 }

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/tasks/GenerateModuleMetadata.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/tasks/GenerateModuleMetadata.java
@@ -22,11 +22,11 @@ import org.gradle.api.Buildable;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.api.artifacts.PublishArtifact;
+import org.gradle.api.component.SoftwareComponentVariant;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyPublicationResolver;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
-import org.gradle.api.internal.component.UsageContext;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.collections.MinimalFileSet;
 import org.gradle.api.internal.project.ProjectInternal;
@@ -317,8 +317,8 @@ public abstract class GenerateModuleMetadata extends DefaultTask {
         }
 
         private void forEachArtifactOf(SoftwareComponentInternal component, Action<PublishArtifact> action) {
-            for (UsageContext usageContext : component.getUsages()) {
-                for (PublishArtifact publishArtifact : usageContext.getArtifacts()) {
+            for (SoftwareComponentVariant variant : component.getAllVariants()) {
+                for (PublishArtifact publishArtifact : variant.getArtifacts()) {
                     action.execute(publishArtifact);
                 }
             }

--- a/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/metadata/GradleModuleMetadataWriterTest.groovy
+++ b/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/metadata/GradleModuleMetadataWriterTest.groovy
@@ -36,6 +36,7 @@ import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConst
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyPublicationResolver
 import org.gradle.api.internal.attributes.ImmutableAttributes
+import org.gradle.api.internal.component.DefaultSoftwareComponentPublications
 import org.gradle.api.internal.component.SoftwareComponentInternal
 import org.gradle.api.publish.internal.PublicationInternal
 import org.gradle.api.publish.internal.versionmapping.VariantVersionMappingStrategyInternal
@@ -103,7 +104,7 @@ class GradleModuleMetadataWriterTest extends Specification {
         v1.attributes >> attributes(usage: "compile")
         v1.dependencies >> []
 
-        component.allVariants >> [v1]
+        component.outgoing >> new DefaultSoftwareComponentPublications([v1] as Set)
 
         when:
         publication.attributes >> attributes(status: 'release', 'test': 'value')
@@ -176,7 +177,7 @@ class GradleModuleMetadataWriterTest extends Specification {
         v2.attributes >> attributes(usage: "runtime")
         v2.artifacts >> [a2]
 
-        component.allVariants >> [v1, v2]
+        component.outgoing >> new DefaultSoftwareComponentPublications([v1, v2] as Set)
 
         when:
         writeTo(writer, publication, [publication])
@@ -310,7 +311,7 @@ class GradleModuleMetadataWriterTest extends Specification {
         v2.attributes >> attributes(usage: "runtime")
         v2.dependencies >> [d2, d3, d4, d5, d6, d7]
 
-        component.allVariants >> [v1, v2]
+        component.outgoing >> new DefaultSoftwareComponentPublications([v1, v2] as Set)
 
         when:
         writeTo(writer, publication, [publication])
@@ -489,7 +490,7 @@ class GradleModuleMetadataWriterTest extends Specification {
         v2.attributes >> attributes(usage: "runtime")
         v2.dependencyConstraints >> [dc2, dc3, dc4]
 
-        component.allVariants >> [v1, v2]
+        component.outgoing >> new DefaultSoftwareComponentPublications([v1, v2] as Set)
 
         when:
         writeTo(writer, publication, [publication])
@@ -593,7 +594,7 @@ class GradleModuleMetadataWriterTest extends Specification {
                 (Attribute.of("platform", Named)): platform,
                 (Attribute.of("linkage", SomeEnum)): SomeEnum.VALUE_2)
 
-        component.allVariants >> [v1, v2]
+        component.outgoing >> new DefaultSoftwareComponentPublications([v1, v2] as Set)
 
         when:
         writeTo(writer, publication, [publication])
@@ -663,9 +664,9 @@ class GradleModuleMetadataWriterTest extends Specification {
         v2.attributes >> attributes(usage: "runtime")
 
         rootComponent.variants >> [comp1, comp2]
-        rootComponent.allVariants >> []
-        comp1.allVariants >> [v1]
-        comp2.allVariants >> [v2]
+        rootComponent.outgoing >> new DefaultSoftwareComponentPublications([] as Set)
+        comp1.outgoing >> new DefaultSoftwareComponentPublications([v1] as Set)
+        comp2.outgoing >> new DefaultSoftwareComponentPublications([v2] as Set)
 
         when:
         writeTo(writer, rootPublication, [rootPublication, publication1, publication2])
@@ -742,8 +743,8 @@ class GradleModuleMetadataWriterTest extends Specification {
         v1.capabilities >> [c1]
 
         rootComponent.variants >> [comp1]
-        rootComponent.allVariants >> []
-        comp1.allVariants >> [v1]
+        rootComponent.outgoing >> new DefaultSoftwareComponentPublications([] as Set)
+        comp1.outgoing >> new DefaultSoftwareComponentPublications([v1] as Set)
 
         when:
         writeTo(writer, rootPublication, [rootPublication, publication1])
@@ -767,8 +768,8 @@ class GradleModuleMetadataWriterTest extends Specification {
         variant.attributes >> attributes(usage: "compile")
 
         rootComponent.variants >> [childComponent]
-        rootComponent.allVariants >> []
-        childComponent.allVariants >> [variant]
+        rootComponent.outgoing >> new DefaultSoftwareComponentPublications([] as Set)
+        childComponent.outgoing >> new DefaultSoftwareComponentPublications([variant] as Set)
 
         when:
         writeTo(writer, childPublication, [rootPublication, childPublication])
@@ -828,7 +829,7 @@ class GradleModuleMetadataWriterTest extends Specification {
         v2.dependencies >> []
         v2.capabilities >> [c1, c2]
 
-        component.allVariants >> [v1, v2]
+        component.outgoing >> new DefaultSoftwareComponentPublications([v1, v2] as Set)
 
         when:
         writeTo(writer, publication, [publication])
@@ -923,7 +924,7 @@ class GradleModuleMetadataWriterTest extends Specification {
         v2.dependencies >> [runtimeDependency, intransitiveDependency]
         v2.globalExcludes >> [new DefaultExcludeRule("org.example.runtime", null)]
 
-        component.allVariants >> [v1, v2]
+        component.outgoing >> new DefaultSoftwareComponentPublications([v1, v2] as Set)
 
         when:
         writeTo(writer, publication, [publication])
@@ -1005,7 +1006,7 @@ class GradleModuleMetadataWriterTest extends Specification {
         v1.name >> "v1"
         v1.dependencies >> [apiDependency]
 
-        component.allVariants >> [v1]
+        component.outgoing >> new DefaultSoftwareComponentPublications([v1] as Set)
 
         when:
         writeTo(writer, publication, [publication])
@@ -1082,7 +1083,7 @@ class GradleModuleMetadataWriterTest extends Specification {
         v2.attributes >> attributes(usage: "runtime")
         v2.dependencies >> [d2, d3, d4, d5]
 
-        component.allVariants >> [v1, v2]
+        component.outgoing >> new DefaultSoftwareComponentPublications([v1, v2] as Set)
 
         when:
         writeTo(writer, publication, [publication])
@@ -1188,7 +1189,7 @@ class GradleModuleMetadataWriterTest extends Specification {
         v2.name >> "v2"
         v2.attributes >> attributes(usage: "runtime")
 
-        comp.allVariants >> [v1, v2]
+        comp.outgoing >> new DefaultSoftwareComponentPublications([v1, v2] as Set)
 
         when:
         writeTo(writer, publication1, [publication1, publication2])

--- a/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/metadata/GradleModuleMetadataWriterTest.groovy
+++ b/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/metadata/GradleModuleMetadataWriterTest.groovy
@@ -27,6 +27,7 @@ import org.gradle.api.artifacts.VersionConstraint
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.capabilities.Capability
 import org.gradle.api.component.ComponentWithVariants
+import org.gradle.api.component.SoftwareComponentVariant
 import org.gradle.api.internal.artifacts.DefaultExcludeRule
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultDependencyArtifact
@@ -36,7 +37,6 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModu
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyPublicationResolver
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.component.SoftwareComponentInternal
-import org.gradle.api.internal.component.UsageContext
 import org.gradle.api.publish.internal.PublicationInternal
 import org.gradle.api.publish.internal.versionmapping.VariantVersionMappingStrategyInternal
 import org.gradle.api.publish.internal.versionmapping.VersionMappingStrategyInternal
@@ -98,12 +98,12 @@ class GradleModuleMetadataWriterTest extends Specification {
         def writer = new StringWriter()
         def component = Stub(TestComponent)
         def publication = publication(component, id, null, withBuildId)
-        def v1 = Stub(UsageContext)
+        def v1 = Stub(SoftwareComponentVariant)
         v1.name >> "v1"
         v1.attributes >> attributes(usage: "compile")
         v1.dependencies >> []
 
-        component.usages >> [v1]
+        component.allVariants >> [v1]
 
         when:
         publication.attributes >> attributes(status: 'release', 'test': 'value')
@@ -167,16 +167,16 @@ class GradleModuleMetadataWriterTest extends Specification {
         a2.classifier >> "windows"
         publication.getPublishedFile(a2) >> new SimplePublishedFile("a2.name", "a2.url")
 
-        def v1 = Stub(UsageContext)
+        def v1 = Stub(SoftwareComponentVariant)
         v1.name >> "v1"
         v1.attributes >> attributes(usage: "compile")
         v1.artifacts >> [a1]
-        def v2 = Stub(UsageContext)
+        def v2 = Stub(SoftwareComponentVariant)
         v2.name >> "v2"
         v2.attributes >> attributes(usage: "runtime")
         v2.artifacts >> [a2]
 
-        component.usages >> [v1, v2]
+        component.allVariants >> [v1, v2]
 
         when:
         writeTo(writer, publication, [publication])
@@ -300,17 +300,17 @@ class GradleModuleMetadataWriterTest extends Specification {
         d8.attributes >> ImmutableAttributes.EMPTY
         d8.requestedCapabilities >> [new ImmutableCapability("org", "test", "1.0")]
 
-        def v1 = Stub(UsageContext)
+        def v1 = Stub(SoftwareComponentVariant)
         v1.name >> "v1"
         v1.attributes >> attributes(usage: "compile")
         v1.dependencies >> [d1, d8]
 
-        def v2 = Stub(UsageContext)
+        def v2 = Stub(SoftwareComponentVariant)
         v2.name >> "v2"
         v2.attributes >> attributes(usage: "runtime")
         v2.dependencies >> [d2, d3, d4, d5, d6, d7]
 
-        component.usages >> [v1, v2]
+        component.allVariants >> [v1, v2]
 
         when:
         writeTo(writer, publication, [publication])
@@ -480,16 +480,16 @@ class GradleModuleMetadataWriterTest extends Specification {
         dc4.versionConstraint >> strictly("v4")
         dc4.attributes >> attributes(quality: 'awesome', channel: 'canary')
 
-        def v1 = Stub(UsageContext)
+        def v1 = Stub(SoftwareComponentVariant)
         v1.name >> "v1"
         v1.attributes >> attributes(usage: "compile")
         v1.dependencyConstraints >> [dc1]
-        def v2 = Stub(UsageContext)
+        def v2 = Stub(SoftwareComponentVariant)
         v2.name >> "v2"
         v2.attributes >> attributes(usage: "runtime")
         v2.dependencyConstraints >> [dc2, dc3, dc4]
 
-        component.usages >> [v1, v2]
+        component.allVariants >> [v1, v2]
 
         when:
         writeTo(writer, publication, [publication])
@@ -578,14 +578,14 @@ class GradleModuleMetadataWriterTest extends Specification {
 
         def platform = TestUtil.objectFactory().named(Named, "windows")
 
-        def v1 = Stub(UsageContext)
+        def v1 = Stub(SoftwareComponentVariant)
         v1.name >> "v1"
         v1.attributes >> attributesTyped(
                 (Attribute.of("usage", String)): "compile",
                 (Attribute.of("debuggable", Boolean)): true,
                 (Attribute.of("platform", Named)): platform,
                 (Attribute.of("linkage", SomeEnum)): SomeEnum.VALUE_1)
-        def v2 = Stub(UsageContext)
+        def v2 = Stub(SoftwareComponentVariant)
         v2.name >> "v2"
         v2.attributes >> attributesTyped(
                 (Attribute.of("usage", String)): "runtime",
@@ -593,7 +593,7 @@ class GradleModuleMetadataWriterTest extends Specification {
                 (Attribute.of("platform", Named)): platform,
                 (Attribute.of("linkage", SomeEnum)): SomeEnum.VALUE_2)
 
-        component.usages >> [v1, v2]
+        component.allVariants >> [v1, v2]
 
         when:
         writeTo(writer, publication, [publication])
@@ -654,18 +654,18 @@ class GradleModuleMetadataWriterTest extends Specification {
             getVersion() >> '1'
         }
 
-        def v1 = Stub(UsageContext)
+        def v1 = Stub(SoftwareComponentVariant)
         v1.name >> "v1"
         v1.attributes >> attributes(usage: "compile")
         v1.capabilities >> [c1]
-        def v2 = Stub(UsageContext)
+        def v2 = Stub(SoftwareComponentVariant)
         v2.name >> "v2"
         v2.attributes >> attributes(usage: "runtime")
 
         rootComponent.variants >> [comp1, comp2]
-        rootComponent.usages >> []
-        comp1.usages >> [v1]
-        comp2.usages >> [v2]
+        rootComponent.allVariants >> []
+        comp1.allVariants >> [v1]
+        comp2.allVariants >> [v2]
 
         when:
         writeTo(writer, rootPublication, [rootPublication, publication1, publication2])
@@ -736,14 +736,14 @@ class GradleModuleMetadataWriterTest extends Specification {
             getVersion() >> '1'
         }
 
-        def v1 = Stub(UsageContext)
+        def v1 = Stub(SoftwareComponentVariant)
         v1.name >> "v1"
         v1.attributes >> attributes(usage: "compile")
         v1.capabilities >> [c1]
 
         rootComponent.variants >> [comp1]
-        rootComponent.usages >> []
-        comp1.usages >> [v1]
+        rootComponent.allVariants >> []
+        comp1.allVariants >> [v1]
 
         when:
         writeTo(writer, rootPublication, [rootPublication, publication1])
@@ -762,13 +762,13 @@ class GradleModuleMetadataWriterTest extends Specification {
         def childComponent = Stub(TestComponent)
         def childPublication = publication(childComponent, child1)
 
-        def variant = Stub(UsageContext)
+        def variant = Stub(SoftwareComponentVariant)
         variant.name >> "v1"
         variant.attributes >> attributes(usage: "compile")
 
         rootComponent.variants >> [childComponent]
-        rootComponent.usages >> []
-        childComponent.usages >> [variant]
+        rootComponent.allVariants >> []
+        childComponent.allVariants >> [variant]
 
         when:
         writeTo(writer, childPublication, [rootPublication, childPublication])
@@ -816,19 +816,19 @@ class GradleModuleMetadataWriterTest extends Specification {
             getVersion() >> '2'
         }
 
-        def v1 = Stub(UsageContext)
+        def v1 = Stub(SoftwareComponentVariant)
         v1.name >> "v1"
         v1.attributes >> attributes(usage: "compile")
         v1.dependencies >> []
         v1.capabilities >> [c1]
 
-        def v2 = Stub(UsageContext)
+        def v2 = Stub(SoftwareComponentVariant)
         v2.name >> "v2"
         v2.attributes >> attributes(usage: "runtime")
         v2.dependencies >> []
         v2.capabilities >> [c1, c2]
 
-        component.usages >> [v1, v2]
+        component.allVariants >> [v1, v2]
 
         when:
         writeTo(writer, publication, [publication])
@@ -913,17 +913,17 @@ class GradleModuleMetadataWriterTest extends Specification {
         intransitiveDependency.transitive >> false
         intransitiveDependency.attributes >> ImmutableAttributes.EMPTY
 
-        def v1 = Stub(UsageContext)
+        def v1 = Stub(SoftwareComponentVariant)
         v1.name >> "v1"
         v1.dependencies >> [apiDependency]
         v1.globalExcludes >> [new DefaultExcludeRule("org.example.api", null)]
 
-        def v2 = Stub(UsageContext)
+        def v2 = Stub(SoftwareComponentVariant)
         v2.name >> "v2"
         v2.dependencies >> [runtimeDependency, intransitiveDependency]
         v2.globalExcludes >> [new DefaultExcludeRule("org.example.runtime", null)]
 
-        component.usages >> [v1, v2]
+        component.allVariants >> [v1, v2]
 
         when:
         writeTo(writer, publication, [publication])
@@ -1001,11 +1001,11 @@ class GradleModuleMetadataWriterTest extends Specification {
         apiDependency.excludeRules >> [new DefaultExcludeRule("com.example.bad", "api")]
         apiDependency.attributes >> ImmutableAttributes.EMPTY
 
-        def v1 = Stub(UsageContext)
+        def v1 = Stub(SoftwareComponentVariant)
         v1.name >> "v1"
         v1.dependencies >> [apiDependency]
 
-        component.usages >> [v1]
+        component.allVariants >> [v1]
 
         when:
         writeTo(writer, publication, [publication])
@@ -1072,17 +1072,17 @@ class GradleModuleMetadataWriterTest extends Specification {
         d6.transitive >> true
         d6.attributes >> ImmutableAttributes.EMPTY
 
-        def v1 = Stub(UsageContext)
+        def v1 = Stub(SoftwareComponentVariant)
         v1.name >> "v1"
         v1.attributes >> attributes(usage: "compile")
         v1.dependencies >> [d1, d6]
 
-        def v2 = Stub(UsageContext)
+        def v2 = Stub(SoftwareComponentVariant)
         v2.name >> "v2"
         v2.attributes >> attributes(usage: "runtime")
         v2.dependencies >> [d2, d3, d4, d5]
 
-        component.usages >> [v1, v2]
+        component.allVariants >> [v1, v2]
 
         when:
         writeTo(writer, publication, [publication])
@@ -1181,14 +1181,14 @@ class GradleModuleMetadataWriterTest extends Specification {
         def id2 = DefaultModuleVersionIdentifier.newId("group", "other-2", "2")
         def publication2 = publication(comp, id2)
 
-        def v1 = Stub(UsageContext)
+        def v1 = Stub(SoftwareComponentVariant)
         v1.name >> "v1"
         v1.attributes >> attributes(usage: "compile")
-        def v2 = Stub(UsageContext)
+        def v2 = Stub(SoftwareComponentVariant)
         v2.name >> "v2"
         v2.attributes >> attributes(usage: "runtime")
 
-        comp.usages >> [v1, v2]
+        comp.allVariants >> [v1, v2]
 
         when:
         writeTo(writer, publication1, [publication1, publication2])


### PR DESCRIPTION
Deprecate `UsageContext` in favor of `SoftwareComponentVariant`.