### PR TITLE
Update wrapper to the latest nightly

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.0-branch-eskatos_kotlin_dsl_script_compilation_jvm_target-20221204002257+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.0-20221205153545+0000-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
with Kotlin DSL build scripts compiled against build JVM target 
with Kotlin compiler avoidance for declarative plugins blocks
getting rid of the branch snapshot