### PR TITLE
Try adaptive maxParallelForks

### DIFF
--- a/.teamcity/src/main/kotlin/common/extensions.kt
+++ b/.teamcity/src/main/kotlin/common/extensions.kt
@@ -198,13 +198,13 @@ fun BuildStep.skipConditionally(buildType: BuildType? = null) {
     }
 }
 
-fun buildToolGradleParameters(daemon: Boolean = true, isContinue: Boolean = true): List<String> =
+fun buildToolGradleParameters(daemon: Boolean = true, isContinue: Boolean = true, maxParallelForks: String = "%maxParallelForks%"): List<String> =
     listOf(
         // We pass the 'maxParallelForks' setting as 'workers.max' to limit the maximum number of executers even
         // if multiple test tasks run in parallel. We also pass it to the Gradle build as a maximum (maxParallelForks)
         // for each test task, such that we are independent of whatever default value is defined in the build itself.
-        "-Dorg.gradle.workers.max=%maxParallelForks%",
-        "-PmaxParallelForks=%maxParallelForks%",
+        "-Dorg.gradle.workers.max=$maxParallelForks",
+        "-PmaxParallelForks=$maxParallelForks",
         pluginPortalUrlOverride,
         "-s",
         "--no-configuration-cache",

--- a/.teamcity/src/main/kotlin/configurations/FunctionalTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/FunctionalTest.kt
@@ -19,6 +19,7 @@ class FunctionalTest(
     enableTestDistribution: Boolean,
     subprojects: List<String> = listOf(),
     extraParameters: String = "",
+    maxParallelForks: String = "%maxParallelForks%",
     extraBuildSteps: BuildSteps.() -> Unit = {},
     preBuildSteps: BuildSteps.() -> Unit = {}
 ) : BaseGradleBuildType(stage = stage, init = {
@@ -40,6 +41,7 @@ class FunctionalTest(
                 extraParameters
             ).filter { it.isNotBlank() }.joinToString(separator = " "),
         timeout = testCoverage.testType.timeout,
+        maxParallelForks = testCoverage.testType.maxParallelForks.toString(),
         extraSteps = extraBuildSteps,
         preSteps = preBuildSteps
     )

--- a/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
+++ b/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
@@ -86,10 +86,17 @@ fun ProjectFeatures.buildReportTab(title: String, startPage: String) {
     }
 }
 
-fun BaseGradleBuildType.gradleRunnerStep(model: CIBuildModel, gradleTasks: String, os: Os = Os.LINUX, extraParameters: String = "", daemon: Boolean = true) {
+fun BaseGradleBuildType.gradleRunnerStep(
+    model: CIBuildModel,
+    gradleTasks: String,
+    os: Os = Os.LINUX,
+    extraParameters: String = "",
+    daemon: Boolean = true,
+    maxParallelForks: String = "%maxParallelForks%"
+) {
     val buildScanTags = model.buildScanTags + listOfNotNull(stage?.id)
     val parameters = (
-        buildToolGradleParameters(daemon) +
+        buildToolGradleParameters(daemon, maxParallelForks = maxParallelForks) +
             listOf(extraParameters) +
             buildScanTags.map { buildScanTag(it) } +
             functionalTestParameters(os)
@@ -138,6 +145,7 @@ fun applyTestDefaults(
     arch: Arch = Arch.AMD64,
     extraParameters: String = "",
     timeout: Int = 90,
+    maxParallelForks: String = "%maxParallelForks%",
     extraSteps: BuildSteps.() -> Unit = {}, // the steps after runner steps
     daemon: Boolean = true,
     preSteps: BuildSteps.() -> Unit = {} // the steps before runner steps
@@ -150,7 +158,7 @@ fun applyTestDefaults(
 
     buildType.killProcessStep("KILL_LEAKED_PROCESSES_FROM_PREVIOUS_BUILDS", os, arch)
 
-    buildType.gradleRunnerStep(model, gradleTasks, os, extraParameters, daemon)
+    buildType.gradleRunnerStep(model, gradleTasks, os, extraParameters, daemon, maxParallelForks = maxParallelForks)
 
     buildType.killProcessStep("KILL_PROCESSES_STARTED_BY_GRADLE", os, arch)
 

--- a/.teamcity/src/main/kotlin/model/CIBuildModel.kt
+++ b/.teamcity/src/main/kotlin/model/CIBuildModel.kt
@@ -270,9 +270,9 @@ data class TestCoverage(
         "${testType.name.toCapitalized()} ${testJvmVersion.name.toCapitalized()} ${vendor.displayName} ${os.asName()} ${arch.asName()}${if (withoutDependencies) " without dependencies" else ""}"
 }
 
-enum class TestType(val unitTests: Boolean = true, val functionalTests: Boolean = true, val crossVersionTests: Boolean = false, val timeout: Int = 180) {
+enum class TestType(val unitTests: Boolean = true, val functionalTests: Boolean = true, val crossVersionTests: Boolean = false, val timeout: Int = 180, val maxParallelForks: Int = 4) {
     // Include cross version tests, these take care of selecting a very small set of versions to cover when run as part of this stage, including the current version
-    quick(true, true, true, 60),
+    quick(true, true, true, 60, 2),
 
     // Include cross version tests, these take care of selecting a very small set of versions to cover when run as part of this stage, including the current version
     platform(true, true, true),

--- a/build-logic/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
+++ b/build-logic/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
@@ -359,8 +359,7 @@ val Project.maxTestDistributionPartitionSecond: Long?
 
 
 val Project.maxParallelForks: Int
-    get() = gradleProperty(MAX_PARALLEL_FORKS).getOrElse("4").toInt() *
-        environmentVariable("BUILD_AGENT_VARIANT").getOrElse("").let { if (it == "AX41") 2 else 1 }
+    get() = gradleProperty(MAX_PARALLEL_FORKS).getOrElse("4").toInt()
 
 
 val Project.autoDownloadAndroidStudio: Boolean


### PR DESCRIPTION
Experiments show that best maxParallelForks differs in different types of functional test. For example,

QuickFeedbackLinux: 2
QuickFeedbackWindows: 2
PlatformLinux: 2
PlatformWindows: 4
NoDaemonLinux: 6
NoDaemonWindows: 6

Let's try different maxParallelForks for different build configurations and see if they are faster.
