### PR TITLE
Fix some configuration cache edge cases

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheTaskSerializationIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheTaskSerializationIntegrationTest.groovy
@@ -278,4 +278,92 @@ class ConfigurationCacheTaskSerializationIntegrationTest extends AbstractConfigu
         outputContains("thisTask = true")
         outputContains("bean.owner = true")
     }
+
+    def "retains Property identity for each task"() {
+        buildFile << """
+            abstract class SomeTask extends DefaultTask {
+                @Internal
+                abstract Property<String> getValue()
+
+                @TaskAction
+                void run() {
+                    println "this.value = " + value.getOrNull()
+                }
+            }
+
+            task ok(type: SomeTask) {
+                value = "42"
+                def valueRef = value
+                doFirst {
+                    valueRef.set("123")
+                }
+            }
+
+            task other {
+                mustRunAfter(tasks.ok)
+                def value = tasks.ok.value
+                doLast {
+                    println("ok.value = " + value.getOrNull())
+                }
+            }
+        """
+
+        when:
+        configurationCacheRun "ok", "other"
+
+        then:
+        outputContains("this.value = 123")
+        outputContains("ok.value = 123") // not isolated on first run
+
+        when:
+        configurationCacheRun "ok", "other"
+
+        then:
+        outputContains("this.value = 123")
+        outputContains("ok.value = 42")
+    }
+
+    def "retains ConfigurableFileCollection identity for each task"() {
+        buildFile << """
+            abstract class SomeTask extends DefaultTask {
+                @Internal
+                abstract ConfigurableFileCollection getValue()
+
+                @TaskAction
+                void run() {
+                    println "this.value = " + value*.name
+                }
+            }
+
+            task ok(type: SomeTask) {
+                value.from("file1.txt")
+                def valueRef = value
+                doFirst {
+                    valueRef.from("file2.txt")
+                }
+            }
+
+            task other {
+                mustRunAfter(tasks.ok)
+                def value = tasks.ok.value
+                doLast {
+                    println("ok.value = " + value*.name)
+                }
+            }
+        """
+
+        when:
+        configurationCacheRun "ok", "other"
+
+        then:
+        outputContains("this.value = [file1.txt, file2.txt]")
+        outputContains("ok.value = [file1.txt, file2.txt]") // not isolated on first run
+
+        when:
+        configurationCacheRun "ok", "other"
+
+        then:
+        outputContains("this.value = [file1.txt, file2.txt]")
+        outputContains("ok.value = [file1.txt]")
+    }
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/ArtifactCollectionCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/ArtifactCollectionCodec.kt
@@ -79,7 +79,7 @@ class ArtifactCollectionCodec(
 
 
 private
-class FixedFileArtifactSpec(
+data class FixedFileArtifactSpec(
     val id: ComponentArtifactIdentifier,
     val variantAttributes: AttributeContainer,
     val capabilities: List<Capability>,
@@ -92,6 +92,8 @@ private
 class CollectingArtifactVisitor : ArtifactVisitor {
     val elements = mutableListOf<Any>()
     val failures = mutableListOf<Throwable>()
+    private
+    val artifacts = mutableSetOf<ResolvableArtifact>()
 
     override fun prepareForVisit(source: FileCollectionInternal.Source): FileCollectionStructureVisitor.VisitType {
         return if (source is TransformedProjectArtifactSet || source is LocalFileDependencyBackedArtifactSet || source is TransformedExternalArtifactSet) {
@@ -115,7 +117,9 @@ class CollectingArtifactVisitor : ArtifactVisitor {
     }
 
     override fun visitArtifact(variantName: DisplayName, variantAttributes: AttributeContainer, capabilities: List<Capability>, artifact: ResolvableArtifact) {
-        elements.add(FixedFileArtifactSpec(artifact.id, variantAttributes, capabilities, variantName, artifact.file))
+        if (artifacts.add(artifact)) {
+            elements.add(FixedFileArtifactSpec(artifact.id, variantAttributes, capabilities, variantName, artifact.file))
+        }
     }
 
     override fun endVisitCollection(source: FileCollectionInternal.Source) {

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/FileCollectionCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/FileCollectionCodec.kt
@@ -53,35 +53,43 @@ class FileCollectionCodec(
 
     override suspend fun WriteContext.encode(value: FileCollectionInternal) {
         encodePreservingIdentityOf(value) {
-            val visitor = CollectingVisitor()
-            value.visitStructure(visitor)
-            write(visitor.elements)
+            encodeContents(value)
         }
+    }
+
+    suspend fun WriteContext.encodeContents(value: FileCollectionInternal) {
+        val visitor = CollectingVisitor()
+        value.visitStructure(visitor)
+        write(visitor.elements)
     }
 
     override suspend fun ReadContext.decode(): FileCollectionInternal {
         return decodePreservingIdentity { id ->
-            val contents = read()
-            val collection = if (contents is Collection<*>) {
-                fileCollectionFactory.resolving(
-                    contents.map { element ->
-                        when (element) {
-                            is File -> element
-                            is SubtractingFileCollectionSpec -> element.left.minus(element.right)
-                            is FilteredFileCollectionSpec -> element.collection.filter(element.filter)
-                            is ProviderBackedFileCollectionSpec -> element.provider
-                            is FileTree -> element
-                            is ResolvedArtifactSet -> artifactSetConverter.asFileCollection(element)
-                            is BeanSpec -> element.bean
-                            else -> throw IllegalArgumentException("Unexpected item $element in file collection contents")
-                        }
+            val fileCollection = decodeContents()
+            isolate.identities.putInstance(id, fileCollection)
+            fileCollection
+        }
+    }
+
+    suspend fun ReadContext.decodeContents(): FileCollectionInternal {
+        val contents = read()
+        return if (contents is Collection<*>) {
+            fileCollectionFactory.resolving(
+                contents.map { element ->
+                    when (element) {
+                        is File -> element
+                        is SubtractingFileCollectionSpec -> element.left.minus(element.right)
+                        is FilteredFileCollectionSpec -> element.collection.filter(element.filter)
+                        is ProviderBackedFileCollectionSpec -> element.provider
+                        is FileTree -> element
+                        is ResolvedArtifactSet -> artifactSetConverter.asFileCollection(element)
+                        is BeanSpec -> element.bean
+                        else -> throw IllegalArgumentException("Unexpected item $element in file collection contents")
                     }
-                )
-            } else {
-                fileCollectionFactory.create(ErrorFileSet(contents as BrokenValue))
-            }
-            isolate.identities.putInstance(id, collection)
-            collection
+                }
+            )
+        } else {
+            fileCollectionFactory.create(ErrorFileSet(contents as BrokenValue))
         }
     }
 }
@@ -109,11 +117,13 @@ class CollectingVisitor : FileCollectionStructureVisitor {
                 elements.add(SubtractingFileCollectionSpec(fileCollection.left, fileCollection.right))
                 false
             }
+
             is FilteredFileCollection -> {
                 // TODO - when the collection is static then we should serialize the current contents of the collection
                 elements.add(FilteredFileCollectionSpec(fileCollection.collection, fileCollection.filterSpec))
                 false
             }
+
             is ProviderBackedFileCollection -> {
                 // Guard against file collection created from a task provider such as `layout.files(compileJava)`
                 // being referenced from a different task.
@@ -125,14 +135,17 @@ class CollectingVisitor : FileCollectionStructureVisitor {
                     true
                 }
             }
+
             is FileTreeInternal -> {
                 elements.add(fileCollection)
                 false
             }
+
             is FailingFileCollection -> {
                 elements.add(BeanSpec(fileCollection))
                 false
             }
+
             else -> {
                 true
             }
@@ -155,12 +168,15 @@ class CollectingVisitor : FileCollectionStructureVisitor {
             is TransformedProjectArtifactSet -> {
                 elements.add(source)
             }
+
             is LocalFileDependencyBackedArtifactSet -> {
                 elements.add(source)
             }
+
             is TransformedExternalArtifactSet -> {
                 elements.add(source)
             }
+
             else -> {
                 elements.addAll(contents)
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyHandlerProviderIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyHandlerProviderIntegrationTest.groovy
@@ -87,9 +87,10 @@ class DependencyHandlerProviderIntegrationTest extends AbstractHttpDependencyRes
 
         task resolve {
             inputs.files(configurations.conf)
-            outputs.file("out.txt")
+            def outFile = file("out.txt")
+            outputs.file(outFile)
             doLast {
-               file("out.txt") << 'Hello'
+               outFile << 'Hello'
             }
         }
 
@@ -147,8 +148,9 @@ class DependencyHandlerProviderIntegrationTest extends AbstractHttpDependencyRes
         }
 
         task resolve {
+            def files = configurations.conf
             doLast {
-                 configurations.conf.resolve()
+                 files*.name
             }
         }
         """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyNotationIntegrationSpec.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyNotationIntegrationSpec.groovy
@@ -23,7 +23,7 @@ import spock.lang.Issue
 
 class DependencyNotationIntegrationSpec extends AbstractIntegrationSpec {
 
-    @ToBeFixedForConfigurationCache(because = "unsupported type Dependency")
+    @ToBeFixedForConfigurationCache(because = "Task uses the Configuration API")
     def "understands dependency notations"() {
         when:
         buildFile <<  """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
@@ -1523,18 +1523,9 @@ configurations.all {
                 }
             }
 
-
             dependencies {
                 conf 'org:lib:1.0:classy'
                 conf 'org:other:1.0'
-            }
-
-            checkDeps {
-               def files = configurations.conf
-               doLast {
-                  // additional check on top of what the test fixture allows
-                  assert files*.name as Set == ['lib-1.1.jar', 'other-1.0.jar'] as Set
-               }
             }
         """
 
@@ -1610,14 +1601,6 @@ configurations.all {
                 conf 'org:lib:1.0'
                 conf 'org:other:1.0'
             }
-
-            checkDeps {
-               def files = configurations.conf
-               doLast {
-                  // additional check on top of what the test fixture allows
-                  assert files*.name as Set == ['lib-1.1-classy.jar', 'other-1.0.jar'] as Set
-               }
-            }
         """
 
         when:
@@ -1635,7 +1618,6 @@ configurations.all {
                 }
             }
         }
-
     }
 
     @Issue("https://github.com/gradle/gradle/issues/13658")

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/LazyDownloadsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/LazyDownloadsIntegrationTest.groovy
@@ -34,7 +34,7 @@ class LazyDownloadsIntegrationTest extends AbstractHttpDependencyResolutionTest 
                     create('default').extendsFrom compile
                 }
             }
-            
+
             dependencies {
                 compile project(':child')
             }
@@ -42,7 +42,7 @@ class LazyDownloadsIntegrationTest extends AbstractHttpDependencyResolutionTest 
                 dependencies {
                     compile 'test:test:1.0'
                     compile 'test:test2:1.0'
-                }                
+                }
             }
 """
     }
@@ -51,8 +51,9 @@ class LazyDownloadsIntegrationTest extends AbstractHttpDependencyResolutionTest 
         given:
         buildFile << """
             task graph {
+                def root = configurations.compile.incoming.resolutionResult.rootComponent
                 doLast {
-                    println configurations.compile.incoming.resolutionResult.allComponents
+                    root.get()
                 }
             }
 """
@@ -87,8 +88,9 @@ class LazyDownloadsIntegrationTest extends AbstractHttpDependencyResolutionTest 
         given:
         buildFile << """
             task artifacts {
+                def files = configurations.compile
                 doLast {
-                    configurations.compile.${expression}.each { it }
+                    files*.name
                 }
             }
 """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationDependenciesBuildOperationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationDependenciesBuildOperationIntegrationTest.groovy
@@ -21,19 +21,19 @@ import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
 import org.gradle.integtests.fixtures.BuildOperationNotificationsFixture
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import org.gradle.integtests.fixtures.resolve.ResolveFailureTestFixture
 import org.gradle.test.fixtures.maven.MavenFileRepository
 import org.gradle.test.fixtures.server.http.AuthScheme
 import org.gradle.test.fixtures.server.http.MavenHttpModule
 import org.gradle.test.fixtures.server.http.MavenHttpRepository
 
 class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends AbstractHttpDependencyResolutionTest {
-
+    def failedResolve = new ResolveFailureTestFixture(buildFile, "compile")
     def operations = new BuildOperationsFixture(executer, temporaryFolder)
 
     @SuppressWarnings("GroovyUnusedDeclaration")
     def operationNotificationsFixture = new BuildOperationNotificationsFixture(executer, temporaryFolder)
 
-    @ToBeFixedForConfigurationCache(because = "different error reporting")
     def "resolved configurations are exposed via build operation"() {
         setup:
         buildFile << """
@@ -49,12 +49,8 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
                 implementation project(":child")
                 implementation 'org.foo:rock:1.0' //contains unresolved transitive dependency
             }
