### PR TITLE
Undo bits re: safe credentials in CC docs/relnotes

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -370,8 +370,6 @@ The `dependencies`, `buildEnvironment`, `projects` and `properties` tasks are no
 
 The [Maven Publish Plugin](userguide/publishing_maven.html) is now compatible with the configuration cache.
 
-Note that when using credentials, the configuration cache requires [safe credential containers](userguide/configuration_cache.html#config_cache:requirements:safe_credentials).
-
 #### Improved handling of `--offline` option
 
 Gradle now stores configuration caches for online and offline modes separately.

--- a/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
@@ -956,15 +956,6 @@ include::sample[dir="snippets/valueProviders/fileContentsDo/kotlin",files="build
 In general, you should avoid reading files at configuration time, to avoid invalidating configuration cache entries when the file content changes.
 Instead, you can connect the `Provider` returned by link:{javadocPath}/org/gradle/api/provider/ProviderFactory.html#fileContents-org.gradle.api.file.RegularFile-[providers.fileContents()] to task properties.
 
-[[config_cache:requirements:safe_credentials]]
-
-=== Safe credentials
-
-For security reasons, the configuration cache does not store credentials declared inline.
-
-To use credentials in build scripts with the configuration cache, declare credentials with Gradle Properties. To learn more about using credentials with Gradle Properties, check out the example in the
-<<declaring_repositories.adoc#sec:handling_credentials,credential handling documentation>>.
-
 [[config_cache:not_yet_implemented]]
 == Not yet implemented
 


### PR DESCRIPTION
These are doc-only changes. Code changes were released [as part of 7.6 rc2](https://github.com/gradle/gradle/pull/22626).

Issue: #22618
