### PR TITLE
Add missing `@UsesNativeServices`

### DIFF
--- a/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/cpp/internal/DefaultCppTestSuiteTest.groovy
+++ b/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/cpp/internal/DefaultCppTestSuiteTest.groovy
@@ -26,9 +26,11 @@ import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal
 import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.TestUtil
+import org.gradle.util.UsesNativeServices
 import org.junit.Rule
 import spock.lang.Specification
 
+@UsesNativeServices
 class DefaultCppTestSuiteTest extends Specification {
     @Rule
     TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())

--- a/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/cunit/CUnitTest.groovy
+++ b/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/cunit/CUnitTest.groovy
@@ -20,11 +20,13 @@ import org.gradle.nativeplatform.test.cunit.plugins.CUnitConventionPlugin
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.testing.base.TestSuiteSpec
 import org.gradle.util.TestUtil
+import org.gradle.util.UsesNativeServices
 import org.junit.Rule
 import spock.lang.Specification
 
 import static org.gradle.model.internal.type.ModelTypes.modelMap
 
+@UsesNativeServices
 class CUnitTest extends Specification {
     @Rule
     TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider(getClass())

--- a/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/internal/DefaultNativeTestSuiteBinarySpecTest.groovy
+++ b/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/internal/DefaultNativeTestSuiteBinarySpecTest.groovy
@@ -23,9 +23,11 @@ import org.gradle.nativeplatform.test.tasks.RunTestExecutable
 import org.gradle.platform.base.internal.DefaultBinaryTasksCollection
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.TestUtil
+import org.gradle.util.UsesNativeServices
 import org.junit.Rule
 import spock.lang.Specification
 
+@UsesNativeServices
 class DefaultNativeTestSuiteBinarySpecTest extends Specification {
     @Rule
     TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider(getClass())

--- a/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/plugins/NativeTestingBasePluginTest.groovy
+++ b/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/plugins/NativeTestingBasePluginTest.groovy
@@ -19,9 +19,11 @@ package org.gradle.nativeplatform.test.plugins
 import org.gradle.api.tasks.TaskDependencyMatchers
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.testfixtures.ProjectBuilder
+import org.gradle.util.UsesNativeServices
 import org.junit.Rule
 import spock.lang.Specification
 
+@UsesNativeServices
 class NativeTestingBasePluginTest extends Specification {
     @Rule
     TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())

--- a/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/xctest/internal/DefaultSwiftXCTestSuiteTest.groovy
+++ b/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/xctest/internal/DefaultSwiftXCTestSuiteTest.groovy
@@ -26,9 +26,11 @@ import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal
 import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.TestUtil
+import org.gradle.util.UsesNativeServices
 import org.junit.Rule
 import spock.lang.Specification
 
+@UsesNativeServices
 class DefaultSwiftXCTestSuiteTest extends Specification {
     @Rule
     TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())

--- a/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPluginTest.groovy
+++ b/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPluginTest.groovy
@@ -32,9 +32,11 @@ import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.testfixtures.ProjectBuilder
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
+import org.gradle.util.UsesNativeServices
 import org.junit.Rule
 import spock.lang.Specification
 
+@UsesNativeServices
 class XCTestConventionPluginTest extends Specification {
     @Rule
     TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())


### PR DESCRIPTION
We found the flakiness rate increasing in `CppUnitTestPluginTest`, probably due to test execution order:

https://ge.gradle.org/scans/tests?search.timeZoneId=Asia/Shanghai&tests.container=org.gradle.nativeplatform.test.cpp.plugins.CppUnitTestPluginTest&tests.sortField=FLAKY

If a test without `@UsesNativeServices` runs first, the wrong [`FileSystems`](https://github.com/gradle/gradle/blob/97a00a7428ee722d15c3b1d1d29f4cce32a7601e/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java#L418) is used, breaking the subsequent `CppUnitTestPluginTest`.
