### PR TITLE
Visit leaf properties without exposing getter

### DIFF
--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/model/annotations/AbstractInputPropertyAnnotationHandler.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/model/annotations/AbstractInputPropertyAnnotationHandler.java
@@ -26,7 +26,6 @@ import org.gradle.internal.reflect.problems.ValidationProblemId;
 import org.gradle.internal.reflect.validation.TypeValidationContext;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -64,7 +63,7 @@ abstract class AbstractInputPropertyAnnotationHandler extends AbstractPropertyAn
                     problem.withId(ValidationProblemId.UNSUPPORTED_VALUE_TYPE)
                         .forProperty(propertyMetadata.getPropertyName())
                         .reportAs(ERROR)
-                        .withDescription(() -> String.format("has @%s annotation used on property of type '%s'", annotationType.getSimpleName(), TypeOf.typeOf(propertyMetadata.getGetterMethod().getGenericReturnType()).getSimpleName()))
+                        .withDescription(() -> String.format("has @%s annotation used on property of type '%s'", annotationType.getSimpleName(), TypeOf.typeOf(propertyMetadata.getDeclaredType().getType()).getSimpleName()))
                         .happensBecause(() -> String.format("%s is not supported on task properties annotated with @%s", unsupportedType.getSimpleName(), annotationType.getSimpleName()));
                     for (String possibleSolution : possibleSolutions) {
                         problem.addPossibleSolution(possibleSolution);
@@ -77,10 +76,9 @@ abstract class AbstractInputPropertyAnnotationHandler extends AbstractPropertyAn
 
     private static List<Class<?>> unpackValueTypesOf(PropertyMetadata propertyMetadata) {
         List<Class<?>> unpackedValueTypes = new ArrayList<>();
-        Method getter = propertyMetadata.getGetterMethod();
-        Class<?> returnType = getter.getReturnType();
+        Class<?> returnType = propertyMetadata.getDeclaredType().getRawType();
         if (Provider.class.isAssignableFrom(returnType)) {
-            List<TypeOf<?>> typeArguments = TypeOf.typeOf(getter.getGenericReturnType()).getActualTypeArguments();
+            List<TypeOf<?>> typeArguments = TypeOf.typeOf(propertyMetadata.getDeclaredType().getType()).getActualTypeArguments();
             for (TypeOf<?> typeArgument : typeArguments) {
                 unpackedValueTypes.add(typeArgument.getConcreteClass());
             }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/model/annotations/InputPropertyAnnotationHandler.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/model/annotations/InputPropertyAnnotationHandler.java
@@ -53,7 +53,7 @@ public class InputPropertyAnnotationHandler extends AbstractInputPropertyAnnotat
     @Override
     public void validatePropertyMetadata(PropertyMetadata propertyMetadata, TypeValidationContext validationContext) {
         validateUnsupportedInputPropertyValueTypes(propertyMetadata, validationContext, getAnnotationType());
-        Class<?> valueType = propertyMetadata.getGetterMethod().getReturnType();
+        Class<?> valueType = propertyMetadata.getDeclaredType().getRawType();
         validateNotDirectoryType(propertyMetadata, validationContext, valueType);
         validateNotFileType(propertyMetadata, validationContext, valueType);
         validateNotPrimitiveType(propertyMetadata, validationContext, valueType);

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/model/annotations/ServiceReferencePropertyAnnotationHandler.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/model/annotations/ServiceReferencePropertyAnnotationHandler.java
@@ -28,7 +28,6 @@ import org.gradle.internal.reflect.problems.ValidationProblemId;
 import org.gradle.internal.reflect.validation.TypeValidationContext;
 import org.gradle.model.internal.type.ModelType;
 
-import java.lang.reflect.Method;
 import java.util.List;
 
 import static org.gradle.internal.execution.model.annotations.ModifierAnnotationCategory.OPTIONAL;
@@ -54,8 +53,7 @@ public class ServiceReferencePropertyAnnotationHandler extends AbstractPropertyA
 
     @Override
     public void validatePropertyMetadata(PropertyMetadata propertyMetadata, TypeValidationContext validationContext) {
-        Method getter = propertyMetadata.getGetterMethod();
-        ModelType<?> propertyType = ModelType.returnType(getter);
+        ModelType<?> propertyType = ModelType.of(propertyMetadata.getDeclaredType().getType());
         List<ModelType<?>> typeVariables = Cast.uncheckedNonnullCast(propertyType.getTypeVariables());
         if (typeVariables.size() != 1 || !BuildService.class.isAssignableFrom(typeVariables.get(0).getRawClass())) {
             validationContext.visitPropertyProblem(problem ->

--- a/subprojects/model-core/src/main/java/org/gradle/internal/properties/annotations/AbstractTypeMetadataWalker.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/properties/annotations/AbstractTypeMetadataWalker.java
@@ -85,7 +85,7 @@ abstract class AbstractTypeMetadataWalker<T, V extends TypeMetadataWalker.TypeMe
             if (propertyMetadata.getPropertyType() == nestedAnnotation) {
                 walkNestedChild(node, childQualifiedName, propertyMetadata, visitor, child -> walkNested(child, childQualifiedName, propertyMetadata, visitor, nestedNodesOnPath, false));
             } else {
-                visitor.visitLeaf(childQualifiedName, propertyMetadata, () -> getChild(node, propertyMetadata));
+                visitor.visitLeaf(node, childQualifiedName, propertyMetadata);
             }
         });
     }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/properties/annotations/DefaultTypeMetadataStore.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/properties/annotations/DefaultTypeMetadataStore.java
@@ -19,6 +19,7 @@ package org.gradle.internal.properties.annotations;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
+import com.google.common.reflect.TypeToken;
 import org.gradle.api.internal.GeneratedSubclasses;
 import org.gradle.cache.internal.CrossBuildInMemoryCache;
 import org.gradle.cache.internal.CrossBuildInMemoryCacheFactory;
@@ -32,7 +33,6 @@ import org.gradle.internal.reflect.validation.TypeValidationContext;
 
 import javax.annotation.Nullable;
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
@@ -256,8 +256,14 @@ public class DefaultTypeMetadataStore implements TypeMetadataStore {
         }
 
         @Override
-        public Method getGetterMethod() {
-            return annotationMetadata.getGetter();
+        public TypeToken<?> getDeclaredType() {
+            return annotationMetadata.getDeclaredType();
+        }
+
+        @Nullable
+        @Override
+        public Object getPropertyValue(Object object) {
+            return annotationMetadata.getPropertyValue(object);
         }
 
         @Override

--- a/subprojects/model-core/src/main/java/org/gradle/internal/properties/annotations/PropertyMetadata.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/properties/annotations/PropertyMetadata.java
@@ -16,10 +16,11 @@
 
 package org.gradle.internal.properties.annotations;
 
+import com.google.common.reflect.TypeToken;
 import org.gradle.internal.reflect.annotations.AnnotationCategory;
 
+import javax.annotation.Nullable;
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
 import java.util.Optional;
 
 public interface PropertyMetadata {
@@ -35,5 +36,8 @@ public interface PropertyMetadata {
 
     Class<? extends Annotation> getPropertyType();
 
-    Method getGetterMethod();
+    TypeToken<?> getDeclaredType();
+
+    @Nullable
+    Object getPropertyValue(Object object);
 }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/properties/annotations/TypeMetadataWalker.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/properties/annotations/TypeMetadataWalker.java
@@ -21,7 +21,6 @@ import org.gradle.api.provider.Provider;
 
 import javax.annotation.Nullable;
 import java.lang.annotation.Annotation;
-import java.util.function.Supplier;
 
 /***
  * A generalized type metadata walker for traversing annotated types and instances using their {@link TypeMetadata}.
@@ -72,7 +71,7 @@ public interface TypeMetadataWalker<T, V extends TypeMetadataWalker.TypeMetadata
 
         void visitNested(TypeMetadata typeMetadata, String qualifiedName, PropertyMetadata propertyMetadata, T value);
 
-        void visitLeaf(String qualifiedName, PropertyMetadata propertyMetadata, Supplier<T> value);
+        void visitLeaf(T parent, String qualifiedName, PropertyMetadata propertyMetadata);
     }
 
     interface StaticMetadataVisitor extends TypeMetadataVisitor<TypeToken<?>> {}

--- a/subprojects/model-core/src/main/java/org/gradle/internal/properties/annotations/TypeMetadataWalker.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/properties/annotations/TypeMetadataWalker.java
@@ -65,13 +65,9 @@ public interface TypeMetadataWalker<T, V extends TypeMetadataWalker.TypeMetadata
 
     interface InstanceMetadataWalker extends TypeMetadataWalker<Object, InstanceMetadataVisitor> {}
 
-
     interface TypeMetadataVisitor<T> {
         void visitRoot(TypeMetadata typeMetadata, T value);
-
         void visitNested(TypeMetadata typeMetadata, String qualifiedName, PropertyMetadata propertyMetadata, T value);
-
-        void visitLeaf(T parent, String qualifiedName, PropertyMetadata propertyMetadata);
     }
 
     interface StaticMetadataVisitor extends TypeMetadataVisitor<TypeToken<?>> {}
@@ -80,5 +76,6 @@ public interface TypeMetadataWalker<T, V extends TypeMetadataWalker.TypeMetadata
         @Override
         void visitNested(TypeMetadata typeMetadata, String qualifiedName, PropertyMetadata propertyMetadata, @Nullable Object value);
         void visitNestedUnpackingError(String qualifiedName, Exception e);
+        void visitLeaf(Object parent, String qualifiedName, PropertyMetadata propertyMetadata);
     }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/properties/bean/DefaultPropertyWalker.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/properties/bean/DefaultPropertyWalker.java
@@ -40,7 +40,6 @@ import org.gradle.internal.snapshot.impl.ImplementationValue;
 
 import javax.annotation.Nullable;
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Map;
 import java.util.function.Function;
@@ -86,7 +85,7 @@ public class DefaultPropertyWalker implements PropertyWalker {
 
             @Override
             public void visitLeaf(String qualifiedName, PropertyMetadata propertyMetadata, Supplier<Object> value) {
-                PropertyValue cachedValue = new CachedPropertyValue(value, propertyMetadata.getGetterMethod());
+                PropertyValue cachedValue = new CachedPropertyValue(value, propertyMetadata.getDeclaredType().getRawType());
                 PropertyAnnotationHandler handler = handlers.get(propertyMetadata.getPropertyType());
                 if (handler == null) {
                     throw new IllegalStateException("Property handler should not be null for: " + propertyMetadata.getPropertyType());
@@ -98,11 +97,11 @@ public class DefaultPropertyWalker implements PropertyWalker {
 
     private static class CachedPropertyValue implements PropertyValue {
 
-        private final Method method;
         private final Supplier<Object> cachedInvoker;
+        private final Class<?> declaredType;
 
-        public CachedPropertyValue(Supplier<Object> supplier, Method method) {
-            this.method = method;
+        public CachedPropertyValue(Supplier<Object> supplier, Class<?> declaredType) {
+            this.declaredType = declaredType;
             this.cachedInvoker = Suppliers.memoize(() -> DeprecationLogger.whileDisabled(supplier::get));
         }
 
@@ -131,26 +130,21 @@ public class DefaultPropertyWalker implements PropertyWalker {
         }
 
         private boolean isProvider() {
-            return Provider.class.isAssignableFrom(method.getReturnType());
+            return Provider.class.isAssignableFrom(declaredType);
         }
 
         private boolean isConfigurable() {
-            return HasConfigurableValue.class.isAssignableFrom(method.getReturnType());
+            return HasConfigurableValue.class.isAssignableFrom(declaredType);
         }
 
         private boolean isBuildable() {
-            return Buildable.class.isAssignableFrom(method.getReturnType());
+            return Buildable.class.isAssignableFrom(declaredType);
         }
 
         @Nullable
         @Override
         public Object call() {
             return cachedInvoker.get();
-        }
-
-        @Override
-        public String toString() {
-            return "Method: " + method;
         }
     }
 

--- a/subprojects/model-core/src/main/java/org/gradle/internal/properties/bean/DefaultPropertyWalker.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/properties/bean/DefaultPropertyWalker.java
@@ -84,8 +84,8 @@ public class DefaultPropertyWalker implements PropertyWalker {
             }
 
             @Override
-            public void visitLeaf(String qualifiedName, PropertyMetadata propertyMetadata, Supplier<Object> value) {
-                PropertyValue cachedValue = new CachedPropertyValue(value, propertyMetadata.getDeclaredType().getRawType());
+            public void visitLeaf(Object parent, String qualifiedName, PropertyMetadata propertyMetadata) {
+                PropertyValue cachedValue = new CachedPropertyValue(() -> propertyMetadata.getPropertyValue(parent), propertyMetadata.getDeclaredType().getRawType());
                 PropertyAnnotationHandler handler = handlers.get(propertyMetadata.getPropertyType());
                 if (handler == null) {
                     throw new IllegalStateException("Property handler should not be null for: " + propertyMetadata.getPropertyType());

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/annotations/PropertyAnnotationMetadata.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/annotations/PropertyAnnotationMetadata.java
@@ -17,7 +17,9 @@
 package org.gradle.internal.reflect.annotations;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
 
+import javax.annotation.Nullable;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.Optional;
@@ -32,4 +34,9 @@ public interface PropertyAnnotationMetadata extends Comparable<PropertyAnnotatio
     <T extends Annotation> Optional<T> getAnnotation(Class<T> annotationType);
 
     ImmutableMap<AnnotationCategory, Annotation> getAnnotations();
+
+    TypeToken<?> getDeclaredType();
+
+    @Nullable
+    Object getPropertyValue(Object object);
 }

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/properties/annotations/AbstractTypeMetadataWalkerTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/properties/annotations/AbstractTypeMetadataWalkerTest.groovy
@@ -67,7 +67,7 @@ class AbstractTypeMetadataWalkerTest extends Specification implements TestAnnota
 
         then:
         visitor.roots == ["null::MyTask"]
-        visitor.nested == [
+        visitor.nested ==~ [
             "nested::NestedType",
             "nestedList.*::NestedType",
             "nestedListOfLists.*.*::NestedType",
@@ -75,7 +75,7 @@ class AbstractTypeMetadataWalkerTest extends Specification implements TestAnnota
             "nestedNamedList.<name>::NamedType",
             "nestedProperty::NestedType"
         ]
-        visitor.leaves == [
+        visitor.leaves ==~ [
             "inputProperty::org.gradle.api.provider.Property<java.lang.String>",
             "nested.inputProperty::org.gradle.api.provider.Property<java.lang.String>",
             "nestedList.*.inputProperty::org.gradle.api.provider.Property<java.lang.String>",
@@ -284,12 +284,12 @@ class AbstractTypeMetadataWalkerTest extends Specification implements TestAnnota
         TypeMetadataWalker.instanceWalker(typeMetadataStore, TestNested.class).walk(instance, visitor)
 
         then:
-        visitor.getNested("nested") == new CollectedNode(checkNotNull(typeMetadataStore.getTypeMetadata(NestedType.class)), "nested", null)
-        visitor.getNested("nestedObject") == new CollectedNode(checkNotNull(typeMetadataStore.getTypeMetadata(Object.class)), "nestedObject", null)
-        visitor.getNested("nestedList") == new CollectedNode(checkNotNull(typeMetadataStore.getTypeMetadata(List.class)), "nestedList", null)
-        visitor.getNested("nestedMap") == new CollectedNode(checkNotNull(typeMetadataStore.getTypeMetadata(Map.class)), "nestedMap", null)
-        visitor.getNested("nestedProvider") == new CollectedNode(checkNotNull(typeMetadataStore.getTypeMetadata(NestedType.class)), "nestedProvider", null)
-        visitor.getNested("nestedGenericProvider") == new CollectedNode(checkNotNull(typeMetadataStore.getTypeMetadata(Object.class)), "nestedGenericProvider", null)
+        visitor.getNested("nested") == new CollectedNode(checkNotNull(typeMetadataStore.getTypeMetadata(NestedType.class)), "nested", "null")
+        visitor.getNested("nestedObject") == new CollectedNode(checkNotNull(typeMetadataStore.getTypeMetadata(Object.class)), "nestedObject", "null")
+        visitor.getNested("nestedList") == new CollectedNode(checkNotNull(typeMetadataStore.getTypeMetadata(List.class)), "nestedList", "null")
+        visitor.getNested("nestedMap") == new CollectedNode(checkNotNull(typeMetadataStore.getTypeMetadata(Map.class)), "nestedMap", "null")
+        visitor.getNested("nestedProvider") == new CollectedNode(checkNotNull(typeMetadataStore.getTypeMetadata(NestedType.class)), "nestedProvider", "null")
+        visitor.getNested("nestedGenericProvider") == new CollectedNode(checkNotNull(typeMetadataStore.getTypeMetadata(Object.class)), "nestedGenericProvider", "null")
     }
 
     def "instance walker should allow visiting null nested values for providers with null values"() {
@@ -318,10 +318,10 @@ class AbstractTypeMetadataWalkerTest extends Specification implements TestAnnota
         TypeMetadataWalker.instanceWalker(typeMetadataStore, TestNested.class).walk(instance, visitor)
 
         then:
-        visitor.getNested("nested") == new CollectedNode(checkNotNull(typeMetadataStore.getTypeMetadata(NestedType.class)), "nested", null)
-        visitor.getNested("nestedObject") == new CollectedNode(checkNotNull(typeMetadataStore.getTypeMetadata(Object.class)), "nestedObject", null)
-        visitor.getNested("nestedProvider") == new CollectedNode(checkNotNull(typeMetadataStore.getTypeMetadata(NestedType.class)), "nestedProvider", null)
-        visitor.getNested("nestedGenericProvider") == new CollectedNode(checkNotNull(typeMetadataStore.getTypeMetadata(Object.class)), "nestedGenericProvider", null)
+        visitor.getNested("nested") == new CollectedNode(checkNotNull(typeMetadataStore.getTypeMetadata(NestedType.class)), "nested", "null")
+        visitor.getNested("nestedObject") == new CollectedNode(checkNotNull(typeMetadataStore.getTypeMetadata(Object.class)), "nestedObject", "null")
+        visitor.getNested("nestedProvider") == new CollectedNode(checkNotNull(typeMetadataStore.getTypeMetadata(NestedType.class)), "nestedProvider", "null")
+        visitor.getNested("nestedGenericProvider") == new CollectedNode(checkNotNull(typeMetadataStore.getTypeMetadata(Object.class)), "nestedGenericProvider", "null")
     }
 
     def "instance walker should allow visiting null nested Provider values"() {
@@ -358,12 +358,12 @@ class AbstractTypeMetadataWalkerTest extends Specification implements TestAnnota
         TypeMetadataWalker.instanceWalker(typeMetadataStore, TestNested.class).walk(instance, visitor)
 
         then:
-        visitor.getNested("nested") == new CollectedNode(checkNotNull(typeMetadataStore.getTypeMetadata(NestedType.class)), "nested", null)
-        visitor.getNested("nestedObject") == new CollectedNode(checkNotNull(typeMetadataStore.getTypeMetadata(Object.class)), "nestedObject", null)
-        visitor.getNested("nestedList") == new CollectedNode(checkNotNull(typeMetadataStore.getTypeMetadata(List.class)), "nestedList", null)
-        visitor.getNested("nestedMap") == new CollectedNode(checkNotNull(typeMetadataStore.getTypeMetadata(Map.class)), "nestedMap", null)
-        visitor.getNested("nestedProvider") == new CollectedNode(checkNotNull(typeMetadataStore.getTypeMetadata(NestedType.class)), "nestedProvider", null)
-        visitor.getNested("nestedGenericProvider") == new CollectedNode(checkNotNull(typeMetadataStore.getTypeMetadata(Object.class)), "nestedGenericProvider", null)
+        visitor.getNested("nested") == new CollectedNode(checkNotNull(typeMetadataStore.getTypeMetadata(NestedType.class)), "nested", "null")
+        visitor.getNested("nestedObject") == new CollectedNode(checkNotNull(typeMetadataStore.getTypeMetadata(Object.class)), "nestedObject", "null")
+        visitor.getNested("nestedList") == new CollectedNode(checkNotNull(typeMetadataStore.getTypeMetadata(List.class)), "nestedList", "null")
+        visitor.getNested("nestedMap") == new CollectedNode(checkNotNull(typeMetadataStore.getTypeMetadata(Map.class)), "nestedMap", "null")
+        visitor.getNested("nestedProvider") == new CollectedNode(checkNotNull(typeMetadataStore.getTypeMetadata(NestedType.class)), "nestedProvider", "null")
+        visitor.getNested("nestedGenericProvider") == new CollectedNode(checkNotNull(typeMetadataStore.getTypeMetadata(Object.class)), "nestedGenericProvider", "null")
     }
 
     static String normalizeToString(String toString) {
@@ -371,11 +371,37 @@ class AbstractTypeMetadataWalkerTest extends Specification implements TestAnnota
     }
 
     static class TestStaticMetadataVisitor extends TestNodeMetadataVisitor<TypeToken<?>> implements TypeMetadataWalker.StaticMetadataVisitor {
+        @Override
+        protected String valueToString(TypeToken<?> value) {
+            return value.toString()
+        }
+
+        @Override
+        protected String childToString(TypeToken<?> parent, PropertyMetadata propertyMetadata) {
+            return propertyMetadata.getDeclaredType().toString()
+        }
     }
 
     static class TestInstanceMetadataVisitor extends TestNodeMetadataVisitor<Object> implements TypeMetadataWalker.InstanceMetadataVisitor {
         @Override
         void visitNestedUnpackingError(String qualifiedName, Exception e) {
+            throw e
+        }
+
+        @Override
+        protected String valueToString(Object value) {
+            if (value instanceof Property<?>) {
+                return "Property[" + value.get() + "]"
+            } else if (value instanceof Provider<?>) {
+                return "Provider[" + value.get() + "]"
+            } else {
+                return Objects.toString(value)
+            }
+        }
+
+        @Override
+        protected String childToString(Object parent, PropertyMetadata propertyMetadata) {
+            return valueToString(propertyMetadata.getPropertyValue(parent))
         }
     }
 
@@ -387,24 +413,29 @@ class AbstractTypeMetadataWalkerTest extends Specification implements TestAnnota
 
         @Override
         void visitRoot(TypeMetadata typeMetadata, T value) {
-            def node = new CollectedNode(typeMetadata, null, value)
+            def node = new CollectedNode(typeMetadata, null, String.valueOf(value))
             all.add(node)
             roots.add(node)
         }
 
         @Override
         void visitNested(TypeMetadata typeMetadata, String qualifiedName, PropertyMetadata propertyMetadata, T value) {
-            def node = new CollectedNode(typeMetadata, qualifiedName, value)
+            def node = new CollectedNode(typeMetadata, qualifiedName, String.valueOf(value))
             all.add(node)
             nested.add(node)
         }
 
         @Override
-        void visitLeaf(String qualifiedName, PropertyMetadata propertyMetadata, Supplier<T> value) {
-            def node = new CollectedNode(null, qualifiedName, value.get())
+        void visitLeaf(T parent, String qualifiedName, PropertyMetadata propertyMetadata) {
+            def value = childToString(parent, propertyMetadata)
+            def node = new CollectedNode(null, qualifiedName, value)
             all.add(node)
             leaves.add(node)
         }
+
+        abstract protected String valueToString(T value);
+
+        abstract protected String childToString(T parent, PropertyMetadata propertyMetadata)
 
         List<String> getAll() {
             return all.collect { it.toString() }
@@ -531,27 +562,17 @@ class AbstractTypeMetadataWalkerTest extends Specification implements TestAnnota
     static class CollectedNode {
         TypeMetadata typeMetadata
         String qualifiedName
-        Object value
+        String toString
 
-        CollectedNode(TypeMetadata typeMetadata, String qualifiedName, Object value) {
+        CollectedNode(TypeMetadata typeMetadata, String qualifiedName, String toString = null) {
             this.typeMetadata = typeMetadata
             this.qualifiedName = qualifiedName
-            this.value = value
+            this.toString = toString
         }
 
         @Override
         String toString() {
-            return normalizeToString("$qualifiedName::${valueToString()}")
-        }
-
-        private String valueToString() {
-            if (value instanceof Property<?>) {
-                return "Property[" + value.get() + "]"
-            } else if (value instanceof Provider<?>) {
-                return "Provider[" + value.get() + "]"
-            } else {
-                return Objects.toString(value)
-            }
+            return normalizeToString(toString == null ? qualifiedName : "$qualifiedName::$toString")
         }
     }
 }

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/properties/annotations/AbstractTypeMetadataWalkerTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/properties/annotations/AbstractTypeMetadataWalkerTest.groovy
@@ -60,7 +60,7 @@ class AbstractTypeMetadataWalkerTest extends Specification implements TestAnnota
         visitor.leaves == ["inputProperty::null"] as List<String>
     }
 
-    def "type walker should visit all nested nodes and properties"() {
+    def "type walker should visit all nested nodes"() {
         when:
         def visitor = new TestStaticMetadataVisitor()
         TypeMetadataWalker.typeWalker(typeMetadataStore, TestNested.class).walk(TypeToken.of(MyTask), visitor)
@@ -74,15 +74,6 @@ class AbstractTypeMetadataWalkerTest extends Specification implements TestAnnota
             "nestedMap.<key>::NestedType",
             "nestedNamedList.<name>::NamedType",
             "nestedProperty::NestedType"
-        ]
-        visitor.leaves ==~ [
-            "inputProperty::org.gradle.api.provider.Property<java.lang.String>",
-            "nested.inputProperty::org.gradle.api.provider.Property<java.lang.String>",
-            "nestedList.*.inputProperty::org.gradle.api.provider.Property<java.lang.String>",
-            "nestedListOfLists.*.*.inputProperty::org.gradle.api.provider.Property<java.lang.String>",
-            "nestedMap.<key>.inputProperty::org.gradle.api.provider.Property<java.lang.String>",
-            "nestedNamedList.<name>.inputProperty::org.gradle.api.provider.Property<java.lang.String>",
-            "nestedProperty.inputProperty::org.gradle.api.provider.Property<java.lang.String>"
         ]
     }
 
@@ -141,11 +132,11 @@ class AbstractTypeMetadataWalkerTest extends Specification implements TestAnnota
         then:
         visitor.allQualifiedNames == [
             null,
-            "nested", "nested.secondNested", "nested.secondNested.thirdNested", "nested.secondNested.thirdNested.input",
-            "nestedList.*", "nestedList.*.secondNested", "nestedList.*.secondNested.thirdNested", "nestedList.*.secondNested.thirdNested.input",
-            "nestedListOfLists.*.*", "nestedListOfLists.*.*.secondNested", "nestedListOfLists.*.*.secondNested.thirdNested", "nestedListOfLists.*.*.secondNested.thirdNested.input",
-            "nestedMap.<key>", "nestedMap.<key>.secondNested", "nestedMap.<key>.secondNested.thirdNested", "nestedMap.<key>.secondNested.thirdNested.input",
-            "nestedProperty", "nestedProperty.secondNested", "nestedProperty.secondNested.thirdNested", "nestedProperty.secondNested.thirdNested.input",
+            "nested", "nested.secondNested", "nested.secondNested.thirdNested",
+            "nestedList.*", "nestedList.*.secondNested", "nestedList.*.secondNested.thirdNested",
+            "nestedListOfLists.*.*", "nestedListOfLists.*.*.secondNested", "nestedListOfLists.*.*.secondNested.thirdNested",
+            "nestedMap.<key>", "nestedMap.<key>.secondNested", "nestedMap.<key>.secondNested.thirdNested",
+            "nestedProperty", "nestedProperty.secondNested", "nestedProperty.secondNested.thirdNested",
         ]
     }
 
@@ -375,14 +366,11 @@ class AbstractTypeMetadataWalkerTest extends Specification implements TestAnnota
         protected String valueToString(TypeToken<?> value) {
             return value.toString()
         }
-
-        @Override
-        protected String childToString(TypeToken<?> parent, PropertyMetadata propertyMetadata) {
-            return propertyMetadata.getDeclaredType().toString()
-        }
     }
 
     static class TestInstanceMetadataVisitor extends TestNodeMetadataVisitor<Object> implements TypeMetadataWalker.InstanceMetadataVisitor {
+        private final List<CollectedNode> leaves = []
+
         @Override
         void visitNestedUnpackingError(String qualifiedName, Exception e) {
             throw e
@@ -399,43 +387,44 @@ class AbstractTypeMetadataWalkerTest extends Specification implements TestAnnota
             }
         }
 
+
         @Override
-        protected String childToString(Object parent, PropertyMetadata propertyMetadata) {
-            return valueToString(propertyMetadata.getPropertyValue(parent))
+        void visitLeaf(Object parent, String qualifiedName, PropertyMetadata propertyMetadata) {
+            def value = valueToString(propertyMetadata.getPropertyValue(parent))
+            def node = new CollectedNode(null, qualifiedName, value)
+            addNode(node)
+            leaves.add(node)
+        }
+
+        List<String> getLeaves() {
+            return leaves.collect { it.toString() }
         }
     }
 
     static abstract class TestNodeMetadataVisitor<T> implements TypeMetadataWalker.TypeMetadataVisitor<T> {
-        private List<CollectedNode> all = []
-        private List<CollectedNode> roots = []
-        private List<CollectedNode> nested = []
-        private List<CollectedNode> leaves = []
+        private final List<CollectedNode> all = []
+        private final List<CollectedNode> roots = []
+        private final List<CollectedNode> nested = []
+
+        protected void addNode(CollectedNode node) {
+            all.add(node)
+        }
 
         @Override
         void visitRoot(TypeMetadata typeMetadata, T value) {
             def node = new CollectedNode(typeMetadata, null, String.valueOf(value))
-            all.add(node)
+            addNode(node)
             roots.add(node)
         }
 
         @Override
         void visitNested(TypeMetadata typeMetadata, String qualifiedName, PropertyMetadata propertyMetadata, T value) {
             def node = new CollectedNode(typeMetadata, qualifiedName, String.valueOf(value))
-            all.add(node)
+            addNode(node)
             nested.add(node)
         }
 
-        @Override
-        void visitLeaf(T parent, String qualifiedName, PropertyMetadata propertyMetadata) {
-            def value = childToString(parent, propertyMetadata)
-            def node = new CollectedNode(null, qualifiedName, value)
-            all.add(node)
-            leaves.add(node)
-        }
-
-        abstract protected String valueToString(T value);
-
-        abstract protected String childToString(T parent, PropertyMetadata propertyMetadata)
+        abstract protected String valueToString(T value)
 
         List<String> getAll() {
             return all.collect { it.toString() }
@@ -451,10 +440,6 @@ class AbstractTypeMetadataWalkerTest extends Specification implements TestAnnota
 
         CollectedNode getNested(String name) {
             return nested.find { it.qualifiedName == name }
-        }
-
-        List<String> getLeaves() {
-            return leaves.collect { it.toString() }
         }
 
         List<String> getAllQualifiedNames() {

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/internal/PropertyValidationAccess.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/internal/PropertyValidationAccess.java
@@ -101,10 +101,6 @@ public class PropertyValidationAccess {
             public void visitNested(TypeMetadata typeMetadata, String qualifiedName, PropertyMetadata propertyMetadata, TypeToken<?> value) {
                 typeMetadata.visitValidationFailures(qualifiedName, validationContext);
             }
-
-            @Override
-            public void visitLeaf(TypeToken<?> parent, String qualifiedName, PropertyMetadata propertyMetadata) {
-            }
         });
     }
 

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/internal/PropertyValidationAccess.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/internal/PropertyValidationAccess.java
@@ -40,7 +40,6 @@ import org.gradle.internal.state.DefaultManagedFactoryRegistry;
 
 import javax.annotation.Nullable;
 import java.util.List;
-import java.util.function.Supplier;
 
 /**
  * Class for easy access to property validation from the validator task.
@@ -104,7 +103,7 @@ public class PropertyValidationAccess {
             }
 
             @Override
-            public void visitLeaf(String qualifiedName, PropertyMetadata propertyMetadata, Supplier<TypeToken<?>> value) {
+            public void visitLeaf(TypeToken<?> parent, String qualifiedName, PropertyMetadata propertyMetadata) {
             }
         });
     }


### PR DESCRIPTION
We just keep track of the parent node instead of passing around a `Supplier<Object>`.

Also stop visiting leaves when visiting the static type hiearchy.