-
-            task resolve(type: Copy) {
-                from configurations.compileClasspath
-                into "build/resolved"
-            }
         """
+        failedResolve.prepare("compileClasspath")
         settingsFile << "include 'child'"
         def m1 = mavenHttpRepo.module('org.foo', 'hiphop').publish()
         def m2 = mavenHttpRepo.module('org.foo', 'unknown')
@@ -67,9 +63,10 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
         m4.allowAll()
 
         when:
-        fails "resolve"
+        fails "checkDeps"
 
         then:
+        failedResolve.assertFailurePresent(failure)
         def op = operations.first(ResolveConfigurationDependenciesBuildOperationType)
         op.details.configurationName == "compileClasspath"
         op.details.projectPath == ":"
@@ -82,7 +79,6 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
         op.result.resolvedDependenciesCount == 4
     }
 
-    @ToBeFixedForConfigurationCache(because = "Task.getProject() during execution")
     def "resolved detached configurations are exposed"() {
         setup:
         buildFile << """
@@ -90,11 +86,11 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
             maven { url '${mavenHttpRepo.uri}' }
         }
 
-        task resolve {
-            doLast {
-                project.configurations.detachedConfiguration(dependencies.create('org.foo:dep:1.0')).files
-            }
+        task resolve(type: Copy) {
+            from project.configurations.detachedConfiguration(dependencies.create('org.foo:dep:1.0'))
+            into "build/resolved"
         }
+
         """
         def m1 = mavenHttpRepo.module('org.foo', 'dep').publish()
 
@@ -378,22 +374,19 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
                compile 'org:a:1.0'
                compile 'org:b:1.0'
             }
-
-            task resolve {
-              doLast {
-                  println(configurations.compile.files.name)
-              }
-            }
 """
+        failedResolve.prepare()
+
         a.pom.expectGet()
         b.pom.expectGet()
         leaf1.pom.expectGet()
         leaf2.pom.expectGet()
 
         then:
-        fails "resolve"
+        fails "checkDeps"
 
         and:
+        failedResolve.assertFailurePresent(failure)
         def op = operations.first(ResolveConfigurationDependenciesBuildOperationType)
         op.details.configurationName == "compile"
         op.failure == "org.gradle.api.artifacts.ResolveException: Could not resolve all dependencies for configuration ':compile'."
@@ -422,25 +415,22 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
             dependencies {
                compile 'org:a:1.0'
             }
-
-            task resolve {
-              doLast {
-                  println(configurations.compile.files.name)
-              }
-            }
 """
+        failedResolve.prepare()
+
         then:
         mod.allowAll()
-        fails "resolve"
+        fails "checkDeps"
 
         and:
+        failedResolve.assertFailurePresent(failure)
         def op = operations.first(ResolveConfigurationDependenciesBuildOperationType)
         op.details.configurationName == "compile"
         op.failure == null
         op.result.resolvedDependenciesCount == 1
     }
 
-    @ToBeFixedForConfigurationCache(because = "access to configuration container in task action")
+    @ToBeFixedForConfigurationCache(because = "Runtime classpath for CompileJava task is resolved even though the task will not run")
     def "resolved components contain their source repository name, even when taken from the cache"() {
         setup:
         def secondMavenHttpRepo = new MavenHttpRepository(server, '/repo-2', new MavenFileRepository(file('maven-repo-2')))
@@ -479,7 +469,10 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
                 implementation project(':child')
             }
 
-            task resolve { doLast { configurations.runtimeClasspath.resolve() } }
+            task resolve(type: Copy) {
+                from configurations.runtimeClasspath
+                into "build/resolved"
+            }
 
             project(':child') {
                 apply plugin: "java"
@@ -544,8 +537,6 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
                 implementation project(':child')
             }
 
-            task resolve { doLast { configurations.runtimeClasspath.resolve() } }
-
             project(':child') {
                 apply plugin: "java"
                 dependencies {
@@ -553,6 +544,7 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
                 }
             }
         """
+        failedResolve.prepare("runtimeClasspath")
         settingsFile << "include 'child'"
 
         when:
@@ -560,9 +552,10 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
         mavenHttpRepo.module('org.foo', 'broken-transitive').pom.expectGetBroken()
 
         and:
-        fails 'resolve'
+        fails 'checkDeps'
 
         then:
+        failedResolve.assertFailurePresent(failure)
         def op = operations.first(ResolveConfigurationDependenciesBuildOperationType)
         def resolvedComponents = op.result.components
         resolvedComponents.size() == 4
@@ -572,7 +565,7 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
         resolvedComponents.'org.foo:transitive1:1.0'.repoName == 'maven1'
     }
 
