### PR TITLE
Clean in the first step of FlakyTestQuarantine build

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/FlakyTestQuarantine.kt
+++ b/.teamcity/src/main/kotlin/configurations/FlakyTestQuarantine.kt
@@ -44,7 +44,7 @@ class FlakyTestQuarantine(model: CIBuildModel, stage: Stage, os: Os, arch: Arch 
         }
     }
 
-    testsWithOs.forEach { testCoverage ->
+    testsWithOs.forEachIndexed { index, testCoverage ->
         val extraParameters = functionalTestExtraParameters("FlakyTestQuarantine", os, arch, testCoverage.testJvmVersion.major.toString(), testCoverage.vendor.name)
         val parameters = (
             buildToolGradleParameters(true) +
@@ -56,7 +56,7 @@ class FlakyTestQuarantine(model: CIBuildModel, stage: Stage, os: Os, arch: Arch 
         steps {
             gradleWrapper {
                 name = "FLAKY_TEST_QUARANTINE_${testCoverage.testType.name.uppercase()}_${testCoverage.testJvmVersion.name.uppercase()}"
-                tasks = "${testCoverage.testType.name}Test"
+                tasks = "${if (index == 0) "clean " else ""}${testCoverage.testType.name}Test"
                 gradleParams = parameters
                 executionMode = BuildStep.ExecutionMode.ALWAYS
             }


### PR DESCRIPTION
https://gradle.slack.com/archives/C01SUR5709G/p1668387610973599

Otherwise, we may see potential problems when re-mapping the project directory to another disk with Windows `subst`:

```
Output property ‘destinationDirectory’ file P:\subprojects\base-annotations\build\classes\java\main has been removed.	
Output property ‘destinationDirectory’ file P:\subprojects\base-annotations\build\classes\java\main\org has been removed.	
Output property ‘destinationDirectory’ file P:\subprojects\base-annotations\build\classes\java\main\org\gradle has been removed.	
Not cacheable	Overlapping outputs: Gradle does not know how file ‘build\classes\java\main’ was created (output property ‘destinationDirectory’).

Overlapping outputs: Gradle does not know how file 'build\classes\java\main' was created (output property 'destinationDirectory'). Task output caching requires exclusive access to output paths to guarantee correctness (i.e. multiple tasks are not allowed to produce output in the same location).
```