### PR TITLE
Remove "Remote test distribution enabled" log

### DIFF
--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -285,8 +285,6 @@ fun configureTests() {
         }
 
         if (project.testDistributionEnabled && !isUnitTest() && !isPerformanceProject()) {
-            println("Remote test distribution has been enabled for $testName")
-
             distribution {
                 this as TestDistributionExtensionInternal
                 enabled.set(true)


### PR DESCRIPTION
It was for debugging purpose, and now we no longer need it. We can find this information in trace.json.
