### PR TITLE
Cache layout test fix

### DIFF
--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild.cross-version-tests.gradle.kts
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild.cross-version-tests.gradle.kts
@@ -20,6 +20,7 @@ import gradlebuild.integrationtests.addDependenciesAndConfigurations
 import gradlebuild.integrationtests.addSourceSet
 import gradlebuild.integrationtests.configureIde
 import gradlebuild.integrationtests.createTestTask
+import gradlebuild.integrationtests.setSystemPropertiesOfTestJVM
 
 plugins {
     java
@@ -50,7 +51,7 @@ fun createQuickFeedbackTasks() {
     testType.executers.forEach { executer ->
         val taskName = "$executer${prefix.capitalize()}Test"
         val testTask = createTestTask(taskName, executer, sourceSet, testType) {
-            this.systemProperties["org.gradle.integtest.versions"] = "latest"
+            this.setSystemPropertiesOfTestJVM("latest")
             this.systemProperties["org.gradle.integtest.crossVersion"] = "true"
 
             // We should always be using JUnitPlatform at this point, so don't call useJUnitPlatform(), else this will

--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild.distribution-testing.gradle.kts
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild.distribution-testing.gradle.kts
@@ -17,6 +17,7 @@
 import gradlebuild.basics.repoRoot
 import gradlebuild.cleanup.services.CachesCleaner
 import gradlebuild.integrationtests.tasks.DistributionTest
+import gradlebuild.integrationtests.setSystemPropertiesOfTestJVM
 
 plugins {
     java
@@ -91,15 +92,5 @@ fun DistributionTest.setJvmArgsOfTestJvm() {
     jvmArgs("-Xmx512m", "-XX:+HeapDumpOnOutOfMemoryError")
     if (!javaVersion.isJava8Compatible) {
         jvmArgs("-XX:MaxPermSize=768m")
-    }
-}
-
-fun DistributionTest.setSystemPropertiesOfTestJVM() {
-    // use -PtestVersions=all or -PtestVersions=1.2,1.3…
-    val integTestVersionsSysProp = "org.gradle.integtest.versions"
-    if (project.hasProperty("testVersions")) {
-        systemProperties[integTestVersionsSysProp] = project.property("testVersions")
-    } else {
-        systemProperties[integTestVersionsSysProp] = "default"
     }
 }

--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild.distribution-testing.gradle.kts
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild.distribution-testing.gradle.kts
@@ -39,7 +39,7 @@ tasks.withType<DistributionTest>().configureEach {
     shouldRunAfter("test")
 
     setJvmArgsOfTestJvm()
-    setSystemPropertiesOfTestJVM()
+    setSystemPropertiesOfTestJVM("default")
     configureGradleTestEnvironment()
     addSetUpAndTearDownActions()
 }

--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/shared-configuration.kt
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/shared-configuration.kt
@@ -177,7 +177,7 @@ fun IntegrationTest.addDebugProperties() {
 }
 
 
-fun DistributionTest.setSystemPropertiesOfTestJVM(defaultVersions: String = "default") {
+fun DistributionTest.setSystemPropertiesOfTestJVM(defaultVersions: String) {
     // use -PtestVersions=all or -PtestVersions=1.2,1.3…
     val integTestVersionsSysProp = "org.gradle.integtest.versions"
     if (project.hasProperty("testVersions")) {

--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/shared-configuration.kt
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/shared-configuration.kt
@@ -24,6 +24,7 @@ import gradlebuild.basics.testSplitOnlyTestGradleVersion
 import gradlebuild.basics.testing.TestType
 import gradlebuild.capitalize
 import gradlebuild.integrationtests.extension.IntegrationTestExtension
+import gradlebuild.integrationtests.tasks.DistributionTest
 import gradlebuild.integrationtests.tasks.IntegrationTest
 import gradlebuild.modules.extension.ExternalModulesExtension
 import gradlebuild.testing.services.BuildBucketProvider
@@ -172,6 +173,17 @@ fun IntegrationTest.addDebugProperties() {
     // TODO Move magic property out
     if (project.hasProperty("org.gradle.integtest.launcher.debug")) {
         systemProperties["org.gradle.integtest.launcher.debug"] = "true"
+    }
+}
+
+
+fun DistributionTest.setSystemPropertiesOfTestJVM(defaultVersions: String = "default") {
+    // use -PtestVersions=all or -PtestVersions=1.2,1.3…
+    val integTestVersionsSysProp = "org.gradle.integtest.versions"
+    if (project.hasProperty("testVersions")) {
+        systemProperties[integTestVersionsSysProp] = project.property("testVersions")
+    } else {
+        systemProperties[integTestVersionsSysProp] = defaultVersions
     }
 }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
@@ -72,7 +72,7 @@ public enum CacheLayout {
         .changedTo(96, "6.4-rc-1")
         .changedTo(97, "6.8-rc-1")
         .changedTo(99, "7.5-rc-1")
-        .changedTo(100, "8.0-rc-1")
+        .changedTo(100, "8.0-milestone-5")
     ),
 
     RESOURCES(ROOT, "resources", introducedIn("1.9-rc-1")),

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/CrossVersionIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/CrossVersionIntegrationSpec.groovy
@@ -29,6 +29,9 @@ import spock.lang.Specification
 
 import static spock.lang.Retry.Mode.SETUP_FEATURE_CLEANUP
 
+/**
+ * For running these tests against specific versions, see {@link org.gradle.integtests.fixtures.compatibility.AbstractContextualMultiVersionTestInterceptor}
+ */
 @CrossVersionTest
 @Retry(condition = { RetryConditions.onIssueWithReleasedGradleVersion(instance, failure) }, mode = SETUP_FEATURE_CLEANUP, count = 2)
 abstract class CrossVersionIntegrationSpec extends Specification {

--- a/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/CrossVersionTestEngine.java
+++ b/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/CrossVersionTestEngine.java
@@ -292,7 +292,7 @@ class ToolingApiClassloaderDiscoveryRequest extends DelegatingDiscoveryRequest {
 
     private String getToolingApiVersionToLoad() {
         String candidateTapiVersion = System.getProperty(VERSIONS_SYSPROP_NAME);
-        if (CoverageContext.LATEST.selector.equals(candidateTapiVersion)) {
+        if (CoverageContext.LATEST.selector.equals(candidateTapiVersion) || CoverageContext.PARTIAL.selector.equals(candidateTapiVersion)) {
             ReleasedVersionDistributions releasedVersions = new ReleasedVersionDistributions(IntegrationTestBuildContext.INSTANCE);
             return releasedVersions.getMostRecentRelease().getVersion().getVersion();
         }


### PR DESCRIPTION
* Support for `-PtestVersion=` in cross version tests
* Fix cache layout version boundary following the release of 8.0-milestone-5