### PR TITLE
Explicitly manage JUnit launcher session

### DIFF
--- a/subprojects/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestClassProcessor.java
+++ b/subprojects/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestClassProcessor.java
@@ -17,8 +17,8 @@
 package org.gradle.api.internal.tasks.testing.junitplatform;
 
 import org.gradle.api.Action;
-import org.gradle.api.internal.tasks.testing.filter.TestFilterSpec;
 import org.gradle.api.internal.tasks.testing.TestResultProcessor;
+import org.gradle.api.internal.tasks.testing.filter.TestFilterSpec;
 import org.gradle.api.internal.tasks.testing.filter.TestSelectionMatcher;
 import org.gradle.api.internal.tasks.testing.junit.AbstractJUnitTestClassProcessor;
 import org.gradle.internal.UncheckedException;
@@ -35,11 +35,14 @@ import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.engine.support.descriptor.MethodSource;
 import org.junit.platform.launcher.Launcher;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.LauncherSession;
 import org.junit.platform.launcher.PostDiscoveryFilter;
+import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
 import org.junit.platform.launcher.core.LauncherFactory;
 
 import javax.annotation.Nonnull;
+import javax.annotation.WillCloseWhenClosed;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
@@ -55,6 +58,8 @@ import static org.junit.platform.launcher.TagFilter.includeTags;
 public class JUnitPlatformTestClassProcessor extends AbstractJUnitTestClassProcessor {
     JUnitPlatformSpec spec;
     private CollectAllTestClassesExecutor testClassExecutor;
+    private BackwardsCompatibleLauncherSession launcherSession;
+    private ClassLoader junitClassLoader;
 
     public JUnitPlatformTestClassProcessor(JUnitPlatformSpec spec, IdGenerator<?> idGenerator, ActorFactory actorFactory, Clock clock) {
         super(idGenerator, actorFactory, clock);
@@ -69,6 +74,8 @@ public class JUnitPlatformTestClassProcessor extends AbstractJUnitTestClassProce
     @Override
     protected Action<String> createTestExecutor(Actor resultProcessorActor) {
         TestResultProcessor threadSafeResultProcessor = resultProcessorActor.getProxy(TestResultProcessor.class);
+        launcherSession = BackwardsCompatibleLauncherSession.open();
+        junitClassLoader = Thread.currentThread().getContextClassLoader();
         testClassExecutor = new CollectAllTestClassesExecutor(threadSafeResultProcessor);
         return testClassExecutor;
     }
@@ -76,6 +83,7 @@ public class JUnitPlatformTestClassProcessor extends AbstractJUnitTestClassProce
     @Override
     public void stop() {
         testClassExecutor.processAllTestClasses();
+        launcherSession.close();
         super.stop();
     }
 
@@ -97,9 +105,9 @@ public class JUnitPlatformTestClassProcessor extends AbstractJUnitTestClassProce
         }
 
         private void processAllTestClasses() {
-            Launcher launcher = LauncherFactory.create();
-            launcher.registerTestExecutionListeners(new JUnitPlatformTestExecutionListener(resultProcessor, clock, idGenerator));
-            launcher.execute(createLauncherDiscoveryRequest(testClasses));
+            LauncherDiscoveryRequest discoveryRequest = createLauncherDiscoveryRequest(testClasses);
+            TestExecutionListener executionListener = new JUnitPlatformTestExecutionListener(resultProcessor, clock, idGenerator);
+            launcherSession.getLauncher().execute(discoveryRequest, executionListener);
         }
     }
 