-    @ToBeFixedForConfigurationCache(because = "access to configuration container in task action")
+    @ToBeFixedForConfigurationCache(because = "Dependency resolution does not run for a from-cache build")
     def "resolved components contain their source repository id, even when they are structurally identical"() {
         setup:
         buildFile << """
@@ -595,7 +588,10 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
                 implementation 'org.foo:good:1.0'
             }
 
-            task resolve { doLast { configurations.compileClasspath.resolve() } }
+            task resolve(type: Copy) {
+                from configurations.compileClasspath
+                into "build/resolved"
+            }
         """
         def module = mavenHttpRepo.module('org.foo', 'good').publish()
         server.authenticationScheme = AuthScheme.BASIC

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/AddingConfigurationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/AddingConfigurationIntegrationTest.groovy
@@ -36,9 +36,11 @@ class AddingConfigurationIntegrationTest extends AbstractIntegrationSpec {
             }
 
             task addConfigs {
+                def files1 = configurations.conf1
+                def files2 = configurations.conf2
                 doLast {
-                    FileCollection sum = configurations.conf1
-                    sum += configurations.conf2
+                    FileCollection sum = files1
+                    sum += files2
                     assert sum.files.sort() == [ file1, file2 ]
                 }
             }
@@ -67,10 +69,13 @@ class AddingConfigurationIntegrationTest extends AbstractIntegrationSpec {
             }
 
             task addConfigs {
+                def files1 = configurations.conf1
+                def files2 = configurations.conf2
+                def files3 = configurations.conf3
                 doLast {
-                    FileCollection difference = configurations.conf3
-                    difference -= configurations.conf2
-                    difference -= configurations.conf1
+                    FileCollection difference = files3
+                    difference -= files2
+                    difference -= files1
                     assert difference.files.sort() == [ file3 ]
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ArtifactDeclarationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ArtifactDeclarationIntegrationTest.groovy
@@ -101,14 +101,6 @@ class ArtifactDeclarationIntegrationTest extends AbstractIntegrationSpec {
                 dependencies {
                     compile project(':a')
                 }
-                task checkArtifacts {
-                    doLast {
-                        assert configurations.compile.incoming.artifacts.collect { it.file.name } == ["a", "b", "c"]
-                        assert configurations.compile.resolvedConfiguration.resolvedArtifacts.collect { it.file.name } == ["a", "b", "c"]
-                        assert configurations.compile.resolvedConfiguration.resolvedArtifacts.collect { "\$it.name:\$it.extension:\$it.type" } == ["thing-a:txt:report", "thing-b:txt:report", "thing-c::report"]
-                        assert configurations.compile.resolvedConfiguration.resolvedArtifacts.collect { it.classifier } == ["report", "report", "report"]
-                    }
-                }
             }
         """
 
@@ -141,27 +133,25 @@ class ArtifactDeclarationIntegrationTest extends AbstractIntegrationSpec {
                         }
                     }
                 }
-                task checkArtifacts {
-                    doLast {
-                        assert configurations.compile.artifacts.size() == 2
-                    }
-                }
+                assert configurations.compile.artifacts.size() == 2
             }
             project(':b') {
                 dependencies {
                     compile project(':a')
                 }
-                task checkArtifacts {
-                    doLast {
-                        assert configurations.compile.incoming.artifacts.collect { it.file.name } == ["lib1.jar", "lib2.zip"]
-                        assert configurations.compile.resolvedConfiguration.resolvedArtifacts.collect { it.file.name } == ["lib1.jar", "lib2.zip"]
-                    }
-                }
             }
 """
 
         expect:
-        succeeds("checkArtifacts")
+        succeeds(":b:checkDeps")
+        resolve.expectGraph {
+            root(":b", "test:b:") {
+                project(":a", "test:a:") {
+                    artifact(name: "lib1")
+                    artifact(name: "not-a-lib", extension: "zip", type: "not-a-lib", fileName: "lib2.zip")
+                }
+            }
+        }
     }
 
     def "can define outgoing variants and artifacts for configuration"() {
@@ -189,16 +179,12 @@ configurations {
         }
     }
 }
-task checkArtifacts {
-    doLast {
-        def classes = configurations.compile.outgoing.variants['classes']
-        classes.attributes.keySet().collect { it.name } == ['usage', 'format']
-    }
-}
+def classes = configurations.compile.outgoing.variants['classes']
+classes.attributes.keySet().collect { it.name } == ['usage', 'format']
 """
 
         expect:
-        succeeds("checkArtifacts")
+        succeeds()
     }
 
     def "can declare build dependency of artifact using String notation"() {
@@ -217,20 +203,21 @@ task checkArtifacts {
                     compile project(':a')
                 }
                 task jar {} // ignored
-                task checkArtifacts {
-                    inputs.files configurations.compile
-                    doLast {
-                        configurations.compile.resolvedConfiguration.resolvedArtifacts.forEach { println it }
-                    }
-                }
             }
         """
 
         when:
-        succeeds ':b:checkArtifacts'
+        succeeds ':b:checkDeps'
 
         then:
-        result.assertTasksExecuted(":a:jar", ":b:checkArtifacts")
+        result.assertTasksExecuted(":a:jar", ":b:checkDeps")
+        resolve.expectGraph {
+            root(":b", "test:b:") {
+                project(":a", "test:a:") {
+                    artifact(name: "lib1")
+                }
+            }
+        }
     }
 
     def "can declare build dependency of outgoing artifact using String notation"() {
@@ -255,20 +242,21 @@ task checkArtifacts {
                     compile project(':a')
                 }
                 task jar {} // ignored
-                task checkArtifacts {
-                    inputs.files configurations.compile
-                    doLast {
-                        assert configurations.compile.resolvedConfiguration.resolvedArtifacts.each { println it }
-                    }
-                }
             }
 """
 
         when:
-        succeeds ':b:checkArtifacts'
+        succeeds ':b:checkDeps'
 
         then:
-        result.assertTasksExecuted(":a:jar", ":b:checkArtifacts")
+        result.assertTasksExecuted(":a:jar", ":b:checkDeps")
+        resolve.expectGraph {
+            root(":b", "test:b:") {
+                project(":a", "test:a:") {
+                    artifact(name: "lib1")
+                }
+            }
+        }
     }
 
     def "can declare build dependency of outgoing variant artifact using String notation"() {
@@ -297,20 +285,21 @@ task checkArtifacts {
                     compile project(':a')
                 }
                 task classes {} // ignored
-                task checkArtifacts {
-                    inputs.files configurations.compile
-                    doLast {
-                        assert configurations.compile.resolvedConfiguration.resolvedArtifacts.each { println it }
-                    }
-                }
             }
 """
 
         when:
