### PR TITLE
Improve the testability of snippets/java/toolchain-filters

### DIFF
--- a/subprojects/docs/build.gradle
+++ b/subprojects/docs/build.gradle
@@ -752,10 +752,6 @@ tasks.named("docsTest") { task ->
                 "snippet-ivy-publish-quickstart_kotlin_publishingIvyPublishSingle.sample",
                 "snippet-tooling-api-custom-model_groovy_sanityCheck.sample",
 
-                // TODO(https://github.com/gradle/gradle/issues/21717)
-                "snippet-java-toolchain-filters_groovy_toolchainFilters.sample",
-                "snippet-java-toolchain-filters_kotlin_toolchainFilters.sample",
-
                 // TODO(https://github.com/gradle/gradle/issues/13470) Signing plugin support
                 "snippet-signing-configurations_groovy_signingArchivesOutput.sample",
                 "snippet-signing-configurations_kotlin_signingArchivesOutput.sample",

--- a/subprojects/docs/src/snippets/java/toolchain-filters/common/src/main/java/Source.java
+++ b/subprojects/docs/src/snippets/java/toolchain-filters/common/src/main/java/Source.java
@@ -1,0 +1,2 @@
+public class Source {
+}

--- a/subprojects/docs/src/snippets/java/toolchain-filters/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/java/toolchain-filters/groovy/build.gradle
@@ -2,6 +2,10 @@ plugins {
     id 'java'
 }
 
+def testToolchain = System.getProperty("testToolchain", "knownVendor")
+
+if (testToolchain == "knownVendor") {
+// The bodies of the if statements are intentionally not indented to make the user guide page prettier.
 // tag::toolchain-known-vendor[]
 java {
     toolchain {
@@ -11,7 +15,7 @@ java {
 }
 // end::toolchain-known-vendor[]
 
-
+} else if (testToolchain == "matchingVendor") {
 // tag::toolchain-matching-vendor[]
 java {
     toolchain {
@@ -21,6 +25,7 @@ java {
 }
 // end::toolchain-matching-vendor[]
 
+} else if (testToolchain == "matchingImplementation") {
 // tag::toolchain-matching-implementation[]
 java {
     toolchain {
@@ -30,3 +35,4 @@ java {
     }
 }
 // end::toolchain-matching-implementation[]
+}

--- a/subprojects/docs/src/snippets/java/toolchain-filters/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java/toolchain-filters/kotlin/build.gradle.kts
@@ -2,6 +2,11 @@ plugins {
     java
 }
 
+val testToolchain = System.getProperty("testToolchain", "knownVendor")
+
+if (testToolchain == "knownVendor") {
+// The bodies of the if statements are intentionally not indented to make the user guide page prettier.
+
 // tag::toolchain-known-vendor[]
 java {
     toolchain {
@@ -11,7 +16,7 @@ java {
 }
 // end::toolchain-known-vendor[]
 
-
+} else if (testToolchain == "matchingVendor") {
 // tag::toolchain-matching-vendor[]
 java {
     toolchain {
@@ -21,7 +26,7 @@ java {
 }
 // end::toolchain-matching-vendor[]
 
-
+} else if (testToolchain == "matchingImplementation") {
 // tag::toolchain-matching-implementation[]
 java {
     toolchain {
@@ -31,3 +36,4 @@ java {
     }
 }
 // end::toolchain-matching-implementation[]
+}

--- a/subprojects/docs/src/snippets/java/toolchain-filters/tests/matchingVendorWithCC.out
+++ b/subprojects/docs/src/snippets/java/toolchain-filters/tests/matchingVendorWithCC.out
@@ -1,0 +1,2 @@
+> Failed to calculate the value of task ':compileJava' property 'javaCompiler'.
+   > No compatible toolchains found for request specification: {languageVersion=11, vendor=matching('customString'), implementation=vendor-specific} (auto-detect true, auto-download false).

--- a/subprojects/docs/src/snippets/java/toolchain-filters/tests/matchingVendorWithoutCC.out
+++ b/subprojects/docs/src/snippets/java/toolchain-filters/tests/matchingVendorWithoutCC.out
@@ -1,0 +1,4 @@
+Execution failed for task ':compileJava'.
+> Error while evaluating property 'javaCompiler' of task ':compileJava'.
+   > Failed to calculate the value of task ':compileJava' property 'javaCompiler'.
+      > No compatible toolchains found for request specification: {languageVersion=11, vendor=matching('customString'), implementation=vendor-specific} (auto-detect true, auto-download false).

--- a/subprojects/docs/src/snippets/java/toolchain-filters/tests/sanityCheck.sample.conf
+++ b/subprojects/docs/src/snippets/java/toolchain-filters/tests/sanityCheck.sample.conf
@@ -1,0 +1,10 @@
+commands:[{
+    executable: gradle
+    args: "tasks -DtestToolchain=knownVendor"
+}, {
+    executable: gradle
+    args: "tasks -DtestToolchain=matchingVendor"
+}, {
+    executable: gradle
+    args: "tasks -DtestToolchain=matchingImplementation"
+}]

--- a/subprojects/docs/src/snippets/java/toolchain-filters/tests/toolchainFilters.sample.conf
+++ b/subprojects/docs/src/snippets/java/toolchain-filters/tests/toolchainFilters.sample.conf
@@ -1,2 +1,0 @@
-executable: gradle
-args: build

--- a/subprojects/docs/src/snippets/java/toolchain-filters/tests/toolchainFiltersWithCC.sample.conf
+++ b/subprojects/docs/src/snippets/java/toolchain-filters/tests/toolchainFiltersWithCC.sample.conf
@@ -1,0 +1,10 @@
+commands:[{
+    executable: gradle
+    args: "build -DtestToolchain=knownVendor"
+}, {
+    executable: gradle
+    args: "build -DtestToolchain=matchingVendor"
+    expect-failure: true  # The matching vendor uses a dummy vendor string that is never matched
+    expected-output-file: matchingVendorWithCC.out
+    allow-additional-output: true
+}]

--- a/subprojects/docs/src/snippets/java/toolchain-filters/tests/toolchainFiltersWithoutCC.sample.conf
+++ b/subprojects/docs/src/snippets/java/toolchain-filters/tests/toolchainFiltersWithoutCC.sample.conf
@@ -1,0 +1,10 @@
+commands:[{
+    executable: gradle
+    args: "build -DtestToolchain=knownVendor"
+}, {
+    executable: gradle
+    args: "build -DtestToolchain=matchingVendor"
+    expect-failure: true  # The matching vendor uses a dummy vendor string that is never matched
+    expected-output-file: matchingVendorWithoutCC.out
+    allow-additional-output: true
+}]


### PR DESCRIPTION
This snippet was asking for the OpenJ9 toolchain, which is not available on CI. The test wasn't failing without the configuration cache enabled only because there were no sources.

This commit:
1. Adds some dummy source file to make behavior consistent between CC and non-CC cases.
2. Multiple toolchain requests can now be examined separately by setting a system property. Test is updated to reflect that.

There is no coverage for OpenJ9 toolchain, though, as it isn't available on CI.

Unfortunately, the error output is slightly different for CC and non-CC cases, so the test case had to be split.

<!--- The issue this PR addresses -->
Fixes #21717
