### PR TITLE
Lazily Create Decompression Cache

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/WorkerSharedProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/WorkerSharedProjectScopeServices.java
@@ -18,6 +18,7 @@ package org.gradle.internal.service.scopes;
 
 import org.gradle.api.file.ArchiveOperations;
 import org.gradle.api.file.FileSystemOperations;
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.file.DefaultArchiveOperations;
@@ -158,11 +159,12 @@ public class WorkerSharedProjectScopeServices {
     }
 
     protected CacheRepository createCacheRepository(CacheFactory cacheFactory, DefaultProjectLayout projectLayout) {
+        // It looks like this is eagerly evaluating the build dir, but remember this is only the default cache dir for the scope, we'll provide a specific one to use so this is largely irrelevant
         return new DefaultCacheRepository(new DefaultCacheScopeMapping(projectLevelCacheDir(projectLayout), GradleVersion.current()), cacheFactory);
     }
 
     protected ProjectScopedCache createProjectScopedCache(CacheRepository cacheRepository, DefaultProjectLayout projectLayout) {
-        return new DefaultProjectScopedCache(projectLevelCacheDir(projectLayout), cacheRepository);
+        return new DefaultProjectScopedCache(() -> projectLevelCacheDir(projectLayout), cacheRepository);
     }
 
     protected DecompressionCache createDecompressionCache(ProjectScopedCache cacheFactory) {

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/scopes/AbstractLazilyLocatedScopedCache.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/scopes/AbstractLazilyLocatedScopedCache.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.cache.internal.scopes;
+
+import org.gradle.cache.CacheBuilder;
+import org.gradle.cache.CacheRepository;
+import org.gradle.cache.internal.CacheScopeMapping;
+import org.gradle.cache.internal.VersionStrategy;
+import org.gradle.cache.scopes.ScopedCache;
+import org.gradle.util.GradleVersion;
+
+import java.io.File;
+import java.util.function.Supplier;
+
+/**
+ * Abstract implementation of {@link ScopedCache}, similar to {@link AbstractScopedCache} but performs
+ * lazy evaluation of the root directory, so that user has time to configure the location of the project's
+ * build directory before the cache is created there.
+ */
+public abstract class AbstractLazilyLocatedScopedCache implements ScopedCache {
+    private final Supplier<File> rootDirSupplier;
+    private File rootDir;
+    private final CacheRepository cacheRepository;
+    private CacheScopeMapping cacheScopeMapping;
+
+    public AbstractLazilyLocatedScopedCache(Supplier<File> rootDirSupplier, CacheRepository cacheRepository) {
+        this.rootDirSupplier = rootDirSupplier;
+        this.cacheRepository = cacheRepository;
+    }
+
+    private File createOrRetrieveRootDir() {
+        if (null == rootDir) {
+            this.rootDir = rootDirSupplier.get();
+        }
+        return rootDir;
+    }
+
+    private CacheScopeMapping createOrRetrieveCacheScopeMapping() {
+        if (null == cacheScopeMapping) {
+           this.cacheScopeMapping = new DefaultCacheScopeMapping(createOrRetrieveRootDir(), GradleVersion.current());
+        }
+        return cacheScopeMapping;
+    }
+
+    @Override
+    public File getRootDir() {
+        return createOrRetrieveRootDir();
+    }
+
+    @Override
+    public CacheBuilder cache(String key) {
+        return cacheRepository.cache(baseDirForCache(key));
+    }
+
+    @Override
+    public CacheBuilder crossVersionCache(String key) {
+        return cacheRepository.cache(baseDirForCrossVersionCache(key));
+    }
+
+    @Override
+    public File baseDirForCache(String key) {
+        return createOrRetrieveCacheScopeMapping().getBaseDirectory(createOrRetrieveRootDir(), key, VersionStrategy.CachePerVersion);
+    }
+
+    @Override
+    public File baseDirForCrossVersionCache(String key) {
+        return createOrRetrieveCacheScopeMapping().getBaseDirectory(createOrRetrieveRootDir(), key, VersionStrategy.SharedCache);
+    }
+}

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/scopes/DefaultCacheScopeMapping.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/scopes/DefaultCacheScopeMapping.java
@@ -31,14 +31,24 @@ public class DefaultCacheScopeMapping implements CacheScopeMapping {
     public static final String GLOBAL_CACHE_DIR_NAME = "caches";
     private static final Pattern CACHE_KEY_NAME_PATTERN = Pattern.compile("\\p{Alpha}+[-/.\\w]*");
 
-    private final File globalCacheDir;
+    private final File defaultGlobalCacheDir;
     private final GradleVersion version;
 
-    public DefaultCacheScopeMapping(File rootDir, GradleVersion version) {
-        this.globalCacheDir = rootDir;
+    /**
+     * Creates a new cache scope mapping for a given Gradle version.
+     *
+     * @param defaultRootDir The default global cache directory which will be used if the user does not specify a different one when
+     * requesting the base directory via {@link #getBaseDirectory(File, String, VersionStrategy)}
+     * @param version The current version of Gradle
+     */
+    public DefaultCacheScopeMapping(File defaultRootDir, GradleVersion version) {
+        this.defaultGlobalCacheDir = defaultRootDir;
         this.version = version;
     }
 
+    /**
+     * @implNote if no {@code cacheDir} is provided, the default global cache directory is used
+     */
     @Override
     public File getBaseDirectory(@Nullable File baseDir, String key, VersionStrategy versionStrategy) {
         if (!CACHE_KEY_NAME_PATTERN.matcher(key).matches()) {
@@ -50,7 +60,7 @@ public class DefaultCacheScopeMapping implements CacheScopeMapping {
 
     private File getRootDirectory(@Nullable File scope) {
         if (scope == null) {
-            return globalCacheDir;
+            return defaultGlobalCacheDir;
         } else {
             return scope;
         }

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/scopes/DefaultProjectScopedCache.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/scopes/DefaultProjectScopedCache.java
@@ -20,12 +20,13 @@ import org.gradle.cache.CacheRepository;
 import org.gradle.cache.scopes.ProjectScopedCache;
 
 import java.io.File;
+import java.util.function.Supplier;
 
 /**
- * Default implementation of {@link ProjectScopedCache}, implements interface using {@link AbstractScopedCache}.
+ * Default implementation of {@link ProjectScopedCache}, implements interface using {@link AbstractLazilyLocatedScopedCache}.
  */
-public class DefaultProjectScopedCache extends AbstractScopedCache implements ProjectScopedCache {
-    public DefaultProjectScopedCache(File rootDir, CacheRepository cacheRepository) {
-        super(rootDir, cacheRepository);
+public class DefaultProjectScopedCache extends AbstractLazilyLocatedScopedCache implements ProjectScopedCache {
+    public DefaultProjectScopedCache(Supplier<File> buildDirSupplier, CacheRepository cacheRepository) {
+        super(buildDirSupplier, cacheRepository);
     }
 }


### PR DESCRIPTION
This is an idea for #22809 to prevent the eager creation of empty cache directories (and cause well-behaved plugin tests to fail.

It should be merged into that branch, prior to that branch being merged to master, if we decide to use it.