### PR TITLE
Update user guides and docs regarding tasks using Java toolchains

### DIFF
--- a/subprojects/docs/README.md
+++ b/subprojects/docs/README.md
@@ -134,7 +134,9 @@ Let's break down this example to explain:
 
 It is possible to embed sample sources, commands, and expected output directly in the Asciidoc (or a mixture of embedded and `include`d), but we don't use this for the user manual yet. See the [Exemplar documentation](https://github.com/gradle/exemplar/#configuring-embedded-samples) if you're interested in this.
 
-### Code Samples
+### Testing samples and snippets
+
+#### Code samples
 
 Samples and output belong under `src/samples` and are published beside the user manual. See the `org.gradle.samples` plugin.
 
@@ -148,20 +150,27 @@ To run tests for a single sample, let's say from `samples/java/application`:
 ./gradlew :docs:docsTest --tests "org.gradle.docs.samples.DependencyManagementSnippetsTest.java-application*"
 ```
 
-To run tests for a single snippet:
+#### Code snippets
 
-Let's say you want to run the snippet found at `src/snippets/dependencyManagement/customizingResolution-consistentResolution`.
+Snippets live under `src/snippets`.
 
-then you can run the following command line:
-
+As an example, you can run Kotlin and Groovy snippets tests from [`src/snippets/java/toolchain-task/`](src/snippets/java/toolchain-task) using:
 ```
