### PR TITLE
Removing incubating on a number of methods and types

### DIFF
--- a/subprojects/build-events/src/main/java/org/gradle/build/event/BuildEventsListenerRegistry.java
+++ b/subprojects/build-events/src/main/java/org/gradle/build/event/BuildEventsListenerRegistry.java
@@ -16,7 +16,6 @@
 
 package org.gradle.build.event;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.provider.Provider;
 import org.gradle.tooling.events.OperationCompletionListener;
 
@@ -27,7 +26,6 @@ import org.gradle.tooling.events.OperationCompletionListener;
  *
  * @since 6.1
  */
-@Incubating
 public interface BuildEventsListenerRegistry {
     /**
      * Subscribes the given listener to the finish events for tasks, if not already subscribed. The listener receives a {@link org.gradle.tooling.events.task.TaskFinishEvent} as each task completes.

--- a/subprojects/core-api/src/main/java/org/gradle/api/Task.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Task.java
@@ -302,7 +302,6 @@ public interface Task extends Comparable<Task>, ExtensionAware {
      *
      * @since 7.4
      */
-    @Incubating
     void notCompatibleWithConfigurationCache(String reason);
 
     /**
@@ -832,6 +831,5 @@ public interface Task extends Comparable<Task>, ExtensionAware {
      * @param service The service provider.
      * @since 6.1
      */
-    @Incubating
     void usesService(Provider<? extends BuildService<?>> service);
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/BuildController.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/BuildController.java
@@ -17,7 +17,6 @@
 package org.gradle.tooling;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.tooling.model.Model;
 import org.gradle.tooling.model.gradle.GradleBuild;
 
@@ -199,7 +198,6 @@ public interface BuildController {
      * @return The action results. These are returned in the same order as the actions that produce them.
      * @since 6.8
      */
-    @Incubating
     <T> List<T> run(Collection<? extends BuildAction<? extends T>> actions);
 
     /**
@@ -210,6 +208,5 @@ public interface BuildController {
      * @return {@code true} when project models may be queried in parallel.
      * @since 6.8
      */
-    @Incubating
     boolean getCanQueryProjectModelInParallel(Class<?> modelType);
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/OperationType.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/OperationType.java
@@ -135,7 +135,6 @@ public enum OperationType {
      *
      * @since 7.3
      */
-    @Incubating
     FILE_DOWNLOAD,
 
 

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/download/FileDownloadFinishEvent.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/download/FileDownloadFinishEvent.java
@@ -16,7 +16,6 @@
 
 package org.gradle.tooling.events.download;
 
-import org.gradle.api.Incubating;
 import org.gradle.tooling.events.FinishEvent;
 
 /**
@@ -24,7 +23,6 @@ import org.gradle.tooling.events.FinishEvent;
  *
  * @since 7.3
  */
-@Incubating
 public interface FileDownloadFinishEvent extends FileDownloadProgressEvent, FinishEvent {
     @Override
     FileDownloadResult getResult();

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/download/FileDownloadOperationDescriptor.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/download/FileDownloadOperationDescriptor.java
@@ -16,7 +16,6 @@
 
 package org.gradle.tooling.events.download;
 
-import org.gradle.api.Incubating;
 import org.gradle.tooling.events.OperationDescriptor;
 
 import java.net.URI;
@@ -26,7 +25,6 @@ import java.net.URI;
  *
  * @since 7.3
  */
-@Incubating
 public interface FileDownloadOperationDescriptor extends OperationDescriptor {
     /**
      * Returns the URI that the file is downloaded from.

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/download/FileDownloadProgressEvent.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/download/FileDownloadProgressEvent.java
@@ -16,7 +16,6 @@
 
 package org.gradle.tooling.events.download;
 
-import org.gradle.api.Incubating;
 import org.gradle.tooling.events.ProgressEvent;
 
 /**
@@ -24,7 +23,6 @@ import org.gradle.tooling.events.ProgressEvent;
  *
  * @since 7.3
  */
-@Incubating
 public interface FileDownloadProgressEvent extends ProgressEvent {
     @Override
     FileDownloadOperationDescriptor getDescriptor();

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/download/FileDownloadResult.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/download/FileDownloadResult.java
@@ -16,7 +16,6 @@
 
 package org.gradle.tooling.events.download;
 
-import org.gradle.api.Incubating;
 import org.gradle.tooling.events.OperationResult;
 
 /**
@@ -24,7 +23,6 @@ import org.gradle.tooling.events.OperationResult;
  *
  * @since 7.3
  */
-@Incubating
 public interface FileDownloadResult extends OperationResult {
     /**
      * Returns the total download size. Note that this might not be the same as the file size.

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/download/FileDownloadStartEvent.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/download/FileDownloadStartEvent.java
@@ -16,7 +16,6 @@
 
 package org.gradle.tooling.events.download;
 
-import org.gradle.api.Incubating;
 import org.gradle.tooling.events.StartEvent;
 
 /**
@@ -24,6 +23,5 @@ import org.gradle.tooling.events.StartEvent;
  *
  * @since 7.3
  */
-@Incubating
 public interface FileDownloadStartEvent extends FileDownloadProgressEvent, StartEvent {
 }


### PR DESCRIPTION
The PR is using different commits to separate the different areas. Best reviewed by commit.

@gradle/bt-configuration-cache Would be great to have you confirm these de-incubation are good to go for Gradle 8