-        succeeds ':b:checkArtifacts'
+        succeeds ':b:checkDeps'
 
         then:
-        result.assertTasksExecuted(":a:classes", ":b:checkArtifacts")
+        result.assertTasksExecuted(":a:classes", ":b:checkDeps")
+        resolve.expectGraph {
+            root(":b", "test:b:") {
+                project(":a", "test:a:") {
+                    artifact(name: "classes", type: "")
+                }
+            }
+        }
     }
 
     def "can define artifact using File provider"() {
@@ -326,20 +315,20 @@ task checkArtifacts {
                 dependencies {
                     compile project(':a')
                 }
-                task checkArtifacts {
-                    inputs.files configurations.compile
-                    doLast {
-                        assert configurations.compile.incoming.artifacts.collect { it.file.name } == ["a.jar"]
-                    }
-                }
             }
         """
 
         when:
-        succeeds ':b:checkArtifacts'
+        succeeds ':b:checkDeps'
 
         then:
-        result.assertTasksExecuted(":b:checkArtifacts")
+        result.assertTasksExecuted(":b:checkDeps")
+        resolve.expectGraph {
+            root(":b", "test:b:") {
+                project(":a", "test:a:") {
+                }
+            }
+        }
     }
 
     def "can define artifact using RegularFile task output"() {
@@ -359,20 +348,20 @@ task checkArtifacts {
                 dependencies {
                     compile project(':a')
                 }
-                task checkArtifacts {
-                    inputs.files configurations.compile
-                    doLast {
-                        assert configurations.compile.incoming.artifacts.collect { it.file.name } == ["a.jar"]
-                    }
-                }
             }
         """
 
         when:
-        succeeds ':b:checkArtifacts'
+        succeeds ':b:checkDeps'
 
         then:
-        result.assertTasksExecuted(":a:classes", ":b:checkArtifacts")
+        result.assertTasksExecuted(":a:classes", ":b:checkDeps")
+        resolve.expectGraph {
+            root(":b", "test:b:") {
+                project(":a", "test:a:") {
+                }
+            }
+        }
     }
 
     def "can define artifact using Directory task output"() {
@@ -392,20 +381,21 @@ task checkArtifacts {
                 dependencies {
                     compile project(':a')
                 }
-                task checkArtifacts {
-                    inputs.files configurations.compile
-                    doLast {
-                        assert configurations.compile.incoming.artifacts.collect { it.file.name } == ["classes"]
-                    }
-                }
             }
         """
 
         when:
-        succeeds ':b:checkArtifacts'
+        succeeds ':b:checkDeps'
 
         then:
-        result.assertTasksExecuted(":a:classes", ":b:checkArtifacts")
+        result.assertTasksExecuted(":a:classes", ":b:checkDeps")
+        resolve.expectGraph {
+            root(":b", "test:b:") {
+                project(":a", "test:a:") {
+                    artifact(name: "classes", type: "")
+                }
+            }
+        }
     }
 
     def "can define artifact using RegularFile type"() {
@@ -420,17 +410,18 @@ task checkArtifacts {
                 dependencies {
                     compile project(':a')
                 }
-                task checkArtifacts {
-                    inputs.files configurations.compile
-                    doLast {
-                        assert configurations.compile.incoming.artifacts.collect { it.file.name } == ["someFile.txt"]
-                    }
-                }
             }
         """
 
         expect:
-        succeeds ':b:checkArtifacts'
+        succeeds ':b:checkDeps'
+        resolve.expectGraph {
+            root(":b", "test:b:") {
+                project(":a", "test:a:") {
+                    artifact(name: "someFile", type: "", extension: "txt")
+                }
+            }
+        }
     }
 
     def "can define artifact using Directory type"() {
@@ -455,7 +446,14 @@ task checkArtifacts {
         """
 
         expect:
-        succeeds ':b:checkArtifacts'
+        succeeds ':b:checkDeps'
+        resolve.expectGraph {
+            root(":b", "test:b:") {
+                project(":a", "test:a:") {
+                    artifact(name: "someDir", type: "")
+                }
+            }
+        }
     }
 
     // This isn't strictly supported and will be deprecated later
@@ -481,31 +479,25 @@ task checkArtifacts {
                         builtBy jar
                     }
                 }
-                task checkArtifacts {
-                    doLast {
-                        assert configurations.compile.artifacts.collect { it.file.name }  == ["lib1.jar"]
-                        assert configurations.compile.artifacts.collect { it.name }  == ["thing"]
-                    }
-                }
+                assert configurations.compile.artifacts.collect { it.file.name }  == ["lib1.jar"]
+                assert configurations.compile.artifacts.collect { it.name }  == ["thing"]
             }
             project(':b') {
                 dependencies {
                     compile project(':a')
                 }
-                task checkArtifacts {
-                    inputs.files configurations.compile
-                    doLast {
-                        assert configurations.compile.incoming.artifacts.collect { it.file.name } == ["lib1.jar"]
-                        assert configurations.compile.incoming.artifacts.collect { it.id.displayName } == ["thing.jar (project :a)"]
-                        assert configurations.compile.resolvedConfiguration.resolvedArtifacts.collect { it.name } == ["thing"]
-                    }
-                }
             }
 """
 
         expect:
-        succeeds("checkArtifacts")
-        result.assertTasksExecutedInOrder(":a:checkArtifacts", ":a:jar", ":b:checkArtifacts")
+        succeeds("b:checkDeps")
+        result.assertTasksExecutedInOrder(":a:jar", ":b:checkDeps")
+        resolve.expectGraph {
+            root(":b", "test:b:") {
+                project(":a", "test:a:") {
+                    artifact(name: "thing", fileName: "lib1.jar")
+                }
+            }
+        }
     }
-
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationDefaultsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationDefaultsIntegrationTest.groovy
@@ -17,14 +17,18 @@ package org.gradle.integtests.resolve.api
 
 import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import spock.lang.Issue
 
 class ConfigurationDefaultsIntegrationTest extends AbstractDependencyResolutionTest {
+    ResolveTestFixture resolve = new ResolveTestFixture(buildFile, "conf")
 
     def setup() {
         mavenRepo.module("org", "default-dependency").publish()
         mavenRepo.module("org", "explicit-dependency").publish()
-
+        settingsFile << """
+            rootProject.name = 'test'
+        """
         buildFile << """
 configurations {
     conf
@@ -34,58 +38,55 @@ repositories {
     maven { url '${mavenRepo.uri}' }
 }
 
-if (providers.systemProperty('explicitDeps').present) {
+if (System.getProperty('explicitDeps')) {
     dependencies {
         conf "org:explicit-dependency:1.0"
-    }
-}
-task checkDefault {
-    doLast {
-        if (System.getProperty('resolveChild')) {
-            configurations.child.resolve()
-        }
-
-        def deps = configurations.conf.incoming.resolutionResult.allDependencies
-        assert deps*.selected.id.displayName == ['org:default-dependency:1.0']
-
-        def files = configurations.conf.files
-        assert files*.name == ["default-dependency-1.0.jar"]
-    }
-}
-task checkExplicit {
-    doLast {
-        def deps = configurations.conf.incoming.resolutionResult.allDependencies
-        assert deps*.selected.id.displayName == ['org:explicit-dependency:1.0']
-
-        def files = configurations.conf.files
-        assert files*.name == ["explicit-dependency-1.0.jar"]
     }
 }
 """
     }
 
-    @ToBeFixedForConfigurationCache
     def "can use defaultDependencies to specify default dependencies"() {
         buildFile << """
 configurations.conf.defaultDependencies { deps ->
     deps.add project.dependencies.create("org:default-dependency:1.0")
 }
 """
-
-        expect:
-        succeeds "checkDefault"
+        resolve.prepare {
+            config("conf", "checkDeps")
+            config("child", "checkChild")
+        }
 
         when:
-        executer.withArgument("-DresolveChild=yes")
+        run "checkDeps"
 
         then:
-        succeeds "checkDefault"
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module("org:default-dependency:1.0")
+            }
+        }
+
+        when:
+        run "checkChild"
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module("org:default-dependency:1.0")
+            }
+        }
 
         when:
         executer.withArgument("-DexplicitDeps=yes")
