### PR TITLE
Make SoftwareComponentInternal finalizable for v8.1

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/component/SoftwareComponentInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/component/SoftwareComponentInternal.java
@@ -35,4 +35,6 @@ public interface SoftwareComponentInternal extends SoftwareComponent {
      * This method and {@link UsageContext} should both be deprecated in favor of a new public API.
      */
     Set<? extends UsageContext> getUsages();
+
+    default void finalizeValue() {}
 }

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 [[upgrading_version_7]]
-= Upgrading your build from Gradle 7.x to the latest
+= Upgrading your build from Gradle 7.x to 8.x
 
 This chapter provides the information you need to migrate your Gradle 7.x builds to the latest Gradle release.
 For migrating from Gradle 4.x, 5.x, or 6.x, see the <<upgrading_version_6.adoc#upgrading_version_6, older migration guide>> first.

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
@@ -58,3 +58,46 @@ This includes calling any of the following `Configuration` methods:
 
 The ability to change the allowed usage of a configuration after
 creation will be removed in Gradle 9.0.
+
+[[gmm_modification_after_publication_populated]]
+==== Modifying Gradle Module Metadata after a publication has been populated
+
+Altering the link:publishing_gradle_module_metadata.html[GMM] (e.g., changing a component configuration variants) *after* a Maven or Ivy publication has been populated from their components is now deprecated. This feature will be removed in Gradle 9.0.
+
+Eager population of the publication can happen if the following methods are called:
+
+====== Maven
+
+* link:{javadocPath}/org/gradle/api/publish/maven/MavenPublication.html#getArtifacts--[MavenPublication.getArtifacts()]
+
+====== Ivy
+
+* link:{javadocPath}/org/gradle/api/publish/ivy/IvyPublication.html#getArtifacts--[IvyPublication.getArtifacts()]
+* link:{javadocPath}/org/gradle/api/publish/ivy/IvyPublication.html#getConfigurations--[IvyPublication.getConfigurations()]
+* link:{javadocPath}/org/gradle/api/publish/ivy/IvyPublication.html#configurations(Action)--[IvyPublication.configurations(Action)]
+
+Previously, this code block did not generate warnings, but it created inconsistencies between published artifacts:
+
+```kotlin
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            from(components["java"])
+        }
+        create<IvyPublication>("ivy") {
+            from(components["java"])
+        }
+    }
+}
+
+// These calls eagerly populate the Maven and Ivy publications
+(publishing.publications["maven"] as MavenPublication).artifacts
+(publishing.publications["ivy"] as IvyPublication).artifacts
+
+(components["java"] as AdhocComponentWithVariants).apply {
+  withVariantsFromConfiguration(configurations["apiElements"]) { skip() }
+  withVariantsFromConfiguration(configurations["runtimeElements"]) { skip() }
+}
+```
+
+In this example, the Maven and Ivy publications will contain the main JAR artifacts for the project, whereas the GMM link:https://github.com/gradle/gradle/blob/master/subprojects/docs/src/docs/design/gradle-module-metadata-latest-specification.md[module file] will omit them.

--- a/subprojects/docs/src/main/resources/header.html
+++ b/subprojects/docs/src/main/resources/header.html
@@ -99,7 +99,8 @@
             <li><a href="../release-notes.html">Release Notes</a></li>
             <li><a class="nav-dropdown" data-toggle="collapse" href="#upgrading-gradle" aria-expanded="false" aria-controls="upgrading-gradle">Upgrading Gradle</a>
                 <ul id="upgrading-gradle">
-                    <li><a href="../userguide/upgrading_version_7.html">version 7.X to latest</a></li>
+                    <li><a href="../userguide/upgrading_version_8.html">version 8.X to latest</a></li>
+                    <li><a href="../userguide/upgrading_version_7.html">version 7.X to 8.0</a></li>
                     <li><a href="../userguide/upgrading_version_6.html">version 6.X to 7.0</a></li>
                     <li><a href="../userguide/upgrading_version_5.html">version 5.X to 6.0</a></li>
                     <li><a href="../userguide/upgrading_version_4.html">version 4.X to 5.0</a></li>

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
@@ -272,6 +272,9 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
             return;
         }
         PublicationErrorChecker.checkForUnpublishableAttributes(component, documentationRegistry);
+        // Finalize the component to avoid GMM later modification
+        // See issue https://github.com/gradle/gradle/issues/20581
+        component.finalizeValue();
 
         PublicationWarningsCollector publicationWarningsCollector = new PublicationWarningsCollector(LOG, UNSUPPORTED_FEATURE, "", PUBLICATION_WARNING_FOOTER, "suppressIvyMetadataWarningsFor");
         Set<? extends SoftwareComponentVariant> variants = component.getUsages();

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishIssuesIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishIssuesIntegTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTes
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.maven.MavenFileModule
 import org.gradle.test.fixtures.maven.MavenFileRepository
+import org.gradle.util.GradleVersion
 import org.spockframework.util.TextUtil
 import spock.lang.Issue
 
