### PR TITLE
Verify TestNG parameters in worker

### DIFF
--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmTestSuite.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmTestSuite.java
@@ -204,7 +204,7 @@ public abstract class DefaultJvmTestSuite implements JvmTestSuite {
                 case SPOCK:
                     return new JUnitPlatformTestFramework((DefaultTestFilter) task.getFilter(), false);
                 case TESTNG:
-                    return new TestNGTestFramework(task, task.getClasspath(), (DefaultTestFilter) task.getFilter(), getObjectFactory());
+                    return new TestNGTestFramework(task, (DefaultTestFilter) task.getFilter(), getObjectFactory());
                 default:
                     throw new IllegalStateException("do not know how to handle " + vtf);
             }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFailurePolicyIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFailurePolicyIntegrationTest.groovy
@@ -16,11 +16,13 @@
 
 package org.gradle.testing.testng
 
+import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import org.gradle.integtests.fixtures.TestClassExecutionResult
 import org.gradle.integtests.fixtures.TestNGExecutionResult
 import org.gradle.integtests.fixtures.TestResources
 import org.junit.Rule
 
+import static org.hamcrest.CoreMatchers.containsString
 import static org.junit.Assume.assumeFalse
 import static org.junit.Assume.assumeTrue
 
@@ -109,6 +111,8 @@ class TestNGFailurePolicyIntegrationTest extends AbstractTestNGVersionIntegratio
         fails "test"
 
         and:
-        failure.assertHasCause("The version of TestNG used does not support setting config failure policy to 'continue'.")
+        def result = new DefaultTestExecutionResult(testDirectory)
+        result.testClassStartsWith('Gradle Test Executor').assertExecutionFailedWithCause(
+            containsString("The version of TestNG used does not support setting config failure policy to 'continue'."))
     }
 }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGGroupByInstancesNotSupportedIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGGroupByInstancesNotSupportedIntegrationTest.groovy
@@ -17,8 +17,11 @@
 package org.gradle.testing.testng
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 
-public class TestNGGroupByInstancesNotSupportedIntegrationTest extends AbstractIntegrationSpec {
+import static org.hamcrest.CoreMatchers.containsString
+
+class TestNGGroupByInstancesNotSupportedIntegrationTest extends AbstractIntegrationSpec {
 
     def "run tests using TestNG version not supporting groupByInstances"() {
         given:
@@ -43,6 +46,8 @@ public class TestNGGroupByInstancesNotSupportedIntegrationTest extends AbstractI
         fails "test"
 
         then:
-        failure.assertHasCause("Grouping tests by instances is not supported by this version of TestNG.")
+        def result = new DefaultTestExecutionResult(testDirectory)
+        result.testClassStartsWith('Gradle Test Executor').assertExecutionFailedWithCause(
+            containsString("Grouping tests by instances is not supported by this version of TestNG."))
     }
 }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGPreserveOrderNotSupportedIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGPreserveOrderNotSupportedIntegrationTest.groovy
@@ -17,8 +17,11 @@
 package org.gradle.testing.testng
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 
-public class TestNGPreserveOrderNotSupportedIntegrationTest extends AbstractIntegrationSpec {
+import static org.hamcrest.CoreMatchers.containsString
+
+class TestNGPreserveOrderNotSupportedIntegrationTest extends AbstractIntegrationSpec {
 
     def "run tests using TestNG version not supporting preserveOrder"() {
         given:
@@ -43,6 +46,8 @@ public class TestNGPreserveOrderNotSupportedIntegrationTest extends AbstractInte
         fails "test"
 
         then:
-        failure.assertHasCause("Preserving the order of tests is not supported by this version of TestNG.")
+        def result = new DefaultTestExecutionResult(testDirectory)
+        result.testClassStartsWith('Gradle Test Executor').assertExecutionFailedWithCause(
+            containsString("Preserving the order of tests is not supported by this version of TestNG."))
     }
 }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -1020,7 +1020,7 @@ public abstract class Test extends AbstractTestTask implements JavaForkOptions, 
      * @see #useTestNG(org.gradle.api.Action) Configure TestNG specific options.
      */
     public void useTestNG() {
-        useTestFramework(new TestNGTestFramework(this, stableClasspath, (DefaultTestFilter) getFilter(), getObjectFactory()));
+        useTestFramework(new TestNGTestFramework(this, (DefaultTestFilter) getFilter(), getObjectFactory()));
 
     }
 

--- a/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/testng/TestNGTestFrameworkTest.groovy
+++ b/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/testng/TestNGTestFrameworkTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.tasks.testing.testng
 
-import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.tasks.testing.filter.DefaultTestFilter
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.testing.Test
@@ -45,7 +44,6 @@ public class TestNGTestFrameworkTest extends Specification {
 
         then:
         processor instanceof TestNGTestClassProcessor
-        framework.testTaskPath == testTask.path
         framework.detector
     }
 
@@ -60,6 +58,6 @@ public class TestNGTestFrameworkTest extends Specification {
     }
 
     TestNGTestFramework createFramework() {
-        new TestNGTestFramework(testTask, Stub(FileCollection), new DefaultTestFilter(), objects)
+        new TestNGTestFramework(testTask, new DefaultTestFilter(), objects)
     }
 }


### PR DESCRIPTION
Previously we would load up the test runtime claspath in TestNGTestFramework, then load some TestNG classes to verify which version we are running. Based on the version we performed verification to ensure the user set the test options correctly relative to the version of TestNG they are running.

We were caching this ClassLoader even after the build was complete, thus production jars could have had their files held open after the build was complete. To avoid this, we move the verification to inside the test worker -- when the application classloader already has TestNG on the path. This allows us to not construct the test ClassLoader in the main Gradle daemon, and thus avoid creating a ClassLoader which points at the test runtime classpath and thus the production jars.
