### PR TITLE
Relax requirement for safe maven credentials in CC

### DIFF
--- a/released-versions.json
+++ b/released-versions.json
@@ -1,7 +1,7 @@
 {
   "latestReleaseSnapshot": {
-    "version": "7.5.1-20220805205215+0000",
-    "buildTime": "20220805205215+0000"
+    "version": "7.6-20221105002636+0000",
+    "buildTime": "20221105002636+0000"
   },
   "latestRc": {
     "version": "7.5-rc-5",

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCachePublishingIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCachePublishingIntegrationTest.groovy
@@ -22,6 +22,8 @@ import org.gradle.test.fixtures.server.http.HttpServer
 import org.gradle.test.fixtures.server.http.MavenHttpRepository
 import org.gradle.util.internal.GUtil
 import org.junit.Rule
+import spock.lang.Ignore
+import spock.lang.Issue
 
 import static org.gradle.util.internal.GFileUtils.deleteDirectory
 import static org.gradle.util.internal.GFileUtils.listFiles
@@ -170,6 +172,8 @@ class ConfigurationCachePublishingIntegrationTest extends AbstractConfigurationC
         storeTimeMetadata == loadTimeMetadata
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/22618")
+    @Ignore("This relies on being able to reliably detect unsafe credentials")
     def "cannot use unsafe credentials provider with configuration cache"() {
         def username = "someuser"
         def password = "somepassword"
@@ -190,6 +194,8 @@ class ConfigurationCachePublishingIntegrationTest extends AbstractConfigurationC
         failure.assertHasCause("Credential values found in configuration for: repository testMavenRepo")
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/22618")
+    @Ignore("This relies on being able to reliably detect unsafe credentials")
     def "cannot use identity-incompatible repository name credentials provider with configuration cache"() {
         def username = "someuser"
         def password = "somepassword"

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/PublishToMavenRepository.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/PublishToMavenRepository.java
@@ -130,6 +130,12 @@ public class PublishToMavenRepository extends AbstractPublishToMaven {
     }
 
     private boolean areCredentialsSafe(String identity, Credentials toCheck) {
+        // TODO:RC not using a provider does not necessarily imply unsafe credentials
+        // https://github.com/gradle/gradle/issues/22618
+        return true /* isUsingCredentialsProvider(identity, toCheck) */;
+    }
+
+    private boolean isUsingCredentialsProvider(String identity, Credentials toCheck) {
         ProviderFactory providerFactory = getServices().get(ProviderFactory.class);
         Credentials referenceCredentials;
         try {

--- a/subprojects/resources-sftp/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishSftpIntegrationTest.groovy
+++ b/subprojects/resources-sftp/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishSftpIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.api.publish.maven
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTest
 import org.gradle.test.fixtures.server.sftp.MavenSftpRepository
 import org.gradle.test.fixtures.server.sftp.SFTPServer
@@ -38,7 +37,6 @@ class MavenPublishSftpIntegrationTest extends AbstractMavenPublishIntegTest {
         }
     }
 
-    @ToBeFixedForConfigurationCache
     def "can publish to a SFTP repository"() {
         given:
         def mavenSftpRepo = getMavenSftpRepo()


### PR DESCRIPTION
Currently, there is no reliable way to determine whether credentials are safe (using a provider is not the only means). This change disables that check.

Issue: #22618
