### PR TITLE
Remove duplicated `jcenter` block

### DIFF
--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -36,12 +36,6 @@ dependencyResolutionManagement {
                 includeModule("org.codehaus.groovy.modules", "http-builder-ng-core")
             }
         }
-        jcenter {
-            content {
-                includeModule("org.openmbee.junit", "junit-xml-parser")
-                includeModule("org.codehaus.groovy.modules", "http-builder-ng-core")
-            }
-        }
         mavenCentral()
         gradlePluginPortal()
     }


### PR DESCRIPTION
Seems like, in #22640, we accidentally added two `jcenter` blocks.
One should be enough.