### PR TITLE
Add archive library change to the list of potentially breaking changes

### DIFF
--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -274,6 +274,10 @@ In the Gradle 8.0, setting `ruleSetConfig` or `ruleSetFiles` to a non-empty valu
 The incubating plugin `ExternalPluginValidationPlugin` has been removed.
 Use the link:java_gradle_plugin.html[`java-gradle-plugin`]'s `validatePlugins` task to validate plugins under development.
 
+==== Reproducible archives can change compared to past versions
+
+Gradle changes the compression library used for creating archives from an Ant based one to https://commons.apache.org/proper/commons-compress/[Apache Commons Compress™]. As a consequence archives created from the same content, are unlikely to end up identical byte-by-byte to their older versions, created with the old library.
+
 [[changes_7.6]]
 == Upgrading from 7.5 and earlier
 


### PR DESCRIPTION
Adding the consequences of https://github.com/gradle/gradle/pull/19570 to the list of potentially breaking changes.