### PR TITLE
Add further debug info to flaky test output

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractContinuousIntegrationTest.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractContinuousIntegrationTest.groovy
@@ -200,6 +200,9 @@ ${result.error}
         if (gradle.isRunning() && !endOfBuildReached) {
             throw new RuntimeException("""Timeout waiting for build to complete. Output:
 $lastOutput
+
+Error: 
+${gradle.errorOutput}
 """)
         }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractContinuousIntegrationTest.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractContinuousIntegrationTest.groovy
@@ -148,10 +148,7 @@ ${result.error}
         executer.withStdinPipe()
             .withTasks(tasks)
             .withForceInteractive(true)
-            .withArgument("--info")
             .withArgument("--full-stacktrace")
-            .withArgument("--console")
-            .withArgument("plain")
         if (!withoutContinuousArg) {
             executer.withArgument("--continuous")
         }
@@ -199,7 +196,7 @@ ${result.error}
             }
         }
         if (gradle.isRunning() && !endOfBuildReached) {
-            new JavaProcessStackTracesMonitor(temporaryFolder).printAllStackTracesByJstack()
+            new JavaProcessStackTracesMonitor(temporaryFolder.getTestDirectory()).printAllStackTracesByJstack()
             throw new RuntimeException("""Timeout waiting for build to complete. Output:
 $lastOutput
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractContinuousIntegrationTest.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractContinuousIntegrationTest.groovy
@@ -147,7 +147,10 @@ ${result.error}
         executer.withStdinPipe()
             .withTasks(tasks)
             .withForceInteractive(true)
+            .withArgument("--info")
             .withArgument("--full-stacktrace")
+            .withArgument("--console")
+            .withArgument("plain")
         if (!withoutContinuousArg) {
             executer.withArgument("--continuous")
         }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractContinuousIntegrationTest.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractContinuousIntegrationTest.groovy
@@ -23,6 +23,7 @@ import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.executer.GradleHandle
 import org.gradle.integtests.fixtures.executer.OutputScrapingExecutionResult
 import org.gradle.integtests.fixtures.executer.UnexpectedBuildFailure
+import org.gradle.integtests.fixtures.timeout.JavaProcessStackTracesMonitor
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.test.fixtures.ConcurrentTestUtil
 import org.junit.Assume
@@ -198,11 +199,14 @@ ${result.error}
             }
         }
         if (gradle.isRunning() && !endOfBuildReached) {
+            new JavaProcessStackTracesMonitor(temporaryFolder).printAllStackTracesByJstack()
             throw new RuntimeException("""Timeout waiting for build to complete. Output:
 $lastOutput
 
 Error: 
 ${gradle.errorOutput}
+
+Look for additional thread dump files in the following folder: $temporaryFolder
 """)
         }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/timeout/JavaProcessStackTracesMonitor.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/timeout/JavaProcessStackTracesMonitor.java
@@ -16,6 +16,7 @@
 
 package org.gradle.integtests.fixtures.timeout;
 
+import javax.annotation.Nullable;
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -56,6 +57,7 @@ public class JavaProcessStackTracesMonitor {
     private static final Pattern WINDOWS_PID_PATTERN = Pattern.compile("([0-9]+)\\s*$");
     private static final Pattern UNIX_PID_PATTERN = Pattern.compile("([0-9]+)");
 
+    @Nullable
     private final File outputFile;
     private final PrintStream output;
 
@@ -185,9 +187,9 @@ public class JavaProcessStackTracesMonitor {
     private StdoutAndPatterns ps() {
         String[] command = isWindows() ? new String[]{"wmic", "process", "get", "processid,commandline"} : new String[]{"ps", "x"};
         ExecResult result = run(command);
-        output.printf("Run: " + Arrays.toString(command));
-        output.printf("Stdout: " + result.stdout);
-        output.printf("Stderr: " + result.stderr);
+        output.printf("Run: %s", Arrays.toString(command));
+        output.printf("Stdout: %s", result.stdout);
+        output.printf("Stderr: %s", result.stderr);
 
         result.assertZeroExit();
         return new StdoutAndPatterns(result.stdout);

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/timeout/JavaProcessStackTracesMonitor.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/timeout/JavaProcessStackTracesMonitor.java
@@ -16,7 +16,6 @@
 
 package org.gradle.integtests.fixtures.timeout;
 
-import javax.annotation.Nullable;
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -57,7 +56,6 @@ public class JavaProcessStackTracesMonitor {
     private static final Pattern WINDOWS_PID_PATTERN = Pattern.compile("([0-9]+)\\s*$");
     private static final Pattern UNIX_PID_PATTERN = Pattern.compile("([0-9]+)");
 
-    @Nullable
     private final File outputFile;
     private final PrintStream output;
 


### PR DESCRIPTION
Add more debug info to be able to diagnose the flakiness of `JavaApplicationDeploymentIntegrationTest.can run application`.