### PR TITLE
Enable 'Method can be static' inspection in IntelliJ

### DIFF
--- a/.idea/inspectionProfiles/Gradle.xml
+++ b/.idea/inspectionProfiles/Gradle.xml
@@ -15,6 +15,10 @@
     <inspection_tool class="FoldExpressionIntoStream" enabled="false" level="INFORMATION" enabled_by_default="false" />
     <inspection_tool class="JavadocBlankLines" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="KotlinUnusedImport" enabled="true" level="ERROR" enabled_by_default="true" />
+    <inspection_tool class="MethodMayBeStatic" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="m_onlyPrivateOrFinal" value="false" />
+      <option name="m_ignoreEmptyMethods" value="true" />
+    </inspection_tool>
     <inspection_tool class="NewMethodNamingConvention" enabled="true" level="ERROR" enabled_by_default="true">
       <extension name="InstanceMethodNamingConvention" enabled="true">
         <option name="m_regex" value="[a-z][A-Za-z\d]*" />


### PR DESCRIPTION
For methods that don't need access to the current instance it is good practice to mark as `static`: only allow access to context that is actually needed.

Note that the corresponding inspection is already enabled for Groovy.