### PR TITLE
Add configuration cache incompatibility notes to the user guide

### DIFF
--- a/subprojects/docs/src/docs/userguide/authoring-builds/ant.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/ant.adoc
@@ -25,6 +25,8 @@ Finally, since build scripts are Groovy scripts, you can always execute an Ant b
 
 You can use Gradle's Ant integration as a path for migrating your build from Ant to Gradle. For example, you could start by importing your existing Ant build. Then you could move your dependency declarations from the Ant script to your build file. Finally, you could move your tasks across to your build file, or replace them with some of Gradle's plugins. This process can be done in parts over time, and you can have a working Gradle build during the entire process.
 
+WARNING: Ant integration is not fully compatible with the <<configuration_cache.adoc#config_cache,configuration cache>>.
+Using link:{javadocPath}/org/gradle/api/Task.html#getAnt--[Task.ant] to run Ant task in the task action may work, but importing the Ant build is not supported.
 
 [[sec:using_ant_tasks]]
 == Using Ant tasks and types in your build

--- a/subprojects/docs/src/docs/userguide/authoring-builds/build_lifecycle.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/build_lifecycle.adoc
@@ -194,6 +194,10 @@ Task execution includes most of the work you normally associate with a build: do
 
 ==== React to Task Execution Notifications
 
+WARNING: Task execution events are not compatible with the <<configuration_cache.adoc#config_cache:requirements:build_listeners,configuration cache>>.
+You can use <<build_services#build_services,build services>> to receive information about <<build_services#operation_listener, task execution>>
+in a way compatible with the configuration cache.
+
 You can receive a notification immediately before and after Gradle executes any task.
 These notifications work even when task execution fails.
 The following example logs the start and end of each task execution:

