### PR TITLE
Remove workaround for the gradle-org-conventions-plugin

### DIFF
--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -871,9 +871,9 @@
             <pgp value="7186BBF993566D8C2F4F7ED7D945E643368FEF62"/>
          </artifact>
       </component>
-      <component group="io.github.gradle" name="gradle-enterprise-conventions-plugin" version="0.9.0">
-         <artifact name="gradle-enterprise-conventions-plugin-0.9.0.jar">
-            <sha256 value="8987bf4627725ba89942f8871c86585b781576d5af6c49e3789028805636788b" origin="Verified" reason="Artifact is not signed"/>
+      <component group="io.github.gradle" name="gradle-enterprise-conventions-plugin" version="0.9.1">
+         <artifact name="gradle-enterprise-conventions-plugin-0.9.1.jar">
+            <sha256 value="e894e097ed05878f2730807a452c4fb01bd229dfdedc42e9908f0b200c68d058" origin="Verified" reason="Artifact is not signed"/>
          </artifact>
       </component>
       <component group="io.github.java-diff-utils" name="java-diff-utils" version="4.12">

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/Workarounds.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/Workarounds.kt
@@ -61,7 +61,7 @@ object Workarounds {
 
     fun canStartExternalProcesses(from: String): Boolean =
         withWorkaroundsFor("processes") {
-            isBuildScanPlugin(from) || isEnterpriseConventionsPlugin(from)
+            isBuildScanPlugin(from)
         }
 
     fun canReadFiles(from: String): Boolean =
@@ -94,11 +94,6 @@ object Workarounds {
             || startsWith("com.gradle.enterprise.agent.")
             || startsWith("com.gradle.enterprise.gradleplugin.testacceleration.")
     }
-
-    // TODO(https://github.com/gradle/gradle-org-conventions-plugin/issues/18) Remove the workaround when our conventions plugin is compatible.
-    private
-    fun isEnterpriseConventionsPlugin(from: String): Boolean =
-        from.startsWith("com.gradle.enterprise.conventions.")
 
     private
     inline fun withWorkaroundsFor(area: String, isEnabled: () -> Boolean): Boolean =

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -27,7 +27,7 @@ pluginManagement {
 
 plugins {
     id("com.gradle.enterprise").version("3.16.2") // Sync with `build-logic-commons/build-platform/build.gradle.kts`
-    id("io.github.gradle.gradle-enterprise-conventions-plugin").version("0.9.0")
+    id("io.github.gradle.gradle-enterprise-conventions-plugin").version("0.9.1")
     id("org.gradle.toolchains.foojay-resolver-convention") version ("0.8.0")
 //    id("net.ltgt.errorprone").version("3.1.0")
 }


### PR DESCRIPTION
The plugin calls `git` in the `buildScan.background` callback. Since 7.6 these are safe to use with the configuration cache.
