### PR TITLE
Using FileCollectionListener in Composite&Opaque file collections

### DIFF
--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
@@ -374,7 +374,12 @@ public abstract class AbstractFileCollection implements FileCollectionInternal {
         }
     }
 
-    protected void visitContents(FileCollectionStructureVisitor visitor) {
+    @Override
+    public final void visitContentsInternal(FileCollectionStructureVisitor visitor) {
         visitor.visitCollection(OTHER, this);
+    }
+
+    protected void visitContents(FileCollectionStructureVisitor visitor) {
+        visitContentsInternal(visitor);
     }
 }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractOpaqueFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractOpaqueFileCollection.java
@@ -57,7 +57,7 @@ public abstract class AbstractOpaqueFileCollection extends AbstractFileCollectio
 
     @Override
     protected void visitContents(FileCollectionStructureVisitor visitor) {
-        visitor.visitCollection(OTHER, this);
+        super.visitContents(visitor);
         fileCollectionListener.fileCollectionObserved(this, "Consumer?");
     }
 

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractOpaqueFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractOpaqueFileCollection.java
@@ -35,8 +35,8 @@ public abstract class AbstractOpaqueFileCollection extends AbstractFileCollectio
         super(taskDependencyFactory);
     }
 
-    public AbstractOpaqueFileCollection(TaskDependencyFactory taskDependencyFactory, Factory<PatternSet> patternSetFactory) {
-        super(taskDependencyFactory, patternSetFactory);
+    public AbstractOpaqueFileCollection(TaskDependencyFactory taskDependencyFactory, Factory<PatternSet> patternSetFactory, FileCollectionListener fileCollectionListener) {
+        super(taskDependencyFactory, patternSetFactory, fileCollectionListener);
     }
 
     /**
@@ -58,6 +58,7 @@ public abstract class AbstractOpaqueFileCollection extends AbstractFileCollectio
     @Override
     protected void visitContents(FileCollectionStructureVisitor visitor) {
         visitor.visitCollection(OTHER, this);
+        fileCollectionListener.fileCollectionObserved(this, "Consumer?");
     }
 
     abstract protected Set<File> getIntrinsicFiles();

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/CompositeFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/CompositeFileCollection.java
@@ -39,8 +39,8 @@ import java.util.function.Supplier;
  * <p>The dependencies of this collection are calculated from the result of calling {@link #visitDependencies(TaskDependencyResolveContext)}.</p>
  */
 public abstract class CompositeFileCollection extends AbstractFileCollection implements TaskDependencyContainer {
-    public CompositeFileCollection(TaskDependencyFactory taskDependencyFactory, Factory<PatternSet> patternSetFactory) {
-        super(taskDependencyFactory, patternSetFactory);
+    public CompositeFileCollection(TaskDependencyFactory taskDependencyFactory, Factory<PatternSet> patternSetFactory, FileCollectionListener fileCollectionListener) {
+        super(taskDependencyFactory, patternSetFactory, fileCollectionListener);
     }
 
     public CompositeFileCollection(TaskDependencyFactory taskDependencyFactory) {
@@ -79,7 +79,7 @@ public abstract class CompositeFileCollection extends AbstractFileCollection imp
 
     @Override
     public FileCollectionInternal filter(final Spec<? super File> filterSpec) {
-        return new CompositeFileCollection(taskDependencyFactory, patternSetFactory) {
+        return new CompositeFileCollection(taskDependencyFactory, patternSetFactory, fileCollectionListener) {
             @Override
             public FileCollectionInternal replace(FileCollectionInternal original, Supplier<FileCollectionInternal> supplier) {
                 FileCollectionInternal newCollection = CompositeFileCollection.this.replace(original, supplier);
@@ -122,5 +122,6 @@ public abstract class CompositeFileCollection extends AbstractFileCollection imp
     @Override
     protected void visitContents(FileCollectionStructureVisitor visitor) {
         visitChildren(child -> child.visitStructure(visitor));
+        fileCollectionListener.fileCollectionObserved(this, "Consumer?");
     }
 }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/CompositeFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/CompositeFileCollection.java
@@ -121,7 +121,13 @@ public abstract class CompositeFileCollection extends AbstractFileCollection imp
 
     @Override
     protected void visitContents(FileCollectionStructureVisitor visitor) {
-        visitChildren(child -> child.visitStructure(visitor));
+        visitChildren(child -> visitChild(child, visitor));
         fileCollectionListener.fileCollectionObserved(this, "Consumer?");
+    }
+
+    private void visitChild(FileCollectionInternal child, FileCollectionStructureVisitor visitor) {
+        if (visitor.startVisit(OTHER, this)) {
+            child.visitContentsInternal(visitor);
+        }
     }
 }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionInternal.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionInternal.java
@@ -48,6 +48,8 @@ public interface FileCollectionInternal extends FileCollection, TaskDependencyCo
      */
     void visitStructure(FileCollectionStructureVisitor visitor);
 
+    void visitContentsInternal(FileCollectionStructureVisitor visitor);
+
     /**
      * Appends diagnostic information about the contents of this collection to the given formatter.
      */


### PR DESCRIPTION
We want to treat CompositeFileCollection as a one build input. We don't want to call Listener during of visiting each child.