-   ./gradlew :docs:docsTest --tests "*.snippet-dependency-management-customizing-resolution-consistent-resolution*"
+./gradlew :docs:docsTest --tests "*.snippet-java-toolchain-task_*"
 ```
 
-which would run both Groovy and Kotlin tests.
+You can also filter the tests for a specific DSL like this:
+```
+./gradlew :docs:docsTest --tests "*.snippet-java-toolchain-task_kotlin_*"
+```
+
+#### Testing with configuration cache
 
 It is possible to run samples and snippets with the configuration cache enabled to ensure compatibility.
-To do that set the Gradle property `enableConfigurationCacheForDocsTests=true` in the command line or in the `gradle.properties` file.
+You can do that by setting the Gradle property `enableConfigurationCacheForDocsTests` in the command line or in the `gradle.properties` file.
+```
+./gradlew :docs:docsTest --tests "*.snippet-java-toolchain-task_*" -PenableConfigurationCacheForDocsTests=true
+```
 
 ## Groovy DSL Reference
 

--- a/subprojects/docs/src/docs/userguide/jvm/building_java_projects.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/building_java_projects.adoc
@@ -59,7 +59,7 @@ This isn't sufficient to build any non-trivial Java project — at the very leas
 [NOTE]
 ====
 Although the properties in the example are optional, we recommend that you specify them in your projects.
-The toolchain options protects against problems with the project being built with different Java versions.
+Configuring the toolchain protects against problems with the project being built with different Java versions.
 The version string is important for tracking the progression of the project.
 The project version is also used in archive names by default.
 ====
@@ -240,17 +240,40 @@ That's also how you can change the verbosity of the compiler, disable debug outp
 === Targeting a specific Java version
 
 By default, Gradle will compile Java code to the language level of the JVM running Gradle.
-With the usage of <<toolchains.adoc#toolchains,Java toolchains>>, you can break that link by making sure a given Java version, defined by the build, is used for compilation, execution and documentation.
-It is however possible to override some compiler and execution options at the task level.
+If you need to target a specific version of Java when compiling, Gradle provides multiple options:
 
-Since version 9, the Java compiler can be configured to produce bytecode for an older Java version while making sure the code does not use any APIs from a more recent version.
-Gradle now supports this link:{groovyDslPath}/org.gradle.api.tasks.compile.CompileOptions.html#org.gradle.api.tasks.compile.CompileOptions:release[release] flag on `CompileOptions` directly for Java compilation.
-This option takes precedence over the properties described below.
+1. Using <<toolchains.adoc#toolchains,Java toolchains>> is a preferred way to target a language version. +
+A toolchain uniformly handles compilation, execution and Javadoc generation, and it can be configured on the project level.
+2. Using link:{groovyDslPath}/org.gradle.api.tasks.compile.CompileOptions.html#org.gradle.api.tasks.compile.CompileOptions:release[`release`] property is possible starting from Java 10. +
+Selecting a Java release makes sure that compilation is done with the configured language level and against the JDK APIs from that Java version.
+3. Using `sourceCompatibility` and `targetCompatibility` properties. +
+Although not generally advised, these options were historically used to configure the Java version during compilation.
 
-[WARNING]
+[[sec:compiling_with_toolchain]]
+==== Using toolchains
+
+When Java code is compiled using a specific toolchain, the actual compilation is carried out by a compiler of the specified Java version.
+The compiler provides access to the language features and JDK APIs for the requested Java language version.
+
+In the simplest case, the toolchain can be configured for a project using the `java` extension.
+This way, not only compilation benefits from it, but also other tasks such as `test` and `javadoc` will also consistently use the same toolchain.
+
 ====
-Due to a https://bugs.openjdk.java.net/browse/JDK-8139607[bug in Java 9] that was fixed in Java 10, Gradle cannot leverage the `release` flag when compiling with Java 9.
+include::sample[dir="snippets/java/toolchain-basic/kotlin",files="build.gradle.kts[tags=toolchain]"]
+include::sample[dir="snippets/java/toolchain-basic/groovy",files="build.gradle[tags=toolchain]"]
 ====
+
+You can learn more about this in the <<toolchains.adoc#toolchains,Java toolchains>> guide.
+
+[[sec:compiling_with_release]]
+==== Using Java release version
+
+Setting the link:{groovyDslPath}/org.gradle.api.tasks.compile.CompileOptions.html#org.gradle.api.tasks.compile.CompileOptions:release[release] flag ensures the specified language level is used regardless of which compiler actually performs the compilation.
+To use this feature, the compiler must support the requested release version.
+It is possible to specify an earlier release version while compiling with a more recent <<#sec:compiling_with_toolchain,toolchain>>.
+
+Gradle supports using the release flag from Java 10.
+It can be configured on the compilation task as follows.
 
 .Setting Java release flag
 ====
@@ -258,27 +281,37 @@ include::sample[dir="snippets/java/basic/kotlin",files="build.gradle.kts[tags=ja
 include::sample[dir="snippets/java/basic/groovy",files="build.gradle[tags=java-release-flag]"]
 ====
 
-Historical options for the Java compiler remain available:
+The release flag provides guarantees similar to toolchains.
+It validates that the Java sources are not using language features introduced in later Java versions, and also that the code does not access APIs from more recent JDKs.
+The bytecode produced by the compiler also corresponds to the requested Java version, meaning that the compiled code cannot be executed on older JVMs.
+
+The `release` option of the Java compiler was introduced in Java 9.
+However, using this option with Gradle is only possible starting with Java 10, due to a https://bugs.openjdk.java.net/browse/JDK-8139607[bug in Java 9].
+
+==== Using Java compatibility options
+
+[WARNING]
+====
+Using compatibility properties can lead to runtime failures when executing compiled code due to weaker guarantees they provide.
+Instead, consider using <<#sec:compiling_with_toolchain,toolchains>> or the <<#sec:compiling_with_release,release>> flag.
+====
+
+The `sourceCompatibility` and `targetCompatibility` options correspond to the Java compiler options `-source` and `-target`.
+They are considered a legacy mechanism for targeting a specific Java version.
+However, these options do not protect against the use of APIs introduced in later Java versions.
 
 `sourceCompatibility`::
-Defines which language version of Java your source files should be treated as.
+Defines the language version of Java used in your source files.
 
 `targetCompatibility`::
-Defines the minimum JVM version your code should run on, i.e. it determines the version of byte code the compiler generates.
+Defines the minimum JVM version your code should run on, i.e. it determines the version of the bytecode generated by the compiler.
 
 These options can be set per link:{groovyDslPath}/org.gradle.api.tasks.compile.JavaCompile.html[JavaCompile] task, or on the `java { }` extension for all compile tasks, using properties with the same names.
 
-[NOTE]
-====
-Using a toolchain makes it illegal to configure the `sourceCompatibility` or `targetCompatibility` at the `java { }` extension level.
-====
+==== Targeting Java 6 and Java 7
 
-However, these options do not protect against the use of APIs introduced in later Java versions.
-
-==== Compiling and testing Java 6/7
-
-Gradle can only run on Java version 8 or higher.
-Gradle still supports compiling, testing, generating Javadoc and executing applications for Java 6 and Java 7.
+Gradle itself can only run on a JVM with Java version 8 or higher.
+However, Gradle still supports compiling, testing, generating Javadocs and executing applications for Java 6 and Java 7.
 Java 5 and below are not supported.
 
 [NOTE]
@@ -294,8 +327,7 @@ To use Java 6 or Java 7, the following tasks need to be configured:
 
 With the usage of Java toolchains, this can be done as follows:
 
-==== Example: Configure Java 7 build
-
+.Configuring Java 7 build
 ====
 include::sample[dir="snippets/java/crossCompilation/kotlin",files="build.gradle.kts[tags=java-cross-compilation]"]
 include::sample[dir="snippets/java/crossCompilation/groovy",files="build.gradle[tags=java-cross-compilation]"]

--- a/subprojects/docs/src/docs/userguide/jvm/java_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/java_plugin.adoc
@@ -379,17 +379,28 @@ Runtime classpath contains elements of the implementation, as well as runtime on
 The Java plugin adds the link:{groovyDslPath}/org.gradle.api.plugins.JavaPluginExtension.html[`java` extension] to the project.
 This allows to configure a number of Java related properties inside a dedicated DSL block.
 
-.Using the `java` extension
+.Using the `java` extension to configure a toolchain
 ====
 include::sample[dir="snippets/java/basic/kotlin",files="build.gradle.kts[tags=java-extension]"]
 include::sample[dir="snippets/java/basic/groovy",files="build.gradle[tags=java-extension]"]
 ====
 
+Below is the list of properties and DSL functions with short explanations available inside the `java` extension.
+
+=== Toolchain and compatibility
+
+`toolchain`::
+<<toolchains.adoc#toolchains, Java toolchain>> to be used by tasks using JVM tools, such as compilation and execution. Default value: build JVM toolchain.
+
 `link:{javadocPath}/org/gradle/api/JavaVersion.html[JavaVersion] sourceCompatibility`::
-Java version compatibility to use when compiling Java source. Default value: version of the current JVM in use.
+Java version compatibility to use when compiling Java source. Default value: language version of the toolchain from this extension. +
+_Note that using a <<toolchains.adoc#toolchains, toolchain>> is preferred to using a compatibility setting for most cases._
 
 `link:{javadocPath}/org/gradle/api/JavaVersion.html[JavaVersion] targetCompatibility`::
-Java version to generate classes for. Default value: `__sourceCompatibility__`.
+Java version to generate classes for. Default value: `__sourceCompatibility__`. +
+_Note that using a <<toolchains.adoc#toolchains, toolchain>> is preferred to using a compatibility setting for most cases._
+
+=== Packaging
 
 `withJavadocJar()`::
 Automatically packages Javadoc and creates a variant `javadocElements` with an artifact `-javadoc.jar`, which will be part of the publication.
@@ -436,7 +447,7 @@ The name of the directory to generate documentation into, relative to the build 
 The directory to generate documentation into. Default value: `__buildDir__/__docsDirName__`
 
 `String dependencyCacheDirName`::
-The name of the directory to use to cache source dependency information, relative to the build directory. Default value: `dependency-cache`
+The name of the directory to cache source dependency information relative to the build directory. Default value: `dependency-cache`.
 
 === Other properties
 

--- a/subprojects/docs/src/docs/userguide/jvm/scala_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/scala_plugin.adoc
@@ -16,8 +16,7 @@
 = The Scala Plugin
 
 The Scala plugin extends the <<java_plugin.adoc#java_plugin,Java plugin>> to add support for https://www.scala-lang.org/[Scala] projects.
-It can deal with Scala code, mixed Scala and Java code, and even pure Java code (although we don't necessarily recommend to use it for the latter).
-The plugin supports _joint compilation_, which allows you to freely mix and match Scala and Java code, with dependencies in both directions.
+The plugin also supports _joint compilation_, which allows you to freely mix and match Scala and Java code with dependencies in both directions.
 For example, a Scala class can extend a Java class that in turn extends a Scala class.
 This makes it possible to use the best language for the job, and to rewrite any class in the other language if needed.
 
@@ -60,7 +59,7 @@ Compiles the given source set's Scala source files.
 +
 Generates API documentation for the production Scala source files.
 
-The `ScalaCompile` and `ScalaDoc` tasks can also leverage the <<toolchains.adoc#toolchains,Java toolchain support>>.
+The `ScalaCompile` and `ScalaDoc` tasks support <<toolchains.adoc#toolchains,Java toolchains>> out of the box.
 
 The Scala plugin adds the following dependencies to tasks added by the Java plugin.
 

--- a/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
@@ -15,31 +15,36 @@
 [[toolchains]]
 = Toolchains for JVM projects
 
-By default, Gradle uses the same Java version for running Gradle itself and building JVM projects.
+Working on multiple projects can require interacting with multiple versions of the Java language.
+Even within a single project different parts of the codebase may be fixed to a particular language level due to backward compatibility requirements.
+This means different versions of the same tools (a toolchain) must be installed and managed on each machine that builds the project.
 
-This is not always desirable.
+A **Java toolchain** is a set of tools to build and run Java projects, which is usually provided by the environment via local JRE or JDK installations.
+Compile tasks may use `javac` as their compiler, test and exec tasks may use the `java` command while `javadoc` will be used to generate documentation.
+
+By default, Gradle uses the same Java toolchain for running Gradle itself and building JVM projects.
+However, this may only sometimes be desirable.
 Building projects with different Java versions on different developer machines and CI servers may lead to unexpected issues.
 Additionally, you may want to build a project using a Java version that is not supported for running Gradle.
 
-A Java Toolchain (from now on referred to simply as toolchain) is a set of tools, usually taken from a local JRE/JDK installation that are used to configure different aspects of a build.
-Compile tasks may use `javac` as their compiler, test and exec tasks may use the `java` command while `javadoc` will be used to generate documentation.
+In order to improve reproducibility of the builds and make build requirements clearer, Gradle allows configuring toolchains on both project and task levels.
 
 [[sec:consuming]]
-== Consuming Toolchains
+== Toolchains for projects
 
-A build can globally define what toolchain it targets by stating the Java Language version it needs and optionally the vendor:
+You can define what toolchain to use for a project by stating the Java language version in the `java` extension block:
 
 ====
-include::sample[dir="samples/java/jvm-multi-project-with-toolchains/kotlin/",files="buildSrc/src/main/kotlin/myproject.java-conventions.gradle.kts[tags=toolchain]"]
-include::sample[dir="samples/java/jvm-multi-project-with-toolchains/groovy/",files="buildSrc/src/main/groovy/myproject.java-conventions.gradle[tags=toolchain]"]
+include::sample[dir="snippets/java/toolchain-basic/kotlin",files="build.gradle.kts[tags=toolchain]"]
+include::sample[dir="snippets/java/toolchain-basic/groovy",files="build.gradle[tags=toolchain]"]
 ====
 
 Executing the build (e.g. using `gradle check`) will now handle several things for you and others running your build:
 
-1. Setup all compile, test and javadoc tasks to use the defined toolchain which may be different than the one Gradle itself uses
-2. Gradle detects <<#sec:auto_detection,locally installed JVMs>>
-3. Gradle chooses a JRE/JDK matching the requirements of the build (in this case a JVM supporting Java 11)
-4. If no matching JVM is found, it will automatically download a matching JDK based on the <<#sub:download_repositories,toolchain download repositories>> configured.
+1. Gradle configures all compile, test and javadoc tasks to use the defined toolchain.
+2. Gradle detects <<#sec:auto_detection,locally installed toolchains>>.
+3. Gradle chooses a toolchain matching the requirements (any Java 17 toolchain for the example above).
+4. If no matching toolchain is found, Gradle can automatically download a matching one based on the configured <<#sub:download_repositories,toolchain download repositories>>.
 
 [NOTE]
 ====
@@ -49,7 +54,7 @@ For the Scala plugin, compilation and Scaladoc generation are supported.
 ====
 
 [[sec:vendors]]
-=== Using toolchains by specific vendors
+=== Selecting toolchains by vendor
 
 In case your build has specific requirements from the used JRE/JDK, you may want to define the vendor for the toolchain as well.
 link:{javadocPath}/org/gradle/jvm/toolchain/JvmVendorSpec.html[`JvmVendorSpec`] has a list of well-known JVM vendors recognized by Gradle.
@@ -71,7 +76,7 @@ include::sample[dir="snippets/java/toolchain-filters/kotlin/",files="build.gradl
 include::sample[dir="snippets/java/toolchain-filters/groovy/",files="build.gradle[tags=toolchain-matching-vendor]"]
 ====
 
-=== Selecting toolchains by their virtual machine implementation
+=== Selecting toolchains by virtual machine implementation
 
 If your project requires a specific implementation, you can filter based on the implementation as well.
 Currently available implementations to choose from are:
@@ -113,20 +118,20 @@ A specification without a language version, in most cases, would be treated as a
 Usage of _invalid_ instances of `JavaToolchainSpec` results in a build error since Gradle 8.0.
 
 
-== Specify custom toolchains for individual tasks
+== Toolchains for tasks
 
 In case you want to tweak which toolchain is used for a specific task, you can specify the exact tool a task is using.
 For example, the `Test` task exposes a `JavaLauncher` property that defines which java executable to use for launching the tests.
 
-In the example below, we configure all java compilation tasks to use JDK8.
-Additionally, we introduce a new `Test` task that is going to run our unit tests but using a JDK 14.
+In the example below, we configure all java compilation tasks to use Java 8.
+Additionally, we introduce a new `Test` task that will run our unit tests using a JDK 17.
 
 ====
 include::sample[dir="samples/java/jvm-multi-project-with-toolchains/kotlin",files="list/build.gradle.kts[tags=customToolchain]"]
 include::sample[dir="samples/java/jvm-multi-project-with-toolchains/groovy/",files="list/build.gradle[tags=customToolchain]"]
 ====
 
-In addition, in the `application` subproject, we add another Java execution task to run our application with JDK 14.
+In addition, in the `application` subproject, we add another Java execution task to run our application with JDK 17.
 
 ====
 include::sample[dir="samples/java/jvm-multi-project-with-toolchains/kotlin",files="application/build.gradle.kts[tags=customExec]"]
@@ -146,9 +151,9 @@ Three tools are available:
 
 === Integration with tasks relying on a Java executable or Java home
 
-Any tasks that can be configured with a path to a Java executable, or a Java home location, can benefit from toolchains.
+Any task that can be configured with a path to a Java executable, or a Java home location, can benefit from toolchains.
 
-While you will not be able to wire a toolchain tool directly, they all have metadata that gives access to their full path or to the path of the Java installation they belong to.
+While you will not be able to wire a toolchain tool directly, they all have the metadata that gives access to their full path or to the path of the Java installation they belong to.
 
 For example, you can configure the `java` executable for a task as follows:
 
@@ -157,14 +162,14 @@ include::sample[dir="snippets/java/toolchain-config-task/kotlin/",files="build.g
 include::sample[dir="snippets/java/toolchain-config-task/groovy/",files="build.gradle[tags=java-executable]"]
 ====
 
-Another example, you can configure the _Java Home_ for a task as follows:
+As another example, you can configure the _Java Home_ for a task as follows:
 
 ====
 include::sample[dir="snippets/java/toolchain-config-task/kotlin/",files="build.gradle.kts[tags=java-home]"]
 include::sample[dir="snippets/java/toolchain-config-task/groovy/",files="build.gradle[tags=java-home]"]
 ====
 
-Yet another example, you can configure the Java _compiler_ executable for a task as follows:
+If you require a path to a specific tool such as Java compiler, you can obtain it as follows:
 
 ====
 include::sample[dir="snippets/java/toolchain-config-task/kotlin/",files="build.gradle.kts[tags=java-compiler]"]
@@ -202,7 +207,7 @@ In order to disable auto-detection, you can use the `org.gradle.java.installatio
 * Or put `org.gradle.java.installations.auto-detect=false` into your `gradle.properties` file.
 
 [[sec:provisioning]]
