### PR TITLE
Use abstract task subclasses for Gradle 8+ when checking binary compatibility

### DIFF
--- a/subprojects/integ-test/src/crossVersionTest/groovy/org/gradle/integtests/TaskSubclassingBinaryCompatibilityCrossVersionSpec.groovy
+++ b/subprojects/integ-test/src/crossVersionTest/groovy/org/gradle/integtests/TaskSubclassingBinaryCompatibilityCrossVersionSpec.groovy
@@ -63,8 +63,8 @@ class TaskSubclassingBinaryCompatibilityCrossVersionSpec extends CrossVersionInt
             Tar,
             War,
             JavaCompile,
-            // GroovyCompile,
-            // ScalaCompile,
+            GroovyCompile,
+            ScalaCompile,
             Test,
             CodeNarc,
             Checkstyle,
@@ -102,7 +102,7 @@ class TaskSubclassingBinaryCompatibilityCrossVersionSpec extends CrossVersionInt
             taskClasses.remove(JavaCompile)
         }
 
-        Map<String, String> subclasses = taskClasses.collectEntries { ["custom_" + it.name.replace(".", "_"), it.name] }
+        Map<String, String> subclasses = taskClasses.collectEntries { ["custom" + it.name.replace(".", "_"), it.name] }
         def apiDepConf = "implementation"
         if (previous.version < GradleVersion.version("7.0-rc-1")) {
             apiDepConf = "compile"

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/CrossVersionIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/CrossVersionIntegrationSpec.groovy
@@ -20,6 +20,7 @@ import org.gradle.integtests.fixtures.executer.GradleDistribution
 import org.gradle.integtests.fixtures.executer.GradleExecuter
 import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext
 import org.gradle.integtests.fixtures.executer.UnderDevelopmentGradleDistribution
+import org.gradle.test.fixtures.file.CleanupTestDirectory
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.test.fixtures.maven.MavenFileRepository
@@ -31,6 +32,7 @@ import static spock.lang.Retry.Mode.SETUP_FEATURE_CLEANUP
 
 @CrossVersionTest
 @Retry(condition = { RetryConditions.onIssueWithReleasedGradleVersion(instance, failure) }, mode = SETUP_FEATURE_CLEANUP, count = 2)
+@CleanupTestDirectory
 abstract class CrossVersionIntegrationSpec extends Specification {
     @Rule TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
     private final List<GradleExecuter> executers = []
@@ -71,11 +73,11 @@ abstract class CrossVersionIntegrationSpec extends Specification {
     }
 
     TestFile getTestDirectory() {
-        temporaryFolder.getTestDirectory();
+        temporaryFolder.getTestDirectory()
     }
 
     protected TestFile file(Object... path) {
-        testDirectory.file(path);
+        testDirectory.file(path)
     }
 
     protected MavenFileRepository getMavenRepo() {


### PR DESCRIPTION
In Gradle 8 all the task classes have been converted to being abstract with the intention of using injected properties in the form of abstract methods. This in turn forces all task sub-classes to be abstract too (not technically, but from the best practice point of view).

When we check for binary compatibility of task sub-classes compiled with Gradle 8+ we should make them abstract as well.