### PR TITLE
Allow GUH cleanup retention times to be specified as timestamps

### DIFF
--- a/subprojects/build-cache/build.gradle.kts
+++ b/subprojects/build-cache/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     implementation(project(":core-api"))
     implementation(project(":files"))
     implementation(project(":file-temp"))
+    implementation(project(":functional"))
     implementation(project(":native"))
     implementation(project(":persistent-cache"))
     implementation(project(":resources"))

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/local/internal/DirectoryBuildCacheServiceFactory.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/local/internal/DirectoryBuildCacheServiceFactory.java
@@ -82,10 +82,11 @@ public class DirectoryBuildCacheServiceFactory implements BuildCacheServiceFacto
         }
         checkDirectory(target);
 
-        Supplier<Long> removeUnusedEntriesTimestamp = TimestampSuppliers.daysAgo(configuration.getRemoveUnusedEntriesAfterDays());
+        int removeUnusedEntriesAfterDays = configuration.getRemoveUnusedEntriesAfterDays();
+        Supplier<Long> removeUnusedEntriesTimestamp = TimestampSuppliers.daysAgo(removeUnusedEntriesAfterDays);
         describer.type(DIRECTORY_BUILD_CACHE_TYPE).
             config("location", target.getAbsolutePath()).
-            config("removeUnusedEntriesAfter", String.valueOf(removeUnusedEntriesTimestamp) + " days");
+            config("removeUnusedEntriesAfter", String.valueOf(removeUnusedEntriesAfterDays) + " days");
 
         PathKeyFileStore fileStore = fileStoreFactory.createFileStore(target);
         PersistentCache persistentCache = cacheRepository

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/local/internal/DirectoryBuildCacheServiceFactory.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/local/internal/DirectoryBuildCacheServiceFactory.java
@@ -17,9 +17,10 @@
 package org.gradle.caching.local.internal;
 
 import org.gradle.api.UncheckedIOException;
-import org.gradle.api.internal.cache.DefaultCacheCleanup;
+import org.gradle.api.internal.cache.DefaultCacheCleanupStrategy;
 import org.gradle.api.internal.file.temp.TemporaryFileProvider;
 import org.gradle.cache.CacheBuilder;
+import org.gradle.cache.CacheCleanupStrategy;
 import org.gradle.cache.CacheRepository;
 import org.gradle.cache.internal.CleanupActionDecorator;
 import org.gradle.cache.PersistentCache;
@@ -91,7 +92,7 @@ public class DirectoryBuildCacheServiceFactory implements BuildCacheServiceFacto
         PathKeyFileStore fileStore = fileStoreFactory.createFileStore(target);
         PersistentCache persistentCache = cacheRepository
             .cache(target)
-            .withCleanup(createCacheCleanup(removeUnusedEntriesTimestamp))
+            .withCleanupStrategy(createCacheCleanupStrategy(removeUnusedEntriesTimestamp))
             .withDisplayName("Build cache")
             .withLockOptions(mode(OnDemand))
             .withCrossVersionCache(CacheBuilder.LockTarget.DefaultTarget)
@@ -102,8 +103,8 @@ public class DirectoryBuildCacheServiceFactory implements BuildCacheServiceFacto
         return new DirectoryBuildCacheService(fileStore, persistentCache, tempFileStore, fileAccessTracker, FAILED_READ_SUFFIX);
     }
 
-    private DefaultCacheCleanup createCacheCleanup(Supplier<Long> removeUnusedEntriesTimestamp) {
-        return DefaultCacheCleanup.from(cleanupActionDecorator.decorate(createCleanupAction(removeUnusedEntriesTimestamp)));
+    private CacheCleanupStrategy createCacheCleanupStrategy(Supplier<Long> removeUnusedEntriesTimestamp) {
+        return DefaultCacheCleanupStrategy.from(cleanupActionDecorator.decorate(createCleanupAction(removeUnusedEntriesTimestamp)));
     }
 
     private LeastRecentlyUsedCacheCleanup createCleanupAction(Supplier<Long> removeUnusedEntriesTimestamp) {

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/local/internal/DirectoryBuildCacheServiceFactory.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/local/internal/DirectoryBuildCacheServiceFactory.java
@@ -84,7 +84,7 @@ public class DirectoryBuildCacheServiceFactory implements BuildCacheServiceFacto
         checkDirectory(target);
 
         int removeUnusedEntriesAfterDays = configuration.getRemoveUnusedEntriesAfterDays();
-        Supplier<Long> removeUnusedEntriesTimestamp = TimestampSuppliers.daysAgo(removeUnusedEntriesAfterDays);
+        Supplier<Long> removeUnusedEntriesOlderThan = TimestampSuppliers.daysAgo(removeUnusedEntriesAfterDays);
         describer.type(DIRECTORY_BUILD_CACHE_TYPE).
             config("location", target.getAbsolutePath()).
             config("removeUnusedEntriesAfter", String.valueOf(removeUnusedEntriesAfterDays) + " days");
@@ -92,7 +92,7 @@ public class DirectoryBuildCacheServiceFactory implements BuildCacheServiceFacto
         PathKeyFileStore fileStore = fileStoreFactory.createFileStore(target);
         PersistentCache persistentCache = cacheRepository
             .cache(target)
-            .withCleanupStrategy(createCacheCleanupStrategy(removeUnusedEntriesTimestamp))
+            .withCleanupStrategy(createCacheCleanupStrategy(removeUnusedEntriesOlderThan))
             .withDisplayName("Build cache")
             .withLockOptions(mode(OnDemand))
             .withCrossVersionCache(CacheBuilder.LockTarget.DefaultTarget)

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheRepository.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheRepository.kt
@@ -16,6 +16,7 @@
 
 package org.gradle.configurationcache
 
+import org.gradle.api.cache.TimestampSupplier
 import org.gradle.api.internal.BuildDefinition
 import org.gradle.cache.CacheBuilder
 import org.gradle.cache.internal.CleanupActionDecorator
@@ -220,7 +221,7 @@ class ConfigurationCacheRepository(
                     LeastRecentlyUsedCacheCleanup(
                         SingleDepthFilesFinder(cleanupDepth),
                         fileAccessTimeJournal,
-                        { cleanupMaxAgeDays }
+                        TimestampSupplier.olderThanInDays(cleanupMaxAgeDays)
                     )
                 )
             )

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheRepository.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheRepository.kt
@@ -16,7 +16,7 @@
 
 package org.gradle.configurationcache
 
-import org.gradle.api.cache.TimestampSupplier
+import org.gradle.internal.time.TimestampSuppliers
 import org.gradle.api.internal.BuildDefinition
 import org.gradle.cache.CacheBuilder
 import org.gradle.cache.internal.CleanupActionDecorator
@@ -221,7 +221,7 @@ class ConfigurationCacheRepository(
                     LeastRecentlyUsedCacheCleanup(
                         SingleDepthFilesFinder(cleanupDepth),
                         fileAccessTimeJournal,
-                        TimestampSupplier.olderThanInDays(cleanupMaxAgeDays)
+                        TimestampSuppliers.daysAgo(cleanupMaxAgeDays)
                     )
                 )
             )

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheRepository.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheRepository.kt
@@ -23,7 +23,7 @@ import org.gradle.cache.internal.CleanupActionDecorator
 import org.gradle.cache.FileLockManager
 import org.gradle.cache.PersistentCache
 import org.gradle.api.internal.cache.CacheConfigurationsInternal
-import org.gradle.api.internal.cache.DefaultCacheCleanup
+import org.gradle.api.internal.cache.DefaultCacheCleanupStrategy
 import org.gradle.cache.internal.LeastRecentlyUsedCacheCleanup
 import org.gradle.cache.internal.SingleDepthFilesFinder
 import org.gradle.cache.internal.filelock.LockOptionsBuilder
