### PR TITLE
Update Gradle Enterprise Gradle plugin to v3.12

### DIFF
--- a/build-logic-commons/gradle-plugin/build.gradle.kts
+++ b/build-logic-commons/gradle-plugin/build.gradle.kts
@@ -12,7 +12,7 @@ java {
 }
 
 dependencies {
-    compileOnly("com.gradle:gradle-enterprise-gradle-plugin:3.11.4")
+    compileOnly("com.gradle:gradle-enterprise-gradle-plugin:3.12")
 
     implementation("org.gradle.kotlin.kotlin-dsl:org.gradle.kotlin.kotlin-dsl.gradle.plugin:3.2.6")
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.22")

--- a/build-logic/build-platform/build.gradle.kts
+++ b/build-logic/build-platform/build.gradle.kts
@@ -22,7 +22,7 @@ val kotlinVersion = providers.gradleProperty("buildKotlinVersion")
 dependencies {
     constraints {
         api("org.gradle.guides:gradle-guides-plugin:0.21")
-        api("com.gradle:gradle-enterprise-gradle-plugin:3.11.4") // Sync with `settings.gradle.kts`
+        api("com.gradle:gradle-enterprise-gradle-plugin:3.12") // Sync with `settings.gradle.kts`
         api("com.gradle.publish:plugin-publish-plugin:1.1.0")
         api("gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext:1.0.1")
         api("me.champeau.gradle:japicmp-gradle-plugin:0.4.1")

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,3 +24,6 @@ systemProp.gradle.internal.testdistribution.queryResponseTimeout=PT20S
 
 # Default performance baseline
 defaultPerformanceBaselines=8.0-commit-c6d0e67c
+
+# Disable Test Retry in GE plugin as long as Test Retry Gradle plugin is in use
+systemProp.gradle.enterprise.testretry.enabled=false

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,7 +24,7 @@ pluginManagement {
 }
 
 plugins {
-    id("com.gradle.enterprise").version("3.11.4") // Sync with `build-logic/build-platform/build.gradle.kts`
+    id("com.gradle.enterprise").version("3.12") // Sync with `build-logic/build-platform/build.gradle.kts`
     id("io.github.gradle.gradle-enterprise-conventions-plugin").version("0.7.6")
     id("gradlebuild.internal.cc-experiment")
 }

--- a/subprojects/core/src/main/java/org/gradle/plugin/management/internal/autoapply/AutoAppliedGradleEnterprisePlugin.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/management/internal/autoapply/AutoAppliedGradleEnterprisePlugin.java
@@ -28,7 +28,7 @@ public final class AutoAppliedGradleEnterprisePlugin {
 
     public static final String GROUP = "com.gradle";
     public static final String NAME = "gradle-enterprise-gradle-plugin";
-    public static final String VERSION = "3.11.4";
+    public static final String VERSION = "3.12";
 
     public static final PluginId ID = new DefaultPluginId("com.gradle.enterprise");
     public static final PluginId BUILD_SCAN_PLUGIN_ID = new DefaultPluginId("com.gradle.build-scan");

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
@@ -77,7 +77,8 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
         "3.11.1",
         "3.11.2",
         "3.11.3",
-        "3.11.4"
+        "3.11.4",
+        "3.12"
     ]
 
     private static final VersionNumber FIRST_VERSION_SUPPORTING_CONFIGURATION_CACHE = VersionNumber.parse("3.4")


### PR DESCRIPTION
This PR updates the GE Gradle plugin to v3.12

Note that build scans cannot be published at the moment, because https://ge.gradle.org/ is not yet updated to GE 2022.4.

```
Publishing build scan...

The request was rejected.
Gradle Enterprise plugin version 3.12 is newer than the newest version supported by Gradle Enterprise 2022.3.7 which is 3.11. Please update to a newer version of Gradle Enterprise.
```

The new GE Gradle plugin has integrated support for test retry. But this means, that the Test Retry Gradle plugin has to be removed from this build build. For the time being, we disable the test retry functionality in GE by setting the system property `gradle.enterprise.testretry.enabled` to `false`.

See also: https://docs.gradle.com/enterprise/gradle-plugin/#test_retry_migration
