### PR TITLE
fix doc environment references init scripts

### DIFF
--- a/subprojects/docs/src/docs/userguide/authoring-builds/organizing_gradle_projects.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/organizing_gradle_projects.adoc
@@ -222,7 +222,7 @@ The `gradle.properties` helps with keeping properties separate from the build sc
 It's a good location for placing <<build_environment.adoc#sec:gradle_configuration_properties,properties that control the build environment>>.
 
 A typical project setup places the `gradle.properties` file in the root directory of the build.
-Alternatively, the file can also live in the `GRADLE_USER_HOME` directory if you want to it apply to all builds on your machine.
+Alternatively, the file can also live in the `<<directory_layout.adoc#dir:gradle_user_home,GRADLE_USER_HOME>>` directory if you want it to apply to all builds on your machine.
 
 ====
 [.multi-language-sample]

--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/declaring_repositories.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/declaring_repositories.adoc
@@ -207,8 +207,8 @@ include::sample[dir="snippets/artifacts/defineRepository/groovy",files="build.gr
 
 Gradle uses the same logic as Maven to identify the location of your local Maven cache.
 If a local repository location is defined in a `settings.xml`, this location will be used.
-The `settings.xml` in `__USER_HOME__/.m2` takes precedence over the `settings.xml` in `__M2_HOME__/conf`.
-If no `settings.xml` is available, Gradle uses the default location `__USER_HOME__/.m2/repository`.
+The `settings.xml` in `<home directory of the current user>/.m2` takes precedence over the `settings.xml` in `__M2_HOME__/conf`.
+If no `settings.xml` is available, Gradle uses the default location `<home directory of the current user>/.m2/repository`.
 
 [[sec:case-for-maven-local]]
 == The case for mavenLocal()

--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/dependency_resolution.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/dependency_resolution.adoc
@@ -212,7 +212,7 @@ Blacklisting happens when the repository cannot be contacted, either because of 
 
 Gradle contains a highly sophisticated dependency caching mechanism, which seeks to minimise the number of remote requests made in dependency resolution, while striving to guarantee that the results of dependency resolution are correct and reproducible.
 
-The Gradle dependency cache consists of two storage types located under `GRADLE_USER_HOME/caches`:
+The Gradle dependency cache consists of two storage types located under `$<<directory_layout.adoc#dir:gradle_user_home,GRADLE_USER_HOME>>/caches`:
 
 * A file-based store of downloaded artifacts, including binaries like jars as well as raw downloaded meta-data like POM files and Ivy files.
 The storage path for a downloaded artifact includes the SHA1 checksum, meaning that 2 artifacts with the same name but different content can easily be cached.

--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/dependency_verification.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/dependency_verification.adoc
@@ -851,7 +851,7 @@ This is facilitated by the fact the error message tells you were the file is loc
   This can indicate that a dependency has been compromised. Please carefully verify the signatures and checksums.
 
   For your information here are the path to the files which failed verification:
-    - GRADLE_USER_HOME/caches/modules-2/files-2.1/com.google.j2objc/j2objc-annotations/1.1/976d8d30bebc251db406f2bdb3eb01962b5685b3/j2objc-annotations-1.1.jar (signature: GRADLE_USER_HOME/caches/modules-2/files-2.1/com.google.j2objc/j2objc-annotations/1.1/82e922e14f57d522de465fd144ec26eb7da44501/j2objc-annotations-1.1.jar.asc)
+    - $<<directory_layout.adoc#dir:gradle_user_home,GRADLE_USER_HOME>>/caches/modules-2/files-2.1/com.google.j2objc/j2objc-annotations/1.1/976d8d30bebc251db406f2bdb3eb01962b5685b3/j2objc-annotations-1.1.jar (signature: GRADLE_USER_HOME/caches/modules-2/files-2.1/com.google.j2objc/j2objc-annotations/1.1/82e922e14f57d522de465fd144ec26eb7da44501/j2objc-annotations-1.1.jar.asc)
 
   GRADLE_USER_HOME = /home/jiraya/.gradle
 ----

--- a/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_maven.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_maven.adoc
@@ -44,7 +44,7 @@ Creates a POM file for the publication named _PubName_, populating the known met
 Publishes the _PubName_ publication to the repository named _RepoName_. If you have a repository definition without an explicit name, _RepoName_ will be "Maven".
 
 `publish__PubName__PublicationToMavenLocal` — link:{javadocPath}/org/gradle/api/publish/maven/tasks/PublishToMavenLocal.html[PublishToMavenLocal]::
-Copies the _PubName_ publication to the local Maven cache — typically _$USER_HOME/.m2/repository_ — along with the publication's POM file and other metadata.
+Copies the _PubName_ publication to the local Maven cache — typically _<home directory of the current user>/.m2/repository_ — along with the publication's POM file and other metadata.
 
 `publish`::
 _Depends on_: All `publish__PubName__PublicationTo__RepoName__Repository` tasks
@@ -184,7 +184,7 @@ include::sample[dir="snippets/maven-publish/javaProject/groovy",files="build.gra
 [[publishing_maven:install]]
 == Publishing to Maven Local
 
-For integration with a local Maven installation, it is sometimes useful to publish the module into the Maven local repository (typically at _$USER_HOME/.m2/repository_), along with its POM file and other metadata. In Maven parlance, this is referred to as 'installing' the module.
+For integration with a local Maven installation, it is sometimes useful to publish the module into the Maven local repository (typically at _<home directory of the current user>/.m2/repository_), along with its POM file and other metadata. In Maven parlance, this is referred to as 'installing' the module.
 
 The Maven Publish Plugin makes this easy to do by automatically creating a link:{javadocPath}/org/gradle/api/publish/maven/tasks/PublishToMavenLocal.html[PublishToMavenLocal] task for each link:{groovyDslPath}/org.gradle.api.publish.maven.MavenPublication.html[MavenPublication] in the `publishing.publications` container. The task name follows the pattern of `publish__PubName__PublicationToMavenLocal`. Each of these tasks is wired into the `publishToMavenLocal` aggregate task. You do not need to have `mavenLocal()` in your `publishing.repositories` section.
 

--- a/subprojects/docs/src/docs/userguide/installation.adoc
+++ b/subprojects/docs/src/docs/userguide/installation.adoc
@@ -101,6 +101,7 @@ Alternatively, you can unpack the Gradle distribution ZIP into `C:\Gradle` using
 
 To run Gradle, the path to the unpacked files from the Gradle website need to be on your terminal's path. The steps to do this are different for each operating system.
 
+[[sec:linux_macos_users_2]]
 ==== Linux & MacOS users
 
 Configure your `PATH` environment variable to include the `bin` directory of the unzipped distribution, e.g.:

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -973,7 +973,7 @@ We also recommend to update Checkstyle to version 9.3 or later.
 
 ==== Missing files specified with relative paths when running Checkstyle
 
-Gradle 7.5 consistently sets the current working directory for the Checkstyle task to `GRADLE_USER_HOME/workers`.
+Gradle 7.5 consistently sets the current working directory for the Checkstyle task to `$<<directory_layout.adoc#dir:gradle_user_home,GRADLE_USER_HOME>>/workers`.
 This may cause problems with custom Checkstyle tasks or Checkstyle configuration files that assume a different directory for relative paths.
 
 Previously, Gradle selected the current working directory based on the directory where you ran Gradle. If you ran Gradle in:
@@ -981,7 +981,7 @@ Previously, Gradle selected the current working directory based on the directory
 - the root directory of a project: Gradle uses the root directory as the current working directory.
 - a nested directory of a project: Gradle uses the root directory of the subproject as the current working directory.
 
-In version 7.5 and above, Gradle consistently sets the current working directory for the Checkstyle task to `GRADLE_USER_HOME/workers`.
+In version 7.5 and above, Gradle consistently sets the current working directory for the Checkstyle task to `$<<directory_layout.adoc#dir:gradle_user_home,GRADLE_USER_HOME>>/workers`.
 
 === Deprecations
 

--- a/subprojects/docs/src/docs/userguide/reference/directory_layout.adoc
+++ b/subprojects/docs/src/docs/userguide/reference/directory_layout.adoc
@@ -22,7 +22,7 @@ The following two sections describe what is stored in each of them and how trans
 [[dir:gradle_user_home]]
 == Gradle user home directory
 
-The Gradle user home directory (`$USER_HOME/.gradle` by default) is used to store global configuration properties and initialization scripts as well as caches and log files.
+The Gradle user home directory (`<home directory of the current user>/.gradle` by default) is used to store global configuration properties and initialization scripts as well as caches and log files.
 It is roughly structured as follows:
 
 [listing]

--- a/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
@@ -24,7 +24,7 @@ When configuring Gradle behavior you can use these methods, listed in order of h
 
 * <<command_line_interface.adoc#command_line_interface, Command-line flags>> such as `--build-cache`. These have precedence over properties and environment variables.
 * <<#sec:gradle_system_properties, System properties>> such as `systemProp.http.proxyHost=somehost.org` stored in a `gradle.properties` file in a root project directory.
-* <<#sec:gradle_configuration_properties, Gradle properties>> such as `org.gradle.caching=true` that are typically stored in a `gradle.properties` file in a project directory or in the `GRADLE_USER_HOME`.
+* <<#sec:gradle_configuration_properties, Gradle properties>> such as `org.gradle.caching=true` that are typically stored in a `gradle.properties` file in a project directory or in the `<<directory_layout.adoc#dir:gradle_user_home,GRADLE_USER_HOME>>`.
 * <<#sec:gradle_environment_variables, Environment variables>> such as `GRADLE_OPTS` sourced by the environment that executes Gradle.
 
 Aside from configuring Gradle behavior you can configure the build using the same mechanisms and reading the environment from the build logic.
@@ -37,7 +37,7 @@ Gradle provides several options that make it easy to configure the Java process 
 The final configuration taken into account by Gradle is a combination of all Gradle properties set on the command line and your `gradle.properties` files. If an option is configured in multiple locations, the _first one_ found in any of these locations wins:
 
 * command line, as set using `-D`.
-* `gradle.properties` in `GRADLE_USER_HOME` directory.
+* `gradle.properties` in `<<directory_layout.adoc#dir:gradle_user_home,GRADLE_USER_HOME>>` directory.
 * `gradle.properties` in the project's directory, then its parent project's directory up to the build's root directory.
 * `gradle.properties` in Gradle installation directory.
 
@@ -253,8 +253,8 @@ The following environment variables are available for the `gradle` command. Note
 `GRADLE_OPTS`::
 Specifies JVM arguments to use when starting the Gradle client VM. The client VM only handles command line input/output, so it is rare that one would need to change its VM options.
 The actual build is run by the Gradle daemon, which is not affected by this environment variable.
-`GRADLE_USER_HOME`::
-Specifies the Gradle user home directory (which defaults to `$USER_HOME/.gradle` if not set).
+`<<directory_layout.adoc#dir:gradle_user_home,GRADLE_USER_HOME>>`::
+Specifies the Gradle user home directory (which defaults to `<home directory of the current user>/.gradle` if not set).
 `JAVA_HOME`::
 Specifies the JDK installation directory to use for the client VM. This VM is also used for the daemon, unless a different one is specified in a Gradle properties file with `org.gradle.java.home`.
 

--- a/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
@@ -1005,7 +1005,7 @@ When running builds using <<test_kit#test_kit, TestKit>>, the configuration cach
 [[config_cache:not_yet_implemented:fine_grained_tracking_of_gradle_properties]]
 === Fine-grained tracking of Gradle properties as build configuration inputs
 
-Currently, all external sources of Gradle properties (`gradle.properties` in project directories and in the `GRADLE_USER_HOME`, environment variables and system properties that set properties, and properties specified with
+Currently, all external sources of Gradle properties (`gradle.properties` in project directories and in the `<<directory_layout.adoc#dir:gradle_user_home,GRADLE_USER_HOME>>`, environment variables and system properties that set properties, and properties specified with
 command-line flags) are considered build configuration inputs regardless of what properties are actually used at configuration time. These sources, however, are not included in the configuration cache report.
 
 [[config_cache:not_yet_implemented:java_serialization]]

--- a/subprojects/docs/src/docs/userguide/running-builds/gradle_daemon.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/gradle_daemon.adoc
@@ -127,7 +127,7 @@ mkdir -p ~/.gradle && echo "org.gradle.daemon=false" >> ~/.gradle/gradle.propert
 
 There are two recommended ways to disable the Daemon globally across an environment:
 
-* add `org.gradle.daemon=false` to the `<GRADLE_USER_HOME>/gradle.properties` file
+* add `org.gradle.daemon=false` to the `$<<directory_layout.adoc#dir:gradle_user_home,GRADLE_USER_HOME>>`/gradle.properties` file
 * add the flag `-Dorg.gradle.daemon=false` to the `GRADLE_OPTS` environment variable
 
 [[sec:stopping_an_existing_daemon]]

--- a/subprojects/docs/src/docs/userguide/running-builds/init_scripts.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/init_scripts.adoc
@@ -40,9 +40,9 @@ One main limitation of init scripts is that they cannot access classes in the `b
 There are several ways to use an init script:
 
 * Specify a file on the command line. The command line option is `-I` or `--init-script` followed by the path to the script. The command line option can appear more than once, each time adding another init script. The build will fail if any of the files specified on the command line does not exist.
-* Put a file called `init.gradle` (or `init.gradle.kts` for Kotlin) in the `__USER_HOME__/.gradle/` directory.
-* Put a file that ends with `.gradle` (or `.init.gradle.kts` for Kotlin) in the `__USER_HOME__/.gradle/init.d/` directory.
-* Put a file that ends with `.gradle` (or `.init.gradle.kts` for Kotlin) in the `__GRADLE_HOME__/init.d/` directory, in the Gradle distribution. This allows you to package up a custom Gradle distribution containing some custom build logic and plugins. You can combine this with the <<gradle_wrapper.adoc#gradle_wrapper,Gradle wrapper>> as a way to make custom logic available to all builds in your enterprise.
+* Put a file called `init.gradle` (or `init.gradle.kts` for Kotlin) in the `__$<<directory_layout.adoc#dir:gradle_user_home,GRADLE_USER_HOME>>__/` directory.
+* Put a file that ends with `.gradle` (or `.init.gradle.kts` for Kotlin) in the `__$<<directory_layout.adoc#dir:gradle_user_home,GRADLE_USER_HOME>>__/init.d/` directory.
+* Put a file that ends with `.gradle` (or `.init.gradle.kts` for Kotlin) in the `$<<installation.adoc#sec:linux_macos_users_2,__GRADLE_HOME__>>/init.d/` directory, in the Gradle distribution. This allows you to package a custom Gradle distribution containing custom build logic and plugins. You can combine this with the <<gradle_wrapper.adoc#gradle_wrapper,Gradle wrapper>> as a way to make custom logic available to all builds in your enterprise.
 
 If more than one init script is found they will all be executed, in the order specified above. Scripts in a given directory are executed in alphabetical order. This allows, for example, a tool to specify an init script on the command line and the user to put one in their home directory for defining the environment and both scripts will run when Gradle is executed.
 

--- a/subprojects/docs/src/docs/userguide/troubleshooting.adoc
+++ b/subprojects/docs/src/docs/userguide/troubleshooting.adoc
@@ -121,7 +121,7 @@ In addition to <<command_line_interface.adoc#sec:command_line_logging,controllin
 You can also replace much of Gradle’s logging with your own by registering various event listeners. One example of a <<logging.adoc#sec:changing_what_gradle_logs,custom event logger is explained in the logging documentation>>. You can also <<logging.adoc#sec:external_tools,control logging from external tools>>, making them more verbose in order to debug their execution.
 
 [NOTE]
-Additional logs from the <<gradle_daemon.adoc#gradle_daemon,Gradle Daemon>> can be found under `GRADLE_USER_HOME/daemon/<gradle-version>/`.
+Additional logs from the <<gradle_daemon.adoc#gradle_daemon,Gradle Daemon>> can be found under `$<<directory_layout.adoc#dir:gradle_user_home,GRADLE_USER_HOME>>/daemon/<gradle-version>/`.
 
 === Task executed when it should have been UP-TO-DATE
 
@@ -175,7 +175,7 @@ We have observed this can occur when network address translation (NAT) masquerad
 
 The solution to this problem is to adjust your network configuration such that local connections are not modified to appear as from external addresses.
 
-You can monitor the detected network setup and the connection requests in the daemon log file (`<GRADLE_USER_HOME>/daemon/<Gradle version>/daemon-<PID>.out.log`).
+You can monitor the detected network setup and the connection requests in the daemon log file (`$<<directory_layout.adoc#dir:gradle_user_home,GRADLE_USER_HOME>>/daemon/<Gradle version>/daemon-<PID>.out.log`).
 
 ```
 2021-08-12T12:01:50.755+0200 [DEBUG] [org.gradle.internal.remote.internal.inet.InetAddresses] Adding IP addresses for network interface enp0s3


### PR DESCRIPTION
- add a link to the introduction of the GRADLE_HOME
- use $ to indicate it is an environment variable

Fixes: #22750