### PR TITLE
Request vendor for build logic toolchain always

### DIFF
--- a/build-logic-commons/gradle-plugin/src/main/kotlin/common.kt
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/common.kt
@@ -20,9 +20,6 @@ import org.gradle.jvm.toolchain.JvmVendorSpec
 fun JavaPluginExtension.configureJavaToolChain() {
     toolchain {
         languageVersion.set(JavaLanguageVersion.of(11))
-        // Do not force Adoptium vendor for M1 Macs
-        if (System.getProperty("os.arch") != "aarch64") {
-            vendor.set(JvmVendorSpec.ADOPTIUM)
-        }
+        vendor.set(JvmVendorSpec.ADOPTIUM)
     }
 }


### PR DESCRIPTION
Now that we have Temurian on macOS M1 as well, we can always request the vendor for the build logic toolchain. We already do that for the toolchain of the main build, though it seems like we missed it here.

This fixes the build cache miss seen in this build: https://ge.gradle.org/c/senmqef5l4t4w/mko35zcb44jhc/task-inputs#5wjma2k22fask-javacompiler.metadata.taskinputs.vendor