### PR TITLE
Disable config cache for init task

### DIFF
--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BuildInitPluginIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BuildInitPluginIntegrationTest.groovy
@@ -60,7 +60,7 @@ class BuildInitPluginIntegrationTest extends AbstractInitIntegrationSpec {
                 containsString("Learn more about Gradle by exploring our samples at")))
 
         expect:
-        succeeds 'help'
+        succeeds 'properties'
 
         where:
         scriptDsl << ScriptDslFixture.SCRIPT_DSLS
@@ -85,7 +85,7 @@ class BuildInitPluginIntegrationTest extends AbstractInitIntegrationSpec {
                 containsString(BuildScriptBuilder.getIncubatingApisWarning())))
 
         expect:
-        succeeds 'help'
+        succeeds 'properties'
 
         where:
         scriptDsl << ScriptDslFixture.SCRIPT_DSLS

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/BuildInitPlugin.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/BuildInitPlugin.java
@@ -42,6 +42,7 @@ public abstract class BuildInitPlugin implements Plugin<Project> {
     public void apply(Project project) {
         if (project.getParent() == null) {
             project.getTasks().register("init", InitBuild.class, initBuild -> {
+                initBuild.notCompatibleWithConfigurationCache("Not applicable");
                 initBuild.setGroup("Build Setup");
                 initBuild.setDescription("Initializes a new Gradle build.");
 

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheIntegrationTest.groovy
@@ -408,4 +408,22 @@ class ConfigurationCacheIntegrationTest extends AbstractConfigurationCacheIntegr
         then:
         outputContains("value = value")
     }
+
+    def "can init two projects in a row"() {
+        when:
+        useTestDirectoryThatIsNotEmbeddedInAnotherBuild()
+        configurationCacheRun "init", "--dsl", "groovy", "--type", "basic"
+
+        then:
+        outputContains("> Task :init")
+        succeeds 'properties'
+
+        when:
+        useTestDirectoryThatIsNotEmbeddedInAnotherBuild()
+        configurationCacheRun "init", "--dsl", "groovy", "--type", "basic"
+
+        then:
+        outputContains("> Task :init")
+        succeeds 'properties'
+    }
 }


### PR DESCRIPTION
`init` task does not make sense for configuration cache. This change set disables it.

Fixes: #20156
