### PR TITLE
Use Temurin JDK as build JVM on Mac M1

### DIFF
--- a/.teamcity/src/main/kotlin/common/Jvm.kt
+++ b/.teamcity/src/main/kotlin/common/Jvm.kt
@@ -32,10 +32,3 @@ object BuildToolBuildJvm : Jvm {
     override val vendor: JvmVendor
         get() = JvmVendor.openjdk
 }
-
-object BuildToolBuildJvmM1 : Jvm {
-    override val version: JvmVersion
-        get() = JvmVersion.java11
-    override val vendor: JvmVendor
-        get() = JvmVendor.zulu
-}

--- a/.teamcity/src/main/kotlin/model/CIBuildModel.kt
+++ b/.teamcity/src/main/kotlin/model/CIBuildModel.kt
@@ -2,7 +2,6 @@ package model
 
 import common.Arch
 import common.BuildToolBuildJvm
-import common.BuildToolBuildJvmM1
 import common.Jvm
 import common.JvmCategory
 import common.JvmVendor
@@ -125,7 +124,7 @@ data class CIBuildModel(
                 TestCoverage(15, TestType.forceRealizeDependencyManagement, Os.LINUX, JvmCategory.MIN_VERSION, DEFAULT_LINUX_FUNCTIONAL_TEST_BUCKET_SIZE),
                 TestCoverage(33, TestType.allVersionsIntegMultiVersion, Os.LINUX, JvmCategory.MIN_VERSION, ALL_CROSS_VERSION_BUCKETS.size),
                 TestCoverage(34, TestType.allVersionsIntegMultiVersion, Os.WINDOWS, JvmCategory.MIN_VERSION_WINDOWS, ALL_CROSS_VERSION_BUCKETS.size),
-                TestCoverage(36, TestType.platform, Os.MACOS, JvmCategory.MAX_LTS_VERSION, expectedBucketNumber = 20, arch = Arch.AARCH64, buildJvm = BuildToolBuildJvmM1)
+                TestCoverage(36, TestType.platform, Os.MACOS, JvmCategory.MAX_LTS_VERSION, expectedBucketNumber = 20, arch = Arch.AARCH64)
             ),
             performanceTests = slowPerformanceTestCoverages,
             performanceTestPartialTriggers = listOf(PerformanceTestPartialTrigger("All Performance Tests", "AllPerformanceTests", performanceRegressionTestCoverages + slowPerformanceTestCoverages))


### PR DESCRIPTION
Otherwise there would be a cache miss: https://ge.gradle.org/s/zlitxgmzvx6vk/timeline?details=ltxd6zygrehuq&expanded=WyIyMCJd&outcome=success&task-path=compile