### PR TITLE
Exclude unnecessary expensive tests in FlakyTestQuarantine

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/FlakyTestQuarantine.kt
+++ b/.teamcity/src/main/kotlin/configurations/FlakyTestQuarantine.kt
@@ -11,6 +11,7 @@ import common.functionalTestParameters
 import common.gradleWrapper
 import common.killProcessStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import model.CIBuildModel
 import model.Stage
 import model.StageName
@@ -31,11 +32,23 @@ class FlakyTestQuarantine(model: CIBuildModel, stage: Stage, os: Os, arch: Arch 
         )
     }.flatMap { it.functionalTests }.filter { it.os == os }
 
+    if (os == Os.LINUX) {
+        steps {
+            script {
+                // Because we exclude tests in `distributions-integ-tests` below, `@Flaky` won't work in that subproject.
+                // Here we check the existence of `@Flaky` annotation to make sure nobody use that annotation in `distributions-integ-tests` subproject.
+                name = "MAKE_SURE_NO_@FLAKY_IN_DISTRIBUTIONS_INTEG_TESTS"
+                executionMode = BuildStep.ExecutionMode.ALWAYS
+                scriptContent = "! grep 'org.gradle.test.fixtures.Flaky' -r subprojects/distributions-integ-tests/src"
+            }
+        }
+    }
+
     testsWithOs.forEach { testCoverage ->
         val extraParameters = functionalTestExtraParameters("FlakyTestQuarantine", os, arch, testCoverage.testJvmVersion.major.toString(), testCoverage.vendor.name)
         val parameters = (
             buildToolGradleParameters(true) +
-                listOf("-PflakyTests=only") +
+                listOf("-PflakyTests=only", "-x", ":docs:platformTest", "-x", ":distributions-integ-tests:quickTest", "-x", ":distributions-integ-tests:platformTest") +
                 listOf(extraParameters) +
                 functionalTestParameters(os) +
                 listOf(buildScanTag(functionalTestTag))


### PR DESCRIPTION
I noticed FlakyTestQuarantine is running many unnecessary tasks:

- `docs` tests. It doesn't recognize `-PflakyTestQuarantine=ONLY` and includes a lot of sample installation tasks: https://ge.gradle.org/s/ablpsvlgtvsvq/timeline?details=maivoroyiseh4&page=20
- `distributions-integ-tests` depends on expensive full distribution tasks: https://ge.gradle.org/s/ddytaiaugzjvo/timeline?details=v7jcd46mokbbc&task-path=userguide

<img width="1205" alt="image" src="https://user-images.githubusercontent.com/12689835/200752848-83b337da-cbd2-41eb-ba2c-4083b1103cd6.png">

<img width="969" alt="image" src="https://user-images.githubusercontent.com/12689835/200752947-932ded3a-dadf-404d-8dce-53975305c7e7.png">

<img width="1087" alt="image" src="https://user-images.githubusercontent.com/12689835/200753111-ed790a81-4215-4b51-a0a9-2f2eb72ace91.png">

After this change, the full windows `FlakyTestQuarantine` time decreases from >3h to 1h37m:

<img width="1274" alt="image" src="https://user-images.githubusercontent.com/12689835/200753335-557a93f6-0538-4e00-b80f-e8a66ce49e28.png">
