### PR TITLE
Fix IDE-reported error in `ProblemReportingProject.projectPath`

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -132,6 +132,7 @@ import org.gradle.util.Path;
 import org.gradle.util.internal.ClosureBackedAction;
 import org.gradle.util.internal.ConfigureUtil;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.io.File;
@@ -625,6 +626,7 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
     }
 
     @Override
+    @Nonnull
     public Path getProjectPath() {
         return owner.getProjectPath();
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
@@ -48,6 +48,7 @@ import org.gradle.model.internal.registry.ModelRegistryScope;
 import org.gradle.normalization.internal.InputNormalizationHandlerInternal;
 import org.gradle.util.Path;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Map;
 import java.util.Set;
@@ -181,6 +182,7 @@ public interface ProjectInternal extends Project, ProjectIdentifier, HasScriptSe
      * Returns a unique path for this project within its containing build.
      */
     @Override
+    @Nonnull
     Path getProjectPath();
 
     /**


### PR DESCRIPTION
The IDE would report an error on a nullable `delegate.projectPath` used as the return value of the non-null `Path`. If you change the return type to `Path?`, the compiler reports an error because of the return type not matching the supertype's annotation. 

So annotating `ProjectInternal.getProjectPath` with `@Nonnull` seems to be the right way to make both the compiler and the IDE happy with `ProblemReportingProject.projectPath`.

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
