### PR TITLE
Fix dynamic calls context tracking in DefaultProject_Decorated

### DIFF
--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/AsmBackedClassGenerator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/AsmBackedClassGenerator.java
@@ -944,6 +944,12 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
                 return;
             }
 
+            // DefaultProject has its own implementation of GroovyObject's methods, and we want to keep those implementations.
+            // TODO: introduce a better way to communicate this for classes that don't need generated dynamic-object methods?
+            if (type.getName().equals("org.gradle.api.internal.project.DefaultProject")) {
+                return;
+            }
+
             // GENERATE public Object getProperty(String name) { return getAsDynamicObject().getProperty(name); }
             addGetter("getProperty", OBJECT_TYPE, RETURN_OBJECT_FROM_STRING, methodVisitor -> new MethodVisitorScope(methodVisitor) {{
                 // GENERATE getAsDynamicObject().getProperty(name);


### PR DESCRIPTION
The decorated class would lose the implementations in DefaultProject and instead delegate the methods directly to the extensibleDynamicObject. This led to broken invariant in dynamic calls tracking with isolated projects: the tracker needed to report a dynamic call, while the stored context would not know about the ongoing dynamic call.

<!--- The issue this PR addresses -->
Fixes https://github.com/gradle/gradle/issues/22949

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
