### PR TITLE
Standardization of test platform configuration with lazy approach

### DIFF
--- a/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/groovy/buildSrc/build.gradle
+++ b/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/groovy/buildSrc/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation 'org.spockframework:spock-core'
 }
 
-tasks.named('test') {
+tasks.named('test', Test) {
     useJUnitPlatform()
 }
 // end::repositories-and-dependencies[]

--- a/subprojects/docs/src/samples/build-organization/publishing-convention-plugins/groovy/convention-plugins/build.gradle
+++ b/subprojects/docs/src/samples/build-organization/publishing-convention-plugins/groovy/convention-plugins/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     testImplementation 'org.spockframework:spock-core'
 }
 
-tasks.named('test') {
+tasks.named('test', Test) {
     useJUnitPlatform()
 }
 

--- a/subprojects/docs/src/samples/spring-boot-web-application/kotlin/app/build.gradle.kts
+++ b/subprojects/docs/src/samples/spring-boot-web-application/kotlin/app/build.gradle.kts
@@ -23,6 +23,6 @@ dependencies {
     }
 }
 
-tasks.test {
+tasks.named<Test>("test") {
     useJUnitPlatform()
 }

--- a/subprojects/docs/src/snippets/configurationCache/testKit/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/configurationCache/testKit/groovy/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     testImplementation 'org.spockframework:spock-core'
 }
 