@@ -215,8 +215,8 @@ class ConfigurationCacheRepository(
 
     private
     fun CacheBuilder.withLruCacheCleanup(cleanupActionDecorator: CleanupActionDecorator): CacheBuilder =
-        withCleanup(
-            DefaultCacheCleanup.from(
+        withCleanupStrategy(
+            DefaultCacheCleanupStrategy.from(
                 cleanupActionDecorator.decorate(
                     LeastRecentlyUsedCacheCleanup(
                         SingleDepthFilesFinder(cleanupDepth),

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
@@ -17,13 +17,13 @@
 package org.gradle.configurationcache
 
 import org.gradle.api.artifacts.component.BuildIdentifier
-import org.gradle.api.cache.CacheResourceConfiguration
 import org.gradle.api.cache.Cleanup
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.BuildDefinition
 import org.gradle.api.internal.FeaturePreviews
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.SettingsInternal.BUILD_SRC
+import org.gradle.api.internal.cache.CacheResourceConfigurationInternal
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.services.internal.BuildServiceProvider
@@ -557,10 +557,10 @@ class ConfigurationCacheState(
     private
     suspend fun DefaultReadContext.readCacheConfigurations(gradle: GradleInternal) {
         gradle.settings.caches.let { cacheConfigurations ->
-            cacheConfigurations.releasedWrappers = read() as CacheResourceConfiguration?
-            cacheConfigurations.snapshotWrappers = read() as CacheResourceConfiguration?
-            cacheConfigurations.downloadedResources = read() as CacheResourceConfiguration?
-            cacheConfigurations.createdResources = read() as CacheResourceConfiguration?
+            cacheConfigurations.releasedWrappers = read() as CacheResourceConfigurationInternal?
+            cacheConfigurations.snapshotWrappers = read() as CacheResourceConfigurationInternal?
+            cacheConfigurations.downloadedResources = read() as CacheResourceConfigurationInternal?
+            cacheConfigurations.createdResources = read() as CacheResourceConfigurationInternal?
             cacheConfigurations.cleanup = readNonNull<Property<Cleanup>>()
         }
     }

--- a/subprojects/core-api/build.gradle.kts
+++ b/subprojects/core-api/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     implementation(project(":base-services-groovy"))
     implementation(project(":enterprise-operations"))
     implementation(project(":files"))
+    implementation(project(":functional"))
     implementation(project(":logging"))
     implementation(project(":persistent-cache"))
     implementation(project(":resources"))

--- a/subprojects/core-api/build.gradle.kts
+++ b/subprojects/core-api/build.gradle.kts
@@ -11,7 +11,6 @@ dependencies {
     implementation(project(":base-services-groovy"))
     implementation(project(":enterprise-operations"))
     implementation(project(":files"))
-    implementation(project(":functional"))
     implementation(project(":logging"))
     implementation(project(":persistent-cache"))
     implementation(project(":resources"))

--- a/subprojects/core-api/src/main/java/org/gradle/api/cache/CacheResourceConfiguration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/cache/CacheResourceConfiguration.java
@@ -33,13 +33,13 @@ public interface CacheResourceConfiguration {
      *
      * See {@link #setRemoveUnusedEntriesAfterDays(int)}.
      */
-    Property<Long> getRemoveUnusedEntriesAfter();
+    Property<Long> getRemoveUnusedEntriesOlderThan();
 
     /**
      * Sets the timestamp before which unused entries will be removed to be calculated exactly
      * the given number of days previous to the current time.
      *
-     * See {@link #getRemoveUnusedEntriesAfter()}
+     * See {@link #getRemoveUnusedEntriesOlderThan()}
      */
     void setRemoveUnusedEntriesAfterDays(int removeUnusedEntriesAfterDays);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/cache/CacheResourceConfiguration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/cache/CacheResourceConfiguration.java
@@ -29,5 +29,5 @@ public interface CacheResourceConfiguration {
     /**
      * Configures the maximum number of days an unused entry will be retained in the cache.
      */
-    Property<Integer> getRemoveUnusedEntriesAfterDays();
+    Property<TimestampSupplier> getRemoveUnusedEntries();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/cache/CacheResourceConfiguration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/cache/CacheResourceConfiguration.java
@@ -18,6 +18,10 @@ package org.gradle.api.cache;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.provider.Property;
+import org.gradle.internal.HasInternalProtocol;
+import org.gradle.internal.time.TimestampSuppliers;
+
+import java.util.function.Supplier;
 
 /**
  * Represents the configuration of a given type of cache resource.
@@ -25,20 +29,21 @@ import org.gradle.api.provider.Property;
  * @since 8.0
  */
 @Incubating
+@HasInternalProtocol
 public interface CacheResourceConfiguration {
     /**
      * Configures the the timestamp before which an unused entry will be removed from the cache.
      *
-     * See {@link TimestampSupplier#olderThanInDays(int)}.
+     * See {@link TimestampSuppliers#daysAgo(int)}.
      */
-    Property<TimestampSupplier> getRemoveUnusedEntriesAfter();
+    Property<Supplier<Long>> getRemoveUnusedEntriesAfter();
 
     /**
      * Returns a timestamp supplier that calculates a timestamp exactly the given number
      * of days prior to the current time, or 0 if the number of days extends beyond the
      * epoch.
      */
-    static TimestampSupplier days(int days) {
-        return TimestampSupplier.olderThanInDays(days);
+    static Supplier<Long> days(int days) {
+        return TimestampSuppliers.daysAgo(days);
     }
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/cache/CacheResourceConfiguration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/cache/CacheResourceConfiguration.java
@@ -27,7 +27,18 @@ import org.gradle.api.provider.Property;
 @Incubating
 public interface CacheResourceConfiguration {
     /**
-     * Configures the maximum number of days an unused entry will be retained in the cache.
+     * Configures the the timestamp before which an unused entry will be removed from the cache.
+     *
+     * See {@link TimestampSupplier#olderThanInDays(int)}.
      */
-    Property<TimestampSupplier> getRemoveUnusedEntries();
+    Property<TimestampSupplier> getRemoveUnusedEntriesAfter();
+
+    /**
+     * Returns a timestamp supplier that calculates a timestamp exactly the given number
+     * of days prior to the current time, or 0 if the number of days extends beyond the
+     * epoch.
+     */
+    static TimestampSupplier days(int days) {
+        return TimestampSupplier.olderThanInDays(days);
+    }
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/cache/CacheResourceConfiguration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/cache/CacheResourceConfiguration.java
@@ -19,9 +19,6 @@ package org.gradle.api.cache;
 import org.gradle.api.Incubating;
 import org.gradle.api.provider.Property;
 import org.gradle.internal.HasInternalProtocol;
-import org.gradle.internal.time.TimestampSuppliers;
-
-import java.util.function.Supplier;
 
 /**
  * Represents the configuration of a given type of cache resource.
@@ -32,18 +29,17 @@ import java.util.function.Supplier;
 @HasInternalProtocol
 public interface CacheResourceConfiguration {
     /**
-     * Configures the the timestamp before which an unused entry will be removed from the cache.
+     * Configures the timestamp before which an unused entry will be removed from the cache.
      *
-     * See {@link TimestampSuppliers#daysAgo(int)}.
+     * See {@link #setRemoveUnusedEntriesAfterDays(int)}.
      */
-    Property<Supplier<Long>> getRemoveUnusedEntriesAfter();
+    Property<Long> getRemoveUnusedEntriesAfter();
 
     /**
-     * Returns a timestamp supplier that calculates a timestamp exactly the given number
-     * of days prior to the current time, or 0 if the number of days extends beyond the
-     * epoch.
+     * Sets the timestamp before which unused entries will be removed to be calculated exactly
+     * the given number of days previous to the current time.
+     *
+     * See {@link #getRemoveUnusedEntriesAfter()}
      */
-    static Supplier<Long> days(int days) {
-        return TimestampSuppliers.daysAgo(days);
-    }
+    void setRemoveUnusedEntriesAfterDays(int removeUnusedEntriesAfterDays);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/cache/TimestampSupplier.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/cache/TimestampSupplier.java
@@ -38,7 +38,9 @@ public interface TimestampSupplier extends Supplier<Long> {
         // This needs to be an anonymous inner class instead of a lambda for configuration cache compatibility
         return new TimestampSupplier() {
             @Override
-            public Long get() {return Math.max(0, System.currentTimeMillis() - TimeUnit.DAYS.toMillis(days));}
+            public Long get() {
+                return Math.max(0, System.currentTimeMillis() - TimeUnit.DAYS.toMillis(days));
+            }
         };
     }
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/cache/TimestampSupplier.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/cache/TimestampSupplier.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.cache;
+
+import org.gradle.api.Incubating;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+/**
+ * A supplier of timestamps for the purposes of calculating expiration dates
+ * on cache entries.
+ *
+ * @since 8.0
+ */
+@Incubating
+public interface TimestampSupplier extends Supplier<Long> {
+    /**
+     * Returns a timestamp supplier that calculates a timestamp exactly the given number
+     * of days prior to the current time, or 0 if the number of days extends beyond the
+     * epoch.
+     */
+    static TimestampSupplier olderThanInDays(int days) {
+        // This needs to be an anonymous inner class instead of a lambda for configuration cache compatibility
+        return new TimestampSupplier() {
+            @Override
+            public Long get() {return Math.max(0, System.currentTimeMillis() - TimeUnit.DAYS.toMillis(days));}
+        };
+    }
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/cache/CacheConfigurationsInternal.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/cache/CacheConfigurationsInternal.java
@@ -21,10 +21,8 @@ import org.gradle.api.cache.Cleanup;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.cache.CleanupFrequency;
-import org.gradle.cache.internal.CleanupActionDecorator;
-import org.gradle.internal.cache.MonitoredCleanupActionDecorator;
 
-public interface CacheConfigurationsInternal extends CacheConfigurations, CleanupActionDecorator, MonitoredCleanupActionDecorator {
+public interface CacheConfigurationsInternal extends CacheConfigurations {
     int DEFAULT_MAX_AGE_IN_DAYS_FOR_RELEASED_DISTS = 30;
     int DEFAULT_MAX_AGE_IN_DAYS_FOR_SNAPSHOT_DISTS = 7;
     int DEFAULT_MAX_AGE_IN_DAYS_FOR_DOWNLOADED_CACHE_ENTRIES = 30;

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/cache/CacheConfigurationsInternal.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/cache/CacheConfigurationsInternal.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.cache;
 
 import org.gradle.api.cache.CacheConfigurations;
-import org.gradle.api.cache.CacheResourceConfiguration;
 import org.gradle.api.cache.Cleanup;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
@@ -31,10 +30,19 @@ public interface CacheConfigurationsInternal extends CacheConfigurations, Cleanu
     int DEFAULT_MAX_AGE_IN_DAYS_FOR_DOWNLOADED_CACHE_ENTRIES = 30;
     int DEFAULT_MAX_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES = 7;
 
-    void setReleasedWrappers(CacheResourceConfiguration releasedWrappers);
-    void setSnapshotWrappers(CacheResourceConfiguration snapshotWrappers);
-    void setDownloadedResources(CacheResourceConfiguration downloadedResources);
-    void setCreatedResources(CacheResourceConfiguration createdResources);
+    @Override
+    CacheResourceConfigurationInternal getReleasedWrappers();
+    @Override
+    CacheResourceConfigurationInternal getSnapshotWrappers();
+    @Override
+    CacheResourceConfigurationInternal getDownloadedResources();
+    @Override
+    CacheResourceConfigurationInternal getCreatedResources();
+
+    void setReleasedWrappers(CacheResourceConfigurationInternal releasedWrappers);
+    void setSnapshotWrappers(CacheResourceConfigurationInternal snapshotWrappers);
+    void setDownloadedResources(CacheResourceConfigurationInternal downloadedResources);
+    void setCreatedResources(CacheResourceConfigurationInternal createdResources);
     void setCleanup(Property<Cleanup> cleanup);
 
     void finalizeConfigurations();

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/cache/CacheResourceConfigurationInternal.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/cache/CacheResourceConfigurationInternal.java
@@ -21,5 +21,5 @@ import org.gradle.api.cache.CacheResourceConfiguration;
 import java.util.function.Supplier;
 
 public interface CacheResourceConfigurationInternal extends CacheResourceConfiguration {
-    Supplier<Long> getRemoveUnusedEntriesAfterAsSupplier();
+    Supplier<Long> getRemoveUnusedEntriesOlderThanAsSupplier();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/cache/CacheResourceConfigurationInternal.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/cache/CacheResourceConfigurationInternal.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.cache;
+
+import org.gradle.api.cache.CacheResourceConfiguration;
+
+import java.util.function.Supplier;
+
+public interface CacheResourceConfigurationInternal extends CacheResourceConfiguration {
+    Supplier<Long> getRemoveUnusedEntriesAfterAsSupplier();
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/cache/DefaultCacheCleanup.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/cache/DefaultCacheCleanup.java
@@ -21,23 +21,23 @@ import org.gradle.cache.CacheCleanup;
 import org.gradle.cache.CleanupAction;
 import org.gradle.cache.CleanupFrequency;
 
-import javax.annotation.Nullable;
+import java.util.function.Supplier;
 
 public class DefaultCacheCleanup implements CacheCleanup {
     private final CleanupAction cleanupAction;
-    private final Provider<CleanupFrequency> cleanupFrequency;
+    private final Supplier<CleanupFrequency> cleanupFrequency;
 
-    private DefaultCacheCleanup(CleanupAction cleanupAction, @Nullable Provider<CleanupFrequency> cleanupFrequency) {
+    private DefaultCacheCleanup(CleanupAction cleanupAction, Supplier<CleanupFrequency> cleanupFrequency) {
         this.cleanupAction = cleanupAction;
         this.cleanupFrequency = cleanupFrequency;
     }
 
     public static DefaultCacheCleanup from(CleanupAction cleanupAction, Provider<CleanupFrequency> cleanupFrequency) {
-        return new DefaultCacheCleanup(cleanupAction, cleanupFrequency);
+        return new DefaultCacheCleanup(cleanupAction, cleanupFrequency::get);
     }
 
     public static DefaultCacheCleanup from(CleanupAction cleanupAction) {
-        return new DefaultCacheCleanup(cleanupAction, null);
+        return new DefaultCacheCleanup(cleanupAction, () -> CleanupFrequency.DAILY);
     }
 
     @Override
@@ -47,6 +47,6 @@ public class DefaultCacheCleanup implements CacheCleanup {
 
     @Override
     public CleanupFrequency getCleanupFrequency() {
-        return cleanupFrequency != null ? cleanupFrequency.get() : CleanupFrequency.DAILY;
+        return cleanupFrequency.get();
     }
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/cache/DefaultCacheCleanupStrategy.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/cache/DefaultCacheCleanupStrategy.java
@@ -17,27 +17,27 @@
 package org.gradle.api.internal.cache;
 
 import org.gradle.api.provider.Provider;
-import org.gradle.cache.CacheCleanup;
+import org.gradle.cache.CacheCleanupStrategy;
 import org.gradle.cache.CleanupAction;
 import org.gradle.cache.CleanupFrequency;
 
 import java.util.function.Supplier;
 
-public class DefaultCacheCleanup implements CacheCleanup {
+public class DefaultCacheCleanupStrategy implements CacheCleanupStrategy {
     private final CleanupAction cleanupAction;
     private final Supplier<CleanupFrequency> cleanupFrequency;
 
-    private DefaultCacheCleanup(CleanupAction cleanupAction, Supplier<CleanupFrequency> cleanupFrequency) {
+    private DefaultCacheCleanupStrategy(CleanupAction cleanupAction, Supplier<CleanupFrequency> cleanupFrequency) {
         this.cleanupAction = cleanupAction;
         this.cleanupFrequency = cleanupFrequency;
     }
 
-    public static DefaultCacheCleanup from(CleanupAction cleanupAction, Provider<CleanupFrequency> cleanupFrequency) {
-        return new DefaultCacheCleanup(cleanupAction, cleanupFrequency::get);
+    public static DefaultCacheCleanupStrategy from(CleanupAction cleanupAction, Provider<CleanupFrequency> cleanupFrequency) {
+        return new DefaultCacheCleanupStrategy(cleanupAction, cleanupFrequency::get);
     }
 
-    public static DefaultCacheCleanup from(CleanupAction cleanupAction) {
-        return new DefaultCacheCleanup(cleanupAction, () -> CleanupFrequency.DAILY);
+    public static DefaultCacheCleanupStrategy from(CleanupAction cleanupAction) {
+        return new DefaultCacheCleanupStrategy(cleanupAction, () -> CleanupFrequency.DAILY);
     }
 
     @Override

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/cache/CacheConfigurationsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/cache/CacheConfigurationsIntegrationTest.groovy
@@ -26,7 +26,7 @@ class CacheConfigurationsIntegrationTest extends AbstractIntegrationSpec {
     private static final int MODIFIED_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES = CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES + 1
 
     private static final String THIS_PROPERTY_FINAL_ERROR = "The value for this property is final and cannot be changed any further"
-    private static final String REMOVE_UNUSED_ENTRIES_FINAL_ERROR = "The value for property 'removeUnusedEntriesAfterDays' is final and cannot be changed any further"
+    private static final String REMOVE_UNUSED_ENTRIES_FINAL_ERROR = "The value for property 'removeUnusedEntries' is final and cannot be changed any further"
 
     def setup() {
         requireOwnGradleUserHomeDir()
@@ -39,19 +39,19 @@ class CacheConfigurationsIntegrationTest extends AbstractIntegrationSpec {
             beforeSettings { settings ->
                 settings.caches {
                     cleanup = Cleanup.DISABLED
-                    releasedWrappers.removeUnusedEntriesAfterDays = ${MODIFIED_AGE_IN_DAYS_FOR_RELEASED_DISTS}
-                    snapshotWrappers.removeUnusedEntriesAfterDays = ${MODIFIED_AGE_IN_DAY_FOR_SNAPSHOT_DISTS}
-                    downloadedResources.removeUnusedEntriesAfterDays = ${MODIFIED_AGE_IN_DAYS_FOR_DOWNLOADED_CACHE_ENTRIES}
-                    createdResources.removeUnusedEntriesAfterDays = ${MODIFIED_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES}
+                    releasedWrappers.removeUnusedEntries = TimestampSupplier.olderThanInDays(${MODIFIED_AGE_IN_DAYS_FOR_RELEASED_DISTS})
+                    snapshotWrappers.removeUnusedEntries = TimestampSupplier.olderThanInDays(${MODIFIED_AGE_IN_DAY_FOR_SNAPSHOT_DISTS})
+                    downloadedResources.removeUnusedEntries = TimestampSupplier.olderThanInDays(${MODIFIED_AGE_IN_DAYS_FOR_DOWNLOADED_CACHE_ENTRIES})
+                    createdResources.removeUnusedEntries = TimestampSupplier.olderThanInDays(${MODIFIED_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES})
                 }
             }
         """
         settingsFile << """
             caches {
-                assert releasedWrappers.removeUnusedEntriesAfterDays.get() == ${MODIFIED_AGE_IN_DAYS_FOR_RELEASED_DISTS}
-                assert snapshotWrappers.removeUnusedEntriesAfterDays.get() == ${MODIFIED_AGE_IN_DAY_FOR_SNAPSHOT_DISTS}
-                assert downloadedResources.removeUnusedEntriesAfterDays.get() == ${MODIFIED_AGE_IN_DAYS_FOR_DOWNLOADED_CACHE_ENTRIES}
-                assert createdResources.removeUnusedEntriesAfterDays.get() == ${MODIFIED_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES}
+                assert releasedWrappers.removeUnusedEntries.get() != null
+                assert snapshotWrappers.removeUnusedEntries.get() != null
+                assert downloadedResources.removeUnusedEntries.get() != null
+                assert createdResources.removeUnusedEntries.get() != null
             }
         """
 
@@ -71,12 +71,12 @@ class CacheConfigurationsIntegrationTest extends AbstractIntegrationSpec {
         failureCauseContains(error)
 
         where:
-        property                                           | error                             | value
-        'cleanup'                                          | THIS_PROPERTY_FINAL_ERROR         | 'Cleanup.DISABLED'
-        'releasedWrappers.removeUnusedEntriesAfterDays'    | REMOVE_UNUSED_ENTRIES_FINAL_ERROR | "${MODIFIED_AGE_IN_DAYS_FOR_RELEASED_DISTS}"
-        'snapshotWrappers.removeUnusedEntriesAfterDays'    | REMOVE_UNUSED_ENTRIES_FINAL_ERROR | "${MODIFIED_AGE_IN_DAY_FOR_SNAPSHOT_DISTS}"
-        'downloadedResources.removeUnusedEntriesAfterDays' | REMOVE_UNUSED_ENTRIES_FINAL_ERROR | "${MODIFIED_AGE_IN_DAYS_FOR_DOWNLOADED_CACHE_ENTRIES}"
-        'createdResources.removeUnusedEntriesAfterDays'    | REMOVE_UNUSED_ENTRIES_FINAL_ERROR | "${MODIFIED_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES}"
+        property                                  | error                             | value
+        'cleanup'                                 | THIS_PROPERTY_FINAL_ERROR         | 'Cleanup.DISABLED'
+        'releasedWrappers.removeUnusedEntries'    | REMOVE_UNUSED_ENTRIES_FINAL_ERROR | "TimestampSupplier.olderThanInDays(${MODIFIED_AGE_IN_DAYS_FOR_RELEASED_DISTS})"
+        'snapshotWrappers.removeUnusedEntries'    | REMOVE_UNUSED_ENTRIES_FINAL_ERROR | "TimestampSupplier.olderThanInDays(${MODIFIED_AGE_IN_DAY_FOR_SNAPSHOT_DISTS})"
+        'downloadedResources.removeUnusedEntries' | REMOVE_UNUSED_ENTRIES_FINAL_ERROR | "TimestampSupplier.olderThanInDays(${MODIFIED_AGE_IN_DAYS_FOR_DOWNLOADED_CACHE_ENTRIES})"
+        'createdResources.removeUnusedEntries'    | REMOVE_UNUSED_ENTRIES_FINAL_ERROR | "TimestampSupplier.olderThanInDays(${MODIFIED_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES})"
     }
 
     static String modifyCacheConfiguration(String property, String value) {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/cache/CacheConfigurationsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/cache/CacheConfigurationsIntegrationTest.groovy
@@ -26,7 +26,7 @@ class CacheConfigurationsIntegrationTest extends AbstractIntegrationSpec {
     private static final int MODIFIED_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES = CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES + 1
 
     private static final String THIS_PROPERTY_FINAL_ERROR = "The value for this property is final and cannot be changed any further"
-    private static final String REMOVE_UNUSED_ENTRIES_FINAL_ERROR = "The value for property 'removeUnusedEntriesAfter' is final and cannot be changed any further"
+    private static final String REMOVE_UNUSED_ENTRIES_FINAL_ERROR = "The value for property 'removeUnusedEntriesOlderThan' is final and cannot be changed any further"
 
     def setup() {
         requireOwnGradleUserHomeDir()
@@ -39,10 +39,10 @@ class CacheConfigurationsIntegrationTest extends AbstractIntegrationSpec {
             beforeSettings { settings ->
                 settings.caches {
                     cleanup = Cleanup.DISABLED
-                    releasedWrappers { removeUnusedEntriesAfterDays = ${MODIFIED_AGE_IN_DAYS_FOR_RELEASED_DISTS} }
-                    snapshotWrappers { removeUnusedEntriesAfterDays = ${MODIFIED_AGE_IN_DAY_FOR_SNAPSHOT_DISTS} }
-                    downloadedResources { removeUnusedEntriesAfterDays = ${MODIFIED_AGE_IN_DAYS_FOR_DOWNLOADED_CACHE_ENTRIES} }
-                    createdResources { removeUnusedEntriesAfterDays = ${MODIFIED_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES} }
+                    releasedWrappers.removeUnusedEntriesAfterDays = ${MODIFIED_AGE_IN_DAYS_FOR_RELEASED_DISTS}
+                    snapshotWrappers.removeUnusedEntriesAfterDays = ${MODIFIED_AGE_IN_DAY_FOR_SNAPSHOT_DISTS}
+                    downloadedResources.removeUnusedEntriesAfterDays = ${MODIFIED_AGE_IN_DAYS_FOR_DOWNLOADED_CACHE_ENTRIES}
+                    createdResources.removeUnusedEntriesAfterDays = ${MODIFIED_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES}
                 }
             }
         """
@@ -74,19 +74,19 @@ class CacheConfigurationsIntegrationTest extends AbstractIntegrationSpec {
             beforeSettings { settings ->
                 settings.caches {
                     cleanup = Cleanup.DISABLED
-                    releasedWrappers { removeUnusedEntriesAfter = ${releasedDistTimestamp} }
-                    snapshotWrappers { removeUnusedEntriesAfter = ${snapshotDistTimestamp} }
-                    downloadedResources { removeUnusedEntriesAfter = ${downloadedResourcesTimestamp} }
-                    createdResources { removeUnusedEntriesAfter = ${createdResourcesTimestamp} }
+                    releasedWrappers.removeUnusedEntriesOlderThan = ${releasedDistTimestamp}
+                    snapshotWrappers.removeUnusedEntriesOlderThan = ${snapshotDistTimestamp}
+                    downloadedResources.removeUnusedEntriesOlderThan = ${downloadedResourcesTimestamp}
+                    createdResources.removeUnusedEntriesOlderThan = ${createdResourcesTimestamp}
                 }
             }
         """
         settingsFile << """
             caches {
-                assert releasedWrappers.removeUnusedEntriesAfter.get() == ${releasedDistTimestamp}
-                assert snapshotWrappers.removeUnusedEntriesAfter.get() == ${snapshotDistTimestamp}
-                assert downloadedResources.removeUnusedEntriesAfter.get() == ${downloadedResourcesTimestamp}
-                assert createdResources.removeUnusedEntriesAfter.get() == ${createdResourcesTimestamp}
+                assert releasedWrappers.removeUnusedEntriesOlderThan.get() == ${releasedDistTimestamp}
+                assert snapshotWrappers.removeUnusedEntriesOlderThan.get() == ${snapshotDistTimestamp}
+                assert downloadedResources.removeUnusedEntriesOlderThan.get() == ${downloadedResourcesTimestamp}
+                assert createdResources.removeUnusedEntriesOlderThan.get() == ${createdResourcesTimestamp}
             }
         """
 
@@ -122,7 +122,7 @@ class CacheConfigurationsIntegrationTest extends AbstractIntegrationSpec {
 
     static String assertValueIsSameInDays(int configuredDaysAgo) {
         return """
-            def timestamp = removeUnusedEntriesAfter.get()
+            def timestamp = removeUnusedEntriesOlderThan.get()
             def daysAgo = java.util.concurrent.TimeUnit.MILLISECONDS.toDays(System.currentTimeMillis() - timestamp)
             assert daysAgo == ${configuredDaysAgo}
         """

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/cache/CacheConfigurationsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/cache/CacheConfigurationsIntegrationTest.groovy
@@ -26,7 +26,7 @@ class CacheConfigurationsIntegrationTest extends AbstractIntegrationSpec {
     private static final int MODIFIED_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES = CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES + 1
 
     private static final String THIS_PROPERTY_FINAL_ERROR = "The value for this property is final and cannot be changed any further"
-    private static final String REMOVE_UNUSED_ENTRIES_FINAL_ERROR = "The value for property 'removeUnusedEntries' is final and cannot be changed any further"
+    private static final String REMOVE_UNUSED_ENTRIES_FINAL_ERROR = "The value for property 'removeUnusedEntriesAfter' is final and cannot be changed any further"
 
     def setup() {
         requireOwnGradleUserHomeDir()
@@ -39,19 +39,19 @@ class CacheConfigurationsIntegrationTest extends AbstractIntegrationSpec {
             beforeSettings { settings ->
                 settings.caches {
                     cleanup = Cleanup.DISABLED
-                    releasedWrappers.removeUnusedEntries = TimestampSupplier.olderThanInDays(${MODIFIED_AGE_IN_DAYS_FOR_RELEASED_DISTS})
-                    snapshotWrappers.removeUnusedEntries = TimestampSupplier.olderThanInDays(${MODIFIED_AGE_IN_DAY_FOR_SNAPSHOT_DISTS})
-                    downloadedResources.removeUnusedEntries = TimestampSupplier.olderThanInDays(${MODIFIED_AGE_IN_DAYS_FOR_DOWNLOADED_CACHE_ENTRIES})
-                    createdResources.removeUnusedEntries = TimestampSupplier.olderThanInDays(${MODIFIED_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES})
+                    releasedWrappers { removeUnusedEntriesAfter = days(${MODIFIED_AGE_IN_DAYS_FOR_RELEASED_DISTS}) }
+                    snapshotWrappers { removeUnusedEntriesAfter = days(${MODIFIED_AGE_IN_DAY_FOR_SNAPSHOT_DISTS}) }
+                    downloadedResources { removeUnusedEntriesAfter = days(${MODIFIED_AGE_IN_DAYS_FOR_DOWNLOADED_CACHE_ENTRIES}) }
+                    createdResources { removeUnusedEntriesAfter = days(${MODIFIED_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES}) }
                 }
             }
         """
         settingsFile << """
             caches {
-                assert releasedWrappers.removeUnusedEntries.get() != null
-                assert snapshotWrappers.removeUnusedEntries.get() != null
-                assert downloadedResources.removeUnusedEntries.get() != null
-                assert createdResources.removeUnusedEntries.get() != null
+                assert releasedWrappers.removeUnusedEntriesAfter.get() != null
+                assert snapshotWrappers.removeUnusedEntriesAfter.get() != null
+                assert downloadedResources.removeUnusedEntriesAfter.get() != null
+                assert createdResources.removeUnusedEntriesAfter.get() != null
             }
         """
 
@@ -71,12 +71,12 @@ class CacheConfigurationsIntegrationTest extends AbstractIntegrationSpec {
         failureCauseContains(error)
 
         where:
-        property                                  | error                             | value
-        'cleanup'                                 | THIS_PROPERTY_FINAL_ERROR         | 'Cleanup.DISABLED'
-        'releasedWrappers.removeUnusedEntries'    | REMOVE_UNUSED_ENTRIES_FINAL_ERROR | "TimestampSupplier.olderThanInDays(${MODIFIED_AGE_IN_DAYS_FOR_RELEASED_DISTS})"
-        'snapshotWrappers.removeUnusedEntries'    | REMOVE_UNUSED_ENTRIES_FINAL_ERROR | "TimestampSupplier.olderThanInDays(${MODIFIED_AGE_IN_DAY_FOR_SNAPSHOT_DISTS})"
-        'downloadedResources.removeUnusedEntries' | REMOVE_UNUSED_ENTRIES_FINAL_ERROR | "TimestampSupplier.olderThanInDays(${MODIFIED_AGE_IN_DAYS_FOR_DOWNLOADED_CACHE_ENTRIES})"
-        'createdResources.removeUnusedEntries'    | REMOVE_UNUSED_ENTRIES_FINAL_ERROR | "TimestampSupplier.olderThanInDays(${MODIFIED_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES})"
+        property                                       | error                             | value
+        'cleanup'                                      | THIS_PROPERTY_FINAL_ERROR         | 'Cleanup.DISABLED'
+        'releasedWrappers.removeUnusedEntriesAfter'    | REMOVE_UNUSED_ENTRIES_FINAL_ERROR | "CacheResourceConfiguration.days(${MODIFIED_AGE_IN_DAYS_FOR_RELEASED_DISTS})"
+        'snapshotWrappers.removeUnusedEntriesAfter'    | REMOVE_UNUSED_ENTRIES_FINAL_ERROR | "CacheResourceConfiguration.days(${MODIFIED_AGE_IN_DAY_FOR_SNAPSHOT_DISTS})"
+        'downloadedResources.removeUnusedEntriesAfter' | REMOVE_UNUSED_ENTRIES_FINAL_ERROR | "CacheResourceConfiguration.days(${MODIFIED_AGE_IN_DAYS_FOR_DOWNLOADED_CACHE_ENTRIES})"
+        'createdResources.removeUnusedEntriesAfter'    | REMOVE_UNUSED_ENTRIES_FINAL_ERROR | "CacheResourceConfiguration.days(${MODIFIED_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES})"
     }
 
     static String modifyCacheConfiguration(String property, String value) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/cache/DefaultCacheConfigurations.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/cache/DefaultCacheConfigurations.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.cache;
 import org.gradle.api.Action;
 import org.gradle.api.cache.CacheResourceConfiguration;
 import org.gradle.api.cache.Cleanup;
+import org.gradle.api.cache.TimestampSupplier;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
@@ -52,7 +53,7 @@ abstract public class DefaultCacheConfigurations implements CacheConfigurationsI
 
     private static CacheResourceConfiguration createResourceConfiguration(ObjectFactory objectFactory, int defaultDays) {
         CacheResourceConfiguration resourceConfiguration = objectFactory.newInstance(CacheResourceConfiguration.class);
-        resourceConfiguration.getRemoveUnusedEntriesAfterDays().convention(defaultDays);
+        resourceConfiguration.getRemoveUnusedEntries().convention(TimestampSupplier.olderThanInDays(defaultDays));
         return resourceConfiguration;
     }
 
@@ -133,10 +134,10 @@ abstract public class DefaultCacheConfigurations implements CacheConfigurationsI
 
     @Override
     public void finalizeConfigurations() {
-        releasedWrappersConfiguration.getRemoveUnusedEntriesAfterDays().finalizeValue();
-        snapshotWrappersConfiguration.getRemoveUnusedEntriesAfterDays().finalizeValue();
-        downloadedResourcesConfiguration.getRemoveUnusedEntriesAfterDays().finalizeValue();
-        createdResourcesConfiguration.getRemoveUnusedEntriesAfterDays().finalizeValue();
+        releasedWrappersConfiguration.getRemoveUnusedEntries().finalizeValue();
+        snapshotWrappersConfiguration.getRemoveUnusedEntries().finalizeValue();
+        downloadedResourcesConfiguration.getRemoveUnusedEntries().finalizeValue();
+        createdResourcesConfiguration.getRemoveUnusedEntries().finalizeValue();
         getCleanup().finalizeValue();
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/cache/DefaultCacheConfigurations.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/cache/DefaultCacheConfigurations.java
@@ -149,7 +149,7 @@ abstract public class DefaultCacheConfigurations implements CacheConfigurationsI
         }
 
         /**
-         * Returns a supplier mapped from the property.  This provides a supplier that is resilient
+         * @implNote Returns a supplier mapped from the property.  This provides a supplier that is resilient
          * to subsequent changes to the property value as opposed to just calling get() on the property.
          */
         @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/cache/DefaultCacheConfigurations.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/cache/DefaultCacheConfigurations.java
@@ -55,7 +55,7 @@ abstract public class DefaultCacheConfigurations implements CacheConfigurationsI
 
     private static CacheResourceConfigurationInternal createResourceConfiguration(ObjectFactory objectFactory, int defaultDays) {
         CacheResourceConfigurationInternal resourceConfiguration = objectFactory.newInstance(DefaultCacheResourceConfiguration.class);
-        resourceConfiguration.getRemoveUnusedEntriesAfter().convention(providerFromSupplier(TimestampSuppliers.daysAgo(defaultDays)));
+        resourceConfiguration.getRemoveUnusedEntriesOlderThan().convention(providerFromSupplier(TimestampSuppliers.daysAgo(defaultDays)));
         return resourceConfiguration;
     }
 
@@ -136,10 +136,10 @@ abstract public class DefaultCacheConfigurations implements CacheConfigurationsI
 
     @Override
     public void finalizeConfigurations() {
-        releasedWrappersConfiguration.getRemoveUnusedEntriesAfter().finalizeValue();
-        snapshotWrappersConfiguration.getRemoveUnusedEntriesAfter().finalizeValue();
-        downloadedResourcesConfiguration.getRemoveUnusedEntriesAfter().finalizeValue();
-        createdResourcesConfiguration.getRemoveUnusedEntriesAfter().finalizeValue();
+        releasedWrappersConfiguration.getRemoveUnusedEntriesOlderThan().finalizeValue();
+        snapshotWrappersConfiguration.getRemoveUnusedEntriesOlderThan().finalizeValue();
+        downloadedResourcesConfiguration.getRemoveUnusedEntriesOlderThan().finalizeValue();
+        createdResourcesConfiguration.getRemoveUnusedEntriesOlderThan().finalizeValue();
         getCleanup().finalizeValue();
     }
 
@@ -187,14 +187,14 @@ abstract public class DefaultCacheConfigurations implements CacheConfigurationsI
          * to subsequent changes to the property value as opposed to just calling get() on the property.
          */
         @Override
-        public Supplier<Long> getRemoveUnusedEntriesAfterAsSupplier() {
-            return () -> getRemoveUnusedEntriesAfter().get();
+        public Supplier<Long> getRemoveUnusedEntriesOlderThanAsSupplier() {
+            return () -> getRemoveUnusedEntriesOlderThan().get();
         }
 
 
         @Override
         public void setRemoveUnusedEntriesAfterDays(int removeUnusedEntriesAfterDays) {
-            getRemoveUnusedEntriesAfter().set(providerFromSupplier(TimestampSuppliers.daysAgo(removeUnusedEntriesAfterDays)));
+            getRemoveUnusedEntriesOlderThan().set(providerFromSupplier(TimestampSuppliers.daysAgo(removeUnusedEntriesAfterDays)));
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/cache/DefaultCacheConfigurations.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/cache/DefaultCacheConfigurations.java
@@ -53,7 +53,7 @@ abstract public class DefaultCacheConfigurations implements CacheConfigurationsI
 
     private static CacheResourceConfiguration createResourceConfiguration(ObjectFactory objectFactory, int defaultDays) {
         CacheResourceConfiguration resourceConfiguration = objectFactory.newInstance(CacheResourceConfiguration.class);
-        resourceConfiguration.getRemoveUnusedEntries().convention(TimestampSupplier.olderThanInDays(defaultDays));
+        resourceConfiguration.getRemoveUnusedEntriesAfter().convention(TimestampSupplier.olderThanInDays(defaultDays));
         return resourceConfiguration;
     }
 
@@ -134,10 +134,10 @@ abstract public class DefaultCacheConfigurations implements CacheConfigurationsI
 
     @Override
     public void finalizeConfigurations() {
-        releasedWrappersConfiguration.getRemoveUnusedEntries().finalizeValue();
-        snapshotWrappersConfiguration.getRemoveUnusedEntries().finalizeValue();
-        downloadedResourcesConfiguration.getRemoveUnusedEntries().finalizeValue();
-        createdResourcesConfiguration.getRemoveUnusedEntries().finalizeValue();
+        releasedWrappersConfiguration.getRemoveUnusedEntriesAfter().finalizeValue();
+        snapshotWrappersConfiguration.getRemoveUnusedEntriesAfter().finalizeValue();
+        downloadedResourcesConfiguration.getRemoveUnusedEntriesAfter().finalizeValue();
+        createdResourcesConfiguration.getRemoveUnusedEntriesAfter().finalizeValue();
         getCleanup().finalizeValue();
     }
 

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/GradleUserHomeCleanupService.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/GradleUserHomeCleanupService.java
@@ -62,8 +62,8 @@ public class GradleUserHomeCleanupService implements Stoppable {
             cleanupActionDecorator.decorate(
                 new VersionSpecificCacheCleanupAction(
                     cacheBaseDir,
-                    cacheConfigurations.getReleasedWrappers().getRemoveUnusedEntriesAfterDays().get(),
-                    cacheConfigurations.getSnapshotWrappers().getRemoveUnusedEntriesAfterDays().get(),
+                    cacheConfigurations.getReleasedWrappers().getRemoveUnusedEntries().get(),
+                    cacheConfigurations.getSnapshotWrappers().getRemoveUnusedEntries().get(),
                     deleter,
                     cacheConfigurations.getCleanupFrequency().get()
                 )

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/GradleUserHomeCleanupService.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/GradleUserHomeCleanupService.java
@@ -62,8 +62,8 @@ public class GradleUserHomeCleanupService implements Stoppable {
             cleanupActionDecorator.decorate(
                 new VersionSpecificCacheCleanupAction(
                     cacheBaseDir,
-                    cacheConfigurations.getReleasedWrappers().getRemoveUnusedEntriesAfterAsSupplier(),
-                    cacheConfigurations.getSnapshotWrappers().getRemoveUnusedEntriesAfterAsSupplier(),
+                    cacheConfigurations.getReleasedWrappers().getRemoveUnusedEntriesOlderThanAsSupplier(),
+                    cacheConfigurations.getSnapshotWrappers().getRemoveUnusedEntriesOlderThanAsSupplier(),
                     deleter,
                     cacheConfigurations.getCleanupFrequency().get()
                 )

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/GradleUserHomeCleanupService.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/GradleUserHomeCleanupService.java
@@ -62,8 +62,8 @@ public class GradleUserHomeCleanupService implements Stoppable {
             cleanupActionDecorator.decorate(
                 new VersionSpecificCacheCleanupAction(
                     cacheBaseDir,
-                    cacheConfigurations.getReleasedWrappers().getRemoveUnusedEntriesAfter().get(),
-                    cacheConfigurations.getSnapshotWrappers().getRemoveUnusedEntriesAfter().get(),
+                    cacheConfigurations.getReleasedWrappers().getRemoveUnusedEntriesAfterAsSupplier(),
+                    cacheConfigurations.getSnapshotWrappers().getRemoveUnusedEntriesAfterAsSupplier(),
                     deleter,
                     cacheConfigurations.getCleanupFrequency().get()
                 )

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/GradleUserHomeCleanupService.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/GradleUserHomeCleanupService.java
@@ -62,8 +62,8 @@ public class GradleUserHomeCleanupService implements Stoppable {
             cleanupActionDecorator.decorate(
                 new VersionSpecificCacheCleanupAction(
                     cacheBaseDir,
-                    cacheConfigurations.getReleasedWrappers().getRemoveUnusedEntries().get(),
-                    cacheConfigurations.getSnapshotWrappers().getRemoveUnusedEntries().get(),
+                    cacheConfigurations.getReleasedWrappers().getRemoveUnusedEntriesAfter().get(),
+                    cacheConfigurations.getSnapshotWrappers().getRemoveUnusedEntriesAfter().get(),
                     deleter,
                     cacheConfigurations.getCleanupFrequency().get()
                 )

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/VersionSpecificCacheCleanupAction.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/VersionSpecificCacheCleanupAction.java
@@ -90,7 +90,7 @@ public class VersionSpecificCacheCleanupAction implements MonitoredCleanupAction
             if (!gcFile.getParentFile().exists()) {
                 return false;
             } else {
-                lastCleanupTimestamp = -1;
+                lastCleanupTimestamp = CleanupFrequency.NEVER_CLEANED;
             }
         } else {
             lastCleanupTimestamp = gcFile.lastModified();

--- a/subprojects/core/src/main/java/org/gradle/initialization/layout/ProjectCacheDir.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/layout/ProjectCacheDir.java
@@ -16,7 +16,7 @@
 
 package org.gradle.initialization.layout;
 
-import org.gradle.api.cache.TimestampSupplier;
+import org.gradle.internal.time.TimestampSuppliers;
 import org.gradle.cache.CleanupFrequency;
 import org.gradle.cache.internal.DefaultCleanupProgressMonitor;
 import org.gradle.cache.internal.VersionSpecificCacheCleanupAction;
@@ -69,7 +69,7 @@ public class ProjectCacheDir implements Stoppable {
         }
         VersionSpecificCacheCleanupAction cleanupAction = new VersionSpecificCacheCleanupAction(
             dir,
-            TimestampSupplier.olderThanInDays(MAX_UNUSED_DAYS_FOR_RELEASES_AND_SNAPSHOTS),
+            TimestampSuppliers.daysAgo(MAX_UNUSED_DAYS_FOR_RELEASES_AND_SNAPSHOTS),
             deleter,
             CleanupFrequency.DAILY
         );

--- a/subprojects/core/src/main/java/org/gradle/initialization/layout/ProjectCacheDir.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/layout/ProjectCacheDir.java
@@ -16,6 +16,7 @@
 
 package org.gradle.initialization.layout;
 
+import org.gradle.api.cache.TimestampSupplier;
 import org.gradle.cache.CleanupFrequency;
 import org.gradle.cache.internal.DefaultCleanupProgressMonitor;
 import org.gradle.cache.internal.VersionSpecificCacheCleanupAction;
@@ -35,7 +36,7 @@ import java.io.IOException;
 public class ProjectCacheDir implements Stoppable {
     private static final Logger LOGGER = LoggerFactory.getLogger(ProjectCacheDir.class);
 
-    private static final long MAX_UNUSED_DAYS_FOR_RELEASES_AND_SNAPSHOTS = 7;
+    private static final int MAX_UNUSED_DAYS_FOR_RELEASES_AND_SNAPSHOTS = 7;
 
     private final File dir;
     private final ProgressLoggerFactory progressLoggerFactory;
@@ -68,7 +69,7 @@ public class ProjectCacheDir implements Stoppable {
         }
         VersionSpecificCacheCleanupAction cleanupAction = new VersionSpecificCacheCleanupAction(
             dir,
-            MAX_UNUSED_DAYS_FOR_RELEASES_AND_SNAPSHOTS,
+            TimestampSupplier.olderThanInDays(MAX_UNUSED_DAYS_FOR_RELEASES_AND_SNAPSHOTS),
             deleter,
             CleanupFrequency.DAILY
         );

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultClasspathTransformerCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultClasspathTransformerCacheFactory.java
@@ -85,7 +85,7 @@ public class DefaultClasspathTransformerCacheFactory implements ClasspathTransfo
                 new LeastRecentlyUsedCacheCleanup(
                     new SingleDepthFilesFinder(FILE_TREE_DEPTH_TO_TRACK_AND_CLEANUP),
                     fileAccessTimeJournal,
-                    cacheConfigurations.getCreatedResources().getRemoveUnusedEntries().get()
+                    cacheConfigurations.getCreatedResources().getRemoveUnusedEntriesAfter().get()
                 )
             ).build();
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultClasspathTransformerCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultClasspathTransformerCacheFactory.java
@@ -18,8 +18,9 @@ package org.gradle.internal.classpath;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.gradle.api.internal.cache.CacheConfigurationsInternal;
-import org.gradle.api.internal.cache.DefaultCacheCleanup;
+import org.gradle.api.internal.cache.DefaultCacheCleanupStrategy;
 import org.gradle.cache.CacheBuilder;
+import org.gradle.cache.CacheCleanupStrategy;
 import org.gradle.cache.internal.CleanupActionDecorator;
 import org.gradle.cache.FileLockManager;
 import org.gradle.cache.PersistentCache;
@@ -67,12 +68,12 @@ public class DefaultClasspathTransformerCacheFactory implements ClasspathTransfo
             .withDisplayName(CACHE_NAME)
             .withCrossVersionCache(CacheBuilder.LockTarget.DefaultTarget)
             .withLockOptions(mode(FileLockManager.LockMode.OnDemand))
-            .withCleanup(createCacheCleanup(fileAccessTimeJournal))
+            .withCleanupStrategy(createCacheCleanupStrategy(fileAccessTimeJournal))
             .open();
     }
 
-    private DefaultCacheCleanup createCacheCleanup(FileAccessTimeJournal fileAccessTimeJournal) {
-        return DefaultCacheCleanup.from(
+    private CacheCleanupStrategy createCacheCleanupStrategy(FileAccessTimeJournal fileAccessTimeJournal) {
+        return DefaultCacheCleanupStrategy.from(
             cleanupActionDecorator.decorate(createCleanupAction(fileAccessTimeJournal)),
             cacheConfigurations.getCleanupFrequency()
         );

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultClasspathTransformerCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultClasspathTransformerCacheFactory.java
@@ -85,7 +85,7 @@ public class DefaultClasspathTransformerCacheFactory implements ClasspathTransfo
                 new LeastRecentlyUsedCacheCleanup(
                     new SingleDepthFilesFinder(FILE_TREE_DEPTH_TO_TRACK_AND_CLEANUP),
                     fileAccessTimeJournal,
-                    () -> cacheConfigurations.getCreatedResources().getRemoveUnusedEntriesAfterDays().get()
+                    cacheConfigurations.getCreatedResources().getRemoveUnusedEntries().get()
                 )
             ).build();
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultClasspathTransformerCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultClasspathTransformerCacheFactory.java
@@ -85,7 +85,7 @@ public class DefaultClasspathTransformerCacheFactory implements ClasspathTransfo
                 new LeastRecentlyUsedCacheCleanup(
                     new SingleDepthFilesFinder(FILE_TREE_DEPTH_TO_TRACK_AND_CLEANUP),
                     fileAccessTimeJournal,
-                    cacheConfigurations.getCreatedResources().getRemoveUnusedEntriesAfterAsSupplier()
+                    cacheConfigurations.getCreatedResources().getRemoveUnusedEntriesOlderThanAsSupplier()
                 )
             ).build();
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultClasspathTransformerCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultClasspathTransformerCacheFactory.java
@@ -85,7 +85,7 @@ public class DefaultClasspathTransformerCacheFactory implements ClasspathTransfo
                 new LeastRecentlyUsedCacheCleanup(
                     new SingleDepthFilesFinder(FILE_TREE_DEPTH_TO_TRACK_AND_CLEANUP),
                     fileAccessTimeJournal,
-                    cacheConfigurations.getCreatedResources().getRemoveUnusedEntriesAfter().get()
+                    cacheConfigurations.getCreatedResources().getRemoveUnusedEntriesAfterAsSupplier()
                 )
             ).build();
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleUserHomeScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleUserHomeScopeServices.java
@@ -41,6 +41,7 @@ import org.gradle.cache.internal.DefaultFileContentCacheFactory;
 import org.gradle.cache.internal.DefaultGeneratedGradleJarCache;
 import org.gradle.cache.internal.DefaultGlobalCacheLocations;
 import org.gradle.cache.internal.FileContentCacheFactory;
+import org.gradle.cache.internal.GradleUserHomeCacheCleanupActionDecorator;
 import org.gradle.cache.internal.GradleUserHomeCleanupServices;
 import org.gradle.cache.internal.InMemoryCacheDecoratorFactory;
 import org.gradle.cache.internal.scopes.DefaultCacheScopeMapping;
@@ -113,6 +114,10 @@ public class GradleUserHomeScopeServices extends WorkerSharedUserHomeScopeServic
         for (PluginServiceRegistry plugin : globalServices.getAll(PluginServiceRegistry.class)) {
             plugin.registerGradleUserHomeServices(registration);
         }
+    }
+
+    GradleUserHomeCacheCleanupActionDecorator createCacheCleanupDecorator(GradleUserHomeDirProvider gradleUserHomeDirProvider) {
+        return new GradleUserHomeCacheCleanupActionDecorator(gradleUserHomeDirProvider);
     }
 
     CacheRepository createCacheRepository(GlobalCacheDir globalCacheDir, CacheFactory cacheFactory) {
@@ -226,7 +231,7 @@ public class GradleUserHomeScopeServices extends WorkerSharedUserHomeScopeServic
         return new DefaultTimeoutHandler(executorFactory.createScheduled("execution timeouts", 1), currentBuildOperationRef);
     }
 
-    protected CacheConfigurationsInternal createCachesConfiguration(ObjectFactory objectFactory, GradleUserHomeDirProvider gradleUserHomeDirProvider) {
-        return objectFactory.newInstance(DefaultCacheConfigurations.class, objectFactory, gradleUserHomeDirProvider);
+    protected CacheConfigurationsInternal createCachesConfiguration(ObjectFactory objectFactory) {
+        return objectFactory.newInstance(DefaultCacheConfigurations.class, objectFactory);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/internal/TestInMemoryCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/internal/TestInMemoryCacheFactory.java
@@ -18,7 +18,7 @@ package org.gradle.testfixtures.internal;
 import com.google.common.collect.Maps;
 import org.gradle.api.Action;
 import org.gradle.cache.CacheBuilder;
-import org.gradle.cache.CacheCleanup;
+import org.gradle.cache.CacheCleanupStrategy;
 import org.gradle.cache.CacheOpenException;
 import org.gradle.cache.CleanupAction;
 import org.gradle.cache.CleanupProgressMonitor;
@@ -48,9 +48,9 @@ public class TestInMemoryCacheFactory implements CacheFactory {
     final Map<Pair<File, String>, PersistentIndexedCache<?, ?>> caches = Collections.synchronizedMap(Maps.newLinkedHashMap());
 
     @Override
-    public PersistentCache open(File cacheDir, String displayName, Map<String, ?> properties, CacheBuilder.LockTarget lockTarget, LockOptions lockOptions, Action<? super PersistentCache> initializer, @Nullable CacheCleanup cacheCleanup) throws CacheOpenException {
+    public PersistentCache open(File cacheDir, String displayName, Map<String, ?> properties, CacheBuilder.LockTarget lockTarget, LockOptions lockOptions, Action<? super PersistentCache> initializer, @Nullable CacheCleanupStrategy cacheCleanupStrategy) throws CacheOpenException {
         GFileUtils.mkdirs(cacheDir);
-        InMemoryCache cache = new InMemoryCache(cacheDir, displayName, cacheCleanup != null ? cacheCleanup.getCleanupAction() : null);
+        InMemoryCache cache = new InMemoryCache(cacheDir, displayName, cacheCleanupStrategy != null ? cacheCleanupStrategy.getCleanupAction() : null);
         if (initializer != null) {
             initializer.execute(cache);
         }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/cache/DefaultCacheConfigurationsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/cache/DefaultCacheConfigurationsTest.groovy
@@ -91,4 +91,30 @@ class DefaultCacheConfigurationsTest extends Specification {
         releasedWrappers.get() == twoDaysAgo
         snapshotWrappers.get() == twoDaysAgo
     }
+
+    def "cannot set values in days to less than one"() {
+        when:
+        cacheConfigurations.createdResources.setRemoveUnusedEntriesAfterDays(0)
+
+        then:
+        thrown(IllegalArgumentException)
+
+        when:
+        cacheConfigurations.downloadedResources.setRemoveUnusedEntriesAfterDays(0)
+
+        then:
+        thrown(IllegalArgumentException)
+
+        when:
+        cacheConfigurations.releasedWrappers.setRemoveUnusedEntriesAfterDays(0)
+
+        then:
+        thrown(IllegalArgumentException)
+
+        when:
+        cacheConfigurations.snapshotWrappers.setRemoveUnusedEntriesAfterDays(0)
+
+        then:
+        thrown(IllegalArgumentException)
+    }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/cache/DefaultCacheConfigurationsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/cache/DefaultCacheConfigurationsTest.groovy
@@ -21,17 +21,17 @@ import org.gradle.initialization.GradleUserHomeDirProvider
 import org.gradle.util.TestUtil
 import spock.lang.Specification
 
-import static org.gradle.api.cache.TimestampSupplier.olderThanInDays
+import static org.gradle.internal.time.TimestampSuppliers.daysAgo
 
 class DefaultCacheConfigurationsTest extends Specification {
     def cacheConfigurations = TestUtil.objectFactory().newInstance(DefaultCacheConfigurations.class, Stub(GradleUserHomeDirProvider))
 
     def "cannot modify cache configurations once finalized"() {
         when:
-        cacheConfigurations.createdResources.removeUnusedEntriesAfter.set(olderThanInDays(2))
-        cacheConfigurations.downloadedResources.removeUnusedEntriesAfter.set(olderThanInDays(2))
-        cacheConfigurations.releasedWrappers.removeUnusedEntriesAfter.set(olderThanInDays(2))
-        cacheConfigurations.snapshotWrappers.removeUnusedEntriesAfter.set(olderThanInDays(2))
+        cacheConfigurations.createdResources.removeUnusedEntriesAfter.set(daysAgo(2))
+        cacheConfigurations.downloadedResources.removeUnusedEntriesAfter.set(daysAgo(2))
+        cacheConfigurations.releasedWrappers.removeUnusedEntriesAfter.set(daysAgo(2))
+        cacheConfigurations.snapshotWrappers.removeUnusedEntriesAfter.set(daysAgo(2))
         cacheConfigurations.cleanup.set(Cleanup.DISABLED)
 
         then:
@@ -41,25 +41,25 @@ class DefaultCacheConfigurationsTest extends Specification {
         cacheConfigurations.finalizeConfigurations()
 
         and:
-        cacheConfigurations.createdResources.removeUnusedEntriesAfter.set(olderThanInDays(1))
+        cacheConfigurations.createdResources.removeUnusedEntriesAfter.set(daysAgo(1))
 
         then:
         thrown(IllegalStateException)
 
         when:
-        cacheConfigurations.downloadedResources.removeUnusedEntriesAfter.set(olderThanInDays(1))
+        cacheConfigurations.downloadedResources.removeUnusedEntriesAfter.set(daysAgo(1))
 
         then:
         thrown(IllegalStateException)
 
         when:
-        cacheConfigurations.releasedWrappers.removeUnusedEntriesAfter.set(olderThanInDays(1))
+        cacheConfigurations.releasedWrappers.removeUnusedEntriesAfter.set(daysAgo(1))
 
         then:
         thrown(IllegalStateException)
 
         when:
-        cacheConfigurations.snapshotWrappers.removeUnusedEntriesAfter.set(olderThanInDays(1))
+        cacheConfigurations.snapshotWrappers.removeUnusedEntriesAfter.set(daysAgo(1))
 
         then:
         thrown(IllegalStateException)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/cache/DefaultCacheConfigurationsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/cache/DefaultCacheConfigurationsTest.groovy
@@ -73,17 +73,17 @@ class DefaultCacheConfigurationsTest extends Specification {
 
     def "suppliers reflect changes in property values"() {
         when:
-        def createdResources = cacheConfigurations.createdResources.removeUnusedEntriesAfterAsSupplier
-        def downloadedResources = cacheConfigurations.downloadedResources.removeUnusedEntriesAfterAsSupplier
-        def releasedWrappers = cacheConfigurations.releasedWrappers.removeUnusedEntriesAfterAsSupplier
-        def snapshotWrappers = cacheConfigurations.snapshotWrappers.removeUnusedEntriesAfterAsSupplier
+        def createdResources = cacheConfigurations.createdResources.removeUnusedEntriesOlderThanAsSupplier
+        def downloadedResources = cacheConfigurations.downloadedResources.removeUnusedEntriesOlderThanAsSupplier
+        def releasedWrappers = cacheConfigurations.releasedWrappers.removeUnusedEntriesOlderThanAsSupplier
+        def snapshotWrappers = cacheConfigurations.snapshotWrappers.removeUnusedEntriesOlderThanAsSupplier
 
         and:
         def twoDaysAgo = daysAgo(2).get()
-        cacheConfigurations.createdResources.removeUnusedEntriesAfter.set(twoDaysAgo)
-        cacheConfigurations.downloadedResources.removeUnusedEntriesAfter.set(twoDaysAgo)
-        cacheConfigurations.releasedWrappers.removeUnusedEntriesAfter.set(twoDaysAgo)
-        cacheConfigurations.snapshotWrappers.removeUnusedEntriesAfter.set(twoDaysAgo)
+        cacheConfigurations.createdResources.removeUnusedEntriesOlderThan.set(twoDaysAgo)
+        cacheConfigurations.downloadedResources.removeUnusedEntriesOlderThan.set(twoDaysAgo)
+        cacheConfigurations.releasedWrappers.removeUnusedEntriesOlderThan.set(twoDaysAgo)
+        cacheConfigurations.snapshotWrappers.removeUnusedEntriesOlderThan.set(twoDaysAgo)
 
         then:
         createdResources.get() == twoDaysAgo

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/cache/DefaultCacheConfigurationsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/cache/DefaultCacheConfigurationsTest.groovy
@@ -21,16 +21,17 @@ import org.gradle.initialization.GradleUserHomeDirProvider
 import org.gradle.util.TestUtil
 import spock.lang.Specification
 
+import static org.gradle.api.cache.TimestampSupplier.olderThanInDays
 
 class DefaultCacheConfigurationsTest extends Specification {
     def cacheConfigurations = TestUtil.objectFactory().newInstance(DefaultCacheConfigurations.class, Stub(GradleUserHomeDirProvider))
 
     def "cannot modify cache configurations once finalized"() {
         when:
-        cacheConfigurations.createdResources.removeUnusedEntriesAfterDays.set(2)
-        cacheConfigurations.downloadedResources.removeUnusedEntriesAfterDays.set(2)
-        cacheConfigurations.releasedWrappers.removeUnusedEntriesAfterDays.set(2)
-        cacheConfigurations.snapshotWrappers.removeUnusedEntriesAfterDays.set(2)
+        cacheConfigurations.createdResources.removeUnusedEntries.set(olderThanInDays(2))
+        cacheConfigurations.downloadedResources.removeUnusedEntries.set(olderThanInDays(2))
+        cacheConfigurations.releasedWrappers.removeUnusedEntries.set(olderThanInDays(2))
+        cacheConfigurations.snapshotWrappers.removeUnusedEntries.set(olderThanInDays(2))
         cacheConfigurations.cleanup.set(Cleanup.DISABLED)
 
         then:
@@ -40,25 +41,25 @@ class DefaultCacheConfigurationsTest extends Specification {
         cacheConfigurations.finalizeConfigurations()
 
         and:
-        cacheConfigurations.createdResources.removeUnusedEntriesAfterDays.set(1)
+        cacheConfigurations.createdResources.removeUnusedEntries.set(olderThanInDays(1))
 
         then:
         thrown(IllegalStateException)
 
         when:
-        cacheConfigurations.downloadedResources.removeUnusedEntriesAfterDays.set(1)
+        cacheConfigurations.downloadedResources.removeUnusedEntries.set(olderThanInDays(1))
 
         then:
         thrown(IllegalStateException)
 
         when:
-        cacheConfigurations.releasedWrappers.removeUnusedEntriesAfterDays.set(1)
+        cacheConfigurations.releasedWrappers.removeUnusedEntries.set(olderThanInDays(1))
 
         then:
         thrown(IllegalStateException)
 
         when:
-        cacheConfigurations.snapshotWrappers.removeUnusedEntriesAfterDays.set(1)
+        cacheConfigurations.snapshotWrappers.removeUnusedEntries.set(olderThanInDays(1))
 
         then:
         thrown(IllegalStateException)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/cache/DefaultCacheConfigurationsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/cache/DefaultCacheConfigurationsTest.groovy
@@ -28,10 +28,10 @@ class DefaultCacheConfigurationsTest extends Specification {
 
     def "cannot modify cache configurations once finalized"() {
         when:
-        cacheConfigurations.createdResources.removeUnusedEntries.set(olderThanInDays(2))
-        cacheConfigurations.downloadedResources.removeUnusedEntries.set(olderThanInDays(2))
-        cacheConfigurations.releasedWrappers.removeUnusedEntries.set(olderThanInDays(2))
-        cacheConfigurations.snapshotWrappers.removeUnusedEntries.set(olderThanInDays(2))
+        cacheConfigurations.createdResources.removeUnusedEntriesAfter.set(olderThanInDays(2))
+        cacheConfigurations.downloadedResources.removeUnusedEntriesAfter.set(olderThanInDays(2))
+        cacheConfigurations.releasedWrappers.removeUnusedEntriesAfter.set(olderThanInDays(2))
+        cacheConfigurations.snapshotWrappers.removeUnusedEntriesAfter.set(olderThanInDays(2))
         cacheConfigurations.cleanup.set(Cleanup.DISABLED)
 
         then:
@@ -41,25 +41,25 @@ class DefaultCacheConfigurationsTest extends Specification {
         cacheConfigurations.finalizeConfigurations()
 
         and:
-        cacheConfigurations.createdResources.removeUnusedEntries.set(olderThanInDays(1))
+        cacheConfigurations.createdResources.removeUnusedEntriesAfter.set(olderThanInDays(1))
 
         then:
         thrown(IllegalStateException)
 
         when:
-        cacheConfigurations.downloadedResources.removeUnusedEntries.set(olderThanInDays(1))
+        cacheConfigurations.downloadedResources.removeUnusedEntriesAfter.set(olderThanInDays(1))
 
         then:
         thrown(IllegalStateException)
 
         when:
-        cacheConfigurations.releasedWrappers.removeUnusedEntries.set(olderThanInDays(1))
+        cacheConfigurations.releasedWrappers.removeUnusedEntriesAfter.set(olderThanInDays(1))
 
         then:
         thrown(IllegalStateException)
 
         when:
-        cacheConfigurations.snapshotWrappers.removeUnusedEntries.set(olderThanInDays(1))
+        cacheConfigurations.snapshotWrappers.removeUnusedEntriesAfter.set(olderThanInDays(1))
 
         then:
         thrown(IllegalStateException)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/cache/DefaultCacheConfigurationsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/cache/DefaultCacheConfigurationsTest.groovy
@@ -21,6 +21,8 @@ import org.gradle.initialization.GradleUserHomeDirProvider
 import org.gradle.util.TestUtil
 import spock.lang.Specification
 
+import java.util.function.Supplier
+
 import static org.gradle.internal.time.TimestampSuppliers.daysAgo
 
 class DefaultCacheConfigurationsTest extends Specification {
@@ -69,5 +71,27 @@ class DefaultCacheConfigurationsTest extends Specification {
 
         then:
         thrown(IllegalStateException)
+    }
+
+    def "suppliers reflect changes in property values"() {
+        when:
+        def createdResources = cacheConfigurations.createdResources.removeUnusedEntriesAfterAsSupplier
+        def downloadedResources = cacheConfigurations.downloadedResources.removeUnusedEntriesAfterAsSupplier
+        def releasedWrappers = cacheConfigurations.releasedWrappers.removeUnusedEntriesAfterAsSupplier
+        def snapshotWrappers = cacheConfigurations.snapshotWrappers.removeUnusedEntriesAfterAsSupplier
+
+        and:
+        def twoDaysAgo = daysAgo(2).get()
+        def twoDaysAgoSupplier = { twoDaysAgo } as Supplier<Long>
+        cacheConfigurations.createdResources.removeUnusedEntriesAfter.set(twoDaysAgoSupplier)
+        cacheConfigurations.downloadedResources.removeUnusedEntriesAfter.set(twoDaysAgoSupplier)
+        cacheConfigurations.releasedWrappers.removeUnusedEntriesAfter.set(twoDaysAgoSupplier)
+        cacheConfigurations.snapshotWrappers.removeUnusedEntriesAfter.set(twoDaysAgoSupplier)
+
+        then:
+        createdResources.get() == twoDaysAgo
+        downloadedResources.get() == twoDaysAgo
+        releasedWrappers.get() == twoDaysAgo
+        snapshotWrappers.get() == twoDaysAgo
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/cache/DefaultCacheConfigurationsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/cache/DefaultCacheConfigurationsTest.groovy
@@ -21,8 +21,6 @@ import org.gradle.initialization.GradleUserHomeDirProvider
 import org.gradle.util.TestUtil
 import spock.lang.Specification
 
-import java.util.function.Supplier
-
 import static org.gradle.internal.time.TimestampSuppliers.daysAgo
 
 class DefaultCacheConfigurationsTest extends Specification {
@@ -30,10 +28,10 @@ class DefaultCacheConfigurationsTest extends Specification {
 
     def "cannot modify cache configurations once finalized"() {
         when:
-        cacheConfigurations.createdResources.removeUnusedEntriesAfter.set(daysAgo(2))
-        cacheConfigurations.downloadedResources.removeUnusedEntriesAfter.set(daysAgo(2))
-        cacheConfigurations.releasedWrappers.removeUnusedEntriesAfter.set(daysAgo(2))
-        cacheConfigurations.snapshotWrappers.removeUnusedEntriesAfter.set(daysAgo(2))
+        cacheConfigurations.createdResources.setRemoveUnusedEntriesAfterDays(2)
+        cacheConfigurations.downloadedResources.setRemoveUnusedEntriesAfterDays(2)
+        cacheConfigurations.releasedWrappers.setRemoveUnusedEntriesAfterDays(2)
+        cacheConfigurations.snapshotWrappers.setRemoveUnusedEntriesAfterDays(2)
         cacheConfigurations.cleanup.set(Cleanup.DISABLED)
 
         then:
@@ -43,25 +41,25 @@ class DefaultCacheConfigurationsTest extends Specification {
         cacheConfigurations.finalizeConfigurations()
 
         and:
-        cacheConfigurations.createdResources.removeUnusedEntriesAfter.set(daysAgo(1))
+        cacheConfigurations.createdResources.setRemoveUnusedEntriesAfterDays(1)
 
         then:
         thrown(IllegalStateException)
 
         when:
-        cacheConfigurations.downloadedResources.removeUnusedEntriesAfter.set(daysAgo(1))
+        cacheConfigurations.downloadedResources.setRemoveUnusedEntriesAfterDays(1)
 
         then:
         thrown(IllegalStateException)
 
         when:
-        cacheConfigurations.releasedWrappers.removeUnusedEntriesAfter.set(daysAgo(1))
+        cacheConfigurations.releasedWrappers.setRemoveUnusedEntriesAfterDays(1)
 
         then:
         thrown(IllegalStateException)
 
         when:
-        cacheConfigurations.snapshotWrappers.removeUnusedEntriesAfter.set(daysAgo(1))
+        cacheConfigurations.snapshotWrappers.setRemoveUnusedEntriesAfterDays(1)
 
         then:
         thrown(IllegalStateException)
@@ -82,11 +80,10 @@ class DefaultCacheConfigurationsTest extends Specification {
 
         and:
         def twoDaysAgo = daysAgo(2).get()
-        def twoDaysAgoSupplier = { twoDaysAgo } as Supplier<Long>
-        cacheConfigurations.createdResources.removeUnusedEntriesAfter.set(twoDaysAgoSupplier)
-        cacheConfigurations.downloadedResources.removeUnusedEntriesAfter.set(twoDaysAgoSupplier)
-        cacheConfigurations.releasedWrappers.removeUnusedEntriesAfter.set(twoDaysAgoSupplier)
-        cacheConfigurations.snapshotWrappers.removeUnusedEntriesAfter.set(twoDaysAgoSupplier)
+        cacheConfigurations.createdResources.removeUnusedEntriesAfter.set(twoDaysAgo)
+        cacheConfigurations.downloadedResources.removeUnusedEntriesAfter.set(twoDaysAgo)
+        cacheConfigurations.releasedWrappers.removeUnusedEntriesAfter.set(twoDaysAgo)
+        cacheConfigurations.snapshotWrappers.removeUnusedEntriesAfter.set(twoDaysAgo)
 
         then:
         createdResources.get() == twoDaysAgo

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/cache/DefaultCacheConfigurationsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/cache/DefaultCacheConfigurationsTest.groovy
@@ -17,14 +17,13 @@
 package org.gradle.api.internal.cache
 
 import org.gradle.api.cache.Cleanup
-import org.gradle.initialization.GradleUserHomeDirProvider
 import org.gradle.util.TestUtil
 import spock.lang.Specification
 
 import static org.gradle.internal.time.TimestampSuppliers.daysAgo
 
 class DefaultCacheConfigurationsTest extends Specification {
-    def cacheConfigurations = TestUtil.objectFactory().newInstance(DefaultCacheConfigurations.class, Stub(GradleUserHomeDirProvider))
+    def cacheConfigurations = TestUtil.objectFactory().newInstance(DefaultCacheConfigurations.class)
 
     def "cannot modify cache configurations once finalized"() {
         when:

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/GradleUserHomeCleanupServiceTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/GradleUserHomeCleanupServiceTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.cache.internal
 
-import org.gradle.api.cache.CacheResourceConfiguration
+import org.gradle.api.internal.cache.CacheResourceConfigurationInternal
 import org.gradle.api.internal.cache.CacheConfigurationsInternal
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.provider.Property
@@ -26,6 +26,7 @@ import org.gradle.initialization.GradleUserHomeDirProvider
 import org.gradle.internal.cache.MonitoredCleanupAction
 import org.gradle.internal.cache.MonitoredCleanupActionDecorator
 import org.gradle.internal.logging.progress.ProgressLoggerFactory
+import org.gradle.internal.time.TimestampSuppliers
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.GradleVersion
@@ -58,11 +59,15 @@ class GradleUserHomeCleanupServiceTest extends Specification implements GradleUs
     def cleanupActionDecorator = Stub(MonitoredCleanupActionDecorator) {
         decorate(_) >> { args -> args[0] }
     }
-    def releasedWrappers = Stub(CacheResourceConfiguration) {
-        getRemoveUnusedEntriesAfterDays() >> property(CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_RELEASED_DISTS)
+    def releasedWrappers = Stub(CacheResourceConfigurationInternal) {
+        getRemoveUnusedEntriesAfterAsSupplier() >> TimestampSuppliers.daysAgo(CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_RELEASED_DISTS)
+    }
+    def snapshotWrappers = Stub(CacheResourceConfigurationInternal) {
+        getRemoveUnusedEntriesAfterAsSupplier() >> TimestampSuppliers.daysAgo(CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_SNAPSHOT_DISTS)
     }
     def cacheConfigurations = Stub(CacheConfigurationsInternal) {
         getReleasedWrappers() >> releasedWrappers
+        getSnapshotWrappers() >> snapshotWrappers
     }
 
     def property(Object value) {
@@ -109,7 +114,7 @@ class GradleUserHomeCleanupServiceTest extends Specification implements GradleUs
         cleanupService.cleanup()
 
         then:
-        releasedWrappers.getRemoveUnusedEntriesAfterDays() >> property(TWICE_DEFAULT_MAX_AGE_IN_DAYS - 1)
+        releasedWrappers.getRemoveUnusedEntriesAfterAsSupplier() >> TimestampSuppliers.daysAgo(TWICE_DEFAULT_MAX_AGE_IN_DAYS - 1)
 
         and:
         oldCacheDir.assertDoesNotExist()
@@ -129,7 +134,7 @@ class GradleUserHomeCleanupServiceTest extends Specification implements GradleUs
         cleanupService.cleanup()
 
         then:
-        releasedWrappers.getRemoveUnusedEntriesAfterDays() >> property(TWICE_DEFAULT_MAX_AGE_IN_DAYS)
+        releasedWrappers.getRemoveUnusedEntriesAfterAsSupplier() >> TimestampSuppliers.daysAgo(TWICE_DEFAULT_MAX_AGE_IN_DAYS)
         usedGradleVersions.getUsedGradleVersions() >> ([ GradleVersion.version('2.3.4') ] as SortedSet)
 
         and:

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/GradleUserHomeCleanupServiceTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/GradleUserHomeCleanupServiceTest.groovy
@@ -60,10 +60,10 @@ class GradleUserHomeCleanupServiceTest extends Specification implements GradleUs
         decorate(_) >> { args -> args[0] }
     }
     def releasedWrappers = Stub(CacheResourceConfigurationInternal) {
-        getRemoveUnusedEntriesAfterAsSupplier() >> TimestampSuppliers.daysAgo(CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_RELEASED_DISTS)
+        getRemoveUnusedEntriesOlderThanAsSupplier() >> TimestampSuppliers.daysAgo(CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_RELEASED_DISTS)
     }
     def snapshotWrappers = Stub(CacheResourceConfigurationInternal) {
-        getRemoveUnusedEntriesAfterAsSupplier() >> TimestampSuppliers.daysAgo(CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_SNAPSHOT_DISTS)
+        getRemoveUnusedEntriesOlderThanAsSupplier() >> TimestampSuppliers.daysAgo(CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_SNAPSHOT_DISTS)
     }
     def cacheConfigurations = Stub(CacheConfigurationsInternal) {
         getReleasedWrappers() >> releasedWrappers
@@ -114,7 +114,7 @@ class GradleUserHomeCleanupServiceTest extends Specification implements GradleUs
         cleanupService.cleanup()
 
         then:
-        releasedWrappers.getRemoveUnusedEntriesAfterAsSupplier() >> TimestampSuppliers.daysAgo(TWICE_DEFAULT_MAX_AGE_IN_DAYS - 1)
+        releasedWrappers.getRemoveUnusedEntriesOlderThanAsSupplier() >> TimestampSuppliers.daysAgo(TWICE_DEFAULT_MAX_AGE_IN_DAYS - 1)
 
         and:
         oldCacheDir.assertDoesNotExist()
@@ -134,7 +134,7 @@ class GradleUserHomeCleanupServiceTest extends Specification implements GradleUs
         cleanupService.cleanup()
 
         then:
-        releasedWrappers.getRemoveUnusedEntriesAfterAsSupplier() >> TimestampSuppliers.daysAgo(TWICE_DEFAULT_MAX_AGE_IN_DAYS)
+        releasedWrappers.getRemoveUnusedEntriesOlderThanAsSupplier() >> TimestampSuppliers.daysAgo(TWICE_DEFAULT_MAX_AGE_IN_DAYS)
         usedGradleVersions.getUsedGradleVersions() >> ([ GradleVersion.version('2.3.4') ] as SortedSet)
 
         and:

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/VersionSpecificCacheCleanupActionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/VersionSpecificCacheCleanupActionTest.groovy
@@ -33,6 +33,8 @@ import static org.gradle.cache.internal.VersionSpecificCacheCleanupFixture.Marke
 import static org.gradle.cache.internal.VersionSpecificCacheCleanupFixture.MarkerFileType.NOT_USED_WITHIN_7_DAYS
 import static org.gradle.cache.internal.VersionSpecificCacheCleanupFixture.MarkerFileType.USED_TODAY
 
+import static org.gradle.internal.time.TimestampSuppliers.daysAgo
+
 class VersionSpecificCacheCleanupActionTest extends Specification implements GradleUserHomeCleanupFixture {
 
     @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
@@ -42,7 +44,7 @@ class VersionSpecificCacheCleanupActionTest extends Specification implements Gra
     def progressMonitor = Mock(CleanupProgressMonitor)
     def deleter = TestFiles.deleter()
 
-    @Subject def cleanupAction = new VersionSpecificCacheCleanupAction(cachesDir, 30, 7, deleter, CleanupFrequency.DAILY)
+    @Subject def cleanupAction = new VersionSpecificCacheCleanupAction(cachesDir, daysAgo(30), daysAgo(7), deleter, CleanupFrequency.DAILY)
 
     def "cleans up unused version-specific cache directories"() {
         given:

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
@@ -55,7 +55,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         withDisplayName(_) >> { cacheBuilder }
         withCrossVersionCache(_) >> { cacheBuilder }
         withLockOptions(_) >> { cacheBuilder }
-        withCleanup(_) >> { cacheBuilder }
+        withCleanupStrategy(_) >> { cacheBuilder }
     }
     def cacheRepository = Stub(GlobalScopedCache) {
         crossVersionCache(_) >> cacheBuilder

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/GradleUserHomeCleanupFixture.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/GradleUserHomeCleanupFixture.groovy
@@ -118,7 +118,7 @@ trait GradleUserHomeCleanupFixture implements VersionSpecificCacheCleanupFixture
         new File(initDir, "cache-settings.gradle") << """
             beforeSettings { settings ->
                 settings.caches {
-                    ${resources}.removeUnusedEntriesAfterDays = ${days}
+                    ${resources}.removeUnusedEntries = TimestampSupplier.olderThanInDays(${days})
                 }
             }
         """

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/GradleUserHomeCleanupFixture.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/GradleUserHomeCleanupFixture.groovy
@@ -118,7 +118,7 @@ trait GradleUserHomeCleanupFixture implements VersionSpecificCacheCleanupFixture
         new File(initDir, "cache-settings.gradle") << """
             beforeSettings { settings ->
                 settings.caches {
-                    ${resources} { removeUnusedEntriesAfter = days(${days}) }
+                    ${resources} { removeUnusedEntriesAfterDays = ${days} }
                 }
             }
         """

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/GradleUserHomeCleanupFixture.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/GradleUserHomeCleanupFixture.groovy
@@ -118,7 +118,7 @@ trait GradleUserHomeCleanupFixture implements VersionSpecificCacheCleanupFixture
         new File(initDir, "cache-settings.gradle") << """
             beforeSettings { settings ->
                 settings.caches {
-                    ${resources}.removeUnusedEntries = TimestampSupplier.olderThanInDays(${days})
+                    ${resources} { removeUnusedEntriesAfter = days(${days}) }
                 }
             }
         """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -1644,7 +1644,7 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
         outputDir2.assertExists()
     }
 
-    def "does not cleans up cache when retention is configured greater than the default"() {
+    def "does not clean up cache when retention is configured greater than the default"() {
         given:
         buildFile << declareAttributes() << multiProjectWithJarSizeTransform()
         ["lib1", "lib2"].each { name ->

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/WritableArtifactCacheLockingManager.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/WritableArtifactCacheLockingManager.java
@@ -87,7 +87,7 @@ public class WritableArtifactCacheLockingManager implements ArtifactCacheLocking
     private Supplier<Long> getMaxAgeTimestamp(CacheConfigurationsInternal cacheConfigurations) {
         Integer maxAgeProperty = Integer.getInteger("org.gradle.internal.cleanup.external.max.age");
         if (maxAgeProperty == null) {
-            return cacheConfigurations.getDownloadedResources().getRemoveUnusedEntriesAfterAsSupplier();
+            return cacheConfigurations.getDownloadedResources().getRemoveUnusedEntriesOlderThanAsSupplier();
         } else {
             return TimestampSuppliers.daysAgo(maxAgeProperty);
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/WritableArtifactCacheLockingManager.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/WritableArtifactCacheLockingManager.java
@@ -15,9 +15,10 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice;
 
+import org.gradle.cache.CacheCleanupStrategy;
 import org.gradle.internal.time.TimestampSuppliers;
 import org.gradle.api.internal.cache.CacheConfigurationsInternal;
-import org.gradle.api.internal.cache.DefaultCacheCleanup;
+import org.gradle.api.internal.cache.DefaultCacheCleanupStrategy;
 import org.gradle.api.internal.filestore.DefaultArtifactIdentifierFileStore;
 import org.gradle.cache.CacheBuilder;
 import org.gradle.cache.CacheRepository;
@@ -59,12 +60,12 @@ public class WritableArtifactCacheLockingManager implements ArtifactCacheLocking
                 .withCrossVersionCache(CacheBuilder.LockTarget.CacheDirectory)
                 .withDisplayName("artifact cache")
                 .withLockOptions(mode(FileLockManager.LockMode.OnDemand)) // Don't need to lock anything until we use the caches
-                .withCleanup(createCacheCleanup(cacheMetaData, fileAccessTimeJournal, usedGradleVersions, cleanupActionDecorator, cacheConfigurations))
+                .withCleanupStrategy(createCacheCleanupStrategy(cacheMetaData, fileAccessTimeJournal, usedGradleVersions, cleanupActionDecorator, cacheConfigurations))
                 .open();
     }
 
-    private DefaultCacheCleanup createCacheCleanup(ArtifactCacheMetadata cacheMetaData, FileAccessTimeJournal fileAccessTimeJournal, UsedGradleVersions usedGradleVersions, CleanupActionDecorator cleanupActionDecorator, CacheConfigurationsInternal cacheConfigurations) {
-        return DefaultCacheCleanup.from(
+    private CacheCleanupStrategy createCacheCleanupStrategy(ArtifactCacheMetadata cacheMetaData, FileAccessTimeJournal fileAccessTimeJournal, UsedGradleVersions usedGradleVersions, CleanupActionDecorator cleanupActionDecorator, CacheConfigurationsInternal cacheConfigurations) {
+        return DefaultCacheCleanupStrategy.from(
             cleanupActionDecorator.decorate(createCleanupAction(cacheMetaData, fileAccessTimeJournal, usedGradleVersions, cacheConfigurations)),
             cacheConfigurations.getCleanupFrequency()
         );

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/WritableArtifactCacheLockingManager.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/WritableArtifactCacheLockingManager.java
@@ -87,7 +87,7 @@ public class WritableArtifactCacheLockingManager implements ArtifactCacheLocking
     private TimestampSupplier getMaxAgeTimestamp(CacheConfigurations cacheConfigurations) {
         Integer maxAgeProperty = Integer.getInteger("org.gradle.internal.cleanup.external.max.age");
         if (maxAgeProperty == null) {
-            return cacheConfigurations.getDownloadedResources().getRemoveUnusedEntries().get();
+            return cacheConfigurations.getDownloadedResources().getRemoveUnusedEntriesAfter().get();
         } else {
             return TimestampSupplier.olderThanInDays(maxAgeProperty);
         }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultArtifactCacheLockingManagerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultArtifactCacheLockingManagerTest.groovy
@@ -16,19 +16,21 @@
 
 package org.gradle.api.internal.artifacts.ivyservice
 
-import org.gradle.api.cache.CacheResourceConfiguration
+import org.gradle.api.internal.cache.CacheResourceConfigurationInternal
 import org.gradle.cache.internal.CleanupActionDecorator
 import org.gradle.api.internal.cache.CacheConfigurationsInternal
-import org.gradle.api.provider.Property
 import org.gradle.cache.internal.DefaultCacheRepository
 import org.gradle.cache.internal.UsedGradleVersions
 import org.gradle.internal.resource.local.ModificationTimeFileAccessTimeJournal
+import org.gradle.internal.time.TimestampSuppliers
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.testfixtures.internal.TestInMemoryCacheFactory
 import org.junit.Rule
 import spock.lang.AutoCleanup
 import spock.lang.Specification
 import spock.lang.Subject
+
+import static org.gradle.api.internal.cache.CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_DOWNLOADED_CACHE_ENTRIES
 
 class DefaultArtifactCacheLockingManagerTest extends Specification {
     @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
@@ -50,10 +52,8 @@ class DefaultArtifactCacheLockingManagerTest extends Specification {
         decorate(_) >> { args -> args[0] }
     }
     def cacheConfigurations = Stub(CacheConfigurationsInternal) {
-        getDownloadedResources() >> Stub(CacheResourceConfiguration) {
-            getRemoveUnusedEntriesAfterDays() >> Stub(Property) {
-                get() >> CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_DOWNLOADED_CACHE_ENTRIES
-            }
+        getDownloadedResources() >> Stub(CacheResourceConfigurationInternal) {
+            getRemoveUnusedEntriesAfterAsSupplier() >> TimestampSuppliers.daysAgo(DEFAULT_MAX_AGE_IN_DAYS_FOR_DOWNLOADED_CACHE_ENTRIES)
         }
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultArtifactCacheLockingManagerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultArtifactCacheLockingManagerTest.groovy
@@ -53,7 +53,7 @@ class DefaultArtifactCacheLockingManagerTest extends Specification {
     }
     def cacheConfigurations = Stub(CacheConfigurationsInternal) {
         getDownloadedResources() >> Stub(CacheResourceConfigurationInternal) {
-            getRemoveUnusedEntriesAfterAsSupplier() >> TimestampSuppliers.daysAgo(DEFAULT_MAX_AGE_IN_DAYS_FOR_DOWNLOADED_CACHE_ENTRIES)
+            getRemoveUnusedEntriesOlderThanAsSupplier() >> TimestampSuppliers.daysAgo(DEFAULT_MAX_AGE_IN_DAYS_FOR_DOWNLOADED_CACHE_ENTRIES)
         }
     }
 

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/workspace/impl/DefaultImmutableWorkspaceProvider.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/workspace/impl/DefaultImmutableWorkspaceProvider.java
@@ -20,7 +20,6 @@ import org.gradle.api.internal.cache.CacheConfigurationsInternal;
 import org.gradle.api.internal.cache.DefaultCacheCleanup;
 import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.cache.CacheBuilder;
-import org.gradle.api.cache.CacheConfigurations;
 import org.gradle.cache.CleanupAction;
 import org.gradle.cache.internal.CleanupActionDecorator;
 import org.gradle.cache.FileLockManager;
@@ -132,11 +131,11 @@ public class DefaultImmutableWorkspaceProvider implements WorkspaceProvider, Clo
         );
     }
 
-    private static CleanupAction createCleanupAction(FileAccessTimeJournal fileAccessTimeJournal, int treeDepthToTrackAndCleanup, CacheConfigurations cacheConfigurations) {
+    private static CleanupAction createCleanupAction(FileAccessTimeJournal fileAccessTimeJournal, int treeDepthToTrackAndCleanup, CacheConfigurationsInternal cacheConfigurations) {
         return new LeastRecentlyUsedCacheCleanup(
             new SingleDepthFilesFinder(treeDepthToTrackAndCleanup),
             fileAccessTimeJournal,
-            cacheConfigurations.getCreatedResources().getRemoveUnusedEntriesAfter().get()
+            cacheConfigurations.getCreatedResources().getRemoveUnusedEntriesAfterAsSupplier()
         );
     }
 

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/workspace/impl/DefaultImmutableWorkspaceProvider.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/workspace/impl/DefaultImmutableWorkspaceProvider.java
@@ -135,7 +135,7 @@ public class DefaultImmutableWorkspaceProvider implements WorkspaceProvider, Clo
         return new LeastRecentlyUsedCacheCleanup(
             new SingleDepthFilesFinder(treeDepthToTrackAndCleanup),
             fileAccessTimeJournal,
-            cacheConfigurations.getCreatedResources().getRemoveUnusedEntriesAfterAsSupplier()
+            cacheConfigurations.getCreatedResources().getRemoveUnusedEntriesOlderThanAsSupplier()
         );
     }
 

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/workspace/impl/DefaultImmutableWorkspaceProvider.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/workspace/impl/DefaultImmutableWorkspaceProvider.java
@@ -17,9 +17,10 @@
 package org.gradle.internal.execution.workspace.impl;
 
 import org.gradle.api.internal.cache.CacheConfigurationsInternal;
-import org.gradle.api.internal.cache.DefaultCacheCleanup;
+import org.gradle.api.internal.cache.DefaultCacheCleanupStrategy;
 import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.cache.CacheBuilder;
+import org.gradle.cache.CacheCleanupStrategy;
 import org.gradle.cache.CleanupAction;
 import org.gradle.cache.internal.CleanupActionDecorator;
 import org.gradle.cache.FileLockManager;
@@ -115,7 +116,7 @@ public class DefaultImmutableWorkspaceProvider implements WorkspaceProvider, Clo
         CacheConfigurationsInternal cacheConfigurations
     ) {
         PersistentCache cache = cacheBuilder
-            .withCleanup(createCacheCleanup(fileAccessTimeJournal, treeDepthToTrackAndCleanup, cleanupActionDecorator, cacheConfigurations))
+            .withCleanupStrategy(createCacheCleanupStrategy(fileAccessTimeJournal, treeDepthToTrackAndCleanup, cleanupActionDecorator, cacheConfigurations))
             .withLockOptions(mode(FileLockManager.LockMode.OnDemand)) // Lock on demand
             .open();
         this.cache = cache;
@@ -124,8 +125,8 @@ public class DefaultImmutableWorkspaceProvider implements WorkspaceProvider, Clo
         this.executionHistoryStore = historyFactory.apply(cache);
     }
 
-    private DefaultCacheCleanup createCacheCleanup(FileAccessTimeJournal fileAccessTimeJournal, int treeDepthToTrackAndCleanup, CleanupActionDecorator cleanupActionDecorator, CacheConfigurationsInternal cacheConfigurations) {
-        return DefaultCacheCleanup.from(
+    private CacheCleanupStrategy createCacheCleanupStrategy(FileAccessTimeJournal fileAccessTimeJournal, int treeDepthToTrackAndCleanup, CleanupActionDecorator cleanupActionDecorator, CacheConfigurationsInternal cacheConfigurations) {
+        return DefaultCacheCleanupStrategy.from(
             cleanupActionDecorator.decorate(createCleanupAction(fileAccessTimeJournal, treeDepthToTrackAndCleanup, cacheConfigurations)),
             cacheConfigurations.getCleanupFrequency()
         );

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/workspace/impl/DefaultImmutableWorkspaceProvider.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/workspace/impl/DefaultImmutableWorkspaceProvider.java
@@ -136,7 +136,7 @@ public class DefaultImmutableWorkspaceProvider implements WorkspaceProvider, Clo
         return new LeastRecentlyUsedCacheCleanup(
             new SingleDepthFilesFinder(treeDepthToTrackAndCleanup),
             fileAccessTimeJournal,
-            () -> cacheConfigurations.getCreatedResources().getRemoveUnusedEntriesAfterDays().get()
+            cacheConfigurations.getCreatedResources().getRemoveUnusedEntries().get()
         );
     }
 

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/workspace/impl/DefaultImmutableWorkspaceProvider.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/workspace/impl/DefaultImmutableWorkspaceProvider.java
@@ -136,7 +136,7 @@ public class DefaultImmutableWorkspaceProvider implements WorkspaceProvider, Clo
         return new LeastRecentlyUsedCacheCleanup(
             new SingleDepthFilesFinder(treeDepthToTrackAndCleanup),
             fileAccessTimeJournal,
-            cacheConfigurations.getCreatedResources().getRemoveUnusedEntries().get()
+            cacheConfigurations.getCreatedResources().getRemoveUnusedEntriesAfter().get()
         );
     }
 

--- a/subprojects/functional/src/main/java/org/gradle/internal/time/TimestampSuppliers.java
+++ b/subprojects/functional/src/main/java/org/gradle/internal/time/TimestampSuppliers.java
@@ -14,33 +14,36 @@
  * limitations under the License.
  */
 
-package org.gradle.api.cache;
-
-import org.gradle.api.Incubating;
+package org.gradle.internal.time;
 
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 /**
- * A supplier of timestamps for the purposes of calculating expiration dates
- * on cache entries.
+ * Suppliers for the purposes of calculating timestamps for dates in the past.
  *
  * @since 8.0
  */
-@Incubating
-public interface TimestampSupplier extends Supplier<Long> {
+public interface TimestampSuppliers {
     /**
-     * Returns a timestamp supplier that calculates a timestamp exactly the given number
-     * of days prior to the current time, or 0 if the number of days extends beyond the
-     * epoch.
+     * Returns a timestamp supplier that calculates a timestamp exactly the given amount of time
+     * prior to the current time, or 0 if the amount of time extends beyond the epoch.
      */
-    static TimestampSupplier olderThanInDays(int days) {
+    static Supplier<Long> since(int value, TimeUnit timeUnit) {
         // This needs to be an anonymous inner class instead of a lambda for configuration cache compatibility
-        return new TimestampSupplier() {
+        return new Supplier<Long>() {
             @Override
             public Long get() {
-                return Math.max(0, System.currentTimeMillis() - TimeUnit.DAYS.toMillis(days));
+                return Math.max(0, System.currentTimeMillis() - timeUnit.toMillis(value));
             }
         };
+    }
+
+    /**
+     * Returns a supplier that calculates a timestamp exactly the given number of days
+     * prior to the current time, or 0 if the number of days extends beyond the epoch.
+     */
+    static Supplier<Long> daysAgo(int days) {
+        return since(days, TimeUnit.DAYS);
     }
 }

--- a/subprojects/functional/src/main/java/org/gradle/internal/time/TimestampSuppliers.java
+++ b/subprojects/functional/src/main/java/org/gradle/internal/time/TimestampSuppliers.java
@@ -24,12 +24,12 @@ import java.util.function.Supplier;
  *
  * @since 8.0
  */
-public interface TimestampSuppliers {
+public class TimestampSuppliers {
     /**
-     * Returns a timestamp supplier that calculates a timestamp exactly the given amount of time
+     * Returns a supplier that calculates a timestamp exactly the given amount of time
      * prior to the current time, or 0 if the amount of time extends beyond the epoch.
      */
-    static Supplier<Long> since(int value, TimeUnit timeUnit) {
+    public static Supplier<Long> inThePast(int value, TimeUnit timeUnit) {
         // This needs to be an anonymous inner class instead of a lambda for configuration cache compatibility
         return new Supplier<Long>() {
             @Override
@@ -43,7 +43,7 @@ public interface TimestampSuppliers {
      * Returns a supplier that calculates a timestamp exactly the given number of days
      * prior to the current time, or 0 if the number of days extends beyond the epoch.
      */
-    static Supplier<Long> daysAgo(int days) {
-        return since(days, TimeUnit.DAYS);
+    public static Supplier<Long> daysAgo(int days) {
+        return inThePast(days, TimeUnit.DAYS);
     }
 }

--- a/subprojects/functional/src/test/groovy/org/gradle/internal/time/TimestampSuppliersTest.groovy
+++ b/subprojects/functional/src/test/groovy/org/gradle/internal/time/TimestampSuppliersTest.groovy
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.time
+
+import spock.lang.Specification
+
+import java.util.concurrent.TimeUnit
+
+
+class TimestampSuppliersTest extends Specification {
+    def "timestamps earlier than the epoch evaluate to zero"() {
+        expect:
+        TimestampSuppliers.inThePast(Integer.MAX_VALUE, TimeUnit.HOURS).get() == 0
+
+        and:
+        TimestampSuppliers.daysAgo(Integer.MAX_VALUE).get() == 0
+    }
+}

--- a/subprojects/persistent-cache/build.gradle.kts
+++ b/subprojects/persistent-cache/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     implementation(libs.commonsLang)
 
     testImplementation(project(":core-api"))
+    testImplementation(project(":functional"))
     testImplementation(testFixtures(project(":core")))
 
     testRuntimeOnly(project(":distributions-core")) {

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/CacheBuilder.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/CacheBuilder.java
@@ -73,9 +73,9 @@ public interface CacheBuilder {
     /**
      * Specifies an action to execute when the cache needs to be cleaned up. An exclusive lock is held while the cleanup is executing, to prevent cross-process access.
      *
-     * A clean-up action is run when a cache is closed, but only after the interval specified by the provided {@link CacheCleanup}.
+     * A clean-up action is run when a cache is closed, but only after the interval specified by the provided {@link CacheCleanupStrategy}.
      */
-    CacheBuilder withCleanup(CacheCleanup cleanup);
+    CacheBuilder withCleanupStrategy(CacheCleanupStrategy cleanup);
 
     /**
      * Opens the cache. It is the caller's responsibility to close the cache when finished with it.

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/CacheCleanupStrategy.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/CacheCleanupStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,19 @@
  * limitations under the License.
  */
 
-package org.gradle.cache.internal;
+package org.gradle.cache;
 
-public interface CacheCleanupAction {
+/**
+ * Specifies the details of cache cleanup, including the action to be performed and the frequency at which cache cleanup should occur.
+ */
+public interface CacheCleanupStrategy {
     /**
-     * Determines if this action should run. Called when the cache is closed, holding an exclusive lock.
+     * Returns the action to perform on cleanup.
      */
-    boolean requiresCleanup();
+    CleanupAction getCleanupAction();
 
     /**
-     * Executes the action to cleanup the cache. Called only if {@link #requiresCleanup()} returns true, holding an exclusive lock.
-     * The lock is not released between calling {@link #requiresCleanup()} and this method.
+     * Returns the frequency at which cache cleanup can occur.  Possible values are only once a day, every time, or never.
      */
-    void cleanup();
+    CleanupFrequency getCleanupFrequency();
 }

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/CleanupFrequency.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/CleanupFrequency.java
@@ -30,9 +30,13 @@ public enum CleanupFrequency {
     DAILY() {
         @Override
         public boolean requiresCleanup(long lastCleanupTimestamp) {
-            long duration = System.currentTimeMillis() - lastCleanupTimestamp;
-            long timeInHours = TimeUnit.MILLISECONDS.toHours(duration);
-            return timeInHours >= 24;
+            if (lastCleanupTimestamp == NEVER_CLEANED) {
+                return true;
+            } else {
+                long duration = System.currentTimeMillis() - lastCleanupTimestamp;
+                long timeInHours = TimeUnit.MILLISECONDS.toHours(duration);
+                return timeInHours >= 24;
+            }
         }
     },
     /**
@@ -58,6 +62,8 @@ public enum CleanupFrequency {
             return false;
         }
     };
+
+    public static final long NEVER_CLEANED = 0;
 
     public abstract boolean requiresCleanup(long lastCleanupTimestamp);
     public boolean shouldCleanupOnEndOfSession() {

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CacheCleanupExecutor.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CacheCleanupExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,11 @@
  * limitations under the License.
  */
 
-package org.gradle.cache;
+package org.gradle.cache.internal;
 
-/**
- * Specifies the details of cache cleanup, including the action to be performed and the frequency at which cache cleanup should occur.
- */
-public interface CacheCleanup {
+public interface CacheCleanupExecutor {
     /**
-     * Returns the action to perform on cleanup.
+     * Executes the action to clean up the cache, should be called while holding the lock.
      */
-    CleanupAction getCleanupAction();
-
-    /**
-     * Returns the frequency at which cache cleanup can occur.  Possible values are only once a day, every time, or never.
-     */
-    CleanupFrequency getCleanupFrequency();
+    void cleanup();
 }

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CacheFactory.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CacheFactory.java
@@ -17,7 +17,7 @@ package org.gradle.cache.internal;
 
 import org.gradle.api.Action;
 import org.gradle.cache.CacheBuilder;
-import org.gradle.cache.CacheCleanup;
+import org.gradle.cache.CacheCleanupStrategy;
 import org.gradle.cache.CacheOpenException;
 import org.gradle.cache.LockOptions;
 import org.gradle.cache.PersistentCache;
@@ -30,7 +30,7 @@ public interface CacheFactory {
     /**
      * Opens a cache with the given options. The caller must close the cache when finished with it.
      */
-    PersistentCache open(File cacheDir, String displayName, Map<String, ?> properties, CacheBuilder.LockTarget lockTarget, LockOptions lockOptions, @Nullable Action<? super PersistentCache> initializer, @Nullable CacheCleanup cacheCleanup) throws CacheOpenException;
+    PersistentCache open(File cacheDir, String displayName, Map<String, ?> properties, CacheBuilder.LockTarget lockTarget, LockOptions lockOptions, @Nullable Action<? super PersistentCache> initializer, @Nullable CacheCleanupStrategy cacheCleanupStrategy) throws CacheOpenException;
 
     /**
      * Visit the caches created by this factory.

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheAccess.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheAccess.java
@@ -67,7 +67,7 @@ public class DefaultCacheAccess implements CacheCoordinator {
 
     private final String cacheDisplayName;
     private final File baseDir;
-    private final CacheCleanupAction cleanupAction;
+    private final CacheCleanupExecutor cleanupAction;
     private final ExecutorFactory executorFactory;
     private final FileAccess fileAccess;
     private final Map<String, IndexedCacheEntry<?, ?>> caches = new HashMap<String, IndexedCacheEntry<?, ?>>();
@@ -87,7 +87,7 @@ public class DefaultCacheAccess implements CacheCoordinator {
     private int cacheClosedCount;
     private boolean alreadyCleaned;
 
-    public DefaultCacheAccess(String cacheDisplayName, File lockTarget, LockOptions lockOptions, File baseDir, FileLockManager lockManager, CacheInitializationAction initializationAction, CacheCleanupAction cleanupAction, ExecutorFactory executorFactory) {
+    public DefaultCacheAccess(String cacheDisplayName, File lockTarget, LockOptions lockOptions, File baseDir, FileLockManager lockManager, CacheInitializationAction initializationAction, CacheCleanupExecutor cleanupAction, ExecutorFactory executorFactory) {
         this.cacheDisplayName = cacheDisplayName;
         this.baseDir = baseDir;
         this.cleanupAction = cleanupAction;
@@ -146,7 +146,7 @@ public class DefaultCacheAccess implements CacheCoordinator {
 
     @Override
     public void cleanup() {
-        if (cleanupAction != null && cleanupAction.requiresCleanup()) {
+        if (cleanupAction != null) {
             if (cacheAccessWorker != null) {
                 cacheAccessWorker.flush();
             }
@@ -184,7 +184,7 @@ public class DefaultCacheAccess implements CacheCoordinator {
 
                 // If cleanup is required, but has not already been invoked (e.g. at the end of the build session)
                 // perform cleanup on close.
-                if (cleanupAction != null && cleanupAction.requiresCleanup() && !alreadyCleaned) {
+                if (cleanupAction != null && !alreadyCleaned) {
                     doCleanup();
                 }
 

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheFactory.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheFactory.java
@@ -17,7 +17,7 @@ package org.gradle.cache.internal;
 
 import org.gradle.api.Action;
 import org.gradle.cache.CacheBuilder;
-import org.gradle.cache.CacheCleanup;
+import org.gradle.cache.CacheCleanupStrategy;
 import org.gradle.cache.CacheOpenException;
 import org.gradle.cache.FileLockManager;
 import org.gradle.cache.LockOptions;
@@ -62,10 +62,10 @@ public class DefaultCacheFactory implements CacheFactory, Closeable {
     }
 
     @Override
-    public PersistentCache open(File cacheDir, String displayName, Map<String, ?> properties, CacheBuilder.LockTarget lockTarget, LockOptions lockOptions, Action<? super PersistentCache> initializer, @Nullable CacheCleanup cacheCleanup) throws CacheOpenException {
+    public PersistentCache open(File cacheDir, String displayName, Map<String, ?> properties, CacheBuilder.LockTarget lockTarget, LockOptions lockOptions, Action<? super PersistentCache> initializer, @Nullable CacheCleanupStrategy cacheCleanupStrategy) throws CacheOpenException {
         lock.lock();
         try {
-            return doOpen(cacheDir, displayName, properties, lockTarget, lockOptions, initializer, cacheCleanup);
+            return doOpen(cacheDir, displayName, properties, lockTarget, lockOptions, initializer, cacheCleanupStrategy);
         } finally {
             lock.unlock();
         }
@@ -94,16 +94,16 @@ public class DefaultCacheFactory implements CacheFactory, Closeable {
         CacheBuilder.LockTarget lockTarget,
         LockOptions lockOptions,
         @Nullable Action<? super PersistentCache> initializer,
-        @Nullable CacheCleanup cacheCleanup
+        @Nullable CacheCleanupStrategy cacheCleanupStrategy
     ) {
         File canonicalDir = FileUtils.canonicalize(cacheDir);
         DirCacheReference dirCacheReference = dirCaches.get(canonicalDir);
         if (dirCacheReference == null) {
             ReferencablePersistentCache cache;
             if (!properties.isEmpty() || initializer != null) {
-                cache = new DefaultPersistentDirectoryCache(canonicalDir, displayName, properties, lockTarget, lockOptions, initializer, cacheCleanup, lockManager, executorFactory, progressLoggerFactory);
+                cache = new DefaultPersistentDirectoryCache(canonicalDir, displayName, properties, lockTarget, lockOptions, initializer, cacheCleanupStrategy, lockManager, executorFactory, progressLoggerFactory);
             } else {
-                cache = new DefaultPersistentDirectoryStore(canonicalDir, displayName, lockTarget, lockOptions, cacheCleanup, lockManager, executorFactory, progressLoggerFactory);
+                cache = new DefaultPersistentDirectoryStore(canonicalDir, displayName, lockTarget, lockOptions, cacheCleanupStrategy, lockManager, executorFactory, progressLoggerFactory);
             }
             cache.open();
             dirCacheReference = new DirCacheReference(cache, properties, lockTarget, lockOptions);

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheRepository.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheRepository.java
@@ -17,7 +17,7 @@ package org.gradle.cache.internal;
 
 import org.gradle.api.Action;
 import org.gradle.cache.CacheBuilder;
-import org.gradle.cache.CacheCleanup;
+import org.gradle.cache.CacheCleanupStrategy;
 import org.gradle.cache.CacheRepository;
 import org.gradle.cache.FileLockManager;
 import org.gradle.cache.LockOptions;
@@ -53,7 +53,7 @@ public class DefaultCacheRepository implements CacheRepository {
         final File baseDir;
         Map<String, ?> properties = Collections.emptyMap();
         Action<? super PersistentCache> initializer;
-        CacheCleanup cacheCleanup;
+        CacheCleanupStrategy cacheCleanupStrategy;
         LockOptions lockOptions = mode(FileLockManager.LockMode.Shared);
         String displayName;
         VersionStrategy versionStrategy = VersionStrategy.CachePerVersion;
@@ -101,8 +101,8 @@ public class DefaultCacheRepository implements CacheRepository {
         }
 
         @Override
-        public CacheBuilder withCleanup(CacheCleanup cacheCleanup) {
-            this.cacheCleanup = cacheCleanup;
+        public CacheBuilder withCleanupStrategy(CacheCleanupStrategy cacheCleanupStrategy) {
+            this.cacheCleanupStrategy = cacheCleanupStrategy;
             return this;
         }
 
@@ -115,7 +115,7 @@ public class DefaultCacheRepository implements CacheRepository {
                 cacheBaseDir = cacheScopeMapping.getBaseDirectory(null, key, versionStrategy);
             }
 
-            return factory.open(cacheBaseDir, displayName, properties, lockTarget, lockOptions, initializer, cacheCleanup);
+            return factory.open(cacheBaseDir, displayName, properties, lockTarget, lockOptions, initializer, cacheCleanupStrategy);
         }
     }
 }

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultPersistentDirectoryCache.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultPersistentDirectoryCache.java
@@ -18,7 +18,7 @@ package org.gradle.cache.internal;
 import org.gradle.api.Action;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.cache.CacheBuilder;
-import org.gradle.cache.CacheCleanup;
+import org.gradle.cache.CacheCleanupStrategy;
 import org.gradle.cache.FileLock;
 import org.gradle.cache.FileLockManager;
 import org.gradle.cache.LockOptions;
@@ -41,8 +41,8 @@ public class DefaultPersistentDirectoryCache extends DefaultPersistentDirectoryS
     private final Properties properties = new Properties();
     private final Action<? super PersistentCache> initAction;
 
-    public DefaultPersistentDirectoryCache(File dir, String displayName, Map<String, ?> properties, CacheBuilder.LockTarget lockTarget, LockOptions lockOptions, Action<? super PersistentCache> initAction, CacheCleanup cacheCleanup, FileLockManager lockManager, ExecutorFactory executorFactory, ProgressLoggerFactory progressLoggerFactory) {
-        super(dir, displayName, lockTarget, lockOptions, cacheCleanup, lockManager, executorFactory, progressLoggerFactory);
+    public DefaultPersistentDirectoryCache(File dir, String displayName, Map<String, ?> properties, CacheBuilder.LockTarget lockTarget, LockOptions lockOptions, Action<? super PersistentCache> initAction, CacheCleanupStrategy cacheCleanupStrategy, FileLockManager lockManager, ExecutorFactory executorFactory, ProgressLoggerFactory progressLoggerFactory) {
+        super(dir, displayName, lockTarget, lockOptions, cacheCleanupStrategy, lockManager, executorFactory, progressLoggerFactory);
         this.initAction = initAction;
         this.properties.putAll(properties);
     }

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultPersistentDirectoryStore.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultPersistentDirectoryStore.java
@@ -16,7 +16,7 @@
 package org.gradle.cache.internal;
 
 import org.gradle.cache.CacheBuilder;
-import org.gradle.cache.CacheCleanup;
+import org.gradle.cache.CacheCleanupStrategy;
 import org.gradle.cache.CacheOpenException;
 import org.gradle.cache.FileLock;
 import org.gradle.cache.FileLockManager;
@@ -50,7 +50,7 @@ public class DefaultPersistentDirectoryStore implements ReferencablePersistentCa
     private final CacheBuilder.LockTarget lockTarget;
     private final LockOptions lockOptions;
     @Nullable
-    private final CacheCleanup cacheCleanup;
+    private final CacheCleanupStrategy cacheCleanupStrategy;
     private final FileLockManager lockManager;
     private final ExecutorFactory executorFactory;
     private final String displayName;
@@ -64,7 +64,7 @@ public class DefaultPersistentDirectoryStore implements ReferencablePersistentCa
         @Nullable String displayName,
         CacheBuilder.LockTarget lockTarget,
         LockOptions lockOptions,
-        @Nullable CacheCleanup cacheCleanup,
+        @Nullable CacheCleanupStrategy cacheCleanupStrategy,
         FileLockManager fileLockManager,
         ExecutorFactory executorFactory,
         ProgressLoggerFactory progressLoggerFactory
@@ -72,7 +72,7 @@ public class DefaultPersistentDirectoryStore implements ReferencablePersistentCa
         this.dir = dir;
         this.lockTarget = lockTarget;
         this.lockOptions = lockOptions;
-        this.cacheCleanup = cacheCleanup;
+        this.cacheCleanupStrategy = cacheCleanupStrategy;
         this.lockManager = fileLockManager;
         this.executorFactory = executorFactory;
         this.propertiesFile = new File(dir, "cache.properties");
@@ -95,7 +95,7 @@ public class DefaultPersistentDirectoryStore implements ReferencablePersistentCa
     }
 
     private CacheCoordinator createCacheAccess() {
-        return new DefaultCacheAccess(displayName, getLockTarget(), lockOptions, dir, lockManager, getInitAction(), getCleanupAction(), executorFactory);
+        return new DefaultCacheAccess(displayName, getLockTarget(), lockOptions, dir, lockManager, getInitAction(), getCleanupExecutor(), executorFactory);
     }
 
     private File getLockTarget() {
@@ -124,8 +124,8 @@ public class DefaultPersistentDirectoryStore implements ReferencablePersistentCa
         };
     }
 
-    protected CacheCleanupAction getCleanupAction() {
-        return new Cleanup();
+    protected CacheCleanupExecutor getCleanupExecutor() {
+        return new CleanupExecutor();
     }
 
     @Override
@@ -208,17 +208,16 @@ public class DefaultPersistentDirectoryStore implements ReferencablePersistentCa
         cacheAccess.cleanup();
     }
 
-    private class Cleanup implements CacheCleanupAction {
-        @Override
-        public boolean requiresCleanup() {
-            if (dir.exists() && cacheCleanup != null) {
+    private class CleanupExecutor implements CacheCleanupExecutor {
+        private boolean requiresCleanup() {
+            if (dir.exists() && cacheCleanupStrategy != null) {
                 if (!gcFile.exists()) {
                     GFileUtils.touch(gcFile);
                 } else {
                     long duration = System.currentTimeMillis() - gcFile.lastModified();
                     long timeInHours = TimeUnit.MILLISECONDS.toHours(duration);
                     LOGGER.debug("{} has last been fully cleaned up {} hours ago", DefaultPersistentDirectoryStore.this, timeInHours);
-                    return cacheCleanup.getCleanupFrequency().requiresCleanup(gcFile.lastModified());
+                    return cacheCleanupStrategy.getCleanupFrequency().requiresCleanup(gcFile.lastModified());
                 }
             }
             return false;
@@ -226,12 +225,12 @@ public class DefaultPersistentDirectoryStore implements ReferencablePersistentCa
 
         @Override
         public void cleanup() {
-            if (cacheCleanup != null) {
+            if (cacheCleanupStrategy != null && requiresCleanup()) {
                 String description = "Cleaning " + getDisplayName();
-                ProgressLogger progressLogger = progressLoggerFactory.newOperation(CacheCleanupAction.class).start(description, description);
+                ProgressLogger progressLogger = progressLoggerFactory.newOperation(CacheCleanupExecutor.class).start(description, description);
                 Timer timer = Time.startTimer();
                 try {
-                    cacheCleanup.getCleanupAction().clean(DefaultPersistentDirectoryStore.this, new DefaultCleanupProgressMonitor(progressLogger));
+                    cacheCleanupStrategy.getCleanupAction().clean(DefaultPersistentDirectoryStore.this, new DefaultCleanupProgressMonitor(progressLogger));
                     GFileUtils.touch(gcFile);
                 } finally {
                     LOGGER.info("{} cleaned up in {}.", DefaultPersistentDirectoryStore.this, timer.getElapsed());

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultCacheAccessTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultCacheAccessTest.groovy
@@ -45,14 +45,14 @@ class DefaultCacheAccessTest extends ConcurrentSpec {
     @Rule final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     final FileLockManager lockManager = Mock()
     final CacheInitializationAction initializationAction = Mock()
-    final CacheCleanupAction cleanupAction = Mock()
+    final CacheCleanupExecutor cleanupExecutor = Mock()
     final File lockFile = tmpDir.file('lock.bin')
     final File cacheDir = tmpDir.file('caches')
     final FileLock lock = Mock()
     final BTreePersistentIndexedCache<String, Integer> backingCache = Mock()
 
     private DefaultCacheAccess newAccess(FileLockManager.LockMode lockMode) {
-        new DefaultCacheAccess("<display-name>", lockFile, mode(lockMode), cacheDir, lockManager, initializationAction, cleanupAction, executorFactory) {
+        new DefaultCacheAccess("<display-name>", lockFile, mode(lockMode), cacheDir, lockManager, initializationAction, cleanupExecutor, executorFactory) {
             @Override
             <K, V> BTreePersistentIndexedCache<K, V> doCreateCache(File cacheFile, Serializer<K> keySerializer, Serializer<V> valueSerializer) {
                 return backingCache
@@ -77,7 +77,7 @@ class DefaultCacheAccessTest extends ConcurrentSpec {
 
         then:
         _ * lock.state
-        1 * cleanupAction.requiresCleanup() >> false
+        1 * cleanupExecutor.cleanup()
         1 * lock.close()
         0 * _._
     }
@@ -99,20 +99,19 @@ class DefaultCacheAccessTest extends ConcurrentSpec {
 
         then:
         _ * lock.state
-        1 * cleanupAction.requiresCleanup() >> false
+        1 * cleanupExecutor.cleanup()
         1 * lock.close()
         0 * _._
     }
 
-    def "cleans up when cleanup action is required with access #accessType"() {
+    def "cleans up using cleanup executor with access #accessType"() {
         def access = newAccess(accessType)
         when:
         access.cleanup()
 
         then:
         _ * lock.state
-        1 * cleanupAction.requiresCleanup() >> true
-        1 * cleanupAction.cleanup()
+        1 * cleanupExecutor.cleanup()
         0 * _._
 
         where:
@@ -127,8 +126,7 @@ class DefaultCacheAccessTest extends ConcurrentSpec {
         access.close()
 
         then:
-        1 * cleanupAction.requiresCleanup() >> true
-        1 * cleanupAction.cleanup()
+        1 * cleanupExecutor.cleanup()
         0 * _
     }
 
@@ -140,15 +138,13 @@ class DefaultCacheAccessTest extends ConcurrentSpec {
         access.cleanup()
 
         then:
-        1 * cleanupAction.requiresCleanup() >> true
-        1 * cleanupAction.cleanup()
+        1 * cleanupExecutor.cleanup()
         0 * _
 
         when:
         access.close()
 
         then:
-        1 * cleanupAction.requiresCleanup() >> true
         0 * _
     }
 
@@ -159,16 +155,14 @@ class DefaultCacheAccessTest extends ConcurrentSpec {
         access.cleanup()
 
         then:
-        1 * cleanupAction.requiresCleanup() >> true
-        1 * cleanupAction.cleanup()
+        1 * cleanupExecutor.cleanup()
         0 * _
 
         when:
         access.cleanup()
 
         then:
-        1 * cleanupAction.requiresCleanup() >> true
-        1 * cleanupAction.cleanup()
+        1 * cleanupExecutor.cleanup()
         0 * _
     }
 
@@ -318,7 +312,7 @@ class DefaultCacheAccessTest extends ConcurrentSpec {
         access.close()
 
         then:
-        1 * cleanupAction.requiresCleanup() >> false
+        1 * cleanupExecutor.cleanup()
         0 * _._
 
         and:
@@ -594,7 +588,7 @@ class DefaultCacheAccessTest extends ConcurrentSpec {
         access.close()
 
         then:
-        1 * cleanupAction.requiresCleanup() >> false
+        1 * cleanupExecutor.cleanup()
         0 * _
     }
 
@@ -682,8 +676,7 @@ class DefaultCacheAccessTest extends ConcurrentSpec {
         access.cleanup()
 
         then:
-        1 * cleanupAction.requiresCleanup() >> true
-        1 * cleanupAction.cleanup()
+        1 * cleanupExecutor.cleanup()
         0 * lockManager._
     }
 
@@ -698,14 +691,13 @@ class DefaultCacheAccessTest extends ConcurrentSpec {
         access.useCache { cache.getIfPresent("key") }
 
         when:
-        access.close()
+        access.cleanup()
 
         then:
         lock.close()
 
         then:
-        cleanupAction.requiresCleanup() >> true
-        cleanupAction.cleanup()
+        1 * cleanupExecutor.cleanup()
     }
 
     def "returns the same cache object when using same cache parameters"() {

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultPersistentDirectoryCacheTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultPersistentDirectoryCacheTest.groovy
@@ -17,7 +17,7 @@ package org.gradle.cache.internal
 
 import org.gradle.api.Action
 import org.gradle.cache.CacheBuilder
-import org.gradle.cache.CacheCleanup
+import org.gradle.cache.CacheCleanupStrategy
 import org.gradle.cache.FileLockManager
 import org.gradle.cache.PersistentCache
 import org.gradle.cache.internal.locklistener.NoOpFileLockContentionHandler
@@ -38,7 +38,7 @@ class DefaultPersistentDirectoryCacheTest extends AbstractProjectBuilderSpec {
     }
     def lockManager = new DefaultFileLockManager(metaDataProvider, new NoOpFileLockContentionHandler())
     def initializationAction = Mock(Action)
-    def cacheCleanup = Stub(CacheCleanup)
+    def cacheCleanup = Stub(CacheCleanupStrategy)
     def progressLoggerFactory = Stub(ProgressLoggerFactory)
 
     def properties = ['prop': 'value', 'prop2': 'other-value']

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultPersistentDirectoryStoreTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultPersistentDirectoryStoreTest.groovy
@@ -16,7 +16,7 @@
 package org.gradle.cache.internal
 
 import org.gradle.cache.CacheBuilder
-import org.gradle.cache.CacheCleanup
+import org.gradle.cache.CacheCleanupStrategy
 import org.gradle.cache.CleanupAction
 import org.gradle.cache.CleanupFrequency
 import org.gradle.cache.FileLock
@@ -44,7 +44,7 @@ class DefaultPersistentDirectoryStoreTest extends Specification {
 
     def cacheDir = tmpDir.file("dir")
     def cleanupAction = Mock(CleanupAction)
-    def cacheCleanup = Mock(CacheCleanup)
+    def cacheCleanup = Mock(CacheCleanupStrategy)
     def lockManager = Mock(FileLockManager)
     def lock = Mock(FileLock)
     def progressLoggerFactory = Stub(ProgressLoggerFactory) {

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/LeastRecentlyUsedCacheCleanupTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/LeastRecentlyUsedCacheCleanupTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.cache.internal
 
+import org.gradle.api.cache.TimestampSupplier
 import org.gradle.cache.CleanableStore
 import org.gradle.cache.CleanupProgressMonitor
 import org.gradle.internal.resource.local.ModificationTimeFileAccessTimeJournal
@@ -35,7 +36,7 @@ class LeastRecentlyUsedCacheCleanupTest extends Specification {
     def fileAccessTimeJournal = Spy(ModificationTimeFileAccessTimeJournal)
     def progressMonitor = Stub(CleanupProgressMonitor)
     @Subject def cleanupAction = new LeastRecentlyUsedCacheCleanup(
-        new SingleDepthFilesFinder(1), fileAccessTimeJournal, () -> 1)
+        new SingleDepthFilesFinder(1), fileAccessTimeJournal, TimestampSupplier.olderThanInDays(1))
 
     def "finds files to delete when files are old"() {
         given:

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/LeastRecentlyUsedCacheCleanupTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/LeastRecentlyUsedCacheCleanupTest.groovy
@@ -16,10 +16,10 @@
 
 package org.gradle.cache.internal
 
-import org.gradle.api.cache.TimestampSupplier
 import org.gradle.cache.CleanableStore
 import org.gradle.cache.CleanupProgressMonitor
 import org.gradle.internal.resource.local.ModificationTimeFileAccessTimeJournal
+import org.gradle.internal.time.TimestampSuppliers
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
 import spock.lang.Specification
@@ -36,7 +36,7 @@ class LeastRecentlyUsedCacheCleanupTest extends Specification {
     def fileAccessTimeJournal = Spy(ModificationTimeFileAccessTimeJournal)
     def progressMonitor = Stub(CleanupProgressMonitor)
     @Subject def cleanupAction = new LeastRecentlyUsedCacheCleanup(
-        new SingleDepthFilesFinder(1), fileAccessTimeJournal, TimestampSupplier.olderThanInDays(1))
+        new SingleDepthFilesFinder(1), fileAccessTimeJournal, TimestampSuppliers.daysAgo(1))
 
     def "finds files to delete when files are old"() {
         given:

--- a/subprojects/version-control/build.gradle.kts
+++ b/subprojects/version-control/build.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
     implementation(project(":messaging"))
     implementation(project(":logging"))
     implementation(project(":files"))
+    implementation(project(":functional"))
     implementation(project(":file-collections"))
     implementation(project(":persistent-cache"))
     implementation(project(":core-api"))

--- a/subprojects/version-control/src/main/java/org/gradle/vcs/internal/services/DefaultVersionControlRepositoryFactory.java
+++ b/subprojects/version-control/src/main/java/org/gradle/vcs/internal/services/DefaultVersionControlRepositoryFactory.java
@@ -17,7 +17,8 @@
 package org.gradle.vcs.internal.services;
 
 import org.gradle.api.GradleException;
-import org.gradle.api.internal.cache.DefaultCacheCleanup;
+import org.gradle.api.internal.cache.DefaultCacheCleanupStrategy;
+import org.gradle.cache.CacheCleanupStrategy;
 import org.gradle.cache.internal.CleanupActionDecorator;
 import org.gradle.cache.FileLockManager;
 import org.gradle.cache.PersistentCache;
@@ -53,12 +54,12 @@ public class DefaultVersionControlRepositoryFactory implements VersionControlRep
             .crossVersionCache("vcs-1")
             .withLockOptions(mode(FileLockManager.LockMode.OnDemand))
             .withDisplayName("VCS Checkout Cache")
-            .withCleanup(createCacheCleanup(cleanupActionDecorator))
+            .withCleanupStrategy(createCacheCleanupStrategy(cleanupActionDecorator))
             .open();
     }
 
-    private DefaultCacheCleanup createCacheCleanup(CleanupActionDecorator cleanupActionDecorator) {
-        return DefaultCacheCleanup.from(
+    private CacheCleanupStrategy createCacheCleanupStrategy(CleanupActionDecorator cleanupActionDecorator) {
+        return DefaultCacheCleanupStrategy.from(
             cleanupActionDecorator.decorate(
                 new LeastRecentlyUsedCacheCleanup(new SingleDepthFilesFinder(1), new ModificationTimeFileAccessTimeJournal(), daysAgo(DEFAULT_MAX_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES))
             )

--- a/subprojects/version-control/src/main/java/org/gradle/vcs/internal/services/DefaultVersionControlRepositoryFactory.java
+++ b/subprojects/version-control/src/main/java/org/gradle/vcs/internal/services/DefaultVersionControlRepositoryFactory.java
@@ -40,7 +40,7 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Set;
 
-import static org.gradle.api.cache.TimestampSupplier.olderThanInDays;
+import static org.gradle.internal.time.TimestampSuppliers.daysAgo;
 import static org.gradle.api.internal.cache.CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES;
 import static org.gradle.cache.internal.filelock.LockOptionsBuilder.mode;
 import static org.gradle.internal.hash.Hashing.hashString;
@@ -60,7 +60,7 @@ public class DefaultVersionControlRepositoryFactory implements VersionControlRep
     private DefaultCacheCleanup createCacheCleanup(CleanupActionDecorator cleanupActionDecorator) {
         return DefaultCacheCleanup.from(
             cleanupActionDecorator.decorate(
-                new LeastRecentlyUsedCacheCleanup(new SingleDepthFilesFinder(1), new ModificationTimeFileAccessTimeJournal(), olderThanInDays(DEFAULT_MAX_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES))
+                new LeastRecentlyUsedCacheCleanup(new SingleDepthFilesFinder(1), new ModificationTimeFileAccessTimeJournal(), daysAgo(DEFAULT_MAX_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES))
             )
         );
     }

--- a/subprojects/version-control/src/main/java/org/gradle/vcs/internal/services/DefaultVersionControlRepositoryFactory.java
+++ b/subprojects/version-control/src/main/java/org/gradle/vcs/internal/services/DefaultVersionControlRepositoryFactory.java
@@ -21,7 +21,6 @@ import org.gradle.api.internal.cache.DefaultCacheCleanup;
 import org.gradle.cache.internal.CleanupActionDecorator;
 import org.gradle.cache.FileLockManager;
 import org.gradle.cache.PersistentCache;
-import org.gradle.api.internal.cache.CacheConfigurationsInternal;
 import org.gradle.cache.internal.LeastRecentlyUsedCacheCleanup;
 import org.gradle.cache.internal.SingleDepthFilesFinder;
 import org.gradle.cache.scopes.BuildTreeScopedCache;
@@ -41,6 +40,8 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Set;
 
+import static org.gradle.api.cache.TimestampSupplier.olderThanInDays;
+import static org.gradle.api.internal.cache.CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES;
 import static org.gradle.cache.internal.filelock.LockOptionsBuilder.mode;
 import static org.gradle.internal.hash.Hashing.hashString;
 
@@ -59,7 +60,7 @@ public class DefaultVersionControlRepositoryFactory implements VersionControlRep
     private DefaultCacheCleanup createCacheCleanup(CleanupActionDecorator cleanupActionDecorator) {
         return DefaultCacheCleanup.from(
             cleanupActionDecorator.decorate(
-                new LeastRecentlyUsedCacheCleanup(new SingleDepthFilesFinder(1), new ModificationTimeFileAccessTimeJournal(), () -> CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES)
+                new LeastRecentlyUsedCacheCleanup(new SingleDepthFilesFinder(1), new ModificationTimeFileAccessTimeJournal(), olderThanInDays(DEFAULT_MAX_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES))
             )
         );
     }


### PR DESCRIPTION
This allows things like the Gradle Github Action to specify a timestamp (rather than a number of days) before which entries should be cleaned.  Users can still easily specify this value in days.  