### PR TITLE
Remove CompileView attribute from derived Maven variants

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/JavaEcosystemSupport.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/JavaEcosystemSupport.java
@@ -162,7 +162,6 @@ public abstract class JavaEcosystemSupport {
 
     private static void configureView(AttributesSchema attributesSchema, final ObjectFactory objectFactory) {
         AttributeMatchingStrategy<CompileView> viewSchema = attributesSchema.attribute(CompileView.VIEW_ATTRIBUTE);
-        viewSchema.getCompatibilityRules().add(CompileViewCompatibilityRules.class);
         viewSchema.getDisambiguationRules().add(CompileViewDisambiguationRules.class, actionConfiguration -> {
             actionConfiguration.params(objectFactory.named(CompileView.class, CompileView.JAVA_API));
             actionConfiguration.params(objectFactory.named(CompileView.class, CompileView.JAVA_INTERNAL));
@@ -195,26 +194,6 @@ public abstract class JavaEcosystemSupport {
             } else if (candidateValues.contains(consumerValue)) {
                 // Use what they requested, if available
                 details.closestMatch(consumerValue);
-            }
-        }
-    }
-
-    @VisibleForTesting
-    static class CompileViewCompatibilityRules implements AttributeCompatibilityRule<CompileView>, ReusableAction {
-
-        @Override
-        public void execute(CompatibilityCheckDetails<CompileView> details) {
-            CompileView consumerValue = details.getConsumerValue();
-            CompileView producerValue = details.getProducerValue();
-            if (consumerValue == null) {
-                // consumer didn't express any preferences, everything fits
-                details.compatible();
-                return;
-            }
-            // The API view is a subset of the internal view, so the internal view can fulfill
-            // a request for the API.
-            if (CompileView.JAVA_API.equals(consumerValue.getName()) && CompileView.JAVA_INTERNAL.equals(producerValue.getName())) {
-                details.compatible();
             }
         }
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/JavaEcosystemSupportTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/JavaEcosystemSupportTest.groovy
@@ -102,34 +102,6 @@ class JavaEcosystemSupportTest extends Specification {
         Usage.JAVA_API          | [JavaEcosystemSupport.DEPRECATED_JAVA_API_JARS, Usage.JAVA_API, JavaEcosystemSupport.DEPRECATED_JAVA_RUNTIME_JARS] | JavaEcosystemSupport.DEPRECATED_JAVA_API_JARS
     }
 
-    def "check compile-view compatibility rules consumer=#consumer producer=#producer compatible=#compatible"() {
-        CompatibilityCheckDetails details = Mock(CompatibilityCheckDetails)
-
-        when:
-        new JavaEcosystemSupport.CompileViewCompatibilityRules().execute(details)
-
-        then:
-        1 * details.getConsumerValue() >> compileView(consumer)
-        1 * details.getProducerValue() >> compileView(producer)
-
-        if (compatible && !(consumer == producer)) {
-            1 * details.compatible()
-        } else {
-            0 * _
-        }
-
-        where:
-        consumer                  | producer                  | compatible
-        null                      | CompileView.JAVA_API      | true
-        null                      | CompileView.JAVA_INTERNAL | true
-
-        CompileView.JAVA_API      | CompileView.JAVA_API      | true
-        CompileView.JAVA_API      | CompileView.JAVA_INTERNAL | true
-
-        CompileView.JAVA_INTERNAL | CompileView.JAVA_API      | false
-        CompileView.JAVA_INTERNAL | CompileView.JAVA_INTERNAL | true
-    }
-
     def "check compile-view disambiguation rules consumer=#consumer and candidates=#candidates chooses=#expected"() {
         MultipleCandidatesDetails details = Mock(MultipleCandidatesDetails)
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/DependenciesAttributesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/DependenciesAttributesIntegrationTest.groovy
@@ -151,7 +151,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
 
         where:
         attributeValue | expectedVariant | expectedAttributes
-        'c1'           | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api', 'org.gradle.compile-view':'java-internal', 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: 'c1']
+        'c1'           | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api', 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: 'c1']
         'c2'           | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: 'c2']
     }
 
@@ -252,7 +252,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
 
         where:
         attributeValue | expectedVariant | expectedAttributes
-        'c1'           | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api', 'org.gradle.compile-view':'java-internal', 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', lifecycle: 'c1']
+        'c1'           | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api', 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', lifecycle: 'c1']
         'c2'           | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', lifecycle: 'c2']
     }
 
@@ -345,7 +345,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
             root(":", ":test:") {
                 module('org:test:1.0') {
                     configuration = 'api'
-                    variant('api', ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': 'java-api', 'org.gradle.compile-view':'java-internal', 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: 'c1'])
+                    variant('api', ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': 'java-api', 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: 'c1'])
                 }
             }
         }
@@ -440,7 +440,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
 
         where:
         configurationValue | dependencyValue | expectedVariant | expectedAttributes
-        'c2'               | 'c1'            | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api', 'org.gradle.compile-view':'java-internal', 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: 'c1']
+        'c2'               | 'c1'            | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api', 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: 'c1']
         'c1'               | 'c2'            | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: 'c2']
     }
 
@@ -498,7 +498,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
 
         where:
         configurationValue | dependencyValue | expectedVariant | expectedAttributes
-        'c2'               | 'c1'            | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api', 'org.gradle.compile-view':'java-internal', 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: 'c1']
+        'c2'               | 'c1'            | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api', 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: 'c1']
         'c1'               | 'c2'            | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: 'c2']
     }
 
@@ -557,7 +557,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
 
         where:
         configurationValue | dependencyValue | expectedVariant | expectedAttributes
-        'c2'               | 'c1'            | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api', 'org.gradle.compile-view':'java-internal', 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: 'c1']
+        'c2'               | 'c1'            | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api', 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: 'c1']
         'c1'               | 'c2'            | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: 'c2']
     }
 
@@ -731,7 +731,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
 
         where:
         attributeValue | expectedVariant | expectedAttributes
-        'c1'           | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api', 'org.gradle.compile-view':'java-internal', 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: 'c1']
+        'c1'           | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api', 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: 'c1']
         'c2'           | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: 'c2']
     }
 
@@ -879,7 +879,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
 
         where:
         attributeValue | expectedVariant | expectedAttributes
-        'c1'           | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api', 'org.gradle.compile-view':'java-internal', 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: 'c1']
+        'c1'           | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api', 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: 'c1']
         'c2'           | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: 'c2']
     }
 
