### PR TITLE
Mark publishing tasks of samples/credentials-handling as CC-incompatible

### DIFF
--- a/subprojects/docs/build.gradle
+++ b/subprojects/docs/build.gradle
@@ -739,10 +739,6 @@ tasks.named("docsTest") { task ->
             // These tests cover features that the configuration cache doesn't support yet, but we plan to do that before hitting stable.
             // The tests should be removed from this list when the feature becomes supported.
             def testsForNotYetSupportedFeatures = [
-                // TODO(https://github.com/gradle/gradle/issues/21642)
-                "publishing-credentials_groovy_publishCommandLineCredentials.sample",
-                "publishing-credentials_kotlin_publishCommandLineCredentials.sample",
-
                 // TODO(https://github.com/gradle/gradle/issues/14880)
                 "snippet-dependency-management-working-with-dependencies-iterate-dependencies_groovy_iterating-dependencies.sample",
                 "snippet-dependency-management-working-with-dependencies-iterate-dependencies_kotlin_iterating-dependencies.sample",

--- a/subprojects/docs/src/samples/credentials-handling/publishing-credentials/groovy/maven-repository-stub/src/main/groovy/maven-repository-stub.gradle
+++ b/subprojects/docs/src/samples/credentials-handling/publishing-credentials/groovy/maven-repository-stub/src/main/groovy/maven-repository-stub.gradle
@@ -1,4 +1,5 @@
 tasks.withType(PublishToMavenRepository).configureEach {
+    notCompatibleWithConfigurationCache("Configures repository at execution time")
     doFirst {
         def address = com.example.MavenRepositoryStub.start()
         getRepository().setUrl(address)

--- a/subprojects/docs/src/samples/credentials-handling/publishing-credentials/kotlin/maven-repository-stub/src/main/kotlin/maven-repository-stub.gradle.kts
+++ b/subprojects/docs/src/samples/credentials-handling/publishing-credentials/kotlin/maven-repository-stub/src/main/kotlin/maven-repository-stub.gradle.kts
@@ -1,4 +1,5 @@
 tasks.withType<PublishToMavenRepository>().configureEach {
+    notCompatibleWithConfigurationCache("Configures repository at execution time")
     doFirst {
         val address = com.example.MavenRepositoryStub.start()
         getRepository().setUrl(address)


### PR DESCRIPTION
These tasks modify their repository at the execution time, but this isn't supported with the configuration cache. When running from cache, the Repository instance is not restored completely, as only information essential for publishing is persisted.

There are several ways we can work around this, but all require non-trivial changes to the Publish task, e.g. one option could be to introduce a lazy API to set the URL. This work is going to be tracked separately.

Fixes #21642 