### PR TITLE
Fix wrong nightly version comparison

### DIFF
--- a/build-logic/cleanup/src/main/kotlin/gradlebuild/testing/services/BuildBucketProvider.kt
+++ b/build-logic/cleanup/src/main/kotlin/gradlebuild/testing/services/BuildBucketProvider.kt
@@ -87,7 +87,7 @@ abstract class BuildBucketProvider : BuildService<BuildBucketProvider.Params> {
 
         private
         fun currentVersionEnabled(currentVersionUnderTest: String): Boolean {
-            val versionUnderTest = GradleVersion.version(currentVersionUnderTest)
+            val versionUnderTest = GradleVersion.version(currentVersionUnderTest).baseVersion
             return GradleVersion.version(startVersionInclusive) <= versionUnderTest
                 && versionUnderTest < GradleVersion.version(endVersionExclusive)
         }


### PR DESCRIPTION
We split cross version tests into buckets: `1.0<=X<2.0`, ..., `7.0<=X<8.0`, `8.0<=X<9.0`, etc. However, the nightly version "8.0-202212070000+0000" was incorrectly executed in `7.0<=X<8.0` bucket. This is not a big deal, but let's fix it.
