### PR TITLE
Add output normalizer for Scala compiler

### DIFF
--- a/subprojects/docs/src/docsTest/java/org/gradle/docs/samples/BaseSamplesTest.java
+++ b/subprojects/docs/src/docsTest/java/org/gradle/docs/samples/BaseSamplesTest.java
@@ -30,6 +30,7 @@ import org.gradle.integtests.fixtures.logging.EmbeddedKotlinOutputNormalizer;
 import org.gradle.integtests.fixtures.logging.GradleWelcomeOutputNormalizer;
 import org.gradle.integtests.fixtures.logging.NativeComponentReportOutputNormalizer;
 import org.gradle.integtests.fixtures.logging.SampleOutputNormalizer;
+import org.gradle.integtests.fixtures.logging.ZincScalaCompilerOutputNormalizer;
 import org.gradle.integtests.fixtures.mirror.SetMirrorsSampleModifier;
 
 @SamplesOutputNormalizers({
@@ -43,7 +44,8 @@ import org.gradle.integtests.fixtures.mirror.SetMirrorsSampleModifier;
     DependencyInsightOutputNormalizer.class,
     ConfigurationCacheOutputCleaner.class,
     ConfigurationCacheOutputNormalizer.class,
-    EmbeddedKotlinOutputNormalizer.class
+    EmbeddedKotlinOutputNormalizer.class,
+    ZincScalaCompilerOutputNormalizer.class
 })
 @SampleModifiers({
     SetMirrorsSampleModifier.class,

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/ZincScalaCompilerOutputNormalizer.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/ZincScalaCompilerOutputNormalizer.groovy
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.integtests.fixtures.logging
+
+import org.gradle.exemplar.executor.ExecutionMetadata
+import org.gradle.exemplar.test.normalizer.OutputNormalizer
+
+import java.util.regex.Pattern
+
+/**
+ * Removes Scala Zinc compilation time logging from the build-init Scala samples output.
+ * */
+class ZincScalaCompilerOutputNormalizer implements OutputNormalizer {
+
+    private static final PATTERN = Pattern.compile(
+        "Scala Compiler interface compilation took ([0-9]+ hrs )?([0-9]+ mins )?[0-9.]+ secs\n\n",
+        Pattern.MULTILINE
+    )
+
+    @Override
+    String normalize(String output, ExecutionMetadata executionMetadata) {
+        executionMetadata.tempSampleProjectDir.name.startsWith('building-scala')
+            ? normalizeScalaOutput(output)
+            : output
+    }
+
+    private String normalizeScalaOutput(String output) {
+        PATTERN.matcher(output)
+            .replaceAll("")
+            .with {
+                // remove starting empty line
+                it.startsWith('\n')
+                    ? it.substring(1)
+                    : it
+            }
+    }
+}

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/logging/ZincScalaCompilerOutputNormalizerTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/logging/ZincScalaCompilerOutputNormalizerTest.groovy
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.integtests.fixtures.logging
+
+import org.gradle.exemplar.executor.ExecutionMetadata
+import org.gradle.exemplar.test.normalizer.OutputNormalizer
+import spock.lang.Specification
+
+class ZincScalaCompilerOutputNormalizerTest extends Specification {
+    OutputNormalizer outputNormalizer = new ZincScalaCompilerOutputNormalizer()
+    ExecutionMetadata executionMetadata = new ExecutionMetadata(new File('building-scala'), [:])
+
+    String expected = """
+> Task :app:compileJava NO-SOURCE
+> Task :app:compileScala
+> Task :app:processResources NO-SOURCE
+> Task :app:classes
+> Task :app:jar
+> Task :app:startScripts
+> Task :app:distTar
+> Task :app:distZip
+> Task :app:assemble
+> Task :app:compileTestJava NO-SOURCE
+> Task :app:compileTestScala
+> Task :app:processTestResources NO-SOURCE
+> Task :app:testClasses
+> Task :app:test
+> Task :app:check
+> Task :app:build
+
+BUILD SUCCESSFUL in 0s
+7 actionable tasks: 7 executed
+""".trim()
+
+    def "successfully normalizes Scala compiler output"() {
+        given:
+        String input = """
+> Task :app:compileJava NO-SOURCE
+> Task :app:compileScala
+Scala Compiler interface compilation took 1 hrs 20 mins 41.884 secs
+
+> Task :app:processResources NO-SOURCE
+> Task :app:classes
+> Task :app:jar
+> Task :app:startScripts
+> Task :app:distTar
+> Task :app:distZip
+> Task :app:assemble
+> Task :app:compileTestJava NO-SOURCE
+> Task :app:compileTestScala
+> Task :app:processTestResources NO-SOURCE
+> Task :app:testClasses
+> Task :app:test
+> Task :app:check
+> Task :app:build
+
+BUILD SUCCESSFUL in 0s
+7 actionable tasks: 7 executed
+""".trim()
+
+        when:
+        String normalized = outputNormalizer.normalize(input, executionMetadata)
+
+        then:
+        normalized == expected
+    }
+}


### PR DESCRIPTION
Implement an output normalizer that removes lines like:

```
Scala Compiler interface compilation took 1 hrs 20 mins 41.884 secs
```

Time isn't likely to be that much but the normalizer takes into account verbose formatting of the compile duration.