+        run "checkDeps"
 
         then:
-        succeeds "checkExplicit"
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module("org:explicit-dependency:1.0")
+            }
+        }
     }
 
     @Issue("gradle/gradle#3908")
@@ -109,14 +110,22 @@ println configurations.other.files
 
 project.status = 'foo'
 """
+        resolve.prepare()
 
-        expect:
-        succeeds "checkDefault"
+        when:
+        run "checkDeps"
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module("org:default-dependency:1.0")
+            }
+        }
     }
 
     @Issue("gradle/gradle#812")
     def "can use defaultDependencies in a multi-project build"() {
-        buildFile.text = """
+        buildFile << """
 subprojects {
     apply plugin: 'java'
 
@@ -145,33 +154,39 @@ project(":consumer") {
         implementation project(":producer")
     }
 }
-
-subprojects {
-    task resolve {
-        dependsOn configurations.compileClasspath
-
-        doLast {
-            def resolvedJars = configurations.runtimeClasspath.files.collect { it.name }
-            if (System.getProperty('explicitDeps')) {
-                assert "explicit-dependency-1.0.jar" in resolvedJars
-            } else {
-                assert "default-dependency-1.0.jar" in resolvedJars
-            }
-        }
-    }
-}
 """
+        resolve.prepare("runtimeClasspath")
+        resolve.expectDefaultConfiguration("runtimeElements")
         settingsFile << """
 include 'consumer', 'producer'
 """
