### PR TITLE
Add configuration cache incompatibility note for C++ and Swift samples

### DIFF
--- a/build-logic/build-init-samples/src/main/kotlin/gradlebuild/samples/SamplesGenerator.kt
+++ b/build-logic/build-init-samples/src/main/kotlin/gradlebuild/samples/SamplesGenerator.kt
@@ -142,6 +142,20 @@ Enter selection (default: JUnit 4) [1..4]
         else
             "link:{userManualPath}/${descriptor.language.name}_plugin.html[${descriptor.language} Plugin]"
 
+        val pluginType = if (descriptor.componentType === ComponentType.LIBRARY) "Library" else "Application"
+        val configurationCacheCompatMatrixLink = "link:{userManualPath}/configuration_cache.html#config_cache:plugins:core"
+        val configurationCacheCompatibility = when (descriptor.language) {
+            Language.CPP -> {
+                "WARNING: The {cpp} $pluginType Plugin is not compatible with the $configurationCacheCompatMatrixLink[configuration cache]."
+            }
+            Language.SWIFT -> {
+                "WARNING: The Swift $pluginType Plugin is not compatible with the $configurationCacheCompatMatrixLink[configuration cache]."
+            }
+            else -> {
+                ""
+            }
+        }
+
         projectLayoutSetupRegistry.templateOperationFactory.newTemplateOperation()
             .withTemplate(templateFolder.template("$templateFragment.adoc"))
             .withTarget(settings.target.file("../README.adoc").asFile)
@@ -164,6 +178,7 @@ Enter selection (default: JUnit 4) [1..4]
             .withBinding("testFrameworkChoice", testFrameworkChoice)
             .withBinding("tasksExecuted", "" + tasksExecuted(descriptor))
             .withBinding("languagePluginDocsLink", "" + languagePluginDocsLink)
+            .withBinding("configurationCacheCompatibility", configurationCacheCompatibility)
             .create().generate()
     }
 

--- a/subprojects/docs/src/samples/readme-templates/common-body.adoc.template
+++ b/subprojects/docs/src/samples/readme-templates/common-body.adoc.template
@@ -3,6 +3,8 @@ NOTE: You can open this sample inside an IDE using the https://www.jetbrains.com
 This guide demonstrates how to create a ${language.raw} ${componentType.raw} with Gradle using `gradle init`.
 You can follow the guide step-by-step to create a new project from scratch or download the complete sample project using the links above.
 
+${configurationCacheCompatibility.raw}
+
 == What you’ll build
 
 You'll generate a ${language.raw} ${componentType.raw} that follows Gradle's conventions.


### PR DESCRIPTION
The documentation pages for the samples are generated, so the generator itself has to be tweaked.

Part of #21027.