@@ -110,9 +118,8 @@ public class JUnitPlatformTestClassProcessor extends AbstractJUnitTestClassProce
      */
     private boolean supportsVintageTests() {
         try {
-            ClassLoader applicationClassloader = Thread.currentThread().getContextClassLoader();
-            Class.forName("org.junit.vintage.engine.VintageTestEngine", false, applicationClassloader);
-            Class.forName("org.junit.runner.Request", false, applicationClassloader);
+            Class.forName("org.junit.vintage.engine.VintageTestEngine", false, junitClassLoader);
+            Class.forName("org.junit.runner.Request", false, junitClassLoader);
             return true;
         } catch (ClassNotFoundException e) {
             return false;
@@ -125,8 +132,7 @@ public class JUnitPlatformTestClassProcessor extends AbstractJUnitTestClassProce
 
     private Class<?> loadClass(String className) {
         try {
-            ClassLoader applicationClassloader = Thread.currentThread().getContextClassLoader();
-            return Class.forName(className, false, applicationClassloader);
+            return Class.forName(className, false, junitClassLoader);
         } catch (ClassNotFoundException e) {
             throw UncheckedException.throwAsUncheckedException(e);
         }
@@ -240,6 +246,40 @@ public class JUnitPlatformTestClassProcessor extends AbstractJUnitTestClassProce
                 .filter(ClassSource.class::isInstance)
                 .map(ClassSource.class::cast)
                 .map(ClassSource::getClassName);
+        }
+    }
+
+    private static class BackwardsCompatibleLauncherSession implements AutoCloseable {
+
+        static BackwardsCompatibleLauncherSession open() {
+            try {
+                LauncherSession launcherSession = LauncherFactory.openSession();
+                return new BackwardsCompatibleLauncherSession(launcherSession);
+            } catch (NoSuchMethodError ignore) {
+                // JUnit Platform version on test classpath does not yet support launcher sessions
+                return new BackwardsCompatibleLauncherSession(LauncherFactory.create(), () -> {});
+            }
+        }
+
+        private final Launcher launcher;
+        private final Runnable onClose;
+
+        BackwardsCompatibleLauncherSession(@WillCloseWhenClosed LauncherSession session) {
+            this(session.getLauncher(), session::close);
+        }
+
+        BackwardsCompatibleLauncherSession(Launcher launcher, Runnable onClose) {
+            this.launcher = launcher;
+            this.onClose = onClose;
+        }
+
+        Launcher getLauncher() {
+            return launcher;
+        }
+
+        @Override
+        public void close() {
+            onClose.run();
         }
     }
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformIntegrationSpec.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformIntegrationSpec.groovy
@@ -41,4 +41,17 @@ class JUnitPlatformIntegrationSpec extends AbstractIntegrationSpec {
             $script
         """)
     }
+
+    void createSimpleJupiterTest() {
+        file('src/test/java/org/gradle/JUnitJupiterTest.java') << '''
+            package org.gradle;
+
+            import org.junit.jupiter.api.Test;
+
+            public class JUnitJupiterTest {
+                @Test
+                public void ok() { }
+            }
+            '''
+    }
 }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformIntegrationTest.groovy
@@ -409,4 +409,48 @@ public class StaticInnerTest {
         "w/o filters"  | []
         "with filters" | ['--tests', 'JUnitJupiterTest']
     }
+
+    def "creates LauncherSession before loading test classes"() {
+        given:
+        createSimpleJupiterTest()
+        buildFile << """
+            dependencies {
+                testImplementation 'org.junit.platform:junit-platform-launcher:${LATEST_PLATFORM_VERSION}'
+            }
+            test {
+                testLogging {
+                    showStandardStreams = true
+                }
+            }
+        """
+        file('src/test/java/NoisyLauncherSessionListener.java') << '''
+            import org.junit.platform.launcher.*;
+            public class NoisyLauncherSessionListener implements LauncherSessionListener {
+                @Override public void launcherSessionOpened(LauncherSession session) {
+                    System.out.println("launcherSessionOpened");
+                    Thread thread = Thread.currentThread();
+                    ClassLoader parent = thread.getContextClassLoader();
+                    ClassLoader replacement = new ClassLoader(parent) {
+                        @Override protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+                            System.out.println("Loading class " + name);
+                            return super.loadClass(name, resolve);
+                        }
+                    };
+                    thread.setContextClassLoader(replacement);
+                }
+                @Override public void launcherSessionClosed(LauncherSession session) {
+                    System.out.println("launcherSessionClosed");
+                }
+            }
+        '''
+        file('src/test/resources/META-INF/services/org.junit.platform.launcher.LauncherSessionListener') << '''\
+            NoisyLauncherSessionListener
+        '''.stripIndent(true)
+
+        expect:
+        succeeds('test')
+        outputContains('launcherSessionOpened')
+        outputContains('Loading class org.gradle.JUnitJupiterTest')
+        outputContains('launcherSessionClosed')
+    }
 }


### PR DESCRIPTION
### Context

In order to allow JUnit Platform extensions like
`LauncherSessionListener` (introduced in JUnit Platform 1.8) to prepare
resources and replace the classloader for tests, the
`TestClassProcessor` now explicitly creates a `LauncherSession` when
running on JUnit Platform 1.8 or later prior to loading potential test
classes. To allow replacing the thread's context class loader, it is
stored after the session has been created since it will be replaced
again by `ContextClassLoaderDispatch`.

This will enable use cases like running tests in an OSGi environment.
