### PR TITLE
Misc deprecation removals

### DIFF
--- a/subprojects/logging/src/main/java/org/gradle/util/TextUtil.java
+++ b/subprojects/logging/src/main/java/org/gradle/util/TextUtil.java
@@ -34,7 +34,7 @@ import java.util.regex.Pattern;
  * <p>
  * Plugins should prefer external frameworks over this class.
  *
- * @deprecated Will be removed in Gradle 8.0.
+ * @deprecated Will be removed in Gradle 9.0.
  */
 @Deprecated
 public class TextUtil {

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/AbstractPluginValidationIntegrationSpec.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/AbstractPluginValidationIntegrationSpec.groovy
@@ -671,12 +671,6 @@ abstract class AbstractPluginValidationIntegrationSpec extends AbstractIntegrati
 
     abstract void assertValidationSucceeds()
 
-    @Deprecated
-    final void assertValidationFailsWith(Map<String, Severity> messages) {
-        assertValidationFailsWith(messages.collect { message, severity ->
-            new DocumentedProblem(message, severity)
-        })
-    }
 
     abstract void assertValidationFailsWith(List<DocumentedProblem> messages)
 


### PR DESCRIPTION
* ~Logging operation progress details~ This has been postponed to Gradle 9 instead.
* Test fixture

Best reviewed per commit