### PR TITLE
Small tweaks to reduce retained heap 

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/exceptions/DefaultMultiCauseException.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/exceptions/DefaultMultiCauseException.java
@@ -74,12 +74,14 @@ public class DefaultMultiCauseException extends GradleException implements Multi
     }
 
     private ThreadLocal<Boolean> threadLocal() {
-        return new ThreadLocal<Boolean>() {
-            @Override
-            protected Boolean initialValue() {
-                return false;
-            }
-        };
+        return new HideStacktrace();
+    }
+
+    private static class HideStacktrace extends ThreadLocal<Boolean> {
+        @Override
+        protected Boolean initialValue() {
+            return false;
+        }
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultMutationGuard.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultMutationGuard.java
@@ -19,12 +19,13 @@ package org.gradle.api.internal;
 import org.gradle.api.Action;
 
 public class DefaultMutationGuard extends AbstractMutationGuard {
-    private final ThreadLocal<Boolean> mutationGuardState = new ThreadLocal<Boolean>() {
+    private final ThreadLocal<Boolean> mutationGuardState = new GuardState();
+    private static class GuardState extends ThreadLocal<Boolean> {
         @Override
         protected Boolean initialValue() {
             return Boolean.TRUE;
         }
-    };
+    }
 
     @Override
     public boolean isMutationAllowed() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/DefaultArtifactSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/DefaultArtifactSelector.java
@@ -67,9 +67,11 @@ public class DefaultArtifactSelector implements ArtifactSelector {
 
     @Override
     public ArtifactSet resolveArtifacts(ComponentResolveMetadata component, @Nullable Map<VariantResolveMetadata.Identifier, ResolvedVariant> resolvedVariantCache, Supplier<Set<? extends VariantResolveMetadata>> allVariants, Set<? extends VariantResolveMetadata> legacyVariants, ExcludeSpec exclusions, ImmutableAttributes overriddenAttributes) {
+        ModuleVersionIdentifier moduleVersionId = component.getModuleVersionId();
+        ModuleSources sources = component.getSources();
 
-        ImmutableSet<ResolvedVariant> legacyResolvedVariants = buildResolvedVariants(component, legacyVariants, exclusions, resolvedVariantCache);
-        ComponentArtifactResolveVariantState componentArtifactResolveVariantState = () -> buildResolvedVariants(component, allVariants.get(), exclusions, resolvedVariantCache);
+        ImmutableSet<ResolvedVariant> legacyResolvedVariants = buildResolvedVariants(moduleVersionId, sources, legacyVariants, exclusions, resolvedVariantCache);
+        ComponentArtifactResolveVariantState componentArtifactResolveVariantState = () -> buildResolvedVariants(moduleVersionId, sources, allVariants.get(), exclusions, resolvedVariantCache);
 
         for (OriginArtifactSelector selector : selectors) {
             ArtifactSet artifacts = selector.resolveArtifacts(component, componentArtifactResolveVariantState, legacyResolvedVariants, exclusions, overriddenAttributes);
@@ -80,10 +82,10 @@ public class DefaultArtifactSelector implements ArtifactSelector {
         throw new IllegalStateException("No artifacts selected.");
     }
 
-    private ImmutableSet<ResolvedVariant> buildResolvedVariants(ComponentResolveMetadata component, Set<? extends VariantResolveMetadata> allVariants, ExcludeSpec exclusions, @Nullable Map<VariantResolveMetadata.Identifier, ResolvedVariant> resolvedVariantCache) {
+    private ImmutableSet<ResolvedVariant> buildResolvedVariants(ModuleVersionIdentifier moduleVersionId, ModuleSources sources, Set<? extends VariantResolveMetadata> allVariants, ExcludeSpec exclusions, @Nullable Map<VariantResolveMetadata.Identifier, ResolvedVariant> resolvedVariantCache) {
         ImmutableSet.Builder<ResolvedVariant> resolvedVariantBuilder = ImmutableSet.builder();
         for (VariantResolveMetadata variant : allVariants) {
-            ResolvedVariant resolvedVariant = toResolvedVariant(variant.getIdentifier(), variant.asDescribable(), variant.getAttributes(), variant.getArtifacts(), variant.getCapabilities(), exclusions, component.getModuleVersionId(), component.getSources(), resolvedVariantCache);
+            ResolvedVariant resolvedVariant = toResolvedVariant(variant.getIdentifier(), variant.asDescribable(), variant.getAttributes(), variant.getArtifacts(), variant.getCapabilities(), exclusions, moduleVersionId, sources, resolvedVariantCache);
             resolvedVariantBuilder.add(resolvedVariant);
         }
         return resolvedVariantBuilder.build();

--- a/subprojects/model-core/src/main/java/org/gradle/model/internal/registry/RuleContext.java
+++ b/subprojects/model-core/src/main/java/org/gradle/model/internal/registry/RuleContext.java
@@ -24,12 +24,7 @@ import java.util.Deque;
 
 public class RuleContext {
 
-    private static final ThreadLocal<Deque<ModelRuleDescriptor>> STACK = new ThreadLocal<Deque<ModelRuleDescriptor>>() {
-        @Override
-        protected Deque<ModelRuleDescriptor> initialValue() {
-            return new ArrayDeque<ModelRuleDescriptor>();
-        }
-    };
+    private static final ThreadLocal<Deque<ModelRuleDescriptor>> STACK = ThreadLocal.withInitial(ArrayDeque::new);
 
     @Nullable
     public static ModelRuleDescriptor get() {


### PR DESCRIPTION
When profiling the mediumJavaMultiProject build with 7.5 and 7.6-rc-4, I found a couple of changes:
1. ComponentResolveMetadata metadata was being retained until the end of the build
2. A ThreadLocal in `DefaultMultiCauseException` holds on to the outer failure, which in turn holds onto an instance of the Task. Through there you can track back to most of a build's state and (1). 

(1) was caused by the new lambda in DefaultArtifactSelector that holds on to a reference to ComponentResolveMetadata. The fix is to pull out the bits we need out of that structure and only hold on to those.

(2) the thread local didn't actually need to hold on to the task failure. I found a couple of other places that were doing something similar and cleaned those up too. 

Ultimately for (2), we might want to consider changing TaskExecutionException so that it doesn't hold on to the task that failed.