### PR TITLE
Generate commit distributions in build directory

### DIFF
--- a/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/tasks/PerformanceTest.groovy
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/tasks/PerformanceTest.groovy
@@ -25,8 +25,8 @@ import groovy.json.JsonOutput
 import groovy.transform.CompileStatic
 import org.apache.commons.io.FileUtils
 import org.gradle.api.GradleException
-import org.gradle.api.Task
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.internal.tasks.testing.filter.DefaultTestFilter
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
@@ -115,6 +115,9 @@ abstract class PerformanceTest extends DistributionTest {
 
     @Input
     abstract Property<String> getReportGeneratorClass()
+
+    @Internal
+    abstract DirectoryProperty getCommitDistributionsDir()
 
     private final PerformanceReporter performanceReporter = project.objects.newInstance(PerformanceReporter)
 
@@ -268,11 +271,6 @@ abstract class PerformanceTest extends DistributionTest {
     @InputFiles
     abstract ConfigurableFileCollection getTestProjectFiles()
 
-    void setTestProjectGenerationTask(Task testProjectGenerationTask) {
-        getTestProjectName().set(testProjectGenerationTask.name)
-        getTestProjectFiles().setFrom(testProjectGenerationTask)
-    }
-
     void addDatabaseParameters(Map<String, String> databaseConnectionParameters) {
         this.databaseParameters.putAll(databaseConnectionParameters)
     }
@@ -317,6 +315,7 @@ abstract class PerformanceTest extends DistributionTest {
         }
 
         private void addExecutionParameters(List<String> result) {
+            addSystemPropertyIfExist(result, "integTest.commitDistributionsDir", commitDistributionsDir.get().asFile.absolutePath)
             addSystemPropertyIfExist(result, "org.gradle.performance.scenarios", scenarios)
             addSystemPropertyIfExist(result, "org.gradle.performance.testProject", getTestProjectName().getOrNull())
             addSystemPropertyIfExist(result, "org.gradle.performance.baselines", baselines.getOrNull())

--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
@@ -93,6 +93,7 @@ object Config {
     const val performanceTestReportsDir = "performance-tests/report"
     const val performanceTestResultsJsonName = "perf-results.json"
     const val performanceTestResultsJson = "performance-tests/$performanceTestResultsJsonName"
+
     // Android Studio Electric Eel (2022.1.1) Beta 2
     const val androidStudioVersion = "2022.1.1.12"
     val defaultAndroidStudioJvmArgs = listOf("-Xms256m", "-Xmx4096m")
@@ -327,6 +328,7 @@ class PerformanceTestPlugin : Plugin<Project> {
         // determineBaselines.determinedBaselines -> buildCommitDistribution.baselines
         val determineBaselines = tasks.register("determineBaselines", DetermineBaselines::class, false)
         val buildCommitDistribution = tasks.register("buildCommitDistribution", BuildCommitDistribution::class)
+        val buildCommitDistributionsDir = project.rootProject.layout.buildDirectory.dir("commit-distributions")
 
         determineBaselines.configure {
             configuredBaselines.set(extension.baselines)
@@ -338,12 +340,13 @@ class PerformanceTestPlugin : Plugin<Project> {
             dependsOn(determineBaselines)
             releasedVersionsFile.set(project.releasedVersionsFile())
             commitBaseline.set(determineBaselines.flatMap { it.determinedBaselines })
-            commitDistribution.set(project.rootProject.layout.projectDirectory.file(commitBaseline.map { "intTestHomeDir/commit-distributions/gradle-$it.zip" }))
-            commitDistributionToolingApiJar.set(project.rootProject.layout.projectDirectory.file(commitBaseline.map { "intTestHomeDir/commit-distributions/gradle-$it-tooling-api.jar" }))
+            commitDistribution.set(buildCommitDistributionsDir.zip(commitBaseline) { dir, version -> dir.file("gradle-$version.zip") })
+            commitDistributionToolingApiJar.set(buildCommitDistributionsDir.zip(commitBaseline) { dir, version -> dir.file("gradle-$version-tooling-api.jar") })
         }
 
         tasks.withType<PerformanceTest>().configureEach {
             dependsOn(buildCommitDistribution)
+            commitDistributionsDir.set(buildCommitDistributionsDir)
             baselines.set(determineBaselines.flatMap { it.determinedBaselines })
         }
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/CommitDistribution.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/CommitDistribution.groovy
@@ -26,7 +26,7 @@ import org.gradle.util.GradleVersion
  *
  * The commit distributions are generated at the following location:
  *
- * +-- intTestHomeDir
+ * +-- build
  *    +-- commit-distributions
  *        +-- gradle-7.5-commit-1a2b3c4.zip
  *        +-- gradle-7.5-commit-1a2b3c4-tooling-api.jar

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/IntegrationTestBuildContext.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/IntegrationTestBuildContext.java
@@ -39,6 +39,10 @@ public class IntegrationTestBuildContext {
         return file("integTest.samplesdir", null);
     }
 
+    public TestFile getCommitDistributionsDir() {
+        return file("integTest.commitDistributionsDir", null);
+    }
+
     @Nullable
     public TestFile getNormalizedBinDistribution() {
         return optionalFile("integTest.normalizedDistribution");
@@ -106,7 +110,7 @@ public class IntegrationTestBuildContext {
         }
 
         if (CommitDistribution.isCommitDistribution(version)) {
-            return new CommitDistribution(version, getGradleUserHomeDir().getParentFile().file("commit-distributions"));
+            return new CommitDistribution(version, getCommitDistributionsDir());
         }
         return new ReleasedGradleDistribution(version, previousVersionDir.file(version));
     }


### PR DESCRIPTION
Previously, we put generated commit distributions in `intTestHomeDir`, which is not cleaned across builds. Actually, commit distributions are build outputs so they are more suitable for build directory.

Fixes https://github.com/gradle/gradle-private/issues/3649