### PR TITLE
Improve accuracy of `ProjectsIdentifiedProgressDetails` events for builds loaded from configuration cache

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildTreeStructureIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildTreeStructureIntegrationTest.groovy
@@ -59,6 +59,7 @@ class ConfigurationCacheBuildTreeStructureIntegrationTest extends AbstractConfig
             include 'a', 'b', 'c'
             include 'a:b'
             project(':a:b').projectDir = file('custom')
+            project(':c').buildFileName = 'custom.gradle.kts'
         """
         defineTaskInSettings(settingsFile)
 
@@ -70,20 +71,9 @@ class ConfigurationCacheBuildTreeStructureIntegrationTest extends AbstractConfig
             it.details.buildPath == ":"
         }
         with(fixture.only(LoadProjectsBuildOperationType)) {
-            result.rootProject.name == 'thing'
-            result.rootProject.path == ':'
-            result.rootProject.children.size() == 3 // All projects are created when storing
-            with(result.rootProject.children.first() as Map<String, Object>) {
-                name == 'a'
-                path == ':a'
-                projectDir == file('a').absolutePath
-                with(children.first()) {
-                    name == 'b'
-                    path == ':a:b'
-                    projectDir == file('custom').absolutePath
-                    children.empty
-                }
-            }
+            details.buildPath == ":"
+            result.buildPath == ":"
+            checkProjects(result.rootProject)
         }
         with(fixture.progress(BuildIdentifiedProgressDetails)) {
             size() == 1
@@ -92,21 +82,8 @@ class ConfigurationCacheBuildTreeStructureIntegrationTest extends AbstractConfig
         with(fixture.progress(ProjectsIdentifiedProgressDetails)) {
             size() == 1
             with(first()) {
-                details.rootProject.name == 'thing'
-                details.rootProject.path == ':'
-                details.rootProject.projectDir == testDirectory.absolutePath
-                details.rootProject.children.size() == 3
-                with(details.rootProject.children.first() as Map<String, Object>) {
-                    name == 'a'
-                    path == ':a'
-                    projectDir == file('a').absolutePath
-                    with(children.first()) {
-                        name == 'b'
-                        path == ':a:b'
-                        projectDir == file('custom').absolutePath
-                        children.empty
-                    }
-                }
+                details.buildPath == ":"
+                checkProjects(details.rootProject)
             }
         }
 
@@ -127,21 +104,8 @@ class ConfigurationCacheBuildTreeStructureIntegrationTest extends AbstractConfig
         with(fixture.progress(ProjectsIdentifiedProgressDetails)) {
             size() == 1
             with(first()) {
-                details.rootProject.name == 'thing'
-                details.rootProject.path == ':'
-                details.rootProject.projectDir == testDirectory.absolutePath
-                details.rootProject.children.size() == 3
-                with(details.rootProject.children.first() as Map<String, Object>) {
-                    name == 'a'
-                    path == ':a'
-                    projectDir == file('a').absolutePath
-                    children.size() == 1
-                    with(children.first() as Map<String, Object>) {
-                        name == 'b'
-                        path == ':a:b'
-                        projectDir == file('custom').absolutePath
-                    }
-                }
+                details.buildPath == ":"
+                checkProjects(details.rootProject)
             }
         }
 
@@ -151,6 +115,31 @@ class ConfigurationCacheBuildTreeStructureIntegrationTest extends AbstractConfig
         [":thing"]     | [':']
         [":a:thing"]   | [':', ':a']
         [":a:b:thing"] | [':', ':a', ':a:b']
+    }
+
+    void checkProjects(def rootProject) {
+        assert rootProject.name == 'thing'
+        assert rootProject.path == ':'
+        assert rootProject.projectDir == testDirectory.absolutePath
+        assert rootProject.buildFile == buildFile.absolutePath
+        assert rootProject.children.size() == 3 // All projects are created when storing
+        with(rootProject.children.first() as Map<String, Object>) {
+            assert name == 'a'
+            assert path == ':a'
+            assert projectDir == file('a').absolutePath
+            assert buildFile == file('a/build.gradle').absolutePath
+            with(children.first()) {
+                assert name == 'b'
+                assert path == ':a:b'
+                assert projectDir == file('custom').absolutePath
+                assert buildFile == file('custom/build.gradle').absolutePath
+                assert children.empty
+            }
+        }
+        with(rootProject.children[2] as Map<String, Object>) {
+            assert name == 'c'
+            assert buildFile == file('c/custom.gradle.kts').absolutePath
+        }
     }
 
     def "restores only projects that have work scheduled when buildSrc present"() {

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/CachedBuildState.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/CachedBuildState.kt
@@ -29,7 +29,7 @@ internal
 sealed class CachedProjectState(
     val path: Path,
     val projectDir: File,
-    val buildDir: File
+    val buildFile: File
 )
 
 
@@ -37,17 +37,18 @@ internal
 class ProjectWithWork(
     path: Path,
     projectDir: File,
-    buildDir: File,
+    buildFile: File,
+    val buildDir: File,
     val normalizationState: InputNormalizationHandlerInternal.CachedState?
-) : CachedProjectState(path, projectDir, buildDir)
+) : CachedProjectState(path, projectDir, buildFile)
 
 
 internal
 class ProjectWithNoWork(
     path: Path,
     projectDir: File,
-    buildDir: File
-) : CachedProjectState(path, projectDir, buildDir)
+    buildFile: File
+) : CachedProjectState(path, projectDir, buildFile)
 
 
 data class BuildToStore(val build: VintageGradleBuild, val hasWork: Boolean)

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/CachedBuildState.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/CachedBuildState.kt
@@ -60,11 +60,23 @@ data class BuildToStore(val build: VintageGradleBuild, val hasWork: Boolean)
 internal
 sealed class CachedBuildState(
     val identityPath: Path,
-    val rootProjectName: String,
-    val projects: List<CachedProjectState>,
 )
 
 
+/**
+ * A build in the tree whose projects were loaded. May or may not have work scheduled.
+ */
+internal
+sealed class BuildWithProjects(
+    identityPath: Path,
+    val rootProjectName: String,
+    val projects: List<CachedProjectState>
+) : CachedBuildState(identityPath)
+
+
+/**
+ * A build in the tree with work scheduled.
+ */
 internal
 class BuildWithWork(
     identityPath: Path,
@@ -72,12 +84,24 @@ class BuildWithWork(
     rootProjectName: String,
     projects: List<CachedProjectState>,
     val workGraph: List<Node>
-) : CachedBuildState(identityPath, rootProjectName, projects)
+) : BuildWithProjects(identityPath, rootProjectName, projects)
 
 
+/**
+ * A build in the tree with no work scheduled.
+ */
 internal
 class BuildWithNoWork(
     identityPath: Path,
     rootProjectName: String,
     projects: List<ProjectWithNoWork>
-) : CachedBuildState(identityPath, rootProjectName, projects)
+) : BuildWithProjects(identityPath, rootProjectName, projects)
+
+
+/**
+ * A build in the tree whose projects were not loaded. Has no work as a result.
+ */
+internal
+class BuildWithNoProjects(
+    identityPath: Path
+) : CachedBuildState(identityPath)

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
@@ -161,9 +161,9 @@ class ConfigurationCacheState(
     ): BuildStructureOperationProject {
         val childProjects = children.getOrDefault(project.path, emptyList()).map { convertProject(converted, it, rootProjectName, children) }.toSet()
         return converted.computeIfAbsent(project.path) {
-            // Root project name is serialized separately, could perhaps move it to this cached project state
+            // Root project name is serialized separately, could perhaps move it to this cached project state object
             val projectName = project.path.name ?: rootProjectName
-            BuildStructureOperationProject(projectName, project.path.path, project.path.path, project.projectDir.absolutePath, project.buildDir.absolutePath, childProjects)
+            BuildStructureOperationProject(projectName, project.path.path, project.path.path, project.projectDir.absolutePath, project.buildFile.absolutePath, childProjects)
         }
     }
 
@@ -688,11 +688,11 @@ class ConfigurationCacheState(
         val relevantProjects = relevantProjectsRegistry.relevantProjects(nodes)
         return projects.allProjects.map { project ->
             val mutableModel = project.mutableModel
-            mutableModel.layout.buildDirectory.finalizeValue()
             if (relevantProjects.contains(project)) {
-                ProjectWithWork(project.projectPath, mutableModel.projectDir, mutableModel.buildDir, mutableModel.normalization.computeCachedState())
+                mutableModel.layout.buildDirectory.finalizeValue()
+                ProjectWithWork(project.projectPath, mutableModel.projectDir, mutableModel.buildFile, mutableModel.buildDir, mutableModel.normalization.computeCachedState())
             } else {
-                ProjectWithNoWork(project.projectPath, mutableModel.projectDir, mutableModel.buildDir)
+                ProjectWithNoWork(project.projectPath, mutableModel.projectDir, mutableModel.buildFile)
             }
         }
     }

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/LoadBuildStructureBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/LoadBuildStructureBuildOperationIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.initialization
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationsFixture
-import org.gradle.internal.operations.trace.BuildOperationRecord
 
 class LoadBuildStructureBuildOperationIntegrationTest extends AbstractIntegrationSpec {
 
@@ -42,20 +41,28 @@ class LoadBuildStructureBuildOperationIntegrationTest extends AbstractIntegratio
         succeeds('help')
 
         then:
-        def operation = buildOperations.only(LoadProjectsBuildOperationType)
-        def opResult = operation.result
-        opResult.buildPath == ":"
-        opResult.rootProject.path == ":"
+        def loadProjectsOp = buildOperations.only(LoadProjectsBuildOperationType)
+        loadProjectsOp.result.buildPath == ":"
+        def rootProject = loadProjectsOp.result.rootProject
+        rootProject.path == ":"
 
-        verifyProject(opResult.rootProject, 'root', ':', [':a', ':b'], testDirectory, 'root.gradle')
-        verifyProject(project(':a', operation), 'a', ':a', [':a:c'])
-        verifyProject(project(':b', operation), 'b')
-        verifyProject(project(':a:c', operation), 'c', ':a:c', [':a:c:d'], testDirectory.file('a/c'))
-        verifyProject(project(':a:c:d', operation), 'd', ':a:c:d', [], testDirectory.file('d'), 'd.gradle')
+        verifyProject(rootProject, 'root', ':', [':a', ':b'], testDirectory, 'root.gradle')
+        verifyProject(project(':a', rootProject), 'a', ':a', [':a:c'])
+        verifyProject(project(':b', rootProject), 'b')
+        verifyProject(project(':a:c', rootProject), 'c', ':a:c', [':a:c:d'], testDirectory.file('a/c'))
+        verifyProject(project(':a:c:d', rootProject), 'd', ':a:c:d', [], testDirectory.file('d'), 'd.gradle')
 
         def events = buildOperations.progress(ProjectsIdentifiedProgressDetails)
         events.size() == 1
-        events[0].details.buildPath == ":"
+        def identityProjectsEvent = events[0]
+        identityProjectsEvent.details.buildPath == ":"
+
+        def eventRootProject = identityProjectsEvent.details.rootProject
+        verifyProject(eventRootProject, 'root', ':', [':a', ':b'], testDirectory, 'root.gradle')
+        verifyProject(project(':a', eventRootProject), 'a', ':a', [':a:c'])
+        verifyProject(project(':b', eventRootProject), 'b')
+        verifyProject(project(':a:c', eventRootProject), 'c', ':a:c', [':a:c:d'], testDirectory.file('a/c'))
+        verifyProject(project(':a:c:d', eventRootProject), 'd', ':a:c:d', [], testDirectory.file('d'), 'd.gradle')
     }
 
     def "settings set via cmdline flag are exposed correctly"() {
@@ -78,13 +85,15 @@ class LoadBuildStructureBuildOperationIntegrationTest extends AbstractIntegratio
         def operation = buildOperations.only(LoadProjectsBuildOperationType)
         def opResult = operation.result
         opResult.buildPath == ":"
-        opResult.rootProject.name == "root"
+
+        def rootProject = opResult.rootProject
+        rootProject.name == "root"
         opResult.rootProject.path == ":"
         opResult.rootProject.projectDir == customSettingsDir.absolutePath
         opResult.rootProject.buildFile == customSettingsDir.file("root.gradle").absolutePath
 
-        verifyProject(opResult.rootProject, 'root', ':', [':a'], customSettingsDir, 'root.gradle')
-        verifyProject(project(':a', operation), 'a', ':a', [], customSettingsDir.file('a'))
+        verifyProject(rootProject, 'root', ':', [':a'], customSettingsDir, 'root.gradle')
+        verifyProject(project(':a', rootProject), 'a', ':a', [], customSettingsDir.file('a'))
 
         def events = buildOperations.progress(ProjectsIdentifiedProgressDetails)
         events.size() == 1
@@ -121,15 +130,19 @@ class LoadBuildStructureBuildOperationIntegrationTest extends AbstractIntegratio
 
         def rootBuildOperation = buildOperations[0]
         rootBuildOperation.result.buildPath == ":"
-        rootBuildOperation.result.rootProject.path == ":"
-        verifyProject(rootBuildOperation.result.rootProject, 'root', ':', [':a'], testDirectory, 'root.gradle')
-        verifyProject(project(":a", rootBuildOperation), 'a')
+
+        def rootProject = rootBuildOperation.result.rootProject
+        rootProject.path == ":"
+        verifyProject(rootProject, 'root', ':', [':a'], testDirectory, 'root.gradle')
+        verifyProject(project(":a", rootProject), 'a')
 
         def nestedBuildOperation = buildOperations[1]
         nestedBuildOperation.result.buildPath == ":nested"
-        nestedBuildOperation.result.rootProject.path == ":"
-        verifyProject(nestedBuildOperation.result.rootProject, 'nested', ':nested', [':b'], testDirectory.file('nested'))
-        verifyProject(project(":b", nestedBuildOperation), 'b', ':nested:b', [], testDirectory.file('nested/b'))
+
+        def nestedRootProject = nestedBuildOperation.result.rootProject
+        nestedRootProject.path == ":"
+        verifyProject(nestedRootProject, 'nested', ':nested', [':b'], testDirectory.file('nested'))
+        verifyProject(project(":b", nestedRootProject), 'b', ':nested:b', [], testDirectory.file('nested/b'))
     }
 
     private void verifyProject(def project, String name, String identityPath = null, List<String> children = [], File projectDir = testDirectory.file(name), String buildFileName = 'build.gradle') {
@@ -140,12 +153,12 @@ class LoadBuildStructureBuildOperationIntegrationTest extends AbstractIntegratio
         assert project.children*.path == children
     }
 
-    def project(String path, BuildOperationRecord operation, Map parent = null) {
+    Map project(String path, Map rootProject, Map parent = null) {
         if (parent == null) {
             if (path.lastIndexOf(':') == 0) {
-                return operation.result.rootProject.children.find { it.path == path }
+                return rootProject.children.find { it.path == path }
             } else {
-                return project(path, operation, project(path.substring(0, path.lastIndexOf(':')), operation))
+                return project(path, rootProject, project(path.substring(0, path.lastIndexOf(':')), rootProject))
             }
         }
         return parent.children.find { it.path == path }

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationIntegrationTest.groovy
@@ -295,6 +295,4 @@ class BuildOperationNotificationIntegrationTest extends AbstractIntegrationSpec 
         notifications.recordedOps.findAll { it.detailsType == ConfigureProjectBuildOperationType.Details.name }.size() == 2
         notifications.recordedOps.findAll { it.detailsType == ExecuteTaskBuildOperationType.Details.name }.size() == 14 // including all buildSrc task execution events
     }
-
-
 }

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractLoggingHooksFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractLoggingHooksFunctionalTest.groovy
@@ -261,7 +261,7 @@ abstract class AbstractLoggingHooksFunctionalTest extends AbstractConsoleGrouped
                 }
             }
             task ok {
-                mustRunAfter brokenOut, brokenErr // Must not run in parallel with the broken tasks, otherwise the logging in this task will also cause this task to fail
+                mustRunAfter brokenOut, brokenErr // Must not run in parallel with the broken tasks, otherwise the logging done by this task will also fail
                 doLast {
                     System.out.println "output 2"
                     System.err.println "error 2"


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context

- Use build file rather than build directory for `Project.getBuildFile()`
- Do not fire this event for builds whose projects were not loaded.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
