### PR TITLE
Add build operation progress events when builds in the tree and their projects are identified

### DIFF
--- a/subprojects/build-operations/src/main/java/org/gradle/internal/operations/notify/BuildOperationProgressNotification.java
+++ b/subprojects/build-operations/src/main/java/org/gradle/internal/operations/notify/BuildOperationProgressNotification.java
@@ -19,7 +19,7 @@ package org.gradle.internal.operations.notify;
 import org.gradle.internal.scan.UsedByScanPlugin;
 
 /**
- * A notification that a build operation has finished.
+ * A notification that a build operation has made progress in some way.
  *
  * The methods of this interface are awkwardly prefixed to allow
  * internal types to implement this interface along with other internal interfaces

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcBuildOperationsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcBuildOperationsIntegrationTest.groovy
@@ -192,8 +192,8 @@ class CompositeBuildBuildSrcBuildOperationsIntegrationTest extends AbstractCompo
         buildIdentifiedEvents.size() == 4
         buildIdentifiedEvents[0].details.buildPath == ':'
         buildIdentifiedEvents[1].details.buildPath == ':buildB'
-        buildIdentifiedEvents[2].details.buildPath == ':buildSrc'
-        buildIdentifiedEvents[3].details.buildPath == ':buildB:buildSrc'
+        buildIdentifiedEvents[2].details.buildPath == ':buildB:buildSrc'
+        buildIdentifiedEvents[3].details.buildPath == ':buildSrc'
 
         def configureOps = operations.all(ConfigureBuildBuildOperationType)
         configureOps.size() == 4

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcBuildOperationsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcBuildOperationsIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests.composite
 
 import org.gradle.execution.taskgraph.NotifyTaskGraphWhenReadyBuildOperationType
+import org.gradle.initialization.BuildIdentifiedProgressDetails
 import org.gradle.initialization.ConfigureBuildBuildOperationType
 import org.gradle.initialization.LoadBuildBuildOperationType
 import org.gradle.initialization.buildsrc.BuildBuildSrcBuildOperationType
@@ -76,6 +77,12 @@ class CompositeBuildBuildSrcBuildOperationsIntegrationTest extends AbstractCompo
         loadOps[2].displayName == "Load build (:buildB:buildSrc)"
         loadOps[2].details.buildPath == ":buildB:buildSrc"
         loadOps[2].parentId == buildSrcOps[0].id
+
+        def buildIdentifiedEvents = operations.progress(BuildIdentifiedProgressDetails)
+        buildIdentifiedEvents.size() == 3
+        buildIdentifiedEvents[0].details.buildPath == ':'
+        buildIdentifiedEvents[1].details.buildPath == ':buildB'
+        buildIdentifiedEvents[2].details.buildPath == ':buildB:buildSrc'
 
         def configureOps = operations.all(ConfigureBuildBuildOperationType)
         configureOps.size() == 3
@@ -180,6 +187,13 @@ class CompositeBuildBuildSrcBuildOperationsIntegrationTest extends AbstractCompo
         loadOps[3].displayName == "Load build (:buildSrc)"
         loadOps[3].details.buildPath == ":buildSrc"
         loadOps[3].parentId == buildSrcOps[1].id
+
+        def buildIdentifiedEvents = operations.progress(BuildIdentifiedProgressDetails)
+        buildIdentifiedEvents.size() == 4
+        buildIdentifiedEvents[0].details.buildPath == ':'
+        buildIdentifiedEvents[1].details.buildPath == ':buildB'
+        buildIdentifiedEvents[2].details.buildPath == ':buildSrc'
+        buildIdentifiedEvents[3].details.buildPath == ':buildB:buildSrc'
 
         def configureOps = operations.all(ConfigureBuildBuildOperationType)
         configureOps.size() == 4

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.configurationcache
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.initialization.LoadProjectsBuildOperationType
+import org.gradle.initialization.ProjectsIdentifiedProgressDetails
 import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheRecreateOption
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.integtests.fixtures.configurationcache.ConfigurationCacheFixture
@@ -235,62 +236,96 @@ class ConfigurationCacheIntegrationTest extends AbstractConfigurationCacheIntegr
         configurationCacheRun "help"
 
         then:
-        def event = fixture.first(LoadProjectsBuildOperationType)
-        event.result.rootProject.name == 'thing'
-        event.result.rootProject.path == ':'
-        event.result.rootProject.children.size() == 3 // All projects are created when storing
+        def op1 = fixture.only(LoadProjectsBuildOperationType)
+        op1.result.rootProject.name == 'thing'
+        op1.result.rootProject.path == ':'
+        op1.result.rootProject.children.size() == 3 // All projects are created when storing
+
+        def events1 = fixture.progress(ProjectsIdentifiedProgressDetails)
+        events1.size() == 1
+        events1[0].details.rootProject.name == 'thing'
+        events1[0].details.rootProject.path == ':'
+        events1[0].details.rootProject.children.size() == 3
 
         when:
         configurationCacheRun "help"
 
         then:
-        def event2 = fixture.first(LoadProjectsBuildOperationType)
-        event2.result.rootProject.name == 'thing'
-        event2.result.rootProject.path == ':'
-        event2.result.rootProject.projectDir == testDirectory.absolutePath
-        event2.result.rootProject.children.empty // None of the child projects are created when loading, as they have no tasks scheduled
+        def op2 = fixture.only(LoadProjectsBuildOperationType)
+        op2.result.rootProject.name == 'thing'
+        op2.result.rootProject.path == ':'
+        op2.result.rootProject.projectDir == testDirectory.absolutePath
+        op2.result.rootProject.children.empty // None of the child projects are created when loading, as they have no tasks scheduled
+
+        def events2 = fixture.progress(ProjectsIdentifiedProgressDetails)
+        events2.size() == 1
+        events2[0].details.rootProject.name == 'thing'
+        events2[0].details.rootProject.path == ':'
+        events2[0].details.rootProject.projectDir == testDirectory.absolutePath
+        events2[0].details.rootProject.children.empty
 
         when:
         configurationCacheRun ":a:thing"
 
         then:
-        def event3 = fixture.first(LoadProjectsBuildOperationType)
-        event3.result.rootProject.name == 'thing'
-        event3.result.rootProject.children.size() == 3 // All projects are created when storing
+        def op3 = fixture.only(LoadProjectsBuildOperationType)
+        op3.result.rootProject.name == 'thing'
+        op3.result.rootProject.children.size() == 3 // All projects are created when storing
+
+        def events3 = fixture.progress(ProjectsIdentifiedProgressDetails)
+        events3.size() == 1
+        events3[0].details.rootProject.name == 'thing'
+        events3[0].details.rootProject.children.size() == 3
 
         when:
         configurationCacheRun ":a:thing"
 
         then:
-        def event4 = fixture.first(LoadProjectsBuildOperationType)
-        event4.result.rootProject.name == 'thing'
-        event4.result.rootProject.path == ':'
-        event4.result.rootProject.projectDir == testDirectory.absolutePath
-        event4.result.rootProject.children.size() == 1 // Only project a is created when loading
-        def project1 = event4.result.rootProject.children.first()
+        def op4 = fixture.only(LoadProjectsBuildOperationType)
+        op4.result.rootProject.name == 'thing'
+        op4.result.rootProject.path == ':'
+        op4.result.rootProject.projectDir == testDirectory.absolutePath
+        op4.result.rootProject.children.size() == 1 // Only project a is created when loading
+        def project1 = op4.result.rootProject.children.first()
         project1.name == 'a'
         project1.path == ':a'
         project1.projectDir == file('a').absolutePath
         project1.children.empty
 
+        def events4 = fixture.progress(ProjectsIdentifiedProgressDetails)
+        events4.size() == 1
+        events4[0].details.rootProject.name == 'thing'
+        events4[0].details.rootProject.path == ':'
+        events4[0].details.rootProject.children.size() == 1
+        def project2 = events4[0].details.rootProject.children.first()
+        project2.name == 'a'
+        project2.path == ':a'
+        project2.projectDir == file('a').absolutePath
+        project2.children.empty
+
         when:
         configurationCacheRun ":a:b:thing"
 
         then:
-        def event5 = fixture.first(LoadProjectsBuildOperationType)
-        event5.result.rootProject.name == 'thing'
-        event5.result.rootProject.children.size() == 3 // All projects are created when storing
+        def op5 = fixture.only(LoadProjectsBuildOperationType)
+        op5.result.rootProject.name == 'thing'
+        op5.result.rootProject.children.size() == 3 // All projects are created when storing
+
+        def events5 = fixture.progress(ProjectsIdentifiedProgressDetails)
+        events5.size() == 1
+        events5[0].details.rootProject.name == 'thing'
+        events5[0].details.rootProject.children.size() == 3
 
         when:
         configurationCacheRun ":a:b:thing"
 
         then:
-        def event6 = fixture.first(LoadProjectsBuildOperationType)
-        event6.result.rootProject.name == 'thing'
-        event6.result.rootProject.path == ':'
-        event6.result.rootProject.projectDir == testDirectory.absolutePath
-        event6.result.rootProject.children.size() == 1
-        def project3 = event6.result.rootProject.children.first()
+        def op6 = fixture.only(LoadProjectsBuildOperationType)
+        op6.result.rootProject.name == 'thing'
+        op6.result.rootProject.path == ':'
+        op6.result.rootProject.projectDir == testDirectory.absolutePath
+        op6.result.rootProject.children.size() == 1
+        def project3 = op6.result.rootProject.children.first()
         project3.name == 'a'
         project3.path == ':a'
         project3.projectDir == file('a').absolutePath
@@ -299,6 +334,21 @@ class ConfigurationCacheIntegrationTest extends AbstractConfigurationCacheIntegr
         project4.name == 'b'
         project4.path == ':a:b'
         project4.projectDir == file('custom').absolutePath
+
+        def events6 = fixture.progress(ProjectsIdentifiedProgressDetails)
+        events6.size() == 1
+        events6[0].details.rootProject.name == 'thing'
+        events6[0].details.rootProject.path == ':'
+        events6[0].details.rootProject.children.size() == 1
+        def project5 = events6[0].details.rootProject.children.first()
+        project5.name == 'a'
+        project5.path == ':a'
+        project5.projectDir == file('a').absolutePath
+        project5.children.size() == 1
+        def project6 = project5.children.first()
+        project6.name == 'b'
+        project6.path == ':a:b'
+        project6.projectDir == file('custom').absolutePath
     }
 
     def "does not configure build when task graph is already cached for requested tasks"() {

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
@@ -74,6 +74,7 @@ import org.gradle.internal.execution.BuildOutputCleanupRegistry
 import org.gradle.internal.operations.BuildOperationContext
 import org.gradle.internal.operations.BuildOperationDescriptor
 import org.gradle.internal.operations.BuildOperationExecutor
+import org.gradle.internal.operations.BuildOperationProgressEventEmitter
 import org.gradle.internal.operations.RunnableBuildOperation
 import org.gradle.internal.serialize.Decoder
 import org.gradle.internal.serialize.Encoder
@@ -133,7 +134,7 @@ class ConfigurationCacheState(
         val gradle = state.build.gradle
         val buildOperationExecutor = gradle.serviceOf<BuildOperationExecutor>()
         fireConfigureBuild(buildOperationExecutor, gradle) {
-            fireLoadProjects(buildOperationExecutor, gradle)
+            fireLoadProjects(buildOperationExecutor, gradle.serviceOf(), gradle)
             state.children.forEach(::configureBuild)
             fireConfigureProject(buildOperationExecutor, gradle)
         }
@@ -742,8 +743,8 @@ class ConfigurationCacheState(
      * Fire _Load projects_ build operation required by build scans to determine the build's project structure (and build load time).
      **/
     private
