### PR TITLE
Make GUH cleanup frequency configurable via dsl

### DIFF
--- a/subprojects/build-cache/src/integTest/groovy/org/gradle/caching/local/internal/DirectoryBuildCacheCleanupIntegrationTest.groovy
+++ b/subprojects/build-cache/src/integTest/groovy/org/gradle/caching/local/internal/DirectoryBuildCacheCleanupIntegrationTest.groovy
@@ -100,10 +100,10 @@ class DirectoryBuildCacheCleanupIntegrationTest extends AbstractIntegrationSpec 
         assertCacheWasCleanedUpSince(lastCleanupCheck)
     }
 
-    def "cleans up entries even if gradle user home cache cleanup is disabled"() {
+    def "cleans up entries even if gradle user home cache cleanup is disabled via #method"() {
         executer.requireIsolatedDaemons() // needs to stop daemon
         requireOwnGradleUserHomeDir() // needs its own journal
-        disableCacheCleanup()
+        disableCacheCleanup(method)
         run() // Make sure cache directory is initialized
         run '--stop' // ensure daemon does not cache file access times in memory
         def lastCleanupCheck = gcFile().makeOlder().lastModified()
@@ -128,6 +128,9 @@ class DirectoryBuildCacheCleanupIntegrationTest extends AbstractIntegrationSpec 
         newTrashFile.assertIsFile()
         oldTrashFile.assertDoesNotExist()
         assertCacheWasCleanedUpSince(lastCleanupCheck)
+
+        where:
+        method << CleanupMethod.values()
     }
 
     def "cleans up entries even if created resource cache cleanup is configured later than the default"() {

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/local/internal/DirectoryBuildCacheServiceFactory.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/local/internal/DirectoryBuildCacheServiceFactory.java
@@ -17,6 +17,7 @@
 package org.gradle.caching.local.internal;
 
 import org.gradle.api.UncheckedIOException;
+import org.gradle.api.internal.cache.DefaultCacheCleanup;
 import org.gradle.api.internal.file.temp.TemporaryFileProvider;
 import org.gradle.cache.CacheBuilder;
 import org.gradle.cache.CacheRepository;
@@ -87,7 +88,7 @@ public class DirectoryBuildCacheServiceFactory implements BuildCacheServiceFacto
         PathKeyFileStore fileStore = fileStoreFactory.createFileStore(target);
         PersistentCache persistentCache = cacheRepository
             .cache(target)
-            .withCleanup(cleanupActionDecorator.decorate(createCleanupAction(removeUnusedEntriesAfterDays)))
+            .withCleanup(createCacheCleanup(removeUnusedEntriesAfterDays))
             .withDisplayName("Build cache")
             .withLockOptions(mode(OnDemand))
             .withCrossVersionCache(CacheBuilder.LockTarget.DefaultTarget)
@@ -96,6 +97,10 @@ public class DirectoryBuildCacheServiceFactory implements BuildCacheServiceFacto
         FileAccessTracker fileAccessTracker = new SingleDepthFileAccessTracker(fileAccessTimeJournal, target, FILE_TREE_DEPTH_TO_TRACK_AND_CLEANUP);
 
         return new DirectoryBuildCacheService(fileStore, persistentCache, tempFileStore, fileAccessTracker, FAILED_READ_SUFFIX);
+    }
+
+    private DefaultCacheCleanup createCacheCleanup(int removeUnusedEntriesAfterDays) {
+        return DefaultCacheCleanup.from(cleanupActionDecorator.decorate(createCleanupAction(removeUnusedEntriesAfterDays)));
     }
 
     private LeastRecentlyUsedCacheCleanup createCleanupAction(int removeUnusedEntriesAfterDays) {

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheRepository.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheRepository.kt
@@ -22,6 +22,7 @@ import org.gradle.cache.internal.CleanupActionDecorator
 import org.gradle.cache.FileLockManager
 import org.gradle.cache.PersistentCache
 import org.gradle.api.internal.cache.CacheConfigurationsInternal
+import org.gradle.api.internal.cache.DefaultCacheCleanup
 import org.gradle.cache.internal.LeastRecentlyUsedCacheCleanup
 import org.gradle.cache.internal.SingleDepthFilesFinder
 import org.gradle.cache.internal.filelock.LockOptionsBuilder
@@ -214,11 +215,13 @@ class ConfigurationCacheRepository(
     private
     fun CacheBuilder.withLruCacheCleanup(cleanupActionDecorator: CleanupActionDecorator): CacheBuilder =
         withCleanup(
-            cleanupActionDecorator.decorate(
-                LeastRecentlyUsedCacheCleanup(
-                    SingleDepthFilesFinder(cleanupDepth),
-                    fileAccessTimeJournal,
-                    { cleanupMaxAgeDays }
+            DefaultCacheCleanup.from(
+                cleanupActionDecorator.decorate(
+                    LeastRecentlyUsedCacheCleanup(
+                        SingleDepthFilesFinder(cleanupDepth),
+                        fileAccessTimeJournal,
+                        { cleanupMaxAgeDays }
+                    )
                 )
             )
         )

--- a/subprojects/core-api/src/main/java/org/gradle/api/cache/CacheConfigurations.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/cache/CacheConfigurations.java
@@ -77,16 +77,8 @@ public interface CacheConfigurations {
     CacheResourceConfiguration getCreatedResources();
 
     /**
-     * Represents the configuration of a given type of cache resource.
-     *
-     * @since 8.0
+     * Returns the cache cleanup settings that apply to all caches.
      */
-    @HasInternalProtocol
-    @Incubating
-    interface CacheResourceConfiguration {
-        /**
-         * Configures the maximum number of days an unused entry will be retained in the cache.
-         */
-        Property<Integer> getRemoveUnusedEntriesAfterDays();
-    }
+    Property<Cleanup> getCleanup();
+
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/cache/CacheResourceConfiguration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/cache/CacheResourceConfiguration.java
@@ -25,8 +25,7 @@ import org.gradle.api.provider.Property;
  * @since 8.0
  */
 @Incubating
-public
-interface CacheResourceConfiguration {
+public interface CacheResourceConfiguration {
     /**
      * Configures the maximum number of days an unused entry will be retained in the cache.
      */

--- a/subprojects/core-api/src/main/java/org/gradle/api/cache/CacheResourceConfiguration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/cache/CacheResourceConfiguration.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.cache;
+
+import org.gradle.api.Incubating;
+import org.gradle.api.provider.Property;
+
+/**
+ * Represents the configuration of a given type of cache resource.
+ *
+ * @since 8.0
+ */
+@Incubating
+public
+interface CacheResourceConfiguration {
+    /**
+     * Configures the maximum number of days an unused entry will be retained in the cache.
+     */
+    Property<Integer> getRemoveUnusedEntriesAfterDays();
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/cache/Cleanup.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/cache/Cleanup.java
@@ -28,8 +28,7 @@ import org.gradle.internal.HasInternalProtocol;
  */
 @HasInternalProtocol
 @Incubating
-public
-interface Cleanup {
+public interface Cleanup {
     /**
      * Perform cache cleanup periodically (default is only once every 24 hours).
      */

--- a/subprojects/core-api/src/main/java/org/gradle/api/cache/Cleanup.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/cache/Cleanup.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.cache;
+
+import org.gradle.api.Incubating;
+import org.gradle.api.internal.cache.DefaultCleanup;
+import org.gradle.cache.CleanupFrequency;
+import org.gradle.internal.HasInternalProtocol;
+
+/**
+ * Configures cache cleanup settings that apply to all caches.
+ *
+ * @since 8.0
+ */
+@HasInternalProtocol
+@Incubating
+public
+interface Cleanup {
+    /**
+     * Perform cache cleanup periodically (default is only once every 24 hours).
+     */
+    Cleanup DEFAULT = new DefaultCleanup(CleanupFrequency.DAILY);
+
+    /**
+     * Never perform cache cleanup.
+     */
+    Cleanup DISABLED = new DefaultCleanup(CleanupFrequency.NEVER);
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/cache/CacheConfigurationsInternal.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/cache/CacheConfigurationsInternal.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.cache;
+
+import org.gradle.api.cache.CacheConfigurations;
+import org.gradle.api.provider.Provider;
+import org.gradle.cache.CleanupFrequency;
+import org.gradle.cache.internal.CleanupActionDecorator;
+import org.gradle.internal.cache.MonitoredCleanupActionDecorator;
+
+public interface CacheConfigurationsInternal extends CacheConfigurations, CleanupActionDecorator, MonitoredCleanupActionDecorator {
+    int DEFAULT_MAX_AGE_IN_DAYS_FOR_RELEASED_DISTS = 30;
+    int DEFAULT_MAX_AGE_IN_DAYS_FOR_SNAPSHOT_DISTS = 7;
+    int DEFAULT_MAX_AGE_IN_DAYS_FOR_DOWNLOADED_CACHE_ENTRIES = 30;
+    int DEFAULT_MAX_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES = 7;
+
+    void finalizeConfigurations();
+
+    Provider<CleanupFrequency> getCleanupFrequency();
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/cache/CleanupInternal.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/cache/CleanupInternal.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.cache;
+
+import org.gradle.api.cache.Cleanup;
+import org.gradle.cache.CleanupFrequency;
+
+public interface CleanupInternal extends Cleanup {
+    CleanupFrequency getCleanupFrequency();
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/cache/DefaultCacheCleanup.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/cache/DefaultCacheCleanup.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.cache;
+
+import org.gradle.api.provider.Provider;
+import org.gradle.cache.CacheCleanup;
+import org.gradle.cache.CleanupAction;
+import org.gradle.cache.CleanupFrequency;
+
+import javax.annotation.Nullable;
+
+public class DefaultCacheCleanup implements CacheCleanup {
+    private final CleanupAction cleanupAction;
+    private final Provider<CleanupFrequency> cleanupFrequency;
+
+    private DefaultCacheCleanup(CleanupAction cleanupAction, @Nullable Provider<CleanupFrequency> cleanupFrequency) {
+        this.cleanupAction = cleanupAction;
+        this.cleanupFrequency = cleanupFrequency;
+    }
+
+    public static DefaultCacheCleanup from(CleanupAction cleanupAction, Provider<CleanupFrequency> cleanupFrequency) {
+        return new DefaultCacheCleanup(cleanupAction, cleanupFrequency);
+    }
+
+    public static DefaultCacheCleanup from(CleanupAction cleanupAction) {
+        return new DefaultCacheCleanup(cleanupAction, null);
+    }
+
+    @Override
+    public CleanupAction getCleanupAction() {
+        return cleanupAction;
+    }
+
+    @Override
+    public CleanupFrequency getCleanupFrequency() {
+        return cleanupFrequency != null ? cleanupFrequency.get() : CleanupFrequency.DAILY;
+    }
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/cache/DefaultCleanup.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/cache/DefaultCleanup.java
@@ -16,13 +16,19 @@
 
 package org.gradle.api.internal.cache;
 
-import org.gradle.api.cache.CacheConfigurations;
+import org.gradle.cache.CleanupFrequency;
 
-public interface CacheConfigurationsInternal extends CacheConfigurations {
-    int DEFAULT_MAX_AGE_IN_DAYS_FOR_RELEASED_DISTS = 30;
-    int DEFAULT_MAX_AGE_IN_DAYS_FOR_SNAPSHOT_DISTS = 7;
-    int DEFAULT_MAX_AGE_IN_DAYS_FOR_DOWNLOADED_CACHE_ENTRIES = 30;
-    int DEFAULT_MAX_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES = 7;
+import java.io.Serializable;
 
-    void finalizeConfigurations();
+public class DefaultCleanup implements CleanupInternal, Serializable {
+    private final CleanupFrequency cleanupFrequency;
+
+    public DefaultCleanup(CleanupFrequency cleanupFrequency) {
+        this.cleanupFrequency = cleanupFrequency;
+    }
+
+    @Override
+    public CleanupFrequency getCleanupFrequency() {
+        return cleanupFrequency;
+    }
 }

--- a/subprojects/core-api/src/main/java/org/gradle/internal/cache/MonitoredCleanupAction.java
+++ b/subprojects/core-api/src/main/java/org/gradle/internal/cache/MonitoredCleanupAction.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.cache;
+
+import org.gradle.api.Describable;
+import org.gradle.cache.CleanupProgressMonitor;
+
+/**
+ * An action that cleans up some resource and reports to a {@link CleanupProgressMonitor}.
+ */
+public interface MonitoredCleanupAction extends Describable {
+    /**
+     * Perform the cleanup action, returning true if any resources were actually cleaned up.
+     *
+     * @param progressMonitor
+     * @return true if resources were cleaned
+     */
+    boolean execute(CleanupProgressMonitor progressMonitor);
+}

--- a/subprojects/core-api/src/main/java/org/gradle/internal/cache/MonitoredCleanupActionDecorator.java
+++ b/subprojects/core-api/src/main/java/org/gradle/internal/cache/MonitoredCleanupActionDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,20 +14,14 @@
  * limitations under the License.
  */
 
-package org.gradle.cache.internal;
-
-import org.gradle.api.Describable;
-import org.gradle.cache.CleanupProgressMonitor;
+package org.gradle.internal.cache;
 
 /**
- * An action that cleans up some resource and reports to a {@link CleanupProgressMonitor}.
+ * Allows {@link MonitoredCleanupAction} instances to be decorated with additional functionality, such as checking whether cleanup has been disabled or not.
  */
-public interface MonitoredCleanupAction extends Describable {
+public interface MonitoredCleanupActionDecorator {
     /**
-     * Perform the cleanup action, returning true if any resources were actually cleaned up.
-     *
-     * @param progressMonitor
-     * @return true if resources were cleaned
+     * Decorates the provided {@link MonitoredCleanupAction}
      */
-    boolean execute(CleanupProgressMonitor progressMonitor);
+    MonitoredCleanupAction decorate(MonitoredCleanupAction cleanupAction);
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/cache/CacheConfigurationsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/cache/CacheConfigurationsIntegrationTest.groovy
@@ -35,7 +35,7 @@ class CacheConfigurationsIntegrationTest extends AbstractIntegrationSpec {
         new File(initDir, "cache-settings.gradle") << """
             beforeSettings { settings ->
                 settings.caches {
-                    cleanup = Cleanup.NEVER
+                    cleanup = Cleanup.DISABLED
                     releasedWrappers.removeUnusedEntriesAfterDays = ${MODIFIED_AGE_IN_DAYS_FOR_RELEASED_DISTS}
                     snapshotWrappers.removeUnusedEntriesAfterDays = ${MODIFIED_AGE_IN_DAY_FOR_SNAPSHOT_DISTS}
                     downloadedResources.removeUnusedEntriesAfterDays = ${MODIFIED_AGE_IN_DAYS_FOR_DOWNLOADED_CACHE_ENTRIES}
@@ -69,7 +69,7 @@ class CacheConfigurationsIntegrationTest extends AbstractIntegrationSpec {
 
         where:
         property                                           | name                           | value
-        'cleanup'                                          | 'cleanup'                      | 'Cleanup.NEVER'
+        'cleanup'                                          | 'cleanup'                      | 'Cleanup.DISABLED'
         'releasedWrappers.removeUnusedEntriesAfterDays'    | 'removeUnusedEntriesAfterDays' | "${MODIFIED_AGE_IN_DAYS_FOR_RELEASED_DISTS}"
         'snapshotWrappers.removeUnusedEntriesAfterDays'    | 'removeUnusedEntriesAfterDays' | "${MODIFIED_AGE_IN_DAY_FOR_SNAPSHOT_DISTS}"
         'downloadedResources.removeUnusedEntriesAfterDays' | 'removeUnusedEntriesAfterDays' | "${MODIFIED_AGE_IN_DAYS_FOR_DOWNLOADED_CACHE_ENTRIES}"

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/GradleUserHomeCacheCleanupActionDecorator.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/GradleUserHomeCacheCleanupActionDecorator.java
@@ -19,6 +19,8 @@ package org.gradle.cache.internal;
 import org.gradle.cache.CleanupAction;
 import org.gradle.cache.CleanupProgressMonitor;
 import org.gradle.initialization.GradleUserHomeDirProvider;
+import org.gradle.internal.cache.MonitoredCleanupAction;
+import org.gradle.internal.cache.MonitoredCleanupActionDecorator;
 import org.gradle.util.internal.GUtil;
 
 import java.io.File;

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/GradleUserHomeCleanupService.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/GradleUserHomeCleanupService.java
@@ -16,9 +16,11 @@
 
 package org.gradle.cache.internal;
 
-import org.gradle.api.cache.CacheConfigurations;
+import org.gradle.api.internal.cache.CacheConfigurationsInternal;
 import org.gradle.cache.scopes.GlobalScopedCache;
 import org.gradle.initialization.GradleUserHomeDirProvider;
+import org.gradle.internal.cache.MonitoredCleanupAction;
+import org.gradle.internal.cache.MonitoredCleanupActionDecorator;
 import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.file.Deleter;
 import org.gradle.internal.logging.progress.ProgressLogger;
@@ -27,17 +29,13 @@ import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import java.io.File;
 
 public class GradleUserHomeCleanupService implements Stoppable {
-
-    private static final long MAX_UNUSED_DAYS_FOR_RELEASES = 30;
-    private static final long MAX_UNUSED_DAYS_FOR_SNAPSHOTS = 7;
-
     private final Deleter deleter;
     private final GradleUserHomeDirProvider userHomeDirProvider;
     private final GlobalScopedCache globalScopedCache;
     private final UsedGradleVersions usedGradleVersions;
     private final ProgressLoggerFactory progressLoggerFactory;
     private final MonitoredCleanupActionDecorator cleanupActionDecorator;
-    private final CacheConfigurations cacheConfigurations;
+    private final CacheConfigurationsInternal cacheConfigurations;
 
     public GradleUserHomeCleanupService(
         Deleter deleter,
@@ -46,7 +44,7 @@ public class GradleUserHomeCleanupService implements Stoppable {
         UsedGradleVersions usedGradleVersions,
         ProgressLoggerFactory progressLoggerFactory,
         MonitoredCleanupActionDecorator cleanupActionDecorator,
-        CacheConfigurations cacheConfigurations
+        CacheConfigurationsInternal cacheConfigurations
     ) {
         this.deleter = deleter;
         this.userHomeDirProvider = userHomeDirProvider;
@@ -66,7 +64,8 @@ public class GradleUserHomeCleanupService implements Stoppable {
                     cacheBaseDir,
                     cacheConfigurations.getReleasedWrappers().getRemoveUnusedEntriesAfterDays().get(),
                     cacheConfigurations.getSnapshotWrappers().getRemoveUnusedEntriesAfterDays().get(),
-                    deleter
+                    deleter,
+                    cacheConfigurations.getCleanupFrequency().get()
                 )
             ));
         if (wasCleanedUp) {

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/GradleUserHomeCleanupServices.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/GradleUserHomeCleanupServices.java
@@ -16,9 +16,10 @@
 
 package org.gradle.cache.internal;
 
-import org.gradle.api.cache.CacheConfigurations;
+import org.gradle.api.internal.cache.CacheConfigurationsInternal;
 import org.gradle.cache.scopes.GlobalScopedCache;
 import org.gradle.initialization.GradleUserHomeDirProvider;
+import org.gradle.internal.cache.MonitoredCleanupActionDecorator;
 import org.gradle.internal.file.Deleter;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.service.ServiceRegistration;
@@ -32,7 +33,7 @@ public class GradleUserHomeCleanupServices {
         GradleUserHomeDirProvider gradleUserHomeDirProvider,
         ProgressLoggerFactory progressLoggerFactory,
         MonitoredCleanupActionDecorator monitoredCleanupActionDecorator,
-        CacheConfigurations cacheConfigurations
+        CacheConfigurationsInternal cacheConfigurations
     ) {
         UsedGradleVersions usedGradleVersions = new UsedGradleVersionsFromGradleUserHomeCaches(globalScopedCache);
         registration.add(UsedGradleVersions.class, usedGradleVersions);

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/WrapperDistributionCleanupAction.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/WrapperDistributionCleanupAction.java
@@ -28,6 +28,7 @@ import org.apache.commons.io.filefilter.RegexFileFilter;
 import org.apache.commons.lang.StringUtils;
 import org.gradle.cache.CleanupProgressMonitor;
 import org.gradle.internal.IoActions;
+import org.gradle.internal.cache.MonitoredCleanupAction;
 import org.gradle.util.GradleVersion;
 import org.gradle.util.internal.DefaultGradleVersion;
 import org.slf4j.Logger;

--- a/subprojects/core/src/main/java/org/gradle/initialization/layout/ProjectCacheDir.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/layout/ProjectCacheDir.java
@@ -16,6 +16,7 @@
 
 package org.gradle.initialization.layout;
 
+import org.gradle.cache.CleanupFrequency;
 import org.gradle.cache.internal.DefaultCleanupProgressMonitor;
 import org.gradle.cache.internal.VersionSpecificCacheCleanupAction;
 import org.gradle.internal.concurrent.Stoppable;
@@ -68,7 +69,8 @@ public class ProjectCacheDir implements Stoppable {
         VersionSpecificCacheCleanupAction cleanupAction = new VersionSpecificCacheCleanupAction(
             dir,
             MAX_UNUSED_DAYS_FOR_RELEASES_AND_SNAPSHOTS,
-            deleter
+            deleter,
+            CleanupFrequency.DAILY
         );
         String description = cleanupAction.getDisplayName();
         ProgressLogger progressLogger = progressLoggerFactory.newOperation(ProjectCacheDir.class).start(description, description);

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleUserHomeScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleUserHomeScopeServices.java
@@ -41,7 +41,6 @@ import org.gradle.cache.internal.DefaultFileContentCacheFactory;
 import org.gradle.cache.internal.DefaultGeneratedGradleJarCache;
 import org.gradle.cache.internal.DefaultGlobalCacheLocations;
 import org.gradle.cache.internal.FileContentCacheFactory;
-import org.gradle.cache.internal.GradleUserHomeCacheCleanupActionDecorator;
 import org.gradle.cache.internal.GradleUserHomeCleanupServices;
 import org.gradle.cache.internal.InMemoryCacheDecoratorFactory;
 import org.gradle.cache.internal.scopes.DefaultCacheScopeMapping;
@@ -114,10 +113,6 @@ public class GradleUserHomeScopeServices extends WorkerSharedUserHomeScopeServic
         for (PluginServiceRegistry plugin : globalServices.getAll(PluginServiceRegistry.class)) {
             plugin.registerGradleUserHomeServices(registration);
         }
-    }
-
-    GradleUserHomeCacheCleanupActionDecorator createCacheCleanupEnablement(GradleUserHomeDirProvider gradleUserHomeDirProvider) {
-        return new GradleUserHomeCacheCleanupActionDecorator(gradleUserHomeDirProvider);
     }
 
     CacheRepository createCacheRepository(GlobalCacheDir globalCacheDir, CacheFactory cacheFactory) {
@@ -231,7 +226,7 @@ public class GradleUserHomeScopeServices extends WorkerSharedUserHomeScopeServic
         return new DefaultTimeoutHandler(executorFactory.createScheduled("execution timeouts", 1), currentBuildOperationRef);
     }
 
-    protected CacheConfigurationsInternal createCachesConfiguration(ObjectFactory objectFactory) {
-        return new DefaultCacheConfigurations(objectFactory);
+    protected CacheConfigurationsInternal createCachesConfiguration(ObjectFactory objectFactory, GradleUserHomeDirProvider gradleUserHomeDirProvider) {
+        return objectFactory.newInstance(DefaultCacheConfigurations.class, objectFactory, gradleUserHomeDirProvider);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/internal/TestInMemoryCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/internal/TestInMemoryCacheFactory.java
@@ -18,6 +18,7 @@ package org.gradle.testfixtures.internal;
 import com.google.common.collect.Maps;
 import org.gradle.api.Action;
 import org.gradle.cache.CacheBuilder;
+import org.gradle.cache.CacheCleanup;
 import org.gradle.cache.CacheOpenException;
 import org.gradle.cache.CleanupAction;
 import org.gradle.cache.CleanupProgressMonitor;
@@ -32,6 +33,7 @@ import org.gradle.internal.Pair;
 import org.gradle.internal.serialize.Serializer;
 import org.gradle.util.internal.GFileUtils;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Collection;
 import java.util.Collections;
@@ -45,9 +47,9 @@ public class TestInMemoryCacheFactory implements CacheFactory {
     final Map<Pair<File, String>, PersistentIndexedCache<?, ?>> caches = Collections.synchronizedMap(Maps.newLinkedHashMap());
 
     @Override
-    public PersistentCache open(File cacheDir, String displayName, Map<String, ?> properties, CacheBuilder.LockTarget lockTarget, LockOptions lockOptions, Action<? super PersistentCache> initializer, CleanupAction cleanup) throws CacheOpenException {
+    public PersistentCache open(File cacheDir, String displayName, Map<String, ?> properties, CacheBuilder.LockTarget lockTarget, LockOptions lockOptions, Action<? super PersistentCache> initializer, @Nullable CacheCleanup cacheCleanup) throws CacheOpenException {
         GFileUtils.mkdirs(cacheDir);
-        InMemoryCache cache = new InMemoryCache(cacheDir, displayName, cleanup);
+        InMemoryCache cache = new InMemoryCache(cacheDir, displayName, cacheCleanup != null ? cacheCleanup.getCleanupAction() : null);
         if (initializer != null) {
             initializer.execute(cache);
         }
@@ -64,7 +66,7 @@ public class TestInMemoryCacheFactory implements CacheFactory {
         private boolean closed;
         private final CleanupAction cleanup;
 
-        public InMemoryCache(File cacheDir, String displayName, CleanupAction cleanup) {
+        public InMemoryCache(File cacheDir, String displayName, @Nullable CleanupAction cleanup) {
             this.cacheDir = cacheDir;
             this.displayName = displayName;
             this.cleanup = cleanup;

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/cache/DefaultCacheConfigurationsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/cache/DefaultCacheConfigurationsTest.groovy
@@ -31,7 +31,7 @@ class DefaultCacheConfigurationsTest extends Specification {
         cacheConfigurations.downloadedResources.removeUnusedEntriesAfterDays.set(2)
         cacheConfigurations.releasedWrappers.removeUnusedEntriesAfterDays.set(2)
         cacheConfigurations.snapshotWrappers.removeUnusedEntriesAfterDays.set(2)
-        cacheConfigurations.cleanup.set(Cleanup.ALWAYS)
+        cacheConfigurations.cleanup.set(Cleanup.DISABLED)
 
         then:
         noExceptionThrown()
@@ -64,7 +64,7 @@ class DefaultCacheConfigurationsTest extends Specification {
         thrown(IllegalStateException)
 
         when:
-        cacheConfigurations.cleanup.set(Cleanup.DISABLED)
+        cacheConfigurations.cleanup.set(Cleanup.DEFAULT)
 
         then:
         thrown(IllegalStateException)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/cache/DefaultCacheConfigurationsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/cache/DefaultCacheConfigurationsTest.groovy
@@ -16,12 +16,14 @@
 
 package org.gradle.api.internal.cache
 
+import org.gradle.api.cache.Cleanup
+import org.gradle.initialization.GradleUserHomeDirProvider
 import org.gradle.util.TestUtil
 import spock.lang.Specification
 
 
 class DefaultCacheConfigurationsTest extends Specification {
-    def cacheConfigurations = new DefaultCacheConfigurations(TestUtil.objectFactory())
+    def cacheConfigurations = TestUtil.objectFactory().newInstance(DefaultCacheConfigurations.class, Stub(GradleUserHomeDirProvider))
 
     def "cannot modify cache configurations once finalized"() {
         when:
@@ -29,6 +31,7 @@ class DefaultCacheConfigurationsTest extends Specification {
         cacheConfigurations.downloadedResources.removeUnusedEntriesAfterDays.set(2)
         cacheConfigurations.releasedWrappers.removeUnusedEntriesAfterDays.set(2)
         cacheConfigurations.snapshotWrappers.removeUnusedEntriesAfterDays.set(2)
+        cacheConfigurations.cleanup.set(Cleanup.ALWAYS)
 
         then:
         noExceptionThrown()
@@ -56,6 +59,12 @@ class DefaultCacheConfigurationsTest extends Specification {
 
         when:
         cacheConfigurations.snapshotWrappers.removeUnusedEntriesAfterDays.set(1)
+
+        then:
+        thrown(IllegalStateException)
+
+        when:
+        cacheConfigurations.cleanup.set(Cleanup.DISABLED)
 
         then:
         thrown(IllegalStateException)

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/GradleUserHomeCacheCleanupActionDecoratorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/GradleUserHomeCacheCleanupActionDecoratorTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.cache.CleanableStore
 import org.gradle.cache.CleanupAction
 import org.gradle.cache.CleanupProgressMonitor
 import org.gradle.initialization.GradleUserHomeDirProvider
+import org.gradle.internal.cache.MonitoredCleanupAction
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/GradleUserHomeCleanupServiceTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/GradleUserHomeCleanupServiceTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.cache.internal
 
-import org.gradle.api.cache.CacheConfigurations
 import org.gradle.api.cache.CacheResourceConfiguration
 import org.gradle.api.internal.cache.CacheConfigurationsInternal
 import org.gradle.api.internal.file.TestFiles
@@ -61,7 +60,7 @@ class GradleUserHomeCleanupServiceTest extends Specification implements GradleUs
     def releasedWrappers = Stub(CacheResourceConfiguration) {
         getRemoveUnusedEntriesAfterDays() >> property(CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_RELEASED_DISTS)
     }
-    def cacheConfigurations = Stub(CacheConfigurations) {
+    def cacheConfigurations = Stub(CacheConfigurationsInternal) {
         getReleasedWrappers() >> releasedWrappers
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/GradleUserHomeCleanupServiceTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/GradleUserHomeCleanupServiceTest.groovy
@@ -17,11 +17,14 @@
 package org.gradle.cache.internal
 
 import org.gradle.api.cache.CacheConfigurations
+import org.gradle.api.cache.CacheResourceConfiguration
 import org.gradle.api.internal.cache.CacheConfigurationsInternal
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.provider.Property
 import org.gradle.cache.scopes.GlobalScopedCache
 import org.gradle.initialization.GradleUserHomeDirProvider
+import org.gradle.internal.cache.MonitoredCleanupAction
+import org.gradle.internal.cache.MonitoredCleanupActionDecorator
 import org.gradle.internal.logging.progress.ProgressLoggerFactory
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -55,7 +58,7 @@ class GradleUserHomeCleanupServiceTest extends Specification implements GradleUs
     def cleanupActionDecorator = Stub(MonitoredCleanupActionDecorator) {
         decorate(_) >> { args -> args[0] }
     }
-    def releasedWrappers = Stub(CacheConfigurations.CacheResourceConfiguration) {
+    def releasedWrappers = Stub(CacheResourceConfiguration) {
         getRemoveUnusedEntriesAfterDays() >> property(CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_RELEASED_DISTS)
     }
     def cacheConfigurations = Stub(CacheConfigurations) {

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/VersionSpecificCacheCleanupActionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/VersionSpecificCacheCleanupActionTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.cache.internal
 
 import org.gradle.api.internal.file.TestFiles
+import org.gradle.cache.CleanupFrequency
 import org.gradle.cache.CleanupProgressMonitor
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -41,7 +42,7 @@ class VersionSpecificCacheCleanupActionTest extends Specification implements Gra
     def progressMonitor = Mock(CleanupProgressMonitor)
     def deleter = TestFiles.deleter()
 
-    @Subject def cleanupAction = new VersionSpecificCacheCleanupAction(cachesDir, 30, 7, deleter)
+    @Subject def cleanupAction = new VersionSpecificCacheCleanupAction(cachesDir, 30, 7, deleter, CleanupFrequency.DAILY)
 
     def "cleans up unused version-specific cache directories"() {
         given:

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.internal.classpath
 
 import org.gradle.api.Action
-import org.gradle.api.cache.CacheConfigurations
+import org.gradle.api.internal.cache.CacheConfigurationsInternal
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.cache.CacheBuilder
 import org.gradle.cache.internal.CleanupActionDecorator
@@ -63,7 +63,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
     def fileAccessTimeJournal = Mock(FileAccessTimeJournal)
     def usedGradleVersions = Stub(UsedGradleVersions)
     def cleanupActionDecorator = Stub(CleanupActionDecorator)
-    def cacheConfigurations = Stub(CacheConfigurations)
+    def cacheConfigurations = Stub(CacheConfigurationsInternal)
     def cacheFactory = new DefaultClasspathTransformerCacheFactory(usedGradleVersions, cleanupActionDecorator, cacheConfigurations)
     def classpathWalker = new ClasspathWalker(TestFiles.fileSystem())
     def classpathBuilder = new ClasspathBuilder(TestFiles.tmpDirTemporaryFileProvider(testDirectoryProvider.root))

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/GradleUserHomeCleanupFixture.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/GradleUserHomeCleanupFixture.groovy
@@ -60,11 +60,36 @@ trait GradleUserHomeCleanupFixture implements VersionSpecificCacheCleanupFixture
         gradleUserHomeDir.file(WRAPPER_DISTRIBUTION_FILE_PATH)
     }
 
-    void disableCacheCleanup() {
+    void disableCacheCleanupViaProperty() {
         gradleUserHomeDir.mkdirs()
         new File(gradleUserHomeDir, 'gradle.properties') << """
             ${GradleUserHomeCacheCleanupActionDecorator.CACHE_CLEANUP_PROPERTY}=false
         """.stripIndent()
+    }
+
+    void disableCacheCleanupViaDsl() {
+        def initDir = new File(gradleUserHomeDir, "init.d")
+        initDir.mkdirs()
+        new File(initDir, "cache-settings.gradle") << """
+            beforeSettings { settings ->
+                settings.caches {
+                    cleanup = Cleanup.DISABLED
+                }
+            }
+        """.stripIndent()
+    }
+
+    void disableCacheCleanup(CleanupMethod method) {
+        switch (method) {
+            case CleanupMethod.PROPERTY:
+                disableCacheCleanupViaProperty()
+                break
+            case CleanupMethod.DSL:
+                disableCacheCleanupViaDsl()
+                break
+            default:
+                throw new IllegalArgumentException()
+        }
     }
 
     void withCreatedResourcesRetentionInDays(int days) {
@@ -89,4 +114,12 @@ trait GradleUserHomeCleanupFixture implements VersionSpecificCacheCleanupFixture
 
     abstract TestFile getGradleUserHomeDir()
 
+    enum CleanupMethod {
+        PROPERTY, DSL
+
+        @Override
+        String toString() {
+            return super.toString().toLowerCase()
+        }
+    }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/DefaultArtifactCacheLockingManagerIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/DefaultArtifactCacheLockingManagerIntegrationTest.groovy
@@ -172,14 +172,14 @@ class DefaultArtifactCacheLockingManagerIntegrationTest extends AbstractHttpDepe
         findFiles(cacheDir, 'files-*/*').isEmpty()
     }
 
-    def "does not clean up resources and files when cache cleanup is disabled"() {
+    def "does not clean up resources and files when cache cleanup is disabled via #method"() {
         given:
         buildscriptWithDependency(snapshotModule)
 
         when:
         executer.requireIsolatedDaemons() // needs to stop daemon
         requireOwnGradleUserHomeDir() // needs its own journal
-        disableCacheCleanup()
+        disableCacheCleanup(method)
         succeeds 'resolve'
 
         then:
@@ -205,6 +205,9 @@ class DefaultArtifactCacheLockingManagerIntegrationTest extends AbstractHttpDepe
         resource.assertExists()
         files[0].assertExists()
         files[1].assertExists()
+
+        where:
+        method << CleanupMethod.values()
     }
 
     @ToBeFixedForConfigurationCache

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -1733,7 +1733,7 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
         transformingBuild.waitForFinish()
     }
 
-    def "does not clean up cache when cache cleanup is disabled"() {
+    def "does not clean up cache when cache cleanup is disabled via #method"() {
         given:
         buildFile << declareAttributes() << multiProjectWithJarSizeTransform()
         ["lib1", "lib2"].each { name ->
@@ -1743,7 +1743,7 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
         when:
         executer.requireIsolatedDaemons() // needs to stop daemon
         requireOwnGradleUserHomeDir() // needs its own journal
-        disableCacheCleanup()
+        disableCacheCleanup(method)
         succeeds ":app:resolve"
 
         then:
@@ -1764,6 +1764,9 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
         then:
         outputDir1.assertExists()
         outputDir2.assertExists()
+
+        where:
+        method << CleanupMethod.values()
     }
 
     String getResolveTask() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGradleUserHomeScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGradleUserHomeScopeServices.java
@@ -22,12 +22,12 @@ import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.artifacts.ivyservice.ArtifactCachesProvider;
 import org.gradle.api.internal.artifacts.ivyservice.DefaultArtifactCaches;
 import org.gradle.api.internal.artifacts.transform.ImmutableTransformationWorkspaceServices;
+import org.gradle.api.internal.cache.CacheConfigurationsInternal;
 import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.api.internal.changedetection.state.DefaultExecutionHistoryCacheAccess;
 import org.gradle.cache.CacheBuilder;
 import org.gradle.cache.CacheRepository;
 import org.gradle.cache.internal.CleanupActionDecorator;
-import org.gradle.api.cache.CacheConfigurations;
 import org.gradle.cache.internal.CrossBuildInMemoryCacheFactory;
 import org.gradle.cache.internal.InMemoryCacheDecoratorFactory;
 import org.gradle.cache.internal.UsedGradleVersions;
@@ -63,7 +63,7 @@ public class DependencyManagementGradleUserHomeScopeServices {
         ListenerManager listenerManager,
         DocumentationRegistry documentationRegistry,
         CleanupActionDecorator cleanupActionDecorator,
-        CacheConfigurations cacheConfigurations
+        CacheConfigurationsInternal cacheConfigurations
     ) {
         DefaultArtifactCaches artifactCachesProvider = new DefaultArtifactCaches(globalScopedCache, cacheRepository, parameters, documentationRegistry, cleanupActionDecorator, cacheConfigurations);
         listenerManager.addListener(new BuildAdapter() {
@@ -103,7 +103,7 @@ public class DependencyManagementGradleUserHomeScopeServices {
         FileAccessTimeJournal fileAccessTimeJournal,
         ExecutionHistoryStore executionHistoryStore,
         CleanupActionDecorator cleanupActionDecorator,
-        CacheConfigurations cacheConfigurations
+        CacheConfigurationsInternal cacheConfigurations
     ) {
         return new ImmutableTransformationWorkspaceServices(
             cacheRepository

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultArtifactCaches.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultArtifactCaches.java
@@ -18,11 +18,11 @@ package org.gradle.api.internal.artifacts.ivyservice;
 import com.google.common.collect.ImmutableList;
 import org.apache.commons.lang.StringUtils;
 import org.gradle.api.internal.DocumentationRegistry;
+import org.gradle.api.internal.cache.CacheConfigurationsInternal;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.cache.CacheRepository;
 import org.gradle.cache.internal.CleanupActionDecorator;
-import org.gradle.api.cache.CacheConfigurations;
 import org.gradle.cache.PersistentIndexedCache;
 import org.gradle.cache.internal.UsedGradleVersions;
 import org.gradle.cache.scopes.GlobalScopedCache;
@@ -50,7 +50,7 @@ public class DefaultArtifactCaches implements ArtifactCachesProvider {
                                  WritableArtifactCacheLockingParameters params,
                                  DocumentationRegistry documentationRegistry,
                                  CleanupActionDecorator cleanupActionDecorator,
-                                 CacheConfigurations cacheConfigurations
+                                 CacheConfigurationsInternal cacheConfigurations
                                  ) {
         writableCacheMetadata = new DefaultArtifactCacheMetadata(globalScopedCache);
         writableArtifactCacheLockingManager = new LateInitWritableArtifactCacheLockingManager(() -> {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ImmutableTransformationWorkspaceServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ImmutableTransformationWorkspaceServices.java
@@ -16,9 +16,9 @@
 
 package org.gradle.api.internal.artifacts.transform;
 
+import org.gradle.api.internal.cache.CacheConfigurationsInternal;
 import org.gradle.cache.CacheBuilder;
 import org.gradle.cache.internal.CleanupActionDecorator;
-import org.gradle.api.cache.CacheConfigurations;
 import org.gradle.cache.internal.CrossBuildInMemoryCache;
 import org.gradle.internal.Try;
 import org.gradle.internal.execution.UnitOfWork;
@@ -40,7 +40,7 @@ public class ImmutableTransformationWorkspaceServices implements TransformationW
         ExecutionHistoryStore executionHistoryStore,
         CrossBuildInMemoryCache<UnitOfWork.Identity, Try<TransformationResult>> identityCache,
         CleanupActionDecorator cleanupActionDecorator,
-        CacheConfigurations cacheConfigurations
+        CacheConfigurationsInternal cacheConfigurations
     ) {
         this.workspaceProvider = DefaultImmutableWorkspaceProvider.withExternalHistory(cacheBuilder, fileAccessTimeJournal, executionHistoryStore, cleanupActionDecorator, cacheConfigurations);
         this.identityCache = identityCache;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/DependenciesAccessorsWorkspaceProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/DependenciesAccessorsWorkspaceProvider.java
@@ -15,9 +15,9 @@
  */
 package org.gradle.api.internal.catalog;
 
+import org.gradle.api.internal.cache.CacheConfigurationsInternal;
 import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.cache.internal.CleanupActionDecorator;
-import org.gradle.api.cache.CacheConfigurations;
 import org.gradle.cache.internal.InMemoryCacheDecoratorFactory;
 import org.gradle.cache.scopes.BuildTreeScopedCache;
 import org.gradle.internal.execution.workspace.WorkspaceProvider;
@@ -37,7 +37,7 @@ public class DependenciesAccessorsWorkspaceProvider implements WorkspaceProvider
         StringInterner stringInterner,
         ClassLoaderHierarchyHasher classLoaderHasher,
         CleanupActionDecorator cleanupActionDecorator,
-        CacheConfigurations cacheConfigurations
+        CacheConfigurationsInternal cacheConfigurations
     ) {
         this.delegate = DefaultImmutableWorkspaceProvider.withBuiltInHistory(
             scopedCache

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultArtifactCacheLockingManagerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultArtifactCacheLockingManagerTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.api.internal.artifacts.ivyservice
 
 import org.gradle.api.cache.CacheResourceConfiguration
 import org.gradle.cache.internal.CleanupActionDecorator
-import org.gradle.api.cache.CacheConfigurations
 import org.gradle.api.internal.cache.CacheConfigurationsInternal
 import org.gradle.api.provider.Property
 import org.gradle.cache.internal.DefaultCacheRepository
@@ -50,7 +49,7 @@ class DefaultArtifactCacheLockingManagerTest extends Specification {
     def cleanupActionFactory = Stub(CleanupActionDecorator) {
         decorate(_) >> { args -> args[0] }
     }
-    def cacheConfigurations = Stub(CacheConfigurations) {
+    def cacheConfigurations = Stub(CacheConfigurationsInternal) {
         getDownloadedResources() >> Stub(CacheResourceConfiguration) {
             getRemoveUnusedEntriesAfterDays() >> Stub(Property) {
                 get() >> CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_DOWNLOADED_CACHE_ENTRIES

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultArtifactCacheLockingManagerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultArtifactCacheLockingManagerTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice
 
+import org.gradle.api.cache.CacheResourceConfiguration
 import org.gradle.cache.internal.CleanupActionDecorator
 import org.gradle.api.cache.CacheConfigurations
 import org.gradle.api.internal.cache.CacheConfigurationsInternal
@@ -50,7 +51,7 @@ class DefaultArtifactCacheLockingManagerTest extends Specification {
         decorate(_) >> { args -> args[0] }
     }
     def cacheConfigurations = Stub(CacheConfigurations) {
-        getDownloadedResources() >> Stub(CacheConfigurations.CacheResourceConfiguration) {
+        getDownloadedResources() >> Stub(CacheResourceConfiguration) {
             getRemoveUnusedEntriesAfterDays() >> Stub(Property) {
                 get() >> CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_DOWNLOADED_CACHE_ENTRIES
             }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/cache/GradleUserHomeServices.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/cache/GradleUserHomeServices.kt
@@ -18,7 +18,7 @@ package org.gradle.kotlin.dsl.cache
 
 import org.gradle.api.internal.cache.StringInterner
 import org.gradle.cache.internal.CleanupActionDecorator
-import org.gradle.api.cache.CacheConfigurations
+import org.gradle.api.internal.cache.CacheConfigurationsInternal
 import org.gradle.cache.internal.InMemoryCacheDecoratorFactory
 import org.gradle.cache.scopes.GlobalScopedCache
 import org.gradle.internal.file.FileAccessTimeJournal
@@ -36,7 +36,7 @@ object GradleUserHomeServices {
         stringInterner: StringInterner,
         classLoaderHasher: ClassLoaderHierarchyHasher,
         cleanupActionDecorator: CleanupActionDecorator,
-        cacheConfigurations: CacheConfigurations
+        cacheConfigurations: CacheConfigurationsInternal
     ): KotlinDslWorkspaceProvider {
         return KotlinDslWorkspaceProvider(
             cacheRepository,

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/cache/KotlinDslWorkspaceProvider.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/cache/KotlinDslWorkspaceProvider.kt
@@ -18,7 +18,7 @@ package org.gradle.kotlin.dsl.cache
 
 import org.gradle.api.internal.cache.StringInterner
 import org.gradle.cache.internal.CleanupActionDecorator
-import org.gradle.api.cache.CacheConfigurations
+import org.gradle.api.internal.cache.CacheConfigurationsInternal
 import org.gradle.cache.internal.InMemoryCacheDecoratorFactory
 import org.gradle.cache.scopes.GlobalScopedCache
 import org.gradle.internal.execution.workspace.WorkspaceProvider
@@ -35,7 +35,7 @@ class KotlinDslWorkspaceProvider(
     stringInterner: StringInterner,
     classLoaderHasher: ClassLoaderHierarchyHasher,
     cleanupActionDecorator: CleanupActionDecorator,
-    cacheConfigurations: CacheConfigurations
+    cacheConfigurations: CacheConfigurationsInternal
 ) : Closeable {
 
     private

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/CacheBuilder.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/CacheBuilder.java
@@ -73,12 +73,9 @@ public interface CacheBuilder {
     /**
      * Specifies an action to execute when the cache needs to be cleaned up. An exclusive lock is held while the cleanup is executing, to prevent cross-process access.
      *
-     * A clean-up action is run when a cache is closed, but only after a certain interval of time after the last clean-up.
-     *
-     * Currently, a clean-up action is run after {@value org.gradle.cache.internal.DefaultPersistentDirectoryCache#CLEANUP_INTERVAL_IN_HOURS} hours.
-     *
+     * A clean-up action is run when a cache is closed, but only after the interval specified by the provided {@link CacheCleanup}.
      */
-    CacheBuilder withCleanup(CleanupAction cleanup);
+    CacheBuilder withCleanup(CacheCleanup cleanup);
 
     /**
      * Opens the cache. It is the caller's responsibility to close the cache when finished with it.

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/CacheCleanup.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/CacheCleanup.java
@@ -14,14 +14,19 @@
  * limitations under the License.
  */
 
-package org.gradle.cache.internal;
+package org.gradle.cache;
 
 /**
- * Allows {@link MonitoredCleanupAction} instances to be decorated with additional functionality, such as checking whether cleanup has been disabled or not.
+ * Specifies the details of cache cleanup, including the action to be performed and the frequency at which cache cleanup should occur.
  */
-public interface MonitoredCleanupActionDecorator {
+public interface CacheCleanup {
     /**
-     * Decorates the provided {@link MonitoredCleanupAction}
+     * Returns the action to perform on cleanup.
      */
-    MonitoredCleanupAction decorate(MonitoredCleanupAction cleanupAction);
+    CleanupAction getCleanupAction();
+
+    /**
+     * Returns the frequency at which cache cleanup can occur.  Possible values are only once a day, every time, or never.
+     */
+    CleanupFrequency getCleanupFrequency();
 }

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/CleanupFrequency.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/CleanupFrequency.java
@@ -39,7 +39,7 @@ public enum CleanupFrequency {
         }
     },
     /**
-     * Disable cleanup completely
+     * Disable cleanup completely.
      */
     NEVER() {
         @Override

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/CleanupFrequency.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/CleanupFrequency.java
@@ -28,7 +28,7 @@ import java.util.concurrent.TimeUnit;
 @Incubating
 public enum CleanupFrequency {
     /**
-     * Trigger cleanup only once every 24 hours
+     * Trigger cleanup once every 24 hours.
      */
     DAILY() {
         @Override

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/CleanupFrequency.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/CleanupFrequency.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.cache;
+
+import org.gradle.api.Incubating;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Represents when cache cleanup should be triggered.
+ *
+ * @since 8.0
+ */
+@Incubating
+public enum CleanupFrequency {
+    /**
+     * Trigger cleanup only once every 24 hours
+     */
+    DAILY() {
+        @Override
+        public boolean requiresCleanup(long lastCleanupTimestamp) {
+            long duration = System.currentTimeMillis() - lastCleanupTimestamp;
+            long timeInHours = TimeUnit.MILLISECONDS.toHours(duration);
+            return timeInHours >= 24;
+        }
+    },
+    /**
+     * Disable cleanup completely
+     */
+    NEVER() {
+        @Override
+        public boolean requiresCleanup(long lastCleanupTimestamp) {
+            return false;
+        }
+    };
+
+    public abstract boolean requiresCleanup(long lastCleanupTimestamp);
+}

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CacheFactory.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CacheFactory.java
@@ -17,8 +17,8 @@ package org.gradle.cache.internal;
 
 import org.gradle.api.Action;
 import org.gradle.cache.CacheBuilder;
+import org.gradle.cache.CacheCleanup;
 import org.gradle.cache.CacheOpenException;
-import org.gradle.cache.CleanupAction;
 import org.gradle.cache.LockOptions;
 import org.gradle.cache.PersistentCache;
 
@@ -30,5 +30,5 @@ public interface CacheFactory {
     /**
      * Opens a cache with the given options. The caller must close the cache when finished with it.
      */
-    PersistentCache open(File cacheDir, String displayName, Map<String, ?> properties, CacheBuilder.LockTarget lockTarget, LockOptions lockOptions, @Nullable Action<? super PersistentCache> initializer, @Nullable CleanupAction cleanup) throws CacheOpenException;
+    PersistentCache open(File cacheDir, String displayName, Map<String, ?> properties, CacheBuilder.LockTarget lockTarget, LockOptions lockOptions, @Nullable Action<? super PersistentCache> initializer, @Nullable CacheCleanup cacheCleanup) throws CacheOpenException;
 }

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheFactory.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheFactory.java
@@ -17,8 +17,8 @@ package org.gradle.cache.internal;
 
 import org.gradle.api.Action;
 import org.gradle.cache.CacheBuilder;
+import org.gradle.cache.CacheCleanup;
 import org.gradle.cache.CacheOpenException;
-import org.gradle.cache.CleanupAction;
 import org.gradle.cache.FileLockManager;
 import org.gradle.cache.LockOptions;
 import org.gradle.cache.PersistentCache;
@@ -62,10 +62,10 @@ public class DefaultCacheFactory implements CacheFactory, Closeable {
     }
 
     @Override
-    public PersistentCache open(File cacheDir, String displayName, Map<String, ?> properties, CacheBuilder.LockTarget lockTarget, LockOptions lockOptions, Action<? super PersistentCache> initializer, CleanupAction cleanup) throws CacheOpenException {
+    public PersistentCache open(File cacheDir, String displayName, Map<String, ?> properties, CacheBuilder.LockTarget lockTarget, LockOptions lockOptions, Action<? super PersistentCache> initializer, @Nullable CacheCleanup cacheCleanup) throws CacheOpenException {
         lock.lock();
         try {
-            return doOpen(cacheDir, displayName, properties, lockTarget, lockOptions, initializer, cleanup);
+            return doOpen(cacheDir, displayName, properties, lockTarget, lockOptions, initializer, cacheCleanup);
         } finally {
             lock.unlock();
         }
@@ -89,16 +89,16 @@ public class DefaultCacheFactory implements CacheFactory, Closeable {
         CacheBuilder.LockTarget lockTarget,
         LockOptions lockOptions,
         @Nullable Action<? super PersistentCache> initializer,
-        @Nullable CleanupAction cleanup
+        @Nullable CacheCleanup cacheCleanup
     ) {
         File canonicalDir = FileUtils.canonicalize(cacheDir);
         DirCacheReference dirCacheReference = dirCaches.get(canonicalDir);
         if (dirCacheReference == null) {
             ReferencablePersistentCache cache;
             if (!properties.isEmpty() || initializer != null) {
-                cache = new DefaultPersistentDirectoryCache(canonicalDir, displayName, properties, lockTarget, lockOptions, initializer, cleanup, lockManager, executorFactory, progressLoggerFactory);
+                cache = new DefaultPersistentDirectoryCache(canonicalDir, displayName, properties, lockTarget, lockOptions, initializer, cacheCleanup, lockManager, executorFactory, progressLoggerFactory);
             } else {
-                cache = new DefaultPersistentDirectoryStore(canonicalDir, displayName, lockTarget, lockOptions, cleanup, lockManager, executorFactory, progressLoggerFactory);
+                cache = new DefaultPersistentDirectoryStore(canonicalDir, displayName, lockTarget, lockOptions, cacheCleanup, lockManager, executorFactory, progressLoggerFactory);
             }
             cache.open();
             dirCacheReference = new DirCacheReference(cache, properties, lockTarget, lockOptions);

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheRepository.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheRepository.java
@@ -17,8 +17,8 @@ package org.gradle.cache.internal;
 
 import org.gradle.api.Action;
 import org.gradle.cache.CacheBuilder;
+import org.gradle.cache.CacheCleanup;
 import org.gradle.cache.CacheRepository;
-import org.gradle.cache.CleanupAction;
 import org.gradle.cache.FileLockManager;
 import org.gradle.cache.LockOptions;
 import org.gradle.cache.PersistentCache;
@@ -53,7 +53,7 @@ public class DefaultCacheRepository implements CacheRepository {
         final File baseDir;
         Map<String, ?> properties = Collections.emptyMap();
         Action<? super PersistentCache> initializer;
-        CleanupAction cleanup;
+        CacheCleanup cacheCleanup;
         LockOptions lockOptions = mode(FileLockManager.LockMode.Shared);
         String displayName;
         VersionStrategy versionStrategy = VersionStrategy.CachePerVersion;
@@ -101,8 +101,8 @@ public class DefaultCacheRepository implements CacheRepository {
         }
 
         @Override
-        public CacheBuilder withCleanup(CleanupAction cleanup) {
-            this.cleanup = cleanup;
+        public CacheBuilder withCleanup(CacheCleanup cacheCleanup) {
+            this.cacheCleanup = cacheCleanup;
             return this;
         }
 
@@ -114,7 +114,8 @@ public class DefaultCacheRepository implements CacheRepository {
             } else {
                 cacheBaseDir = cacheScopeMapping.getBaseDirectory(null, key, versionStrategy);
             }
-            return factory.open(cacheBaseDir, displayName, properties, lockTarget, lockOptions, initializer, cleanup);
+
+            return factory.open(cacheBaseDir, displayName, properties, lockTarget, lockOptions, initializer, cacheCleanup);
         }
     }
 }

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultPersistentDirectoryCache.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultPersistentDirectoryCache.java
@@ -18,7 +18,7 @@ package org.gradle.cache.internal;
 import org.gradle.api.Action;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.cache.CacheBuilder;
-import org.gradle.cache.CleanupAction;
+import org.gradle.cache.CacheCleanup;
 import org.gradle.cache.FileLock;
 import org.gradle.cache.FileLockManager;
 import org.gradle.cache.LockOptions;
@@ -41,8 +41,8 @@ public class DefaultPersistentDirectoryCache extends DefaultPersistentDirectoryS
     private final Properties properties = new Properties();
     private final Action<? super PersistentCache> initAction;
 
-    public DefaultPersistentDirectoryCache(File dir, String displayName, Map<String, ?> properties, CacheBuilder.LockTarget lockTarget, LockOptions lockOptions, Action<? super PersistentCache> initAction, CleanupAction cleanupAction, FileLockManager lockManager, ExecutorFactory executorFactory, ProgressLoggerFactory progressLoggerFactory) {
-        super(dir, displayName, lockTarget, lockOptions, cleanupAction, lockManager, executorFactory, progressLoggerFactory);
+    public DefaultPersistentDirectoryCache(File dir, String displayName, Map<String, ?> properties, CacheBuilder.LockTarget lockTarget, LockOptions lockOptions, Action<? super PersistentCache> initAction, CacheCleanup cacheCleanup, FileLockManager lockManager, ExecutorFactory executorFactory, ProgressLoggerFactory progressLoggerFactory) {
+        super(dir, displayName, lockTarget, lockOptions, cacheCleanup, lockManager, executorFactory, progressLoggerFactory);
         this.initAction = initAction;
         this.properties.putAll(properties);
     }

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultPersistentDirectoryCacheTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultPersistentDirectoryCacheTest.groovy
@@ -17,7 +17,7 @@ package org.gradle.cache.internal
 
 import org.gradle.api.Action
 import org.gradle.cache.CacheBuilder
-import org.gradle.cache.CleanupAction
+import org.gradle.cache.CacheCleanup
 import org.gradle.cache.FileLockManager
 import org.gradle.cache.PersistentCache
 import org.gradle.cache.internal.locklistener.NoOpFileLockContentionHandler
@@ -38,7 +38,7 @@ class DefaultPersistentDirectoryCacheTest extends AbstractProjectBuilderSpec {
     }
     def lockManager = new DefaultFileLockManager(metaDataProvider, new NoOpFileLockContentionHandler())
     def initializationAction = Mock(Action)
-    def cleanupAction = Stub(CleanupAction)
+    def cacheCleanup = Stub(CacheCleanup)
     def progressLoggerFactory = Stub(ProgressLoggerFactory)
 
     def properties = ['prop': 'value', 'prop2': 'other-value']
@@ -51,7 +51,7 @@ class DefaultPersistentDirectoryCacheTest extends AbstractProjectBuilderSpec {
         emptyDir.assertDoesNotExist()
 
         when:
-        def cache = new DefaultPersistentDirectoryCache(emptyDir, "<display-name>", properties, CacheBuilder.LockTarget.DefaultTarget, mode(FileLockManager.LockMode.Shared), initializationAction, cleanupAction, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
+        def cache = new DefaultPersistentDirectoryCache(emptyDir, "<display-name>", properties, CacheBuilder.LockTarget.DefaultTarget, mode(FileLockManager.LockMode.Shared), initializationAction, cacheCleanup, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
         try {
             cache.open()
         } finally {
@@ -67,7 +67,7 @@ class DefaultPersistentDirectoryCacheTest extends AbstractProjectBuilderSpec {
     def initializesCacheWhenPropertiesFileDoesNotExist() {
         given:
         def dir = temporaryFolder.getTestDirectory().file("dir").createDir()
-        def cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", properties, CacheBuilder.LockTarget.DefaultTarget, mode(FileLockManager.LockMode.Shared), initializationAction, cleanupAction, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
+        def cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", properties, CacheBuilder.LockTarget.DefaultTarget, mode(FileLockManager.LockMode.Shared), initializationAction, cacheCleanup, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
 
         when:
         try {
@@ -85,7 +85,7 @@ class DefaultPersistentDirectoryCacheTest extends AbstractProjectBuilderSpec {
     def rebuildsCacheWhenPropertiesHaveChanged() {
         given:
         def dir = createCacheDir(prop: "other-value")
-        def cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", properties, CacheBuilder.LockTarget.DefaultTarget, mode(FileLockManager.LockMode.Shared), initializationAction, cleanupAction, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
+        def cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", properties, CacheBuilder.LockTarget.DefaultTarget, mode(FileLockManager.LockMode.Shared), initializationAction, cacheCleanup, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
 
         when:
         try {
@@ -104,7 +104,7 @@ class DefaultPersistentDirectoryCacheTest extends AbstractProjectBuilderSpec {
         given:
         def dir = createCacheDir()
         def properties = properties + [newProp: 'newValue']
-        def cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", properties, CacheBuilder.LockTarget.DefaultTarget, mode(FileLockManager.LockMode.Shared), initializationAction, cleanupAction, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
+        def cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", properties, CacheBuilder.LockTarget.DefaultTarget, mode(FileLockManager.LockMode.Shared), initializationAction, cacheCleanup, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
 
         when:
         try {
@@ -126,7 +126,7 @@ class DefaultPersistentDirectoryCacheTest extends AbstractProjectBuilderSpec {
         Action<PersistentCache> failingAction = Stub(Action) {
             execute(_ as PersistentCache) >> { throw failure }
         }
-        def cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", properties, CacheBuilder.LockTarget.DefaultTarget, mode(FileLockManager.LockMode.Shared), failingAction, cleanupAction, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
+        def cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", properties, CacheBuilder.LockTarget.DefaultTarget, mode(FileLockManager.LockMode.Shared), failingAction, cacheCleanup, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
 
         when:
         try {
@@ -140,7 +140,7 @@ class DefaultPersistentDirectoryCacheTest extends AbstractProjectBuilderSpec {
         e.cause.is(failure)
 
         when:
-        cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", properties, CacheBuilder.LockTarget.DefaultTarget, mode(FileLockManager.LockMode.Shared), initializationAction, cleanupAction, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
+        cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", properties, CacheBuilder.LockTarget.DefaultTarget, mode(FileLockManager.LockMode.Shared), initializationAction, cacheCleanup, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
         try {
             cache.open()
         } finally {
@@ -156,7 +156,7 @@ class DefaultPersistentDirectoryCacheTest extends AbstractProjectBuilderSpec {
     def doesNotInitializeCacheWhenCacheDirExistsAndIsNotInvalid() {
         given:
         def dir = createCacheDir()
-        def cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", properties, CacheBuilder.LockTarget.DefaultTarget, mode(FileLockManager.LockMode.Shared), initializationAction, cleanupAction, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
+        def cache = new DefaultPersistentDirectoryCache(dir, "<display-name>", properties, CacheBuilder.LockTarget.DefaultTarget, mode(FileLockManager.LockMode.Shared), initializationAction, cacheCleanup, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
 
         when:
         try {
@@ -177,7 +177,7 @@ class DefaultPersistentDirectoryCacheTest extends AbstractProjectBuilderSpec {
         def initialized = false
         def init = { initialized = true } as Action
         def cache = new DefaultPersistentDirectoryCache(dir, "test", [:], CacheBuilder.LockTarget.DefaultTarget,
-            mode(FileLockManager.LockMode.Exclusive), init, CleanupAction.NO_OP, createDefaultFileLockManager(), Mock(ExecutorFactory), progressLoggerFactory)
+            mode(FileLockManager.LockMode.Exclusive), init, cacheCleanup, createDefaultFileLockManager(), Mock(ExecutorFactory), progressLoggerFactory)
 
         when:
         unlockUncleanly(dir.file("cache.properties"))
@@ -197,7 +197,7 @@ class DefaultPersistentDirectoryCacheTest extends AbstractProjectBuilderSpec {
         def init = { initialized = true } as Action
         def properties = [foo: 'bar']
         def cache = new DefaultPersistentDirectoryCache(dir, "test", properties, CacheBuilder.LockTarget.DefaultTarget,
-            mode(FileLockManager.LockMode.Exclusive), init, CleanupAction.NO_OP, createDefaultFileLockManager(), Mock(ExecutorFactory), progressLoggerFactory)
+            mode(FileLockManager.LockMode.Exclusive), init, cacheCleanup, createDefaultFileLockManager(), Mock(ExecutorFactory), progressLoggerFactory)
 
         when:
         dir.file("cache.properties").delete()
@@ -217,7 +217,7 @@ class DefaultPersistentDirectoryCacheTest extends AbstractProjectBuilderSpec {
         def init = { initialized = true } as Action
         def properties = [:]
         def cache = new DefaultPersistentDirectoryCache(dir, "test", properties, CacheBuilder.LockTarget.DefaultTarget,
-            mode(FileLockManager.LockMode.Exclusive), init, CleanupAction.NO_OP, createDefaultFileLockManager(), Mock(ExecutorFactory), progressLoggerFactory)
+            mode(FileLockManager.LockMode.Exclusive), init, cacheCleanup, createDefaultFileLockManager(), Mock(ExecutorFactory), progressLoggerFactory)
 
         when:
         dir.file("cache.properties").delete()

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultPersistentDirectoryStoreTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultPersistentDirectoryStoreTest.groovy
@@ -16,7 +16,9 @@
 package org.gradle.cache.internal
 
 import org.gradle.cache.CacheBuilder
+import org.gradle.cache.CacheCleanup
 import org.gradle.cache.CleanupAction
+import org.gradle.cache.CleanupFrequency
 import org.gradle.cache.FileLock
 import org.gradle.cache.FileLockManager
 import org.gradle.internal.concurrent.ExecutorFactory
@@ -42,6 +44,7 @@ class DefaultPersistentDirectoryStoreTest extends Specification {
 
     def cacheDir = tmpDir.file("dir")
     def cleanupAction = Mock(CleanupAction)
+    def cacheCleanup = Mock(CacheCleanup)
     def lockManager = Mock(FileLockManager)
     def lock = Mock(FileLock)
     def progressLoggerFactory = Stub(ProgressLoggerFactory) {
@@ -53,7 +56,7 @@ class DefaultPersistentDirectoryStoreTest extends Specification {
     }
 
     @Subject @AutoCleanup
-    def store = new DefaultPersistentDirectoryStore(cacheDir, "<display>", CacheBuilder.LockTarget.DefaultTarget, mode(OnDemand), cleanupAction, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
+    def store = new DefaultPersistentDirectoryStore(cacheDir, "<display>", CacheBuilder.LockTarget.DefaultTarget, mode(OnDemand), cacheCleanup, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
 
     def "has useful toString() implementation"() {
         expect:
@@ -157,6 +160,8 @@ class DefaultPersistentDirectoryStoreTest extends Specification {
 
         then:
         gcFile.lastModified() > modificationTimeBefore
+        1 * cacheCleanup.cleanupAction >> cleanupAction
+        1 * cacheCleanup.cleanupFrequency >> CleanupFrequency.DAILY
         1 * cleanupAction.clean(store, _)
         0 * _
     }
@@ -176,6 +181,8 @@ class DefaultPersistentDirectoryStoreTest extends Specification {
         store.close()
 
         then:
+        1 * cacheCleanup.cleanupAction >> cleanupAction
+        1 * cacheCleanup.cleanupFrequency >> CleanupFrequency.DAILY
         1 * cleanupAction.clean(store, _) >> {
             throw new RuntimeException("Boom")
         }

--- a/subprojects/version-control/src/main/java/org/gradle/vcs/internal/services/DefaultVersionControlRepositoryFactory.java
+++ b/subprojects/version-control/src/main/java/org/gradle/vcs/internal/services/DefaultVersionControlRepositoryFactory.java
@@ -17,6 +17,7 @@
 package org.gradle.vcs.internal.services;
 
 import org.gradle.api.GradleException;
+import org.gradle.api.internal.cache.DefaultCacheCleanup;
 import org.gradle.cache.internal.CleanupActionDecorator;
 import org.gradle.cache.FileLockManager;
 import org.gradle.cache.PersistentCache;
@@ -51,8 +52,16 @@ public class DefaultVersionControlRepositoryFactory implements VersionControlRep
             .crossVersionCache("vcs-1")
             .withLockOptions(mode(FileLockManager.LockMode.OnDemand))
             .withDisplayName("VCS Checkout Cache")
-            .withCleanup(cleanupActionDecorator.decorate(new LeastRecentlyUsedCacheCleanup(new SingleDepthFilesFinder(1), new ModificationTimeFileAccessTimeJournal(), () -> CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES)))
+            .withCleanup(createCacheCleanup(cleanupActionDecorator))
             .open();
+    }
+
+    private DefaultCacheCleanup createCacheCleanup(CleanupActionDecorator cleanupActionDecorator) {
+        return DefaultCacheCleanup.from(
+            cleanupActionDecorator.decorate(
+                new LeastRecentlyUsedCacheCleanup(new SingleDepthFilesFinder(1), new ModificationTimeFileAccessTimeJournal(), () -> CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES)
+            )
+        );
     }
 
     @Override


### PR DESCRIPTION
This allows the frequency at which cleanup of caches in Gradle User Home occur configurable via DSL in an init script.  Currently the only options are the ones present today (daily cleanup or disabled cleanup) but in followup work we'll add other options (e.g. always perform cleanup).