### PR TITLE
Improve error reporting when a Groovy closure deserialized from the configuration cache references the script object

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheGroovyClosureIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheGroovyClosureIntegrationTest.groovy
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache
+
+class ConfigurationCacheGroovyClosureIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
+    def "build fails when task action closure reads a project property"() {
+        given:
+        buildFile << """
+            tasks.register("some") {
+                doFirst {
+                    println(name) // task property is ok
+                    println(buildDir)
+                }
+            }
+        """
+
+        when:
+        configurationCacheRun ":some"
+
+        then:
+        noExceptionThrown()
+
+        when:
+        configurationCacheFails ":some"
+
+        then:
+        failure.assertHasFileName("Build file '$buildFile'")
+        failure.assertHasLineNumber(5)
+        failure.assertHasFailure("Execution failed for task ':some'.") {
+            it.assertHasCause("Cannot reference a Gradle script object from a Groovy closure as these are not supported with the configuration cache.")
+        }
+    }
+
+    def "build fails when task action closure sets a project property"() {
+        given:
+        buildFile << """
+            tasks.register("some") {
+                doFirst {
+                    description = "broken" // task property is ok
+                    version = 1.2
+                }
+            }
+        """
+
+        when:
+        configurationCacheRun ":some"
+
+        then:
+        noExceptionThrown()
+
+        when:
+        configurationCacheFails ":some"
+
+        then:
+        failure.assertHasFileName("Build file '$buildFile'")
+        failure.assertHasLineNumber(5)
+        failure.assertHasFailure("Execution failed for task ':some'.") {
+            it.assertHasCause("Cannot reference a Gradle script object from a Groovy closure as these are not supported with the configuration cache.")
+        }
+    }
+
+    def "build fails when task action closure invokes a project method"() {
+        given:
+        buildFile << """
+            tasks.register("some") {
+                doFirst {
+                    println(file("broken"))
+                }
+            }
+        """
+
+        when:
+        configurationCacheRun ":some"
+
+        then:
+        noExceptionThrown()
+
+        when:
+        configurationCacheFails ":some"
+
+        then:
+        failure.assertHasFileName("Build file '$buildFile'")
+        failure.assertHasLineNumber(4)
+        failure.assertHasFailure("Execution failed for task ':some'.") {
+            it.assertHasCause("Cannot reference a Gradle script object from a Groovy closure as these are not supported with the configuration cache.")
+        }
+    }
+
+    def "build fails when task action nested closure reads a project property"() {
+        given:
+        buildFile << """
+            tasks.register("some") {
+                doFirst {
+                    def cl = {
+                        println(name) // task property is ok
+                        println(buildDir)
+                    }
+                    cl()
+                }
+            }
+        """
+
+        when:
+        configurationCacheRun ":some"
+
+        then:
+        noExceptionThrown()
+
+        when:
+        configurationCacheFails ":some"
+
+        then:
+        failure.assertHasFileName("Build file '$buildFile'")
+        failure.assertHasLineNumber(6)
+        failure.assertHasFailure("Execution failed for task ':some'.") {
+            it.assertHasCause("Cannot reference a Gradle script object from a Groovy closure as these are not supported with the configuration cache.")
+        }
+    }
+
+    def "build fails when task onlyIf closure reads a project property"() {
+        given:
+        buildFile << """
+            tasks.register("some") {
+                onlyIf { t ->
+                    println(t.name) // task property is ok
+                    println(buildDir)
+                    true
+                }
+                doFirst {
+                }
+            }
+        """
+
+        when:
+        configurationCacheRun ":some"
+
+        then:
+        noExceptionThrown()
+
+        when:
+        configurationCacheFails ":some"
+
+        then:
+        failure.assertHasFileName("Build file '$buildFile'")
+        failure.assertHasLineNumber(5)
+        failure.assertHasFailure("Could not evaluate onlyIf predicate for task ':some'.") {
+            // The cause is not reported
+        }
+    }
+}

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheScriptTaskDefinitionIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheScriptTaskDefinitionIntegrationTest.groovy
@@ -259,6 +259,8 @@ class ConfigurationCacheScriptTaskDefinitionIntegrationTest extends AbstractConf
         configurationCacheFails ":some"
 
         then:
+        failure.assertHasFileName("Build file '$buildFile'")
+        failure.assertHasLineNumber(5)
         failure.assertHasFailure("Execution failed for task ':some'.") {
             it.assertHasCause("Cannot reference a Gradle script object from a Groovy closure as these are not supported with the configuration cache.")
         }
@@ -291,6 +293,8 @@ class ConfigurationCacheScriptTaskDefinitionIntegrationTest extends AbstractConf
         configurationCacheFails ":some"
 
         then:
+        failure.assertHasFileName("Build file '$buildFile'")
+        failure.assertHasLineNumber(5)
         failure.assertHasFailure("Execution failed for task ':some'.") {
             it.assertHasCause("Cannot reference a Gradle script object from a Groovy closure as these are not supported with the configuration cache.")
         }
@@ -322,6 +326,8 @@ class ConfigurationCacheScriptTaskDefinitionIntegrationTest extends AbstractConf
         configurationCacheFails ":some"
 
         then:
+        failure.assertHasFileName("Build file '$buildFile'")
+        failure.assertHasLineNumber(4)
         failure.assertHasFailure("Execution failed for task ':some'.") {
             it.assertHasCause("Cannot reference a Gradle script object from a Groovy closure as these are not supported with the configuration cache.")
         }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheClassLoaderScopeRegistryListener.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheClassLoaderScopeRegistryListener.kt
@@ -21,6 +21,7 @@ import org.gradle.api.internal.initialization.loadercache.ClassLoaderId
 import org.gradle.configurationcache.serialization.ClassLoaderRole
 import org.gradle.configurationcache.serialization.ScopeLookup
 import org.gradle.initialization.ClassLoaderScopeId
+import org.gradle.initialization.ClassLoaderScopeOrigin
 import org.gradle.initialization.ClassLoaderScopeRegistryListener
 import org.gradle.initialization.ClassLoaderScopeRegistryListenerManager
 import org.gradle.internal.buildtree.BuildTreeLifecycleListener
@@ -78,7 +79,7 @@ class ConfigurationCacheClassLoaderScopeRegistryListener(
         }
     }
 
