### PR TITLE
Lazily Create Decompression Cache using Factories

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/cache/AbstractManagedDecompressionCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/cache/AbstractManagedDecompressionCacheFactory.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.cache;
+
+import org.gradle.cache.internal.DecompressionCache;
+import org.gradle.cache.internal.DecompressionCacheFactory;
+import org.gradle.cache.internal.DefaultDecompressionCache;
+import org.gradle.cache.scopes.ScopedCache;
+import org.gradle.internal.concurrent.Stoppable;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Abstract base class for implementing factories that can be used to create {@link DecompressionCache}s.
+ *
+ * This class manages the caches it creates by keeping track of them, and closing them when this factory is
+ * itself closed or stopped.  This allows the caches to be closed when the owning scope containing the
+ * service instance of the factory implementation is closed.
+ */
+/* package */ abstract class AbstractManagedDecompressionCacheFactory implements DecompressionCacheFactory, Stoppable, Closeable {
+    private final Set<DefaultDecompressionCache> createdCaches = new HashSet<>();
+
+    protected abstract ScopedCache getScopedCache();
+
+    @Override
+    public DefaultDecompressionCache create() {
+        DefaultDecompressionCache cache = new DefaultDecompressionCache(getScopedCache());
+        createdCaches.add(cache);
+        return cache;
+    }
+
+    @Override
+    public void close() throws IOException {
+        createdCaches.forEach(DefaultDecompressionCache::close);
+    }
+
+    @Override
+    public void stop() {
+        try {
+            close();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/cache/BuildTreeScopedDecompressionCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/cache/BuildTreeScopedDecompressionCacheFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.cache;
+
+import org.gradle.cache.scopes.BuildTreeScopedCache;
+
+/**
+ * An implementation of {@link AbstractManagedDecompressionCacheFactory} that creates
+ * decompression caches.
+ */
+public final class BuildTreeScopedDecompressionCacheFactory extends AbstractManagedDecompressionCacheFactory {
+    private final BuildTreeScopedCache cacheFactory;
+
+    public BuildTreeScopedDecompressionCacheFactory(BuildTreeScopedCache cacheFactory) {
+        this.cacheFactory = cacheFactory;
+    }
+
+    @Override
+    protected BuildTreeScopedCache getScopedCache() {
+        return cacheFactory;
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/cache/ProjectScopedDecompressionCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/cache/ProjectScopedDecompressionCacheFactory.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.cache;
+
+import org.gradle.api.file.ProjectLayout;
+import org.gradle.cache.CacheRepository;
+import org.gradle.cache.internal.CacheFactory;
+import org.gradle.cache.internal.DecompressionCache;
+import org.gradle.cache.internal.DecompressionCacheFactory;
+import org.gradle.cache.internal.DefaultCacheRepository;
+import org.gradle.cache.internal.DefaultDecompressionCache;
+import org.gradle.cache.internal.scopes.DefaultCacheScopeMapping;
+import org.gradle.cache.internal.scopes.DefaultProjectScopedCache;
+import org.gradle.cache.scopes.ProjectScopedCache;
+import org.gradle.util.GradleVersion;
+
+import java.io.File;
+
+/**
+ * A factory that can be used to create {@link DecompressionCache} instances for a particular project.
+ *
+ * This type exists so that creation of the caches can be done lazily, avoiding the
+ * creation of the cache directory (and, by default, the build directory it will be
+ * a subdirectory of) until it is actually needed.  We need a named factory type
+ * to create a service which can be injected.
+ */
+public class ProjectScopedDecompressionCacheFactory implements DecompressionCacheFactory {
+    private final ProjectLayout projectLayout;
+    private final CacheFactory cacheFactory;
+
+    public ProjectScopedDecompressionCacheFactory(ProjectLayout projectLayout, CacheFactory cacheFactory) {
+        this.projectLayout = projectLayout;
+        this.cacheFactory = cacheFactory;
+    }
+
+    @Override
+    public DecompressionCache create() {
+        File cacheDir = projectLevelCacheDir();
+        CacheRepository cacheRepository = new DefaultCacheRepository(new DefaultCacheScopeMapping(cacheDir, GradleVersion.current()), cacheFactory);
+        ProjectScopedCache scopedCache = new DefaultProjectScopedCache(cacheDir, cacheRepository);
+        return new DefaultDecompressionCache(scopedCache);
+    }
+
+    private File projectLevelCacheDir() {
+        return projectLayout.getBuildDirectory().file(".cache").get().getAsFile();
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileOperations.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileOperations.java
@@ -52,6 +52,7 @@ import org.gradle.api.tasks.WorkResult;
 import org.gradle.api.tasks.WorkResults;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.cache.internal.DecompressionCache;
+import org.gradle.cache.internal.DecompressionCacheFactory;
 import org.gradle.internal.Cast;
 import org.gradle.internal.Factory;
 import org.gradle.internal.file.Deleter;
@@ -88,7 +89,7 @@ public class DefaultFileOperations implements FileOperations {
     private final FileCollectionFactory fileCollectionFactory;
     private final TaskDependencyFactory taskDependencyFactory;
     private final ProviderFactory providers;
-    private final DecompressionCache decompressionCache;
+    private final Factory<DecompressionCache> decompressionCacheFactory;
 
     public DefaultFileOperations(
         FileResolver fileResolver,
@@ -106,7 +107,7 @@ public class DefaultFileOperations implements FileOperations {
         DocumentationRegistry documentationRegistry,
         TaskDependencyFactory taskDependencyFactory,
         ProviderFactory providers,
-        DecompressionCache decompressionCache
+        Factory<DecompressionCache> decompressionCacheFactory
     ) {
         this.fileCollectionFactory = fileCollectionFactory;
         this.fileResolver = fileResolver;
@@ -132,7 +133,7 @@ public class DefaultFileOperations implements FileOperations {
         );
         this.fileSystem = fileSystem;
         this.deleter = deleter;
-        this.decompressionCache = decompressionCache;
+        this.decompressionCacheFactory = decompressionCacheFactory;
     }
 
     @Override
@@ -182,7 +183,7 @@ public class DefaultFileOperations implements FileOperations {
     @Override
     public FileTreeInternal zipTree(Object zipPath) {
         Provider<File> fileProvider = asFileProvider(zipPath);
-        return new FileTreeAdapter(new ZipFileTree(fileProvider, fileSystem, directoryFileTreeFactory, fileHasher, decompressionCache), taskDependencyFactory, patternSetFactory);
+        return new FileTreeAdapter(new ZipFileTree(fileProvider, fileSystem, directoryFileTreeFactory, fileHasher, decompressionCacheFactory.create()), taskDependencyFactory, patternSetFactory);
     }
 
     @Override
@@ -197,7 +198,7 @@ public class DefaultFileOperations implements FileOperations {
             }
         });
 
-        TarFileTree tarTree = new TarFileTree(fileProvider, resource.map(MaybeCompressedFileResource::new), fileSystem, directoryFileTreeFactory, fileHasher, decompressionCache);
+        TarFileTree tarTree = new TarFileTree(fileProvider, resource.map(MaybeCompressedFileResource::new), fileSystem, directoryFileTreeFactory, fileHasher, decompressionCacheFactory.create());
         return new FileTreeAdapter(tarTree, taskDependencyFactory, patternSetFactory);
     }
 
@@ -307,7 +308,7 @@ public class DefaultFileOperations implements FileOperations {
         DocumentationRegistry documentationRegistry = services.get(DocumentationRegistry.class);
         ProviderFactory providers = services.get(ProviderFactory.class);
         TaskDependencyFactory taskDependencyFactory = services.get(TaskDependencyFactory.class);
-        DecompressionCache decompressionCache = services.get(DecompressionCache.class);
+        DecompressionCacheFactory decompressionCacheFactory = services.get(DecompressionCacheFactory.class);
 
         DefaultResourceHandler.Factory resourceHandlerFactory = DefaultResourceHandler.Factory.from(
             fileResolver,
@@ -333,6 +334,6 @@ public class DefaultFileOperations implements FileOperations {
             documentationRegistry,
             taskDependencyFactory,
             providers,
-            decompressionCache);
+            decompressionCacheFactory);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeScopeServices.java
@@ -17,13 +17,12 @@
 package org.gradle.internal.buildtree;
 
 import org.gradle.StartParameter;
+import org.gradle.api.internal.cache.BuildTreeScopedDecompressionCacheFactory;
 import org.gradle.api.internal.project.DefaultProjectStateRegistry;
 import org.gradle.api.internal.provider.DefaultConfigurationTimeBarrier;
 import org.gradle.api.logging.configuration.LoggingConfiguration;
 import org.gradle.api.logging.configuration.ShowStacktrace;
-import org.gradle.cache.internal.DecompressionCache;
 import org.gradle.cache.internal.DecompressionCacheFactory;
-import org.gradle.cache.internal.DefaultDecompressionCache;
 import org.gradle.cache.scopes.BuildTreeScopedCache;
 import org.gradle.execution.DefaultTaskSelector;
 import org.gradle.execution.ProjectConfigurer;
@@ -100,16 +99,7 @@ public class BuildTreeScopeServices {
         return exceptionAnalyser;
     }
 
-    protected DecompressionCache createDecompressionCache(BuildTreeScopedCache cacheFactory) {
-        return new DefaultDecompressionCache(cacheFactory);
-    }
-
     protected DecompressionCacheFactory createDecompressionCacheFactory(BuildTreeScopedCache cacheFactory) {
-        return new DecompressionCacheFactory() {
-            @Override
-            public DecompressionCache create() {
-                return new DefaultDecompressionCache(cacheFactory);
-            }
-        };
+        return new BuildTreeScopedDecompressionCacheFactory(cacheFactory);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeScopeServices.java
@@ -22,6 +22,7 @@ import org.gradle.api.internal.provider.DefaultConfigurationTimeBarrier;
 import org.gradle.api.logging.configuration.LoggingConfiguration;
 import org.gradle.api.logging.configuration.ShowStacktrace;
 import org.gradle.cache.internal.DecompressionCache;
+import org.gradle.cache.internal.DecompressionCacheFactory;
 import org.gradle.cache.internal.DefaultDecompressionCache;
 import org.gradle.cache.scopes.BuildTreeScopedCache;
 import org.gradle.execution.DefaultTaskSelector;
@@ -101,5 +102,14 @@ public class BuildTreeScopeServices {
 
     protected DecompressionCache createDecompressionCache(BuildTreeScopedCache cacheFactory) {
         return new DefaultDecompressionCache(cacheFactory);
+    }
+
+    protected DecompressionCacheFactory createDecompressionCacheFactory(BuildTreeScopedCache cacheFactory) {
+        return new DecompressionCacheFactory() {
+            @Override
+            public DecompressionCache create() {
+                return new DefaultDecompressionCache(cacheFactory);
+            }
+        };
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/WorkerSharedProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/WorkerSharedProjectScopeServices.java
@@ -18,7 +18,9 @@ package org.gradle.internal.service.scopes;
 
 import org.gradle.api.file.ArchiveOperations;
 import org.gradle.api.file.FileSystemOperations;
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.internal.DocumentationRegistry;
+import org.gradle.api.internal.cache.ProjectScopedDecompressionCacheFactory;
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.file.DefaultArchiveOperations;
 import org.gradle.api.internal.file.DefaultFileCollectionFactory;
@@ -44,14 +46,8 @@ import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.util.PatternSet;
-import org.gradle.cache.CacheRepository;
 import org.gradle.cache.internal.CacheFactory;
-import org.gradle.cache.internal.DecompressionCache;
-import org.gradle.cache.internal.DefaultCacheRepository;
-import org.gradle.cache.internal.DefaultDecompressionCache;
-import org.gradle.cache.internal.scopes.DefaultCacheScopeMapping;
-import org.gradle.cache.internal.scopes.DefaultProjectScopedCache;
-import org.gradle.cache.scopes.ProjectScopedCache;
+import org.gradle.cache.internal.DecompressionCacheFactory;
 import org.gradle.internal.Factory;
 import org.gradle.internal.file.Deleter;
 import org.gradle.internal.hash.FileHasher;
@@ -64,7 +60,6 @@ import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.process.ExecOperations;
 import org.gradle.process.internal.DefaultExecOperations;
 import org.gradle.process.internal.ExecFactory;
-import org.gradle.util.GradleVersion;
 
 import java.io.File;
 
@@ -104,7 +99,7 @@ public class WorkerSharedProjectScopeServices {
             DocumentationRegistry documentationRegistry,
             ProviderFactory providers,
             TaskDependencyFactory taskDependencyFactory,
-            DecompressionCache decompressionCache
+            DecompressionCacheFactory decompressionCache
     ) {
         return new DefaultFileOperations(
                 fileResolver,
@@ -157,19 +152,7 @@ public class WorkerSharedProjectScopeServices {
         return new DefaultProjectLayout(projectDir, fileResolver, taskDependencyFactory, patternSetFactory, propertyHost, fileCollectionFactory, filePropertyFactory, fileFactory);
     }
 
-    protected CacheRepository createCacheRepository(CacheFactory cacheFactory, DefaultProjectLayout projectLayout) {
-        return new DefaultCacheRepository(new DefaultCacheScopeMapping(projectLevelCacheDir(projectLayout), GradleVersion.current()), cacheFactory);
-    }
-
-    protected ProjectScopedCache createProjectScopedCache(CacheRepository cacheRepository, DefaultProjectLayout projectLayout) {
-        return new DefaultProjectScopedCache(projectLevelCacheDir(projectLayout), cacheRepository);
-    }
-
-    protected DecompressionCache createDecompressionCache(ProjectScopedCache cacheFactory) {
-        return new DefaultDecompressionCache(cacheFactory);
-    }
-
-    private File projectLevelCacheDir(DefaultProjectLayout projectLayout) {
-        return projectLayout.getBuildDirectory().file(".cache").get().getAsFile();
+    protected DecompressionCacheFactory createDecompressionCacheFactory(ProjectLayout projectLayout, CacheFactory cacheFactory) {
+        return new ProjectScopedDecompressionCacheFactory(projectLayout, cacheFactory);
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultFileOperationsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultFileOperationsTest.groovy
@@ -24,10 +24,9 @@ import org.gradle.api.internal.file.archive.ZipFileTree
 import org.gradle.api.internal.file.collections.DefaultDirectoryFileTreeFactory
 import org.gradle.api.internal.file.collections.FileTreeAdapter
 import org.gradle.api.internal.file.copy.DefaultCopySpec
-import org.gradle.api.internal.file.temp.DefaultTemporaryFileProvider
 import org.gradle.api.internal.file.temp.TemporaryFileProvider
 import org.gradle.api.internal.resources.DefaultResourceHandler
-import org.gradle.cache.internal.TestCaches
+import org.gradle.initialization.GradleUserHomeDirProvider
 import org.gradle.internal.hash.FileHasher
 import org.gradle.internal.hash.StreamHasher
 import org.gradle.internal.reflect.Instantiator
@@ -37,20 +36,13 @@ import org.gradle.util.TestUtil
 import org.gradle.util.UsesNativeServices
 import org.junit.Rule
 import spock.lang.Specification
-import spock.lang.TempDir
 
 @UsesNativeServices
 class DefaultFileOperationsTest extends Specification {
-    @Rule
-    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
-
-    @TempDir
-    File cacheDir
-
     private final FileResolver resolver = Mock() {
         getPatternSetFactory() >> TestFiles.getPatternSetFactory()
     }
-    private final TemporaryFileProvider temporaryFileProvider = new DefaultTemporaryFileProvider(() -> cacheDir);
+    private final TemporaryFileProvider temporaryFileProvider = Mock()
     private final Instantiator instantiator = TestUtil.instantiatorFactory().decorateLenient()
     private final DefaultDirectoryFileTreeFactory directoryFileTreeFactory = Mock()
     private final StreamHasher streamHasher = Mock()
@@ -58,6 +50,8 @@ class DefaultFileOperationsTest extends Specification {
     private final DefaultResourceHandler.Factory resourceHandlerFactory = Mock()
     private final FileCollectionFactory fileCollectionFactory = Mock()
     private DefaultFileOperations fileOperations = instance()
+    @Rule
+    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     private DefaultFileOperations instance(FileResolver resolver = resolver) {
         instantiator.newInstance(
@@ -77,7 +71,8 @@ class DefaultFileOperationsTest extends Specification {
             TestFiles.documentationRegistry(),
             TestFiles.taskDependencyFactory(),
             TestUtil.providerFactory(),
-            TestCaches.decompressionCacheFactory(temporaryFileProvider.newTemporaryDirectory("cache"))
+            TestFiles.cacheFactory(),
+            (GradleUserHomeDirProvider)(() -> temporaryFileProvider.newTemporaryDirectory("user-home"))
         )
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultFileOperationsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultFileOperationsTest.groovy
@@ -24,9 +24,10 @@ import org.gradle.api.internal.file.archive.ZipFileTree
 import org.gradle.api.internal.file.collections.DefaultDirectoryFileTreeFactory
 import org.gradle.api.internal.file.collections.FileTreeAdapter
 import org.gradle.api.internal.file.copy.DefaultCopySpec
+import org.gradle.api.internal.file.temp.DefaultTemporaryFileProvider
 import org.gradle.api.internal.file.temp.TemporaryFileProvider
 import org.gradle.api.internal.resources.DefaultResourceHandler
-import org.gradle.initialization.GradleUserHomeDirProvider
+import org.gradle.cache.internal.TestCaches
 import org.gradle.internal.hash.FileHasher
 import org.gradle.internal.hash.StreamHasher
 import org.gradle.internal.reflect.Instantiator
@@ -36,13 +37,20 @@ import org.gradle.util.TestUtil
 import org.gradle.util.UsesNativeServices
 import org.junit.Rule
 import spock.lang.Specification
+import spock.lang.TempDir
 
 @UsesNativeServices
 class DefaultFileOperationsTest extends Specification {
+    @Rule
+    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
+
+    @TempDir
+    File cacheDir
+
     private final FileResolver resolver = Mock() {
         getPatternSetFactory() >> TestFiles.getPatternSetFactory()
     }
-    private final TemporaryFileProvider temporaryFileProvider = Mock()
+    private final TemporaryFileProvider temporaryFileProvider = new DefaultTemporaryFileProvider(() -> cacheDir);
     private final Instantiator instantiator = TestUtil.instantiatorFactory().decorateLenient()
     private final DefaultDirectoryFileTreeFactory directoryFileTreeFactory = Mock()
     private final StreamHasher streamHasher = Mock()
@@ -50,8 +58,6 @@ class DefaultFileOperationsTest extends Specification {
     private final DefaultResourceHandler.Factory resourceHandlerFactory = Mock()
     private final FileCollectionFactory fileCollectionFactory = Mock()
     private DefaultFileOperations fileOperations = instance()
-    @Rule
-    public final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
     private DefaultFileOperations instance(FileResolver resolver = resolver) {
         instantiator.newInstance(
@@ -71,8 +77,7 @@ class DefaultFileOperationsTest extends Specification {
             TestFiles.documentationRegistry(),
             TestFiles.taskDependencyFactory(),
             TestUtil.providerFactory(),
-            TestFiles.cacheFactory(),
-            (GradleUserHomeDirProvider)(() -> temporaryFileProvider.newTemporaryDirectory("user-home"))
+            TestCaches.decompressionCacheFactory(temporaryFileProvider.newTemporaryDirectory("cache"))
         )
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/AbstractArchiveFileTreeSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/AbstractArchiveFileTreeSpec.groovy
@@ -18,15 +18,16 @@ package org.gradle.api.internal.file.archive
 
 import org.gradle.api.file.FileVisitor
 import org.gradle.api.internal.file.FileTreeInternal
-import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.file.collections.DirectoryFileTree
 import org.gradle.api.internal.file.collections.MinimalFileTree
 import org.gradle.api.provider.Provider
-import org.gradle.cache.scopes.ScopedCache
+import org.gradle.cache.internal.DecompressionCache
+import org.gradle.cache.internal.TestCaches
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.TestUtil
 import org.junit.Rule
 import spock.lang.Specification
+
 /**
  * Tests core functionality in {@link AbstractArchiveFileTree} using a minimal test implementation.
  */
@@ -39,7 +40,7 @@ class AbstractArchiveFileTreeSpec extends Specification {
         def visitor = Mock(MinimalFileTree.MinimalFileTreeStructureVisitor)
         def backingFile = tmpDir.createFile("thing.bin")
 
-        def fileTree = new TestArchiveFileTree(TestFiles.scopedCache(tmpDir.createDir("cache-dir")), backingFile)
+        def fileTree = new TestArchiveFileTree(TestCaches.decompressionCache(tmpDir.createDir("cache-dir")), backingFile)
 
         when:
         fileTree.visitStructure(visitor, owner)
@@ -53,8 +54,8 @@ class AbstractArchiveFileTreeSpec extends Specification {
         File backingFile
         final String displayName = "<display>"
 
-        TestArchiveFileTree(ScopedCache decompressionCacheFactory, File backingFile) {
-            super(decompressionCacheFactory)
+        TestArchiveFileTree(DecompressionCache decompressionCache, File backingFile) {
+            super(decompressionCache)
             this.backingFile = backingFile
         }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
@@ -25,6 +25,7 @@ import org.gradle.api.file.ConfigurableFileTree
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.file.FileOperations
 import org.gradle.api.internal.file.TestFiles
+import org.gradle.api.internal.file.temp.DefaultTemporaryFileProvider
 import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.api.internal.provider.DefaultPropertyFactory
 import org.gradle.api.internal.provider.PropertyHost
@@ -162,7 +163,7 @@ class DefaultProjectSpec extends Specification {
         _ * serviceRegistry.get(DynamicLookupRoutine) >> Stub(DynamicLookupRoutine)
 
         def fileOperations = Stub(FileOperations)
-        fileOperations.fileTree(_) >> TestFiles.fileOperations(tmpDir.testDirectory).fileTree('tree')
+        fileOperations.fileTree(_) >> TestFiles.fileOperations(tmpDir.testDirectory, new DefaultTemporaryFileProvider(() -> new File(tmpDir.testDirectory, "cache"))).fileTree('tree')
         def projectDir = new File("project")
         def objectFactory = Stub(ObjectFactory)
         objectFactory.fileCollection() >> TestFiles.fileCollectionFactory().configurableFiles()

--- a/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/impl/DefaultFileCollectionSnapshotterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/impl/DefaultFileCollectionSnapshotterTest.groovy
@@ -164,7 +164,7 @@ class DefaultFileCollectionSnapshotterTest extends Specification {
 
             @Override
             File newTemporaryDirectory(String... path) {
-                return null
+                return tmpDir.createDir(path)
             }
 
             @Override

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/file/TestFiles.java
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/file/TestFiles.java
@@ -143,10 +143,10 @@ public class TestFiles {
     }
 
     public static FileOperations fileOperations(File basedDir) {
-        return fileOperations(basedDir, null);
+        return fileOperations(basedDir, new DefaultTemporaryFileProvider(() -> new File(basedDir, "tmp")));
     }
 
-    public static FileOperations fileOperations(File basedDir, @Nullable TemporaryFileProvider temporaryFileProvider) {
+    public static FileOperations fileOperations(File basedDir, TemporaryFileProvider temporaryFileProvider) {
         FileResolver fileResolver = resolver(basedDir);
         FileSystem fileSystem = fileSystem();
 

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/file/TestFiles.java
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/file/TestFiles.java
@@ -174,7 +174,7 @@ public class TestFiles {
             documentationRegistry(),
             taskDependencyFactory(),
             providerFactory(),
-            TestCaches.decompressionCache(temporaryFileProvider.newTemporaryDirectory("cache-dir")));
+            TestCaches.decompressionCacheFactory(temporaryFileProvider.newTemporaryDirectory("cache-dir")));
     }
 
     public static ApiTextResourceAdapter.Factory textResourceAdapterFactory(@Nullable TemporaryFileProvider temporaryFileProvider) {

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/TestCaches.java
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/TestCaches.java
@@ -27,6 +27,7 @@ import org.gradle.internal.Actions;
 import org.gradle.internal.Factory;
 import org.gradle.testfixtures.internal.TestInMemoryCacheFactory;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Collections;
 import java.util.Map;
@@ -46,6 +47,16 @@ public abstract class TestCaches {
 
     public static DecompressionCache decompressionCache(File cacheDir) {
         return new TestInMemoryDecompressionCache(cacheDir);
+    }
+
+    public static DecompressionCacheFactory decompressionCacheFactory(File cacheDir) {
+        return new DecompressionCacheFactory() {
+            @Nullable
+            @Override
+            public DecompressionCache create() {
+                return decompressionCache(cacheDir);
+            }
+        };
     }
 
     private static final class TestInMemoryDecompressionCache implements DecompressionCache {

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/transaction/CompileTransactionTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/transaction/CompileTransactionTest.groovy
@@ -17,8 +17,6 @@
 package org.gradle.api.internal.tasks.compile.incremental.transaction
 
 import org.gradle.api.internal.file.TestFiles
-import org.gradle.api.internal.file.temp.DefaultTemporaryFileProvider
-import org.gradle.api.internal.file.temp.TemporaryFileProvider
 import org.gradle.api.internal.tasks.compile.CompilationFailedException
 import org.gradle.api.internal.tasks.compile.DefaultJavaCompileSpec
 import org.gradle.api.internal.tasks.compile.JavaCompileSpec
@@ -45,7 +43,6 @@ class CompileTransactionTest extends Specification {
     File transactionDir
     File stashDir
     JavaCompileSpec spec
-    TemporaryFileProvider temporaryFileProvider = new DefaultTemporaryFileProvider(() -> new File(temporaryFolder, "cache"));
 
     def setup() {
         transactionDir = new File(temporaryFolder, "compileTransaction")
@@ -59,15 +56,15 @@ class CompileTransactionTest extends Specification {
     }
 
     CompileTransaction newCompileTransaction() {
-        return new CompileTransaction(spec, new PatternSet(), Collections.emptyMap(), TestFiles.fileOperations(temporaryFolder, temporaryFileProvider), TestFiles.deleter())
+        return new CompileTransaction(spec, new PatternSet(), Collections.emptyMap(), TestFiles.fileOperations(temporaryFolder), TestFiles.deleter())
     }
 
     CompileTransaction newCompileTransaction(PatternSet classesToDelete) {
-        return new CompileTransaction(spec, classesToDelete, Collections.emptyMap(), TestFiles.fileOperations(temporaryFolder, temporaryFileProvider), TestFiles.deleter())
+        return new CompileTransaction(spec, classesToDelete, Collections.emptyMap(), TestFiles.fileOperations(temporaryFolder), TestFiles.deleter())
     }
 
     CompileTransaction newCompileTransaction(PatternSet classesToDelete, Map<GeneratedResource.Location, PatternSet> resourcesToDelete) {
-        return new CompileTransaction(spec, classesToDelete, resourcesToDelete, TestFiles.fileOperations(temporaryFolder, temporaryFileProvider), TestFiles.deleter())
+        return new CompileTransaction(spec, classesToDelete, resourcesToDelete, TestFiles.fileOperations(temporaryFolder), TestFiles.deleter())
     }
 
     def "transaction base directory is cleared before execution"() {

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/transaction/CompileTransactionTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/transaction/CompileTransactionTest.groovy
@@ -17,6 +17,8 @@
 package org.gradle.api.internal.tasks.compile.incremental.transaction
 
 import org.gradle.api.internal.file.TestFiles
+import org.gradle.api.internal.file.temp.DefaultTemporaryFileProvider
+import org.gradle.api.internal.file.temp.TemporaryFileProvider
 import org.gradle.api.internal.tasks.compile.CompilationFailedException
 import org.gradle.api.internal.tasks.compile.DefaultJavaCompileSpec
 import org.gradle.api.internal.tasks.compile.JavaCompileSpec
@@ -43,6 +45,7 @@ class CompileTransactionTest extends Specification {
     File transactionDir
     File stashDir
     JavaCompileSpec spec
+    TemporaryFileProvider temporaryFileProvider = new DefaultTemporaryFileProvider(() -> new File(temporaryFolder, "cache"));
 
     def setup() {
         transactionDir = new File(temporaryFolder, "compileTransaction")
@@ -56,15 +59,15 @@ class CompileTransactionTest extends Specification {
     }
 
     CompileTransaction newCompileTransaction() {
-        return new CompileTransaction(spec, new PatternSet(), Collections.emptyMap(), TestFiles.fileOperations(temporaryFolder), TestFiles.deleter())
+        return new CompileTransaction(spec, new PatternSet(), Collections.emptyMap(), TestFiles.fileOperations(temporaryFolder, temporaryFileProvider), TestFiles.deleter())
     }
 
     CompileTransaction newCompileTransaction(PatternSet classesToDelete) {
-        return new CompileTransaction(spec, classesToDelete, Collections.emptyMap(), TestFiles.fileOperations(temporaryFolder), TestFiles.deleter())
+        return new CompileTransaction(spec, classesToDelete, Collections.emptyMap(), TestFiles.fileOperations(temporaryFolder, temporaryFileProvider), TestFiles.deleter())
     }
 
     CompileTransaction newCompileTransaction(PatternSet classesToDelete, Map<GeneratedResource.Location, PatternSet> resourcesToDelete) {
-        return new CompileTransaction(spec, classesToDelete, resourcesToDelete, TestFiles.fileOperations(temporaryFolder), TestFiles.deleter())
+        return new CompileTransaction(spec, classesToDelete, resourcesToDelete, TestFiles.fileOperations(temporaryFolder, temporaryFileProvider), TestFiles.deleter())
     }
 
     def "transaction base directory is cleared before execution"() {

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DecompressionCacheFactory.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DecompressionCacheFactory.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.cache.internal;
+
+import org.gradle.internal.Factory;
+
+/**
+ * A factory for creating {@link DecompressionCache} instances.
+ */
+public interface DecompressionCacheFactory extends Factory<DecompressionCache> {
+}

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultDecompressionCache.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultDecompressionCache.java
@@ -21,7 +21,6 @@ import org.gradle.cache.FileLockManager;
 import org.gradle.cache.PersistentCache;
 import org.gradle.cache.scopes.ScopedCache;
 import org.gradle.internal.Factory;
-import org.gradle.internal.concurrent.Stoppable;
 
 import java.io.Closeable;
 import java.io.File;
@@ -34,7 +33,7 @@ import static org.gradle.cache.internal.filelock.LockOptionsBuilder.mode;
  * Will manage access to the cache, so that access to the archive's contents
  * are only permitted to one client at a time.  The cache will be a Gradle cross version cache.
  */
-public class DefaultDecompressionCache implements DecompressionCache, Stoppable, Closeable {
+public class DefaultDecompressionCache implements DecompressionCache, Closeable {
     private static final String EXPANSION_CACHE_KEY = "compressed-file-expansion";
     private static final String EXPANSION_CACHE_NAME = "Compressed Files Expansion Cache";
 
@@ -76,10 +75,5 @@ public class DefaultDecompressionCache implements DecompressionCache, Stoppable,
     @Override
     public void close() {
         cache.close();
-    }
-
-    @Override
-    public void stop() {
-        close();
     }
 }


### PR DESCRIPTION
This is an idea for https://github.com/gradle/gradle/pull/22809 to prevent the eager creation of empty cache directories (and cause well-behaved plugin tests to fail).

It should be merged into that branch, prior to that branch being merged to master, if we decide to use it.