### PR TITLE
Fix 'structuring-software-projects' sample

### DIFF
--- a/subprojects/docs/src/samples/build-organization/structuring-software-projects/kotlin/platforms/plugins-platform/build.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/structuring-software-projects/kotlin/platforms/plugins-platform/build.gradle.kts
@@ -6,7 +6,7 @@ group = "com.example.platform"
 
 dependencies {
     constraints {
-        api("com.android.tools.build:gradle:7.3.0")
+        api("com.android.tools.build:gradle:7.3.1")
         api("org.jetbrains.kotlin.android:org.jetbrains.kotlin.android.gradle.plugin:1.7.22")
         api("org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin:1.7.22")
         api("org.springframework.boot:org.springframework.boot.gradle.plugin:2.7.5")


### PR DESCRIPTION
Importing the sample to IDEA is currently fails with a following error message:

```
Unresolved module dependency (...) Neither the source set nor the artifact property was populated by the Android Gradle plugin.
```

This issue seems to be the root cause: https://issuetracker.google.com/issues/247066500

Updating AGP to 7.3.1 locally fixes the issue.

