### PR TITLE
Don't run CheckLinks tasks in docsTest

### DIFF
--- a/subprojects/docs/build.gradle
+++ b/subprojects/docs/build.gradle
@@ -848,7 +848,7 @@ class GradleInstallationForTestEnvironmentProvider implements CommandLineArgumen
 }
 
 tasks.withType(CheckLinks).configureEach {
-    enabled = !gradle.startParameter.taskNames.contains("docs:platformTest")
+    enabled = !gradle.startParameter.taskNames.contains("docs:docsTest")
 }
 
 tasks.register("checkLinks") {


### PR DESCRIPTION
We have a dedicated `CheckLinks` job that won't fail the stage.
