### PR TITLE
Fixed Windows paths in accepted API changes tests causing illegal escape char problems

### DIFF
--- a/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/AbstractAcceptedApiChangesMaintenanceTaskIntegrationTest.kt
+++ b/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/AbstractAcceptedApiChangesMaintenanceTaskIntegrationTest.kt
@@ -46,13 +46,13 @@ abstract class AbstractAcceptedApiChangesMaintenanceTaskIntegrationTest {
                     val verifyAcceptedApiChangesOrdering = tasks.register<gradlebuild.binarycompatibility.AlphabeticalAcceptedApiChangesTask>("verifyAcceptedApiChangesOrdering") {
                         group = "verification"
                         description = "Ensures the accepted api changes file is kept alphabetically ordered to make merging changes to it easier"
-                        apiChangesFile.set(layout.projectDirectory.file("${FilenameUtils.normalize(acceptedApiChangesFile.absolutePath, true)}"))
+                        apiChangesFile.set(layout.projectDirectory.file("${ FilenameUtils.normalize(acceptedApiChangesFile.absolutePath, true) }"))
                     }
 
                     val sortAcceptedApiChanges = tasks.register<gradlebuild.binarycompatibility.SortAcceptedApiChangesTask>("sortAcceptedApiChanges") {
                         group = "verification"
                         description = "Sort the accepted api changes file alphabetically"
-                        apiChangesFile.set(layout.projectDirectory.file("${FilenameUtils.normalize(acceptedApiChangesFile.absolutePath, true)}"))
+                        apiChangesFile.set(layout.projectDirectory.file("${ FilenameUtils.normalize(acceptedApiChangesFile.absolutePath, true) }"))
                     }
                 """.trimIndent()
             )

--- a/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/AbstractAcceptedApiChangesMaintenanceTaskIntegrationTest.kt
+++ b/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/AbstractAcceptedApiChangesMaintenanceTaskIntegrationTest.kt
@@ -16,6 +16,7 @@
 
 package gradlebuild.binarycompatibility
 
+import org.gradle.internal.impldep.org.apache.commons.io.FilenameUtils
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.jupiter.api.Assertions
@@ -45,13 +46,13 @@ abstract class AbstractAcceptedApiChangesMaintenanceTaskIntegrationTest {
                     val verifyAcceptedApiChangesOrdering = tasks.register<gradlebuild.binarycompatibility.AlphabeticalAcceptedApiChangesTask>("verifyAcceptedApiChangesOrdering") {
                         group = "verification"
                         description = "Ensures the accepted api changes file is kept alphabetically ordered to make merging changes to it easier"
-                        apiChangesFile.set(layout.projectDirectory.file("${acceptedApiChangesFile.absolutePath}"))
+                        apiChangesFile.set(layout.projectDirectory.file("${FilenameUtils.normalize(acceptedApiChangesFile.absolutePath, true)}"))
                     }
 
                     val sortAcceptedApiChanges = tasks.register<gradlebuild.binarycompatibility.SortAcceptedApiChangesTask>("sortAcceptedApiChanges") {
                         group = "verification"
                         description = "Sort the accepted api changes file alphabetically"
-                        apiChangesFile.set(layout.projectDirectory.file("${acceptedApiChangesFile.absolutePath}"))
+                        apiChangesFile.set(layout.projectDirectory.file("${FilenameUtils.normalize(acceptedApiChangesFile.absolutePath, true)}"))
                     }
                 """.trimIndent()
             )

--- a/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/AbstractAcceptedApiChangesMaintenanceTaskIntegrationTest.kt
+++ b/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/AbstractAcceptedApiChangesMaintenanceTaskIntegrationTest.kt
@@ -16,9 +16,9 @@
 
 package gradlebuild.binarycompatibility
 
-import org.gradle.internal.impldep.org.apache.commons.io.FilenameUtils
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
+import org.gradle.util.internal.TextUtil
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.io.TempDir
@@ -46,13 +46,13 @@ abstract class AbstractAcceptedApiChangesMaintenanceTaskIntegrationTest {
                     val verifyAcceptedApiChangesOrdering = tasks.register<gradlebuild.binarycompatibility.AlphabeticalAcceptedApiChangesTask>("verifyAcceptedApiChangesOrdering") {
                         group = "verification"
                         description = "Ensures the accepted api changes file is kept alphabetically ordered to make merging changes to it easier"
-                        apiChangesFile.set(layout.projectDirectory.file("${ FilenameUtils.normalize(acceptedApiChangesFile.absolutePath, true) }"))
+                        apiChangesFile.set(layout.projectDirectory.file("${ TextUtil.normaliseFileSeparators(acceptedApiChangesFile.absolutePath) }"))
                     }
 
                     val sortAcceptedApiChanges = tasks.register<gradlebuild.binarycompatibility.SortAcceptedApiChangesTask>("sortAcceptedApiChanges") {
                         group = "verification"
                         description = "Sort the accepted api changes file alphabetically"
-                        apiChangesFile.set(layout.projectDirectory.file("${ FilenameUtils.normalize(acceptedApiChangesFile.absolutePath, true) }"))
+                        apiChangesFile.set(layout.projectDirectory.file("${ TextUtil.normaliseFileSeparators(acceptedApiChangesFile.absolutePath) }"))
                     }
                 """.trimIndent()
             )


### PR DESCRIPTION
Paths written to test files with Windows style paths were causing errors.  Normalized to UNIX-style paths.