-        expect:
-        // relying on explicit dependency
-        succeeds("resolve", "-DexplicitDeps=yes")
 
-        // relying on default dependency
-        succeeds("resolve")
+        when:
+        executer.withArgument("-DexplicitDeps=yes")
+        run ":consumer:checkDeps"
 
+        then:
+        resolve.expectGraph {
+            root(":consumer", "test:consumer:") {
+                project(":producer", "test:producer:") {
+                    module("org:explicit-dependency:1.0")
+                }
+            }
+        }
+
+        when:
+        run ":consumer:checkDeps"
+
+        then:
+        resolve.expectGraph {
+            root(":consumer", "test:consumer:") {
+                project(":producer", "test:producer:") {
+                    module("org:default-dependency:1.0")
+                }
+            }
+        }
     }
+
     def "can use defaultDependencies in a composite build"() {
         buildTestFixture.withBuildInSubDir()
 
@@ -192,11 +207,10 @@ include 'consumer', 'producer'
 """
         }
 
-        def consumer = singleProjectBuild("consumer") {
-            settingsFile << """
+        settingsFile << """
     includeBuild '${producer.toURI()}'
 """
-            buildFile << """
+        buildFile << """
     apply plugin: 'java'
     repositories {
         maven { url '${mavenRepo.uri}' }
@@ -208,20 +222,21 @@ include 'consumer', 'producer'
     dependencies {
         implementation 'org.test:producer:1.0'
     }
-    task resolve {
-        dependsOn configurations.compileClasspath
-
-        doLast {
-            def resolvedJars = configurations.runtimeClasspath.files.collect { it.name }
-            assert "default-dependency-1.0.jar" in resolvedJars
-        }
-    }
 """
-        }
+        resolve.prepare("runtimeClasspath")
+        resolve.expectDefaultConfiguration("runtimeElements")
 
-        expect:
-        executer.inDirectory(consumer)
-        succeeds ":resolve"
+        when:
+        run ":checkDeps"
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                edge("org.test:producer:1.0", ":producer", "org.test:producer:1.0") {
+                    module("org:default-dependency:1.0")
+                }
+            }
+        }
     }
 
     def "can use beforeResolve to specify default dependencies"() {
@@ -232,38 +247,54 @@ configurations.conf.incoming.beforeResolve {
     }
 }
 """
+        resolve.prepare()
 
-        expect:
-        succeeds "checkDefault"
+        when:
+        run "checkDeps"
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module("org:default-dependency:1.0")
+            }
+        }
 
         when:
         executer.withArgument("-DexplicitDeps=yes")
+        run "checkDeps"
 
         then:
-        succeeds "checkExplicit"
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module("org:explicit-dependency:1.0")
+            }
+        }
     }
 
     def "fails if beforeResolve used to add dependencies to observed configuration"() {
+        resolve.prepare()
         buildFile << """
 configurations.conf.incoming.beforeResolve {
     if (configurations.conf.dependencies.empty) {
         configurations.conf.dependencies.add project.dependencies.create("org:default-dependency:1.0")
     }
 }
+task broken {
+    doLast {
+        configurations.child.resolve()
+        configurations.conf.resolve()
+    }
+}
 """
 
-
         when:
-        executer.withArgument("-DresolveChild=yes")
+        fails "broken"
 
         then:
-        fails "checkDefault"
-
-        and:
         failure.assertHasCause "Cannot change dependencies of dependency configuration ':conf' after it has been included in dependency resolution."
     }
 
