### PR TITLE
Make tasks cacheable: Assemble, LinkExecutable, CreateStaticLibrary

### DIFF
--- a/subprojects/language-native/src/main/java/org/gradle/language/assembler/tasks/Assemble.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/assembler/tasks/Assemble.java
@@ -20,6 +20,7 @@ import org.gradle.api.Incubating;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.IgnoreEmptyDirectories;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
@@ -43,7 +44,6 @@ import org.gradle.nativeplatform.platform.internal.NativePlatformInternal;
 import org.gradle.nativeplatform.toolchain.NativeToolChain;
 import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
 import org.gradle.nativeplatform.toolchain.internal.compilespec.AssembleSpec;
-import org.gradle.work.DisableCachingByDefault;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -54,7 +54,7 @@ import java.util.concurrent.Callable;
  * Translates Assembly language source files into object files.
  */
 @Incubating
-@DisableCachingByDefault(because = "Not made cacheable, yet")
+@CacheableTask
 public abstract class Assemble extends DefaultTask {
     private ConfigurableFileCollection source;
     private ConfigurableFileCollection includes;

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/CreateStaticLibrary.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/CreateStaticLibrary.java
@@ -22,6 +22,7 @@ import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.IgnoreEmptyDirectories;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
@@ -45,14 +46,13 @@ import org.gradle.nativeplatform.platform.internal.NativePlatformInternal;
 import org.gradle.nativeplatform.toolchain.NativeToolChain;
 import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
 import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
-import org.gradle.work.DisableCachingByDefault;
 
 import javax.inject.Inject;
 
 /**
  * Assembles a static library from object files.
  */
-@DisableCachingByDefault(because = "Not made cacheable, yet")
+@CacheableTask
 public abstract class CreateStaticLibrary extends DefaultTask implements ObjectFilesToBinary {
 
     private final ConfigurableFileCollection source;

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/LinkExecutable.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/LinkExecutable.java
@@ -15,14 +15,14 @@
  */
 package org.gradle.nativeplatform.tasks;
 
+import org.gradle.api.tasks.CacheableTask;
 import org.gradle.nativeplatform.internal.DefaultLinkerSpec;
 import org.gradle.nativeplatform.internal.LinkerSpec;
-import org.gradle.work.DisableCachingByDefault;
 
 /**
  * Links a binary executable from object files and libraries.
  */
-@DisableCachingByDefault(because = "Not made cacheable, yet")
+@CacheableTask
 public abstract class LinkExecutable extends AbstractLinkTask {
     @Override
     protected LinkerSpec createLinkerSpec() {


### PR DESCRIPTION
### Context

These tasks (Assemble, LinkExecutable, CreateStaticLibrary) are used when doing native development with Gradle (e.g. compiling/linking `C` code). Right now, they are marked with `@DisableCachingByDefault(because = "Not made cacheable, yet")`. Larger projects however, could benefit a lot from these tasks being cacheable. Right now, we can do this by subclassing the tasks and adding the `@CacheableTask` annotation to the subclass. This seems to work fine for the three tasks. (But is cumbersome if you use one of the native development plugins and do not control which tasks are being registered.)

It's unclear right now why the tasks are not cacheable.  "Not made cacheable, yet" seems to apply that there is something else, more involved, to do than just adding the `@CacheableTask` annotation. If that is the case, it would be great to clarify what that is. (And maybe, whatever it is, can be contributed in this PR or later.)

This PR right now adds the `@CacheableTask` annotation to the tasks. If that is not the right thing to do at the moment, I am happy to replace that with a more informative description of why the tasks are not cacheable. 

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