-    override fun childScopeCreated(parentId: ClassLoaderScopeId, childId: ClassLoaderScopeId) {
+    override fun childScopeCreated(parentId: ClassLoaderScopeId, childId: ClassLoaderScopeId, origin: ClassLoaderScopeOrigin?) {
         synchronized(lock) {
             if (scopeSpecs.containsKey(childId)) {
                 // scope is being reused
@@ -96,7 +97,7 @@ class ConfigurationCacheClassLoaderScopeRegistryListener(
                 lookupParent
             }
 
-            val child = ClassLoaderScopeSpec(parent, childId.name)
+            val child = ClassLoaderScopeSpec(parent, childId.name, origin)
             scopeSpecs[childId] = child
         }
     }
@@ -123,7 +124,8 @@ class ConfigurationCacheClassLoaderScopeRegistryListener(
 internal
 class ClassLoaderScopeSpec(
     val parent: ClassLoaderScopeSpec?,
-    val name: String
+    val name: String,
+    val origin: ClassLoaderScopeOrigin?
 ) {
     var localClassPath: ClassPath = ClassPath.EMPTY
     var localImplementationHash: HashCode? = null

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheHost.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheHost.kt
@@ -145,7 +145,7 @@ class ConfigurationCacheHost internal constructor(
         private
         fun createSettings(): SettingsInternal {
             val baseClassLoaderScope = gradle.classLoaderScope
-            val classLoaderScope = baseClassLoaderScope.createChild("settings")
+            val classLoaderScope = baseClassLoaderScope.createChild("settings", null)
             val settingsSource = if (settingsFile == null) {
                 TextResourceScriptSource(StringTextResource("settings", ""))
             } else {

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/ClosureCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/ClosureCodec.kt
@@ -17,23 +17,128 @@
 package org.gradle.configurationcache.serialization.codecs
 
 import groovy.lang.Closure
+import groovy.lang.GroovyObjectSupport
+import groovy.lang.MissingMethodException
+import groovy.lang.MissingPropertyException
+import org.codehaus.groovy.runtime.InvokerHelper
+import org.gradle.api.Project
+import org.gradle.configurationcache.problems.DocumentationSection
+import org.gradle.configurationcache.problems.PropertyProblem
+import org.gradle.configurationcache.problems.PropertyTrace
+import org.gradle.configurationcache.problems.StructuredMessage
 import org.gradle.configurationcache.serialization.Codec
+import org.gradle.configurationcache.serialization.IsolateContext
 import org.gradle.configurationcache.serialization.ReadContext
 import org.gradle.configurationcache.serialization.WriteContext
+import org.gradle.internal.metaobject.ConfigureDelegate
 
 
 object ClosureCodec : Codec<Closure<*>> {
-
-    private
-    val defaultOwner = Any()
-
     override suspend fun WriteContext.encode(value: Closure<*>) {
-        // TODO - should write the owner, delegate and thisObject, replacing project and script references
+        writeReference(findRootOwner(value))
+        writeReference(value.thisObject)
         BeanCodec.run { encode(value.dehydrate()) }
     }
 
-    override suspend fun ReadContext.decode(): Closure<*>? = BeanCodec.run {
-        val closure = decode() as Closure<*>
-        closure.rehydrate(null, defaultOwner, defaultOwner)
+    private
+    fun findRootOwner(value: Any): Any? {
+        return when (value) {
+            is org.gradle.api.Script -> {
+                value
+            }
+
+            is ConfigureDelegate -> {
+                findRootOwner(value._original_owner())
+            }
+
+            is Closure<*> -> {
+                findRootOwner(value.owner)
+            }
+
+            else -> {
+                null
+            }
+        }
+    }
+
+    private
+    suspend fun WriteContext.writeReference(value: Any?) {
+        when (value) {
+            is org.gradle.api.Script -> {
+                // Cannot warn about an unsupported type here, because we don't know whether the closure will attempt to use the script object
+                // and almost every closure in a Groovy build script legitimately has the script as an owner
+                // So instead, warn when the script object is used by the closure when executing
+                write(ScriptReference())
+            }
+
+            else -> {
+                // Discard the value for now
+                write(null)
+            }
+        }
+    }
+
+    override suspend fun ReadContext.decode(): Closure<*> {
+        val owner = readReference()
+        val thisObject = readReference()
+        return BeanCodec.run {
+            decode() as Closure<*>
+        }.rehydrate(null, owner, thisObject)
+    }
+
+    private
+    suspend fun ReadContext.readReference(): Any? {
+        val reference = read()
+        val trace = trace
+        return if (reference is ScriptReference) {
+            BrokenScript(trace, this)
+        } else {
+            reference
+        }
+    }
+
+    private
+    class ScriptReference
+
+    private
+    class BrokenScript(private val trace: PropertyTrace, private val context: IsolateContext) : GroovyObjectSupport() {
+        private
+        val projectMetadata = InvokerHelper.getMetaClass(Project::class.java)
+
+        override fun getProperty(propertyName: String): Any? {
+            if (projectMetadata.hasProperty(null, propertyName) == null) {
+                throw MissingPropertyException(propertyName)
+            }
+            reportReference()
+            throw IllegalStateException("Cannot reference a Gradle script object from a Groovy closure as these are not supported with the configuration cache.")
+        }
+
+        override fun setProperty(propertyName: String, newValue: Any?) {
+            if (projectMetadata.hasProperty(null, propertyName) == null) {
+                throw MissingPropertyException(propertyName)
+            }
+            reportReference()
+            throw IllegalStateException("Cannot reference a Gradle script object from a Groovy closure as these are not supported with the configuration cache.")
+        }
+
+        override fun invokeMethod(name: String, args: Any): Any {
+            if (projectMetadata.respondsTo(null, name).isEmpty()) {
+                throw MissingMethodException(name, Project::class.java, arrayOf())
+            }
+            reportReference()
+            throw IllegalStateException("Cannot reference a Gradle script object from a Groovy closure as these are not supported with the configuration cache.")
+        }
+
+        private
+        fun reportReference() {
+            context.onProblem(PropertyProblem(
+                trace,
+                StructuredMessage.build {
+                    text("cannot reference a Gradle script object from a Groovy closure as these are not support with the configuration cache.")
+                },
+                null,
+                DocumentationSection.RequirementsDisallowedTypes
+            ))
+        }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/AbstractClassLoaderScope.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/AbstractClassLoaderScope.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.initialization;
 
 import org.gradle.api.internal.initialization.loadercache.ClassLoaderCache;
 import org.gradle.initialization.ClassLoaderScopeId;
+import org.gradle.initialization.ClassLoaderScopeOrigin;
 import org.gradle.initialization.ClassLoaderScopeRegistryListener;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.hash.HashCode;
@@ -31,11 +32,14 @@ import java.util.function.Function;
 public abstract class AbstractClassLoaderScope implements ClassLoaderScope {
 
     protected final ClassLoaderScopeIdentifier id;
+    @Nullable
+    protected final ClassLoaderScopeOrigin origin;
     protected final ClassLoaderCache classLoaderCache;
     protected final ClassLoaderScopeRegistryListener listener;
 
-    protected AbstractClassLoaderScope(ClassLoaderScopeIdentifier id, ClassLoaderCache classLoaderCache, ClassLoaderScopeRegistryListener listener) {
+    protected AbstractClassLoaderScope(ClassLoaderScopeIdentifier id, @Nullable ClassLoaderScopeOrigin origin, ClassLoaderCache classLoaderCache, ClassLoaderScopeRegistryListener listener) {
         this.id = id;
+        this.origin = origin;
         this.classLoaderCache = classLoaderCache;
         this.listener = listener;
     }
@@ -45,6 +49,12 @@ public abstract class AbstractClassLoaderScope implements ClassLoaderScope {
      */
     public ClassLoaderScopeId getId() {
         return id;
+    }
+
+    @Nullable
+    @Override
+    public ClassLoaderScopeOrigin getOrigin() {
+        return origin;
     }
 
     /**
@@ -74,12 +84,12 @@ public abstract class AbstractClassLoaderScope implements ClassLoaderScope {
     }
 
     @Override
-    public ClassLoaderScope createChild(String name) {
-        return new DefaultClassLoaderScope(id.child(name), this, classLoaderCache, listener);
+    public ClassLoaderScope createChild(String name, @Nullable ClassLoaderScopeOrigin origin) {
+        return new DefaultClassLoaderScope(id.child(name), this, origin, classLoaderCache, listener);
     }
 
     @Override
-    public ClassLoaderScope createLockedChild(String name, ClassPath localClasspath, @Nullable HashCode classpathImplementationHash, Function<ClassLoader, ClassLoader> localClassLoaderFactory) {
-        return new ImmutableClassLoaderScope(id.child(name), this, localClasspath, classpathImplementationHash, localClassLoaderFactory, classLoaderCache, listener);
+    public ClassLoaderScope createLockedChild(String name, @Nullable ClassLoaderScopeOrigin origin, ClassPath localClasspath, @Nullable HashCode classpathImplementationHash, @Nullable Function<ClassLoader, ClassLoader> localClassLoaderFactory) {
+        return new ImmutableClassLoaderScope(id.child(name), this, origin, localClasspath, classpathImplementationHash, localClassLoaderFactory, classLoaderCache, listener);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/ClassLoaderScope.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/ClassLoaderScope.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.initialization;
 
 import org.gradle.initialization.ClassLoaderScopeId;
+import org.gradle.initialization.ClassLoaderScopeOrigin;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.hash.HashCode;
 
@@ -32,6 +33,9 @@ import java.util.function.Function;
  */
 public interface ClassLoaderScope {
     ClassLoaderScopeId getId();
+
+    @Nullable
+    ClassLoaderScopeOrigin getOrigin();
 
     /**
      * The classloader for use at this node.
@@ -95,12 +99,12 @@ public interface ClassLoaderScope {
      *
      * @param id an identifier for the child loader
      */
-    ClassLoaderScope createChild(String id);
+    ClassLoaderScope createChild(String id, @Nullable ClassLoaderScopeOrigin origin);
 
     /**
      * Creates a child scope that is immutable and ready to use. Uses the given factory to create the local ClassLoader if not already cached. The factory takes a parent ClassLoader and produces a ClassLoader
      */
-    ClassLoaderScope createLockedChild(String id, ClassPath localClasspath, @Nullable HashCode classpathImplementationHash, @Nullable Function<ClassLoader, ClassLoader> localClassLoaderFactory);
+    ClassLoaderScope createLockedChild(String id, @Nullable ClassLoaderScopeOrigin origin, ClassPath localClasspath, @Nullable HashCode classpathImplementationHash, @Nullable Function<ClassLoader, ClassLoader> localClassLoaderFactory);
 
     /**
      * Signal that no more modifications are to come, allowing the structure to be optimised if possible.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultClassLoaderScope.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultClassLoaderScope.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.initialization;
 
 import org.gradle.api.internal.initialization.loadercache.ClassLoaderCache;
 import org.gradle.api.internal.initialization.loadercache.ClassLoaderId;
+import org.gradle.initialization.ClassLoaderScopeOrigin;
 import org.gradle.initialization.ClassLoaderScopeRegistryListener;
 import org.gradle.internal.classloader.CachingClassLoader;
 import org.gradle.internal.classloader.MultiParentClassLoader;
@@ -48,10 +49,10 @@ public class DefaultClassLoaderScope extends AbstractClassLoaderScope {
     private ClassLoader effectiveLocalClassLoader;
     private ClassLoader effectiveExportClassLoader;
 
-    public DefaultClassLoaderScope(ClassLoaderScopeIdentifier id, ClassLoaderScope parent, ClassLoaderCache classLoaderCache, ClassLoaderScopeRegistryListener listener) {
-        super(id, classLoaderCache, listener);
+    public DefaultClassLoaderScope(ClassLoaderScopeIdentifier id, ClassLoaderScope parent, @Nullable ClassLoaderScopeOrigin origin, ClassLoaderCache classLoaderCache, ClassLoaderScopeRegistryListener listener) {
+        super(id, origin, classLoaderCache, listener);
         this.parent = parent;
-        listener.childScopeCreated(parent.getId(), id);
+        listener.childScopeCreated(parent.getId(), id, origin);
     }
 
     private ClassLoader loader(ClassLoaderId id, ClassLoader parent, ClassPath classPath, @Nullable List<ClassLoader> additionalLoaders) {
@@ -232,7 +233,7 @@ public class DefaultClassLoaderScope extends AbstractClassLoaderScope {
     @Override
     public void onReuse() {
         parent.onReuse();
-        listener.childScopeCreated(parent.getId(), id);
+        listener.childScopeCreated(parent.getId(), id, origin);
         if (!export.isEmpty()) {
             listener.classloaderCreated(this.id, id.exportId(), effectiveExportClassLoader, export, null);
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/ImmutableClassLoaderScope.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/ImmutableClassLoaderScope.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.initialization;
 
 import org.gradle.api.internal.initialization.loadercache.ClassLoaderCache;
 import org.gradle.api.internal.initialization.loadercache.ClassLoaderId;
+import org.gradle.initialization.ClassLoaderScopeOrigin;
 import org.gradle.initialization.ClassLoaderScopeRegistryListener;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.hash.HashCode;
@@ -35,13 +36,21 @@ public class ImmutableClassLoaderScope extends AbstractClassLoaderScope {
     private final HashCode classpathImplementationHash;
     private final ClassLoader localClassLoader;
 
-    public ImmutableClassLoaderScope(ClassLoaderScopeIdentifier id, ClassLoaderScope parent, ClassPath classPath, @Nullable HashCode classpathImplementationHash,
-                                     @Nullable Function<ClassLoader, ClassLoader> localClassLoaderFactory, ClassLoaderCache classLoaderCache, ClassLoaderScopeRegistryListener listener) {
-        super(id, classLoaderCache, listener);
+    public ImmutableClassLoaderScope(
+        ClassLoaderScopeIdentifier id,
+        ClassLoaderScope parent,
+        @Nullable ClassLoaderScopeOrigin origin,
+        ClassPath classPath,
+        @Nullable HashCode classpathImplementationHash,
+        @Nullable Function<ClassLoader, ClassLoader> localClassLoaderFactory,
+        ClassLoaderCache classLoaderCache,
+        ClassLoaderScopeRegistryListener listener
+    ) {
+        super(id, origin, classLoaderCache, listener);
         this.parent = parent;
         this.classPath = classPath;
         this.classpathImplementationHash = classpathImplementationHash;
-        listener.childScopeCreated(parent.getId(), id);
+        listener.childScopeCreated(parent.getId(), id, origin);
         ClassLoaderId classLoaderId = id.localId();
         if (localClassLoaderFactory != null) {
             localClassLoader = classLoaderCache.createIfAbsent(classLoaderId, classPath, parent.getExportClassLoader(), localClassLoaderFactory, classpathImplementationHash);
@@ -74,7 +83,7 @@ public class ImmutableClassLoaderScope extends AbstractClassLoaderScope {
     @Override
     public void onReuse() {
         parent.onReuse();
-        listener.childScopeCreated(parent.getId(), id);
+        listener.childScopeCreated(parent.getId(), id, origin);
         listener.classloaderCreated(id, id.localId(), localClassLoader, classPath, classpathImplementationHash);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/RootClassLoaderScope.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/RootClassLoaderScope.java
@@ -28,7 +28,7 @@ public class RootClassLoaderScope extends AbstractClassLoaderScope {
     private final CachingClassLoader cachingExportClassLoader;
 
     public RootClassLoaderScope(String name, ClassLoader localClassLoader, ClassLoader exportClassLoader, ClassLoaderCache classLoaderCache, ClassLoaderScopeRegistryListener listener) {
-        super(new ClassLoaderScopeIdentifier(null, name), classLoaderCache, listener);
+        super(new ClassLoaderScopeIdentifier(null, name), null, classLoaderCache, listener);
         this.localClassLoader = localClassLoader;
         this.cachingLocalClassLoader = new CachingClassLoader(localClassLoader);
         this.exportClassLoader = exportClassLoader;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultObjectConfigurationAction.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultObjectConfigurationAction.java
@@ -149,7 +149,7 @@ public class DefaultObjectConfigurationAction implements ObjectConfigurationActi
             resource = textUriFileResourceLoaderFactory.create(redirectVerifier).loadUri("script", scriptUri);
         }
         ScriptSource scriptSource = new TextResourceScriptSource(resource);
-        ClassLoaderScope classLoaderScopeChild = classLoaderScope.createChild("script-" + scriptUri.toString());
+        ClassLoaderScope classLoaderScopeChild = classLoaderScope.createChild("script-" + scriptUri, null);
         ScriptHandler scriptHandler = scriptHandlerFactory.create(scriptSource, classLoaderScopeChild);
         ScriptPlugin configurer = configurerFactory.create(scriptSource, scriptHandler, classLoaderScopeChild, classLoaderScope, false);
         for (Object target : targets) {

--- a/subprojects/core/src/main/java/org/gradle/configuration/BuildTreePreparingProjectsPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/BuildTreePreparingProjectsPreparer.java
@@ -49,7 +49,7 @@ public class BuildTreePreparingProjectsPreparer implements ProjectsPreparer {
         // Setup classloader for root project, all other projects will be derived from this.
         SettingsInternal settings = gradle.getSettings();
         ClassLoaderScope settingsClassLoaderScope = settings.getClassLoaderScope();
-        ClassLoaderScope buildSrcClassLoaderScope = settingsClassLoaderScope.createChild("buildSrc[" + gradle.getIdentityPath() + "]");
+        ClassLoaderScope buildSrcClassLoaderScope = settingsClassLoaderScope.createChild("buildSrc[" + gradle.getIdentityPath() + "]", null);
         gradle.setBaseProjectClassLoaderScope(buildSrcClassLoaderScope);
         generateDependenciesAccessorsAndAssignPluginVersions(gradle.getServices(), settings, buildSrcClassLoaderScope);
         // attaches root project

--- a/subprojects/core/src/main/java/org/gradle/configuration/DefaultInitScriptProcessor.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/DefaultInitScriptProcessor.java
@@ -44,7 +44,7 @@ public class DefaultInitScriptProcessor implements InitScriptProcessor {
         ClassLoaderScope baseScope = gradle.getClassLoaderScope();
         URI uri = initScript.getResource().getLocation().getURI();
         String id = uri == null ? idGenerator.generateId().toString() : uri.toString();
-        ClassLoaderScope scriptScope = baseScope.createChild("init-" + id);
+        ClassLoaderScope scriptScope = baseScope.createChild("init-" + id, null);
         ScriptHandler scriptHandler = scriptHandlerFactory.create(initScript, scriptScope);
         ScriptPlugin configurer = configurerFactory.create(initScript, scriptHandler, scriptScope, baseScope, true);
         configurer.apply(gradle);

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/BasicScript.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/BasicScript.java
@@ -36,7 +36,7 @@ import java.util.Map;
 public abstract class BasicScript extends org.gradle.groovy.scripts.Script implements org.gradle.api.Script, DynamicObjectAware, GradleScript {
     private StandardOutputCapture standardOutputCapture;
     private Object target;
-    private ScriptDynamicObject dynamicObject = new ScriptDynamicObject(this);
+    private final ScriptDynamicObject dynamicObject = new ScriptDynamicObject(this);
     private DynamicLookupRoutine dynamicLookupRoutine;
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/DefaultScriptCompilationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/DefaultScriptCompilationHandler.java
@@ -37,6 +37,7 @@ import org.gradle.configuration.ImportsReader;
 import org.gradle.groovy.scripts.ScriptCompilationException;
 import org.gradle.groovy.scripts.ScriptSource;
 import org.gradle.groovy.scripts.Transformer;
+import org.gradle.initialization.ClassLoaderScopeOrigin;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.classloader.ClassLoaderUtils;
 import org.gradle.internal.classloader.ImplementationHashAware;
@@ -268,8 +269,6 @@ public class DefaultScriptCompilationHandler implements ScriptCompilationHandler
         }
     }
 
-
-
     private static class ClassesDirCompiledScript<T extends Script, M> implements CompiledScript<T, M> {
         private final boolean isEmpty;
         private final boolean hasMethods;
@@ -339,7 +338,8 @@ public class DefaultScriptCompilationHandler implements ScriptCompilationHandler
 
         private ClassLoaderScope prepareClassLoaderScope() {
             String scopeName = "groovy-dsl:" + source.getFileName() + ":" + scriptBaseClass.getSimpleName();
-            return targetScope.createLockedChild(scopeName, scriptClassPath, sourceHashCode, parent -> new ScriptClassLoader(source, parent, scriptClassPath, sourceHashCode));
+            ClassLoaderScopeOrigin origin = new ClassLoaderScopeOrigin.Script(source.getFileName(), source.getDisplayName());
+            return targetScope.createLockedChild(scopeName, origin, scriptClassPath, sourceHashCode, parent -> new ScriptClassLoader(source, parent, scriptClassPath, sourceHashCode));
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/ClassLoaderScopeOrigin.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/ClassLoaderScopeOrigin.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.initialization;
+
+/**
+ * Details about the origin of the contents of the ClassLoader scope.
+ */
+public interface ClassLoaderScopeOrigin {
+    class Script implements ClassLoaderScopeOrigin {
+        private final String fileName;
+        private final String displayName;
+
+        public Script(String fileName, String displayName) {
+            this.fileName = fileName;
+            this.displayName = displayName;
+        }
+
+        public String getFileName() {
+            return fileName;
+        }
+
+        public String getDisplayName() {
+            return displayName;
+        }
+
+        @Override
+        public int hashCode() {
+            return fileName.hashCode() ^ displayName.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+            if (obj == null || obj.getClass() != getClass()) {
+                return false;
+            }
+            Script other = (Script) obj;
+            return fileName.equals(other.fileName) && displayName.equals(other.displayName);
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/initialization/ClassLoaderScopeRegistryListener.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/ClassLoaderScopeRegistryListener.java
@@ -35,7 +35,7 @@ import javax.annotation.Nullable;
 @EventScope(Scopes.UserHome.class)
 public interface ClassLoaderScopeRegistryListener {
 
-    void childScopeCreated(ClassLoaderScopeId parentId, ClassLoaderScopeId childId);
+    void childScopeCreated(ClassLoaderScopeId parentId, ClassLoaderScopeId childId, @Nullable ClassLoaderScopeOrigin origin);
 
     void classloaderCreated(ClassLoaderScopeId scopeId, ClassLoaderId classLoaderId, ClassLoader classLoader, ClassPath classPath, @Nullable HashCode implementationHash);
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/InstantiatingBuildLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/InstantiatingBuildLoader.java
@@ -37,7 +37,7 @@ public class InstantiatingBuildLoader implements BuildLoader {
 
     private void createProjects(GradleInternal gradle, DefaultProjectDescriptor rootProjectDescriptor) {
         ClassLoaderScope baseProjectClassLoaderScope = gradle.baseProjectClassLoaderScope();
-        ClassLoaderScope rootProjectClassLoaderScope = baseProjectClassLoaderScope.createChild("root-project[" + gradle.getIdentityPath() + "]");
+        ClassLoaderScope rootProjectClassLoaderScope = baseProjectClassLoaderScope.createChild("root-project[" + gradle.getIdentityPath() + "]", null);
 
         ProjectState projectState = gradle.getOwner().getProjects().getProject(rootProjectDescriptor.path());
         projectState.createMutableModel(rootProjectClassLoaderScope, baseProjectClassLoaderScope);
@@ -49,7 +49,7 @@ public class InstantiatingBuildLoader implements BuildLoader {
 
     private void createChildProjectsRecursively(BuildState owner, DefaultProjectDescriptor parentProjectDescriptor, ClassLoaderScope parentProjectClassLoaderScope, ClassLoaderScope baseProjectClassLoaderScope) {
         for (DefaultProjectDescriptor childProjectDescriptor : parentProjectDescriptor.children()) {
-            ClassLoaderScope childProjectClassLoaderScope = parentProjectClassLoaderScope.createChild("project-" + childProjectDescriptor.getName());
+            ClassLoaderScope childProjectClassLoaderScope = parentProjectClassLoaderScope.createChild("project-" + childProjectDescriptor.getName(), null);
             ProjectState projectState = owner.getProjects().getProject(childProjectDescriptor.path());
             projectState.createMutableModel(childProjectClassLoaderScope, baseProjectClassLoaderScope);
             createChildProjectsRecursively(owner, childProjectDescriptor, childProjectClassLoaderScope, baseProjectClassLoaderScope);

--- a/subprojects/core/src/main/java/org/gradle/initialization/SettingsFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/SettingsFactory.java
@@ -53,7 +53,7 @@ public class SettingsFactory {
         StartParameter startParameter,
         ClassLoaderScope baseClassLoaderScope
     ) {
-        ClassLoaderScope classLoaderScope = baseClassLoaderScope.createChild("settings[" + gradle.getIdentityPath() + "]");
+        ClassLoaderScope classLoaderScope = baseClassLoaderScope.createChild("settings[" + gradle.getIdentityPath() + "]", null);
         DefaultSettings settings = instantiator.newInstance(
             DefaultSettings.class,
             serviceRegistryFactory,

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeScopeServices.java
@@ -30,6 +30,7 @@ import org.gradle.execution.selection.DefaultBuildTaskSelector;
 import org.gradle.initialization.BuildOptionBuildOperationProgressEventsEmitter;
 import org.gradle.initialization.exception.DefaultExceptionAnalyser;
 import org.gradle.initialization.exception.ExceptionAnalyser;
+import org.gradle.initialization.exception.ExceptionCollector;
 import org.gradle.initialization.exception.MultipleBuildFailuresExceptionAnalyser;
 import org.gradle.initialization.exception.StackTraceSanitizingExceptionAnalyser;
 import org.gradle.internal.build.DefaultBuildLifecycleControllerFactory;
@@ -38,7 +39,6 @@ import org.gradle.internal.buildoption.DefaultInternalOptions;
 import org.gradle.internal.buildoption.InternalOptions;
 import org.gradle.internal.enterprise.core.GradleEnterprisePluginManager;
 import org.gradle.internal.event.DefaultListenerManager;
-import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.scopes.PluginServiceRegistry;
 import org.gradle.internal.service.scopes.Scopes;
@@ -72,6 +72,7 @@ public class BuildTreeScopeServices {
         registration.add(DeprecationsReporter.class);
         registration.add(TaskPathProjectEvaluator.class);
         registration.add(DefaultFeatureFlags.class);
+        registration.add(DefaultExceptionAnalyser.class);
         modelServices.applyServicesTo(registration);
     }
 
@@ -87,8 +88,8 @@ public class BuildTreeScopeServices {
         return parent.createChild(Scopes.BuildTree.class);
     }
 
-    protected ExceptionAnalyser createExceptionAnalyser(ListenerManager listenerManager, LoggingConfiguration loggingConfiguration) {
-        ExceptionAnalyser exceptionAnalyser = new MultipleBuildFailuresExceptionAnalyser(new DefaultExceptionAnalyser(listenerManager));
+    protected ExceptionAnalyser createExceptionAnalyser(LoggingConfiguration loggingConfiguration, ExceptionCollector exceptionCollector) {
+        ExceptionAnalyser exceptionAnalyser = new MultipleBuildFailuresExceptionAnalyser(exceptionCollector);
         if (loggingConfiguration.getShowStacktrace() != ShowStacktrace.ALWAYS_FULL) {
             exceptionAnalyser = new StackTraceSanitizingExceptionAnalyser(exceptionAnalyser);
         }

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
@@ -89,7 +89,7 @@ public class ProjectBuilderImpl {
         descriptorRegistry.addProject(projectDescriptor);
 
         ProjectState projectState = parentProject.getServices().get(ProjectStateRegistry.class).registerProject(parentProject.getServices().get(BuildState.class), projectDescriptor);
-        projectState.createMutableModel(parentProject.getClassLoaderScope().createChild("project-" + name), parentProject.getBaseClassLoaderScope());
+        projectState.createMutableModel(parentProject.getClassLoaderScope().createChild("project-" + name, null), parentProject.getBaseClassLoaderScope());
         ProjectInternal project = projectState.getMutableModel();
 
         // Lock the project, these won't ever be released as ProjectBuilder has no lifecycle
@@ -133,7 +133,7 @@ public class ProjectBuilderImpl {
         projectDescriptorRegistry.addProject(projectDescriptor);
 
         ClassLoaderScope baseScope = gradle.getClassLoaderScope();
-        ClassLoaderScope rootProjectScope = baseScope.createChild("root-project");
+        ClassLoaderScope rootProjectScope = baseScope.createChild("root-project", null);
 
         ProjectStateRegistry projectStateRegistry = buildServices.get(ProjectStateRegistry.class);
         ProjectState projectState = projectStateRegistry.registerProject(build, projectDescriptor);

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultClassLoaderScopeTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultClassLoaderScopeTest.groovy
@@ -44,7 +44,7 @@ class DefaultClassLoaderScopeTest extends Specification {
         file("root/root") << "root"
         def rootClassLoader = new URLClassLoader(classPath("root").asURLArray, getClass().classLoader.parent)
         root = new RootClassLoaderScope("root", rootClassLoader, rootClassLoader, classLoaderCache, Stub(ClassLoaderScopeRegistryListener))
-        scope = root.createChild("child")
+        scope = root.createChild("child", null)
     }
 
     TestFile file(String path) {
@@ -247,7 +247,7 @@ class DefaultClassLoaderScopeTest extends Specification {
         file("export/export") << "bar"
         scope.local(classPath("local"))
         scope.export(classPath("export"))
-        def child = scope.lock().createChild("child").lock()
+        def child = scope.lock().createChild("child", null).lock()
 
         then:
         child.localClassLoader.getResource("root").text == "root"
@@ -264,17 +264,17 @@ class DefaultClassLoaderScopeTest extends Specification {
         def c2 = classPath("c2")
 
         when:
-        def scope1 = root.createChild("child1").export(c1).local(c2).lock()
+        def scope1 = root.createChild("child1", null).export(c1).local(c2).lock()
         scope1.exportClassLoader
 
-        def scope2 = root.createChild("child2").export(c1).local(c2).lock()
+        def scope2 = root.createChild("child2", null).export(c1).local(c2).lock()
         scope2.exportClassLoader
 
         then:
         scope1.exportClassLoader.is scope2.exportClassLoader
 
         when:
-        def child = scope1.createChild("child").export(c1).local(c2).lock()
+        def child = scope1.createChild("child", null).export(c1).local(c2).lock()
         child.exportClassLoader
 
         then:
@@ -301,31 +301,31 @@ class DefaultClassLoaderScopeTest extends Specification {
         def c2 = classPath("c2")
 
         when:
-        root.createChild("c").local(c1).export(c2).lock().exportClassLoader
+        root.createChild("c", null).local(c1).export(c2).lock().exportClassLoader
 
         then:
         classLoaderCache.size() == 2
 
         when:
-        root.createChild("d").local(c1).export(c2).lock().exportClassLoader
+        root.createChild("d", null).local(c1).export(c2).lock().exportClassLoader
 
         then:
         classLoaderCache.size() == 2
 
         when:
-        root.createChild("c").local(c1).lock().exportClassLoader
+        root.createChild("c", null).local(c1).lock().exportClassLoader
 
         then:
         classLoaderCache.size() == 3 // c has a local, d has export and local
 
         when:
-        root.createChild("d").lock().exportClassLoader
+        root.createChild("d", null).lock().exportClassLoader
 
         then:
         classLoaderCache.size() == 1
 
         when:
-        root.createChild("c").lock().exportClassLoader
+        root.createChild("c", null).lock().exportClassLoader
 
         then:
         classLoaderCache.size() == 0

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultObjectConfigurationActionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultObjectConfigurationActionTest.groovy
@@ -51,7 +51,7 @@ class DefaultObjectConfigurationActionTest extends Specification {
     void appliesScriptsToDefaultTargetObject() {
         given:
         1 * resolver.resolveUri('script') >> file
-        1 * parentCompileScope.createChild("script-$file") >> scriptCompileScope
+        1 * parentCompileScope.createChild("script-$file", null) >> scriptCompileScope
         1 * scriptHandlerFactory.create(_, scriptCompileScope) >> scriptHandler
         1 * scriptPluginFactory.create(_, scriptHandler, scriptCompileScope, parentCompileScope, false) >> configurer
 
@@ -71,7 +71,7 @@ class DefaultObjectConfigurationActionTest extends Specification {
         1 * scriptPluginFactory.create(_, scriptHandler, scriptCompileScope, parentCompileScope, false) >> configurer
         1 * configurer.apply(target1)
         1 * configurer.apply(target2)
-        1 * parentCompileScope.createChild("script-$file") >> scriptCompileScope
+        1 * parentCompileScope.createChild("script-$file", null) >> scriptCompileScope
 
         then:
         action.from('script')
@@ -89,7 +89,7 @@ class DefaultObjectConfigurationActionTest extends Specification {
         1 * scriptPluginFactory.create(_, scriptHandler, scriptCompileScope, parentCompileScope, false) >> configurer
         1 * configurer.apply(target1)
         1 * configurer.apply(target2)
-        1 * parentCompileScope.createChild("script-$file") >> scriptCompileScope
+        1 * parentCompileScope.createChild("script-$file", null) >> scriptCompileScope
 
         then:
         action.from('script')

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
@@ -165,7 +165,7 @@ class DefaultProjectTest extends Specification {
     DependencyResolutionManagementInternal dependencyResolutionManagement = Stub(DependencyResolutionManagementInternal)
     CrossProjectConfigurator crossProjectConfigurator = new BuildOperationCrossProjectConfigurator(buildOperationExecutor)
     ClassLoaderScope baseClassLoaderScope = new RootClassLoaderScope("root", getClass().classLoader, getClass().classLoader, new DummyClassLoaderCache(), Stub(ClassLoaderScopeRegistryListener))
-    ClassLoaderScope rootProjectClassLoaderScope = baseClassLoaderScope.createChild("root-project")
+    ClassLoaderScope rootProjectClassLoaderScope = baseClassLoaderScope.createChild("root-project", null)
     ObjectFactory objectFactory = new DefaultObjectFactory(instantiatorMock, Stub(NamedObjectInstantiator), Stub(DirectoryFileTreeFactory),  TestFiles.patternSetFactory,  new DefaultPropertyFactory(Stub(PropertyHost)), Stub(FilePropertyFactory), TestFiles.taskDependencyFactory(), Stub(FileCollectionFactory), Stub(DomainObjectCollectionFactory))
 
     def setup() {
@@ -257,15 +257,15 @@ class DefaultProjectTest extends Specification {
         projectState = Mock(ProjectState)
         projectState.name >> 'root'
         project = defaultProject('root', projectState, null, rootDir, rootProjectClassLoaderScope)
-        def child1ClassLoaderScope = rootProjectClassLoaderScope.createChild("project-child1")
+        def child1ClassLoaderScope = rootProjectClassLoaderScope.createChild("project-child1", null)
         child1State = Mock(ProjectState)
         child1 = defaultProject("child1", child1State, project, new File("child1"), child1ClassLoaderScope)
         child1State.mutableModel >> child1
         child1State.name >> "child1"
         chilchildState = Mock(ProjectState)
-        childchild = defaultProject("childchild", chilchildState, child1, new File("childchild"), child1ClassLoaderScope.createChild("project-childchild"))
+        childchild = defaultProject("childchild", chilchildState, child1, new File("childchild"), child1ClassLoaderScope.createChild("project-childchild", null))
         child2State = Mock(ProjectState)
-        child2 = defaultProject("child2", child2State, project, new File("child2"), rootProjectClassLoaderScope.createChild("project-child2"))
+        child2 = defaultProject("child2", child2State, project, new File("child2"), rootProjectClassLoaderScope.createChild("project-child2", null))
         child2State.mutableModel >> child2
         child2State.name >> "child2"
         projectState.childProjects >> ([child1State, child2State] as Set)

--- a/subprojects/core/src/test/groovy/org/gradle/configuration/DefaultInitScriptProcessorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/configuration/DefaultInitScriptProcessorTest.groovy
@@ -45,7 +45,7 @@ class DefaultInitScriptProcessorTest extends Specification {
         def scriptPlugin = Mock(ScriptPlugin)
 
         1 * gradleMock.getClassLoaderScope() >> gradleScope
-        1 * gradleScope.createChild("init-$uri") >> siblingScope
+        1 * gradleScope.createChild("init-$uri", null) >> siblingScope
 
         1 * scriptHandlerFactory.create(initScriptMock, siblingScope) >> scriptHandler
         1 * scriptPluginFactory.create(initScriptMock, scriptHandler, siblingScope, gradleScope, true) >> scriptPlugin

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/InstantiatingBuildLoaderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/InstantiatingBuildLoaderTest.groovy
@@ -56,7 +56,7 @@ class InstantiatingBuildLoaderTest extends Specification {
 
     def rootProjectClassLoaderScope = Mock(ClassLoaderScope)
     def baseProjectClassLoaderScope = Mock(ClassLoaderScope) {
-        1 * createChild("root-project[:]") >> rootProjectClassLoaderScope
+        1 * createChild("root-project[:]", null) >> rootProjectClassLoaderScope
     }
 
     @Rule
@@ -121,7 +121,7 @@ class InstantiatingBuildLoaderTest extends Specification {
         buildLoader.load(settingsInternal, gradle)
 
         then:
-        1 * rootProjectClassLoaderScope.createChild(_) >> childProjectClassLoaderScope
+        1 * rootProjectClassLoaderScope.createChild(_, _) >> childProjectClassLoaderScope
         1 * rootProjectState.mutableModel >> rootProject
         1 * rootProjectState.createMutableModel(rootProjectClassLoaderScope, baseProjectClassLoaderScope)
         1 * childProjectState.createMutableModel(childProjectClassLoaderScope, baseProjectClassLoaderScope)

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/SettingsFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/SettingsFactoryTest.groovy
@@ -58,7 +58,7 @@ class SettingsFactoryTest extends Specification {
         1 * settingsServices.get(DependencyResolutionManagementInternal) >> Stub(DependencyResolutionManagementInternal)
         1 * projectDescriptorRegistry.addProject(_ as DefaultProjectDescriptor)
         1 * scriptHandlerFactory.create(scriptSource, _ as ClassLoaderScope) >> Mock(ScriptHandlerInternal)
-        1 * scope.createChild(_) >> scope
+        1 * scope.createChild(_, _) >> scope
         1 * gradleProperties.mergeProperties(_) >> ['myKey': 'myValue']
 
         when:

--- a/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/GeneratePrecompiledScriptPluginAccessors.kt
+++ b/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/GeneratePrecompiledScriptPluginAccessors.kt
@@ -331,13 +331,13 @@ abstract class GeneratePrecompiledScriptPluginAccessors @Inject internal constru
             controller.withEmptyBuild { settings ->
                 Try.ofFailable {
                     val gradle = settings.gradle
-                    val baseScope = classLoaderScopeRegistry.coreAndPluginsScope.createChild("accessors-classpath").apply {
+                    val baseScope = classLoaderScopeRegistry.coreAndPluginsScope.createChild("accessors-classpath", null).apply {
                         // we export the build logic classpath to the base scope here so that all referenced plugins
                         // can be resolved in the root project scope created below.
                         export(buildLogicClassPath)
                         lock()
                     }
-                    val rootProjectScope = baseScope.createChild("accessors-root-project")
+                    val rootProjectScope = baseScope.createChild("accessors-root-project", null)
                     settings.rootProject.name = "gradle-kotlin-dsl-accessors"
                     val projectState = gradle.serviceOf<ProjectStateRegistry>().registerProject(gradle.owner, settings.rootProject as DefaultProjectDescriptor)
                     projectState.createMutableModel(rootProjectScope, baseScope)

--- a/subprojects/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptModelBuilder.kt
+++ b/subprojects/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptModelBuilder.kt
@@ -345,7 +345,7 @@ fun compilationClassPathForScriptPluginOf(
 ): Pair<ScriptHandlerInternal, ClassPath> {
 
     val scriptSource = textResourceScriptSource(resourceDescription, scriptFile, project.serviceOf())
-    val scriptScope = baseScope.createChild("model-${scriptFile.toURI()}")
+    val scriptScope = baseScope.createChild("model-${scriptFile.toURI()}", null)
     val scriptHandler = scriptHandlerFactory.create(scriptSource, scriptScope)
 
     kotlinScriptFactoryOf(project).evaluate(

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/Interpreter.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/Interpreter.kt
@@ -28,6 +28,7 @@ import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.invocation.Gradle
 import org.gradle.groovy.scripts.ScriptSource
+import org.gradle.initialization.ClassLoaderScopeOrigin
 import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.exceptions.LocationAwareException
 import org.gradle.internal.hash.HashCode
@@ -113,6 +114,7 @@ class Interpreter(val host: Host) {
         fun loadClassInChildScopeOf(
             classLoaderScope: ClassLoaderScope,
             childScopeId: String,
+            origin: ClassLoaderScopeOrigin,
             location: File,
             className: String,
             accessorsClassPath: ClassPath
@@ -366,6 +368,7 @@ class Interpreter(val host: Host) {
         return host.loadClassInChildScopeOf(
             baseScope,
             childScopeId = classLoaderScopeIdFor(scriptPath, scriptTemplateId),
+            origin = ClassLoaderScopeOrigin.Script(scriptSource.fileName, scriptSource.displayName),
             accessorsClassPath = accessorsClassPath,
             location = classesDir,
             className = "Program"

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptEvaluator.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptEvaluator.kt
@@ -26,6 +26,7 @@ import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.cache.CacheOpenException
 import org.gradle.groovy.scripts.ScriptSource
 import org.gradle.groovy.scripts.internal.ScriptSourceHasher
+import org.gradle.initialization.ClassLoaderScopeOrigin
 import org.gradle.internal.classloader.ClasspathHasher
 import org.gradle.internal.classpath.CachedClasspathTransformer
 import org.gradle.internal.classpath.CachedClasspathTransformer.StandardTransform.BuildLogic
@@ -261,13 +262,14 @@ class StandardKotlinScriptEvaluator(
         override fun loadClassInChildScopeOf(
             classLoaderScope: ClassLoaderScope,
             childScopeId: String,
+            origin: ClassLoaderScopeOrigin,
             location: File,
             className: String,
             accessorsClassPath: ClassPath
         ): CompiledScript {
             val instrumentedClasses = cachedClasspathTransformer.transform(DefaultClassPath.of(location), BuildLogic)
             val classpath = instrumentedClasses.plus(accessorsClassPath)
-            return ScopeBackedCompiledScript(classLoaderScope, childScopeId, classpath, className)
+            return ScopeBackedCompiledScript(classLoaderScope, childScopeId, origin, classpath, className)
         }
 
         override val implicitImports: List<String>
@@ -286,6 +288,7 @@ class StandardKotlinScriptEvaluator(
     class ScopeBackedCompiledScript(
         private val classLoaderScope: ClassLoaderScope,
         private val childScopeId: String,
+        private val origin: ClassLoaderScopeOrigin,
         override val classPath: ClassPath,
         private val className: String
     ) : CompiledScript {
@@ -317,6 +320,7 @@ class StandardKotlinScriptEvaluator(
         fun prepareClassLoaderScope() =
             classLoaderScope.createLockedChild(
                 childScopeId,
+                origin,
                 classPath,
                 null,
                 null

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/InterpreterTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/InterpreterTest.kt
@@ -27,6 +27,7 @@ import org.gradle.api.initialization.Settings
 import org.gradle.api.internal.file.temp.GradleUserHomeTemporaryFileProvider
 import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.groovy.scripts.ScriptSource
+import org.gradle.initialization.ClassLoaderScopeOrigin
 import org.gradle.internal.Describables
 import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.hash.TestHashCodes
@@ -50,6 +51,8 @@ class InterpreterTest : TestWithTempFiles() {
         val scriptPath =
             "/src/settings.gradle.kts"
 
+        val scriptSourceDisplayName = "source display name"
+
         val text = """
 
             buildscript {
@@ -70,12 +73,12 @@ class InterpreterTest : TestWithTempFiles() {
         val scriptSourceResource = mock<TextResource> {
             on { getText() } doReturn text
         }
-        val scriptSourceDisplayName = "source display name"
 
         val scriptSource = mock<ScriptSource> {
             on { fileName } doReturn scriptPath
             on { resource } doReturn scriptSourceResource
             on { shortDisplayName } doReturn Describables.of(scriptSourceDisplayName)
+            on { displayName } doReturn scriptSourceDisplayName
         }
         val parentClassLoader = mock<ClassLoader>()
         val baseScope = mock<ClassLoaderScope> {
@@ -146,11 +149,11 @@ class InterpreterTest : TestWithTempFiles() {
             }
 
             on {
-                loadClassInChildScopeOf(any(), any(), any(), any(), same(ClassPath.EMPTY))
+                loadClassInChildScopeOf(any(), any(), any(), any(), any(), same(ClassPath.EMPTY))
             } doAnswer {
 
-                val location = it.getArgument<File>(2)
-                val className = it.getArgument<String>(3)
+                val location = it.getArgument<File>(3)
+                val className = it.getArgument<String>(4)
 
                 val newLocation = relocate(location)
 
@@ -194,6 +197,7 @@ class InterpreterTest : TestWithTempFiles() {
                 verify(host).loadClassInChildScopeOf(
                     baseScope,
                     "kotlin-dsl:$scriptPath:$stage1TemplateId",
+                    ClassLoaderScopeOrigin.Script(scriptPath, scriptSourceDisplayName),
                     stage1CacheDir,
                     "Program",
                     ClassPath.EMPTY
@@ -218,6 +222,7 @@ class InterpreterTest : TestWithTempFiles() {
                 verify(host).loadClassInChildScopeOf(
                     targetScope,
                     "kotlin-dsl:$scriptPath:$stage2TemplateId",
+                    ClassLoaderScopeOrigin.Script(scriptPath, scriptSourceDisplayName),
                     stage2CacheDir,
                     "Program",
                     ClassPath.EMPTY

--- a/subprojects/kotlin-dsl/src/testFixtures/kotlin/org/gradle/kotlin/dsl/fixtures/SimplifiedKotlinScriptEvaluator.kt
+++ b/subprojects/kotlin-dsl/src/testFixtures/kotlin/org/gradle/kotlin/dsl/fixtures/SimplifiedKotlinScriptEvaluator.kt
@@ -23,6 +23,7 @@ import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.configuration.DefaultImportsReader
 import org.gradle.groovy.scripts.ScriptSource
+import org.gradle.initialization.ClassLoaderScopeOrigin
 import org.gradle.internal.Describables
 import org.gradle.internal.classloader.ClasspathUtil
 import org.gradle.internal.classpath.ClassPath
@@ -172,6 +173,7 @@ class SimplifiedKotlinScriptEvaluator(
         override fun loadClassInChildScopeOf(
             classLoaderScope: ClassLoaderScope,
             childScopeId: String,
+            origin: ClassLoaderScopeOrigin,
             location: File,
             className: String,
             accessorsClassPath: ClassPath

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/SessionFailureReportingActionExecuter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/SessionFailureReportingActionExecuter.java
@@ -27,9 +27,7 @@ import org.gradle.initialization.exception.StackTraceSanitizingExceptionAnalyser
 import org.gradle.internal.buildevents.BuildLogger;
 import org.gradle.internal.buildevents.BuildLoggerFactory;
 import org.gradle.internal.buildevents.BuildStartedTime;
-import org.gradle.internal.event.DefaultListenerManager;
 import org.gradle.internal.invocation.BuildAction;
-import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.launcher.exec.BuildActionExecuter;
 import org.gradle.launcher.exec.BuildActionParameters;
 import org.gradle.launcher.exec.BuildActionResult;
@@ -54,7 +52,7 @@ public class SessionFailureReportingActionExecuter implements BuildActionExecute
             // TODO - wire this stuff in properly
 
             // Sanitise the exception and report it
-            ExceptionAnalyser exceptionAnalyser = new MultipleBuildFailuresExceptionAnalyser(new DefaultExceptionAnalyser(new DefaultListenerManager(Scopes.BuildSession.class)));
+            ExceptionAnalyser exceptionAnalyser = new MultipleBuildFailuresExceptionAnalyser(new DefaultExceptionAnalyser(null));
             if (action.getStartParameter().getShowStacktrace() != ShowStacktrace.ALWAYS_FULL) {
                 exceptionAnalyser = new StackTraceSanitizingExceptionAnalyser(exceptionAnalyser);
             }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/metaobject/ConfigureDelegate.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/metaobject/ConfigureDelegate.java
@@ -26,14 +26,12 @@ public class ConfigureDelegate extends GroovyObjectSupport {
     protected final DynamicObject _owner;
     protected final DynamicObject _delegate;
     private final Object _original_owner;
-    private final Object _original_delegate;
     private boolean _configuring;
 
-    public ConfigureDelegate(Closure configureClosure, Object delegate) {
+    public ConfigureDelegate(Closure<?> configureClosure, Object delegate) {
         _original_owner = configureClosure.getOwner();
         _owner = DynamicObjectUtil.asDynamicObject(_original_owner);
-        _original_delegate = delegate;
-        _delegate = DynamicObjectUtil.asDynamicObject(_original_delegate);
+        _delegate = DynamicObjectUtil.asDynamicObject(delegate);
     }
 
     @Override
@@ -43,10 +41,6 @@ public class ConfigureDelegate extends GroovyObjectSupport {
 
     public Object _original_owner() {
         return _original_owner;
-    }
-
-    public Object _original_delegate() {
-        return _original_delegate;
     }
 
     protected DynamicInvokeResult _configure(String name, Object[] params) {

--- a/subprojects/model-core/src/main/java/org/gradle/internal/metaobject/ConfigureDelegate.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/metaobject/ConfigureDelegate.java
@@ -25,16 +25,28 @@ import javax.annotation.concurrent.NotThreadSafe;
 public class ConfigureDelegate extends GroovyObjectSupport {
     protected final DynamicObject _owner;
     protected final DynamicObject _delegate;
+    private final Object _original_owner;
+    private final Object _original_delegate;
     private boolean _configuring;
 
     public ConfigureDelegate(Closure configureClosure, Object delegate) {
-        _owner = DynamicObjectUtil.asDynamicObject(configureClosure.getOwner());
-        _delegate = DynamicObjectUtil.asDynamicObject(delegate);
+        _original_owner = configureClosure.getOwner();
+        _owner = DynamicObjectUtil.asDynamicObject(_original_owner);
+        _original_delegate = delegate;
+        _delegate = DynamicObjectUtil.asDynamicObject(_original_delegate);
     }
 
     @Override
     public String toString() {
         return _delegate.toString();
+    }
+
+    public Object _original_owner() {
+        return _original_owner;
+    }
+
+    public Object _original_delegate() {
+        return _original_delegate;
     }
 
     protected DynamicInvokeResult _configure(String name, Object[] params) {

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/resolve/service/internal/DefaultInjectedClasspathPluginResolver.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/resolve/service/internal/DefaultInjectedClasspathPluginResolver.java
@@ -46,7 +46,7 @@ public class DefaultInjectedClasspathPluginResolver implements ClientInjectedCla
         this.injectedClasspath = injectedClasspath;
         ClassPath cachedClassPath = classpathTransformer.transform(injectedClasspath, instrumentationStrategy.getTransform());
         this.pluginRegistry = new DefaultPluginRegistry(pluginInspector,
-            parentScope.createChild("injected-plugin")
+            parentScope.createChild("injected-plugin", null)
                 .local(cachedClassPath)
                 .lock()
         );

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecMainClassIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecMainClassIntegrationTest.groovy
@@ -18,10 +18,13 @@ package org.gradle.api.tasks
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.configurationcache.ConfigurationCacheFixture
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.fixtures.file.TestFile
+import spock.lang.IgnoreIf
 
 class JavaExecMainClassIntegrationTest extends AbstractIntegrationSpec {
 
+    @IgnoreIf({ GradleContextualExecuter.configCache })
     def "can add JavaExec mainClass convention to automatically find class at execution time"() {
         given:
         def configurationCache = new ConfigurationCacheFixture(this)


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context

Also restore the state used by the exception analysis to determine the script line number to associate with the exception.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
