### PR TITLE
Expose whether GE plugin was declared explicitly or auto-applied

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/PluginManagerInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/PluginManagerInternal.java
@@ -21,12 +21,15 @@ import org.gradle.api.Plugin;
 import org.gradle.api.plugins.AppliedPlugin;
 import org.gradle.api.plugins.PluginContainer;
 import org.gradle.api.plugins.PluginManager;
+import org.gradle.plugin.management.internal.PluginRequestInternal;
 import org.gradle.plugin.use.PluginId;
 
 import java.util.Optional;
 
 public interface PluginManagerInternal extends PluginManager {
-    void apply(PluginImplementation<?> plugin);
+    void apply(PluginImplementation<?> plugin, PluginRequestInternal.Origin origin);
+
+    void apply(PluginId id, PluginRequestInternal.Origin origin);
 
     <P extends Plugin> P addImperativePlugin(PluginImplementation<P> plugin);
 
@@ -37,6 +40,8 @@ public interface PluginManagerInternal extends PluginManager {
     <P extends Plugin<?>> Optional<PluginId> findPluginIdForClass(Class<P> plugin);
 
     DomainObjectSet<PluginWithId> pluginsForId(String id);
+
+    boolean isAutoApplied(PluginId id);
 
     class PluginWithId {
         final PluginId id;

--- a/subprojects/core/src/main/java/org/gradle/initialization/definition/InjectedPluginResolver.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/definition/InjectedPluginResolver.java
@@ -22,6 +22,7 @@ import org.gradle.plugin.management.internal.PluginRequests;
 
 import java.util.List;
 
+import static org.gradle.plugin.management.internal.PluginRequestInternal.Origin.INJECTED;
 import static org.gradle.util.internal.CollectionUtils.collect;
 
 public class InjectedPluginResolver {
@@ -33,6 +34,6 @@ public class InjectedPluginResolver {
     }
 
     private List<PluginRequestInternal> convert(List<DefaultInjectedPluginDependency> requests) {
-        return collect(requests, original -> new DefaultPluginRequest(original.getId(), null, true, null, null));
+        return collect(requests, original -> new DefaultPluginRequest(original.getId(), null, true, null, null, INJECTED));
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/plugin/management/internal/DefaultPluginRequest.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/management/internal/DefaultPluginRequest.java
@@ -31,21 +31,22 @@ public class DefaultPluginRequest implements PluginRequestInternal {
     private final Integer lineNumber;
     private final String scriptDisplayName;
     private final ModuleVersionSelector artifact;
+    private final Origin origin;
     private final PluginRequestInternal originalRequest;
 
-    public DefaultPluginRequest(PluginId id, String version, boolean apply, Integer lineNumber, ScriptSource scriptSource) {
-        this(id, version, apply, lineNumber, scriptSource.getDisplayName(), null);
+    public DefaultPluginRequest(PluginId id, String version, boolean apply, Integer lineNumber, ScriptSource scriptSource, Origin origin) {
+        this(id, version, apply, lineNumber, scriptSource.getDisplayName(), null, origin);
     }
 
-    public DefaultPluginRequest(String id, String version, boolean apply, Integer lineNumber, String scriptDisplayName) {
-        this(DefaultPluginId.of(id), version, apply, lineNumber, scriptDisplayName, null);
+    public DefaultPluginRequest(String id, String version, boolean apply, Integer lineNumber, String scriptDisplayName, Origin origin) {
+        this(DefaultPluginId.of(id), version, apply, lineNumber, scriptDisplayName, null, origin);
     }
 
-    public DefaultPluginRequest(PluginId id, String version, boolean apply, Integer lineNumber, String scriptDisplayName, ModuleVersionSelector artifact) {
-        this(id, version, apply, lineNumber, scriptDisplayName, artifact, null);
+    public DefaultPluginRequest(PluginId id, String version, boolean apply, Integer lineNumber, String scriptDisplayName, ModuleVersionSelector artifact, Origin origin) {
+        this(id, version, apply, lineNumber, scriptDisplayName, artifact, origin, null);
     }
 
-    public DefaultPluginRequest(PluginId id, String version, boolean apply, Integer lineNumber, String scriptDisplayName, ModuleVersionSelector artifact,
+    public DefaultPluginRequest(PluginId id, String version, boolean apply, Integer lineNumber, String scriptDisplayName, ModuleVersionSelector artifact, Origin origin,
                                 PluginRequestInternal originalRequest) {
         this.id = id;
         this.version = version;
@@ -53,6 +54,7 @@ public class DefaultPluginRequest implements PluginRequestInternal {
         this.lineNumber = lineNumber;
         this.scriptDisplayName = scriptDisplayName;
         this.artifact = artifact;
+        this.origin = origin;
         this.originalRequest = originalRequest != null ? originalRequest : this;
     }
 
@@ -108,6 +110,11 @@ public class DefaultPluginRequest implements PluginRequestInternal {
     @Override
     public String getDisplayName() {
         return toString();
+    }
+
+    @Override
+    public Origin getOrigin() {
+        return origin;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/plugin/management/internal/PluginRequestInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/management/internal/PluginRequestInternal.java
@@ -29,4 +29,12 @@ public interface PluginRequestInternal extends PluginRequest {
     String getDisplayName();
 
     PluginRequestInternal getOriginalRequest();
+
+    Origin getOrigin();
+
+    enum Origin {
+        AUTO_APPLIED,
+        INJECTED,
+        PROGRAMMATIC
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/plugin/use/internal/PluginRequestCollector.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/use/internal/PluginRequestCollector.java
@@ -41,6 +41,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import static org.gradle.plugin.management.internal.PluginRequestInternal.Origin.PROGRAMMATIC;
 import static org.gradle.util.internal.CollectionUtils.collect;
 
 /**
@@ -75,7 +76,7 @@ public class PluginRequestCollector {
         List<PluginRequestInternal> pluginRequests = collect(specs, new Transformer<PluginRequestInternal, PluginDependencySpecImpl>() {
             @Override
             public PluginRequestInternal transform(PluginDependencySpecImpl original) {
-                return new DefaultPluginRequest(original.id, original.version, original.apply, original.lineNumber, scriptSource);
+                return new DefaultPluginRequest(original.id, original.version, original.apply, original.lineNumber, scriptSource, PROGRAMMATIC);
             }
         });
 

--- a/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginCheckInFixture.groovy
+++ b/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginCheckInFixture.groovy
@@ -101,6 +101,7 @@ class GradleEnterprisePluginCheckInFixture {
 
                         println "gradleEnterprisePlugin.serviceFactoryCreate.config.buildScanRequest = \$config.buildScanRequest"
                         println "gradleEnterprisePlugin.serviceFactoryCreate.config.taskExecutingBuild = \$config.taskExecutingBuild"
+                        println "gradleEnterprisePlugin.serviceFactoryCreate.config.pluginDeclaration = \$config.pluginDeclaration"
 
                         println "gradleEnterprisePlugin.serviceFactoryCreate.buildState.buildStartedTime = \$buildState.buildStartedTime"
                         println "gradleEnterprisePlugin.serviceFactoryCreate.buildState.currentTime = \$buildState.currentTime"
@@ -170,6 +171,10 @@ class GradleEnterprisePluginCheckInFixture {
 
     void assertBuildScanRequest(String output, GradleEnterprisePluginConfig.BuildScanRequest buildScanRequest) {
         assert output.contains("gradleEnterprisePlugin.serviceFactoryCreate.config.buildScanRequest = $buildScanRequest")
+    }
+
+    void assertPluginDeclaration(String output, GradleEnterprisePluginConfig.PluginDeclaration pluginDeclaration) {
+        assert output.contains("gradleEnterprisePlugin.serviceFactoryCreate.config.pluginDeclaration = $pluginDeclaration")
     }
 
     void assertUnsupportedMessage(String output, String unsupported) {

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginConfig.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginConfig.java
@@ -27,7 +27,14 @@ public interface GradleEnterprisePluginConfig {
         SUPPRESSED // --no-scan is present
     }
 
+    enum PluginDeclaration {
+        IMPLICIT,
+        EXPLICIT
+    }
+
     BuildScanRequest getBuildScanRequest();
+
+    PluginDeclaration getPluginDeclaration();
 
     boolean isTaskExecutingBuild();
 

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginConfig.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginConfig.java
@@ -19,24 +19,34 @@ package org.gradle.internal.enterprise.impl;
 import org.gradle.StartParameter;
 import org.gradle.api.internal.BuildType;
 import org.gradle.api.internal.GradleInternal;
+import org.gradle.api.internal.plugins.PluginManagerInternal;
+import org.gradle.api.plugins.AppliedPlugin;
 import org.gradle.internal.enterprise.GradleEnterprisePluginConfig;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
+import org.gradle.plugin.management.internal.autoapply.AutoAppliedGradleEnterprisePlugin;
 
 @ServiceScope(Scopes.BuildTree.class)
 public class DefaultGradleEnterprisePluginConfig implements GradleEnterprisePluginConfig {
 
     private final BuildScanRequest buildScanRequest;
     private final boolean taskExecutingBuild;
+    private final PluginManagerInternal pluginManager;
 
-    public DefaultGradleEnterprisePluginConfig(GradleInternal gradle, BuildType buildType) {
+    public DefaultGradleEnterprisePluginConfig(GradleInternal gradle, BuildType buildType, PluginManagerInternal pluginManager) {
         this.buildScanRequest = buildScanRequest(gradle.getStartParameter());
         this.taskExecutingBuild = buildType == BuildType.TASKS;
+        this.pluginManager = pluginManager;
     }
 
     @Override
     public BuildScanRequest getBuildScanRequest() {
         return buildScanRequest;
+    }
+
+    @Override
+    public PluginDeclaration getPluginDeclaration() {
+        return pluginManager.isAutoApplied(AutoAppliedGradleEnterprisePlugin.ID) ? PluginDeclaration.IMPLICIT : PluginDeclaration.EXPLICIT;
     }
 
     @Override

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/management/internal/DefaultPluginResolveDetails.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/management/internal/DefaultPluginResolveDetails.java
@@ -47,6 +47,7 @@ public class DefaultPluginResolveDetails implements PluginResolveDetails {
             targetPluginRequest.getLineNumber(),
             targetPluginRequest.getScriptDisplayName(),
             USE_MODULE_NOTATION_PARSER.parseNotation(notation),
+            targetPluginRequest.getOrigin(),
             targetPluginRequest.getOriginalRequest()
         );
     }
@@ -60,6 +61,7 @@ public class DefaultPluginResolveDetails implements PluginResolveDetails {
             targetPluginRequest.getLineNumber(),
             targetPluginRequest.getScriptDisplayName(),
             targetPluginRequest.getModule(),
+            targetPluginRequest.getOrigin(),
             targetPluginRequest.getOriginalRequest()
         );
     }

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/management/internal/autoapply/DefaultAutoAppliedPluginRegistry.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/management/internal/autoapply/DefaultAutoAppliedPluginRegistry.java
@@ -31,6 +31,7 @@ import org.gradle.plugin.management.internal.PluginRequestInternal;
 import org.gradle.plugin.management.internal.PluginRequests;
 
 import static org.gradle.initialization.StartParameterBuildOptions.BuildScanOption;
+import static org.gradle.plugin.management.internal.PluginRequestInternal.Origin.AUTO_APPLIED;
 
 /**
  * A hardcoded {@link AutoAppliedPluginRegistry} that only knows about the build-scan plugin for now.
@@ -74,7 +75,7 @@ public class DefaultAutoAppliedPluginRegistry implements AutoAppliedPluginRegist
     private static PluginRequestInternal createGradleEnterprisePluginRequest() {
         ModuleIdentifier moduleIdentifier = DefaultModuleIdentifier.newId(AutoAppliedGradleEnterprisePlugin.GROUP, AutoAppliedGradleEnterprisePlugin.NAME);
         ModuleVersionSelector artifact = DefaultModuleVersionSelector.newSelector(moduleIdentifier, AutoAppliedGradleEnterprisePlugin.VERSION);
-        return new DefaultPluginRequest(AutoAppliedGradleEnterprisePlugin.ID, AutoAppliedGradleEnterprisePlugin.VERSION, true, null, getScriptDisplayName(), artifact);
+        return new DefaultPluginRequest(AutoAppliedGradleEnterprisePlugin.ID, AutoAppliedGradleEnterprisePlugin.VERSION, true, null, getScriptDisplayName(), artifact, AUTO_APPLIED);
     }
 
     private static String getScriptDisplayName() {

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/internal/DefaultPluginRequestApplicator.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/internal/DefaultPluginRequestApplicator.java
@@ -146,7 +146,7 @@ public class DefaultPluginRequestApplicator implements PluginRequestApplicator {
     private void applyPlugin(PluginManagerInternal target, Result result, PluginImplementation<?> impl) {
         applyPlugin(result.request, result.found.getPluginId(), () -> {
             if (result.request.isApply()) {
-                target.apply(impl);
+                target.apply(impl, result.request.getOrigin());
             }
         });
     }
@@ -157,7 +157,7 @@ public class DefaultPluginRequestApplicator implements PluginRequestApplicator {
     private void applyLegacyPlugin(PluginManagerInternal target, Result result, PluginId id) {
         applyPlugin(result.request, id, () -> {
             if (result.request.isApply()) {
-                target.apply(id.toString());
+                target.apply(id, result.request.getOrigin());
             }
         });
     }

--- a/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/internal/ArtifactRepositoriesPluginResolverTest.groovy
+++ b/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/internal/ArtifactRepositoriesPluginResolverTest.groovy
@@ -30,6 +30,7 @@ import org.gradle.plugin.management.internal.PluginRequestInternal
 import org.gradle.plugin.use.internal.DefaultPluginId
 import spock.lang.Specification
 
+import static org.gradle.plugin.management.internal.PluginRequestInternal.Origin.PROGRAMMATIC
 import static org.gradle.plugin.use.resolve.internal.ArtifactRepositoriesPluginResolver.SOURCE_NAME
 
 class ArtifactRepositoriesPluginResolverTest extends Specification {
@@ -60,7 +61,7 @@ class ArtifactRepositoriesPluginResolverTest extends Specification {
     def resolver = new ArtifactRepositoriesPluginResolver(resolution)
 
     PluginRequestInternal request(String id, String version = null) {
-        new DefaultPluginRequest(DefaultPluginId.of(id), version, true, 1, new TextResourceScriptSource(new StringTextResource("test", "test")))
+        new DefaultPluginRequest(DefaultPluginId.of(id), version, true, 1, new TextResourceScriptSource(new StringTextResource("test", "test")), PROGRAMMATIC)
     }
 
     def "fail pluginRequests without versions"() {

--- a/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/internal/CorePluginResolverTest.groovy
+++ b/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/internal/CorePluginResolverTest.groovy
@@ -29,6 +29,8 @@ import org.gradle.plugin.management.internal.PluginRequestInternal
 import org.gradle.plugin.use.internal.DefaultPluginId
 import spock.lang.Specification
 
+import static org.gradle.plugin.management.internal.PluginRequestInternal.Origin.PROGRAMMATIC
+
 class CorePluginResolverTest extends Specification {
 
     static class MyPlugin implements Plugin {
@@ -44,7 +46,7 @@ class CorePluginResolverTest extends Specification {
     def resolver = new CorePluginResolver(docRegistry, pluginRegistry)
 
     PluginRequestInternal request(String id, String version = null) {
-        new DefaultPluginRequest(DefaultPluginId.of(id), version, true, 1, new TextResourceScriptSource(new StringTextResource("test", "test")))
+        new DefaultPluginRequest(DefaultPluginId.of(id), version, true, 1, new TextResourceScriptSource(new StringTextResource("test", "test")), PROGRAMMATIC)
     }
 
     def "non core plugins are ignored"() {
@@ -86,7 +88,7 @@ class CorePluginResolverTest extends Specification {
 
     def "cannot have custom artifact"() {
         when:
-        resolver.resolve(new DefaultPluginRequest(DefaultPluginId.of("foo"), null, true, 1, "test", Mock(ModuleVersionSelector)), result)
+        resolver.resolve(new DefaultPluginRequest(DefaultPluginId.of("foo"), null, true, 1, "test", Mock(ModuleVersionSelector), PROGRAMMATIC), result)
 
         then:
         1 * pluginRegistry.lookup(DefaultPluginId.of("foo")) >> Mock(PluginImplementation) { asClass() >> MyPlugin }


### PR DESCRIPTION
### Context

This is a non-working spike that aims to expose whether the Gradle Enterprise plugin was applied explicitly in the settings script or implicitly via `--scan` to the Gradle Enterprise plugin so that it knows whether to register extensions on the `Test` task for Test Distribution, Predictive Test Selection, and (soon) retry configuration.

The spike adds an `Origin` to each `PluginRequestInternal` which is then passed to `PluginManagerInternal` when applying the plugin. However, the wrong `PluginManagerInternal` is currently injected into `DefaultGradleEnterprisePluginConfig` so the information does not yet make it there.

See `GradleEnterprisePluginConfigIntegrationTest` for an integration test.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
