### PR TITLE
Remove cygwin gcc from toolchain candidates

### DIFF
--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AvailableToolChains.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AvailableToolChains.java
@@ -118,7 +118,6 @@ public class AvailableToolChains {
             if (OperatingSystem.current().isWindows()) {
                 compilers.addAll(findVisualCpps());
                 compilers.add(findMinGW());
-                compilers.add(findCygwin());
             } else if (OperatingSystem.current().isMacOsX()) {
                 compilers.addAll(findClangs(true));
                 compilers.addAll(findGccs(false));


### PR DESCRIPTION
We had a cygwin package `cygwin32-gcc-g++` installed on windows machines, but somehow it was missing since several days ago: you can still see it in Google cache, but clicking into it you will get 404.

<img width="706" alt="image" src="https://user-images.githubusercontent.com/12689835/205605344-3326c480-8400-42f3-b06b-2001672614cf.png">

<img width="523" alt="image" src="https://user-images.githubusercontent.com/12689835/205605420-02859166-bf45-47ca-9b84-4c6fff6d9207.png">

It's probably because everyone is dropping support for 32bit. Let's remove cygwin gcc from toolchain candidate to unblock us.