-tasks.named("test") {
+tasks.named('test', Test) {
     useJUnitPlatform()
 }
 

--- a/subprojects/docs/src/snippets/developingPlugins/testingPlugins/kotlin/url-verifier-plugin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/developingPlugins/testingPlugins/kotlin/url-verifier-plugin/build.gradle.kts
@@ -58,7 +58,7 @@ dependencies {
     "functionalTestImplementation"("org.spockframework:spock-core")
 }
 
-tasks.withType(Test).configureEach {
+tasks.withType<Test>().configureEach {
     // Using JUnitPlatform for running tests
     useJUnitPlatform()
 }

--- a/subprojects/docs/src/snippets/developingPlugins/testingPlugins/kotlin/url-verifier-plugin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/developingPlugins/testingPlugins/kotlin/url-verifier-plugin/build.gradle.kts
@@ -58,7 +58,7 @@ dependencies {
     "functionalTestImplementation"("org.spockframework:spock-core")
 }
 
-tasks.withType<Test>().configureEach {
+tasks.withType(Test).configureEach {
     // Using JUnitPlatform for running tests
     useJUnitPlatform()
 }

--- a/subprojects/docs/src/snippets/java/basic/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/java/basic/groovy/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter:5.7.1'
 }
 
-test {
+tasks.named('test', Test) {
     useJUnitPlatform()
 
     maxHeapSize = '1G'

--- a/subprojects/docs/src/snippets/java/basic/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java/basic/kotlin/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
 }
 
-tasks.test {
+tasks.named<Test>("test") {
     useJUnitPlatform()
 
     maxHeapSize = "1G"

--- a/subprojects/docs/src/snippets/testKit/automaticClasspathInjectionQuickstart/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/testKit/automaticClasspathInjectionQuickstart/groovy/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 }
 // end::automatic-classpath[]
 
-tasks.withType(Test).configureEach {
+tasks.named('test', Test) {
     useJUnitPlatform()
 }
 

--- a/subprojects/docs/src/snippets/testKit/automaticClasspathInjectionQuickstart/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/testKit/automaticClasspathInjectionQuickstart/kotlin/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
 }
 // end::automatic-classpath[]
 
-tasks.withType<Test>().configureEach {
+tasks.named<Test>("test") {
     useJUnitPlatform()
 }
 

--- a/subprojects/docs/src/snippets/testKit/gradleVersion/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/testKit/gradleVersion/groovy/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     }
 }
 
-tasks.withType(Test).configureEach {
+tasks.named('test', Test) {
     useJUnitPlatform()
 }
 

--- a/subprojects/docs/src/snippets/testKit/junitQuickstart/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/testKit/junitQuickstart/groovy/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
 }
 
-tasks.withType(Test).configureEach {
+tasks.named('test', Test) {
     useJUnitPlatform()
 }
 // end::declare-junit-dependency[]

--- a/subprojects/docs/src/snippets/testKit/junitQuickstart/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/testKit/junitQuickstart/kotlin/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
 }
 
-tasks.withType<Test>().configureEach {
+tasks.named<Test>("test") {
     useJUnitPlatform()
 }
 // end::declare-junit-dependency[]

--- a/subprojects/docs/src/snippets/testKit/spockQuickstart/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/testKit/spockQuickstart/groovy/build.gradle
@@ -15,7 +15,7 @@ dependencies {
 }
 // end::declare-spock-dependency[]
 
-tasks.withType(Test).configureEach {
+tasks.named('test', Test) {
     useJUnitPlatform()
 }
 

--- a/subprojects/docs/src/snippets/testKit/testKitFunctionalTestSpockBuildCache/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/testKit/testKitFunctionalTestSpockBuildCache/groovy/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     }
 }
 
-tasks.withType(Test).configureEach {
+tasks.named('test', Test) {
     useJUnitPlatform()
 }
 

--- a/subprojects/docs/src/snippets/testing/junitplatform-engine/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/testing/junitplatform-engine/groovy/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 }
 
 // tag::filter-engine[]
-test {
+tasks.withType(Test).configureEach {
     useJUnitPlatform {
         includeEngines 'junit-vintage'
         // excludeEngines 'junit-jupiter'

--- a/subprojects/docs/src/snippets/testing/junitplatform-engine/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/testing/junitplatform-engine/kotlin/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
 }
 
 // tag::filter-engine[]
-tasks.withType<Test> {
+tasks.withType<Test>().configureEach {
     useJUnitPlatform {
         includeEngines("junit-vintage")
         // excludeEngines("junit-jupiter")

--- a/subprojects/docs/src/snippets/testing/junitplatform-engine/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/testing/junitplatform-engine/kotlin/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
 }
 
 // tag::filter-engine[]
-tasks.test {
+tasks.withType<Test> {
     useJUnitPlatform {
         includeEngines("junit-vintage")
         // excludeEngines("junit-jupiter")

--- a/subprojects/docs/src/snippets/testing/junitplatform-jupiter/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/testing/junitplatform-jupiter/groovy/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 // end::jupiter-dependencies[]
 
 // tag::enabling-junit-platform[]
-test {
+tasks.named('test', Test) {
     useJUnitPlatform()
 }
 // end::enabling-junit-platform[]

--- a/subprojects/docs/src/snippets/testing/junitplatform-mix/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/testing/junitplatform-mix/groovy/build.gradle
@@ -14,6 +14,6 @@ dependencies {
 }
 // end::vintage-dependencies[]
 
-test {
+tasks.named('test', Test) {
     useJUnitPlatform()
 }

--- a/subprojects/docs/src/snippets/testing/junitplatform-mix/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/testing/junitplatform-mix/kotlin/build.gradle.kts
@@ -14,6 +14,6 @@ dependencies {
 }
 // end::vintage-dependencies[]
 
-tasks.test {
+tasks.named<Test>("test") {
     useJUnitPlatform()
 }

--- a/subprojects/docs/src/snippets/testing/junitplatform-tagging/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/testing/junitplatform-tagging/groovy/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 }
 
 // tag::test-tags[]
-test {
+tasks.withType(Test).configureEach {
     useJUnitPlatform {
         includeTags 'fast'
         excludeTags 'slow'

--- a/subprojects/docs/src/snippets/testing/junitplatform-tagging/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/testing/junitplatform-tagging/kotlin/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
 }
 
 // tag::test-tags[]
-tasks.test {
+tasks.withType<Test> {
     useJUnitPlatform {
         includeTags("fast")
         excludeTags("slow")

--- a/subprojects/docs/src/snippets/testing/junitplatform-tagging/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/testing/junitplatform-tagging/kotlin/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
 }
 
 // tag::test-tags[]
-tasks.withType<Test> {
+tasks.withType<Test>().configureEach {
     useJUnitPlatform {
         includeTags("fast")
         excludeTags("slow")

--- a/subprojects/testing-base/src/integTest/resources/org/gradle/testing/RetainStacktraceForInheritedTestMethodsTest/retainsStackTraceForInheritedTestMethods/build.gradle
+++ b/subprojects/testing-base/src/integTest/resources/org/gradle/testing/RetainStacktraceForInheritedTestMethodsTest/retainsStackTraceForInheritedTestMethods/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
 }
 
-tasks.named('test') {
+tasks.named('test', Test) {
     useJUnitPlatform()
     testLogging {
         exceptionFormat = TestExceptionFormat.FULL


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
These fixes will reduce the inconsistency in the documentation.
The current documentation configures the test engine in several different ways, which leads to misunderstandings.
Before:
```bash
$ grep -F -e 'useJUnitPlatform()' -B 2 -r --include 'build.gradle*' --with-filename . | grep -F -e '{' | grep --only-matching -E -e 'build.gradle.*' | sed 's/-/: /' | sort | uniq -c
      1 build.gradle.kts: tasks.named<Test>("test") {
      3 build.gradle.kts: tasks.test {
      3 build.gradle.kts: tasks.withType<Test>().configureEach {
      1 build.gradle: tasks.named("test") {
      3 build.gradle: tasks.named('test') {
      1 build.gradle: tasks.named('test', Test) {
      6 build.gradle: tasks.withType(Test).configureEach {
      3 build.gradle: test {
```
After:
```bash
$ grep -F -e 'useJUnitPlatform()' -B 2 -r --include 'build.gradle*' --with-filename . | grep -F -e '{' | grep --only-matching -E -e 'build.gradle.*' | sed 's/-/: /' | sort | uniq -c
      7 build.gradle.kts: tasks.test {
     14 build.gradle: test {
```
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
  *Not needed*
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
  *Not needed*
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
  *Not needed*
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
