### PR TITLE
Fix potential deadlock when a task finalizes multiple nodes that are also a dependency of the finalizer node

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/FinalizerTaskIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/FinalizerTaskIntegrationTest.groovy
@@ -126,18 +126,25 @@ class FinalizerTaskIntegrationTest extends AbstractIntegrationSpec {
         }
     }
 
-    @Issue("https://github.com/gradle/gradle/issues/21000")
+    @Issue(value = ["https://github.com/gradle/gradle/issues/21000", "https://github.com/gradle/gradle/issues/22734"])
     def "finalizer task can depend on finalized task that is not an entry point task"() {
         given:
         buildFile '''
             task finalizer(type: BreakingTask) {
-                dependsOn 'finalizerDep'
+                dependsOn 'finalizerDep1'
+                dependsOn 'finalizerDep2'
             }
-            task finalizerDep(type: BreakingTask) {
-                dependsOn 'finalizerDepDep'
+            task finalizerDep1(type: BreakingTask) {
+                dependsOn 'finalizerDepDep1'
                 finalizedBy 'finalizer'
             }
-            task finalizerDepDep(type: BreakingTask) {
+            task finalizerDepDep1(type: BreakingTask) {
+            }
+            task finalizerDep2(type: BreakingTask) {
+                dependsOn 'finalizerDepDep2'
+                finalizedBy 'finalizer'
+            }
+            task finalizerDepDep2(type: BreakingTask) {
             }
             task entryPoint(type: BreakingTask) {
                 finalizedBy 'finalizer'
@@ -147,19 +154,25 @@ class FinalizerTaskIntegrationTest extends AbstractIntegrationSpec {
         expect:
         2.times {
             succeeds 'entryPoint'
-            result.assertTasksExecutedInOrder ':entryPoint', ':finalizerDepDep', ':finalizerDep', ':finalizer'
+            result.assertTaskOrder ':entryPoint', ':finalizerDepDep1', ':finalizerDep1', ':finalizer'
+            result.assertTaskOrder ':entryPoint', ':finalizerDepDep2', ':finalizerDep2', ':finalizer'
         }
         2.times {
             fails 'entryPoint', '-PentryPoint.broken'
-            result.assertTasksExecutedInOrder ':entryPoint', ':finalizerDepDep', ':finalizerDep', ':finalizer'
+            result.assertTaskOrder ':entryPoint', ':finalizerDepDep1', ':finalizerDep1', ':finalizer'
+            result.assertTaskOrder ':entryPoint', ':finalizerDepDep2', ':finalizerDep2', ':finalizer'
         }
         2.times {
-            fails 'entryPoint', '-PfinalizerDepDep.broken'
-            result.assertTasksExecutedInOrder ':entryPoint', ':finalizerDepDep'
+            fails 'entryPoint', '-PfinalizerDepDep1.broken', '--continue'
+            result.assertTasksExecuted(':entryPoint', ':finalizerDepDep1', ':finalizerDepDep2', ':finalizerDep2')
+            result.assertTaskOrder ':entryPoint', ':finalizerDepDep1'
+            result.assertTaskOrder ':entryPoint', ':finalizerDepDep2', ':finalizerDep2'
         }
         2.times {
-            fails 'entryPoint', '-PfinalizerDep.broken'
-            result.assertTasksExecutedInOrder ':entryPoint', ':finalizerDepDep', ':finalizerDep'
+            fails 'entryPoint', '-PfinalizerDep1.broken', '--continue'
+            result.assertTasksExecuted(':entryPoint', ':finalizerDepDep1', ':finalizerDep1', ':finalizerDepDep2', ':finalizerDep2')
+            result.assertTaskOrder ':entryPoint', ':finalizerDepDep1', ':finalizerDep1'
+            result.assertTaskOrder ':entryPoint', ':finalizerDepDep2', ':finalizerDep2'
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/FinalizerGroup.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/FinalizerGroup.java
@@ -162,7 +162,7 @@ public class FinalizerGroup extends HasFinalizers {
         Set<Node> finalizedNodesToBlockOn = findFinalizedNodesThatDoNotIntroduceACycle(reachableGroups);
         WaitForNodesToComplete waitForFinalizers = new WaitForNodesToComplete(finalizedNodesToBlockOn);
 
-        // Determine the finalized nodes that are also members
+        // Determine the finalized nodes that are also members. These may need to block waiting for other finalized nodes to complete
         Set<Node> blockedFinalizedMembers = new HashSet<>(getFinalizedNodes());
         blockedFinalizedMembers.removeAll(finalizedNodesToBlockOn);
         blockedFinalizedMembers.retainAll(members);
@@ -173,35 +173,43 @@ public class FinalizerGroup extends HasFinalizers {
             return;
         }
 
-        // For each member, determine which finalized node to wait for
+        // There are some finalized nodes that are also members
+        // For each member, determine which finalized nodes to wait for
         ImmutableMap.Builder<Node, MemberSuccessors> blockingNodesBuilder = ImmutableMap.builder();
         for (Node member : members) {
             if (isFinalizerNode(member) || memberCanStartAtAnyTime(member)) {
+                // Short-circuit for these, they are handled separately
                 continue;
             }
             if (blockedFinalizedMembers.contains(member)) {
                 if (!finalizedNodesToBlockOn.isEmpty()) {
+                    // This member is finalized and there are some finalized nodes that are not members. Wait for those nodes
                     blockingNodesBuilder.put(member, waitForFinalizers);
                 } else {
+                    // All finalized nodes are also members. Block until some other finalized node is started
                     blockingNodesBuilder.put(member, new WaitForFinalizedNodesToBecomeActive(Collections.singleton(member)));
                 }
             } else {
-                // Wait for the finalized nodes that don't introduce a cycle
-                Set<Node> blockOn = new LinkedHashSet<>(finalizedNodesToBlockOn);
+                // Determine whether this member is a dependency of a finalized node, in which case treat it as if it were a finalized member
+                boolean requiredByBlockedFinalizedMember = false;
                 for (Node finalizedMember : blockedFinalizedMembers) {
-                    if (!dependsOn(finalizedMember, member)) {
-                        blockOn.add(finalizedMember);
+                    if (dependsOn(finalizedMember, member)) {
+                        requiredByBlockedFinalizedMember = true;
+                        break;
                     }
                 }
-                if (blockOn.isEmpty()) {
-                    blockingNodesBuilder.put(member, new WaitForFinalizedNodesToBecomeActive(blockedFinalizedMembers));
-                } else {
-                    blockingNodesBuilder.put(member, new WaitForNodesToComplete(blockOn));
+                if (requiredByBlockedFinalizedMember) {
+                    blockingNodesBuilder.put(member, waitForFinalizers);
+                    continue;
                 }
+                // Wait for the finalized nodes that don't introduce a cycle
+                Set<Node> blockOn = new LinkedHashSet<>(finalizedNodesToBlockOn);
+                blockOn.addAll(blockedFinalizedMembers);
+                blockingNodesBuilder.put(member, new WaitForNodesToComplete(blockOn));
             }
         }
         ImmutableMap<Node, MemberSuccessors> blockingNodes = blockingNodesBuilder.build();
-        successors = node -> blockingNodes.get(node);
+        successors = blockingNodes::get;
     }
 
     private Set<Node> findFinalizedNodesThatDoNotIntroduceACycle(SetMultimap<FinalizerGroup, FinalizerGroup> reachableGroups) {


### PR DESCRIPTION

<!--- The issue this PR addresses -->
Fixes #?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