-== Auto-Provisioning
+== Auto-provisioning
 
 If Gradle can't find a locally available toolchain that matches the requirements of the build, it can automatically download one (as long as a toolchain download repository has been configured; for detail, see <<#sub:download_repositories,relevant section>>).
 Gradle installs the downloaded JDKs in the <<directory_layout.adoc#dir:gradle_user_home,Gradle User Home directory>>.
@@ -314,19 +319,19 @@ In order to disable auto-provisioning, you can use the `org.gradle.java.installa
 * Or put `org.gradle.java.installations.auto-download=false` into a `gradle.properties` file.
 
 [[sec:custom_loc]]
-== Custom Toolchain locations
+== Custom toolchain locations
 
 If auto-detecting local toolchains is not sufficient or disabled, there are additional ways you can let Gradle know about installed toolchains.
 
 If your setup already provides environment variables pointing to installed JVMs, you can also let Gradle know about which environment variables to take into account.
-Assuming the environment variables `JDK8` and `JRE14` point to valid java installations, the following instructs Gradle to resolve those environment variables and consider those installations when looking for a matching toolchain.
+Assuming the environment variables `JDK8` and `JRE17` point to valid java installations, the following instructs Gradle to resolve those environment variables and consider those installations when looking for a matching toolchain.
 
 ----
-org.gradle.java.installations.fromEnv=JDK8,JRE14
+org.gradle.java.installations.fromEnv=JDK8,JRE17
 ----
 
 Additionally, you can provide a comma-separated list of paths to specific installations using the `org.gradle.java.installations.paths` property.
-For example, using the following in your `gradle.properties` will let Gradle know which directories to look at when detecting JVMs.
+For example, using the following in your `gradle.properties` will let Gradle know which directories to look at when detecting toolchains.
 Gradle will treat these directories as possible installations but will not descend into any nested directories.
 
 ----
@@ -337,11 +342,11 @@ org.gradle.java.installations.paths=/custom/path/jdk1.8,/shared/jre11
 ====
 Gradle does not prioritize custom toolchains over <<sec:auto_detection,auto-detected>> toolchains.
 If you enable auto-detection in your build, custom toolchains extend the set of toolchain locations.
-Gradle picks a toolchain according to the <<sec:precedence,Toolchain Precedence Rules>>.
+Gradle picks a toolchain according to the <<sec:precedence,precedence rules>>.
 ====
 
 [[sec:precedence]]
-== Precedence
+== Toolchain installations precedence
 
 Gradle will sort all the JDK/JRE installations matching the toolchain specification of the build and will pick the first one.
 Sorting is done based on the following rules:
@@ -399,17 +404,37 @@ So Gradle picks the first match in this order: Microsoft JDK 17.0.1.
 [[sec:plugins]]
 == Toolchains for plugin authors
 
-Custom tasks that require a tool from the JDK should expose a `Property<T>` with the desired tool as generic type.
-The property should be declared as a <<more_about_tasks.adoc#sec:task_input_nested_inputs,`@Nested` input>>.
-By injecting the `JavaToolchainService` in the plugin or task, it is also possible to wire a convention in those properties by obtaining the `JavaToolchainSpec` from the `java` extension on the project.
+When creating a plugin or a task that uses toolchains, it is essential to provide sensible defaults and allow users to override them.
+
+For JVM projects, it is usually safe to assume that the `java` plugin has been applied to the project.
+The `java` plugin is automatically applied for the core Groovy and Scala plugins, as well as for the Kotlin plugin.
+In such a case, using the toolchain defined via the `java` extension as a default value for the tool property is appropriate.
+This way, the users will need to configure the toolchain only once on the project level.
+
 The example below showcases how to use the default toolchain as convention while allowing users to individually configure the toolchain per task.
 
 ====
-include::sample[dir="snippets/java/toolchain-task/kotlin/",files="build.gradle.kts"]
-include::sample[dir="snippets/java/toolchain-task/groovy/",files="build.gradle"]
+include::sample[dir="snippets/java/toolchain-task/kotlin/",files="build.gradle.kts[tags=custom-toolchain-task-with-java]"]
+include::sample[dir="snippets/java/toolchain-task/groovy/",files="build.gradle[tags=custom-toolchain-task-with-java]"]
 ====
+<1> We declare a `JavaLauncher` property on the task.
+The property must be marked as a <<more_about_tasks.adoc#sec:task_input_nested_inputs,`@Nested` input>> to make sure the task is responsive to toolchain changes.
+<2> We obtain the toolchain spec from the `java` extension to use it as a default.
+<3> Using the `JavaToolchainService` we get a provider of the `JavaLauncher` that matches the toolchain.
+<4> Finally, we wire the launcher provider as a convention for our property.
 
-[NOTE]
+In a project where the `java` plugin was applied, we can use the task as follows:
+
 ====
-With the property correctly configured as `@Nested`, it will automatically track the Java major version, the vendor (if specified) and implementation (if specified) as an input.
+include::sample[dir="snippets/java/toolchain-task/kotlin/",files="build.gradle.kts[tags=custom-toolchain-task-with-java-usage]"]
+include::sample[dir="snippets/java/toolchain-task/groovy/",files="build.gradle[tags=custom-toolchain-task-with-java-usage]"]
 ====
+<1> The toolchain defined on the `java` extension is used by default to resolve the launcher.
+<2> The custom task without additional configuration will use the default Java 8 toolchain.
+<3> The other task overrides the value of the launcher by selecting a different toolchain using `javaToolchains` service.
+
+When a task needs access to toolchains without the `java` plugin being applied the toolchain service can be used directly.
+If an <<#sec:configuring_toolchain_specifications, unconfigured>> toolchain spec is provided to the service, it will always return a tool provider for the toolchain that is running Gradle.
+This can be achieved by passing an empty lambda when requesting a tool: `javaToolchainService.launcherFor({})`.
+
+You can find more details on defining custom tasks in the <<more_about_tasks.adoc#more_about_tasks, Authoring tasks>> documentation.

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -517,6 +517,14 @@ The following configurations were never meant to be consumed:
 These configurations were deprecated for consumption and are now no longer consumable.
 Attempting to consume them will result in an error.
 
+==== Toolchain-based tasks for JVM projects
+
+Starting with Gradle 8.0, all core Java tasks that have toolchain support are now using toolchains unconditionally.
+If `JavaBasePlugin` is applied, the convention value for tool properties on the task is defined by the toolchain configured on the `java` extension.
+In case no toolchains are explicitly configured, the toolchain corresponding to the JVM running Gradle is used.
+
+Similarly, tasks from the Groovy and Scala plugins also rely on toolchains to determine on which JVM they are executed.
+
 [[changes_7.6]]
 == Upgrading from 7.5 and earlier
 

--- a/subprojects/docs/src/main/resources/header.html
+++ b/subprojects/docs/src/main/resources/header.html
@@ -218,7 +218,7 @@
             <li><a href="../userguide/java_testing.html">Testing Java &amp; JVM projects</a></li>
             <li><a class="nav-dropdown" data-toggle="collapse" href="#java-toolchains" aria-expanded="false" aria-controls="java-toolchains">Java Toolchains</a>
                 <ul id="java-toolchains">
-                    <li><a href="../userguide/toolchains.html">Toolchains for Java projects</a></li>
+                    <li><a href="../userguide/toolchains.html">Toolchains for JVM projects</a></li>
                     <li><a href="../userguide/toolchain_plugins.html">Toolchain Resolver Plugins</a></li>
                 </ul>
             </li>

--- a/subprojects/docs/src/samples/java/jvm-multi-project-with-toolchains/groovy/application/build.gradle
+++ b/subprojects/docs/src/samples/java/jvm-multi-project-with-toolchains/groovy/application/build.gradle
@@ -13,9 +13,9 @@ application {
 }
 
 // tag::customExec[]
-task('runOn14', type: JavaExec) {
+task('runOn17', type: JavaExec) {
     javaLauncher = javaToolchains.launcherFor {
-        languageVersion = JavaLanguageVersion.of(14)
+        languageVersion = JavaLanguageVersion.of(17)
     }
 
     classpath = sourceSets.main.runtimeClasspath

--- a/subprojects/docs/src/samples/java/jvm-multi-project-with-toolchains/groovy/list/build.gradle
+++ b/subprojects/docs/src/samples/java/jvm-multi-project-with-toolchains/groovy/list/build.gradle
@@ -9,9 +9,10 @@ tasks.withType(JavaCompile).configureEach {
         languageVersion = JavaLanguageVersion.of(8)
     }
 }
-task('testsOn14', type: Test) {
+
+task('testsOn17', type: Test) {
     javaLauncher = javaToolchains.launcherFor {
-        languageVersion = JavaLanguageVersion.of(14)
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }
 // end::customToolchain[]

--- a/subprojects/docs/src/samples/java/jvm-multi-project-with-toolchains/kotlin/application/build.gradle.kts
+++ b/subprojects/docs/src/samples/java/jvm-multi-project-with-toolchains/kotlin/application/build.gradle.kts
@@ -13,9 +13,9 @@ application {
 }
 
 // tag::customExec[]
-tasks.register<JavaExec>("runOn14") {
+tasks.register<JavaExec>("runOn17") {
     javaLauncher.set(javaToolchains.launcherFor {
-        languageVersion.set(JavaLanguageVersion.of(14))
+        languageVersion.set(JavaLanguageVersion.of(17))
     })
 
     classpath = sourceSets["main"].runtimeClasspath

--- a/subprojects/docs/src/samples/java/jvm-multi-project-with-toolchains/kotlin/list/build.gradle.kts
+++ b/subprojects/docs/src/samples/java/jvm-multi-project-with-toolchains/kotlin/list/build.gradle.kts
@@ -10,9 +10,9 @@ tasks.withType<JavaCompile>().configureEach {
     })
 }
 
-tasks.register<Test>("testsOn14") {
+tasks.register<Test>("testsOn17") {
     javaLauncher.set(javaToolchains.launcherFor {
-        languageVersion.set(JavaLanguageVersion.of(14))
+        languageVersion.set(JavaLanguageVersion.of(17))
     })
 }
 // end::customToolchain[]

--- a/subprojects/docs/src/snippets/java/basic/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/java/basic/groovy/build.gradle
@@ -6,7 +6,7 @@ plugins {
 // tag::java-extension[]
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(11)
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }
 // end::java-extension[]

--- a/subprojects/docs/src/snippets/java/basic/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java/basic/kotlin/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 // tag::java-extension[]
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
+        languageVersion.set(JavaLanguageVersion.of(17))
     }
 }
 // end::java-extension[]

--- a/subprojects/docs/src/snippets/java/preview/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/java/preview/groovy/build.gradle
@@ -3,13 +3,15 @@ plugins {
 }
 
 // tag::enabling-feature-preview[]
-tasks.withType(JavaCompile) {
+tasks.withType(JavaCompile).configureEach {
     options.compilerArgs += "--enable-preview"
 }
-tasks.withType(Test) {
+
+tasks.withType(Test).configureEach {
     jvmArgs += "--enable-preview"
 }
-tasks.withType(JavaExec) {
+
+tasks.withType(JavaExec).configureEach {
     jvmArgs += "--enable-preview"
 }
 // end::enabling-feature-preview[]

--- a/subprojects/docs/src/snippets/java/preview/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java/preview/kotlin/build.gradle.kts
@@ -3,13 +3,15 @@ plugins {
 }
 
 // tag::enabling-feature-preview[]
-tasks.withType<JavaCompile> {
+tasks.withType<JavaCompile>().configureEach {
     options.compilerArgs.add("--enable-preview")
 }
-tasks.withType<Test> {
+
+tasks.withType<Test>().configureEach {
     jvmArgs("--enable-preview")
 }
-tasks.withType<JavaExec> {
+
+tasks.withType<JavaExec>().configureEach {
     jvmArgs("--enable-preview")
 }
 // end::enabling-feature-preview[]

--- a/subprojects/docs/src/snippets/java/toolchain-basic/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/java/toolchain-basic/groovy/build.gradle
@@ -1,0 +1,11 @@
+plugins {
+    id 'java'
+}
+
+// tag::toolchain[]
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+// end::toolchain[]

--- a/subprojects/docs/src/snippets/java/toolchain-basic/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java/toolchain-basic/kotlin/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+    java
+}
+
+// tag::toolchain[]
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
+}
+// end::toolchain[]

--- a/subprojects/docs/src/snippets/java/toolchain-basic/tests/toolchainBasic.sample.conf
+++ b/subprojects/docs/src/snippets/java/toolchain-basic/tests/toolchainBasic.sample.conf
@@ -1,0 +1,2 @@
+executable: gradle
+args: build

--- a/subprojects/docs/src/snippets/java/toolchain-task/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/java/toolchain-task/groovy/build.gradle
@@ -1,21 +1,15 @@
 import javax.inject.Inject;
 
+// tag::custom-toolchain-task-with-java[]
 abstract class CustomTaskUsingToolchains extends DefaultTask {
 
     @Nested
-    abstract Property<JavaLauncher> getLauncher()
+    abstract Property<JavaLauncher> getLauncher() // <1>
 
-    @Inject
     CustomTaskUsingToolchains() {
-        // Access the default toolchain
-        def toolchain = project.getExtensions().getByType(JavaPluginExtension.class).toolchain
-
-        // acquire a provider that returns the launcher for the toolchain
-        JavaToolchainService service = project.getExtensions().getByType(JavaToolchainService.class)
-        Provider<JavaLauncher> defaultLauncher = service.launcherFor(toolchain);
-
-        // use it as our default for the property
-        launcher.convention(defaultLauncher);
+        def toolchain = project.extensions.getByType(JavaPluginExtension.class).toolchain // <2>
+        Provider<JavaLauncher> defaultLauncher = getJavaToolchainService().launcherFor(toolchain) // <3>
+        launcher.convention(defaultLauncher) // <4>
     }
 
     @TaskAction
@@ -23,22 +17,28 @@ abstract class CustomTaskUsingToolchains extends DefaultTask {
         println launcher.get().executablePath
         println launcher.get().metadata.installationPath
     }
-}
 
+    @Inject
+    protected abstract JavaToolchainService getJavaToolchainService()
+}
+// end::custom-toolchain-task-with-java[]
+
+// tag::custom-toolchain-task-with-java-usage[]
 plugins {
     id 'java'
 }
 
 java {
-    toolchain {
+    toolchain { // <1>
         languageVersion = JavaLanguageVersion.of(8)
     }
 }
 
-tasks.register('showDefaultToolchain', CustomTaskUsingToolchains)
+tasks.register('showDefaultToolchain', CustomTaskUsingToolchains) // <2>
 
 tasks.register('showCustomToolchain', CustomTaskUsingToolchains) {
-    launcher = javaToolchains.launcherFor {
+    launcher = javaToolchains.launcherFor { // <3>
         languageVersion = JavaLanguageVersion.of(17)
     }
 }
+// end::custom-toolchain-task-with-java-usage[]

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/ForkOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/ForkOptions.java
@@ -36,11 +36,11 @@ public abstract class ForkOptions extends ProviderAwareCompilerDaemonForkOptions
     private File javaHome;
 
     /**
-     * Returns the compiler executable to be used. If set,
-     * a new compiler process will be forked for every compile task.
-     * Defaults to {@code null}.
-     *
-     * <p>Setting the executable disables task output caching.</p>
+     * Returns the compiler executable to be used.
+     * <p>
+     * Only takes effect if {@code CompileOptions.fork} is {@code true}. Defaults to {@code null}.
+     * <p>
+     * Setting the executable disables task output caching.
      */
     @Nullable
     @Optional
@@ -50,11 +50,11 @@ public abstract class ForkOptions extends ProviderAwareCompilerDaemonForkOptions
     }
 
     /**
-     * Sets the compiler executable to be used. If set,
-     * a new compiler process will be forked for every compile task.
-     * Defaults to {@code null}.
-     *
-     * <p>Setting the executable disables task output caching.</p>
+     * Sets the compiler executable to be used.
+     * <p>
+     * Only takes effect if {@code CompileOptions.fork} is {@code true}. Defaults to {@code null}.
+     * <p>
+     * Setting the executable disables task output caching.
      */
     public void setExecutable(@Nullable String executable) {
         this.executable = executable;
@@ -62,8 +62,8 @@ public abstract class ForkOptions extends ProviderAwareCompilerDaemonForkOptions
 
     /**
      * Returns the Java home which contains the compiler to use.
-     * If set, a new compiler process will be forked for every compile task.
-     * Defaults to {@code null}.
+     * <p>
+     * Only takes effect if {@code CompileOptions.fork} is {@code true}. Defaults to {@code null}.
      *
      * @since 3.5
      */
@@ -75,8 +75,8 @@ public abstract class ForkOptions extends ProviderAwareCompilerDaemonForkOptions
 
     /**
      * Sets the Java home which contains the compiler to use.
-     * If set, a new compiler process will be forked for every compile task.
-     * Defaults to {@code null}.
+     * <p>
+     * Only takes effect if {@code CompileOptions.fork} is {@code true}. Defaults to {@code null}.
      *
      * @since 3.5
      */

--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/java/SamplesJavaTestingIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/java/SamplesJavaTestingIntegrationTest.groovy
@@ -34,7 +34,7 @@ class SamplesJavaTestingIntegrationTest extends AbstractSampleIntegrationTest {
     @UsesSample("java/basic")
     def "can execute simple Java tests with #dsl dsl"() {
         given:
-        configureExecuterForToolchains('11')
+        configureExecuterForToolchains('17')
         TestFile dslDir = sample.dir.file(dsl)
         executer.inDirectory(dslDir)
 
@@ -312,7 +312,7 @@ class SamplesJavaTestingIntegrationTest extends AbstractSampleIntegrationTest {
     @UsesSample("java/basic")
     def "can run simple Java integration tests with #dsl dsl"() {
         given:
-        configureExecuterForToolchains('11')
+        configureExecuterForToolchains('17')
         TestFile dslDir = sample.dir.file(dsl)
         executer.inDirectory(dslDir)
 
@@ -335,7 +335,7 @@ class SamplesJavaTestingIntegrationTest extends AbstractSampleIntegrationTest {
     @UsesSample("java/basic")
     def "can skip the tests with an `onlyIf` condition with #dsl dsl"() {
         given:
-        configureExecuterForToolchains('11')
+        configureExecuterForToolchains('17')
         TestFile dslDir = sample.dir.file(dsl)
 
         when: "run first time to populate configuration cache if it is enabled"


### PR DESCRIPTION
This PR updates javadocs and user guides to include the expanded role of toolchains in the core Java tasks.

This is a follow-up for:
- https://github.com/gradle/gradle/pull/22108