### PR TITLE
Fix for Incremental compilation with modules

### DIFF
--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
@@ -231,6 +231,7 @@ public abstract class GroovyCompile extends AbstractCompile implements HasCompil
         spec.setSourcesRoots(sourceRoots);
         spec.setSourceFiles(stableSourcesAsFileTree);
         spec.setDestinationDir(getDestinationDirectory().getAsFile().get());
+        spec.setOriginalDestinationDir(spec.getDestinationDir());
         spec.setWorkingDir(getProjectLayout().getProjectDirectory().getAsFile());
         spec.setTempDir(getTemporaryDir());
         spec.setCompileClasspath(ImmutableList.copyOf(determineGroovyCompileClasspath()));

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/BaseIncrementalCompilationAfterFailureIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/BaseIncrementalCompilationAfterFailureIntegrationTest.groovy
@@ -258,7 +258,7 @@ class JavaIncrementalCompilationAfterFailureIntegrationTest extends BaseIncremen
     CompiledLanguage language = CompiledLanguage.JAVA
 
     @Requires(TestPrecondition.JDK9_OR_LATER)
-    def "incrementally compilation after failure works with modules #description"() {
+    def "incremental compilation after failure works with modules #description"() {
         file("impl/build.gradle") << """
             def layout = project.layout
             tasks.compileJava {

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/BaseIncrementalCompilationAfterFailureIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/BaseIncrementalCompilationAfterFailureIntegrationTest.groovy
@@ -21,6 +21,8 @@ import org.gradle.api.internal.cache.StringInterner
 import org.gradle.api.internal.tasks.compile.incremental.recomp.PreviousCompilationAccess
 import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.integtests.fixtures.CompiledLanguage
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 import org.gradle.util.internal.TextUtil
 import spock.lang.Issue
 
@@ -254,6 +256,56 @@ abstract class BaseIncrementalCompilationAfterFailureIntegrationTest extends Abs
 
 class JavaIncrementalCompilationAfterFailureIntegrationTest extends BaseIncrementalCompilationAfterFailureIntegrationTest {
     CompiledLanguage language = CompiledLanguage.JAVA
+
+    @Requires(TestPrecondition.JDK9_OR_LATER)
+    def "incrementally compilation after failure works with modules #description"() {
+        file("impl/build.gradle") << """
+            def layout = project.layout
+            tasks.compileJava {
+                modularity.inferModulePath = $inferModulePath
+                options.compilerArgs.addAll($compileArgs)
+                doFirst {
+                    $doFirst
+                }
+            }
+        """
+        source "package a; import b.B; public class A {}",
+            "package b; public class B {}",
+            "package c; public class C {}"
+        file("src/main/${language.name}/module-info.${language.name}").text = """
+            module impl {
+                exports a;
+                exports b;
+                exports c;
+            }
+        """
+        succeeds language.compileTaskName
+        outputs.recompiledClasses("A", "B", "C", "module-info")
+
+        when:
+        outputs.snapshot {
+            source "package a; import b.B; public class A { void m1() {}; }",
+                "package b; import a.A; public class B { A m1() { return new B(); } }"
+        }
+
+        then:
+        fails language.compileTaskName
+
+        when:
+        outputs.snapshot {
+            source "package a; import b.B; public class A { void m1() {}; }",
+                "package b; import a.A; public class B { A m1() { return new A(); } }"
+        }
+        succeeds language.compileTaskName
+
+        then:
+        outputs.recompiledClasses("A", "B", "module-info")
+
+        where:
+        description                 | inferModulePath | compileArgs                                                  | doFirst
+        "with inferred module-path" | "true"          | "[]"                                                         | ""
+        "with manual module-path"   | "false"         | "[\"--module-path=\${classpath.join(File.pathSeparator)}\"]" | "classpath = layout.files()"
+    }
 }
 
 class GroovyIncrementalCompilationAfterFailureIntegrationTest extends BaseIncrementalCompilationAfterFailureIntegrationTest {

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/CrossTaskIncrementalJavaCompilationIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/CrossTaskIncrementalJavaCompilationIntegrationTest.groovy
@@ -86,15 +86,21 @@ abstract class CrossTaskIncrementalJavaCompilationIntegrationTest extends Abstra
                 }
             }
         """
-        source api: ["package a; public class A {}"], impl: ["package b; import a.A; class B extends A {}", "class Unrelated {}"]
+        source api: ["package a; public class A {}"]
         file("api/src/main/${language.name}/module-info.${language.name}").text = """
             module api {
                 exports a;
             }
         """
+        source impl: [
+            "package b; import a.A; public class B extends A {}",
+            "package c; public class Unrelated {}"
+        ]
         file("impl/src/main/${language.name}/module-info.${language.name}").text = """
             module impl {
                 requires api;
+                exports b;
+                exports c;
             }
         """
         succeeds "impl:${language.compileTaskName}"

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/CrossTaskIncrementalJavaCompilationIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/CrossTaskIncrementalJavaCompilationIntegrationTest.groovy
@@ -75,7 +75,7 @@ abstract class CrossTaskIncrementalJavaCompilationIntegrationTest extends Abstra
 
     @Requires(TestPrecondition.JDK9_OR_LATER)
     @Issue("https://github.com/gradle/gradle/issues/23067")
-    def "incrementally compilation works with modules with manual module path with #description"() {
+    def "incremental compilation works with modules with manual module path with #description"() {
         file("impl/build.gradle") << """
             def layout = project.layout
             tasks.compileJava {
@@ -122,7 +122,7 @@ abstract class CrossTaskIncrementalJavaCompilationIntegrationTest extends Abstra
     }
 
     @Requires(TestPrecondition.JDK9_OR_LATER)
-    def "incrementally compilation works with modules with inferred module path"() {
+    def "incremental compilation works with modules with inferred module path"() {
         file("impl/build.gradle") << """
             def layout = project.layout
             tasks.compileJava {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJavaCompileSpec.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJavaCompileSpec.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.tasks.compile;
 
-import com.google.common.collect.ImmutableList;
 import org.gradle.api.internal.tasks.compile.processing.AnnotationProcessorDeclaration;
 import org.gradle.api.tasks.compile.CompileOptions;
 
@@ -35,6 +34,7 @@ public class DefaultJavaCompileSpec extends DefaultJvmLanguageCompileSpec implem
     private Set<String> classes;
     private List<File> modulePath;
     private List<File> sourceRoots;
+    private boolean isIncrementalCompilationOfJavaModule;
 
     @Override
     public MinimalJavaCompileOptions getCompileOptions() {
@@ -102,6 +102,16 @@ public class DefaultJavaCompileSpec extends DefaultJvmLanguageCompileSpec implem
     @Override
     public void setModulePath(List<File> modulePath) {
         this.modulePath = modulePath;
+    }
+
+    @Override
+    public boolean isIncrementalCompilationOfJavaModule() {
+        return isIncrementalCompilationOfJavaModule;
+    }
+
+    @Override
+    public void setIsIncrementalCompilationOfJavaModule(boolean isIncrementalCompilationOfJavaModule) {
+        this.isIncrementalCompilationOfJavaModule = isIncrementalCompilationOfJavaModule;
     }
 
     @Override

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJavaCompileSpec.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJavaCompileSpec.java
@@ -81,10 +81,12 @@ public class DefaultJavaCompileSpec extends DefaultJvmLanguageCompileSpec implem
             // This is kept for backward compatibility - may be removed in the future
             int i = 0;
             List<String> modulePaths = new ArrayList<>();
-            for (String arg : compileOptions.getCompilerArgs()) {
+            // Some arguments can also be a GString, that is why use Object.toString()
+            for (Object argObj : compileOptions.getCompilerArgs()) {
+                String arg = argObj.toString();
                 if ((arg.equals("--module-path") || arg.equals("-p")) && (i + 1) < compileOptions.getCompilerArgs().size()) {
-                    String argValue = compileOptions.getCompilerArgs().get(++i);
-                    String[] modules = argValue.split(File.pathSeparator);
+                    Object argValue = compileOptions.getCompilerArgs().get(++i);
+                    String[] modules = argValue.toString().split(File.pathSeparator);
                     modulePaths.addAll(Arrays.asList(modules));
                 } else if (arg.startsWith("--module-path=")) {
                     String[] modules = arg.replace("--module-path=", "").split(File.pathSeparator);

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompileSpec.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompileSpec.java
@@ -47,6 +47,10 @@ public interface JavaCompileSpec extends JvmLanguageCompileSpec {
 
     void setModulePath(List<File> modulePath);
 
+    boolean isIncrementalCompilationOfJavaModule();
+
+    void setIsIncrementalCompilationOfJavaModule(boolean isIncrementalCompilationOfJavaModule);
+
     default boolean annotationProcessingConfigured() {
         return !getAnnotationProcessorPath().isEmpty() && !getCompileOptions().getCompilerArgs().contains("-proc:none");
     }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/AbstractRecompilationSpecProvider.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/AbstractRecompilationSpecProvider.java
@@ -205,13 +205,14 @@ abstract class AbstractRecompilationSpecProvider implements RecompilationSpecPro
     private static void addModuleInfoToCompile(RecompilationSpec spec, SourceFileClassNameConverter sourceFileClassNameConverter) {
         Set<String> moduleInfoSources = sourceFileClassNameConverter.getRelativeSourcePaths(MODULE_INFO_CLASS);
         if (!moduleInfoSources.isEmpty()) {
-            // Fixes: https://github.com/gradle/gradle/issues/23067
             // Always recompile module-info.java if present.
             // This solves case for incremental compilation for manual --module-path when not combined with --module-source-path or --source-path,
             // since compiled module-info is not in the output after we change compile outputs in the CompileTransaction.
             // Alternative would be, that we would move/copy the module-info class to transaction outputs and add transaction outputs to classpath.
+            // First part of fix for: https://github.com/gradle/gradle/issues/23067
             spec.addClassToCompile(MODULE_INFO_CLASS);
             spec.addSourcePaths(moduleInfoSources);
+            spec.setIsIncrementalCompilationOfJavaModule(true);
         }
     }
 
@@ -231,6 +232,7 @@ abstract class AbstractRecompilationSpecProvider implements RecompilationSpecPro
         includePreviousCompilationOutputOnClasspath(spec);
         addClassesToProcess(spec, recompilationSpec);
         Map<GeneratedResource.Location, PatternSet> resourcesToDelete = prepareResourcePatterns(recompilationSpec.getResourcesToGenerate(), fileOperations);
+        spec.setIsIncrementalCompilationOfJavaModule(recompilationSpec.isIncrementalCompilationOfJavaModule());
         return new CompileTransaction(spec, classesToDelete, resourcesToDelete, fileOperations, deleter);
     }
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/AbstractRecompilationSpecProvider.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/AbstractRecompilationSpecProvider.java
@@ -42,6 +42,10 @@ import java.util.Map;
 import java.util.Set;
 
 abstract class AbstractRecompilationSpecProvider implements RecompilationSpecProvider {
+
+    private static final String MODULE_INFO_CLASS = "module-info";
+    private static final String PACKAGE_INFO_CLASS = "package-info";
+
     private final Deleter deleter;
     private final FileOperations fileOperations;
     private final FileTree sourceTree;
@@ -76,6 +80,7 @@ abstract class AbstractRecompilationSpecProvider implements RecompilationSpecPro
 
         Set<String> typesToReprocess = previous.getTypesToReprocess(recompilationSpec.getClassesToCompile());
         processTypesToReprocess(typesToReprocess, recompilationSpec, sourceFileClassNameConverter);
+        addModuleInfoToCompile(recompilationSpec, sourceFileClassNameConverter);
 
         return recompilationSpec;
     }
@@ -185,7 +190,7 @@ abstract class AbstractRecompilationSpecProvider implements RecompilationSpecPro
 
     private static void processTypesToReprocess(Set<String> typesToReprocess, RecompilationSpec spec, SourceFileClassNameConverter sourceFileClassNameConverter) {
         for (String typeToReprocess : typesToReprocess) {
-            if (typeToReprocess.endsWith("package-info") || typeToReprocess.equals("module-info")) {
+            if (typeToReprocess.endsWith(PACKAGE_INFO_CLASS) || typeToReprocess.equals(MODULE_INFO_CLASS)) {
                 // Fixes: https://github.com/gradle/gradle/issues/17572
                 // package-info classes cannot be passed as classes to reprocess to the Java compiler.
                 // Therefore, we need to recompile them every time anything changes if they are processed by an aggregating annotation processor.
@@ -194,6 +199,19 @@ abstract class AbstractRecompilationSpecProvider implements RecompilationSpecPro
             } else {
                 spec.addClassToReprocess(typeToReprocess);
             }
+        }
+    }
+
+    private static void addModuleInfoToCompile(RecompilationSpec spec, SourceFileClassNameConverter sourceFileClassNameConverter) {
+        Set<String> moduleInfoSources = sourceFileClassNameConverter.getRelativeSourcePaths(MODULE_INFO_CLASS);
+        if (!moduleInfoSources.isEmpty()) {
+            // Fixes: https://github.com/gradle/gradle/issues/23067
+            // Always recompile module-info.java if present.
+            // This solves case for incremental compilation for manual --module-path when not combined with --module-source-path or --source-path,
+            // since compiled module-info is not in the output after we change compile outputs in the CompileTransaction.
+            // Alternative would be, that we would move/copy the module-info class to transaction outputs and add transaction outputs to classpath.
+            spec.addClassToCompile(MODULE_INFO_CLASS);
+            spec.addSourcePaths(moduleInfoSources);
         }
     }
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/RecompilationSpec.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/RecompilationSpec.java
@@ -29,7 +29,6 @@ public class RecompilationSpec {
     private final Collection<String> classesToProcess = new LinkedHashSet<>();
     private final Collection<GeneratedResource> resourcesToGenerate = new LinkedHashSet<>();
     private String fullRebuildCause;
-    private boolean isIncrementalCompilationOfJavaModule;
 
     @Override
     public String toString() {
@@ -54,6 +53,10 @@ public class RecompilationSpec {
 
     public Set<String> getClassesToCompile() {
         return Collections.unmodifiableSet(classesToCompile);
+    }
+
+    public boolean hasClassToCompile(String className) {
+        return classesToCompile.contains(className);
     }
 
     public void addClassToReprocess(String classToReprocess) {
@@ -98,13 +101,5 @@ public class RecompilationSpec {
 
     public void setFullRebuildCause(String description) {
         fullRebuildCause = description;
-    }
-
-    public boolean isIncrementalCompilationOfJavaModule() {
-        return isIncrementalCompilationOfJavaModule;
-    }
-
-    public void setIsIncrementalCompilationOfJavaModule(boolean isIncrementalCompilationOfJavaModule) {
-        this.isIncrementalCompilationOfJavaModule = isIncrementalCompilationOfJavaModule;
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/RecompilationSpec.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/RecompilationSpec.java
@@ -29,6 +29,7 @@ public class RecompilationSpec {
     private final Collection<String> classesToProcess = new LinkedHashSet<>();
     private final Collection<GeneratedResource> resourcesToGenerate = new LinkedHashSet<>();
     private String fullRebuildCause;
+    private boolean isIncrementalCompilationOfJavaModule;
 
     @Override
     public String toString() {
@@ -99,4 +100,11 @@ public class RecompilationSpec {
         fullRebuildCause = description;
     }
 
+    public boolean isIncrementalCompilationOfJavaModule() {
+        return isIncrementalCompilationOfJavaModule;
+    }
+
+    public void setIsIncrementalCompilationOfJavaModule(boolean isIncrementalCompilationOfJavaModule) {
+        this.isIncrementalCompilationOfJavaModule = isIncrementalCompilationOfJavaModule;
+    }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/transaction/CompileTransaction.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/transaction/CompileTransaction.java
@@ -102,9 +102,7 @@ public class CompileTransaction {
             moveCompileOutputToOriginalFolders(stagedOutputs);
             return result;
         } catch (CompilationFailedException t) {
-            if (spec.getCompileOptions().supportsIncrementalCompilationAfterFailure()) {
-                rollbackStash(stashResult.stashedFiles);
-            }
+            rollbackStash(stashResult.stashedFiles);
             throw t;
         } finally {
             restoreSpecOutputs(stagedOutputs);
@@ -233,15 +231,25 @@ public class CompileTransaction {
     }
 
     private void rollbackStash(List<StashedFile> stashedFiles) {
-        stashedFiles.forEach(StashedFile::unstash);
+        if (isIncrementalCompilationAfterFailure()) {
+            stashedFiles.forEach(StashedFile::unstash);
+        }
     }
 
     private void setupSpecOutputs(List<StagedOutput> stagedOutputs) {
-        stagedOutputs.forEach(StagedOutput::setupSpecOutput);
+        if (isIncrementalCompilationAfterFailure()) {
+            stagedOutputs.forEach(StagedOutput::setupSpecOutput);
+        }
     }
 
     private void restoreSpecOutputs(List<StagedOutput> stagedOutputs) {
-        stagedOutputs.forEach(StagedOutput::restoreSpecOutput);
+        if (isIncrementalCompilationAfterFailure()) {
+            stagedOutputs.forEach(StagedOutput::restoreSpecOutput);
+        }
+    }
+
+    private boolean isIncrementalCompilationAfterFailure() {
+        return spec.getCompileOptions().supportsIncrementalCompilationAfterFailure();
     }
 
     private static void moveFile(File sourceFile, File destinationFile) {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/transaction/CompileTransaction.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/transaction/CompileTransaction.java
@@ -231,24 +231,24 @@ public class CompileTransaction {
     }
 
     private void rollbackStash(List<StashedFile> stashedFiles) {
-        if (isIncrementalCompilationAfterFailure()) {
+        if (supportsIncrementalCompilationAfterFailure()) {
             stashedFiles.forEach(StashedFile::unstash);
         }
     }
 
     private void setupSpecOutputs(List<StagedOutput> stagedOutputs) {
-        if (isIncrementalCompilationAfterFailure()) {
+        if (supportsIncrementalCompilationAfterFailure()) {
             stagedOutputs.forEach(StagedOutput::setupSpecOutput);
         }
     }
 
     private void restoreSpecOutputs(List<StagedOutput> stagedOutputs) {
-        if (isIncrementalCompilationAfterFailure()) {
+        if (supportsIncrementalCompilationAfterFailure()) {
             stagedOutputs.forEach(StagedOutput::restoreSpecOutput);
         }
     }
 
-    private boolean isIncrementalCompilationAfterFailure() {
+    private boolean supportsIncrementalCompilationAfterFailure() {
         return spec.getCompileOptions().supportsIncrementalCompilationAfterFailure();
     }
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/reflect/GradleStandardJavaFileManager.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/reflect/GradleStandardJavaFileManager.java
@@ -27,6 +27,7 @@ import javax.tools.StandardJavaFileManager;
 import javax.tools.StandardLocation;
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.URLClassLoader;
 import java.util.Collections;
 import java.util.Set;
@@ -51,7 +52,7 @@ public class GradleStandardJavaFileManager extends ForwardingJavaFileManager<Sta
             try {
                 fileManager.setLocation(GradleLocation.PREVIOUS_CLASS_OUTPUT, Collections.singleton(previousClassOutput));
             } catch (IOException e) {
-                throw new RuntimeException(e);
+                throw new UncheckedIOException("Problem registering previous class output location", e);
             }
         }
     }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/reflect/GradleStandardJavaFileManager.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/reflect/GradleStandardJavaFileManager.java
@@ -96,13 +96,13 @@ public class GradleStandardJavaFileManager extends ForwardingJavaFileManager<Sta
             }
         }
 
-        if (hasPreviousClassOutput && location == StandardLocation.CLASS_OUTPUT) {
+        if (hasPreviousClassOutput && location.equals(StandardLocation.CLASS_OUTPUT)) {
             // For Java module compilation we list also previous class output as class output.
             // This is needed for incremental compilation after a failure where we change output folders.
             // With that we make sure that all module classes/packages are found by javac.
-            // In case case one of --module-source-path or --source-path is provided, this makes sure, that javac won't automatically recompile
-            // classes that are not in CLASS_OUTPUT, but are in PREVIOUS_CLASS_OUTPUT. And in case when --module-source-path or --source-path are not provided,
-            // this makes sure that javac doesn't error on missing packages that are not in CLASS_OUTPUT, but are in PREVIOUS_CLASS_OUTPUT.
+            // In case one of --module-source-path or --source-path is provided, this makes sure, that javac won't automatically recompile
+            // classes that are not in CLASS_OUTPUT. And in case when --module-source-path or --source-path are not provided,
+            // this makes sure that javac doesn't fail on missing packages or classes that are not in CLASS_OUTPUT.
             // Second and last part of fix for: https://github.com/gradle/gradle/issues/23067
             Iterable<JavaFileObject> previousClassOutput = super.list(GradleLocation.PREVIOUS_CLASS_OUTPUT, packageName, kinds, recurse);
             Iterable<JavaFileObject> classOutput = super.list(location, packageName, kinds, recurse);

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/reflect/GradleStandardJavaFileManager.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/reflect/GradleStandardJavaFileManager.java
@@ -16,15 +16,19 @@
 
 package org.gradle.api.internal.tasks.compile.reflect;
 
+import com.google.common.collect.Iterables;
 import org.gradle.internal.classpath.ClassPath;
 
+import javax.annotation.Nullable;
 import javax.tools.ForwardingJavaFileManager;
 import javax.tools.JavaFileManager;
 import javax.tools.JavaFileObject;
 import javax.tools.StandardJavaFileManager;
 import javax.tools.StandardLocation;
+import java.io.File;
 import java.io.IOException;
 import java.net.URLClassLoader;
+import java.util.Collections;
 import java.util.Set;
 
 import static org.gradle.api.internal.tasks.compile.filter.AnnotationProcessorFilter.getFilteredClassLoader;
@@ -32,19 +36,32 @@ import static org.gradle.api.internal.tasks.compile.filter.AnnotationProcessorFi
 public class GradleStandardJavaFileManager extends ForwardingJavaFileManager<StandardJavaFileManager> {
     private final ClassPath annotationProcessorPath;
     private final boolean hasEmptySourcePaths;
+    private final boolean hasPreviousClassOutput;
 
-    private GradleStandardJavaFileManager(StandardJavaFileManager fileManager, ClassPath annotationProcessorPath, boolean hasEmptySourcePaths) {
+    private GradleStandardJavaFileManager(StandardJavaFileManager fileManager, ClassPath annotationProcessorPath, boolean hasEmptySourcePaths, @Nullable File previousClassOutput) {
         super(fileManager);
         this.annotationProcessorPath = annotationProcessorPath;
         this.hasEmptySourcePaths = hasEmptySourcePaths;
+        this.hasPreviousClassOutput = previousClassOutput != null;
+        registerPreviousClassOutput(previousClassOutput);
+    }
+
+    private void registerPreviousClassOutput(@Nullable File previousClassOutput) {
+        if (previousClassOutput != null) {
+            try {
+                fileManager.setLocation(GradleLocation.PREVIOUS_CLASS_OUTPUT, Collections.singleton(previousClassOutput));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
     }
 
     /**
      * Overrides particular methods to prevent javac from accessing source files outside of Gradle's understanding or
      * classloaders outside of Gradle's control.
      */
-    public static JavaFileManager wrap(StandardJavaFileManager delegate, ClassPath annotationProcessorPath, boolean hasEmptySourcePaths) {
-        return new GradleStandardJavaFileManager(delegate, annotationProcessorPath, hasEmptySourcePaths);
+    public static JavaFileManager wrap(StandardJavaFileManager delegate, ClassPath annotationProcessorPath, boolean hasEmptySourcePaths, @Nullable File previousClassOutput) {
+        return new GradleStandardJavaFileManager(delegate, annotationProcessorPath, hasEmptySourcePaths, previousClassOutput);
     }
 
     @Override
@@ -78,6 +95,20 @@ public class GradleStandardJavaFileManager extends ForwardingJavaFileManager<Sta
                 kinds.remove(JavaFileObject.Kind.SOURCE);
             }
         }
+
+        if (hasPreviousClassOutput && location == StandardLocation.CLASS_OUTPUT) {
+            // For Java module compilation we list also previous class output as class output.
+            // This is needed for incremental compilation after a failure where we change output folders.
+            // With that we make sure that all module classes/packages are found by javac.
+            // In case case one of --module-source-path or --source-path is provided, this makes sure, that javac won't automatically recompile
+            // classes that are not in CLASS_OUTPUT, but are in PREVIOUS_CLASS_OUTPUT. And in case when --module-source-path or --source-path are not provided,
+            // this makes sure that javac doesn't error on missing packages that are not in CLASS_OUTPUT, but are in PREVIOUS_CLASS_OUTPUT.
+            // Second and last part of fix for: https://github.com/gradle/gradle/issues/23067
+            Iterable<JavaFileObject> previousClassOutput = super.list(GradleLocation.PREVIOUS_CLASS_OUTPUT, packageName, kinds, recurse);
+            Iterable<JavaFileObject> classOutput = super.list(location, packageName, kinds, recurse);
+            return Iterables.concat(previousClassOutput, classOutput);
+        }
+
         return super.list(location, packageName, kinds, recurse);
     }
 
@@ -91,5 +122,19 @@ public class GradleStandardJavaFileManager extends ForwardingJavaFileManager<Sta
         }
 
         return classLoader;
+    }
+
+    private enum GradleLocation implements Location {
+        PREVIOUS_CLASS_OUTPUT;
+
+        @Override
+        public String getName() {
+            return name();
+        }
+
+        @Override
+        public boolean isOutputLocation() {
+            return false;
+        }
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -234,6 +234,7 @@ public abstract class JavaCompile extends AbstractCompile implements HasCompileO
         DefaultJavaCompileSpec spec = new DefaultJavaCompileSpecFactory(compileOptions, getToolchain()).create();
 
         spec.setDestinationDir(getDestinationDirectory().getAsFile().get());
+        spec.setOriginalDestinationDir(spec.getDestinationDir());
         spec.setWorkingDir(getProjectLayout().getProjectDirectory().getAsFile());
         spec.setTempDir(getTemporaryDir());
         spec.setCompileClasspath(ImmutableList.copyOf(javaModuleDetector.inferClasspath(isModule, getClasspath())));

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/DefaultJavaCompileSpecTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/DefaultJavaCompileSpecTest.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.compile
+
+
+import org.gradle.api.tasks.compile.CompileOptions
+import org.gradle.util.TestUtil
+import spock.lang.Specification
+
+class DefaultJavaCompileSpecTest extends Specification {
+
+    def "parses module-path from compileArgs with #description"() {
+        given:
+        CompileOptions options = TestUtil.newInstance(CompileOptions, TestUtil.objectFactory())
+        options.compilerArgs.addAll(modulePathParameters)
+        DefaultJavaCompileSpec compileSpec = new DefaultJavaCompileSpec()
+        compileSpec.setCompileOptions(options)
+
+        when:
+        def modulePath = compileSpec.modulePath
+
+        then:
+        modulePath == [new File("/some/path"), new File("/some/path2")]
+
+        where:
+        description               | modulePathParameters
+        "--module-path=<modules>" | ["--module-path=/some/path$File.pathSeparator/some/path2"]
+        "--module-path <modules>" | ["--module-path", "/some/path$File.pathSeparator/some/path2"]
+        "-p <modules>"            | ["-p", "/some/path$File.pathSeparator/some/path2"]
+    }
+}

--- a/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJvmLanguageCompileSpec.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJvmLanguageCompileSpec.java
@@ -28,6 +28,7 @@ public class DefaultJvmLanguageCompileSpec implements JvmLanguageCompileSpec, Se
     private File tempDir;
     private List<File> classpath;
     private File destinationDir;
+    private File originalDestinationDir;
     private Iterable<File> sourceFiles;
     private Integer release;
     private String sourceCompatibility;
@@ -52,6 +53,16 @@ public class DefaultJvmLanguageCompileSpec implements JvmLanguageCompileSpec, Se
     @Override
     public void setDestinationDir(File destinationDir) {
         this.destinationDir = destinationDir;
+    }
+
+    @Override
+    public File getOriginalDestinationDir() {
+        return originalDestinationDir;
+    }
+
+    @Override
+    public void setOriginalDestinationDir(File originalDestinationDir) {
+        this.originalDestinationDir = originalDestinationDir;
     }
 
     @Override

--- a/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/JvmLanguageCompileSpec.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/JvmLanguageCompileSpec.java
@@ -35,6 +35,10 @@ public interface JvmLanguageCompileSpec extends CompileSpec {
 
     void setDestinationDir(File destinationDir);
 
+    File getOriginalDestinationDir();
+
+    void setOriginalDestinationDir(File originalDestinationDir);
+
     Iterable<File> getSourceFiles();
 
     void setSourceFiles(Iterable<File> sourceFiles);

--- a/subprojects/scala/src/main/java/org/gradle/language/scala/tasks/AbstractScalaCompile.java
+++ b/subprojects/scala/src/main/java/org/gradle/language/scala/tasks/AbstractScalaCompile.java
@@ -159,6 +159,7 @@ public abstract class AbstractScalaCompile extends AbstractCompile implements Ha
         DefaultScalaJavaJointCompileSpec spec = new DefaultScalaJavaJointCompileSpec(javaExecutable);
         spec.setSourceFiles(getSource().getFiles());
         spec.setDestinationDir(getDestinationDirectory().getAsFile().get());
+        spec.setOriginalDestinationDir(spec.getDestinationDir());
         spec.setWorkingDir(getProjectLayout().getProjectDirectory().getAsFile());
         spec.setTempDir(getTemporaryDir());
         spec.setCompileClasspath(ImmutableList.copyOf(getClasspath()));


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/23067 and also makes sure, that if incremental compilation after failure is disabled we don't change compile outputs. So in the case of some troubles, users can easily use old behavior.

This is a bit complicated fix. There are basically 2 problems we need to handle, because we change output location of javac:
1) External modules are not recognized when compiling incrementally
2) Packages inside the module we compile, but are not recompiled are not recognized by javac

----
1) Is solved by always compiling module-info.java
2) Is a bit harder. We modify GradleStandardJavaFileManager, so when javac tries to list files in CLASS_OUTPUT for module, we return also files in previous output location (normally build/classes/)

Tested also with the Elastic reproducer.

---

I also found a bug in snapshotting of manual module-path. If user sets `--module-path=<modules>` then we don't snapshot that path, but if user sets `--module-path <modules>` then we snapshot module path. The problem is, that we parse only the second option from the compile arguments. That is fixed now.