-    @ToBeFixedForConfigurationCache
+    @ToBeFixedForConfigurationCache(because = "Task uses the Configuration API")
     def "copied configuration has independent set of listeners"() {
         buildFile << """
 configurations {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationMutationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationMutationIntegrationTest.groovy
@@ -257,26 +257,22 @@ project(":consumer") {
         implementation project(":producer")
     }
 }
-
-subprojects {
-    task resolve {
-        inputs.files(configurations.runtimeClasspath)
-
-        doLast {
-            def resolvedJars = configurations.runtimeClasspath.files.collect { it.name }
-            assert "explicit-dependency-3.4.jar" in resolvedJars
-            assert "added-dependency-3.4.jar" in resolvedJars
-        }
-    }
-}
 """
+        resolve.prepare("runtimeClasspath")
         settingsFile << """
 include 'consumer', 'producer'
 """
         expect:
         // relying on default dependency
-        succeeds("resolve")
-
+        succeeds(":consumer:checkDeps")
+        resolve.expectGraph {
+            root(":consumer", "root:consumer:") {
+                project(":producer", "root:producer:") {
+                    module("org:explicit-dependency:3.4")
+                    module("org:added-dependency:3.4")
+                }
+            }
+        }
     }
 
     def "can use defaultDependencies in a composite build"() {
@@ -309,11 +305,10 @@ include 'consumer', 'producer'
 """
         }
 
-        def consumer = singleProjectBuild("consumer") {
-            settingsFile << """
+        settingsFile << """
     includeBuild '${producer.toURI()}'
 """
-            buildFile << """
+        buildFile << """
     apply plugin: 'java'
     repositories {
         maven { url '${mavenRepo.uri}' }
@@ -325,22 +320,18 @@ include 'consumer', 'producer'
     dependencies {
         implementation 'org.test:producer:1.0'
     }
-    task resolve {
-        dependsOn configurations.runtimeClasspath
-
-        doLast {
-            def resolvedJars = configurations.runtimeClasspath.files.collect { it.name }
-            assert "explicit-dependency-3.4.jar" in resolvedJars
-            assert "added-dependency-3.4.jar" in resolvedJars
-        }
-    }
 """
-        }
+        resolve.prepare("runtimeClasspath")
 
         expect:
-        executer.inDirectory(consumer)
-        succeeds ":resolve"
+        succeeds ":checkDeps"
+        resolve.expectGraph {
+            root(":", "org.test:root:1.1") {
+                edge("org.test:producer:1.0", ":producer", "org.test:producer:1.0") {
+                    module("org:explicit-dependency:3.4")
+                    module("org:added-dependency:3.4")
+                }
+            }
+        }
     }
-
-
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalDependencyWithGradleMetadataResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalDependencyWithGradleMetadataResolutionIntegrationTest.groovy
@@ -423,12 +423,6 @@ dependencies {
     debug 'test:a:1.2'
     release 'test:a:1.2'
 }
-task xcheckDebug {
-    doLast { assert configurations.debug.files*.name == ['a-1.2-debug.jar', 'b-2.0.jar', 'c-preview-debug.jar'] }
-}
-task xcheckRelease {
-    doLast { assert configurations.release.files*.name == [] }
-}
 """
         resolve.prepare {
             config("debug")

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariant.java
@@ -57,6 +57,7 @@ public class ArtifactBackedResolvedVariant implements ResolvedVariant {
     public static ResolvedVariant create(@Nullable VariantResolveMetadata.Identifier identifier, DisplayName displayName, AttributeContainerInternal attributes, CapabilitiesMetadata capabilities, Supplier<Collection<? extends ResolvableArtifact>> artifacts) {
         return new ArtifactBackedResolvedVariant(identifier, displayName, attributes, capabilities, supplyResolvedArtifactSet(displayName, attributes, capabilities, artifacts));
     }
+
     private static Supplier<ResolvedArtifactSet> supplyResolvedArtifactSet(DisplayName displayName, AttributeContainerInternal attributes, CapabilitiesMetadata capabilities, Supplier<Collection<? extends ResolvableArtifact>> artifactsSupplier) {
         return () -> {
             Collection<? extends ResolvableArtifact> artifacts = artifactsSupplier.get();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactVisitor.java
@@ -37,6 +37,8 @@ public interface ArtifactVisitor {
 
     /**
      * Visits an artifact. Artifacts are resolved but not necessarily available unless {@link #requireArtifactFiles()} returns true.
+     *
+     * <p>Note that a given artifact may be visited multiple times. The implementation is required to filter out duplicates.</p>
      */
     void visitArtifact(DisplayName variantName, AttributeContainer variantAttributes, List<? extends Capability> capabilities, ResolvableArtifact artifact);
 

--- a/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/FilePropertyLifecycleIntegrationTest.groovy
+++ b/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/FilePropertyLifecycleIntegrationTest.groovy
@@ -34,8 +34,9 @@ class FilePropertyLifecycleIntegrationTest extends AbstractIntegrationSpec imple
 
             task show(type: SomeTask) {
                 prop = file("in.txt")
+                def other = file("other.txt")
                 doFirst {
-                    prop = file("other.txt")
+                    prop = other
                 }
             }
 """
@@ -68,8 +69,9 @@ class FilePropertyLifecycleIntegrationTest extends AbstractIntegrationSpec imple
 
             task show(type: SomeTask) {
                 prop = file("in.dir")
+                def other = file("other.dir")
                 doFirst {
-                    prop = file("other.dir")
+                    prop = other
                 }
             }
 """
@@ -97,8 +99,9 @@ def prop = project.objects.fileProperty()
 task thing {
     ${registrationMethod}(prop)
     prop.set(file("file-1"))
+    def other = file("ignored")
     doLast {
-        prop.set(file("ignored"))
+        prop.set(other)
         println "prop = " + prop.get()
     }
 }
@@ -127,8 +130,9 @@ def prop = project.objects.directoryProperty()
 task thing {
     ${registrationMethod}(prop)
     prop.set(file("file-1"))
+    def other = file("ignored")
     doLast {
-        prop.set(file("ignored"))
+        prop.set(other)
         println "prop = " + prop.get()
     }
 }
@@ -154,16 +158,17 @@ task thing {
             task producer(type: FileProducer) {
                 output = layout.buildDir.file("text.out")
             }
-            println("prop = " + producer.output.get())
+            def output = producer.output
+            println("prop = " + output.get())
             task after {
                 dependsOn(producer)
                 doLast {
-                    println("prop = " + producer.output.get())
+                    println("prop = " + output.get())
                 }
             }
             task before {
                 doLast {
-                    println("prop = " + producer.output.get())
+                    println("prop = " + output.get())
                 }
             }
             producer.dependsOn(before)
@@ -181,16 +186,17 @@ task thing {
                 output = layout.buildDir.dir("dir.out")
                 names = ["a", "b"]
             }
-            println("prop = " + producer.output.get())
+            def output = producer.output
+            println("prop = " + output.get())
             task after {
                 dependsOn(producer)
                 doLast {
-                    println("prop = " + producer.output.get())
+                    println("prop = " + output.get())
                 }
             }
             task before {
                 doLast {
-                    println("prop = " + producer.output.get())
+                    println("prop = " + output.get())
                 }
             }
             producer.dependsOn(before)
@@ -208,17 +214,19 @@ task thing {
             task producer(type: FileProducer) {
                 output.disallowUnsafeRead()
                 output = layout.buildDir.file("text.out")
+                def other = file('ignore')
                 doFirst {
                     try {
-                        output = file('ignore')
+                        output = other
                     } catch(IllegalStateException e) {
                         println("set failed: " + e.message)
                     }
                 }
             }
+            def output = producer.output
 
             try {
-                producer.output.get()
+                output.get()
             } catch(IllegalStateException e) {
                 println("get failed: " + e.message)
             }
@@ -226,14 +234,14 @@ task thing {
             task after {
                 dependsOn(producer)
                 doLast {
-                    println("prop = " + producer.output.get())
+                    println("prop = " + output.get())
                 }
             }
 
             task before {
                 doLast {
                     try {
-                        producer.output.get()
+                        output.get()
                     } catch(IllegalStateException e) {
                         println("get from task failed: " + e.message)
                     }
@@ -258,17 +266,19 @@ task thing {
                 output.disallowUnsafeRead()
                 output = layout.buildDir.dir("dir.out")
                 names = ["a", "b"]
+                def other = file('ignore')
                 doFirst {
                     try {
-                        output = file('ignore')
+                        output = other
                     } catch(IllegalStateException e) {
                         println("set failed: " + e.message)
                     }
                 }
             }
+            def output = producer.output
 
             try {
-                producer.output.get()
+                output.get()
             } catch(IllegalStateException e) {
                 println("get failed: " + e.message)
             }
@@ -276,14 +286,14 @@ task thing {
             task after {
                 dependsOn(producer)
                 doLast {
-                    println("prop = " + producer.output.get())
+                    println("prop = " + output.get())
                 }
             }
 
             task before {
                 doLast {
                     try {
-                        producer.output.get()
+                        output.get()
                     } catch(IllegalStateException e) {
                         println("get from task failed: " + e.message)
                     }
@@ -490,9 +500,10 @@ task thing {
 
             thing.prop.disallowUnsafeRead()
             thing.prop.set(producer.output)
+            def prop = thing.prop
 
             try {
-                thing.prop.get()
+                prop.get()
             } catch(IllegalStateException e) {
                 println("get failed: " + e.message)
             }
@@ -500,14 +511,14 @@ task thing {
             task after {
                 dependsOn(thing.prop)
                 doLast {
-                    println("prop = " + thing.prop.get())
+                    println("prop = " + prop.get())
                 }
             }
 
             task before {
                 doLast {
                     try {
-                        thing.prop.get()
+                        prop.get()
                     } catch(RuntimeException e) {
                         println("get from task failed: " + e.message)
                         println("get from task failed cause: " + e.cause.message)
@@ -541,9 +552,10 @@ task thing {
 
             thing.prop.disallowUnsafeRead()
             thing.prop.set(producer.output)
+            def prop = thing.prop
 
             try {
-                thing.prop.get()
+                prop.get()
             } catch(IllegalStateException e) {
                 println("get failed: " + e.message)
             }
@@ -551,14 +563,14 @@ task thing {
             task after {
                 dependsOn(thing.prop)
                 doLast {
-                    println("prop = " + thing.prop.get())
+                    println("prop = " + prop.get())
                 }
             }
 
             task before {
                 doLast {
                     try {
-                        thing.prop.get()
+                        prop.get()
                     } catch(RuntimeException e) {
                         println("get from task failed: " + e.message)
                         println("get from task failed cause: " + e.cause.message)
@@ -593,15 +605,16 @@ task thing {
 
             thing.prop.disallowUnsafeRead()
             thing.prop.set(producer.output.map { it.asFile.text as Integer })
+            def prop = thing.prop
 
             try {
-                thing.prop.get()
+                prop.get()
             } catch(IllegalStateException e) {
                 println("get failed: " + e.message)
             }
 
             task after {
-                dependsOn(thing.prop)
+                dependsOn(prop)
                 doLast {
                     println("prop = " + thing.prop.get())
                 }
@@ -610,7 +623,7 @@ task thing {
             task before {
                 doLast {
                     try {
-                        thing.prop.get()
+                        prop.get()
                     } catch(RuntimeException e) {
                         println("get from task failed: " + e.message)
                         println("get from task failed cause: " + e.cause.message)

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveFailureTestFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveFailureTestFixture.groovy
@@ -32,7 +32,7 @@ class ResolveFailureTestFixture {
         this.config = config
     }
 
-    void prepare() {
+    void prepare(String config = this.config) {
         buildFile << """
             allprojects {
                 tasks.register("checkDeps") {


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context

- Fix several tests to be compatible with configuration caching
- Remove duplicate artifacts from serialized `ArtifactCollection` instances
- Preserve `Property` and `ConfigurableFileCollection` identity for each task.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
