### PR TITLE
Change the build so it works when the plugin portal redirects to maven central

### DIFF
--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -30,6 +30,12 @@ dependencyResolutionManagement {
                 includeVersionByRegex("com.gradle", "gradle-enterprise-gradle-plugin", rcAndMilestonesPattern)
             }
         }
+        jcenter {
+            content {
+                includeModule("org.openmbee.junit", "junit-xml-parser")
+                includeModule("org.codehaus.groovy.modules", "http-builder-ng-core")
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -1471,6 +1471,9 @@
       </component>
       <component group="org.ysb33r.gradle" name="grolifant" version="0.16.1">
          <artifact name="grolifant-0.16.1.jar">
+            <ignored-keys>
+               <ignored-key id="54ac8e2d98cfeac6" reason="also-trust requires ignoring signatures"/>
+            </ignored-keys>
             <sha256 value="a867e911d060a240b8aa111896b7379282fe61940dfb949e72600f7ca67cb92f" origin="Maven Central (also is JCenter)">
                <also-trust value="362c450c9738834181fdfac1147fa11cf21cefd59d7a5368756e174f93567a43"/>
             </sha256>

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -1471,7 +1471,8 @@
       </component>
       <component group="org.ysb33r.gradle" name="grolifant" version="0.16.1">
          <artifact name="grolifant-0.16.1.jar">
-            <pgp value="ea022560a81e5bd48db3d18b54ac8e2d98cfeac6"/>
+            <sha256 value="a867e911d060a240b8aa111896b7379282fe61940dfb949e72600f7ca67cb92f" origin="Maven Central"/>
+            <sha256 value="362c450c9738834181fdfac1147fa11cf21cefd59d7a5368756e174f93567a43" origin="JCenter"/>
          </artifact>
       </component>
       <component group="software.amazon.ion" name="ion-java" version="1.0.2">

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -1471,8 +1471,9 @@
       </component>
       <component group="org.ysb33r.gradle" name="grolifant" version="0.16.1">
          <artifact name="grolifant-0.16.1.jar">
-            <sha256 value="a867e911d060a240b8aa111896b7379282fe61940dfb949e72600f7ca67cb92f" origin="Maven Central"/>
-            <sha256 value="362c450c9738834181fdfac1147fa11cf21cefd59d7a5368756e174f93567a43" origin="JCenter"/>
+            <sha256 value="a867e911d060a240b8aa111896b7379282fe61940dfb949e72600f7ca67cb92f" origin="Maven Central (also is JCenter)">
+               <also-trust value="362c450c9738834181fdfac1147fa11cf21cefd59d7a5368756e174f93567a43"/>
+            </sha256>
          </artifact>
       </component>
       <component group="software.amazon.ion" name="ion-java" version="1.0.2">

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -109,9 +109,9 @@
          <trusted-key id="31fae244a81d64507b47182e1b2718089ce964b8" group="com.thoughtworks.qdox"/>
          <trusted-key id="34441e504a937f43eb0daef96a65176a0fb1cd0b">
             <trusting group="org.apache.groovy"/>
-            <trusting group="org.codehaus.groovy" name="groovy"/>
-            <trusting group="org.codehaus.groovy"/>
             <trusting group="org.apache.groovy" name="groovy"/>
+            <trusting group="org.codehaus.groovy"/>
+            <trusting group="org.codehaus.groovy" name="groovy"/>
          </trusted-key>
          <trusted-key id="34d6ff19930adf43ac127792a50569c7ca7fa1f0" group="com.jcraft"/>
          <trusted-key id="36390de6a0e61ee4c7b4ba02c1d3063467f1ebd1" group="org.asciidoctor"/>
@@ -1471,7 +1471,7 @@
       </component>
       <component group="org.ysb33r.gradle" name="grolifant" version="0.16.1">
          <artifact name="grolifant-0.16.1.jar">
-            <sha256 value="362c450c9738834181fdfac1147fa11cf21cefd59d7a5368756e174f93567a43" origin="Artifact is not signed"/>
+            <pgp value="ea022560a81e5bd48db3d18b54ac8e2d98cfeac6"/>
          </artifact>
       </component>
       <component group="software.amazon.ion" name="ion-java" version="1.0.2">

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,6 +13,12 @@ pluginManagement {
                 includeVersionByRegex("com.gradle", "gradle-enterprise-gradle-plugin", rcAndMilestonesPattern)
             }
         }
+        jcenter {
+            content {
+                includeModule("org.openmbee.junit", "junit-xml-parser")
+                includeModule("org.codehaus.groovy.modules", "http-builder-ng-core")
+            }
+        }
         gradlePluginPortal()
     }
 }


### PR DESCRIPTION
By adding checksums for both versions of `grolifant` from JCenter and Maven Central.
By adding explicit repository declaration for `jcenter` filtering only on the two dependencies required by the `gradle/gradle` build that cannot be found elsewhere.