### PR TITLE
Scala Plugin: remove `ExternalBinariesLookup`

### DIFF
--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/ZincScalaCompilerIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/ZincScalaCompilerIntegrationTest.groovy
@@ -73,11 +73,7 @@ class ZincScalaCompilerIntegrationTest extends BasicZincScalaCompilerIntegration
 
     }
 
-    @Issue("https://github.com/gradle/gradle/issues/22964")
     def "compiles Scala code incrementally"() {
-        // TODO: remove the assumption when the linked issue fixed for Scala 3
-        Assume.assumeTrue(versionNumber.major == 2)
-
         file("src/main/scala/Person.scala") << """class Person(val name: String = "foo", val age: Int = 1)"""
         file("src/main/scala/House.scala") << """class House(val owner: Person = new Person())"""
         file("src/main/scala/Other.scala") << """class Other"""
@@ -144,11 +140,7 @@ class ZincScalaCompilerIntegrationTest extends BasicZincScalaCompilerIntegration
         other.lastModified() == old(other.lastModified())
     }
 
-    @Issue("https://github.com/gradle/gradle/issues/22964")
     def "compiles Scala incrementally across project boundaries"() {
-        // TODO: remove the assumption when the linked issue fixed for Scala 3
-        Assume.assumeTrue(versionNumber.major == 2)
-
         file("settings.gradle") << """include 'a', 'b'"""
         // overwrite the build file from setup
         file("build.gradle").text = """


### PR DESCRIPTION
Since Gradle 7.x, Gradle's implementation of `ExternalLookup` has become out of sync with Zinc's file stamping and always triggers full recompilation.

Since an implementation of `ExternalLookup` is optional and [Zinc's default](https://github.com/sbt/zinc/blob/develop/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala#L734) already does what Gradle is trying to do here, the Gradle-customization can be completely removed.

Passes all existing tests under `./gradlew scala:build` which are all *intra-project* incremental compilation tests, so we know this change doesn't break anything there. It would probably be good to have (had) an *inter-project* incremental compilation test as well to ensure such a regression doesn't happen again, but that is beyond the scope of what I can contribute at this point. @justinb99's reproducer in #20101 would certainly be a good starting point.

Note that this does not address the interplay of the java-library plugin and https://github.com/sbt/zinc/issues/1140 , i.e. only works for jar dependencies. The [workaround](https://github.com/sbt/zinc/blob/develop/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalCommon.scala#L44) in zinc might be a short-term solution for that.

Signed-off-by: matthias_ernst <matthias_ernst@apple.com>

Fixes #20101
Fixes #22964
