### PR TITLE
Update compatibility matrix for Kotlin language 1.5

### DIFF
--- a/subprojects/docs/src/docs/userguide/compatibility.adoc
+++ b/subprojects/docs/src/docs/userguide/compatibility.adoc
@@ -48,7 +48,7 @@ For older Gradle versions, please see the table below which Java version is supp
 == Kotlin
 Gradle is tested with Kotlin 1.6.10 through 1.7.22.
 
-Gradle plugins written in Kotlin target Kotlin 1.4 for compatibility with Gradle and Kotlin DSL build scripts, even though the embedded Kotlin runtime is Kotlin 1.7.
+Gradle plugins written in Kotlin target Kotlin 1.5 for compatibility with Gradle and Kotlin DSL build scripts, even though the embedded Kotlin runtime is Kotlin 1.7.
 
 .Embedded Kotlin version
 |===
@@ -70,7 +70,7 @@ Gradle plugins written in Kotlin target Kotlin 1.4 for compatibility with Gradle
 | 7.3 | 1.5.31 | 1.4
 | 7.5 | 1.6.21 | 1.4
 | 7.6 | 1.7.10 | 1.4
-| 8.0 | 1.7.22 | 1.4
+| 8.0 | 1.7.22 | 1.5
 |===
 
 == Groovy


### PR DESCRIPTION
As a follow up to

* #23015 