### PR TITLE
Mitigate flakiness

### DIFF
--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/m9/GradlePropertiesToolingApiCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/m9/GradlePropertiesToolingApiCrossVersionSpec.groovy
@@ -17,11 +17,13 @@
 package org.gradle.integtests.tooling.m9
 
 import org.gradle.integtests.fixtures.AvailableJavaHomes
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.TextUtil
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.tooling.model.build.BuildEnvironment
 import org.junit.Assume
 
+@TargetGradleVersion(">=3.0")
 class GradlePropertiesToolingApiCrossVersionSpec extends ToolingApiSpecification {
 
     def setup() {

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r40/ResolveArtifactsProgressCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r40/ResolveArtifactsProgressCrossVersionSpec.groovy
@@ -19,6 +19,7 @@ package org.gradle.integtests.tooling.r40
 import org.gradle.integtests.tooling.fixture.ProgressEvents
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.test.fixtures.maven.MavenFileRepository
 import org.gradle.test.fixtures.server.http.MavenHttpRepository
@@ -44,6 +45,7 @@ class ResolveArtifactsProgressCrossVersionSpec extends ToolingApiSpecification {
         getTargetVersion() < GradleVersion.version("6.0") ? "$name.$extension" : "$name-$version.$extension"
     }
 
+    @Flaky(because = "https://github.com/gradle/gradle-private/issues/3638")
     @LeaksFileHandles
     def "generates event for resolving intrinsic artifacts by iterating the configuration"() {
         given:

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiClientJdkCompatibilityTest.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiClientJdkCompatibilityTest.groovy
@@ -228,6 +228,7 @@ abstract class ToolingApiClientJdkCompatibilityTest extends AbstractIntegrationS
 
         where:
         gradleDaemonJdkVersion  | gradleVersion
+        JavaVersion.VERSION_1_7 | "2.14.1"
         JavaVersion.VERSION_1_7 | "4.6"    // last version with reported regression
         JavaVersion.VERSION_1_7 | "4.10.3" // last Gradle version that can run on Java 1.7
 
@@ -256,6 +257,7 @@ abstract class ToolingApiClientJdkCompatibilityTest extends AbstractIntegrationS
 
         where:
         gradleDaemonJdkVersion  | gradleVersion
+        JavaVersion.VERSION_1_7 | "2.14.1"
         JavaVersion.VERSION_1_7 | "4.6"    // last version with reported regression
         JavaVersion.VERSION_1_7 | "4.10.3" // last Gradle version that can run on Java 1.7
 

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiClientJdkCompatibilityTest.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiClientJdkCompatibilityTest.groovy
@@ -228,8 +228,6 @@ abstract class ToolingApiClientJdkCompatibilityTest extends AbstractIntegrationS
 
         where:
         gradleDaemonJdkVersion  | gradleVersion
-        JavaVersion.VERSION_1_6 | "2.14.1" // last Gradle version that can run on Java 1.6
-
         JavaVersion.VERSION_1_7 | "4.6"    // last version with reported regression
         JavaVersion.VERSION_1_7 | "4.10.3" // last Gradle version that can run on Java 1.7
 
@@ -246,10 +244,6 @@ abstract class ToolingApiClientJdkCompatibilityTest extends AbstractIntegrationS
         def gradleDaemonJdk = AvailableJavaHomes.getJdk(gradleDaemonJdkVersion)
         Assume.assumeTrue(gradleDaemonJdk!=null)
 
-        if (gradleDaemonJdkVersion == JavaVersion.VERSION_1_6 && gradleVersion == "2.14.1") {
-            executer.expectDeprecationWarning("Support for running Gradle using Java 6 has been deprecated and will be removed in Gradle 3.0")
-        }
-
         when:
         succeeds("buildAction",
             "-PclientJdk=" + clientJdkVersion.majorVersion,
@@ -262,8 +256,6 @@ abstract class ToolingApiClientJdkCompatibilityTest extends AbstractIntegrationS
 
         where:
         gradleDaemonJdkVersion  | gradleVersion
-        JavaVersion.VERSION_1_6 | "2.14.1" // last Gradle version that can run on Java 1.6
-
         JavaVersion.VERSION_1_7 | "4.6"    // last version with reported regression
         JavaVersion.VERSION_1_7 | "4.10.3" // last Gradle version that can run on Java 1.7
 


### PR DESCRIPTION
By marking `@Flaky` and using TAPI tests with Gradle 2+Java 7 instead of Java 6.