### PR TITLE
Local toolchain installation repository spike. 

### DIFF
--- a/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/AbstractJavaToolchainDownloadSpiIntegrationTest.groovy
+++ b/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/AbstractJavaToolchainDownloadSpiIntegrationTest.groovy
@@ -20,7 +20,7 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 
 class AbstractJavaToolchainDownloadSpiIntegrationTest extends AbstractIntegrationSpec {
 
-    protected static String applyToolchainResolverPlugin(String pluginName = null, String resolverClass, String code) {
+    protected static String applyToolchainResolverPlugin(String resolverClass, String code, String pluginName = null) {
         if (pluginName == null) {
             pluginName = resolverClass + "Plugin"
         }
@@ -28,15 +28,15 @@ class AbstractJavaToolchainDownloadSpiIntegrationTest extends AbstractIntegratio
             public abstract class ${pluginName} implements Plugin<Settings> {
                 @Inject
                 protected abstract JavaToolchainResolverRegistry getToolchainResolverRegistry();
-            
+
                 void apply(Settings settings) {
                     settings.getPlugins().apply("jvm-toolchain-management");
-                
+
                     JavaToolchainResolverRegistry registry = getToolchainResolverRegistry();
                     registry.register(${resolverClass}.class);
                 }
             }
-            
+
             ${code}
 
             apply plugin: ${pluginName}

--- a/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainResolveLocalIntegrationTest.groovy
+++ b/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainResolveLocalIntegrationTest.groovy
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm.toolchain
+
+import org.gradle.integtests.fixtures.AvailableJavaHomes
+import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import org.gradle.internal.jvm.Jvm
+
+/**
+ * Tests resolution of local Java toolchains. Particularly the behavior of plugins
+ * which implement {@link JavaToolchainResolver#resolveLocal(JavaToolchainRequest)}.
+ */
+class JavaToolchainResolveLocalIntegrationTest extends AbstractJavaToolchainDownloadSpiIntegrationTest {
+
+    @ToBeFixedForConfigurationCache(because = "Fails the build with an additional error")
+    def "can inject custom local toolchain via settings plugin"() {
+
+        Jvm jdk = AvailableJavaHomes.getDifferentJdk()
+        String javaHome = jdk.javaHome.toString()
+        String javaVersion = jdk.javaVersion.getMajorVersion()
+
+        settingsFile << """
+            ${applyToolchainResolverPlugin("CustomToolchainResolver", customToolchainLocalResolverCode(javaHome))}
+            toolchainManagement {
+                jvm {
+                    javaRepositories {
+                        repository('custom') {
+                            resolverClass = CustomToolchainResolver
+                        }
+                    }
+                }
+            }
+        """
+
+        buildFile << """
+            apply plugin: "java"
+
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of($javaVersion)
+                }
+            }
+        """
+
+        file("src/main/java/Foo.java") << "public class Foo {}"
+
+        when:
+        succeeds "compileJava", "--info"
+
+        then:
+        outputContains("Compiling with toolchain '$javaHome'")
+    }
+
+    @ToBeFixedForConfigurationCache(because = "Fails the build with an additional error")
+    def "local JDK is checked against the spec"() {
+
+        Jvm jdk = AvailableJavaHomes.getDifferentJdk()
+        String javaHome = jdk.javaHome.toString()
+        String javaVersion = jdk.javaVersion.getMajorVersion()
+        int otherJavaVersion = Integer.parseInt(javaVersion) + 1
+
+        settingsFile << """
+            ${applyToolchainResolverPlugin("CustomToolchainResolver", customToolchainLocalResolverCode(javaHome))}
+            toolchainManagement {
+                jvm {
+                    javaRepositories {
+                        repository('broken') {
+                            resolverClass = CustomToolchainResolver
+                        }
+                    }
+                }
+            }
+        """
+
+        buildFile << """
+            apply plugin: "java"
+
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of($otherJavaVersion)
+                }
+            }
+        """
+
+        file("src/main/java/Foo.java") << "public class Foo {}"
+
+        when:
+        def failure = fails "compileJava"
+
+        then:
+        failure.assertHasCause("Toolchain provisioned from '$javaHome' doesn't satisfy the specification: {languageVersion=$otherJavaVersion, vendor=any, implementation=vendor-specific}.")
+    }
+
+    @ToBeFixedForConfigurationCache(because = "Fails the build with an additional error")
+    def "local JDKs are prioritized over remote jdk archive downloads"() {
+
+        settingsFile << """
+            ${applyToolchainResolverPlugin("CustomToolchainResolver", loggingLocalResolverCode("CustomToolchainResolver"))}
+            ${applyToolchainResolverPlugin("CustomToolchainResolver2", loggingLocalResolverCode("CustomToolchainResolver2"))}
+            toolchainManagement {
+                jvm {
+                    javaRepositories {
+                        repository('first') {
+                            resolverClass = CustomToolchainResolver
+                        }
+                        repository('second') {
+                            resolverClass = CustomToolchainResolver2
+                        }
+                    }
+                }
+            }
+        """
+
+        buildFile << """
+            apply plugin: "java"
+
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(99)
+                }
+            }
+        """
+
+        file("src/main/java/Foo.java") << "public class Foo {}"
+
+        when:
+        failure = executer
+            .withTasks("compileJava")
+            .requireOwnGradleUserHomeDir()
+            .withToolchainDownloadEnabled()
+            .runWithFailure()
+
+        then:
+        outputContains("""
+CustomToolchainResolver resolveLocal {languageVersion=99, vendor=any, implementation=vendor-specific}
+CustomToolchainResolver2 resolveLocal {languageVersion=99, vendor=any, implementation=vendor-specific}
+CustomToolchainResolver resolve {languageVersion=99, vendor=any, implementation=vendor-specific}
+CustomToolchainResolver2 resolve {languageVersion=99, vendor=any, implementation=vendor-specific}
+""")
+    }
+
+    private static String customToolchainLocalResolverCode(String javaHome, String name = "CustomToolchainResolver") {
+        """
+            import java.nio.file.Paths;
+            import java.util.Optional;
+            import org.gradle.platform.BuildPlatform;
+
+            public abstract class ${name} implements JavaToolchainResolver {
+                @Override
+                public Optional<JavaToolchainInstallation> resolveLocal(JavaToolchainRequest request) {
+                    return Optional.of(JavaToolchainInstallation.fromJavaHome(Paths.get("$javaHome")));
+                }
+            }
+        """
+    }
+
+    private static String loggingLocalResolverCode(String name) {
+        """
+            import java.nio.file.Paths;
+            import java.util.Optional;
+            import org.gradle.platform.BuildPlatform;
+
+            public abstract class ${name} implements JavaToolchainResolver {
+                @Override
+                public Optional<JavaToolchainInstallation> resolveLocal(JavaToolchainRequest request) {
+                    System.out.println("$name resolveLocal " + request.spec);
+                    return Optional.empty();
+                }
+                @Override
+                public Optional<JavaToolchainDownload> resolve(JavaToolchainRequest request) {
+                    System.out.println("$name resolve " + request.spec);
+                    return Optional.empty();
+                }
+            }
+        """
+
+    }
+}

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaToolchainDownload.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaToolchainDownload.java
@@ -23,7 +23,7 @@ import java.net.URI;
 
 /**
  * The response provided by a {@link JavaToolchainResolver} to a specific
- * {@link JavaToolchainRequest}.
+ * {@link JavaToolchainRequest} for remote toolchain archive downloads.
  * <p>
  * Contains the download URI from which a Java toolchain matching the request
  * can be downloaded from. The URI must point to either a ZIP or a TAR archive

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaToolchainInstallation.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaToolchainInstallation.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm.toolchain;
+
+import org.gradle.api.Incubating;
+import org.gradle.jvm.toolchain.internal.DefaultJavaToolchainInstallation;
+
+import java.nio.file.Path;
+
+/**
+ * The response provided by a {@link JavaToolchainResolver} to a specific
+ * {@link JavaToolchainRequest} for local toolchain installation directories.
+ * <p>
+ * Contains the path to the JAVA_HOME directory of a Java toolchain matching the request.
+ * The returned path must exist and contain a valid toolchain installation.
+ *
+ * @since 8.1
+ */
+@Incubating
+public interface JavaToolchainInstallation {
+
+    /**
+     * Get the JAVA_HOME directory of this installation.
+     */
+    Path getJavaHome();
+
+    /**
+     * Create a {@link JavaToolchainInstallation} from the JAVA_HOME directory of a
+     * local Java toolchain installation.
+     *
+     * @param javaHome The JAVA_HOME path. Must exist and point to a directory.
+     *
+     * @return A new {@link JavaToolchainInstallation}.
+     */
+    static JavaToolchainInstallation fromJavaHome(Path javaHome) {
+        return DefaultJavaToolchainInstallation.fromJavaHome(javaHome);
+    }
+
+}

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaToolchainResolver.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaToolchainResolver.java
@@ -25,12 +25,29 @@ import java.util.Optional;
 /**
  * Interface that needs to be implemented by Java toolchain provisioning plugins.
  * <p>
- * Plugin implementors have to provide the mapping from the Java toolchain request to a download information.
+ * Plugin implementors have to provide the mapping from the Java toolchain request to resolution information.
+ * <p>
+ * Resolution of local installation is prioritized over resolution of remote archives.
  *
  * @since 7.6
  */
 @Incubating
 public interface JavaToolchainResolver extends BuildService<BuildServiceParameters.None> {
+
+    /**
+     * Returns a {@link JavaToolchainInstallation} if a local Java toolchain installation
+     * matching the provided specification can be provided.
+     *
+     * @param request   information about the toolchain needed and the environment it's
+     *                  needed in
+     * @return          empty Optional if and only if the provided specification can't be
+     *                  matched
+     *
+     * @since 8.1
+     */
+    default Optional<JavaToolchainInstallation> resolveLocal(JavaToolchainRequest request) {
+        return Optional.empty();
+    }
 
     /**
      * Returns a {@link JavaToolchainDownload} if a Java toolchain matching the provided
@@ -41,6 +58,7 @@ public interface JavaToolchainResolver extends BuildService<BuildServiceParamete
      * @return          empty Optional if and only if the provided specification can't be
      *                  matched
      */
-    Optional<JavaToolchainDownload> resolve(JavaToolchainRequest request);
-
+    default Optional<JavaToolchainDownload> resolve(JavaToolchainRequest request) {
+        return Optional.empty();
+    }
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultJavaToolchainInstallation.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultJavaToolchainInstallation.java
@@ -14,15 +14,26 @@
  * limitations under the License.
  */
 
-package org.gradle.jvm.toolchain.internal.install;
+package org.gradle.jvm.toolchain.internal;
 
-import org.gradle.jvm.toolchain.JavaToolchainSpec;
+import org.gradle.jvm.toolchain.JavaToolchainInstallation;
 
-import java.io.File;
-import java.util.Optional;
+import java.nio.file.Path;
 
-public interface JavaToolchainProvisioningService {
+public class DefaultJavaToolchainInstallation implements JavaToolchainInstallation {
 
-    Optional<File> tryProvision(JavaToolchainSpec spec);
+    public static DefaultJavaToolchainInstallation fromJavaHome(Path path) {
+        return new DefaultJavaToolchainInstallation(path);
+    }
 
+    private final Path javaHome;
+
+    private DefaultJavaToolchainInstallation(Path javaHome) {
+        this.javaHome = javaHome;
+    }
+
+    @Override
+    public Path getJavaHome() {
+        return javaHome;
+    }
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainQueryService.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainQueryService.java
@@ -53,7 +53,7 @@ public class JavaToolchainQueryService {
 
     private final JavaInstallationRegistry registry;
     private final JavaToolchainFactory toolchainFactory;
-    private final JavaToolchainProvisioningService installService;
+    private final JavaToolchainProvisioningService provisioningService;
     private final Provider<Boolean> detectEnabled;
     private final Provider<Boolean> downloadEnabled;
     // Map values are either `JavaToolchain` or `Exception`
@@ -70,7 +70,7 @@ public class JavaToolchainQueryService {
     ) {
         this.registry = registry;
         this.toolchainFactory = toolchainFactory;
-        this.installService = provisioningService;
+        this.provisioningService = provisioningService;
         this.detectEnabled = factory.gradleProperty(AutoDetectingInstallationSupplier.AUTO_DETECT).map(Boolean::parseBoolean);
         this.downloadEnabled = factory.gradleProperty(DefaultJavaToolchainProvisioningService.AUTO_DOWNLOAD).map(Boolean::parseBoolean);
         this.matchingToolchains = new ConcurrentHashMap<>();
@@ -146,14 +146,14 @@ public class JavaToolchainQueryService {
             return detectedToolchain.get();
         }
 
-        InstallationLocation downloadedInstallation = downloadToolchain(spec);
-        JavaToolchain downloadedToolchain = asToolchainOrThrow(downloadedInstallation, spec);
-        registry.addInstallation(downloadedInstallation);
-        return downloadedToolchain;
+        InstallationLocation installation = provisionToolchain(spec);
+        JavaToolchain provisionedToolchain = asToolchainOrThrow(installation, spec);
+        registry.addInstallation(installation);
+        return provisionedToolchain;
     }
 
-    private InstallationLocation downloadToolchain(JavaToolchainSpec spec) {
-        final Optional<File> installation = installService.tryInstall(spec);
+    private InstallationLocation provisionToolchain(JavaToolchainSpec spec) {
+        final Optional<File> installation = provisioningService.tryProvision(spec);
         if (!installation.isPresent()) {
             throw new NoToolchainAvailableException(spec, detectEnabled.getOrElse(true), downloadEnabled.getOrElse(true));
         }

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/install/internal/DefaultJavaToolchainProvisioningServiceTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/install/internal/DefaultJavaToolchainProvisioningServiceTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.internal.provider.Providers
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.authentication.Authentication
 import org.gradle.cache.FileLock
+import org.gradle.internal.jvm.inspection.JvmMetadataDetector
 import org.gradle.internal.operations.BuildOperationDescriptor
 import org.gradle.internal.operations.TestBuildOperationExecutor
 import org.gradle.internal.resource.ExternalResource
@@ -51,6 +52,7 @@ class DefaultJavaToolchainProvisioningServiceTest extends Specification {
     def cache = Mock(JdkCacheDirectory)
     def archiveFileLock = Mock(FileLock)
     def buildPlatform = Mock(BuildPlatform)
+    def detector = Mock(JvmMetadataDetector)
 
     def setup() {
         ExternalResourceMetaData downloadResourceMetadata = Mock(ExternalResourceMetaData)
@@ -75,10 +77,10 @@ class DefaultJavaToolchainProvisioningServiceTest extends Specification {
         given:
         mockRegistry(Optional.of(DOWNLOAD))
 
-        def provisioningService = new DefaultJavaToolchainProvisioningService(registry, downloader, cache, providerFactory, operationExecutor, buildPlatform)
+        def provisioningService = new DefaultJavaToolchainProvisioningService(registry, downloader, cache, providerFactory, operationExecutor, buildPlatform, detector)
 
         when:
-        provisioningService.tryInstall(spec)
+        provisioningService.tryProvision(spec)
 
         then:
         1 * cache.acquireWriteLock(_, _) >> archiveFileLock
@@ -104,10 +106,10 @@ class DefaultJavaToolchainProvisioningServiceTest extends Specification {
         given:
         mockRegistry(Optional.of(DOWNLOAD))
         new File(temporaryFolder, ARCHIVE_NAME).createNewFile()
-        def provisioningService = new DefaultJavaToolchainProvisioningService(registry, downloader, cache, providerFactory, new TestBuildOperationExecutor(), buildPlatform)
+        def provisioningService = new DefaultJavaToolchainProvisioningService(registry, downloader, cache, providerFactory, new TestBuildOperationExecutor(), buildPlatform, detector)
 
         when:
-        provisioningService.tryInstall(spec)
+        provisioningService.tryProvision(spec)
 
         then:
         0 * downloader.download(_, _, _)
@@ -119,10 +121,10 @@ class DefaultJavaToolchainProvisioningServiceTest extends Specification {
 
         given:
         mockRegistry(Optional.empty())
-        def provisioningService = new DefaultJavaToolchainProvisioningService(registry, downloader, cache, providerFactory, new TestBuildOperationExecutor(), buildPlatform)
+        def provisioningService = new DefaultJavaToolchainProvisioningService(registry, downloader, cache, providerFactory, new TestBuildOperationExecutor(), buildPlatform, detector)
 
         when:
-        def result = provisioningService.tryInstall(spec)
+        def result = provisioningService.tryProvision(spec)
 
         then:
         !result.isPresent()
@@ -135,10 +137,10 @@ class DefaultJavaToolchainProvisioningServiceTest extends Specification {
 
         given:
         mockRegistry(Optional.of(DOWNLOAD))
-        def provisioningService = new DefaultJavaToolchainProvisioningService(registry, downloader, cache, providerFactory, new TestBuildOperationExecutor(), buildPlatform)
+        def provisioningService = new DefaultJavaToolchainProvisioningService(registry, downloader, cache, providerFactory, new TestBuildOperationExecutor(), buildPlatform, detector)
 
         when:
-        def result = provisioningService.tryInstall(spec)
+        def result = provisioningService.tryProvision(spec)
 
         then:
         !result.isPresent()
@@ -151,10 +153,10 @@ class DefaultJavaToolchainProvisioningServiceTest extends Specification {
 
         given:
         mockRegistry(Optional.of(DOWNLOAD))
-        def provisioningService = new DefaultJavaToolchainProvisioningService(registry, downloader, cache, providerFactory, operationExecutor, buildPlatform)
+        def provisioningService = new DefaultJavaToolchainProvisioningService(registry, downloader, cache, providerFactory, operationExecutor, buildPlatform, detector)
 
         when:
-        provisioningService.tryInstall(spec)
+        provisioningService.tryProvision(spec)
 
         then:
         1 * downloader.download(DOWNLOAD.getUri(), new File(temporaryFolder, ARCHIVE_NAME), _)

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainQueryServiceTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainQueryServiceTest.groovy
@@ -190,7 +190,7 @@ class JavaToolchainQueryServiceTest extends Specification {
         def registry = createInstallationRegistry(["8", "9", "10"])
         def toolchainFactory = newToolchainFactory()
         def provisioningService = Mock(JavaToolchainProvisioningService)
-        provisioningService.tryInstall(_ as JavaToolchainSpec) >> Optional.empty()
+        provisioningService.tryProvision(_ as JavaToolchainSpec) >> Optional.empty()
         def queryService = new JavaToolchainQueryService(registry, toolchainFactory, provisioningService, createProviderFactory(), TestUtil.objectFactory())
 
         when:
@@ -339,7 +339,7 @@ class JavaToolchainQueryServiceTest extends Specification {
         def toolchainFactory = newToolchainFactory()
         def installed = false
         def provisionService = new JavaToolchainProvisioningService() {
-            Optional<File> tryInstall(JavaToolchainSpec spec) {
+            Optional<File> tryProvision(JavaToolchainSpec spec) {
                 installed = true
                 Optional.of(new File("/path/12"))
             }
@@ -362,7 +362,7 @@ class JavaToolchainQueryServiceTest extends Specification {
         def toolchainFactory = newToolchainFactory()
         def installed = false
         def provisionService = new JavaToolchainProvisioningService() {
-            Optional<File> tryInstall(JavaToolchainSpec spec) {
+            Optional<File> tryProvision(JavaToolchainSpec spec) {
                 installed = true
                 Optional.of(new File("/path/12.broken"))
             }
@@ -386,7 +386,7 @@ class JavaToolchainQueryServiceTest extends Specification {
         def toolchainFactory = newToolchainFactory()
         int installed = 0
         def provisionService = new JavaToolchainProvisioningService() {
-            Optional<File> tryInstall(JavaToolchainSpec spec) {
+            Optional<File> tryProvision(JavaToolchainSpec spec) {
                 installed++
                 Optional.of(new File("/path/12"))
             }


### PR DESCRIPTION
Allows us to declare Java toolchain repositories that resolve existing local toolchain installations. 

[Design Spec](https://docs.google.com/document/d/15gRLZwGrqnb1J1eU8tePJKqENwacxhkZalTlunjW6Zk/edit?usp=sharing)