@@ -967,25 +967,25 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
             root(":", ":test:") {
                 module('org:directA:1.0') {
                     configuration = expectedDirectVariant
-                    variant(expectedDirectVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedDirectVariant}", 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: configurationAttributeValue] + (expectedDirectVariant == 'api' ? ['org.gradle.compile-view': 'java-internal'] : [:]))
+                    variant(expectedDirectVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedDirectVariant}", 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: configurationAttributeValue])
                     module('org:transitiveA:1.0') {
                         configuration = expectedTransitiveVariantA
-                        variant(expectedTransitiveVariantA, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedTransitiveVariantA}", 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: transitiveAttributeValueA] + (expectedTransitiveVariantA == 'api' ? ['org.gradle.compile-view': 'java-internal'] : [:]))
+                        variant(expectedTransitiveVariantA, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedTransitiveVariantA}", 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: transitiveAttributeValueA])
                         module('org:leafA:1.0') {
                             configuration = expectedLeafVariant
-                            variant(expectedLeafVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedLeafVariant}", 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: configurationAttributeValue] + (expectedLeafVariant == 'api' ? ['org.gradle.compile-view': 'java-internal'] : [:]))
+                            variant(expectedLeafVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedLeafVariant}", 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: configurationAttributeValue])
                         }
                     }
                 }
                 module('org:directB:1.0') {
                     configuration = expectedDirectVariant
-                    variant(expectedDirectVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedDirectVariant}", 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: configurationAttributeValue] + (expectedDirectVariant == 'api' ? ['org.gradle.compile-view': 'java-internal'] : [:]))
+                    variant(expectedDirectVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedDirectVariant}", 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: configurationAttributeValue])
                     module('org:transitiveB:1.0') {
                         configuration = expectedTransitiveVariantB
-                        variant(expectedTransitiveVariantB, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedTransitiveVariantB}", 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: transitiveAttributeValueB] + (expectedTransitiveVariantB == 'api' ? ['org.gradle.compile-view': 'java-internal'] : [:]))
+                        variant(expectedTransitiveVariantB, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedTransitiveVariantB}", 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: transitiveAttributeValueB])
                         module('org:leafB:1.0') {
                             configuration = expectedLeafVariant
-                            variant(expectedLeafVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedLeafVariant}", 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: configurationAttributeValue] + (expectedLeafVariant == 'api' ? ['org.gradle.compile-view': 'java-internal'] : [:]))
+                            variant(expectedLeafVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedLeafVariant}", 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: configurationAttributeValue])
                         }
                     }
                 }
@@ -1062,25 +1062,25 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
             root(":", ":test:") {
                 module('org:directA:1.0') {
                     configuration = expectedDirectVariant
-                    variant(expectedDirectVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedDirectVariant}", 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: configurationAttributeValue] + (expectedDirectVariant == 'api' ? ['org.gradle.compile-view': 'java-internal'] : [:]))
+                    variant(expectedDirectVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedDirectVariant}", 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: configurationAttributeValue])
                     module('org:transitiveA:1.0') {
                         configuration = expectedTransitiveVariantA
-                        variant(expectedTransitiveVariantA, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedTransitiveVariantA}", 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: transitiveAttributeValueA] + (expectedTransitiveVariantA == 'api' ? ['org.gradle.compile-view': 'java-internal'] : [:]))
+                        variant(expectedTransitiveVariantA, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedTransitiveVariantA}", 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: transitiveAttributeValueA])
                         module('org:leafA:1.0') {
                             configuration = expectedLeafVariant
-                            variant(expectedLeafVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedLeafVariant}", 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: configurationAttributeValue] + (expectedLeafVariant == 'api' ? ['org.gradle.compile-view': 'java-internal'] : [:]))
+                            variant(expectedLeafVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedLeafVariant}", 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: configurationAttributeValue])
                         }
                     }
                 }
                 module('org:directB:1.0') {
                     configuration = expectedDirectVariant
-                    variant(expectedDirectVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedDirectVariant}", 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: configurationAttributeValue] + (expectedDirectVariant == 'api' ? ['org.gradle.compile-view': 'java-internal'] : [:]))
+                    variant(expectedDirectVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedDirectVariant}", 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: configurationAttributeValue])
                     module('org:transitiveB:1.0') {
                         configuration = expectedTransitiveVariantB
-                        variant(expectedTransitiveVariantB, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedTransitiveVariantB}", 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: transitiveAttributeValueB] + (expectedTransitiveVariantB == 'api' ? ['org.gradle.compile-view': 'java-internal'] : [:]))
+                        variant(expectedTransitiveVariantB, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedTransitiveVariantB}", 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: transitiveAttributeValueB])
                         module('org:leafB:1.0') {
                             configuration = expectedLeafVariant
-                            variant(expectedLeafVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedLeafVariant}", 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: configurationAttributeValue] + (expectedLeafVariant == 'api' ? ['org.gradle.compile-view': 'java-internal'] : [:]))
+                            variant(expectedLeafVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedLeafVariant}", 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: configurationAttributeValue])
                         }
                     }
                 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/bundling/JavaBundlingResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/bundling/JavaBundlingResolveIntegrationTest.groovy
@@ -88,7 +88,6 @@ class JavaBundlingResolveIntegrationTest extends AbstractModuleDependencyResolve
                             'org.gradle.dependency.bundling': 'external',
                             'org.gradle.status': JavaBundlingResolveIntegrationTest.defaultStatus(),
                             'org.gradle.usage': 'java-api',
-                            'org.gradle.compile-view': 'java-internal',
                             'org.gradle.libraryelements': 'jar',
                             'org.gradle.category': 'library'
                     ])

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyGradleMetadataRedirectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyGradleMetadataRedirectionIntegrationTest.groovy
@@ -86,7 +86,7 @@ class IvyGradleMetadataRedirectionIntegrationTest extends AbstractHttpDependency
         resolve.expectGraph {
             root(":", ":test:") {
                 module('org:main:1.0') {
-                    variant('api', ['org.gradle.status': 'integration', 'org.gradle.usage': 'java-api', 'org.gradle.compile-view':'java-internal', 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library'])
+                    variant('api', ['org.gradle.status': 'integration', 'org.gradle.usage': 'java-api', 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library'])
                     edge('org:foo:{prefer 1.9}', 'org:foo:1.9')
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenGradleMetadataRedirectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenGradleMetadataRedirectionIntegrationTest.groovy
@@ -85,7 +85,7 @@ class MavenGradleMetadataRedirectionIntegrationTest extends AbstractHttpDependen
         resolve.expectGraph {
             root(":", ":test:") {
                 module('org:main:1.0') {
-                    variant('api', ['org.gradle.status': 'release', 'org.gradle.usage': 'java-api', 'org.gradle.compile-view': 'java-internal', 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library'])
+                    variant('api', ['org.gradle.status': 'release', 'org.gradle.usage': 'java-api', 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library'])
                     edge('org:foo:{prefer 1.9}', 'org:foo:1.9')
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/VariantAttributesRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/VariantAttributesRulesIntegrationTest.groovy
@@ -206,7 +206,6 @@ class VariantAttributesRulesIntegrationTest extends AbstractModuleDependencyReso
                                 expectedAttributes['org.gradle.usage'] = 'java-api'
                                 expectedAttributes['org.gradle.category'] = 'library'
                                 expectedAttributes['org.gradle.libraryelements'] = 'jar'
-                                expectedAttributes['org.gradle.compile-view'] = 'java-internal'
                             }
                         }
                         variant(expectedTargetVariant, expectedAttributes)

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/VariantFilesMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/VariantFilesMetadataRulesIntegrationTest.groovy
@@ -273,13 +273,13 @@ class VariantFilesMetadataRulesIntegrationTest extends AbstractModuleDependencyR
         resolve.expectGraph {
             root(':', ':test:') {
                 module('org.test:moduleA:1.0') {
-                    variant(allFilesVariant, ['org.gradle.status': 'release', 'org.gradle.usage': 'java-api', 'org.gradle.compile-view': 'java-internal', 'org.gradle.libraryelements': 'jar',
+                    variant(allFilesVariant, ['org.gradle.status': 'release', 'org.gradle.usage': 'java-api', 'org.gradle.libraryelements': 'jar',
                                             'org.gradle.category': 'documentation', 'org.gradle.docstype': 'all-files'])
                     artifact(type: 'jar')
                     artifact(type: 'pom')
                     if (hasModuleFile) { artifact(type: 'module') }
                     module('org.test:moduleB:1.0') {
-                        variant(allFilesVariant, ['org.gradle.status': 'release', 'org.gradle.usage': 'java-api', 'org.gradle.compile-view': 'java-internal', 'org.gradle.libraryelements': 'jar',
+                        variant(allFilesVariant, ['org.gradle.status': 'release', 'org.gradle.usage': 'java-api', 'org.gradle.libraryelements': 'jar',
                                                 'org.gradle.category': 'documentation', 'org.gradle.docstype': 'all-files'])
                         artifact(type: 'jar')
                         artifact(type: 'pom')

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationWritingIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationWritingIntegTest.groovy
@@ -739,8 +739,8 @@ class DependencyVerificationWritingIntegTest extends AbstractDependencyVerificat
             }
             artifact("foo-1.0.module") {
                 declaresChecksums(
-                    sha1: "fd4281442065d8fb640f518aa61ec3c1c6164154",
-                    sha512: "2e1ccfbe5f25bd9789cf5a16f99d6dbdf906bd3a6183e0130ed9a3d7191e5408c87c2c08b6b57572704292e6cc7322c3b8b90e6b20efed8650e46c2c64018f3c"
+                    sha1: "5cb00c1d3c96a6f47cf3f4129a0db4fcd371b1ed",
+                    sha512: "fa852fb8aab53474f4e498026557806de823797398ac86402636801eebbb13bd2c53b64fbefe5c3c038a64fca3c7b70d76865c5d644e9e9c80a50b4076afe997"
                 )
             }
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultMavenImmutableAttributesFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultMavenImmutableAttributesFactory.java
@@ -23,7 +23,6 @@ import org.gradle.api.attributes.Category;
 import org.gradle.api.attributes.DocsType;
 import org.gradle.api.attributes.LibraryElements;
 import org.gradle.api.attributes.Usage;
-import org.gradle.api.attributes.CompileView;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.AttributeMergingException;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
@@ -87,11 +86,10 @@ public class DefaultMavenImmutableAttributesFactory implements MavenImmutableAtt
 
     @Override
     public ImmutableAttributes compileScope(ImmutableAttributes original) {
-        List<Object> key = ImmutableList.of(original, Usage.JAVA_API, CompileView.JAVA_INTERNAL);
+        List<Object> key = ImmutableList.of(original, Usage.JAVA_API);
         return concatCache.computeIfAbsent(key, k -> {
             ImmutableAttributes result = original;
             result = concat(result, USAGE_ATTRIBUTE, new CoercingStringValueSnapshot(Usage.JAVA_API, objectInstantiator));
-            result = concat(result, COMPILE_VIEW_ATTRIBUTE, new CoercingStringValueSnapshot(CompileView.JAVA_INTERNAL, objectInstantiator));
             result = concat(result, FORMAT_ATTRIBUTE, new CoercingStringValueSnapshot(LibraryElements.JAR, objectInstantiator));
             result = concat(result, CATEGORY_ATTRIBUTE, new CoercingStringValueSnapshot(Category.LIBRARY, objectInstantiator));
             return result;

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -1806,16 +1806,16 @@ project :impl
         outputContains """
 org:leaf4:1.0
   Variant compile:
-    | Attribute Name                 | Provided      | Requested    |
-    |--------------------------------|---------------|--------------|
-    | org.gradle.status              | release       |              |
-    | org.gradle.category            | library       | library      |
-    | org.gradle.compile-view        | java-internal | java-api     |
-    | org.gradle.libraryelements     | jar           | classes      |
-    | org.gradle.usage               | java-api      | java-api     |
-    | org.gradle.dependency.bundling |               | external     |
-    | org.gradle.jvm.environment     |               | standard-jvm |
-    | org.gradle.jvm.version         |               | ${jvmVersion.padRight("standard-jvm".length())} |
+    | Attribute Name                 | Provided | Requested    |
+    |--------------------------------|----------|--------------|
+    | org.gradle.status              | release  |              |
+    | org.gradle.category            | library  | library      |
+    | org.gradle.libraryelements     | jar      | classes      |
+    | org.gradle.usage               | java-api | java-api     |
+    | org.gradle.compile-view        |          | java-api     |
+    | org.gradle.dependency.bundling |          | external     |
+    | org.gradle.jvm.environment     |          | standard-jvm |
+    | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
 
 org:leaf4:1.0
 \\--- project :impl
@@ -1846,16 +1846,16 @@ org:leaf4:1.0
         outputContains """
 org:leaf1:1.0
   Variant compile:
-    | Attribute Name                 | Provided      | Requested    |
-    |--------------------------------|---------------|--------------|
-    | org.gradle.status              | release       |              |
-    | org.gradle.category            | library       | library      |
-    | org.gradle.compile-view        | java-internal | java-api     |
-    | org.gradle.libraryelements     | jar           | classes      |
-    | org.gradle.usage               | java-api      | java-api     |
-    | org.gradle.dependency.bundling |               | external     |
-    | org.gradle.jvm.environment     |               | standard-jvm |
-    | org.gradle.jvm.version         |               | ${jvmVersion.padRight("standard-jvm".length())} |
+    | Attribute Name                 | Provided | Requested    |
+    |--------------------------------|----------|--------------|
+    | org.gradle.status              | release  |              |
+    | org.gradle.category            | library  | library      |
+    | org.gradle.libraryelements     | jar      | classes      |
+    | org.gradle.usage               | java-api | java-api     |
+    | org.gradle.compile-view        |          | java-api     |
+    | org.gradle.dependency.bundling |          | external     |
+    | org.gradle.jvm.environment     |          | standard-jvm |
+    | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
 
 org:leaf1:1.0
 \\--- compileClasspath
@@ -1868,16 +1868,16 @@ org:leaf1:1.0
         outputContains """
 org:leaf2:1.0
   Variant compile:
-    | Attribute Name                 | Provided      | Requested    |
-    |--------------------------------|---------------|--------------|
-    | org.gradle.status              | release       |              |
-    | org.gradle.category            | library       | library      |
-    | org.gradle.compile-view        | java-internal | java-api     |
-    | org.gradle.libraryelements     | jar           | classes      |
-    | org.gradle.usage               | java-api      | java-api     |
-    | org.gradle.dependency.bundling |               | external     |
-    | org.gradle.jvm.environment     |               | standard-jvm |
-    | org.gradle.jvm.version         |               | ${jvmVersion.padRight("standard-jvm".length())} |
+    | Attribute Name                 | Provided | Requested    |
+    |--------------------------------|----------|--------------|
+    | org.gradle.status              | release  |              |
+    | org.gradle.category            | library  | library      |
+    | org.gradle.libraryelements     | jar      | classes      |
+    | org.gradle.usage               | java-api | java-api     |
+    | org.gradle.compile-view        |          | java-api     |
+    | org.gradle.dependency.bundling |          | external     |
+    | org.gradle.jvm.environment     |          | standard-jvm |
+    | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
 
 org:leaf2:1.0
 \\--- compileClasspath
@@ -2029,16 +2029,16 @@ project :some:deeply:nested
         outputContains """
 org:leaf3:1.0
   Variant compile:
-    | Attribute Name                 | Provided      | Requested    |
-    |--------------------------------|---------------|--------------|
-    | org.gradle.status              | release       |              |
-    | org.gradle.category            | library       | library      |
-    | org.gradle.compile-view        | java-internal | java-api     |
-    | org.gradle.libraryelements     | jar           | classes      |
-    | org.gradle.usage               | java-api      | java-api     |
-    | org.gradle.dependency.bundling |               | external     |
-    | org.gradle.jvm.environment     |               | standard-jvm |
-    | org.gradle.jvm.version         |               | ${jvmVersion.padRight("standard-jvm".length())} |
+    | Attribute Name                 | Provided | Requested    |
+    |--------------------------------|----------|--------------|
+    | org.gradle.status              | release  |              |
+    | org.gradle.category            | library  | library      |
+    | org.gradle.libraryelements     | jar      | classes      |
+    | org.gradle.usage               | java-api | java-api     |
+    | org.gradle.compile-view        |          | java-api     |
+    | org.gradle.dependency.bundling |          | external     |
+    | org.gradle.jvm.environment     |          | standard-jvm |
+    | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
 
 org:leaf3:1.0
 \\--- org:leaf2:1.0
@@ -2141,16 +2141,16 @@ foo:foo:1.0
         then:
         outputContains """org:foo:$selected
   Variant compile:
-    | Attribute Name                 | Provided      | Requested    |
-    |--------------------------------|---------------|--------------|
-    | org.gradle.status              | release       |              |
-    | org.gradle.category            | library       | library      |
-    | org.gradle.compile-view        | java-internal | java-api     |
-    | org.gradle.libraryelements     | jar           | classes      |
-    | org.gradle.usage               | java-api      | java-api     |
-    | org.gradle.dependency.bundling |               | external     |
-    | org.gradle.jvm.environment     |               | standard-jvm |
-    | org.gradle.jvm.version         |               | ${jvmVersion.padRight("standard-jvm".length())} |
+    | Attribute Name                 | Provided | Requested    |
+    |--------------------------------|----------|--------------|
+    | org.gradle.status              | release  |              |
+    | org.gradle.category            | library  | library      |
+    | org.gradle.libraryelements     | jar      | classes      |
+    | org.gradle.usage               | java-api | java-api     |
+    | org.gradle.compile-view        |          | java-api     |
+    | org.gradle.dependency.bundling |          | external     |
+    | org.gradle.jvm.environment     |          | standard-jvm |
+    | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
    Selection reasons:
       - By constraint: $rejected
 
@@ -2198,16 +2198,16 @@ org:foo -> $selected
         then:
         outputContains """org:foo:$selected
   Variant compile:
-    | Attribute Name                 | Provided      | Requested    |
-    |--------------------------------|---------------|--------------|
-    | org.gradle.status              | release       |              |
-    | org.gradle.category            | library       | library      |
-    | org.gradle.compile-view        | java-internal | java-api     |
-    | org.gradle.libraryelements     | jar           | classes      |
-    | org.gradle.usage               | java-api      | java-api     |
-    | org.gradle.dependency.bundling |               | external     |
-    | org.gradle.jvm.environment     |               | standard-jvm |
-    | org.gradle.jvm.version         |               | ${jvmVersion.padRight("standard-jvm".length())} |
+    | Attribute Name                 | Provided | Requested    |
+    |--------------------------------|----------|--------------|
+    | org.gradle.status              | release  |              |
+    | org.gradle.category            | library  | library      |
+    | org.gradle.libraryelements     | jar      | classes      |
+    | org.gradle.usage               | java-api | java-api     |
+    | org.gradle.compile-view        |          | java-api     |
+    | org.gradle.dependency.bundling |          | external     |
+    | org.gradle.jvm.environment     |          | standard-jvm |
+    | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
    Selection reasons:
       - By constraint: ${rejected}${reason}
 
@@ -2252,16 +2252,16 @@ org:foo -> $selected
         then:
         outputContains """org:foo:$selected
   Variant compile:
-    | Attribute Name                 | Provided      | Requested    |
-    |--------------------------------|---------------|--------------|
-    | org.gradle.status              | release       |              |
-    | org.gradle.category            | library       | library      |
-    | org.gradle.compile-view        | java-internal | java-api     |
-    | org.gradle.libraryelements     | jar           | classes      |
-    | org.gradle.usage               | java-api      | java-api     |
-    | org.gradle.dependency.bundling |               | external     |
-    | org.gradle.jvm.environment     |               | standard-jvm |
-    | org.gradle.jvm.version         |               | ${jvmVersion.padRight("standard-jvm".length())} |
+    | Attribute Name                 | Provided | Requested    |
+    |--------------------------------|----------|--------------|
+    | org.gradle.status              | release  |              |
+    | org.gradle.category            | library  | library      |
+    | org.gradle.libraryelements     | jar      | classes      |
+    | org.gradle.usage               | java-api | java-api     |
+    | org.gradle.compile-view        |          | java-api     |
+    | org.gradle.dependency.bundling |          | external     |
+    | org.gradle.jvm.environment     |          | standard-jvm |
+    | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
    Selection reasons:
       - Was requested: ${rejected}${reason}
 
@@ -2304,16 +2304,16 @@ org:foo:${displayVersion} -> $selected
         then:
         outputContains """org:foo:1.3
   Variant compile:
-    | Attribute Name                 | Provided      | Requested    |
-    |--------------------------------|---------------|--------------|
-    | org.gradle.status              | release       |              |
-    | org.gradle.category            | library       | library      |
-    | org.gradle.compile-view        | java-internal | java-api     |
-    | org.gradle.libraryelements     | jar           | classes      |
-    | org.gradle.usage               | java-api      | java-api     |
-    | org.gradle.dependency.bundling |               | external     |
-    | org.gradle.jvm.environment     |               | standard-jvm |
-    | org.gradle.jvm.version         |               | ${jvmVersion.padRight("standard-jvm".length())} |
+    | Attribute Name                 | Provided | Requested    |
+    |--------------------------------|----------|--------------|
+    | org.gradle.status              | release  |              |
+    | org.gradle.category            | library  | library      |
+    | org.gradle.libraryelements     | jar      | classes      |
+    | org.gradle.usage               | java-api | java-api     |
+    | org.gradle.compile-view        |          | java-api     |
+    | org.gradle.dependency.bundling |          | external     |
+    | org.gradle.jvm.environment     |          | standard-jvm |
+    | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
    Selection reasons:
       - Was requested: didn't match versions 2.0, 1.5, 1.4
 
@@ -2362,16 +2362,16 @@ org:foo:[1.1,1.3] -> 1.3
         then:
         outputContains """org:bar:1.0
   Variant compile:
-    | Attribute Name                 | Provided      | Requested    |
-    |--------------------------------|---------------|--------------|
-    | org.gradle.status              | release       |              |
-    | org.gradle.category            | library       | library      |
-    | org.gradle.compile-view        | java-internal | java-api     |
-    | org.gradle.libraryelements     | jar           | classes      |
-    | org.gradle.usage               | java-api      | java-api     |
-    | org.gradle.dependency.bundling |               | external     |
-    | org.gradle.jvm.environment     |               | standard-jvm |
-    | org.gradle.jvm.version         |               | ${jvmVersion.padRight("standard-jvm".length())} |
+    | Attribute Name                 | Provided | Requested    |
+    |--------------------------------|----------|--------------|
+    | org.gradle.status              | release  |              |
+    | org.gradle.category            | library  | library      |
+    | org.gradle.libraryelements     | jar      | classes      |
+    | org.gradle.usage               | java-api | java-api     |
+    | org.gradle.compile-view        |          | java-api     |
+    | org.gradle.dependency.bundling |          | external     |
+    | org.gradle.jvm.environment     |          | standard-jvm |
+    | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
    Selection reasons:
       - Was requested: rejected versions 1.2, 1.1
 
@@ -2380,16 +2380,16 @@ org:bar:{require [1.0,); reject [1.1, 1.2]} -> 1.0
 
 org:foo:1.1
   Variant compile:
-    | Attribute Name                 | Provided      | Requested    |
-    |--------------------------------|---------------|--------------|
-    | org.gradle.status              | release       |              |
-    | org.gradle.category            | library       | library      |
-    | org.gradle.compile-view        | java-internal | java-api     |
-    | org.gradle.libraryelements     | jar           | classes      |
-    | org.gradle.usage               | java-api      | java-api     |
-    | org.gradle.dependency.bundling |               | external     |
-    | org.gradle.jvm.environment     |               | standard-jvm |
-    | org.gradle.jvm.version         |               | ${jvmVersion.padRight("standard-jvm".length())} |
+    | Attribute Name                 | Provided | Requested    |
+    |--------------------------------|----------|--------------|
+    | org.gradle.status              | release  |              |
+    | org.gradle.category            | library  | library      |
+    | org.gradle.libraryelements     | jar      | classes      |
+    | org.gradle.usage               | java-api | java-api     |
+    | org.gradle.compile-view        |          | java-api     |
+    | org.gradle.dependency.bundling |          | external     |
+    | org.gradle.jvm.environment     |          | standard-jvm |
+    | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
    Selection reasons:
       - Was requested: rejected version 1.2
 
@@ -2442,16 +2442,16 @@ org:foo:{require [1.0,); reject 1.2} -> 1.1
         outputContains """Task :dependencyInsight
 org:bar:1.0
   Variant compile:
-    | Attribute Name                 | Provided      | Requested    |
-    |--------------------------------|---------------|--------------|
-    | org.gradle.status              | release       |              |
-    | org.gradle.category            | library       | library      |
-    | org.gradle.compile-view        | java-internal | java-api     |
-    | org.gradle.libraryelements     | jar           | classes      |
-    | org.gradle.usage               | java-api      | java-api     |
-    | org.gradle.dependency.bundling |               | external     |
-    | org.gradle.jvm.environment     |               | standard-jvm |
-    | org.gradle.jvm.version         |               | ${jvmVersion.padRight("standard-jvm".length())} |
+    | Attribute Name                 | Provided | Requested    |
+    |--------------------------------|----------|--------------|
+    | org.gradle.status              | release  |              |
+    | org.gradle.category            | library  | library      |
+    | org.gradle.libraryelements     | jar      | classes      |
+    | org.gradle.usage               | java-api | java-api     |
+    | org.gradle.compile-view        |          | java-api     |
+    | org.gradle.dependency.bundling |          | external     |
+    | org.gradle.jvm.environment     |          | standard-jvm |
+    | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
    Selection reasons:
       - Rejection: 1.2 by rule because version 1.2 is bad
       - Rejection: 1.1 by rule because version 1.1 is bad
@@ -2461,16 +2461,16 @@ org:bar:[1.0,) -> 1.0
 
 org:foo:1.1
   Variant compile:
-    | Attribute Name                 | Provided      | Requested    |
-    |--------------------------------|---------------|--------------|
-    | org.gradle.status              | release       |              |
-    | org.gradle.category            | library       | library      |
-    | org.gradle.compile-view        | java-internal | java-api     |
-    | org.gradle.libraryelements     | jar           | classes      |
-    | org.gradle.usage               | java-api      | java-api     |
-    | org.gradle.dependency.bundling |               | external     |
-    | org.gradle.jvm.environment     |               | standard-jvm |
-    | org.gradle.jvm.version         |               | ${jvmVersion.padRight("standard-jvm".length())} |
+    | Attribute Name                 | Provided | Requested    |
+    |--------------------------------|----------|--------------|
+    | org.gradle.status              | release  |              |
+    | org.gradle.category            | library  | library      |
+    | org.gradle.libraryelements     | jar      | classes      |
+    | org.gradle.usage               | java-api | java-api     |
+    | org.gradle.compile-view        |          | java-api     |
+    | org.gradle.dependency.bundling |          | external     |
+    | org.gradle.jvm.environment     |          | standard-jvm |
+    | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
    Selection reasons:
       - Was requested: rejected version 1.2
 
@@ -2507,16 +2507,16 @@ org:foo:{require [1.0,); reject 1.2} -> 1.1
         outputContains """
 org:leaf:1.0 (by constraint)
   Variant compile:
-    | Attribute Name                 | Provided      | Requested    |
-    |--------------------------------|---------------|--------------|
-    | org.gradle.status              | release       |              |
-    | org.gradle.category            | library       | library      |
-    | org.gradle.compile-view        | java-internal | java-api     |
-    | org.gradle.libraryelements     | jar           | classes      |
-    | org.gradle.usage               | java-api      | java-api     |
-    | org.gradle.dependency.bundling |               | external     |
-    | org.gradle.jvm.environment     |               | standard-jvm |
-    | org.gradle.jvm.version         |               | ${jvmVersion.padRight("standard-jvm".length())} |
+    | Attribute Name                 | Provided | Requested    |
+    |--------------------------------|----------|--------------|
+    | org.gradle.status              | release  |              |
+    | org.gradle.category            | library  | library      |
+    | org.gradle.libraryelements     | jar      | classes      |
+    | org.gradle.usage               | java-api | java-api     |
+    | org.gradle.compile-view        |          | java-api     |
+    | org.gradle.dependency.bundling |          | external     |
+    | org.gradle.jvm.environment     |          | standard-jvm |
+    | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
 
 org:leaf:1.0
 \\--- org:bom:1.0
@@ -2561,16 +2561,16 @@ org:leaf -> 1.0
         outputContains """
 org.test:leaf:1.0
   Variant compile:
-    | Attribute Name                 | Provided      | Requested    |
-    |--------------------------------|---------------|--------------|
-    | org.gradle.status              | release       |              |
-    | org.gradle.category            | library       | library      |
-    | org.gradle.compile-view        | java-internal | java-api     |
-    | org.gradle.libraryelements     | jar           | classes      |
-    | org.gradle.usage               | java-api      | java-api     |
-    | org.gradle.dependency.bundling |               | external     |
-    | org.gradle.jvm.environment     |               | standard-jvm |
-    | org.gradle.jvm.version         |               | ${jvmVersion.padRight("standard-jvm".length())} |
+    | Attribute Name                 | Provided | Requested    |
+    |--------------------------------|----------|--------------|
+    | org.gradle.status              | release  |              |
+    | org.gradle.category            | library  | library      |
+    | org.gradle.libraryelements     | jar      | classes      |
+    | org.gradle.usage               | java-api | java-api     |
+    | org.gradle.compile-view        |          | java-api     |
+    | org.gradle.dependency.bundling |          | external     |
+    | org.gradle.jvm.environment     |          | standard-jvm |
+    | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
    Selection reasons:
       - Was requested: first reason
 
@@ -2748,16 +2748,16 @@ org:foo:[1.0,) FAILED
         outputContains """
 org:foo:1.0
   Variant compile:
-    | Attribute Name                 | Provided      | Requested    |
-    |--------------------------------|---------------|--------------|
-    | org.gradle.status              | release       |              |
-    | org.gradle.category            | library       | library      |
-    | org.gradle.compile-view        | java-internal | java-api     |
-    | org.gradle.libraryelements     | jar           | classes      |
-    | org.gradle.usage               | java-api      | java-api     |
-    | org.gradle.dependency.bundling |               | external     |
-    | org.gradle.jvm.environment     |               | standard-jvm |
-    | org.gradle.jvm.version         |               | ${jvmVersion.padRight("standard-jvm".length())} |
+    | Attribute Name                 | Provided | Requested    |
+    |--------------------------------|----------|--------------|
+    | org.gradle.status              | release  |              |
+    | org.gradle.category            | library  | library      |
+    | org.gradle.libraryelements     | jar      | classes      |
+    | org.gradle.usage               | java-api | java-api     |
+    | org.gradle.compile-view        |          | java-api     |
+    | org.gradle.dependency.bundling |          | external     |
+    | org.gradle.jvm.environment     |          | standard-jvm |
+    | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
    Selection reasons:
       - By constraint
       - Was requested: rejected versions 1.2, 1.1
@@ -2805,16 +2805,16 @@ org:foo:{require [1.0,); reject 1.1} -> 1.0
         then:
         outputContains """org.test:leaf:1.0
   Variant compile:
-    | Attribute Name                 | Provided      | Requested    |
-    |--------------------------------|---------------|--------------|
-    | org.gradle.status              | release       |              |
-    | org.gradle.category            | library       | library      |
-    | org.gradle.compile-view        | java-internal | java-api     |
-    | org.gradle.libraryelements     | jar           | classes      |
-    | org.gradle.usage               | java-api      | java-api     |
-    | org.gradle.dependency.bundling |               | external     |
-    | org.gradle.jvm.environment     |               | standard-jvm |
-    | org.gradle.jvm.version         |               | ${jvmVersion.padRight("standard-jvm".length())} |
+    | Attribute Name                 | Provided | Requested    |
+    |--------------------------------|----------|--------------|
+    | org.gradle.status              | release  |              |
+    | org.gradle.category            | library  | library      |
+    | org.gradle.libraryelements     | jar      | classes      |
+    | org.gradle.usage               | java-api | java-api     |
+    | org.gradle.compile-view        |          | java-api     |
+    | org.gradle.dependency.bundling |          | external     |
+    | org.gradle.jvm.environment     |          | standard-jvm |
+    | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
    Selection reasons:
       - Was requested: first reason
       - Was requested: transitive reason
@@ -2871,17 +2871,17 @@ org.test:leaf:1.0
         outputContains """Task :dependencyInsight
 org:foo:1.0
   Variant compile:
-    | Attribute Name                 | Provided      | Requested    |
-    |--------------------------------|---------------|--------------|
-    | org.gradle.status              | release       |              |
-    | color                          | blue          | blue         |
-    | org.gradle.category            | library       | library      |
-    | org.gradle.compile-view        | java-internal | java-api     |
-    | org.gradle.libraryelements     | jar           | classes      |
-    | org.gradle.usage               | java-api      | java-api     |
-    | org.gradle.dependency.bundling |               | external     |
-    | org.gradle.jvm.environment     |               | standard-jvm |
-    | org.gradle.jvm.version         |               | ${jvmVersion.padRight("standard-jvm".length())} |
+    | Attribute Name                 | Provided | Requested    |
+    |--------------------------------|----------|--------------|
+    | org.gradle.status              | release  |              |
+    | color                          | blue     | blue         |
+    | org.gradle.category            | library  | library      |
+    | org.gradle.libraryelements     | jar      | classes      |
+    | org.gradle.usage               | java-api | java-api     |
+    | org.gradle.compile-view        |          | java-api     |
+    | org.gradle.dependency.bundling |          | external     |
+    | org.gradle.jvm.environment     |          | standard-jvm |
+    | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
    Selection reasons:
       - Rejection: version 1.2:
           - Attribute 'color' didn't match. Requested 'blue', was: 'red'
@@ -2957,16 +2957,16 @@ org:foo:[1.0,) -> 1.0
         outputContains """> Task :dependencyInsight
 planet:mercury:1.0.2
   Variant compile:
-    | Attribute Name                 | Provided      | Requested    |
-    |--------------------------------|---------------|--------------|
-    | org.gradle.status              | release       |              |
-    | org.gradle.category            | library       | library      |
-    | org.gradle.compile-view        | java-internal | java-api     |
-    | org.gradle.libraryelements     | jar           | classes      |
-    | org.gradle.usage               | java-api      | java-api     |
-    | org.gradle.dependency.bundling |               | external     |
-    | org.gradle.jvm.environment     |               | standard-jvm |
-    | org.gradle.jvm.version         |               | ${jvmVersion.padRight("standard-jvm".length())} |
+    | Attribute Name                 | Provided | Requested    |
+    |--------------------------------|----------|--------------|
+    | org.gradle.status              | release  |              |
+    | org.gradle.category            | library  | library      |
+    | org.gradle.libraryelements     | jar      | classes      |
+    | org.gradle.usage               | java-api | java-api     |
+    | org.gradle.compile-view        |          | java-api     |
+    | org.gradle.dependency.bundling |          | external     |
+    | org.gradle.jvm.environment     |          | standard-jvm |
+    | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
    Selection reasons:
       - By conflict resolution: between versions 1.0.2 and 1.0.1
 
@@ -2990,16 +2990,16 @@ planet:mercury:1.0.1 -> 1.0.2
         outputContains """> Task :dependencyInsight
 planet:venus:2.0.1
   Variant compile:
-    | Attribute Name                 | Provided      | Requested    |
-    |--------------------------------|---------------|--------------|
-    | org.gradle.status              | release       |              |
-    | org.gradle.category            | library       | library      |
-    | org.gradle.compile-view        | java-internal | java-api     |
-    | org.gradle.libraryelements     | jar           | classes      |
-    | org.gradle.usage               | java-api      | java-api     |
-    | org.gradle.dependency.bundling |               | external     |
-    | org.gradle.jvm.environment     |               | standard-jvm |
-    | org.gradle.jvm.version         |               | ${jvmVersion.padRight("standard-jvm".length())} |
+    | Attribute Name                 | Provided | Requested    |
+    |--------------------------------|----------|--------------|
+    | org.gradle.status              | release  |              |
+    | org.gradle.category            | library  | library      |
+    | org.gradle.libraryelements     | jar      | classes      |
+    | org.gradle.usage               | java-api | java-api     |
+    | org.gradle.compile-view        |          | java-api     |
+    | org.gradle.dependency.bundling |          | external     |
+    | org.gradle.jvm.environment     |          | standard-jvm |
+    | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
    Selection reasons:
       - By conflict resolution: between versions 2.0.1, 2.0.0 and 1.0
 
@@ -3023,16 +3023,16 @@ planet:venus:2.0.0 -> 2.0.1
         outputContains """> Task :dependencyInsight
 planet:pluto:1.0.0
   Variant compile:
-    | Attribute Name                 | Provided      | Requested    |
-    |--------------------------------|---------------|--------------|
-    | org.gradle.status              | release       |              |
-    | org.gradle.category            | library       | library      |
-    | org.gradle.compile-view        | java-internal | java-api     |
-    | org.gradle.libraryelements     | jar           | classes      |
-    | org.gradle.usage               | java-api      | java-api     |
-    | org.gradle.dependency.bundling |               | external     |
-    | org.gradle.jvm.environment     |               | standard-jvm |
-    | org.gradle.jvm.version         |               | ${jvmVersion.padRight("standard-jvm".length())} |
+    | Attribute Name                 | Provided | Requested    |
+    |--------------------------------|----------|--------------|
+    | org.gradle.status              | release  |              |
+    | org.gradle.category            | library  | library      |
+    | org.gradle.libraryelements     | jar      | classes      |
+    | org.gradle.usage               | java-api | java-api     |
+    | org.gradle.compile-view        |          | java-api     |
+    | org.gradle.dependency.bundling |          | external     |
+    | org.gradle.jvm.environment     |          | standard-jvm |
+    | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
 
 planet:pluto:1.0.0
 \\--- planet:mercury:1.0.2
@@ -3074,16 +3074,16 @@ planet:pluto:1.0.0
         outputContains("""> Task :dependencyInsight
 org:foo:1.5
   Variant compile:
-    | Attribute Name                 | Provided      | Requested    |
-    |--------------------------------|---------------|--------------|
-    | org.gradle.status              | release       |              |
-    | org.gradle.category            | library       | library      |
-    | org.gradle.compile-view        | java-internal | java-api     |
-    | org.gradle.libraryelements     | jar           | classes      |
-    | org.gradle.usage               | java-api      | java-api     |
-    | org.gradle.dependency.bundling |               | external     |
-    | org.gradle.jvm.environment     |               | standard-jvm |
-    | org.gradle.jvm.version         |               | ${jvmVersion.padRight("standard-jvm".length())} |
+    | Attribute Name                 | Provided | Requested    |
+    |--------------------------------|----------|--------------|
+    | org.gradle.status              | release  |              |
+    | org.gradle.category            | library  | library      |
+    | org.gradle.libraryelements     | jar      | classes      |
+    | org.gradle.usage               | java-api | java-api     |
+    | org.gradle.compile-view        |          | java-api     |
+    | org.gradle.dependency.bundling |          | external     |
+    | org.gradle.jvm.environment     |          | standard-jvm |
+    | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
    Selection reasons:
       - By constraint
       - By ancestor

--- a/subprojects/docs/src/snippets/dependencyManagement/inspectingDependencies-dependencyReason/tests/dependencyReasonReport.out
+++ b/subprojects/docs/src/snippets/dependencyManagement/inspectingDependencies-dependencyReason/tests/dependencyReasonReport.out
@@ -1,15 +1,15 @@
 org.ow2.asm:asm:7.1
   Variant compile:
-    | Attribute Name                 | Provided      | Requested    |
-    |--------------------------------|---------------|--------------|
-    | org.gradle.status              | release       |              |
-    | org.gradle.category            | library       | library      |
-    | org.gradle.compile-view        | java-internal | java-api     |
-    | org.gradle.libraryelements     | jar           | classes      |
-    | org.gradle.usage               | java-api      | java-api     |
-    | org.gradle.dependency.bundling |               | external     |
-    | org.gradle.jvm.environment     |               | standard-jvm |
-    | org.gradle.jvm.version         |               | 11           |
+    | Attribute Name                 | Provided | Requested    |
+    |--------------------------------|----------|--------------|
+    | org.gradle.status              | release  |              |
+    | org.gradle.category            | library  | library      |
+    | org.gradle.libraryelements     | jar      | classes      |
+    | org.gradle.usage               | java-api | java-api     |
+    | org.gradle.compile-view        |          | java-api     |
+    | org.gradle.dependency.bundling |          | external     |
+    | org.gradle.jvm.environment     |          | standard-jvm |
+    | org.gradle.jvm.version         |          | 11           |
    Selection reasons:
       - Was requested: we require a JDK 9 compatible bytecode generator
 

--- a/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-declaringCapabilities/tests/dependencyReport.out
+++ b/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-declaringCapabilities/tests/dependencyReport.out
@@ -19,16 +19,16 @@ org.slf4j:log4j-over-slf4j:1.7.10 FAILED
 
 org.slf4j:slf4j-log4j12:1.6.1
   Variant compile:
-    | Attribute Name                 | Provided      | Requested    |
-    |--------------------------------|---------------|--------------|
-    | org.gradle.status              | release       |              |
-    | org.gradle.category            | library       | library      |
-    | org.gradle.compile-view        | java-internal | java-api     |
-    | org.gradle.libraryelements     | jar           | classes      |
-    | org.gradle.usage               | java-api      | java-api     |
-    | org.gradle.dependency.bundling |               | external     |
-    | org.gradle.jvm.environment     |               | standard-jvm |
-    | org.gradle.jvm.version         |               | 11           |
+    | Attribute Name                 | Provided | Requested    |
+    |--------------------------------|----------|--------------|
+    | org.gradle.status              | release  |              |
+    | org.gradle.category            | library  | library      |
+    | org.gradle.libraryelements     | jar      | classes      |
+    | org.gradle.usage               | java-api | java-api     |
+    | org.gradle.compile-view        |          | java-api     |
+    | org.gradle.dependency.bundling |          | external     |
+    | org.gradle.jvm.environment     |          | standard-jvm |
+    | org.gradle.jvm.version         |          | 11           |
 
 org.slf4j:slf4j-log4j12:1.6.1
 \--- org.apache.zookeeper:zookeeper:3.4.9

--- a/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-declaringCapabilities/tests/dependencyReportReplaced.out
+++ b/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-declaringCapabilities/tests/dependencyReportReplaced.out
@@ -1,15 +1,15 @@
 org.slf4j:log4j-over-slf4j:1.7.10
   Variant compile:
-    | Attribute Name                 | Provided      | Requested    |
-    |--------------------------------|---------------|--------------|
-    | org.gradle.status              | release       |              |
-    | org.gradle.category            | library       | library      |
-    | org.gradle.compile-view        | java-internal | java-api     |
-    | org.gradle.libraryelements     | jar           | classes      |
-    | org.gradle.usage               | java-api      | java-api     |
-    | org.gradle.dependency.bundling |               | external     |
-    | org.gradle.jvm.environment     |               | standard-jvm |
-    | org.gradle.jvm.version         |               | 11           |
+    | Attribute Name                 | Provided | Requested    |
+    |--------------------------------|----------|--------------|
+    | org.gradle.status              | release  |              |
+    | org.gradle.category            | library  | library      |
+    | org.gradle.libraryelements     | jar      | classes      |
+    | org.gradle.usage               | java-api | java-api     |
+    | org.gradle.compile-view        |          | java-api     |
+    | org.gradle.dependency.bundling |          | external     |
+    | org.gradle.jvm.environment     |          | standard-jvm |
+    | org.gradle.jvm.version         |          | 11           |
    Selection reasons:
       - By conflict resolution: On capability log4j:log4j use slf4j in place of log4j
 
@@ -22,16 +22,16 @@ org.slf4j:log4j-over-slf4j:1.7.10
 
 org.slf4j:slf4j-log4j12:1.6.1
   Variant compile:
-    | Attribute Name                 | Provided      | Requested    |
-    |--------------------------------|---------------|--------------|
-    | org.gradle.status              | release       |              |
-    | org.gradle.category            | library       | library      |
-    | org.gradle.compile-view        | java-internal | java-api     |
-    | org.gradle.libraryelements     | jar           | classes      |
-    | org.gradle.usage               | java-api      | java-api     |
-    | org.gradle.dependency.bundling |               | external     |
-    | org.gradle.jvm.environment     |               | standard-jvm |
-    | org.gradle.jvm.version         |               | 11           |
+    | Attribute Name                 | Provided | Requested    |
+    |--------------------------------|----------|--------------|
+    | org.gradle.status              | release  |              |
+    | org.gradle.category            | library  | library      |
+    | org.gradle.libraryelements     | jar      | classes      |
+    | org.gradle.usage               | java-api | java-api     |
+    | org.gradle.compile-view        |          | java-api     |
+    | org.gradle.dependency.bundling |          | external     |
+    | org.gradle.jvm.environment     |          | standard-jvm |
+    | org.gradle.jvm.version         |          | 11           |
 
 org.slf4j:slf4j-log4j12:1.6.1
 \--- org.apache.zookeeper:zookeeper:3.4.9

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
@@ -20,7 +20,6 @@ import org.gradle.api.Action
 import org.gradle.api.attributes.Category
 import org.gradle.api.attributes.LibraryElements
 import org.gradle.api.attributes.Usage
-import org.gradle.api.attributes.CompileView
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.hash.Hashing
@@ -54,7 +53,7 @@ class IvyFileModule extends AbstractModule implements IvyModule {
     final Map extraInfo = [:]
     final List<Map<String, ?>> configurationExcludes = []
 
-    private final List<VariantMetadataSpec> variants = [new VariantMetadataSpec("api", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_API, (CompileView.VIEW_ATTRIBUTE.name): CompileView.JAVA_INTERNAL, (LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE.name): LibraryElements.JAR, (Category.CATEGORY_ATTRIBUTE.name): Category.LIBRARY]),
+    private final List<VariantMetadataSpec> variants = [new VariantMetadataSpec("api", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_API, (LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE.name): LibraryElements.JAR, (Category.CATEGORY_ATTRIBUTE.name): Category.LIBRARY]),
                                                         new VariantMetadataSpec("runtime", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_RUNTIME, (LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE.name): LibraryElements.JAR, (Category.CATEGORY_ATTRIBUTE.name): Category.LIBRARY])]
     String branch = null
     String status = "integration"

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
@@ -21,7 +21,6 @@ import groovy.xml.XmlParser
 import org.gradle.api.attributes.Category
 import org.gradle.api.attributes.LibraryElements
 import org.gradle.api.attributes.Usage
-import org.gradle.api.attributes.CompileView
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.hash.Hashing
@@ -53,7 +52,7 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
     int publishCount = 1
     private boolean hasPom = true
     private boolean gradleMetadataRedirect = false
-    private final List<VariantMetadataSpec> variants = [new VariantMetadataSpec("api", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_API, (CompileView.VIEW_ATTRIBUTE.name): CompileView.JAVA_INTERNAL, (LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE.name): LibraryElements.JAR, (Category.CATEGORY_ATTRIBUTE.name): Category.LIBRARY]),
+    private final List<VariantMetadataSpec> variants = [new VariantMetadataSpec("api", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_API, (LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE.name): LibraryElements.JAR, (Category.CATEGORY_ATTRIBUTE.name): Category.LIBRARY]),
                                                         new VariantMetadataSpec("runtime", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_RUNTIME, (LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE.name): LibraryElements.JAR, (Category.CATEGORY_ATTRIBUTE.name): Category.LIBRARY])]
     private final List dependencies = []
     private Map<String, ?> mainArtifact = [:]

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaApplicationOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaApplicationOutgoingVariantsIntegrationTest.groovy
@@ -156,9 +156,9 @@ project(':consumer') {
             files: [java.jar, file-dep.jar, compile-only-1.0.jar, other-java.jar, implementation-1.0.jar]
             java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.compile-view=java-internal, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-api}
             file-dep.jar {artifactType=jar, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
-            compile-only-1.0.jar (test:compile-only:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.compile-view=java-internal, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-api}
+            compile-only-1.0.jar (test:compile-only:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-api}
             other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.compile-view=java-internal, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-api}
-            implementation-1.0.jar (test:implementation:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.compile-view=java-internal, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-api}
+            implementation-1.0.jar (test:implementation:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-api}
         """)
 
         where:

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryCrossProjectTargetJvmVersionIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryCrossProjectTargetJvmVersionIntegrationTest.groovy
@@ -61,8 +61,8 @@ class JavaLibraryCrossProjectTargetJvmVersionIntegrationTest extends AbstractInt
       - Incompatible because this component declares a component, compatible with Java 7 and the consumer needed a component, compatible with Java 6
       - Other compatible attribute:
           - Doesn't say anything about its target Java environment (preferred optimized for standard JVMs)
-  - Variant 'compileElements' capability test:producer:unspecified declares the internal view of a library for use during compile-time, packaged as a jar, and its dependencies declared externally:
-      - Incompatible because this component declares a component, compatible with Java 7 and the consumer needed a component, compatible with Java 6
+  - Variant 'compileElements' capability test:producer:unspecified declares a library for use during compile-time, packaged as a jar, and its dependencies declared externally:
+      - Incompatible because this component declares the internal view of a component, compatible with Java 7 and the consumer needed the API view of a component, compatible with Java 6
       - Other compatible attribute:
           - Doesn't say anything about its target Java environment (preferred optimized for standard JVMs)
   - Variant 'mainSourceElements' capability test:producer:unspecified declares a component, and its dependencies declared externally:
@@ -171,8 +171,8 @@ class JavaLibraryCrossProjectTargetJvmVersionIntegrationTest extends AbstractInt
       - Incompatible because this component declares a component, compatible with Java 7 and the consumer needed a component, compatible with Java 6
       - Other compatible attribute:
           - Doesn't say anything about its target Java environment (preferred optimized for standard JVMs)
-  - Variant 'compileElements' capability test:producer:unspecified declares the internal view of a library for use during compile-time, packaged as a jar, and its dependencies declared externally:
-      - Incompatible because this component declares a component, compatible with Java 7 and the consumer needed a component, compatible with Java 6
+  - Variant 'compileElements' capability test:producer:unspecified declares a library for use during compile-time, packaged as a jar, and its dependencies declared externally:
+      - Incompatible because this component declares the internal view of a component, compatible with Java 7 and the consumer needed the API view of a component, compatible with Java 6
       - Other compatible attribute:
           - Doesn't say anything about its target Java environment (preferred optimized for standard JVMs)
   - Variant 'mainSourceElements' capability test:producer:unspecified declares a component, and its dependencies declared externally:

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryOutgoingVariantsIntegrationTest.groovy
@@ -135,8 +135,8 @@ project(':consumer') {
         assertResolveOutput("""
             files: [main, api-1.0.jar, compile-only-api-1.0.jar]
             main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.compile-view=java-api, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=classes, org.gradle.usage=java-api}
-            api-1.0.jar (test:api:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.compile-view=java-internal, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-api}
-            compile-only-api-1.0.jar (test:compile-only-api:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.compile-view=java-internal, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-api}
+            api-1.0.jar (test:api:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-api}
+            compile-only-api-1.0.jar (test:compile-only-api:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-api}
         """)
 
         where:
@@ -164,11 +164,11 @@ project(':consumer') {
             files: [java.jar, file-dep.jar, api-1.0.jar, compile-only-1.0.jar, compile-only-api-1.0.jar, other-java.jar, implementation-1.0.jar]
             java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.compile-view=java-internal, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-api}
             file-dep.jar {artifactType=jar, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
-            api-1.0.jar (test:api:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.compile-view=java-internal, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-api}
-            compile-only-1.0.jar (test:compile-only:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.compile-view=java-internal, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-api}
-            compile-only-api-1.0.jar (test:compile-only-api:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.compile-view=java-internal, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-api}
+            api-1.0.jar (test:api:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-api}
+            compile-only-1.0.jar (test:compile-only:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-api}
+            compile-only-api-1.0.jar (test:compile-only-api:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-api}
             other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.compile-view=java-internal, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-api}
-            implementation-1.0.jar (test:implementation:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.compile-view=java-internal, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-api}
+            implementation-1.0.jar (test:implementation:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-api}
         """)
 
         where:

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaProjectOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaProjectOutgoingVariantsIntegrationTest.groovy
@@ -205,9 +205,9 @@ project(':consumer') {
             files: [java.jar, file-dep.jar, compile-only-1.0.jar, other-java.jar, implementation-1.0.jar]
             java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.compile-view=java-internal, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-api}
             file-dep.jar {artifactType=jar, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}
-            compile-only-1.0.jar (test:compile-only:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.compile-view=java-internal, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-api}
+            compile-only-1.0.jar (test:compile-only:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-api}
             other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.compile-view=java-internal, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-api}
-            implementation-1.0.jar (test:implementation:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.compile-view=java-internal, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-api}
+            implementation-1.0.jar (test:implementation:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-api}
         """)
 
         where:

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/fixtures/AbstractJavaTestFixturesIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/fixtures/AbstractJavaTestFixturesIntegrationTest.groovy
@@ -401,7 +401,7 @@ hamcrest-core-1.3.jar
                     ])
                     firstLevelConfigurations = ['testFixturesApiElements']
                     module('com.acme:external-module:1.3') {
-                        variant("api", ['org.gradle.status': 'release', 'org.gradle.usage': 'java-api', 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', 'org.gradle.compile-view': 'java-internal'])
+                        variant("api", ['org.gradle.status': 'release', 'org.gradle.usage': 'java-api', 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library'])
                         artifact(name: 'external-module')
                     }
                     artifact(name: 'external-module', classifier: 'test-fixtures')

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
@@ -236,9 +236,9 @@ class KotlinPluginSmokeTest extends AbstractPluginValidatingSmokeTest implements
             }
 
             task resolve {
-                dependsOn configurations.compileClasspath
+                def files = configurations.compileClasspath
                 doLast {
-                    println("Files: " + configurations.compileClasspath.files)
+                    println("Files: " + files.files)
                 }
             }
         """

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
@@ -221,6 +221,61 @@ class KotlinPluginSmokeTest extends AbstractPluginValidatingSmokeTest implements
         kotlinVersion << TestedVersions.kotlin.versions
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/22952")
+    def "kotlin project can consume kotlin multiplatform java project"() {
+        given:
+        buildFile << """
+            plugins {
+                id 'org.jetbrains.kotlin.jvm' version '$kotlinVersion'
+            }
+
+            ${mavenCentralRepository()}
+
+            dependencies {
+                implementation project(":other")
+            }
+
+            task resolve {
+                dependsOn configurations.compileClasspath
+                doLast {
+                    println("Files: " + configurations.compileClasspath.files)
+                }
+            }
+        """
+
+        settingsFile << "include 'other'"
+        file("other/build.gradle") << """
+            plugins {
+                id 'org.jetbrains.kotlin.multiplatform'
+            }
+
+            ${mavenCentralRepository()}
+
+            kotlin {
+                jvm {
+                    withJava()
+                }
+            }
+        """
+
+        when:
+        def versionNumber = VersionNumber.parse(kotlinVersion)
+        def testRunner = runner(false, versionNumber, ':resolve', '--stacktrace')
+
+        if (versionNumber < VersionNumber.parse('1.7.22')) {
+            testRunner.expectDeprecationWarning("The AbstractCompile.destinationDir property has been deprecated. This is scheduled to be removed in Gradle 9.0. Please use the destinationDirectory property instead. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_7.html#compile_task_wiring", '')
+        }
+
+        def result = testRunner.build()
+
+        then:
+        result.output.contains("other-jvm.jar")
+
+        where:
+        // withJava is incompatible pre 1.6.20 since it attempts to set the `archiveName` convention property on the Jar task.
+        kotlinVersion << TestedVersions.kotlin.versions.findAll { VersionNumber.parse(it) > VersionNumber.parse("1.6.10")}
+    }
+
     private SmokeTestGradleRunner runner(boolean workers, VersionNumber kotlinVersion, String... tasks) {
         return runnerFor(this, workers, kotlinVersion, tasks)
     }


### PR DESCRIPTION
Due to some weirdness with the kotlin multiplatform plugins, there is ambiguity between compileElements and
one of the multiplatform-created variants. The only way to avoid this ambiguity is to disable the
CompileView attribute schema compatibility rule.

This rule is required to allow us to select the derived maven api variant which declared the java-internal
compile view, while we are requesting the java-api compile view. To allow us to continue selecting this variant,
without the compatibility rule, we need to remove the attribute from the derived variant.


Fixes https://github.com/gradle/gradle/issues/22952