### PR TITLE
Partially avoid needing QDox by using -parameters

### DIFF
--- a/build-logic/build-platform/build.gradle.kts
+++ b/build-logic/build-platform/build.gradle.kts
@@ -42,7 +42,7 @@ dependencies {
         api("com.google.errorprone:error_prone_annotations:2.5.1")
         api("com.google.code.gson:gson:2.8.9")
         api("com.nhaarman:mockito-kotlin:1.6.0")
-        api("com.thoughtworks.qdox:qdox:2.0.0")
+        api("com.thoughtworks.qdox:qdox:2.0.3")
         api("com.uwyn:jhighlight:1.0")
         api("com.vladsch.flexmark:flexmark-all:0.34.60") {
             because("Higher versions tested are either incompatible (0.62.2) or bring additional unwanted dependencies (0.36.8)")

--- a/build-logic/build-platform/build.gradle.kts
+++ b/build-logic/build-platform/build.gradle.kts
@@ -42,7 +42,7 @@ dependencies {
         api("com.google.errorprone:error_prone_annotations:2.5.1")
         api("com.google.code.gson:gson:2.8.9")
         api("com.nhaarman:mockito-kotlin:1.6.0")
-        api("com.thoughtworks.qdox:qdox:2.0.3")
+        api("com.thoughtworks.qdox:qdox:2.0.0")
         api("com.uwyn:jhighlight:1.0")
         api("com.vladsch.flexmark:flexmark-all:0.34.60") {
             because("Higher versions tested are either incompatible (0.62.2) or bring additional unwanted dependencies (0.36.8)")

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -44,7 +44,7 @@ plugins {
     id("org.gradle.test-retry")
 }
 
-extensions.create<UnitTestAndCompileExtension>("gradlebuildJava", tasks)
+extensions.create<UnitTestAndCompileExtension>("gradlebuildJava", project, tasks)
 
 removeTeamcityTempProperty()
 addDependencies()
@@ -64,6 +64,7 @@ fun configureCompile() {
 
     tasks.withType<JavaCompile>().configureEach {
         configureCompileTask(options)
+        options.compilerArgs.add("-parameters")
     }
     tasks.withType<GroovyCompile>().configureEach {
         groovyOptions.encoding = "utf-8"

--- a/build-logic/jvm/src/main/kotlin/gradlebuild/jvm/extension/UnitTestAndCompileExtension.kt
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild/jvm/extension/UnitTestAndCompileExtension.kt
@@ -16,12 +16,16 @@
 
 package gradlebuild.jvm.extension
 
+import org.gradle.api.Project
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.kotlin.dsl.*
 
 
-abstract class UnitTestAndCompileExtension(private val tasks: TaskContainer) {
+abstract class UnitTestAndCompileExtension(
+    private val project: Project,
+    private val tasks: TaskContainer,
+) {
 
     /**
      * Enforces **Java 6** compatibility.
@@ -50,8 +54,11 @@ abstract class UnitTestAndCompileExtension(private val tasks: TaskContainer) {
     fun enforceJava6Compatibility() {
         tasks.withType<JavaCompile>().configureEach {
             options.release.set(null)
+            options.compilerArgs.remove("-parameters")
             sourceCompatibility = "6"
             targetCompatibility = "6"
         }
+        // Apply ParameterNamesIndex since 6 doesn't support -parameters
+        project.apply(plugin = "gradlebuild.api-parameter-names-index")
     }
 }

--- a/build-logic/uber-plugins/src/main/kotlin/gradlebuild.distribution-module.gradle.kts
+++ b/build-logic/uber-plugins/src/main/kotlin/gradlebuild.distribution-module.gradle.kts
@@ -17,6 +17,5 @@
 // Common configuration for everything that belongs to the Gradle distribution
 plugins {
     id("gradlebuild.java-library")
-    id("gradlebuild.api-parameter-names-index")
     id("gradlebuild.task-properties-validation")
 }

--- a/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/BinDistributionIntegrationSpec.groovy
+++ b/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/BinDistributionIntegrationSpec.groovy
@@ -31,7 +31,7 @@ class BinDistributionIntegrationSpec extends DistributionIntegrationSpec {
 
     @Override
     int getMaxDistributionSizeBytes() {
-        return 119 * 1024 * 1024
+        return 120 * 1024 * 1024
     }
 
     def binZipContents() {

--- a/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/DistributionIntegritySpec.groovy
+++ b/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/DistributionIntegritySpec.groovy
@@ -35,7 +35,7 @@ class DistributionIntegritySpec extends DistributionIntegrationSpec {
 
     @Override
     int getMaxDistributionSizeBytes() {
-        return 119 * 1024 * 1024
+        return 120 * 1024 * 1024
     }
 
     @Issue(['https://github.com/gradle/gradle/issues/9990', 'https://github.com/gradle/gradle/issues/10038'])

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ApiTypeProvider.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ApiTypeProvider.kt
@@ -33,7 +33,6 @@ import org.jetbrains.org.objectweb.asm.AnnotationVisitor
 import org.jetbrains.org.objectweb.asm.Attribute
 import org.jetbrains.org.objectweb.asm.ClassReader
 import org.jetbrains.org.objectweb.asm.ClassReader.SKIP_CODE
-import org.jetbrains.org.objectweb.asm.ClassReader.SKIP_DEBUG
 import org.jetbrains.org.objectweb.asm.ClassReader.SKIP_FRAMES
 import org.jetbrains.org.objectweb.asm.FieldVisitor
 import org.jetbrains.org.objectweb.asm.Opcodes.ACC_ABSTRACT
@@ -134,7 +133,7 @@ class ApiTypeProvider internal constructor(
     private
     fun classNodeFor(classBytesSupplier: () -> ByteArray) = {
         ApiTypeClassNode().also {
-            ClassReader(classBytesSupplier()).accept(it, SKIP_DEBUG or SKIP_CODE or SKIP_FRAMES)
+            ClassReader(classBytesSupplier()).accept(it, SKIP_CODE or SKIP_FRAMES)
         }
     }
 
@@ -260,7 +259,6 @@ class ApiFunction internal constructor(
     private val delegate: MethodNode,
     private val context: ApiTypeProvider.Context
 ) {
-
     val name: String =
         delegate.name
 
@@ -412,7 +410,9 @@ fun ApiTypeProvider.Context.apiFunctionParametersFor(function: ApiFunction, dele
             ApiFunctionParameter(
                 index = idx,
                 isVarargs = idx == parameterTypesBinaryNames.lastIndex && delegate.access.isVarargs,
-                nameSupplier = { names?.get(idx) },
+                nameSupplier = {
+                    names?.get(idx) ?: delegate.parameters?.get(idx)?.name
+                },
                 type = apiTypeUsageFor(parameterTypeName, isNullable, variance, typeArguments)
             )
         }

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensionsTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensionsTest.kt
@@ -58,7 +58,7 @@ class GradleApiExtensionsTest : TestWithClassPath() {
             ClassAndGroovyNamedArguments::class
         ) {
 
-            assertGeneratedJarHash("c961d3599f8de39dfc8751c9f2ae5794")
+            assertGeneratedJarHash("8d4fa55263cfc143c2e1a22e50a2d460")
         }
     }
 


### PR DESCRIPTION
This only works for Java 8, but it is necessary to avoid issues with using `TYPE_USE` annotations. This change improves debugging Gradle as well, since the parameter info is available at all times in Java 8 code.