### PR TITLE
Add `GradleRunner#run` method

### DIFF
--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/SmokeTestGradleRunner.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/SmokeTestGradleRunner.groovy
@@ -19,6 +19,7 @@ package org.gradle.smoketests
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.InvalidPluginMetadataException
+import org.gradle.testkit.runner.InvalidRunnerConfigurationException
 import org.gradle.testkit.runner.internal.DefaultGradleRunner
 import org.slf4j.LoggerFactory
 
@@ -45,6 +46,13 @@ class SmokeTestGradleRunner extends GradleRunner {
     @Override
     BuildResult buildAndFail() {
         def result = delegate.buildAndFail()
+        verifyDeprecationWarnings(result)
+        return result
+    }
+
+    @Override
+    BuildResult run() throws InvalidRunnerConfigurationException {
+        def result = delegate.run()
         verifyDeprecationWarnings(result)
         return result
     }

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerBuildFailureIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerBuildFailureIntegrationTest.groovy
@@ -162,4 +162,24 @@ $t.buildResult.output"""
         t.buildResult.taskPaths(FAILED) == [':helloWorld']
     }
 
+    def "can expect a build failure without having to call buildAndFail"() {
+        given:
+        buildScript """
+            task helloWorld {
+                doLast {
+                    throw new GradleException('Expected exception')
+                }
+            }
+        """
+
+        when:
+        def result = runner('helloWorld').run()
+
+        then:
+        noExceptionThrown()
+
+        and:
+        result.taskPaths(FAILED) == [':helloWorld']
+    }
+
 }

--- a/subprojects/test-kit/src/main/java/org/gradle/testkit/runner/GradleRunner.java
+++ b/subprojects/test-kit/src/main/java/org/gradle/testkit/runner/GradleRunner.java
@@ -16,6 +16,7 @@
 
 package org.gradle.testkit.runner;
 
+import org.gradle.api.Incubating;
 import org.gradle.testkit.runner.internal.DefaultGradleRunner;
 
 import javax.annotation.Nullable;
@@ -412,4 +413,14 @@ public abstract class GradleRunner {
      */
     public abstract BuildResult buildAndFail() throws InvalidRunnerConfigurationException, UnexpectedBuildSuccess;
 
+    /**
+     * Executes a build, without expecting a particular outcome.
+     * The outcome should then be tested by inspecting the returned {@link BuildResult}.
+     *
+     * @throws InvalidRunnerConfigurationException if the configuration of this runner is invalid (e.g. project directory not set)
+     * @return the build result
+     * @since 8.0
+     */
+    @Incubating
+    public abstract BuildResult run() throws InvalidRunnerConfigurationException;
 }

--- a/subprojects/test-kit/src/main/java/org/gradle/testkit/runner/internal/DefaultGradleRunner.java
+++ b/subprojects/test-kit/src/main/java/org/gradle/testkit/runner/internal/DefaultGradleRunner.java
@@ -276,6 +276,12 @@ public class DefaultGradleRunner extends GradleRunner {
         });
     }
 
+    @Override
+    public BuildResult run() {
+        return run(gradleExecutionResult -> {
+        });
+    }
+
     String createDiagnosticsMessage(String trailingMessage, GradleExecutionResult gradleExecutionResult) {
         String lineBreak = SystemProperties.getInstance().getLineSeparator();
         StringBuilder message = new StringBuilder();

--- a/subprojects/test-kit/src/test/groovy/org/gradle/testkit/runner/internal/DefaultGradleRunnerTest.groovy
+++ b/subprojects/test-kit/src/test/groovy/org/gradle/testkit/runner/internal/DefaultGradleRunnerTest.groovy
@@ -181,6 +181,15 @@ class DefaultGradleRunnerTest extends Specification {
         t.message == 'Please specify a project directory before executing the build'
     }
 
+    def "throws exception if working directory is not provided when run is requested"() {
+        when:
+        createRunner().run()
+
+        then:
+        def t = thrown(InvalidRunnerConfigurationException)
+        t.message == 'Please specify a project directory before executing the build'
+    }
+
     def "throws exception if working directory is not provided when build and fail is requested"() {
         when:
         createRunner().buildAndFail()


### PR DESCRIPTION
This is a copy of https://github.com/gradle/gradle/pull/22754 due to problems merging a PR from a forked repo into release. 

The TestKit `GradleRunner#build` and `#buildAndFail` methods are impractical to use. In practice, at some point a test which uses `build` may fail, because some code introduces a regression. It is then useful to be able to put a breakpoint in the test to inspect some variables, look at the project state, etc. However, since `build` would fail if the outcome is not a success, then it becomes impossible to put a breakpoint _after_ the execution of a build.

The only solution is to _temporarily_ switch the code to `buildAndFail` and re-run, which isn't practical. This commit introduces a simpler method called `run` which makes no particular assertions on the outcome of the build.

Fixes #17671

Please do not merge until @graemerocher approves the PR.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