@@ -369,5 +370,95 @@ subprojects {
         publishedModule.parsedModuleMetadata.variant("javadocElements") {
             assert files*.name == []
         }
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/20581")
+    void "warn deprecated behavior when GMM is modified after a Maven publication is populated"() {
+
+        settingsFile << 'rootProject.name = "test"'
+        buildKotlinFile << """
+             plugins {
+                java
+                `maven-publish`
+                kotlin("jvm") version "1.7.21"
+            }
+            repositories {
+                mavenCentral()
+            }
+            dependencies {
+                implementation(kotlin("stdlib-jdk8"))
+            }
+            publishing {
+                publications {
+                    create<MavenPublication>("maven") {
+                        from(components["java"])
+                    }
+                }
+            }
+            (publishing.publications["maven"] as MavenPublication).artifacts
+            (components["java"] as org.gradle.api.plugins.internal.DefaultAdhocSoftwareComponent).apply {
+                withVariantsFromConfiguration(configurations["apiElements"]) { skip() }
+            }
+        """
+
+        executer.beforeExecute {
+            executer.expectDeprecationWarning(
+                "Gradle Module Metadata is modified after an eagerly populated publication. " +
+                    "This behavior has been deprecated. This will fail with an error in Gradle 9.0. " +
+                    "Consult the upgrading guide for further information: " +
+                    "https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_7.html#gmm_modification_after_publication_populated"
+            )
+        }
+
+        when:
+        succeeds "prepareKotlinBuildScriptModel"
+
+        then:
+        outputContains("Gradle Module Metadata is modified after an eagerly populated publication.")
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/20581")
+    void "warn deprecated behavior when GMM is modified after an Ivy publication is populated"() {
+
+        settingsFile << 'rootProject.name = "test"'
+        buildKotlinFile << """
+             plugins {
+                java
+                `ivy-publish`
+                kotlin("jvm") version "1.7.21"
+            }
+            repositories {
+                mavenCentral()
+            }
+            dependencies {
+                implementation(kotlin("stdlib-jdk8"))
+            }
+            publishing {
+                publications {
+                    create<IvyPublication>("ivy") {
+                        from(components["java"])
+                    }
+                }
+            }
+            (publishing.publications["ivy"] as IvyPublication).artifacts
+            (components["java"] as org.gradle.api.plugins.internal.DefaultAdhocSoftwareComponent).apply {
+                withVariantsFromConfiguration(configurations["apiElements"]) { skip() }
+            }
+        """
+
+        executer.beforeExecute {
+            executer.expectDeprecationWarning(
+                "Gradle Module Metadata is modified after an eagerly populated publication. " +
+                    "This behavior has been deprecated. This will fail with an error in Gradle 9.0. " +
+                    "Consult the upgrading guide for further information: " +
+                    "https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_7.html#gmm_modification_after_publication_populated"
+            )
+        }
+
+        when:
+        succeeds "prepareKotlinBuildScriptModel"
+
+        then:
+        outputContains("Gradle Module Metadata is modified after an eagerly populated publication.")
     }
 }

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishIssuesIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishIssuesIntegTest.groovy
@@ -374,8 +374,7 @@ subprojects {
 
     @Issue("https://github.com/gradle/gradle/issues/20581")
     void "warn deprecated behavior when GMM is modified after a Maven publication is populated"() {
-
-        settingsFile << 'rootProject.name = "test"'
+        given:
         buildKotlinFile << """
              plugins {
                 java
@@ -401,26 +400,21 @@ subprojects {
             }
         """
 
-        executer.beforeExecute {
-            executer.expectDeprecationWarning(
-                "Gradle Module Metadata is modified after an eagerly populated publication. " +
-                    "This behavior has been deprecated. This will fail with an error in Gradle 9.0. " +
-                    "Consult the upgrading guide for further information: " +
-                    "https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_7.html#gmm_modification_after_publication_populated"
-            )
-        }
-
         when:
-        succeeds "prepareKotlinBuildScriptModel"
+        executer.expectDocumentedDeprecationWarning(
+            "Gradle Module Metadata is modified after an eagerly populated publication. " +
+                "This behavior has been deprecated. This will fail with an error in Gradle 9.0. " +
+                "Consult the upgrading guide for further information: " +
+                "https://docs.gradle.org/current/userguide/upgrading_version_8.html#gmm_modification_after_publication_populated"
+        )
 
         then:
-        outputContains("Gradle Module Metadata is modified after an eagerly populated publication.")
+        succeeds "help"
     }
 
     @Issue("https://github.com/gradle/gradle/issues/20581")
     void "warn deprecated behavior when GMM is modified after an Ivy publication is populated"() {
-
-        settingsFile << 'rootProject.name = "test"'
+        given:
         buildKotlinFile << """
              plugins {
                 java
@@ -446,19 +440,15 @@ subprojects {
             }
         """
 
-        executer.beforeExecute {
-            executer.expectDeprecationWarning(
-                "Gradle Module Metadata is modified after an eagerly populated publication. " +
-                    "This behavior has been deprecated. This will fail with an error in Gradle 9.0. " +
-                    "Consult the upgrading guide for further information: " +
-                    "https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_7.html#gmm_modification_after_publication_populated"
-            )
-        }
-
         when:
-        succeeds "prepareKotlinBuildScriptModel"
+        executer.expectDocumentedDeprecationWarning(
+            "Gradle Module Metadata is modified after an eagerly populated publication. " +
+                "This behavior has been deprecated. This will fail with an error in Gradle 9.0. " +
+                "Consult the upgrading guide for further information: " +
+                "https://docs.gradle.org/current/userguide/upgrading_version_8.html#gmm_modification_after_publication_populated"
+        )
 
         then:
-        outputContains("Gradle Module Metadata is modified after an eagerly populated publication.")
+        succeeds "help"
     }
 }

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishIssuesIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishIssuesIntegTest.groovy
@@ -20,7 +20,6 @@ import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTes
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.maven.MavenFileModule
 import org.gradle.test.fixtures.maven.MavenFileRepository
-import org.gradle.util.GradleVersion
 import org.spockframework.util.TextUtil
 import spock.lang.Issue
 

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -300,6 +300,9 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
             return;
         }
         MavenPublicationErrorChecker.checkForUnpublishableAttributes(component, documentationRegistry);
