### PR TITLE
Prevent build services from being instantiated during finalization

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildServiceIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildServiceIntegrationTest.groovy
@@ -69,14 +69,15 @@ class ConfigurationCacheBuildServiceIntegrationTest extends AbstractConfiguratio
         outputDoesNotContain onFinishMessage
     }
 
-    def "build service is restored"(boolean legacy, boolean finalize, boolean finalizeOnRead, boolean registeredByPlugin) {
+    def "build service is restored"(String serviceName, boolean finalize, boolean finalizeOnRead, boolean registeredByPlugin) {
         given:
+        def legacy = serviceName == null
         def propertyAnnotations = legacy ?
             """
             @$Internal.name
         """ :
             """
-            @$ServiceReference.name("counter")
+            @$ServiceReference.name("$serviceName")
             @$Optional.name
         """
 
@@ -127,19 +128,25 @@ class ConfigurationCacheBuildServiceIntegrationTest extends AbstractConfiguratio
         outputContains 'Count: 1'
 
         where:
-        legacy | finalize | finalizeOnRead | registeredByPlugin
-        false  | false    | false          | true
-        false  | true     | false          | true
-        false  | false    | true           | true
-        true   | false    | false          | true
-        true   | true     | false          | true
-        true   | false    | true           | true
-        false  | false    | false          | false
-        false  | true     | false          | false
-        false  | false    | true           | false
-        true   | false    | false          | false
-        true   | true     | false          | false
-        true   | false    | true           | false
+        serviceName | finalize | finalizeOnRead | registeredByPlugin
+        null        | false    | false          | true
+        null        | true     | false          | true
+        null        | false    | true           | true
+        null        | false    | false          | false
+        null        | true     | false          | false
+        null        | false    | true           | false
+        "counter"    | false    | false          | true
+        "counter"   | true     | false          | true
+        "counter"   | false    | true           | true
+        "counter"   | false    | false          | false
+        "counter"   | true     | false          | false
+        "counter"   | false    | true           | false
+        ""          | false    | false          | true
+        ""          | true     | false          | true
+        ""          | false    | true           | true
+        ""          | false    | false          | false
+        ""          | true     | false          | false
+        ""          | false    | true           | false
 
     }
 

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildServiceIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildServiceIntegrationTest.groovy
@@ -69,19 +69,14 @@ class ConfigurationCacheBuildServiceIntegrationTest extends AbstractConfiguratio
         outputDoesNotContain onFinishMessage
     }
 
