### PR TITLE
Discard references to Project instances after storing configuration cache entry

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/CrossProjectConfigurationReportingTaskExecutionGraph.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/CrossProjectConfigurationReportingTaskExecutionGraph.kt
@@ -251,4 +251,8 @@ class CrossProjectConfigurationReportingTaskExecutionGraph(
     }
 
     // endregion
+
+    override fun resetState() {
+        throw UnsupportedOperationException()
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionGraph.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionGraph.java
@@ -289,6 +289,15 @@ public class DefaultTaskExecutionGraph implements TaskExecutionGraphInternal {
         return builder.build();
     }
 
+    @Override
+    public void resetState() {
+        graphListeners.removeAll();
+        taskListeners.removeAll();
+        executionPlan.close();
+        executionPlan = FinalizedExecutionPlan.EMPTY;
+        allTasks = null;
+    }
+
     /**
      * This action wraps the execution of a node into a build operation.
      */

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskExecutionGraphInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskExecutionGraphInternal.java
@@ -61,4 +61,9 @@ public interface TaskExecutionGraphInternal extends TaskExecutionGraph {
      * dependencies from other builds.
      */
     void visitScheduledNodes(Consumer<List<Node>> visitor);
+
+    /**
+     * Resets the lifecycle for this graph.
+     */
+    void resetState();
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/build/AbstractBuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/AbstractBuildState.java
@@ -25,6 +25,7 @@ import org.gradle.initialization.IncludedBuildSpec;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.buildtree.BuildTreeState;
+import org.gradle.internal.execution.BuildOutputCleanupRegistry;
 import org.gradle.internal.lazy.Lazy;
 import org.gradle.internal.service.scopes.BuildScopeServices;
 
@@ -78,6 +79,7 @@ public abstract class AbstractBuildState implements BuildState, Closeable {
         workGraphController.get().resetState();
         buildLifecycleController.get().resetLifecycle();
         buildLifecycleController.get().getGradle().getServices().get(BuildServiceRegistryInternal.class).discardAll();
+        buildLifecycleController.get().getGradle().getServices().get(BuildOutputCleanupRegistry.class).resetLifecycle();
         for (ProjectRegistry<?> projectRegistry : buildLifecycleController.get().getGradle().getServices().getAll(ProjectRegistry.class)) {
             projectRegistry.discardAll();
         }

--- a/subprojects/core/src/main/java/org/gradle/internal/cleanup/DefaultBuildOutputCleanupRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/cleanup/DefaultBuildOutputCleanupRegistry.java
@@ -93,4 +93,10 @@ public class DefaultBuildOutputCleanupRegistry implements BuildOutputCleanupRegi
         }
         return resolvedPaths;
     }
+
+    @Override
+    public void resetLifecycle() {
+        resolvedPaths = null;
+        outputs.clear();
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
@@ -250,10 +250,4 @@ public class GradleScopeServices extends DefaultServiceRegistry {
             return rootGradle.getServices().get(BuildInvocationScopeId.class);
         }
     }
-
-    @Override
-    public void close() {
-        super.close();
-    }
-
 }

--- a/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
+++ b/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
@@ -189,9 +189,12 @@ public abstract class DefaultGradle extends AbstractPluginAware implements Gradl
         classLoaderScope = null;
         baseProjectClassLoaderScope = null;
         rootProject = null;
-        rootProjectActions.clear();
         projectsLoaded = false;
         includedBuilds = null;
+        rootProjectActions.clear();
+        buildListenerBroadcast.removeAll();
+        projectEvaluationListenerBroadcast.removeAll();
+        getTaskGraph().resetState();
     }
 
     @Override

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -63,6 +63,7 @@ import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.TaskDependency
 import org.gradle.configuration.internal.UserCodeApplicationContext
 import org.gradle.internal.Factories