--- a/subprojects/docs/src/docs/userguide/build-cache/common_caching_problems.adoc
+++ b/subprojects/docs/src/docs/userguide/build-cache/common_caching_problems.adoc
@@ -173,6 +173,8 @@ include::sample[dir="snippets/buildCache/configure-task/groovy",files="build.gra
 include::sample[dir="snippets/buildCache/configure-task/kotlin",files="build.gradle.kts[tags=configureTask]"]
 ====
 
+WARNING: Note that configuring a task from other task is not supported when using the <<configuration_cache.adoc#config_cache:requirements:task_access,configuration cache>>.
+
 [[logic_based_on_task_outcome]]
 === Build logic based on the outcome of a task
 

--- a/subprojects/docs/src/docs/userguide/core-plugins/distribution_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/core-plugins/distribution_plugin.adoc
@@ -113,6 +113,8 @@ include::sample[dir="snippets/ivy-publish/distribution/groovy",files="build.grad
 include::sample[dir="snippets/ivy-publish/distribution/kotlin",files="build.gradle.kts[tags=publishing]"]
 ====
 
+WARNING: The Ivy Publish Plugin is not yet compatible with the <<configuration_cache.adoc#config_cache:plugins:core,configuration cache>>.
+
 Similarly, to publish a distribution to a Maven repository using the <<publishing_maven.adoc#publishing_maven, Maven Publish Plugin>>, add one or both of its archive tasks to a link:{groovyDslPath}/org.gradle.api.publish.maven.MavenPublication.html[MavenPublication] as follows:
 
 .Adding distribution archives to a Maven publication

--- a/subprojects/docs/src/docs/userguide/core-plugins/ear_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/core-plugins/ear_plugin.adoc
@@ -15,6 +15,8 @@
 [[ear_plugin]]
 = The Ear Plugin
 
+WARNING: The Ear Plugin is not yet compatible with the <<configuration_cache.adoc#config_cache:plugins:core,configuration cache>>.
+
 The Ear plugin adds support for assembling web application EAR files.
 It adds a default EAR archive task.
 It doesn't require the <<java_plugin.adoc#java_plugin,Java plugin>>, but for projects that also use the Java plugin it disables the default JAR archive generation.

--- a/subprojects/docs/src/docs/userguide/core-plugins/eclipse_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/core-plugins/eclipse_plugin.adoc
@@ -15,6 +15,8 @@
 [[eclipse_plugin]]
 = The Eclipse Plugins
 
+WARNING: The Eclipse Plugins are not compatible with the <<configuration_cache.adoc#config_cache:plugins:core,configuration cache>>.
+
 The Eclipse plugins generate files that are used by the http://eclipse.org[Eclipse IDE], thus making it possible to import the project into Eclipse (`File` - `Import...` - `Existing Projects into Workspace`).
 
 The `eclipse-wtp` is automatically applied whenever the `eclipse` plugin is applied to a <<war_plugin.adoc#war_plugin,War>> or <<ear_plugin.adoc#ear_plugin,Ear>> project. For utility projects (i.e. <<java_plugin.adoc#java_plugin,Java>> projects used by other web projects), you need to apply the `eclipse-wtp` plugin explicitly.

--- a/subprojects/docs/src/docs/userguide/core-plugins/idea_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/core-plugins/idea_plugin.adoc
@@ -15,6 +15,8 @@
 [[idea_plugin]]
 = The IDEA Plugin
 
+WARNING: The IDEA Plugin is not compatible with the <<configuration_cache.adoc#config_cache:plugins:core,configuration cache>>.
+
 The IDEA plugin generates files that are used by http://www.jetbrains.com/idea/[IntelliJ IDEA], thus making it possible to open the project from IDEA (`File` - `Open Project`). Both external dependencies (including associated source and Javadoc files) and project dependencies are considered.
 
 [NOTE]

--- a/subprojects/docs/src/docs/userguide/core-plugins/visual_studio_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/core-plugins/visual_studio_plugin.adoc
@@ -15,6 +15,8 @@
 [[visual_studio_plugin]]
 = Visual Studio
 
+WARNING: The Visual Studio Plugin is not compatible with the <<configuration_cache.adoc#config_cache:plugins:core,configuration cache>>.
+
 The Visual Studio Plugin generate files that are used by the https://visualstudio.microsoft.com/[Visual Studio IDE], thus making it possible to open the solution into Visual Studio (`File` - `Open` - `Project/Solution...`).
 
 What exactly the `visual-studio` plugin generates depends on which other plugins are used:

--- a/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_ivy.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_ivy.adoc
@@ -15,6 +15,8 @@
 [[publishing_ivy]]
 = Ivy Publish Plugin
 
+WARNING: The Ivy Publish Plugin is not yet compatible with the <<configuration_cache.adoc#config_cache:plugins:core,configuration cache>>.
+
 The Ivy Publish Plugin provides the ability to publish build artifacts in the http://ant.apache.org/ivy/[Apache Ivy] format, usually to a repository for consumption by other builds or projects. What is published is one or more artifacts created by the build, and an Ivy _module descriptor_ (normally `ivy.xml`) that describes the artifacts and the dependencies of the artifacts, if any.
 
 A published Ivy module can be consumed by Gradle (see <<declaring_dependencies.adoc#declaring-dependencies,Declaring Dependencies>>) and other tools that understand the Ivy format. You can learn about the fundamentals of publishing in <<publishing_setup.adoc#publishing_overview,Publishing Overview>>.

--- a/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_maven.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_maven.adoc
@@ -256,6 +256,8 @@ The result is that the following artifacts will be published:
 
 The <<signing_plugin.adoc#signing_plugin, Signing Plugin>> is used to generate a signature file for each artifact. In addition, checksum files will be generated for all artifacts and signature files.
 
+WARNING: Note that the Signing plugin is not yet compatible with the <<configuration_cache.adoc#config_cache:plugins:core,configuration cache>>.
+
 [[publishing_maven:deferred_configuration]]
 == Removal of deferred configuration behavior
 

--- a/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_signing.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_signing.adoc
@@ -1,6 +1,8 @@
 [[publishing_maven:signing]]
 = Signing artifacts
 
+WARNING: The Signing Plugin is not yet compatible with the <<configuration_cache.adoc#config_cache:plugins:core,configuration cache>>.
+
 The <<signing_plugin.adoc#signing_plugin, Signing Plugin>> can be used to sign all artifacts and metadata files that make up a publication, including Maven POM files and Ivy module descriptors. In order to use it:
 
 1. Apply the Signing Plugin

--- a/subprojects/docs/src/docs/userguide/dep-man/06-publishing/signing_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/06-publishing/signing_plugin.adoc
@@ -15,6 +15,8 @@
 [[signing_plugin]]
 = The Signing Plugin
 
+WARNING: The Signing Plugin is not yet compatible with the <<configuration_cache.adoc#config_cache:plugins:core,configuration cache>>.
+
 The Signing Plugin adds the ability to digitally sign built files and artifacts. These digital signatures can then be used to prove who built the artifact the signature is attached to as well as other information such as when the signature was generated.
 
 The Signing Plugin currently only provides support for generating https://en.wikipedia.org/wiki/Pretty_Good_Privacy#OpenPGP[OpenPGP signatures] (which is the signature format http://central.sonatype.org/pages/requirements.html#sign-files-with-gpgpgp[required for publication to the Maven Central Repository]).

--- a/subprojects/docs/src/docs/userguide/migration/migrating_from_ant.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/migrating_from_ant.adoc
@@ -80,6 +80,9 @@ The rest of the chapter covers some common scenarios you will likely deal with d
 [[migant:imported_builds]]
 == Working with an imported build
 
+WARNING: Importing an Ant build is not supported with the <<configuration_cache.adoc#config_cache,configuration cache>>.
+You need to complete the conversion to Gradle to get the benefits of caching.
+
 The first step of many migrations will involve <<ant#sec:import_ant_build,importing an Ant build>> using `ant.importBuild()`. If you do that, how do you then move towards a standard Gradle build without replacing everything at once?
 
 The important thing to remember is that the Ant targets become real Gradle tasks, meaning you can do things like modify their task dependencies, attach extra task actions, and so on. This allows you to substitute native Gradle tasks for the equivalent Ant ones, maintaining any links to other existing tasks.

--- a/subprojects/docs/src/docs/userguide/native/building_cpp_projects.adoc
+++ b/subprojects/docs/src/docs/userguide/native/building_cpp_projects.adoc
@@ -15,6 +15,8 @@
 [[building_cpp_projects]]
 = Building {cpp} projects
 
+WARNING: The plugins described in this chapter are not compatible with the <<configuration_cache.adoc#config_cache:plugins:core,configuration cache>>.
+
 Gradle uses a convention-over-configuration approach to building native projects.
 If you are coming from another native build system, these concepts may be unfamiliar at first, but they serve a purpose to simplify build script authoring.
 

--- a/subprojects/docs/src/docs/userguide/native/building_swift_projects.adoc
+++ b/subprojects/docs/src/docs/userguide/native/building_swift_projects.adoc
@@ -15,6 +15,8 @@
 [[building_swift_projects]]
 = Building Swift projects
 
+WARNING: The plugins described in this chapter are not compatible with the <<configuration_cache.adoc#config_cache:plugins:core,configuration cache>>.
+
 Gradle uses a convention-over-configuration approach to building native projects.
 If you are coming from another native build system, these concepts may be unfamiliar at first, but they serve a purpose to simplify build script authoring.
 

--- a/subprojects/docs/src/docs/userguide/native/cpp_application_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/native/cpp_application_plugin.adoc
@@ -15,6 +15,8 @@
 [[cpp_application_plugin]]
 = {cpp} Application
 
+WARNING: The {cpp} Application Plugin is not compatible with the <<configuration_cache.adoc#config_cache:plugins:core,configuration cache>>.
+
 The {cpp} Application Plugin provides the tasks, configurations and conventions for a building {cpp} application.
 
 [[sec:cpp_application_usage]]

--- a/subprojects/docs/src/docs/userguide/native/cpp_library_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/native/cpp_library_plugin.adoc
@@ -15,6 +15,8 @@
 [[cpp_library_plugin]]
 = {cpp} Library
 
+WARNING: The {cpp} Library Plugin is not compatible with the <<configuration_cache.adoc#config_cache:plugins:core,configuration cache>>.
+
 The {cpp} Library Plugin provides the tasks, conventions and conventions for building a {cpp} library.
 In particular, a {cpp} library provides functionality that can be used by consumers (i.e., other projects using this plugin or the <<cpp_application_plugin.adoc#cpp_application_plugin,{cpp} Application Plugin>>).
 

--- a/subprojects/docs/src/docs/userguide/native/cpp_testing.adoc
+++ b/subprojects/docs/src/docs/userguide/native/cpp_testing.adoc
@@ -15,6 +15,8 @@
 [[cpp_testing]]
 = Testing in C++ projects
 
+WARNING: The {cpp} testing support is not compatible with the <<configuration_cache.adoc#config_cache:plugins:core,configuration cache>>.
+
 Testing in the native ecosystem takes many forms.
 
 There are different testing libraries and frameworks, as well as many different types of test.

--- a/subprojects/docs/src/docs/userguide/native/cpp_unit_test_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/native/cpp_unit_test_plugin.adoc
@@ -15,6 +15,8 @@
 [[cpp_unit_test_plugin]]
 = {cpp} Unit Test
 
+WARNING: The {cpp} Unit Test Plugin is not compatible with the <<configuration_cache.adoc#config_cache:plugins:core,configuration cache>>.
+
 The {cpp} Unit Test Plugin provides the tasks, configurations and conventions for integrating with a {cpp} executable-based testing framework, such as https://github.com/google/googletest[Google Test].
 
 [[sec:cpp_unit_test_usage]]

--- a/subprojects/docs/src/docs/userguide/native/native_software.adoc
+++ b/subprojects/docs/src/docs/userguide/native/native_software.adoc
@@ -22,6 +22,8 @@ The https://blog.gradle.org/state-and-future-of-the-gradle-software-model[softwa
 We recommend new projects looking to build C++ applications and libraries use the newer <<building_cpp_projects.adoc#building_cpp_projects,replacement plugins>>.
 ====
 
+WARNING: The native plugins described in this chapter are not compatible with the <<configuration_cache.adoc#config_cache:plugins:core,configuration cache>>.
+
 The native software plugins add support for building native software components, such as executables or shared libraries, from code written in C++, C and other languages. While many excellent build tools exist for this space of software development, Gradle offers developers its trademark power and flexibility together with dependency management practices more traditionally found in the JVM development space.
 
 The native software plugins make use of the Gradle software model.

--- a/subprojects/docs/src/docs/userguide/native/swift_application_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/native/swift_application_plugin.adoc
@@ -15,6 +15,8 @@
 [[swift_application_plugin]]
 = Swift Application
 
+WARNING: The Swift Application Plugin is not compatible with the <<configuration_cache.adoc#config_cache:plugins:core,configuration cache>>.
+
 The Swift Application Plugin provides the tasks, configurations and conventions for a building Swift application.
 
 [[sec:swift_application_usage]]

--- a/subprojects/docs/src/docs/userguide/native/swift_library_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/native/swift_library_plugin.adoc
@@ -15,6 +15,8 @@
 [[swift_library_plugin]]
 = Swift Library
 
+WARNING: The Swift Library Plugin is not compatible with the <<configuration_cache.adoc#config_cache:plugins:core,configuration cache>>.
+
 The Swift Library Plugin provides the tasks, conventions and conventions for building a Swift library.
 In particular, a Swift library provides functionality that can be used by consumers (i.e., other projects using this plugin or the <<swift_application_plugin.adoc#swift_application_plugin,Swift Application Plugin>>).
 

--- a/subprojects/docs/src/docs/userguide/native/swift_testing.adoc
+++ b/subprojects/docs/src/docs/userguide/native/swift_testing.adoc
@@ -15,6 +15,8 @@
 [[swift_testing]]
 = Testing in Swift projects
 
+WARNING: The Swift testing support is not compatible with the <<configuration_cache.adoc#config_cache:plugins:core,configuration cache>>.
+
 Testing in the native ecosystem is a rich subject matter.
 There are many different testing libraries and frameworks, as well as many different types of test.
 All need to be part of the build, whether they are executed frequently or infrequently.

--- a/subprojects/docs/src/docs/userguide/native/xcode_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/native/xcode_plugin.adoc
@@ -15,6 +15,8 @@
 [[xcode_plugin]]
 = Xcode
 
+WARNING: The Xcode Plugin is not compatible with the <<configuration_cache.adoc#config_cache:plugins:core,configuration cache>>.
+
 The Xcode Plugin generate files that are used by the https://developer.apple.com/xcode/[Xcode IDE] to open Gradle projects into Xcode (`File` - `Open...`). The generated Xcode project delegates build actions to Gradle.
 
 What exactly the `xcode` plugin generates depends on which other plugins are used:

--- a/subprojects/docs/src/docs/userguide/native/xctest_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/native/xctest_plugin.adoc
@@ -15,6 +15,8 @@
 [[xctest_plugin]]
 = XCTest
 
+WARNING: The XCTest Plugin is not compatible with the <<configuration_cache.adoc#config_cache:plugins:core,configuration cache>>.
+
 The XCTest Plugin provides the tasks, configurations and conventions for integrating with a https://developer.apple.com/documentation/xctest[XCTest testing framework on macOS] as well as https://github.com/apple/swift-corelibs-xctest[Linux's open source implementation].
 
 [[sec:xctest_usage]]


### PR DESCRIPTION
This is a userguide-only change. A single `WARNING` is added for pages describing unsupported plugins (like Ivy, Sign, IDE plugins, etc.). If the page describes something else, but a particular snippet is not supported, then the warning is added close to the unsupported snippet. I've tried to provide some guidance in these warnings too.
Part of #21027.