### PR TITLE
fix(file-collections): declare parameter as nullable; #22645

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/file/DirectoryProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/DirectoryProperty.java
@@ -67,7 +67,7 @@ public interface DirectoryProperty extends FileSystemLocationProperty<Directory>
      * {@inheritDoc}
      */
     @Override
-    DirectoryProperty convention(Directory value);
+    DirectoryProperty convention(@Nullable Directory value);
 
     /**
      * {@inheritDoc}

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/RegularFileProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/RegularFileProperty.java
@@ -62,7 +62,7 @@ public interface RegularFileProperty extends FileSystemLocationProperty<RegularF
      * {@inheritDoc}
      */
     @Override
-    RegularFileProperty convention(RegularFile value);
+    RegularFileProperty convention(@Nullable RegularFile value);
 
     /**
      * {@inheritDoc}

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ListProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ListProperty.java
@@ -54,7 +54,7 @@ public interface ListProperty<T> extends Provider<List<T>>, HasMultipleValues<T>
      * {@inheritDoc}
      */
     @Override
-    ListProperty<T> convention(Iterable<? extends T> elements);
+    ListProperty<T> convention(@Nullable Iterable<? extends T> elements);
 
     /**
      * {@inheritDoc}

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/SetProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/SetProperty.java
@@ -54,7 +54,7 @@ public interface SetProperty<T> extends Provider<Set<T>>, HasMultipleValues<T> {
      * {@inheritDoc}
      */
     @Override
-    SetProperty<T> convention(Iterable<? extends T> elements);
+    SetProperty<T> convention(@Nullable Iterable<? extends T> elements);
 
     /**
      * {@inheritDoc}

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
@@ -202,7 +202,7 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory, FileFact
         }
 
         @Override
-        public THIS value(T value) {
+        public THIS value(@Nullable T value) {
             super.value(value);
             return Cast.uncheckedNonnullCast(this);
         }
@@ -214,7 +214,7 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory, FileFact
         }
 
         @Override
-        public void set(File file) {
+        public void set(@Nullable File file) {
             if (file == null) {
                 set((T) null);
                 return;

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
@@ -240,7 +240,7 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory, FileFact
         }
 
         @Override
-        public THIS convention(T value) {
+        public THIS convention(@Nullable T value) {
             super.convention(value);
             return Cast.uncheckedNonnullCast(this);
         }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultListProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultListProperty.java
@@ -71,7 +71,7 @@ public class DefaultListProperty<T> extends AbstractCollectionProperty<T, List<T
     }
 
     @Override
-    public ListProperty<T> convention(Iterable<? extends T> elements) {
+    public ListProperty<T> convention(@Nullable Iterable<? extends T> elements) {
         super.convention(elements);
         return this;
     }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
@@ -64,7 +64,7 @@ public class DefaultProperty<T> extends AbstractProperty<T, ProviderInternal<? e
     }
 
     @Override
-    public void set(T value) {
+    public void set(@Nullable T value) {
         if (value == null) {
             discardValue();
         } else {

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultSetProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultSetProperty.java
@@ -71,7 +71,7 @@ public class DefaultSetProperty<T> extends AbstractCollectionProperty<T, Set<T>>
     }
 
     @Override
-    public SetProperty<T> convention(Iterable<? extends T> elements) {
+    public SetProperty<T> convention(@Nullable Iterable<? extends T> elements) {
         super.convention(elements);
         return this;
     }


### PR DESCRIPTION
Declares a parameter in `DefaultFilePropertyFactory.AbstractFileVar` as `@Nullable`, as its superclass (`DefaultProperty`) defines it to be.

Fixes #22645.

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

A method was incorrectly unannotated with `@Nullable`, resulting in IDE warnings (and presumably even breaking Kotlin code); this fixes that fact.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [ ] Recognize contributor in release notes