+import org.gradle.internal.dispatch.Dispatch
 import org.gradle.internal.event.AnonymousListenerBroadcast
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.model.CalculatedValueContainerFactory
@@ -100,7 +101,7 @@ class DefaultConfigurationSpec extends Specification {
     def calculatedValueContainerFactory = Mock(CalculatedValueContainerFactory)
 
     def setup() {
-        _ * listenerManager.createAnonymousBroadcaster(DependencyResolutionListener) >> { new AnonymousListenerBroadcast<DependencyResolutionListener>(DependencyResolutionListener) }
+        _ * listenerManager.createAnonymousBroadcaster(DependencyResolutionListener) >> { new AnonymousListenerBroadcast<DependencyResolutionListener>(DependencyResolutionListener, Stub(Dispatch)) }
         _ * resolver.getRepositories() >> []
         _ * domainObjectCollectioncallbackActionDecorator.decorate(_) >> { args -> args[0] }
         _ * userCodeApplicationContext.reapplyCurrentLater(_) >> { args -> args[0] }
@@ -854,13 +855,13 @@ class DefaultConfigurationSpec extends Specification {
         def config = conf("conf")
 
         expect:
-        config.dependencyResolutionListeners.isEmpty()
+        config.dependencyResolutionListeners.size() == 1 // the listener that forwards to listener manager
 
         when:
         def copy = config.copy()
 
         then:
-        copy.dependencyResolutionListeners.isEmpty()
+        copy.dependencyResolutionListeners.size() == 1
     }
 
     private prepareConfigurationForCopyTest() {

--- a/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
@@ -30,7 +30,7 @@ This feature is currently *_incubating_* and not enabled by default. This featur
 
 - The configuration cache does not support all <<configuration_cache#config_cache:plugins:core, core Gradle plugins>> and <<configuration_cache#config_cache:not_yet_implemented, features>>. Full support is a work in progress.
 - Your build and the plugins you depend on might require changes to fulfil the <<configuration_cache#config_cache:requirements, requirements>>.
-- IDE imports and syncs do not use the configuration cache.
+- IDE imports and syncs do not yet use the configuration cache.
 ====
 
 [[config_cache:intro:how_does_it_work]]
@@ -48,9 +48,9 @@ The first time you run a particular set of tasks, there will be no entry in the 
 4. Run the builds scripts for the build, applying any requested project plugins.
 5. Calculate the task graph for the requested tasks, running any deferred configuration actions.
 
-Following the configuration phase, Gradle writes the state of the task graph to the configuration cache, taking a snapshot for later Gradle invocations.
-The execution phase then runs as normal.
-This means you will not see any build performance improvement the first time you run a particular set of tasks.
+Following the configuration phase, Gradle writes a snapshot of the task graph to a new configuration cache entry, for later Gradle invocations.
+Gradle then loads the task graph from the configuration cache, so that it can apply optimizations to the tasks, and then runs the execution phase as normal.
+Generally, you will not see any build performance improvement the first time you run a particular set of tasks.
 
 When you subsequently run Gradle with this same set of tasks, for example by running `gradlew check` again, Gradle will load the tasks and their configuration directly from the configuration cache and skip the configuration phase entirely.
 Before using a configuration cache entry, Gradle checks that none of the "build configuration inputs", such as build scripts, for the entry have changed.
@@ -65,7 +65,7 @@ Build configuration inputs include:
 - Gradle properties used during the configuration phase
 - Environment variables used during the configuration phase
 - Configuration files accessed using value suppliers such as providers
-- `buildSrc` inputs, including build configuration inputs  and source files.
+- `buildSrc` and plugin included build inputs, including build configuration inputs and source files.
 
 Gradle uses its own optimized serialization mechanism and format to store the configuration cache entries.
 It automatically serializes the state of arbitrary object graphs.
@@ -78,8 +78,9 @@ As a fallback and to provide some aid in migrating existing tasks, some semantic
 
 Apart from skipping the configuration phase, the configuration cache provides some additional performance improvements:
 
-- All tasks run in parallel by default.
+- All tasks run in parallel by default, subject to dependency constraints.
 - Dependency resolution is cached.
+- Configuration state and dependency resolution state is discarded from heap after writing the task graph. This reduces the peak heap usage required for a given set of tasks.
 
 [[config_cache:in_action]]
 === Configuration caching in action

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/BuildOutputCleanupRegistry.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/BuildOutputCleanupRegistry.java
@@ -49,4 +49,9 @@ public interface BuildOutputCleanupRegistry {
      * Gets the set of registered outputs as file collections.
      */
     Set<FileCollection> getRegisteredOutputs();
+
+    /**
+     * Restarts the lifecycle of this registry, discarding any registered outputs.
+     */
+    void resetLifecycle();
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
@@ -23,8 +23,6 @@ import org.gradle.BuildResult;
 import org.gradle.StartParameter;
 import org.gradle.api.Task;
 import org.gradle.api.UncheckedIOException;
-import org.gradle.api.execution.TaskExecutionGraph;
-import org.gradle.api.execution.TaskExecutionGraphListener;
 import org.gradle.api.execution.TaskExecutionListener;
 import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.internal.TaskInternal;
@@ -427,24 +425,9 @@ public class InProcessGradleExecuter extends DaemonGradleExecuter {
         return this;
     }
 
-    private static class BuildListenerImpl implements TaskExecutionGraphListener, InternalListener {
+    private static class BuildListenerImpl implements TaskExecutionListener, InternalListener {
         private final List<String> executedTasks = new CopyOnWriteArrayList<>();
         private final Set<String> skippedTasks = new CopyOnWriteArraySet<>();
-
-        @Override
-        public void graphPopulated(TaskExecutionGraph graph) {
-            graph.addTaskExecutionListener(new TaskListenerImpl(executedTasks, skippedTasks));
-        }
-    }
-
-    private static class TaskListenerImpl implements TaskExecutionListener, InternalListener {
-        private final List<String> executedTasks;
-        private final Set<String> skippedTasks;
-
-        TaskListenerImpl(List<String> executedTasks, Set<String> skippedTasks) {
-            this.executedTasks = executedTasks;
-            this.skippedTasks = skippedTasks;
-        }
 
         @Override
         public void beforeExecute(Task task) {

--- a/subprojects/messaging/src/main/java/org/gradle/internal/event/AnonymousListenerBroadcast.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/event/AnonymousListenerBroadcast.java
@@ -16,8 +16,21 @@
 
 package org.gradle.internal.event;
 
+import org.gradle.internal.dispatch.Dispatch;
+import org.gradle.internal.dispatch.MethodInvocation;
+
 public class AnonymousListenerBroadcast<T> extends ListenerBroadcast<T> {
-    public AnonymousListenerBroadcast(Class<T> type) {
+    private final Dispatch<MethodInvocation> forwardingDispatch;
+
+    public AnonymousListenerBroadcast(Class<T> type, Dispatch<MethodInvocation> forwardingDispatch) {
         super(type);
+        this.forwardingDispatch = forwardingDispatch;
+        add(forwardingDispatch);
+    }
+
+    @Override
+    public void removeAll() {
+        super.removeAll();
+        add(forwardingDispatch);
     }
 }

--- a/subprojects/messaging/src/main/java/org/gradle/internal/event/BroadcastDispatch.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/event/BroadcastDispatch.java
@@ -47,6 +47,8 @@ public abstract class BroadcastDispatch<T> extends AbstractBroadcastDispatch<T> 
 
     public abstract boolean isEmpty();
 
+    public abstract int size();
+
     public BroadcastDispatch<T> add(Dispatch<MethodInvocation> dispatch) {
         return add(dispatch, dispatch);
     }
@@ -110,6 +112,11 @@ public abstract class BroadcastDispatch<T> extends AbstractBroadcastDispatch<T> 
         @Override
         public boolean isEmpty() {
             return true;
+        }
+
+        @Override
+        public int size() {
+            return 0;
         }
 
         @Override
@@ -234,6 +241,11 @@ public abstract class BroadcastDispatch<T> extends AbstractBroadcastDispatch<T> 
         }
 
         @Override
+        public int size() {
+            return 1;
+        }
+
+        @Override
         public void visitListeners(Action<T> visitor) {
             if (getType().isInstance(handler)) {
                 visitor.execute(getType().cast(handler));
@@ -339,6 +351,11 @@ public abstract class BroadcastDispatch<T> extends AbstractBroadcastDispatch<T> 
         @Override
         public boolean isEmpty() {
             return false;
+        }
+
+        @Override
+        public int size() {
+            return dispatchers.size();
         }
 
         @Override

--- a/subprojects/messaging/src/main/java/org/gradle/internal/event/DefaultListenerManager.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/event/DefaultListenerManager.java
@@ -143,9 +143,7 @@ public class DefaultListenerManager implements ListenerManager, AnnotatedService
     @Override
     public <T> AnonymousListenerBroadcast<T> createAnonymousBroadcaster(Class<T> listenerClass) {
         assertCanBroadcast(listenerClass);
-        AnonymousListenerBroadcast<T> broadcast = new AnonymousListenerBroadcast<T>(listenerClass);
-        broadcast.add(getBroadcasterInternal(listenerClass).getDispatch(true));
-        return broadcast;
+        return new AnonymousListenerBroadcast<T>(listenerClass, getBroadcasterInternal(listenerClass).getDispatch(true));
     }
 
     private <T> EventBroadcast<T> getBroadcasterInternal(Class<T> listenerClass) {

--- a/subprojects/messaging/src/main/java/org/gradle/internal/event/ListenerBroadcast.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/event/ListenerBroadcast.java
@@ -75,6 +75,13 @@ public class ListenerBroadcast<T> implements Dispatch<MethodInvocation> {
     }
 
     /**
+     * Returns the number of listeners that are registered with this object.
+     */
+    public int size() {
+        return broadcast.size();
+    }
+
+    /**
      * Adds a listener.
      *
      * @param listener The listener.

--- a/subprojects/messaging/src/test/groovy/org/gradle/internal/event/BroadcastDispatchTest.groovy
+++ b/subprojects/messaging/src/test/groovy/org/gradle/internal/event/BroadcastDispatchTest.groovy
@@ -32,6 +32,7 @@ class BroadcastDispatchTest extends Specification {
         expect:
         def dispatch = BroadcastDispatch.empty(TestListener)
         dispatch.empty
+        dispatch.size() == 0
         dispatch.dispatch(new MethodInvocation(method, ["param"] as Object[]))
     }
 
@@ -42,6 +43,7 @@ class BroadcastDispatchTest extends Specification {
         when:
         def dispatch = BroadcastDispatch.empty(TestListener).add(listener)
         !dispatch.empty
+        dispatch.size() == 1
         dispatch.dispatch(invocation)
 
         then:
@@ -175,6 +177,7 @@ class BroadcastDispatchTest extends Specification {
         when:
         def dispatch = BroadcastDispatch.empty(TestListener).add(listener1).add(listener2)
         !dispatch.empty
+        dispatch.size() == 2
         dispatch.dispatch(invocation)
 
         then:
@@ -194,6 +197,7 @@ class BroadcastDispatchTest extends Specification {
         when:
         def dispatch = BroadcastDispatch.empty(TestListener).addAll([listener1, listener2])
         !dispatch.empty
+        dispatch.size() == 2
         dispatch.dispatch(invocation)
 
         then:
@@ -204,6 +208,7 @@ class BroadcastDispatchTest extends Specification {
         when:
         dispatch = BroadcastDispatch.empty(TestListener).add(listener1).addAll([listener2, listener3])
         !dispatch.empty
+        dispatch.size() == 3
         dispatch.dispatch(invocation)
 
         then:
@@ -215,6 +220,7 @@ class BroadcastDispatchTest extends Specification {
         when:
         dispatch = BroadcastDispatch.empty(TestListener).add(listener1).add(listener2).addAll([listener3])
         !dispatch.empty
+        dispatch.size() == 3
         dispatch.dispatch(invocation)
 
         then:
@@ -233,6 +239,7 @@ class BroadcastDispatchTest extends Specification {
         when:
         def dispatch = BroadcastDispatch.empty(TestListener).addAll([listener1, listener1])
         !dispatch.empty
+        dispatch.size() == 1
         dispatch.dispatch(invocation)
 
         then:
@@ -242,6 +249,7 @@ class BroadcastDispatchTest extends Specification {
         when:
         dispatch = dispatch.addAll([listener2, listener1, listener2])
         !dispatch.empty
+        dispatch.size() == 2
         dispatch.dispatch(invocation)
 
         then:
@@ -252,6 +260,7 @@ class BroadcastDispatchTest extends Specification {
         when:
         dispatch = dispatch.addAll([listener3, listener2, listener3])
         !dispatch.empty
+        dispatch.size() == 3
         dispatch.dispatch(invocation)
 
         then:

--- a/subprojects/messaging/src/test/groovy/org/gradle/internal/event/DefaultListenerManagerTest.groovy
+++ b/subprojects/messaging/src/test/groovy/org/gradle/internal/event/DefaultListenerManagerTest.groovy
@@ -1007,6 +1007,27 @@ class DefaultListenerManagerTest extends ConcurrentSpec {
         manager.hasListeners(TestBarListener)
     }
 
+    def "anonymous broadcaster forwards events after all listeners removed"() {
+        def listener1 = Mock(BuildScopeListener)
+        def listener2 = Mock(BuildScopeListener)
+        def listener3 = Mock(BuildScopeListener)
+
+        manager.addListener(listener1)
+        def child = manager.createChild(Scopes.Build)
+        def broadcast = child.createAnonymousBroadcaster(BuildScopeListener)
+        child.addListener(listener2)
+        broadcast.add(listener3)
+
+        when:
+        broadcast.removeAll()
+        broadcast.source.foo("value")
+
+        then:
+        1 * listener1.foo("value")
+        1 * listener2.foo("value")
+        0 * listener3._
+    }
+
     @EventScope(Scopes.BuildTree.class)
     interface TestFooListener {
         void foo(String param);

--- a/subprojects/messaging/src/test/groovy/org/gradle/internal/event/ListenerBroadcastTest.groovy
+++ b/subprojects/messaging/src/test/groovy/org/gradle/internal/event/ListenerBroadcastTest.groovy
@@ -136,6 +136,19 @@ class ListenerBroadcastTest extends Specification {
         0 * visitor._
     }
 
+    def 'listener is not used after all listeners removed'() {
+        given:
+        def listener = Mock(TestListener)
+        broadcast.add(listener)
+        broadcast.removeAll()
+
+        when:
+        broadcast.source.event1("param")
+
+        then:
+        0 * _._
+    }
+
     def 'can use dispatch to receive notifications'() {
         given:
         Dispatch<MethodInvocation> dispatch1 = Mock()
@@ -312,6 +325,52 @@ class ListenerBroadcastTest extends Specification {
 
         ListenerNotificationException exception = thrown()
         exception.causes == [failure1, failure2]
+    }
+
+    def 'can query the number of registered listeners'() {
+        TestListener listener1 = Mock()
+        TestListener listener2 = Mock()
+        TestListener listener3 = Mock()
+
+        expect:
+        broadcast.empty
+        broadcast.size() == 0
+
+        when:
+        broadcast.add(listener1)
+
+        then:
+        !broadcast.empty
+        broadcast.size() == 1
+
+        when:
+        broadcast.add(listener2)
+        broadcast.add(listener3)
+
+        then:
+        !broadcast.empty
+        broadcast.size() == 3
+
+        when:
+        broadcast.remove(listener1)
+
+        then:
+        !broadcast.empty
+        broadcast.size() == 2
+
+        when:
+        broadcast.remove(listener2)
+
+        then:
+        !broadcast.empty
+        broadcast.size() == 1
+
+        when:
+        broadcast.remove(listener3)
+
+        then:
+        broadcast.empty
+        broadcast.size() == 0
     }
 
     interface TestListener {

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/TestTaskSpec.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/TestTaskSpec.groovy
@@ -273,17 +273,15 @@ class TestTaskSpec extends AbstractProjectBuilderSpec {
         task.addTestOutputListener(Stub(TestOutputListener))
 
         then:
-        !task.testListenerInternalBroadcaster.isEmpty()
-        !task.testOutputListenerBroadcaster.isEmpty()
-        !task.testListenerInternalBroadcaster.isEmpty()
+        task.testListenerBroadcaster.size() == 2
+        task.testOutputListenerBroadcaster.size() == 2
 
         when:
         task.executeTests()
 
         then:
-        task.testListenerInternalBroadcaster.isEmpty()
-        task.testOutputListenerBroadcaster.isEmpty()
-        task.testListenerInternalBroadcaster.isEmpty()
+        task.testListenerBroadcaster.size() == 1
+        task.testOutputListenerBroadcaster.size() == 1
     }
 
     def "removes listeners even if execution fails"() {
@@ -301,9 +299,8 @@ class TestTaskSpec extends AbstractProjectBuilderSpec {
         ex.message == "Boo!"
 
         and:
-        task.testListenerInternalBroadcaster.isEmpty()
-        task.testOutputListenerBroadcaster.isEmpty()
-        task.testListenerInternalBroadcaster.isEmpty()
+        task.testListenerBroadcaster.size() == 1
+        task.testOutputListenerBroadcaster.size() == 1
     }
 
     def "reports all test failures for multiple suites"() {

--- a/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
@@ -179,6 +179,12 @@ public abstract class AbstractTestTask extends ConventionTask implements Verific
 
     @Internal
     @VisibleForTesting
+    ListenerBroadcast<TestListener> getTestListenerBroadcaster() {
+        return testListenerBroadcaster;
+    }
+
+    @Internal
+    @VisibleForTesting
     ListenerBroadcast<TestOutputListener> getTestOutputListenerBroadcaster() {
         return testOutputListenerBroadcaster;
     }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context

Discard various listeners and the state of some internal build scoped services.

Also update docs for the changes in behaviour for a configuration cache miss build.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
