### PR TITLE
Remove SPI reference for toolchains provisioning

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -4,7 +4,7 @@ The Gradle team is excited to announce Gradle @version@.
 This release includes [building and running code with Java 19](#java19),
 a flag to [rerun tasks individually](#individual-rerun),
 a new [strongly-typed dependencies block](#strongly-typed-dependencies) for JVM test suites,
-and a [Service Provider Interface (SPI) for Java Toolchains](#toolchain-spi).
+and a [pluggable system for Java Toolchains provisioning](#toolchain-provision).
 
 As always there are also performance improvements like enhancements to the [configuration cache](#configuration) and
 [incremental compilation](#incremental-compilation-after-failure).
@@ -167,11 +167,12 @@ testing {
 For more information about the test suite `dependencies` block, see
 [Differences Between Test Suite and Top-Level Dependencies](userguide/jvm_test_suite_plugin.html#differences_between_the_test_suite_dependencies_and_the_top_level_dependencies_blocks).
 
-<a name="toolchain-spi"></a>
+<a name="toolchain-provision"></a>
 #### Added support for Java Toolchain downloads from arbitrary repositories
 
 Starting in Gradle 7.6, Gradle can download JVM [toolchains](userguide/toolchains.html) from arbitrary repositories.
-By default, Gradle downloads toolchains from Adoptium/AdoptOpenJDK. You can now override the default providers with repositories of your choice using a toolchain resolver plugin.
+By default, Gradle downloads toolchains from Adoptium/AdoptOpenJDK.
+You can now override the default providers with repositories of your choice using a toolchain resolver plugin.
 
 For example, the following uses custom plugins that provide `AzulResolver` and `AdoptiumResolver` to add custom toolchains for Adoptium and Azul:
 

--- a/subprojects/launcher/src/main/resources/release-features.txt
+++ b/subprojects/launcher/src/main/resources/release-features.txt
@@ -1,4 +1,4 @@
  - Added support for Java 19.
  - Introduced `--rerun` flag for individual task rerun.
  - Improved dependency block for test suites to be strongly typed.
- - Added a service provider interface for Java toolchains provisioning.
+ - Added a pluggable system for Java toolchains provisioning.

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaToolchainResolver.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaToolchainResolver.java
@@ -23,8 +23,9 @@ import org.gradle.api.services.BuildServiceParameters;
 import java.util.Optional;
 
 /**
- * Interface that needs to be implemented by Toolchain SPI plugins, in order to
- * extend Gradle with the spec-to-URI logic required by Java toolchain auto-provisioning.
+ * Interface that needs to be implemented by Java toolchain provisioning plugins.
+ * <p>
+ * Plugin implementors have to provide the mapping from the Java toolchain request to a download information.
  *
  * @since 7.6
  */

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaToolchainResolverRegistry.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaToolchainResolverRegistry.java
@@ -20,7 +20,7 @@ import org.gradle.api.Incubating;
 import org.gradle.internal.HasInternalProtocol;
 
 /**
- * The build level object/service provided by Gradle which Java Toolchain Provisioning SPI plugins can access
+ * The build level object/service provided by Gradle which Java toolchain provisioning plugins can access
  * to register their <code>JavaToolchainResolver</code> implementations/build services into.
  *
  * @since 7.6


### PR DESCRIPTION
SPI in Java is heavily tied to the ServiceLoader system which is not used at all here.