### PR TITLE
Update annotationProcessorGeneratedSourcesDirectory nag to 9.0

### DIFF
--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
@@ -1103,7 +1103,7 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
             package com.example;
             public class Main {}
         """
-        executer.expectDocumentedDeprecationWarning("The CompileOptions.annotationProcessorGeneratedSourcesDirectory property has been deprecated. This is scheduled to be removed in Gradle 8.0. Please use the generatedSourceOutputDirectory property instead. See https://docs.gradle.org/current/dsl/org.gradle.api.tasks.compile.CompileOptions.html#org.gradle.api.tasks.compile.CompileOptions:annotationProcessorGeneratedSourcesDirectory for more details.")
+        executer.expectDocumentedDeprecationWarning("The CompileOptions.annotationProcessorGeneratedSourcesDirectory property has been deprecated. This is scheduled to be removed in Gradle 9.0. Please use the generatedSourceOutputDirectory property instead. See https://docs.gradle.org/current/dsl/org.gradle.api.tasks.compile.CompileOptions.html#org.gradle.api.tasks.compile.CompileOptions:annotationProcessorGeneratedSourcesDirectory for more details.")
 
         then:
         succeeds("compileJava")

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
@@ -519,7 +519,7 @@ public abstract class CompileOptions extends AbstractOptions {
      *
      * @since 4.3
      *
-     * @deprecated Use {@link #getGeneratedSourceOutputDirectory()} instead. This method will be removed in Gradle 8.0.
+     * @deprecated Use {@link #getGeneratedSourceOutputDirectory()} instead. This method will be removed in Gradle 9.0.
      */
     @Nullable
     @Deprecated
@@ -527,7 +527,7 @@ public abstract class CompileOptions extends AbstractOptions {
     public File getAnnotationProcessorGeneratedSourcesDirectory() {
         DeprecationLogger.deprecateProperty(CompileOptions.class, "annotationProcessorGeneratedSourcesDirectory")
             .replaceWith("generatedSourceOutputDirectory")
-            .willBeRemovedInGradle8()
+            .willBeRemovedInGradle9()
             .withDslReference()
             .nagUser();
 
@@ -543,12 +543,12 @@ public abstract class CompileOptions extends AbstractOptions {
      */
     @Deprecated
     public void setAnnotationProcessorGeneratedSourcesDirectory(@Nullable File file) {
-        // Used by Android plugin. Followup with https://github.com/gradle/gradle/issues/16782
-        /*DeprecationLogger.deprecateProperty(CompileOptions.class, "annotationProcessorGeneratedSourcesDirectory")
-            .replaceWith("generatedSourceOutputDirectory")
-            .willBeRemovedInGradle8()
-            .withDslReference()
-            .nagUser();*/
+        // Enable this deprecation in 8.1+. See: https://github.com/gradle/gradle/issues/16782
+//        DeprecationLogger.deprecateProperty(CompileOptions.class, "annotationProcessorGeneratedSourcesDirectory")
+//            .replaceWith("generatedSourceOutputDirectory")
+//            .willBeRemovedInGradle9()
+//            .withDslReference()
+//            .nagUser();
 
         this.generatedSourceOutputDirectory.set(file);
     }
@@ -559,6 +559,13 @@ public abstract class CompileOptions extends AbstractOptions {
      * @since 4.3
      */
     public void setAnnotationProcessorGeneratedSourcesDirectory(Provider<File> file) {
+        // Enable this deprecation in 8.1+.
+//        DeprecationLogger.deprecateProperty(CompileOptions.class, "annotationProcessorGeneratedSourcesDirectory")
+//            .replaceWith("generatedSourceOutputDirectory")
+//            .willBeRemovedInGradle9()
+//            .withDslReference()
+//            .nagUser();
+
         this.generatedSourceOutputDirectory.fileProvider(file);
     }
 


### PR DESCRIPTION
We are punting removal of this method to 9.0 since intellij uses it.

See: https://github.com/gradle/gradle/pull/17105