### PR TITLE
Avoid auto-applying GE plugin if its marker is on the buildscript classpath

### DIFF
--- a/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginCheckInFixture.groovy
+++ b/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginCheckInFixture.groovy
@@ -166,7 +166,7 @@ class GradleEnterprisePluginCheckInFixture {
 
         builder.addPlugin("", "com.gradle.build-scan", 'BuildScanPlugin')
 
-        builder.publishAs("com.gradle:gradle-enterprise-gradle-plugin:${artifactVersion}", mavenRepo, pluginBuildExecuter)
+        builder.publishAs("${AutoAppliedGradleEnterprisePlugin.GROUP}:${AutoAppliedGradleEnterprisePlugin.NAME}:${artifactVersion}", mavenRepo, pluginBuildExecuter)
     }
 
     void assertBuildScanRequest(String output, GradleEnterprisePluginConfig.BuildScanRequest buildScanRequest) {

--- a/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginCheckInFixture.groovy
+++ b/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginCheckInFixture.groovy
@@ -43,7 +43,9 @@ class GradleEnterprisePluginCheckInFixture {
     String artifactVersion = AutoAppliedGradleEnterprisePlugin.VERSION
 
     final String id = AutoAppliedGradleEnterprisePlugin.ID.id
-    final String className = "org.gradle.test.GradleEnterprisePlugin"
+    final String packageName = 'com.gradle.enterprise.gradleplugin'
+    final String simpleClassName = 'GradleEnterprisePlugin'
+    final String className = "${packageName}.${simpleClassName}"
 
     boolean doCheckIn = true
     protected boolean added
@@ -82,10 +84,11 @@ class GradleEnterprisePluginCheckInFixture {
         }
         added = true
         def builder = new PluginBuilder(projectDir.file('plugin-' + AutoAppliedGradleEnterprisePlugin.ID.id))
-        builder.addPluginSource(id, "GradleEnterprisePlugin", """
+        builder.packageName = packageName
+        builder.addPluginSource(id, simpleClassName, """
             package $builder.packageName
 
-            class GradleEnterprisePlugin implements $Plugin.name<$Settings.name> {
+            class ${simpleClassName} implements $Plugin.name<$Settings.name> {
                 void apply($Settings.name settings) {
                     println "gradleEnterprisePlugin.apply.runtimeVersion = $runtimeVersion"
 

--- a/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginConfigIntegrationTest.groovy
+++ b/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginConfigIntegrationTest.groovy
@@ -77,7 +77,7 @@ class GradleEnterprisePluginConfigIntegrationTest extends AbstractIntegrationSpe
 
     def "is not auto-applied when added to classpath via buildscript block"() {
         given:
-        def pluginArtifactId = "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:${plugin.runtimeVersion}"
+        def pluginArtifactId = "com.gradle:gradle-enterprise-gradle-plugin:${plugin.runtimeVersion}"
         settingsFile << """
             buildscript {
                 repositories {

--- a/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginConfigIntegrationTest.groovy
+++ b/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginConfigIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.internal.enterprise
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.plugin.management.internal.autoapply.AutoAppliedGradleEnterprisePlugin
 
 import static org.gradle.internal.enterprise.GradleEnterprisePluginConfig.BuildScanRequest.NONE
 import static org.gradle.internal.enterprise.GradleEnterprisePluginConfig.BuildScanRequest.REQUESTED
@@ -77,14 +78,14 @@ class GradleEnterprisePluginConfigIntegrationTest extends AbstractIntegrationSpe
 
     def "is not auto-applied when added to classpath via buildscript block"() {
         given:
-        def pluginArtifactId = "com.gradle:gradle-enterprise-gradle-plugin:${plugin.runtimeVersion}"
+        def coordinates = "${groupId}:${artifactId}:${plugin.runtimeVersion}"
         settingsFile << """
             buildscript {
                 repositories {
                     maven { url '${mavenRepo.uri}' }
                 }
                 dependencies {
-                    classpath("${pluginArtifactId}")
+                    classpath("${coordinates}")
                 }
             }
 
@@ -96,6 +97,11 @@ class GradleEnterprisePluginConfigIntegrationTest extends AbstractIntegrationSpe
 
         then:
         plugin.assertAutoApplied(output, false)
+
+        where:
+        groupId                                 | artifactId
+        'com.gradle'                            | 'gradle-enterprise-gradle-plugin'
+        AutoAppliedGradleEnterprisePlugin.ID.id | "${AutoAppliedGradleEnterprisePlugin.ID.id}.gradle.plugin"
     }
 
     def "is auto-applied when --scan is used despite init script"() {

--- a/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginConfigIntegrationTest.groovy
+++ b/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginConfigIntegrationTest.groovy
@@ -75,4 +75,27 @@ class GradleEnterprisePluginConfigIntegrationTest extends AbstractIntegrationSpe
         plugin.assertAutoApplied(output, false)
     }
 
+    def "is not auto-applied when added to classpath via buildscript block"() {
+        given:
+        def pluginArtifactId = "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:${plugin.runtimeVersion}"
+        settingsFile << """
+            buildscript {
+                repositories {
+                    maven { url '${mavenRepo.uri}' }
+                }
+                dependencies {
+                    classpath("${pluginArtifactId}")
+                }
+            }
+
+            apply plugin: 'com.gradle.enterprise'
+        """
+
+        when:
+        succeeds "t", "--scan"
+
+        then:
+        plugin.assertAutoApplied(output, false)
+    }
+
 }


### PR DESCRIPTION
Instead of only checking for the group/artifact ID of the plugin's JAR, `DefaultAutoAppliedPluginHandler` now also checks for the plugin marker's coordinates.

Moreover, this PR adds a test for applying the GE plugin via an init script which documents the current behavior: the application triggered by `--scan` comes before the application triggered in a `settingsEvaluated` hook in the init script.

Follow-up on #22674.