-    def "build service is restored"(String serviceName, boolean finalize, boolean finalizeOnRead, boolean registeredByPlugin) {
+    def "build service is restored"(String serviceName, boolean finalize, boolean finalizeOnRead) {
         given:
         def legacy = serviceName == null
         def propertyAnnotations = legacy ?
-            """
-            @$Internal.name
-        """ :
-            """
-            @$ServiceReference.name("$serviceName")
-            @$Optional.name
-        """
+            """@$Internal.name""" :
+            """@$ServiceReference.name("$serviceName")"""
 
-        withCountingServicePlugin(registeredByPlugin, propertyAnnotations)
+        withCountingServicePlugin(true, propertyAnnotations)
         file('settings.gradle') << """
             pluginManagement {
                 includeBuild 'counting-service-plugin'
@@ -128,25 +123,16 @@ class ConfigurationCacheBuildServiceIntegrationTest extends AbstractConfiguratio
         outputContains 'Count: 1'
 
         where:
-        serviceName | finalize | finalizeOnRead | registeredByPlugin
-        null        | false    | false          | true
-        null        | true     | false          | true
-        null        | false    | true           | true
-        null        | false    | false          | false
-        null        | true     | false          | false
-        null        | false    | true           | false
-        "counter"    | false    | false          | true
-        "counter"   | true     | false          | true
-        "counter"   | false    | true           | true
-        "counter"   | false    | false          | false
-        "counter"   | true     | false          | false
-        "counter"   | false    | true           | false
-        ""          | false    | false          | true
-        ""          | true     | false          | true
-        ""          | false    | true           | true
-        ""          | false    | false          | false
-        ""          | true     | false          | false
-        ""          | false    | true           | false
+        serviceName | finalize | finalizeOnRead
+        null        | false    | false
+        null        | true     | false
+        null        | false    | true
+        "counter"   | false    | false
+        "counter"   | true     | false
+        "counter"   | false    | true
+        ""          | false    | false
+        ""          | true     | false
+        ""          | false    | true
 
     }
 

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildServiceIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildServiceIntegrationTest.groovy
@@ -69,20 +69,44 @@ class ConfigurationCacheBuildServiceIntegrationTest extends AbstractConfiguratio
         outputDoesNotContain onFinishMessage
     }
 
-    def "build service is restored when using @ServiceReference"() {
+    def "build service is restored"(boolean legacy, boolean finalize, boolean finalizeOnRead, boolean registeredByPlugin) {
         given:
-        withCountingServicePlugin("counter", "counter")
+        def propertyAnnotations = legacy ?
+            """
+            @$Internal.name
+        """ :
+            """
+            @$ServiceReference.name("counter")
+            @$Optional.name
+        """
+
+        withCountingServicePlugin(registeredByPlugin, propertyAnnotations)
         file('settings.gradle') << """
             pluginManagement {
                 includeBuild 'counting-service-plugin'
             }
+            enableFeaturePreview 'STABLE_CONFIGURATION_CACHE'
         """
         file('build.gradle') << """
             plugins { id 'counting-service-plugin' version '1.0' }
 
+            def altServiceProvider = project.getGradle().getSharedServices().registerIfAbsent(
+                "counter",
+                CountingService.class,
+                (spec) -> {}
+            );
+
             tasks.register('count', CountingTask) {
+                ${ legacy ? """
+                countingService.convention(altServiceProvider)
+                usesService(altServiceProvider)
+                """ : "" }
+                ${ finalizeOnRead ? "countingService.finalizeValueOnRead()" : "" }
+                ${ finalize ? "countingService.finalizeValue()" : "" }
                 doLast {
                     assert countingService.get().increment() == 2
+                    assert requiredServices.elements.size() == 1
+                    assert altServiceProvider.get().increment() == 3
                 }
             }
         """
@@ -101,11 +125,30 @@ class ConfigurationCacheBuildServiceIntegrationTest extends AbstractConfiguratio
         then:
         configurationCache.assertStateLoaded()
         outputContains 'Count: 1'
+
+        where:
+        legacy | finalize | finalizeOnRead | registeredByPlugin
+        false  | false    | false          | true
+        false  | true     | false          | true
+        false  | false    | true           | true
+        true   | false    | false          | true
+        true   | true     | false          | true
+        true   | false    | true           | true
+        false  | false    | false          | false
+        false  | true     | false          | false
+        false  | false    | true           | false
+        true   | false    | false          | false
+        true   | true     | false          | false
+        true   | false    | true           | false
+
     }
 
     def "missing build service when using @ServiceReference"() {
         given:
-        withCountingServicePlugin("registeredCounter", "consumedCounter")
+        withCountingServicePlugin(true, """
+            @$ServiceReference.name("consumedCounter")
+            @$Optional.name
+        """)
         file('settings.gradle') << """
             pluginManagement {
                 includeBuild 'counting-service-plugin'
@@ -139,25 +182,26 @@ class ConfigurationCacheBuildServiceIntegrationTest extends AbstractConfiguratio
         failureCauseContains("Cannot query the value of task ':failedCount' property 'countingService' because it has no value available.")
     }
 
-    private void withCountingServicePlugin(String registeredServiceName, String consumedServiceName) {
+    private void withCountingServicePlugin(boolean register, String propertyAnnotations) {
         createDir('counting-service-plugin') {
             file("src/main/java/CountingServicePlugin.java") << """
                 public abstract class CountingServicePlugin implements $Plugin.name<$Project.name> {
                     private $Provider.name<?> counterProvider;
                     @Override
                     public void apply($Project.name project) {
+                        ${register ? """
                         project.getGradle().getSharedServices().registerIfAbsent(
-                            "${registeredServiceName}",
+                            "counter",
                             CountingService.class,
                             (spec) -> {}
                         );
+                        """ : ""}
                     }
                 }
 
                 abstract class CountingTask extends $DefaultTask.name {
 
-                    @$ServiceReference.name("${consumedServiceName}")
-                    @$Optional.name
+                    $propertyAnnotations
                     public abstract $Property.name<CountingService> getCountingService();
 
                     public CountingTask() {}

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildServiceIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildServiceIntegrationTest.groovy
@@ -133,7 +133,6 @@ class ConfigurationCacheBuildServiceIntegrationTest extends AbstractConfiguratio
         ""          | false    | false
         ""          | true     | false
         ""          | false    | true
-
     }
 
     def "missing build service when using @ServiceReference"() {

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/ProviderCodecs.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/ProviderCodecs.kt
@@ -172,7 +172,7 @@ class BuildServiceProviderCodec(
             if (isResolved) {
                 val parameters = read() as BuildServiceParameters?
                 val maxUsages = readInt()
-                buildServiceRegistryOf(buildIdentifier).register(name, implementationType, parameters, maxUsages)
+                buildServiceRegistryOf(buildIdentifier).registerIfAbsent(name, implementationType, parameters, maxUsages)
             } else {
                 buildServiceRegistryOf(buildIdentifier).consume(name, implementationType)
             }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
@@ -298,7 +298,7 @@ service: closed with value 11
         """
     }
 
-    def "can inject shared build service by name when reference is annotated with @ServiceReference('#name') with service type is #registeredServiceType"() {
+    def "can inject shared build service by name when reference is annotated with @ServiceReference('#name') and service type is #registeredServiceType"() {
         given:
         serviceImplementation()
         customTaskUsingServiceViaProperty("@${ServiceReference.name}('$name')")
@@ -876,7 +876,7 @@ service: closed with value 12
 
         then:
         failureDescriptionContains("An exception occurred applying plugin request [id: 'my.plugin1']")
-        failureCauseContains("java.lang.IllegalArgumentException: Service 'test' has already been registered with type 'MyService', cannot register another with type 'MyService'.")
+        failureCauseContains("java.lang.IllegalArgumentException: Service 'test' has already been registered with type 'MyService', cannot register another with type 'MyService' (same name but from a different classloader).")
     }
 
     def "service provided by a plugin can be shared by subprojects with different classloaders when using by-type service references"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
@@ -28,6 +28,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.LocalState
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
@@ -38,6 +39,8 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.process.ExecOperations
+import org.gradle.test.fixtures.file.TestFile
+import org.gradle.util.internal.ToBeImplemented
 import spock.lang.IgnoreIf
 import spock.lang.Issue
 
@@ -247,29 +250,6 @@ service: closed with value 11
         outputDoesNotContain "'Task#usesService'"
     }
 
-    def "does not nag when service is annotated with @ServiceReference (unnamed) and feature preview is enabled"() {
-        given:
-        serviceImplementation()
-        customTaskUsingServiceViaProperty("@${ServiceReference.name}()")
-        buildFile """
-            def provider = gradle.sharedServices.registerIfAbsent("counterService", CountingService) {
-                parameters.initial = 10
-                maxParallelUsages = 1
-            }
-
-            task implicit(type: Consumer) {
-                counter.convention(provider)
-            }
-        """
-        enableStableConfigurationCache()
-
-        when:
-        succeeds 'implicit'
-
-        then:
-        outputDoesNotContain "'Task#usesService'"
-    }
-
     def "can inject shared build service by name into nested bean property when reference is annotated with @ServiceReference('...')"() {
         given:
         serviceImplementation()
@@ -318,12 +298,15 @@ service: closed with value 11
         """
     }
 
-    def "can inject shared build service by name when reference is annotated with @ServiceReference('...')"() {
+    def "can inject shared build service by name when reference is annotated with @ServiceReference('#name') with service type is #registeredServiceType"() {
         given:
         serviceImplementation()
-        customTaskUsingServiceViaProperty("@${ServiceReference.name}('counter')")
+        customTaskUsingServiceViaProperty("@${ServiceReference.name}('$name')")
         buildFile """
-            gradle.sharedServices.registerIfAbsent("counter", CountingService) {
+
+            abstract class SubCountingService extends CountingService {}
+
+            gradle.sharedServices.registerIfAbsent("counter", $registeredServiceType) {
                 parameters.initial = 10
                 maxParallelUsages = 1
             }
@@ -331,8 +314,8 @@ service: closed with value 11
             task named(type: Consumer) {
                 // reference will be set by name
                 doLast {
-                    assert requiredServices.elements.any { service ->
-                        service.type == CountingService
+                    assert requiredServices.elements.collect { it.type }.any { registeredServiceType ->
+                        registeredServiceType.isAssignableFrom(${registeredServiceType})
                     }
                 }
             }
@@ -341,6 +324,81 @@ service: closed with value 11
 
         when:
         succeeds 'named'
+
+        then:
+        outputDoesNotContain "'Task#usesService'"
+        outputContains """
+service: created with value = 10
+service: value is 11
+service: closed with value 11
+        """
+
+        where:
+        name      | registeredServiceType
+        "counter" | "CountingService"
+        ""        | "CountingService"
+        "counter" | "SubCountingService"
+        ""        | "SubCountingService"
+    }
+
+    def "cannot inject shared build service without a name when multiple services exist"() {
+        given:
+        serviceImplementation()
+        // unnamed service implies type-based lookup
+        customTaskUsingServiceViaProperty("@${ServiceReference.name}")
+        buildFile """
+            gradle.sharedServices.registerIfAbsent("counter1", CountingService) {
+                parameters.initial = 10
+                maxParallelUsages = 1
+            }
+            gradle.sharedServices.registerIfAbsent("counter2", CountingService) {
+                parameters.initial = 10
+                maxParallelUsages = 1
+            }
+
+            task ambiguous(type: Consumer) {
+                // reference cannot be resolved by type as multiple services with the given type exist
+                doLast {
+                    counter.get()
+                }
+            }
+        """
+        enableStableConfigurationCache()
+
+        when:
+        fails 'ambiguous'
+
+        then:
+        errorOutput.contains("Cannot resolve service by type for type 'CountingService' when there are two or more instances. Please also provide a service name. Instances found: counter1: CountingService, counter2: CountingService.")
+    }
+
+    def "can declare a service reference without a name when multiple services exist if a value is explicitly assigned"() {
+        given:
+        serviceImplementation()
+        // unnamed service implies type-based lookup
+        customTaskUsingServiceViaProperty("@${ServiceReference.name}")
+        buildFile """
+            def service1 = gradle.sharedServices.registerIfAbsent("counter1", CountingService) {
+                parameters.initial = 10
+                maxParallelUsages = 1
+            }
+            def service2 = gradle.sharedServices.registerIfAbsent("counter2", CountingService) {
+                parameters.initial = 10
+                maxParallelUsages = 1
+            }
+
+            task unambiguous(type: Consumer) {
+                // explicit assignment avoids ambiguity
+                counter.convention(service1)
+                doLast {
+                    counter.get()
+                }
+            }
+        """
+        enableStableConfigurationCache()
+
+        when:
+        succeeds 'unambiguous'
 
         then:
         outputDoesNotContain "'Task#usesService'"
@@ -759,6 +817,142 @@ service: closed with value 12
 
         then:
         result.assertNotOutput("service:")
+    }
+
+    @ToBeImplemented
+    @Issue("https://github.com/gradle/gradle/issues/17559")
+    def "service provided by a plugin cannot be shared by subprojects with different classloaders"() {
+        settingsFile """
+        pluginManagement {
+            includeBuild 'plugin1'
+            includeBuild 'plugin2'
+        }
+        include 'subproject1'
+        include 'subproject2'
+        """
+        // plugin 1 declares a service
+        groovyFile(file("plugin1/build.gradle"), "plugins { id 'groovy-gradle-plugin' }")
+        groovyFile(file("plugin1/src/main/groovy/my.plugin1.gradle"), """
+            import org.gradle.api.services.BuildService
+            import org.gradle.api.services.BuildServiceParameters
+            abstract class MyService implements BuildService<BuildServiceParameters.None> {
+                String hello(String message) {
+                    "Hello, \$message"
+                }
+            }
+
+            def myService = gradle.sharedServices.registerIfAbsent("test", MyService) {}
+
+            project.task('hello') {
+                def projectName = project.name
+                doLast {
+                    assert MyService == myService.type
+                    println(myService.get().hello(projectName))
+                }
+            }
+        """)
+        // plugin 2
+        groovyFile(file("plugin2/build.gradle"), "plugins { id 'groovy-gradle-plugin' }")
+        groovyFile(file("plugin2/src/main/groovy/my.plugin2.gradle"), "/* no code needed */")
+        // subproject1 and subproject2 apply different sets of plugins, so get different classloaders
+        groovyFile(file("subproject1/build.gradle"), """
+        plugins {
+            id 'my.plugin1'
+            id 'my.plugin2'
+        }
+        """)
+        groovyFile(file("subproject2/build.gradle"), """
+        plugins {
+            // must include the plugin contributing the build service,
+            // and must be a different ordered set than the other project
+            // or else both subprojects are built with the same classloader
+            id 'my.plugin2'
+            id 'my.plugin1'
+        }
+        """)
+
+        when:
+        fails("hello")
+
+        then:
+        failureDescriptionContains("An exception occurred applying plugin request [id: 'my.plugin1']")
+        failureCauseContains("java.lang.IllegalArgumentException: Service 'test' has already been registered with type 'MyService', cannot register another with type 'MyService'.")
+    }
+
+    def "service provided by a plugin can be shared by subprojects with different classloaders when using by-type service references"() {
+        settingsFile """
+        pluginManagement {
+            includeBuild 'plugin1'
+            includeBuild 'plugin2'
+        }
+        include 'subproject1'
+        include 'subproject2'
+        """
+        // plugin 1 declares a service
+        groovyFile(file("plugin1/build.gradle"), "plugins { id 'groovy-gradle-plugin' }")
+        groovyFile(file("plugin1/src/main/groovy/my.plugin1.gradle"), """
+            import org.gradle.api.services.BuildService
+            import org.gradle.api.services.BuildServiceParameters
+            abstract class MyService implements BuildService<BuildServiceParameters.None> {
+                String hello(String message) {
+                    "Hello, \$message"
+                }
+            }
+
+            gradle.sharedServices.registerIfAbsent("test-" + ${UUID.name}.randomUUID(), MyService) {}
+
+            abstract class HelloTask extends DefaultTask {
+                @$ServiceReference.name
+                abstract Property<MyService> getMyServiceReference()
+
+                @$Internal.name
+                abstract Property<String> getProjectName()
+
+                @TaskAction
+                def go() {
+                    println(myServiceReference.get().hello(projectName.get()))
+                }
+            }
+
+            project.tasks.register('hello', HelloTask) {
+                projectName = project.name
+                doLast {
+                    assert MyService == myServiceReference.type
+                }
+            }
+        """)
+
+        // plugin 2
+        groovyFile(file("plugin2/build.gradle"), "plugins { id 'groovy-gradle-plugin' }")
+        groovyFile(file("plugin2/src/main/groovy/my.plugin2.gradle"), "/* no code needed */")
+        // subproject1 and subproject2 apply different sets of plugins, so get different classloaders
+        groovyFile(file("subproject1/build.gradle"), """
+        plugins {
+            id 'my.plugin1'
+            id 'my.plugin2'
+        }
+        """)
+        groovyFile(file("subproject2/build.gradle"), """
+        plugins {
+            // must include the plugin contributing the build service,
+            // and must be a different ordered set than the other project
+            // or else both subprojects are built with the same classloader
+            id 'my.plugin2'
+            id 'my.plugin1'
+        }
+        """)
+
+        when:
+        succeeds(":subproject1:hello")
+
+        then:
+        outputContains("Hello, subproject1")
+
+        when:
+        succeeds(":subproject2:hello")
+
+        then:
+        outputContains("Hello, subproject2")
     }
 
     def "plugin applied to multiple projects can register a shared service"() {
@@ -1259,8 +1453,8 @@ service: closed with value 12
         """
     }
 
-    private void customTaskUsingServiceViaProperty(String annotationSnippet = "@Internal") {
-        buildFile << """
+    private void customTaskUsingServiceViaProperty(String annotationSnippet = "@Internal", TestFile targetBuildFile = buildFile) {
+        targetBuildFile << """
             abstract class Consumer extends DefaultTask {
                 ${annotationSnippet}
                 abstract Property<CountingService> getCounter()

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskRequiredServices.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskRequiredServices.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.tasks;
 
+import com.google.common.collect.ImmutableSet;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.provider.DefaultProperty;
 import org.gradle.api.internal.provider.ProviderInternal;
@@ -53,9 +54,11 @@ public class DefaultTaskRequiredServices implements TaskRequiredServices {
 
     @Override
     public Set<Provider<? extends BuildService<?>>> getElements() {
+        ImmutableSet.Builder<Provider<? extends BuildService<?>>> allUsedServices = ImmutableSet.builder();
         Set<Provider<? extends BuildService<?>>> registeredServices = this.registeredServices != null ? this.registeredServices : emptySet();
-        Set<Provider<? extends BuildService<?>>> allUsedServices = collectRequiredServices(new LinkedHashSet<>(registeredServices));
-        return allUsedServices;
+        allUsedServices.addAll(registeredServices);
+        collectRequiredServices(allUsedServices);
+        return allUsedServices.build();
     }
 
     @Override
@@ -66,11 +69,10 @@ public class DefaultTaskRequiredServices implements TaskRequiredServices {
     /**
      * Collects services declared as referenced (via @ServiceReference) into the given set.
      */
-    private Set<Provider<? extends BuildService<?>>> collectRequiredServices(Set<Provider<? extends BuildService<?>>> requiredServices) {
+    private void collectRequiredServices(ImmutableSet.Builder<Provider<? extends BuildService<?>>> requiredServices) {
         visitServiceReferences(referenceProvider ->
             requiredServices.add(asBuildServiceProvider(referenceProvider))
         );
-        return requiredServices;
     }
 
     private Provider<? extends BuildService<?>> asBuildServiceProvider(Provider<? extends BuildService<?>> referenceProvider) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskRequiredServices.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskRequiredServices.java
@@ -28,7 +28,6 @@ import org.gradle.internal.properties.PropertyVisitor;
 import org.gradle.internal.properties.bean.PropertyWalker;
 
 import javax.annotation.Nullable;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -61,7 +60,7 @@ public class DefaultTaskRequiredServices implements TaskRequiredServices {
 
     @Override
     public boolean isServiceRequired(Provider<? extends BuildService<?>> toCheck) {
-        return getElements().stream().anyMatch(it -> BuildServiceProvider.isSameService(it, toCheck));
+        return getElements().stream().anyMatch(it -> BuildServiceProvider.isSameService(toCheck, it));
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskRequiredServices.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskRequiredServices.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.tasks;
 
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.provider.DefaultProperty;
+import org.gradle.api.internal.provider.ProviderInternal;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.services.BuildService;
 import org.gradle.api.services.internal.BuildServiceProvider;
@@ -44,11 +45,6 @@ public class DefaultTaskRequiredServices implements TaskRequiredServices {
      */
     @Nullable
     private Set<Provider<? extends BuildService<?>>> registeredServices;
-    /**
-     * Lazy union between #registeredServices and properties annotated with @ServiceReference.
-     */
-    @Nullable
-    private Set<Provider<? extends BuildService<?>>> requiredServices;
 
     public DefaultTaskRequiredServices(TaskInternal task, TaskMutator taskMutator, PropertyWalker propertyWalker) {
         this.task = task;
@@ -58,10 +54,9 @@ public class DefaultTaskRequiredServices implements TaskRequiredServices {
 
     @Override
     public Set<Provider<? extends BuildService<?>>> getElements() {
-        if (requiredServices == null) {
-            requiredServices = collectRequiredServices();
-        }
-        return requiredServices;
+        Set<Provider<? extends BuildService<?>>> registeredServices = this.registeredServices != null ? this.registeredServices : emptySet();
+        Set<Provider<? extends BuildService<?>>> allUsedServices = collectRequiredServices(new LinkedHashSet<>(registeredServices));
+        return allUsedServices;
     }
 
     @Override
@@ -70,11 +65,9 @@ public class DefaultTaskRequiredServices implements TaskRequiredServices {
     }
 
     /**
-     * Returns both services declared as referenced (via @ServiceReference) or explicitly as used (via Task#usesService()).
+     * Collects services declared as referenced (via @ServiceReference) into the given set.
      */
-    private Set<Provider<? extends BuildService<?>>> collectRequiredServices() {
-        Set<Provider<? extends BuildService<?>>> registeredServices = this.registeredServices != null ? this.registeredServices : emptySet();
-        Set<Provider<? extends BuildService<?>>> requiredServices = new LinkedHashSet<>(registeredServices);
+    private Set<Provider<? extends BuildService<?>>> collectRequiredServices(Set<Provider<? extends BuildService<?>>> requiredServices) {
         visitServiceReferences(referenceProvider ->
             requiredServices.add(asBuildServiceProvider(referenceProvider))
         );
@@ -84,7 +77,8 @@ public class DefaultTaskRequiredServices implements TaskRequiredServices {
     private Provider<? extends BuildService<?>> asBuildServiceProvider(Provider<? extends BuildService<?>> referenceProvider) {
         if (referenceProvider instanceof DefaultProperty) {
             DefaultProperty<?> asProperty = Cast.uncheckedNonnullCast(referenceProvider);
-            return Cast.uncheckedNonnullCast(asProperty.getProvider());
+            ProviderInternal<?> provider = asProperty.getProvider();
+            return Cast.uncheckedNonnullCast(provider);
         }
         return referenceProvider;
     }
@@ -102,7 +96,7 @@ public class DefaultTaskRequiredServices implements TaskRequiredServices {
     public void registerServiceUsage(Provider<? extends BuildService<?>> service) {
         taskMutator.mutate("Task.usesService(Provider)", () -> {
             if (registeredServices == null) {
-                registeredServices = new HashSet<>();
+                registeredServices = new LinkedHashSet<>();
             }
             // TODO:configuration-cache assert build service is from the same build as the task
             registeredServices.add(service);

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceProvider.java
@@ -88,11 +88,11 @@ public abstract class BuildServiceProvider<T extends BuildService<P>, P extends 
      * This method does not distinguish between consumed/registered providers.
      */
     public static boolean isSameService(Provider<? extends BuildService<?>> thisProvider, Provider<? extends BuildService<?>> anotherProvider) {
-        if (!(thisProvider instanceof BuildServiceProvider && anotherProvider instanceof BuildServiceProvider)) {
-            return false;
-        }
         if (thisProvider == anotherProvider) {
             return true;
+        }
+        if (!(thisProvider instanceof BuildServiceProvider && anotherProvider instanceof BuildServiceProvider)) {
+            return false;
         }
         BuildServiceProvider thisBuildServiceProvider = (BuildServiceProvider) thisProvider;
         BuildServiceProvider otherBuildServiceProvider = (BuildServiceProvider) anotherProvider;

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceProvider.java
@@ -96,12 +96,20 @@ public abstract class BuildServiceProvider<T extends BuildService<P>, P extends 
         }
         BuildServiceProvider thisBuildServiceProvider = (BuildServiceProvider) thisProvider;
         BuildServiceProvider otherBuildServiceProvider = (BuildServiceProvider) anotherProvider;
-        if (!thisBuildServiceProvider.getName().equals(otherBuildServiceProvider.getName())) {
+        String thisName = thisBuildServiceProvider.getName();
+        String otherName = otherBuildServiceProvider.getName();
+        if (!thisName.isEmpty() && !otherName.isEmpty() && !thisName.equals(otherName)) {
             return false;
         }
-        if (thisBuildServiceProvider.getType() != otherBuildServiceProvider.getType()) {
+        if (!isCompatibleServiceType(thisBuildServiceProvider, otherBuildServiceProvider)) {
             return false;
         }
         return thisBuildServiceProvider.getBuildIdentifier().equals(otherBuildServiceProvider.getBuildIdentifier());
+    }
+
+    private static boolean isCompatibleServiceType(BuildServiceProvider thisBuildServiceProvider, BuildServiceProvider otherBuildServiceProvider) {
+        Class<?> otherType = otherBuildServiceProvider.getType();
+        Class<?> thisType = thisBuildServiceProvider.getType();
+        return otherType.isAssignableFrom(Cast.uncheckedCast(thisType));
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceProviderNagger.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceProviderNagger.java
@@ -35,6 +35,9 @@ public class BuildServiceProviderNagger implements BuildServiceProvider.Listener
     public void beforeGet(BuildServiceProvider<?, ?> provider) {
         currentTask().ifPresent(task -> {
             if (!isServiceRequiredBy(task, provider)) {
+                System.out.println("Service not declared but used: " + provider);
+                System.out.println("Required services");
+                task.getRequiredServices().getElements().stream().forEach(it -> System.out.println(it));
                 nagAboutUndeclaredUsageOf(provider, task);
             }
         });

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceProviderNagger.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceProviderNagger.java
@@ -35,9 +35,6 @@ public class BuildServiceProviderNagger implements BuildServiceProvider.Listener
     public void beforeGet(BuildServiceProvider<?, ?> provider) {
         currentTask().ifPresent(task -> {
             if (!isServiceRequiredBy(task, provider)) {
-                System.out.println("Service not declared but used: " + provider);
-                System.out.println("Required services");
-                task.getRequiredServices().getElements().stream().forEach(it -> System.out.println(it));
                 nagAboutUndeclaredUsageOf(provider, task);
             }
         });

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceRegistryInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceRegistryInternal.java
@@ -59,5 +59,11 @@ public interface BuildServiceRegistryInternal extends BuildServiceRegistry {
     @Nullable
     BuildServiceRegistration<?, ?> findByName(String name);
 
+    @Nullable
+    BuildServiceRegistration<?, ?> findByType(Class<?> type);
+
+    @Nullable
+    BuildServiceRegistration<?, ?> findRegistration(Class<?> type, String name);
+
     List<ResourceLock> getSharedResources(Set<Provider<? extends BuildService<?>>> services);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceRegistryInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceRegistryInternal.java
@@ -37,7 +37,20 @@ public interface BuildServiceRegistryInternal extends BuildServiceRegistry {
      */
     BuildServiceProvider<?, ?> register(String name, Class<? extends BuildService<?>> implementationType, @Nullable BuildServiceParameters parameters, int maxUsages);
 
+    /**
+     * Same as #register(name, implementationType, parameters, maxUsages), but conditional.
+     *
+     * @param name
+     * @param implementationType
+     * @param parameters
+     * @param maxUsages
+     * @return the registered or already existing provider
+     */
+    BuildServiceProvider<?, ?> registerIfAbsent(String name, Class<? extends BuildService<?>> implementationType, @Nullable BuildServiceParameters parameters, int maxUsages);
 
+    /**
+     * Returns a shared build service provider that can lazily resolve to the service named and typed as given.
+     */
     BuildServiceProvider<?, ?> consume(String name, Class<? extends BuildService<?>> implementationType);
 
     @Nullable

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/ConsumedBuildServiceProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/ConsumedBuildServiceProvider.java
@@ -62,7 +62,7 @@ public class ConsumedBuildServiceProvider<T extends BuildService<BuildServicePar
     private RegisteredBuildServiceProvider<T, BuildServiceParameters> resolve() {
         if (resolvedProvider == null) {
             BuildServiceRegistry buildServiceRegistry = internalServices.get(BuildServiceRegistry.class);
-            BuildServiceRegistration<?, ?> registration = ((BuildServiceRegistryInternal) buildServiceRegistry).findByName(serviceName);
+            BuildServiceRegistration<?, ?> registration = ((BuildServiceRegistryInternal) buildServiceRegistry).findRegistration(this.getType(), this.getName());
             if (registration == null) {
                 return null;
             }

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/ConsumedBuildServiceProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/ConsumedBuildServiceProvider.java
@@ -17,6 +17,7 @@
 package org.gradle.api.services.internal;
 
 import org.gradle.api.artifacts.component.BuildIdentifier;
+import org.gradle.api.internal.provider.ProviderInternal;
 import org.gradle.api.services.BuildService;
 import org.gradle.api.services.BuildServiceParameters;
 import org.gradle.api.services.BuildServiceRegistration;
@@ -34,7 +35,7 @@ public class ConsumedBuildServiceProvider<T extends BuildService<BuildServicePar
     private final String serviceName;
     private final Class<T> serviceType;
     private final BuildIdentifier buildIdentifier;
-    private volatile BuildServiceProvider<T, BuildServiceParameters> resolvedProvider;
+    private volatile RegisteredBuildServiceProvider<T, BuildServiceParameters> resolvedProvider;
 
     public ConsumedBuildServiceProvider(
         BuildIdentifier buildIdentifier,
@@ -50,7 +51,7 @@ public class ConsumedBuildServiceProvider<T extends BuildService<BuildServicePar
 
     @Override
     protected Value<? extends T> calculateOwnValue(ValueConsumer consumer) {
-        BuildServiceProvider<T, ?> resolvedProvider = resolve();
+        RegisteredBuildServiceProvider<T, ?> resolvedProvider = resolve();
         if (resolvedProvider == null) {
             return Value.missing();
         }
@@ -58,7 +59,7 @@ public class ConsumedBuildServiceProvider<T extends BuildService<BuildServicePar
     }
 
     @Nullable
-    private BuildServiceProvider<T, BuildServiceParameters> resolve() {
+    private RegisteredBuildServiceProvider<T, BuildServiceParameters> resolve() {
         if (resolvedProvider == null) {
             BuildServiceRegistry buildServiceRegistry = internalServices.get(BuildServiceRegistry.class);
             BuildServiceRegistration<?, ?> registration = ((BuildServiceRegistryInternal) buildServiceRegistry).findByName(serviceName);
@@ -90,5 +91,11 @@ public class ConsumedBuildServiceProvider<T extends BuildService<BuildServicePar
     public BuildServiceDetails<T, BuildServiceParameters> getServiceDetails() {
         BuildServiceProvider<T, BuildServiceParameters> resolvedProvider = resolve();
         return resolvedProvider != null ? resolvedProvider.getServiceDetails() : new BuildServiceDetails<>(buildIdentifier, serviceName, serviceType);
+    }
+
+    @Override
+    public ProviderInternal<T> withFinalValue(ValueConsumer consumer) {
+        RegisteredBuildServiceProvider<T, BuildServiceParameters> resolved = resolve();
+        return resolved != null ? resolved.withFinalValue(consumer) : super.withFinalValue(consumer);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/DefaultBuildServicesRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/DefaultBuildServicesRegistry.java
@@ -189,7 +189,10 @@ public class DefaultBuildServicesRegistry implements BuildServiceRegistryInterna
             if (existing != null) {
                 Class existingType = getProvidedType(existing.getService());
                 if (!implementationType.isAssignableFrom(existingType)) {
-                    throw new IllegalArgumentException(String.format("Service '%s' has already been registered with type '%s', cannot register another with type '%s'.", name, existingType.getTypeName(), implementationType.getTypeName()));
+                    boolean sameName = existingType.getTypeName().equals(implementationType.getTypeName());
+                    String additionalDetail = sameName ? " (same name but from a different classloader)" : "";
+                    String message = String.format("Service '%s' has already been registered with type '%s', cannot register another with type '%s'%s.", name, existingType.getName(), implementationType.getName(), additionalDetail);
+                    throw new IllegalArgumentException(message);
                 }
                 // TODO - assert same type
                 // TODO - assert same parameters

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/RegisteredBuildServiceProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/RegisteredBuildServiceProvider.java
@@ -18,6 +18,7 @@ package org.gradle.api.services.internal;
 
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.component.BuildIdentifier;
+import org.gradle.api.internal.provider.ProviderInternal;
 import org.gradle.api.services.BuildService;
 import org.gradle.api.services.BuildServiceParameters;
 import org.gradle.internal.Try;
@@ -173,5 +174,10 @@ public class RegisteredBuildServiceProvider<T extends BuildService<P>, P extends
                 instance = null;
             }
         }
+    }
+
+    @Override
+    public ProviderInternal<T> withFinalValue(ValueConsumer consumer) {
+        return this;
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -159,16 +159,24 @@ abstract class AbstractIntegrationSpec extends Specification {
         testDirectory.file(getDefaultBuildFileName())
     }
 
+    void buildFile(@GroovyBuildScriptLanguage String script) {
+        groovyFile(buildFile, script)
+    }
+
+    void settingsFile(@GroovyBuildScriptLanguage String script) {
+        groovyFile(settingsFile, script)
+    }
+
     /**
      * Provides best-effort groovy script syntax highlighting.
      * The highlighting is imperfect since {@link GroovyBuildScriptLanguage} uses stub methods to create a simulated script target environment.
      */
-    void buildFile(@GroovyBuildScriptLanguage String script) {
-        buildFile << script
+    void groovyFile(TestFile targetBuildFile, @GroovyBuildScriptLanguage String script) {
+        targetBuildFile << script
     }
 
-    void settingsFile(@GroovyBuildScriptLanguage String script) {
-        settingsFile << script
+    String groovyScript(@GroovyBuildScriptLanguage String script) {
+        script
     }
 
     TestFile getBuildKotlinFile() {

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/AsmBackedClassGenerator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/AsmBackedClassGenerator.java
@@ -22,7 +22,6 @@ import groovy.lang.GroovyObject;
 import groovy.lang.GroovySystem;
 import groovy.lang.MetaClass;
 import groovy.lang.MetaClassRegistry;
-import org.apache.commons.lang.StringUtils;
 import org.gradle.api.Action;
 import org.gradle.api.Describable;
 import org.gradle.api.Task;
@@ -1150,7 +1149,7 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
 
                 String buildServiceName = getBuildServiceName(property);
                 if (buildServiceName != null) {
-                    // property is a service reference declaring a name
+                    // property is a service reference
                     _DUP();
                     setBuildServiceConvention(buildServiceName);
                 }
@@ -1179,7 +1178,7 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
             }
 
             // Caller should place property value on the top of the stack
-            protected void setBuildServiceConvention(String serviceName) {
+            protected void setBuildServiceConvention(@Nullable String serviceName) {
                 // GENERATE BuildServiceProvider.setBuildServiceAsConvention(defaultProperty, getServices(), "<serviceName>")
                 _CHECKCAST(DEFAULT_PROPERTY_TYPE);
                 putServiceRegistryOnStack();
@@ -1770,7 +1769,7 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
     private static String getBuildServiceName(PropertyMetadata property) {
         ServiceReference annotation = property.findAnnotation(ServiceReference.class);
         if (annotation != null) {
-            return StringUtils.trimToNull(annotation.value());
+            return annotation.value();
         }
         return null;
     }


### PR DESCRIPTION
There are expetactions in place that shared build services are held by non-finalized properties, so they retain BuildServiceProviders (which hold metadata on shared build services) instead of having them resolved to fixed value providers.

This change basically ensures BuildServiceProviders are preserved even if the property using them is finalized.

Issue: #16168

### Rationale

This addresses issues related to using service references being finalized (and leading to BuildServiceProviders being replaced by fixed value providers, preventing us from accessing service metadata that is only available to instances of BuildServiceProvider). Here are my findings:

`@ServiceReference` properties were implemented as validated (regular @Internal properties are not).

When validating a property, [we unpack its value](https://github.com/gradle/gradle/blob/734c91716ed48229bf05bf8d3d593476da32257d/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/AbstractValidatingProperty.java#L53), which [resolves providers](https://github.com/gradle/gradle/blob/e56d98ee8b46ecd74c247076e0a1fc0183280de1/subprojects/model-core/src/main/java/org/gradle/util/internal/DeferredUtil.java#L59). 

If a property is marked as `finalizeValueOnRead`, any attempt to read it (including during validtion) will finalize its value. 

```
finalValue:133, DefaultProperty (org.gradle.api.internal.provider)
finalizeNow:245, AbstractProperty (org.gradle.api.internal.provider)
beforeRead:239, AbstractProperty (org.gradle.api.internal.provider)
calculateOwnValue:135, AbstractProperty (org.gradle.api.internal.provider)
getOrNull:98, AbstractMinimalProvider (org.gradle.api.internal.provider)
resolve:27, ProviderResolutionStrategy$1 (org.gradle.api.internal.provider)
unpack:59, DeferredUtil (org.gradle.util.internal)
unpackOrNull:49, DeferredUtil (org.gradle.util.internal)
validate:53, AbstractValidatingProperty (org.gradle.api.internal.tasks.properties)
validate:139, DefaultTaskProperties (org.gradle.api.internal.tasks.properties)
validate:466, TaskExecution (org.gradle.api.internal.tasks.execution)
execute:69, ValidateStep (org.gradle.internal.execution.steps)
execute:71, CaptureStateBeforeExecutionStep (org.gradle.internal.execution.steps)
executeWithNonEmptySources:177, SkipEmptyWorkStep (org.gradle.internal.execution.steps)
execute:81, SkipEmptyWorkStep (org.gradle.internal.execution.steps)
execute:32, RemoveUntrackedExecutionStateStep (org.gradle.internal.execution.steps)
execute:38, MarkSnapshottingInputsStartedStep (org.gradle.internal.execution.steps.legacy)
execute:36, LoadPreviousExecutionStateStep (org.gradle.internal.execution.steps)
execute:75, CleanupStaleOutputsStep (org.gradle.internal.execution.steps)
lambda$execute$0:32, AssignWorkspaceStep (org.gradle.internal.execution.steps)
withWorkspace:287, TaskExecution$4 (org.gradle.api.internal.tasks.execution)
execute:30, AssignWorkspaceStep (org.gradle.internal.execution.steps)
execute:37, IdentityCacheStep (org.gradle.internal.execution.steps)
execute:42, IdentifyStep (org.gradle.internal.execution.steps)
execute:64, DefaultExecutionEngine$1 (org.gradle.internal.execution.impl)
executeIfValid:146, ExecuteActionsTaskExecuter (org.gradle.api.internal.tasks.execution)
execute:135, ExecuteActionsTaskExecuter (org.gradle.api.internal.tasks.execution)
execute:46, FinalizePropertiesTaskExecuter (org.gradle.api.internal.tasks.execution)
execute:51, ResolveTaskExecutionModeExecuter (org.gradle.api.internal.tasks.execution)
```

The reason service reference properties are marked for finalization on read is that before validation, we request all properties that are declared as validatable to finalize on next get in [FinalizePropertiesTaskExecuter](https://github.com/gradle/gradle/blob/c68724158ac7c5d93478e584fa714169c6ad63eb/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/FinalizePropertiesTaskExecuter.java#L43). Basically, right now, if a property is validatable, it is also lifecycle aware, and hence is marked as finalizeOnNextGet().

```
finalizeOnNextGet:406, AbstractProperty$NonFinalizedValue (org.gradle.api.internal.provider)
implicitFinalizeValue:211, AbstractProperty (org.gradle.api.internal.provider)
maybeFinalizeValue:133, AbstractNestedRuntimeBeanNode$BeanPropertyValue (org.gradle.internal.properties.bean)
prepareValue:65, AbstractValidatingProperty (org.gradle.api.internal.tasks.properties)
execute:43, FinalizePropertiesTaskExecuter (org.gradle.api.internal.tasks.execution)
execute:51, ResolveTaskExecutionModeExecuter (org.gradle.api.internal.tasks.execution)
```

Long story short, we prematurely finalize service references (if they are marked as `finalizeOnValueRead()`), but not old school shared-build-service-typed properties (as they are @Internal and skipped by validation).

A couple of possible solutions:
1. implement finalization of BuildServiceProviders (which requires overriding [`ProviderInternal#withFinalValue`](https://github.com/gradle/gradle/blob/46f2897929ed721c0a2f6505283843b6a3b45623/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ProviderInternal.java#L134))
1. make ServiceReference properties validatable but not lifecycle-aware (up to now, both sets where always identical, "validatable" implied "lifecycle aware").
1. a third one would be to undo the design decision of service references validatable.

The first option also ensures that even if a user calls `#finalizeValueOnRead` we could still can handle it in a way that made sense for shared build service providers (like if).

The second one misses that case - however, note that today it is already illegal to call `#finalizeValue()`on a property (as it causes the original BSP provider to be replaced with fixed one, and in multiple places we require a BuildService property to hold on to a BuildServiceProvider, not a general provider that returns a build service).

This change set implements #1 above.



