### PR TITLE
Update test-retry plugin to 1.5.0

### DIFF
--- a/build-logic/build-platform/build.gradle.kts
+++ b/build-logic/build-platform/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
         api("me.champeau.gradle:japicmp-gradle-plugin:0.4.1")
         api("me.champeau.jmh:jmh-gradle-plugin:0.6.8")
         api("org.asciidoctor:asciidoctor-gradle-jvm:3.3.2")
-        api("org.gradle:test-retry-gradle-plugin:1.4.0")
+        api("org.gradle:test-retry-gradle-plugin:1.5.0")
         api("org.jetbrains.kotlin:kotlin-gradle-plugin") { version { strictly(kotlinVersion) } }
         api(kotlin("compiler-embeddable")) { version { strictly(kotlinVersion) } }
         api("org.jlleitschuh.gradle:ktlint-gradle:10.3.0")

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -1210,9 +1210,9 @@
             <sha256 value="843245599385e906a4133fed1765c4d9f2e697b0091bb681cffd71dc426ff76b" origin="Artifact is not signed"/>
          </artifact>
       </component>
-      <component group="org.gradle" name="test-retry-gradle-plugin" version="1.4.0">
-         <artifact name="test-retry-gradle-plugin-1.4.0.jar">
-            <sha256 value="fc7ee40f9d73a6a9575c0335baf8084c51cdaf85dea4d220110659a80546bd7c" origin="Artifact is not signed"/>
+      <component group="org.gradle" name="test-retry-gradle-plugin" version="1.5.0">
+         <artifact name="test-retry-gradle-plugin-1.5.0.jar">
+            <sha256 value="8fdac2ede2237b381b2bd99e735b93d648bc580e1115ee95ced673f6a1c4bbcd" origin="Artifact is not signed"/>
          </artifact>
       </component>
       <component group="org.gradle.ci.health" name="common" version="0.63">

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -132,7 +132,7 @@ abstract class AbstractSmokeTest extends Specification {
         static protobufTools = "3.21.5"
 
         // https://plugins.gradle.org/plugin/org.gradle.test-retry
-        static testRetryPlugin = "1.4.1"
+        static testRetryPlugin = "1.5.0"
 
         // https://plugins.gradle.org/plugin/com.jfrog.artifactory
         static artifactoryPlugin = "4.29.0"

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/JvmTestExecutionSpec.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/JvmTestExecutionSpec.java
@@ -23,7 +23,6 @@ import org.gradle.process.JavaForkOptions;
 import org.gradle.util.Path;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.Set;
 
 @UsedByScanPlugin("test-distribution, test-retry")
@@ -41,17 +40,6 @@ public class JvmTestExecutionSpec implements TestExecutionSpec {
     private final int maxParallelForks;
     private final Set<String> previousFailedTestClasses;
     private final boolean testIsModule;
-
-    @SuppressWarnings("unused")
-    @UsedByScanPlugin("test-retry <= 1.1.3")
-    public JvmTestExecutionSpec(TestFramework testFramework, Iterable<? extends File> classpath, FileTree candidateClassFiles, boolean scanForTestClasses, FileCollection testClassesDirs, String path, Path identityPath, long forkEvery, JavaForkOptions javaForkOptions, int maxParallelForks, Set<String> previousFailedTestClasses) {
-        this(testFramework, classpath, Collections.<File>emptyList(), candidateClassFiles, scanForTestClasses, testClassesDirs, path, identityPath, forkEvery, javaForkOptions, maxParallelForks, previousFailedTestClasses);
-    }
-
-    @UsedByScanPlugin("test-retry <= 1.4.1")
-    public JvmTestExecutionSpec(TestFramework testFramework, Iterable<? extends File> classpath, Iterable<? extends File>  modulePath, FileTree candidateClassFiles, boolean scanForTestClasses, FileCollection testClassesDirs, String path, Path identityPath, long forkEvery, JavaForkOptions javaForkOptions, int maxParallelForks, Set<String> previousFailedTestClasses) {
-        this(testFramework, classpath, modulePath, candidateClassFiles, scanForTestClasses, testClassesDirs, path, identityPath, forkEvery, javaForkOptions, maxParallelForks, previousFailedTestClasses, false);
-    }
 
     public JvmTestExecutionSpec(TestFramework testFramework, Iterable<? extends File> classpath, Iterable<? extends File>  modulePath, FileTree candidateClassFiles, boolean scanForTestClasses, FileCollection testClassesDirs, String path, Path identityPath, long forkEvery, JavaForkOptions javaForkOptions, int maxParallelForks, Set<String> previousFailedTestClasses, boolean testIsModule) {
         this.testFramework = testFramework;

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestFramework.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestFramework.java
@@ -39,15 +39,6 @@ public class JUnitPlatformTestFramework implements TestFramework {
     private final DefaultTestFilter filter;
     private final boolean useImplementationDependencies;
 
-    // Used by org.gradle.test-retry plugin.
-    // TODO: Update plugin to pass in correct value for useImplementationDependencies when copying the framework
-    // Or better yet, make it so the plugin doesn't need to access internal APIs.
-    @Deprecated
-    @SuppressWarnings("unused")
-    public JUnitPlatformTestFramework(DefaultTestFilter filter) {
-        this(filter, true);
-    }
-
     public JUnitPlatformTestFramework(DefaultTestFilter filter, boolean useImplementationDependencies) {
         this(filter, useImplementationDependencies, new JUnitPlatformOptions());
     }


### PR DESCRIPTION
The new plugin was just released. Remove old constructors it no longer uses. No reason to leave them in, there are already other binary compatibility breakages for this plugin in 8.0