### PR TITLE
Fix additional sample tests

### DIFF
--- a/subprojects/docs/src/snippets/java-library/module-disabled/tests/buildJavaModule.sample.conf
+++ b/subprojects/docs/src/snippets/java-library/module-disabled/tests/buildJavaModule.sample.conf
@@ -2,3 +2,4 @@ executable: gradle
 args: assemble
 expect-failure: true
 expected-output-file: buildJavaModule.out
+allow-additional-output: true

--- a/subprojects/docs/src/snippets/tasks/addRules/tests/taskRuleDependsOn.sample.conf
+++ b/subprojects/docs/src/snippets/tasks/addRules/tests/taskRuleDependsOn.sample.conf
@@ -2,3 +2,4 @@ executable: gradle
 args: groupPing
 flags: --quiet
 expected-output-file: taskRuleDependsOn.out
+allow-disordered-output: true


### PR DESCRIPTION
To fix flakiness.

For `*_buildJavaModule.sample`:
Long story short, we expect exactly some output, but Gradle can produce some additional, so `allow-additional-output: true` fixes it.

For `tasks-add-rules_*_taskRuleDependsOn.sample` we have:
```
tasks.register("groupPing") {
    dependsOn("pingServer1", "pingServer2")
}
```
And we expect `pingServer1` always finishes before `pingServer2`. This is not always true so we have to add disordered output.