### PR TITLE
Remove manual contributor recognition from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,4 +20,3 @@ Fixes #?
 - [ ] Verify design and implementation 
 - [ ] Verify test coverage and CI build status
 - [ ] Verify documentation
-- [ ] Recognize contributor in release notes


### PR DESCRIPTION
Running `:docs:updateContributorsInReleaseNotes` is already [part of our release process](https://bt-internal-docs.grdev.net/gbt/how-to/release/release-instructions/#finalize-the-release-notes), so doing it manually every time we merge in a contributor PR is a waste of time.

Removing the step from the corresponding template. 