### PR TITLE
Capture exceptions thrown in JavaProcessStackTracesMonitor

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/timeout/JavaProcessStackTracesMonitor.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/timeout/JavaProcessStackTracesMonitor.java
@@ -23,6 +23,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalDateTime;
@@ -130,14 +132,23 @@ public class JavaProcessStackTracesMonitor {
         }
 
         String jstack() {
-            ExecResult result = run(getJstackCommand(), pid);
+            try {
+                ExecResult result = run(getJstackCommand(), pid);
 
-            StringBuilder sb = new StringBuilder(String.format("Run %s %s return %s", getJstackCommand(), pid, result));
-            if (result.code != 0) {
-                result = run(getJstackCommand(), "-F", pid);
-                sb.append(String.format("Run %s -F %s return %s", getJstackCommand(), pid, result.toString()));
+                StringBuilder sb = new StringBuilder(String.format("Run %s %s return %s", getJstackCommand(), pid, result));
+                if (result.code != 0) {
+                    result = run(getJstackCommand(), "-F", pid);
+                    sb.append(String.format("Run %s -F %s return %s", getJstackCommand(), pid, result.toString()));
+                }
+                return sb.toString();
+            } catch (Throwable e) {
+                // e.g. java.lang.IllegalThreadStateException: process has not exited
+                //          at java.base/java.lang.ProcessImpl.exitValue(ProcessImpl.java:553)
+                StringWriter sw = new StringWriter();
+                PrintWriter pw = new PrintWriter(sw);
+                e.printStackTrace(pw);
+                return sw.toString();
             }
-            return sb.toString();
         }
     }
 


### PR DESCRIPTION
We found some exceptions in JavaProcessStackTracesMonitor:

```
Caused by:
java.lang.IllegalThreadStateException: process has not exited
    at java.base/java.lang.ProcessImpl.exitValue(ProcessImpl.java:553)
    at org.gradle.integtests.fixtures.timeout.JavaProcessStackTracesMonitor.run(JavaProcessStackTracesMonitor.java:233)
    at org.gradle.integtests.fixtures.timeout.JavaProcessStackTracesMonitor$JavaProcessInfo.jstack(JavaProcessStackTracesMonitor.java:133)
    ...
```

Which blocks fetching stack dumps for other JVMs:

https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_Quick_2_bucket24/58466722?buildTab=log&focusLine=8776&logView=flowAware&linesState=567.7316.7368.7373#%2F.teamcity%2Fgradle-logs%2Freport-plugins-JavaExecDeb.Test.zip
