### PR TITLE
Fix wrong build environment documentation on using -P for Gradle properties

### DIFF
--- a/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
@@ -36,7 +36,6 @@ Gradle provides several options that make it easy to configure the Java process 
 
 The final configuration taken into account by Gradle is a combination of all Gradle properties set on the command line and your `gradle.properties` files. If an option is configured in multiple locations, the _first one_ found in any of these locations wins:
 
-* command line, as set using the `-P` / `--project-prop` <<command_line_interface.adoc#sec:environment_options, environment options>>.
 * `gradle.properties` in `GRADLE_USER_HOME` directory.
 * `gradle.properties` in the project's directory, then its parent project's directory up to the build's root directory.
 * `gradle.properties` in Gradle installation directory.
@@ -173,13 +172,6 @@ include::sample[dir="snippets/tutorial/gradleProperties/groovy",files="build.gra
 include::sample[dir="snippets/tutorial/gradleProperties/kotlin",files="build.gradle.kts[tags=gradle-properties-task-inputs]"]
 ====
 
-.Setting Gradle properties from the command line
-====
-----
-$ gradle -PgradlePropertiesProp=commandLineValue
-----
-====
-
 Note that <<init_scripts.adoc#init_scripts, initialization scripts>> can't read Gradle properties directly.
 The earliest Gradle properties can be read in initialization scripts is on `settingsEvaluated {}`:
 
@@ -274,7 +266,17 @@ include::sample[dir="snippets/tutorial/environmentVariables/kotlin",files="build
 [[sec:project_properties]]
 == Project properties
 
-Gradle can set properties to your link:{groovyDslPath}/org.gradle.api.Project.html[Project] object when it sees specially-named system properties or environment variables. If the environment variable name looks like `ORG_GRADLE_PROJECT___prop__=somevalue`, then Gradle will set a `prop` property on your project object, with the value of `somevalue`. Gradle also supports this for system properties, but with a different naming pattern, which looks like `org.gradle.project.__prop__`. Both of the following will set the `foo` property on your Project object to `"bar"`.
+Project properties are available on the link:{groovyDslPath}/org.gradle.api.Project.html[Project] object.
+They can be set from the command line using the `-P` / `--project-prop` <<command_line_interface.adoc#sec:environment_options, environment option>>.
+
+.Setting a project property via the command line
+====
+----
+$ gradle -PgradlePropertiesProp=commandLineValue
+----
+====
+
+Gradle can also set project properties when it sees specially-named system properties or environment variables. If the environment variable name looks like `ORG_GRADLE_PROJECT___prop__=somevalue`, then Gradle will set a `prop` property on your project object, with the value of `somevalue`. Gradle also supports this for system properties, but with a different naming pattern, which looks like `org.gradle.project.__prop__`. Both of the following will set the `foo` property on your Project object to `"bar"`.
 
 .Setting a project property via a system property
 ----
@@ -310,8 +312,6 @@ If you need to branch depending on the presence of the property, you can also us
 include::sample[dir="snippets/tutorial/projectProperties/groovy",files="build.gradle[tags=execution]"]
 include::sample[dir="snippets/tutorial/projectProperties/kotlin",files="build.gradle.kts[tags=execution]"]
 ====
-
-Gradle properties and properties set via the `-P` command line option are also available in project properties.
 
 [NOTE]
 ====

--- a/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
@@ -36,6 +36,7 @@ Gradle provides several options that make it easy to configure the Java process 
 
 The final configuration taken into account by Gradle is a combination of all Gradle properties set on the command line and your `gradle.properties` files. If an option is configured in multiple locations, the _first one_ found in any of these locations wins:
 
+* command line, as set using `-D`.
 * `gradle.properties` in `GRADLE_USER_HOME` directory.
 * `gradle.properties` in the project's directory, then its parent project's directory up to the build's root directory.
 * `gradle.properties` in Gradle installation directory.
@@ -170,6 +171,13 @@ If you need to branch depending on the presence of the property, you can also us
 ====
 include::sample[dir="snippets/tutorial/gradleProperties/groovy",files="build.gradle[tags=gradle-properties-task-inputs]"]
 include::sample[dir="snippets/tutorial/gradleProperties/kotlin",files="build.gradle.kts[tags=gradle-properties-task-inputs]"]
+====
+
+.Setting Gradle properties from the command line
+====
+----
+$ gradle -DgradlePropertiesProp=commandLineValue
+----
 ====
 
 Note that <<init_scripts.adoc#init_scripts, initialization scripts>> can't read Gradle properties directly.

--- a/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
@@ -191,10 +191,12 @@ Using the `-D` command-line option, you can pass a system property to the JVM wh
 You can also set system properties in `gradle.properties` files with the prefix `systemProp.`
 
 .Specifying system properties in `gradle.properties`
+====
 ----
 systemProp.gradle.wrapperUser=myuser
 systemProp.gradle.wrapperPassword=mypassword
 ----
+====
 
 The following system properties are available. Note that command-line options take precedence over system properties.
 
@@ -279,14 +281,18 @@ $ gradle -PgradlePropertiesProp=commandLineValue
 Gradle can also set project properties when it sees specially-named system properties or environment variables. If the environment variable name looks like `ORG_GRADLE_PROJECT___prop__=somevalue`, then Gradle will set a `prop` property on your project object, with the value of `somevalue`. Gradle also supports this for system properties, but with a different naming pattern, which looks like `org.gradle.project.__prop__`. Both of the following will set the `foo` property on your Project object to `"bar"`.
 
 .Setting a project property via a system property
+====
 ----
 org.gradle.project.foo=bar
 ----
+====
 
 .Setting a project property via an environment variable
+====
 ----
 ORG_GRADLE_PROJECT_foo=bar
 ----
+====
 
 This feature is useful when you don't have admin rights to a continuous integration server, and you need to set property values that should not be easily visible. Since you cannot use the `-P` option in that scenario, nor change the system-level configuration files, the correct strategy is to change the configuration of your continuous integration build job, adding an environment variable setting that matches an expected pattern. This won't be visible to normal users on the system.
 
@@ -328,16 +334,20 @@ You can adjust JVM options for Gradle in the following ways:
 The `org.gradle.jvmargs` Gradle property controls the VM running the build. It defaults to `-Xmx512m "-XX:MaxMetaspaceSize=256m"`
 
 .Changing JVM settings for the build VM
+====
 ----
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 ----
+====
 
 The `JAVA_OPTS` environment variable controls the command line client, which is only used to display console output. It defaults to `-Xmx64m`
 
 .Changing JVM settings for the client VM
+====
 ----
 JAVA_OPTS="-Xmx64m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
 ----
+====
 
 [NOTE]
 ====
@@ -373,12 +383,11 @@ Suppose you'd like to ensure release builds are only triggered by CI. A simple w
 ====
 include::sample[dir="snippets/tutorial/configureTaskUsingProjectProperty/groovy",files="build.gradle[]"]
 include::sample[dir="snippets/tutorial/configureTaskUsingProjectProperty/kotlin",files="build.gradle.kts[]"]
-====
-
 ----
 $ gradle performRelease -PisCI=true --quiet
 include::{snippetsPath}/tutorial/configureTaskUsingProjectProperty/tests/configureTaskUsingProjectProperty.out[]
 ----
+====
 
 [[sec:accessing_the_web_via_a_proxy]]
 == Accessing the web through a proxy
@@ -386,6 +395,7 @@ include::{snippetsPath}/tutorial/configureTaskUsingProjectProperty/tests/configu
 Configuring a proxy (for downloading dependencies, for example) is done via standard JVM system properties. These properties can be set directly in the build script; for example, setting the HTTP proxy host would be done with `System.setProperty('http.proxyHost', 'www.somehost.org')`. Alternatively, the properties can be <<#sec:gradle_configuration_properties,specified in gradle.properties>>.
 
 .Configuring an HTTP proxy using `gradle.properties`
+====
 ----
 systemProp.http.proxyHost=www.somehost.org
 systemProp.http.proxyPort=8080
@@ -393,10 +403,12 @@ systemProp.http.proxyUser=userid
 systemProp.http.proxyPassword=password
 systemProp.http.nonProxyHosts=*.nonproxyrepos.com|localhost
 ----
+====
 
 There are separate settings for HTTPS.
 
 .Configuring an HTTPS proxy using `gradle.properties`
+====
 ----
 systemProp.https.proxyHost=www.somehost.org
 systemProp.https.proxyPort=8080
@@ -405,16 +417,19 @@ systemProp.https.proxyPassword=password
 # NOTE: this is not a typo.
 systemProp.http.nonProxyHosts=*.nonproxyrepos.com|localhost
 ----
+====
 
 There are separate settings for SOCKS.
 
 .Configuring a SOCKS proxy using `gradle.properties`
+====
 ----
 systemProp.socksProxyHost=www.somehost.org
 systemProp.socksProxyPort=1080
 systemProp.java.net.socks.username=userid
 systemProp.java.net.socks.password=password
 ----
+====
 
 You may need to set other properties to access other networks. Here are 2 references that may be helpful:
 


### PR DESCRIPTION
-P is for project properties only

This is a follow up to 
* https://github.com/gradle/gradle/pull/21006

----

Rendered result available here https://builds.gradle.org/repository/download/Gradle_Release_Check_BuildDistributions/58007012:id/distributions/gradle-7.6-docs.zip!/gradle-7.6-20221110145135%2B0000/docs/userguide/build_environment.html