-    fun fireLoadProjects(buildOperationExecutor: BuildOperationExecutor, gradle: GradleInternal) {
-        NotifyingBuildLoader({ _, _ -> }, buildOperationExecutor).load(gradle.settings, gradle)
+    fun fireLoadProjects(buildOperationExecutor: BuildOperationExecutor, emitter: BuildOperationProgressEventEmitter, gradle: GradleInternal) {
+        NotifyingBuildLoader({ _, _ -> }, buildOperationExecutor, emitter).load(gradle.settings, gradle)
     }
 
     /**

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
@@ -754,6 +754,7 @@ class ConfigurationCacheState(
         BuildOperationFiringSettingsPreparer(
             { preparer() },
             gradle.serviceOf(),
+            gradle.serviceOf(),
             gradle.serviceOf<BuildDefinition>().fromBuild
         ).prepareSettings(gradle)
     }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskTimeoutIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskTimeoutIntegrationTest.groovy
@@ -284,7 +284,7 @@ class TaskTimeoutIntegrationTest extends AbstractIntegrationSpec {
 
     List<String> taskLogging(String taskPath) {
         def taskExecutionOp = operations.only("Task $taskPath")
-        def logging = taskExecutionOp.progress.findAll { it.hasDetailsOfType(LogEventBuildOperationProgressDetails) }*.details
+        def logging = taskExecutionOp.progress(LogEventBuildOperationProgressDetails)*.details
         def timeoutLogging = logging.findAll { it.category == DefaultTimeoutHandler.name }
         timeoutLogging.collect { it.message } as List<String>
     }

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/BuildInitializationBuildOperationsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/BuildInitializationBuildOperationsIntegrationTest.groovy
@@ -39,11 +39,12 @@ class BuildInitializationBuildOperationsIntegrationTest extends AbstractIntegrat
         when:
         succeeds('foo')
 
-        def loadBuildBuildOperation = buildOperations.one(LoadBuildBuildOperationType)
-        def evaluateSettingsBuildOperation = buildOperations.one(EvaluateSettingsBuildOperationType)
-        def configureBuildBuildOperations = buildOperations.one(ConfigureBuildBuildOperationType)
-        def loadProjectsBuildOperation = buildOperations.one(LoadProjectsBuildOperationType)
+        def loadBuildBuildOperation = buildOperations.only(LoadBuildBuildOperationType)
+        def evaluateSettingsBuildOperation = buildOperations.only(EvaluateSettingsBuildOperationType)
+        def configureBuildBuildOperations = buildOperations.only(ConfigureBuildBuildOperationType)
+        def loadProjectsBuildOperation = buildOperations.only(LoadProjectsBuildOperationType)
         def buildIdentifiedEvents = buildOperations.progress(BuildIdentifiedProgressDetails)
+        def projectsIdentifiedEvents = buildOperations.progress(ProjectsIdentifiedProgressDetails)
 
         then:
         loadBuildBuildOperation.details.buildPath == ":"
@@ -62,6 +63,9 @@ class BuildInitializationBuildOperationsIntegrationTest extends AbstractIntegrat
         loadProjectsBuildOperation.details.buildPath == ":"
         loadProjectsBuildOperation.result.rootProject.projectDir == settingsFile.parent
         buildOperations.first('Configure build').id == loadProjectsBuildOperation.parentId
+
+        projectsIdentifiedEvents.size() == 1
+        projectsIdentifiedEvents[0].details.rootProject.projectDir == settingsFile.parent
     }
 
     def "operations are fired for complex nest of builds"() {
@@ -148,7 +152,8 @@ class BuildInitializationBuildOperationsIntegrationTest extends AbstractIntegrat
 
         then:
         def loadBuildBuildOperations = buildOperations.all(LoadBuildBuildOperationType)
-        loadBuildBuildOperations*.details.buildPath == [
+
+        def loadOrder = [
             ":",
             ":nested",
             ":nested-nested",
@@ -165,6 +170,7 @@ class BuildInitializationBuildOperationsIntegrationTest extends AbstractIntegrat
             ":buildSrc",
             ":buildSrc:buildSrc",
         ]
+        loadBuildBuildOperations*.details.buildPath == loadOrder
         loadBuildBuildOperations*.details.includedBy == [
             null,
             ":",
@@ -190,36 +196,20 @@ class BuildInitializationBuildOperationsIntegrationTest extends AbstractIntegrat
             ":nested-cli",
             ":nested-nested",
             ":nested-cli-nested",
-            ":buildSrc",
             ":nested-nested:buildSrc",
-            ":nested:buildSrc",
-            ":nested-cli-nested:buildSrc",
-            ":nested-cli:buildSrc",
-            ":buildSrc:buildSrc",
             ":nested-nested:buildSrc:buildSrc",
+            ":nested:buildSrc",
             ":nested:buildSrc:buildSrc",
+            ":nested-cli-nested:buildSrc",
             ":nested-cli-nested:buildSrc:buildSrc",
+            ":nested-cli:buildSrc",
             ":nested-cli:buildSrc:buildSrc",
+            ":buildSrc",
+            ":buildSrc:buildSrc",
         ]
 
         def evaluateSettingsBuildOperations = buildOperations.all(EvaluateSettingsBuildOperationType)
-        evaluateSettingsBuildOperations*.details.buildPath == [
-            ":",
-            ":nested",
-            ":nested-nested",
-            ":nested-cli",
-            ":nested-cli-nested",
-            ":nested-nested:buildSrc",
-            ":nested-nested:buildSrc:buildSrc",
-            ":nested:buildSrc",
-            ":nested:buildSrc:buildSrc",
-            ":nested-cli-nested:buildSrc",
-            ":nested-cli-nested:buildSrc:buildSrc",
-            ":nested-cli:buildSrc",
-            ":nested-cli:buildSrc:buildSrc",
-            ":buildSrc",
-            ":buildSrc:buildSrc",
-        ]
+        evaluateSettingsBuildOperations*.details.buildPath == loadOrder
 
         def configureOrder = [
                 ":",
@@ -243,6 +233,8 @@ class BuildInitializationBuildOperationsIntegrationTest extends AbstractIntegrat
         configureBuildBuildOperations*.details.buildPath == configureOrder
         def loadProjectsBuildOperations = buildOperations.all(LoadProjectsBuildOperationType)
         loadProjectsBuildOperations*.details.buildPath == configureOrder
+        def projectsIdentifiedEvents = buildOperations.progress(ProjectsIdentifiedProgressDetails)
+        projectsIdentifiedEvents*.details.buildPath == configureOrder
 
         def dirs = configureOrder
             .collect { it.substring(1) } // strip leading :

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/BuildInitializationBuildOperationsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/BuildInitializationBuildOperationsIntegrationTest.groovy
@@ -39,14 +39,18 @@ class BuildInitializationBuildOperationsIntegrationTest extends AbstractIntegrat
         when:
         succeeds('foo')
 
-        def loadBuildBuildOperation = buildOperations.first(LoadBuildBuildOperationType)
-        def evaluateSettingsBuildOperation = buildOperations.first(EvaluateSettingsBuildOperationType)
-        def configureBuildBuildOperations = buildOperations.first(ConfigureBuildBuildOperationType)
-        def loadProjectsBuildOperation = buildOperations.first(LoadProjectsBuildOperationType)
+        def loadBuildBuildOperation = buildOperations.one(LoadBuildBuildOperationType)
+        def evaluateSettingsBuildOperation = buildOperations.one(EvaluateSettingsBuildOperationType)
+        def configureBuildBuildOperations = buildOperations.one(ConfigureBuildBuildOperationType)
+        def loadProjectsBuildOperation = buildOperations.one(LoadProjectsBuildOperationType)
+        def buildIdentifiedEvents = buildOperations.progress(BuildIdentifiedProgressDetails)
 
         then:
         loadBuildBuildOperation.details.buildPath == ":"
         loadBuildBuildOperation.result.isEmpty()
+
+        buildIdentifiedEvents.size() == 1
+        buildIdentifiedEvents[0].details.buildPath == ':'
 
         evaluateSettingsBuildOperation.details.buildPath == ":"
         evaluateSettingsBuildOperation.result.isEmpty()
@@ -177,6 +181,25 @@ class BuildInitializationBuildOperationsIntegrationTest extends AbstractIntegrat
             ":nested-cli:buildSrc",
             ":",
             ":buildSrc",
+        ]
+
+        def buildIdentifiedEvents = buildOperations.progress(BuildIdentifiedProgressDetails)
+        buildIdentifiedEvents*.details.buildPath == [
+            ":",
+            ":nested",
+            ":nested-cli",
+            ":nested-nested",
+            ":nested-cli-nested",
+            ":buildSrc",
+            ":nested-nested:buildSrc",
+            ":nested:buildSrc",
+            ":nested-cli-nested:buildSrc",
+            ":nested-cli:buildSrc",
+            ":buildSrc:buildSrc",
+            ":nested-nested:buildSrc:buildSrc",
+            ":nested:buildSrc:buildSrc",
+            ":nested-cli-nested:buildSrc:buildSrc",
+            ":nested-cli:buildSrc:buildSrc",
         ]
 
         def evaluateSettingsBuildOperations = buildOperations.all(EvaluateSettingsBuildOperationType)

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/LoadBuildStructureBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/LoadBuildStructureBuildOperationIntegrationTest.groovy
@@ -42,14 +42,20 @@ class LoadBuildStructureBuildOperationIntegrationTest extends AbstractIntegratio
         succeeds('help')
 
         then:
+        def operation = buildOperations.only(LoadProjectsBuildOperationType)
+        def opResult = operation.result
         opResult.buildPath == ":"
         opResult.rootProject.path == ":"
 
         verifyProject(opResult.rootProject, 'root', ':', [':a', ':b'], testDirectory, 'root.gradle')
-        verifyProject(project(':a'), 'a', ':a', [':a:c'])
-        verifyProject(project(':b'), 'b')
-        verifyProject(project(':a:c'), 'c', ':a:c', [':a:c:d'], testDirectory.file('a/c'))
-        verifyProject(project(':a:c:d'), 'd', ':a:c:d', [], testDirectory.file('d'), 'd.gradle')
+        verifyProject(project(':a', operation), 'a', ':a', [':a:c'])
+        verifyProject(project(':b', operation), 'b')
+        verifyProject(project(':a:c', operation), 'c', ':a:c', [':a:c:d'], testDirectory.file('a/c'))
+        verifyProject(project(':a:c:d', operation), 'd', ':a:c:d', [], testDirectory.file('d'), 'd.gradle')
+
+        def events = buildOperations.progress(ProjectsIdentifiedProgressDetails)
+        events.size() == 1
+        events[0].details.buildPath == ":"
     }
 
     def "settings set via cmdline flag are exposed correctly"() {
@@ -69,16 +75,20 @@ class LoadBuildStructureBuildOperationIntegrationTest extends AbstractIntegratio
         succeeds('help')
 
         then:
-        operation().result.buildPath == ":"
-        operation().result.rootProject.name == "root"
-        operation().result.rootProject.path == ":"
-        operation().result.rootProject.projectDir == customSettingsDir.absolutePath
-        operation().result.rootProject.buildFile == customSettingsDir.file("root.gradle").absolutePath
-
+        def operation = buildOperations.only(LoadProjectsBuildOperationType)
+        def opResult = operation.result
         opResult.buildPath == ":"
+        opResult.rootProject.name == "root"
         opResult.rootProject.path == ":"
+        opResult.rootProject.projectDir == customSettingsDir.absolutePath
+        opResult.rootProject.buildFile == customSettingsDir.file("root.gradle").absolutePath
+
         verifyProject(opResult.rootProject, 'root', ':', [':a'], customSettingsDir, 'root.gradle')
-        verifyProject(project(':a'), 'a', ':a', [], customSettingsDir.file('a'))
+        verifyProject(project(':a', operation), 'a', ':a', [], customSettingsDir.file('a'))
+
+        def events = buildOperations.progress(ProjectsIdentifiedProgressDetails)
+        events.size() == 1
+        events[0].details.buildPath == ":"
     }
 
     def "composite participants expose their project structure"() {
@@ -106,16 +116,16 @@ class LoadBuildStructureBuildOperationIntegrationTest extends AbstractIntegratio
 
 
         then:
-        def buildOperations = operations()
+        def buildOperations = buildOperations.all(LoadProjectsBuildOperationType)
         buildOperations.size() == 2
 
-        def rootBuildOperation = operations()[0]
+        def rootBuildOperation = buildOperations[0]
         rootBuildOperation.result.buildPath == ":"
         rootBuildOperation.result.rootProject.path == ":"
         verifyProject(rootBuildOperation.result.rootProject, 'root', ':', [':a'], testDirectory, 'root.gradle')
         verifyProject(project(":a", rootBuildOperation), 'a')
 
-        def nestedBuildOperation = operations()[1]
+        def nestedBuildOperation = buildOperations[1]
         nestedBuildOperation.result.buildPath == ":nested"
         nestedBuildOperation.result.rootProject.path == ":"
         verifyProject(nestedBuildOperation.result.rootProject, 'nested', ':nested', [':b'], testDirectory.file('nested'))
@@ -130,27 +140,14 @@ class LoadBuildStructureBuildOperationIntegrationTest extends AbstractIntegratio
         assert project.children*.path == children
     }
 
-    def project(String path, BuildOperationRecord operation = operation(), Map parent = null) {
+    def project(String path, BuildOperationRecord operation, Map parent = null) {
         if (parent == null) {
             if (path.lastIndexOf(':') == 0) {
                 return operation.result.rootProject.children.find { it.path == path }
             } else {
-                return project(path, operation, project(path.substring(0, path.lastIndexOf(':'))))
+                return project(path, operation, project(path.substring(0, path.lastIndexOf(':')), operation))
             }
         }
         return parent.children.find { it.path == path }
-    }
-
-    private BuildOperationRecord operation(){
-        def operationRecords = operations()
-        assert operationRecords.size() == 1
-        operationRecords.iterator().next()
-    }
-
-    private getOpResult() {
-        operation().result
-    }
-    private List<BuildOperationRecord> operations() {
-        buildOperations.all(LoadProjectsBuildOperationType)
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcBuildOperationsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcBuildOperationsIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.initialization.buildsrc
 import org.gradle.api.internal.artifacts.configurations.ResolveConfigurationDependenciesBuildOperationType
 import org.gradle.api.internal.tasks.execution.ExecuteTaskBuildOperationType
 import org.gradle.execution.taskgraph.NotifyTaskGraphWhenReadyBuildOperationType
+import org.gradle.initialization.BuildIdentifiedProgressDetails
 import org.gradle.initialization.ConfigureBuildBuildOperationType
 import org.gradle.initialization.LoadBuildBuildOperationType
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
@@ -57,6 +58,11 @@ class BuildSrcBuildOperationsIntegrationTest extends AbstractIntegrationSpec {
         loadOps[1].displayName == "Load build (:buildSrc)"
         loadOps[1].details.buildPath == ':buildSrc'
         loadOps[1].parentId == buildSrcOps[0].id
+
+        def buildIdentifiedEvents = ops.progress(BuildIdentifiedProgressDetails)
+        buildIdentifiedEvents.size() == 2
+        buildIdentifiedEvents[0].details.buildPath == ':'
+        buildIdentifiedEvents[1].details.buildPath == ':buildSrc'
 
         def configureOps = ops.all(ConfigureBuildBuildOperationType)
         configureOps.size() == 2

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/configurationcache/options/ConfigurationCacheSettingsFinalizedBuildOperationIntegTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/configurationcache/options/ConfigurationCacheSettingsFinalizedBuildOperationIntegTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.internal.configurationcache.options
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
-import org.gradle.internal.operations.trace.BuildOperationRecord
 import spock.lang.IgnoreIf
 
 @IgnoreIf({ GradleContextualExecuter.configCache })
@@ -65,14 +64,6 @@ class ConfigurationCacheSettingsFinalizedBuildOperationIntegTest extends Abstrac
     }
 
     List<ConfigurationCacheSettingsFinalizedProgressDetails> events() {
-        List<BuildOperationRecord.Progress> events = []
-        operations.walk {
-            events.addAll(it.progress.findAll {
-                ConfigurationCacheSettingsFinalizedProgressDetails.isAssignableFrom(it.detailsType)
-            })
-        }
-        events.collect {
-            { -> it.details.enabled } as ConfigurationCacheSettingsFinalizedProgressDetails
-        }
+        return operations.progress(ConfigurationCacheSettingsFinalizedProgressDetails).details
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressIntegTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressIntegTest.groovy
@@ -376,7 +376,7 @@ class LoggingBuildOperationProgressIntegTest extends AbstractIntegrationSpec {
 
         List<BuildOperationRecord.Progress> output = []
         operations.walk(operations.root(RunBuildBuildOperationType)) {
-            output.addAll(it.progress.findAll { it.hasDetailsOfType(LogEventBuildOperationProgressDetails) })
+            output.addAll(it.progress(LogEventBuildOperationProgressDetails))
         }
 
         def uniqueMessages = output.collect { it.details.message }.unique()

--- a/subprojects/core/src/main/java/org/gradle/initialization/BuildOperationFiringSettingsPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/BuildOperationFiringSettingsPreparer.java
@@ -21,6 +21,7 @@ import org.gradle.internal.build.PublicBuildPath;
 import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationExecutor;
+import org.gradle.internal.operations.BuildOperationProgressEventEmitter;
 import org.gradle.internal.operations.RunnableBuildOperation;
 
 import javax.annotation.Nullable;
@@ -31,17 +32,25 @@ public class BuildOperationFiringSettingsPreparer implements SettingsPreparer {
 
     private final SettingsPreparer delegate;
     private final BuildOperationExecutor buildOperationExecutor;
+    private final BuildOperationProgressEventEmitter emitter;
     @Nullable
     private final PublicBuildPath fromBuild;
 
-    public BuildOperationFiringSettingsPreparer(SettingsPreparer delegate, BuildOperationExecutor buildOperationExecutor, @Nullable PublicBuildPath fromBuild) {
+    public BuildOperationFiringSettingsPreparer(SettingsPreparer delegate, BuildOperationExecutor buildOperationExecutor, BuildOperationProgressEventEmitter emitter, @Nullable PublicBuildPath fromBuild) {
         this.delegate = delegate;
         this.buildOperationExecutor = buildOperationExecutor;
+        this.emitter = emitter;
         this.fromBuild = fromBuild;
     }
 
     @Override
     public void prepareSettings(GradleInternal gradle) {
+        emitter.emitNowForCurrent(new BuildIdentifiedProgressDetails() {
+            @Override
+            public String getBuildPath() {
+                return gradle.getIdentityPath().toString();
+            }
+        });
         buildOperationExecutor.run(new LoadBuild(gradle));
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/trace/BuildOperationRecord.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/trace/BuildOperationRecord.java
@@ -19,6 +19,7 @@ package org.gradle.internal.operations.trace;
 import com.google.common.base.Function;
 import com.google.common.collect.Ordering;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -123,6 +124,19 @@ public final class BuildOperationRecord {
 
     public Class<?> getResultType() throws ClassNotFoundException {
         return resultClassName == null ? null : getClass().getClassLoader().loadClass(resultClassName);
+    }
+
+    /**
+     * Returns all progress events with details of the given type.
+     */
+    public List<Progress> progress(Class<?> clazz) throws ClassNotFoundException {
+        List<Progress> result = new ArrayList<>();
+        for (Progress progress : progress) {
+            if (progress.hasDetailsOfType(clazz)) {
+                result.add(progress);
+            }
+        }
+        return result;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -184,6 +184,7 @@ import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
 import org.gradle.internal.operations.BuildOperationExecutor;
+import org.gradle.internal.operations.BuildOperationProgressEventEmitter;
 import org.gradle.internal.operations.logging.BuildOperationLoggerFactory;
 import org.gradle.internal.operations.logging.DefaultBuildOperationLoggerFactory;
 import org.gradle.internal.reflect.Instantiator;
@@ -519,12 +520,13 @@ public class BuildScopeServices extends DefaultServiceRegistry {
         );
     }
 
-    protected SettingsPreparer createSettingsPreparer(SettingsLoaderFactory settingsLoaderFactory, BuildOperationExecutor buildOperationExecutor, BuildDefinition buildDefinition) {
+    protected SettingsPreparer createSettingsPreparer(SettingsLoaderFactory settingsLoaderFactory, BuildOperationExecutor buildOperationExecutor, BuildOperationProgressEventEmitter emitter, BuildDefinition buildDefinition) {
         return new BuildOperationFiringSettingsPreparer(
             new DefaultSettingsPreparer(
                 settingsLoaderFactory
             ),
             buildOperationExecutor,
+            emitter,
             buildDefinition.getFromBuild());
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -403,6 +403,7 @@ public class BuildScopeServices extends DefaultServiceRegistry {
     protected BuildLoader createBuildLoader(
         GradleProperties gradleProperties,
         BuildOperationExecutor buildOperationExecutor,
+        BuildOperationProgressEventEmitter emitter,
         ListenerManager listenerManager
     ) {
         return new NotifyingBuildLoader(
@@ -411,7 +412,8 @@ public class BuildScopeServices extends DefaultServiceRegistry {
                 new InstantiatingBuildLoader(),
                 listenerManager.getBroadcaster(FileResourceListener.class)
             ),
-            buildOperationExecutor
+            buildOperationExecutor,
+            emitter
         );
     }
 

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/initialization/BuildIdentifiedProgressDetails.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/initialization/BuildIdentifiedProgressDetails.java
@@ -17,7 +17,9 @@
 package org.gradle.initialization;
 
 /**
- * Fired after a build in the tree is discovered and before any other build operations reference that build are executed.
+ * Fired once a build in the tree is discovered and before any other build operations reference that build are executed.
+ *
+ * @since 8.0
  */
 public interface BuildIdentifiedProgressDetails {
     String getBuildPath();

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/initialization/BuildIdentifiedProgressDetails.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/initialization/BuildIdentifiedProgressDetails.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.initialization;
+
+/**
+ * Fired after a build in the tree is discovered and before any other build operations reference that build are executed.
+ */
+public interface BuildIdentifiedProgressDetails {
+    String getBuildPath();
+}

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/initialization/LoadProjectsBuildOperationType.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/initialization/LoadProjectsBuildOperationType.java
@@ -98,9 +98,7 @@ public final class LoadProjectsBuildOperationType implements BuildOperationType<
              * @see org.gradle.api.Project#getChildProjects()
              */
 
-            Set<Project> getChildren();
+            Set<? extends Project> getChildren();
         }
     }
-
-
 }

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/initialization/ProjectsIdentifiedProgressDetails.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/initialization/ProjectsIdentifiedProgressDetails.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.initialization;
+
+import java.util.Set;
+
+/**
+ * Fired once the hierarchy of projects is finalized for a build in the tree, and before any build operations
+ * that reference those projects are executed.
+ *
+ * @since 8.0
+ */
+public interface ProjectsIdentifiedProgressDetails {
+    /**
+     * @see LoadProjectsBuildOperationType.Result#getBuildPath()
+     */
+    String getBuildPath();
+
+    /**
+     * @see LoadProjectsBuildOperationType.Result#getRootProject()
+     */
+    Project getRootProject();
+
+    interface Project {
+        /**
+         * @see LoadProjectsBuildOperationType.Result.Project#getName()
+         */
+        String getName();
+
+        /**
+         * @see LoadProjectsBuildOperationType.Result.Project#getPath()
+         */
+        String getPath();
+
+        /**
+         * @see LoadProjectsBuildOperationType.Result.Project#getIdentityPath()
+         */
+        String getIdentityPath();
+
+        /**
+         * @see LoadProjectsBuildOperationType.Result.Project#getProjectDir()
+         */
+        String getProjectDir();
+
+        /**
+         * @see LoadProjectsBuildOperationType.Result.Project#getBuildFile()
+         */
+        String getBuildFile();
+
+        /**
+         * @see LoadProjectsBuildOperationType.Result.Project#getChildren()
+         */
+        Set<? extends Project> getChildren();
+    }
+}

--- a/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/FileSystemWatchingSettingsFinalizedBuildOperationIntegrationTest.groovy
+++ b/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/FileSystemWatchingSettingsFinalizedBuildOperationIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.internal.watch
 
 import com.gradle.enterprise.testing.annotations.LocalOnly
 import org.gradle.integtests.fixtures.BuildOperationsFixture
-import org.gradle.internal.operations.trace.BuildOperationRecord
 import org.gradle.internal.watch.options.FileSystemWatchingSettingsFinalizedProgressDetails
 
 @LocalOnly
@@ -58,14 +57,6 @@ class FileSystemWatchingSettingsFinalizedBuildOperationIntegrationTest extends A
     }
 
     List<FileSystemWatchingSettingsFinalizedProgressDetails> events() {
-        List<BuildOperationRecord.Progress> events = []
-        operations.walk {
-            events.addAll(it.progress.findAll {
-                FileSystemWatchingSettingsFinalizedProgressDetails.isAssignableFrom(it.detailsType)
-            })
-        }
-        events.collect {
-            { -> it.details.enabled } as FileSystemWatchingSettingsFinalizedProgressDetails
-        }
+        return operations.progress(FileSystemWatchingSettingsFinalizedProgressDetails).details
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BuildOperationTreeFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BuildOperationTreeFixture.groovy
@@ -83,6 +83,11 @@ class BuildOperationTreeFixture extends BuildOperationTreeQueries {
     }
 
     @Override
+    List<BuildOperationRecord> all() {
+        return operations.records.values().toList()
+    }
+
+    @Override
     List<BuildOperationRecord> all(Pattern displayName) {
         return operations.records.values().findAll { it.displayName ==~ displayName }
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BuildOperationTreeQueries.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BuildOperationTreeQueries.groovy
@@ -127,6 +127,12 @@ abstract class BuildOperationTreeQueries {
         matches
     }
 
+    List<BuildOperationRecord.Progress> progress(Class<?> clazz) {
+        def matches = []
+        walk { matches.addAll(it.progress( clazz ) ) }
+        return matches
+    }
+
     void walk(Action<? super BuildOperationRecord> action) {
         roots.each { walk(it, action) }
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BuildOperationTreeQueries.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BuildOperationTreeQueries.groovy
@@ -60,6 +60,8 @@ abstract class BuildOperationTreeQueries {
 
     abstract BuildOperationRecord first(Pattern displayName)
 
+    abstract List<BuildOperationRecord> all();
+
     List<BuildOperationRecord> all(String displayName) {
         return all(Pattern.compile(Pattern.quote(displayName)))
     }
@@ -128,9 +130,7 @@ abstract class BuildOperationTreeQueries {
     }
 
     List<BuildOperationRecord.Progress> progress(Class<?> clazz) {
-        def matches = []
-        walk { matches.addAll(it.progress( clazz ) ) }
-        return matches
+        return all().collect { it.progress(clazz) }.flatten()
     }
 
     void walk(Action<? super BuildOperationRecord> action) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BuildOperationsFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BuildOperationsFixture.groovy
@@ -70,6 +70,12 @@ class BuildOperationsFixture extends BuildOperationTreeQueries {
         return tree.all(type, predicate)
     }
 
+    <T extends BuildOperationType<?, ?>> BuildOperationRecord one(Class<T> type, Spec<? super BuildOperationRecord> predicate = Specs.satisfyAll()) {
+        def result = tree.all(type, predicate)
+        assert result.size() == 1
+        return result.first()
+    }
+
     @Override
     BuildOperationRecord first(Pattern displayName) {
         return tree.first(displayName)

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BuildOperationsFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BuildOperationsFixture.groovy
@@ -70,15 +70,14 @@ class BuildOperationsFixture extends BuildOperationTreeQueries {
         return tree.all(type, predicate)
     }
 
-    <T extends BuildOperationType<?, ?>> BuildOperationRecord one(Class<T> type, Spec<? super BuildOperationRecord> predicate = Specs.satisfyAll()) {
-        def result = tree.all(type, predicate)
-        assert result.size() == 1
-        return result.first()
-    }
-
     @Override
     BuildOperationRecord first(Pattern displayName) {
         return tree.first(displayName)
+    }
+
+    @Override
+    List<BuildOperationRecord> all() {
+        return tree.all()
     }
 
     @Override

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/jvm/JavaToolchainBuildOperationsFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/jvm/JavaToolchainBuildOperationsFixture.groovy
@@ -106,9 +106,7 @@ trait JavaToolchainBuildOperationsFixture {
         def buildOperationRecord = operations.first(buildOperationType) { it.details.taskPath == taskPath }
         List<BuildOperationRecord.Progress> events = []
         operations.walk(buildOperationRecord) {
-            events.addAll(it.progress.findAll {
-                detailsType.isAssignableFrom(it.detailsType)
-            })
+            events.addAll(it.progress(detailsType))
         }
         return events
     }

--- a/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyBuildOperationIntegrationTest.groovy
+++ b/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyBuildOperationIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.vcs.internal
 
 import org.gradle.api.internal.artifacts.configurations.ResolveConfigurationDependenciesBuildOperationType
 import org.gradle.execution.taskgraph.NotifyTaskGraphWhenReadyBuildOperationType
+import org.gradle.initialization.BuildIdentifiedProgressDetails
 import org.gradle.initialization.ConfigureBuildBuildOperationType
 import org.gradle.initialization.LoadBuildBuildOperationType
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
@@ -83,6 +84,11 @@ class SourceDependencyBuildOperationIntegrationTest extends AbstractIntegrationS
         loadOps[1].displayName == "Load build (:buildB)"
         loadOps[1].details.buildPath == ":buildB"
         loadOps[1].parentId == resolve.id
+
+        def buildIdentifiedEvents = operations.progress(BuildIdentifiedProgressDetails)
+        buildIdentifiedEvents.size() == 2
+        buildIdentifiedEvents[0].details.buildPath == ':'
+        buildIdentifiedEvents[1].details.buildPath == ':buildB'
 
         def configureOps = operations.all(ConfigureBuildBuildOperationType)
         configureOps.size() == 2


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context

These events allow the structure of the build tree to be collected in a way that does not rely on particular build operations to produce that structure. This will allow those build operations to differ for builds where configuration caching is not enabled, when there is a cache miss and when there is a cache hit.

This PR is preparation work for https://github.com/gradle/gradle/issues/21985

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
