### PR TITLE
Rebaseline JavaFirstUsePerformanceTest

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,4 +23,4 @@ systemProp.gradle.internal.testdistribution.writeTraceFile=true
 systemProp.gradle.internal.testdistribution.queryResponseTimeout=PT20S
 
 # Default performance baseline
-defaultPerformanceBaselines=8.0-commit-c6d0e67c
+defaultPerformanceBaselines=8.1-commit-5aabcdb3


### PR DESCRIPTION
There seems to be 1~1.5% accumulated regression in JavaFirstUsePerformanceTest, rebaseline it.