+        // Finalize the component to avoid GMM later modification
+        // See issue https://github.com/gradle/gradle/issues/20581
+        component.finalizeValue();
 
         PublicationWarningsCollector publicationWarningsCollector = new PublicationWarningsCollector(LOG, UNSUPPORTED_FEATURE, INCOMPATIBLE_FEATURE, PUBLICATION_WARNING_FOOTER, "suppressPomMetadataWarningsFor");
         Set<ArtifactKey> seenArtifacts = Sets.newHashSet();

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultAdhocSoftwareComponent.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultAdhocSoftwareComponent.java
@@ -82,7 +82,7 @@ public class DefaultAdhocSoftwareComponent implements AdhocComponentWithVariants
         if (finalized) {
             DeprecationLogger.deprecateBehaviour("Gradle Module Metadata is modified after an eagerly populated publication.")
                 .willBecomeAnErrorInGradle9()
-                .withUpgradeGuideSection(7, "gmm_modification_after_publication_populated")
+                .withUpgradeGuideSection(8, "gmm_modification_after_publication_populated")
                 .nagUser();
         }
     }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultAdhocSoftwareComponent.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultAdhocSoftwareComponent.java
@@ -26,6 +26,7 @@ import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.component.UsageContext;
 import org.gradle.api.internal.java.usagecontext.ConfigurationVariantMapping;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.reflect.Instantiator;
 
 import java.util.Map;
@@ -35,6 +36,8 @@ public class DefaultAdhocSoftwareComponent implements AdhocComponentWithVariants
     private final String componentName;
     private final Map<Configuration, ConfigurationVariantMapping> variants = Maps.newLinkedHashMapWithExpectedSize(4);
     private final Instantiator instantiator;
+
+    private boolean finalized = false;
 
     public DefaultAdhocSoftwareComponent(String componentName, Instantiator instantiator) {
         this.componentName = componentName;
@@ -48,11 +51,13 @@ public class DefaultAdhocSoftwareComponent implements AdhocComponentWithVariants
 
     @Override
     public void addVariantsFromConfiguration(Configuration outgoingConfiguration, Action<? super ConfigurationVariantDetails> spec) {
+        checkNotFinalized();
         variants.put(outgoingConfiguration, new ConfigurationVariantMapping((ConfigurationInternal) outgoingConfiguration, spec, instantiator));
     }
 
     @Override
     public void withVariantsFromConfiguration(Configuration outgoingConfiguration, Action<? super ConfigurationVariantDetails> action) {
+        checkNotFinalized();
         if (!variants.containsKey(outgoingConfiguration)) {
             throw new InvalidUserDataException("Variant for configuration " + outgoingConfiguration.getName() + " does not exist in component " + componentName);
         }
@@ -66,5 +71,19 @@ public class DefaultAdhocSoftwareComponent implements AdhocComponentWithVariants
             variant.collectVariants(builder);
         }
         return builder.build();
+    }
+
+    @Override
+    public void finalizeValue() {
+        finalized = true;
+    }
+
+    protected void checkNotFinalized() {
+        if (finalized) {
+            DeprecationLogger.deprecateBehaviour("Gradle Module Metadata is modified after an eagerly populated publication.")
+                .willBecomeAnErrorInGradle9()
+                .withUpgradeGuideSection(7, "gmm_modification_after_publication_populated")
+                .nagUser();
+        }
     }
 }


### PR DESCRIPTION
Fixes #20581

### Context

Changes made in pull request #22399 were [reverted](https://github.com/gradle/gradle/pull/22900) to target milestone 8.1 instead of 8.0.