### PR TITLE
Fix compatibility with Kotlin MPP plugin

### DIFF
--- a/subprojects/architecture-test/build.gradle.kts
+++ b/subprojects/architecture-test/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     testImplementation(project(":model-core"))
     testImplementation(project(":file-temp"))
     testImplementation(project(":core"))
+    testImplementation(project(":testing-base"))
     testImplementation(libs.inject)
 
     testImplementation(libs.archunitJunit5)

--- a/subprojects/architecture-test/src/test/java/org/gradle/architecture/test/ProviderMigrationArchitectureTest.java
+++ b/subprojects/architecture-test/src/test/java/org/gradle/architecture/test/ProviderMigrationArchitectureTest.java
@@ -38,6 +38,7 @@ import org.gradle.api.launcher.cli.WelcomeMessageConfiguration;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.resources.TextResource;
+import org.gradle.api.tasks.testing.TestFailure;
 import org.gradle.internal.reflect.PropertyAccessorType;
 
 import javax.inject.Inject;
@@ -77,6 +78,7 @@ public class ProviderMigrationArchitectureTest {
         .and(not(declaredIn(Configuration.class)))
         .and(not(declaredIn(FileCollection.class)))
         .and(not(declaredIn(ConfigurableFileCollection.class)))
+        .and(not(declaredIn(TestFailure.class))) // extends Throwable which has setter
         .and(are(declaredIn(class_with_any_mutable_property)))
         .and(are(getters))
         .and(not(annotatedWith(Inject.class)))

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DefaultTestFailure.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DefaultTestFailure.java
@@ -27,20 +27,19 @@ import java.util.List;
 
 public class DefaultTestFailure extends TestFailure {
 
-    private final Throwable rawFailure;
     private final TestFailureDetails details;
 
     private final List<TestFailure> causes;
 
     public DefaultTestFailure(Throwable rawFailure, TestFailureDetails details, List<TestFailure> causes) {
-        this.rawFailure = rawFailure;
+        super(rawFailure);
         this.details = details;
         this.causes = causes;
     }
 
     @Override
     public Throwable getRawFailure() {
-        return rawFailure;
+        return getCause();
     }
 
     @Override
@@ -64,7 +63,7 @@ public class DefaultTestFailure extends TestFailure {
 
         DefaultTestFailure that = (DefaultTestFailure) o;
 
-        if (rawFailure != null ? !rawFailure.equals(that.rawFailure) : that.rawFailure != null) {
+        if (getCause() != null ? !getCause().equals(that.getCause()) : that.getCause() != null) {
             return false;
         }
         return details != null ? details.equals(that.details) : that.details == null;
@@ -72,7 +71,7 @@ public class DefaultTestFailure extends TestFailure {
 
     @Override
     public int hashCode() {
-        int result = rawFailure != null ? rawFailure.hashCode() : 0;
+        int result = getCause() != null ? getCause().hashCode() : 0;
         result = 31 * result + (details != null ? details.hashCode() : 0);
         return result;
     }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestResultProcessor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestResultProcessor.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.tasks.testing;
 
-import org.gradle.api.tasks.testing.TestFailure;
 import org.gradle.api.tasks.testing.TestOutputEvent;
 import org.gradle.internal.scan.UsedByScanPlugin;
 
@@ -47,5 +46,5 @@ public interface TestResultProcessor {
      * Notifies this processor that a failure has occurred in the given test.
      */
     @UsedByScanPlugin("test-distribution")
-    void failure(Object testId, TestFailure result);
+    void failure(Object testId, Throwable result);
 }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/processors/CaptureTestOutputTestResultProcessor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/processors/CaptureTestOutputTestResultProcessor.java
@@ -20,7 +20,6 @@ import org.gradle.api.internal.tasks.testing.TestCompleteEvent;
 import org.gradle.api.internal.tasks.testing.TestDescriptorInternal;
 import org.gradle.api.internal.tasks.testing.TestResultProcessor;
 import org.gradle.api.internal.tasks.testing.TestStartEvent;
-import org.gradle.api.tasks.testing.TestFailure;
 import org.gradle.api.tasks.testing.TestOutputEvent;
 
 import java.util.Map;
@@ -89,7 +88,7 @@ public class CaptureTestOutputTestResultProcessor implements TestResultProcessor
     }
 
     @Override
-    public void failure(Object testId, TestFailure result) {
+    public void failure(Object testId, Throwable result) {
         processor.failure(testId, result);
     }
 }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/AttachParentTestResultProcessor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/AttachParentTestResultProcessor.java
@@ -20,7 +20,6 @@ import org.gradle.api.internal.tasks.testing.TestCompleteEvent;
 import org.gradle.api.internal.tasks.testing.TestDescriptorInternal;
 import org.gradle.api.internal.tasks.testing.TestResultProcessor;
 import org.gradle.api.internal.tasks.testing.TestStartEvent;
-import org.gradle.api.tasks.testing.TestFailure;
 import org.gradle.api.tasks.testing.TestOutputEvent;
 
 public class AttachParentTestResultProcessor implements TestResultProcessor {
@@ -43,7 +42,7 @@ public class AttachParentTestResultProcessor implements TestResultProcessor {
     }
 
     @Override
-    public void failure(Object testId, TestFailure result) {
+    public void failure(Object testId, Throwable result) {
         processor.failure(testId, result);
     }
 

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/StateTrackingTestResultProcessor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/StateTrackingTestResultProcessor.java
@@ -98,14 +98,18 @@ public class StateTrackingTestResultProcessor implements TestResultProcessor {
     }
 
     @Override
-    public final void failure(Object testId, TestFailure testFailure) {
+    public final void failure(Object testId, Throwable testFailure) {
         TestState testState = executing.get(testId);
         if (testState == null) {
             throw new IllegalArgumentException(String.format(
                     "Received a failure event for test with unknown id '%s'. Registered test ids: '%s'",
                     testId, executing.keySet()));
         }
-        testState.failures.add(testFailure);
+        if (testFailure instanceof TestFailure) {
+            testState.failures.add((TestFailure) testFailure);
+        } else {
+            testState.failures.add(TestFailure.fromTestFrameworkFailure(testFailure));
+        }
     }
 
     @Override

--- a/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/TestFailure.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/TestFailure.java
@@ -27,7 +27,16 @@ import java.util.List;
  * @since 7.6
  */
 @Incubating
-public abstract class TestFailure {
+public abstract class TestFailure extends Throwable {
+
+    /**
+     * Constructor storing the raw failure.
+     *
+     * @since 7.6.1
+     */
+    protected TestFailure(Throwable rawFailure) {
+        super(rawFailure);
+    }
 
     /**
      * Returns the list of causes.

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/TestClassExecutionEventGenerator.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/TestClassExecutionEventGenerator.java
@@ -95,7 +95,7 @@ public class TestClassExecutionEventGenerator implements TestResultProcessor, Te
     }
 
     @Override
-    public void failure(Object testId, TestFailure result) {
+    public void failure(Object testId, Throwable result) {
         resultProcessor.failure(testId, result);
     }
 }


### PR DESCRIPTION
The Kotlin team [reported](https://github.com/gradle/gradle/issues/22973) that Gradle 7.6 broke the Kotlin MPP plugin. The root cause is a change in an [internal TestResultProcessor class](https://github.com/gradle/gradle/commit/b8bdbec5c239ecc0c47e4bbd4f52290fbd37c0ec#diff-fd44104bb7265971cb53f174d7bfdd501ed0ecc8ab8cd890d137204de2c72228L49) that is used by [the](https://github.com/JetBrains/kotlin/blob/d9ddcd991bf9c6122041f0276af644be0432fa38/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/jvm/tasks/KotlinJvmTest.kt#L35) [plugin](https://github.com/JetBrains/kotlin/blob/d9ddcd991bf9c6122041f0276af644be0432fa38/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/internal/testing/TCServiceMessagesClient.kt#L176).

This PR restores compatibility by reverting the changes to the `TestResultProcessor`. More specifically, merging this PR would result in the following changes over the Gradle versions:
- Gradle 7.5: TestResultProcessor.failure(Object id, Throwable failure)
- Gradle 7.6: TestResultProcessor.failure(Object id, TestFailure failure)
- Gradle 7.6.1: TestResultProcessor.failure(Object id, Throwable failure)

Also, to preserve functionality, this PR makes `TestFailure` a subclass of `Throwable`.

