### PR TITLE
Link source set classes to sourceSet.java classes

### DIFF
--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -57,7 +57,6 @@ import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.Jar;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.internal.component.local.model.OpaqueComponentIdentifier;
-import org.gradle.internal.execution.BuildOutputCleanupRegistry;
 import org.gradle.testing.base.TestingExtension;
 
 import javax.inject.Inject;
@@ -281,20 +280,13 @@ public abstract class JavaPlugin implements Plugin<Project> {
         SourceSet mainSourceSet = javaExtension.getSourceSets().create(SourceSet.MAIN_SOURCE_SET_NAME);
         projectInternal.getServices().get(ComponentRegistry.class).setMainComponent(new BuildableJavaComponentImpl(project, mainSourceSet));
 
-        BuildOutputCleanupRegistry buildOutputCleanupRegistry = projectInternal.getServices().get(BuildOutputCleanupRegistry.class);
         PublishArtifact jarArtifact = configureArchives(project, mainSourceSet);
 
         configureBuiltInTest(project, mainSourceSet);
-        configureSourceSets(javaExtension, buildOutputCleanupRegistry);
         createConsumableConfigurations(project, mainSourceSet, jarArtifact);
         configureJavaDocTask(null, mainSourceSet, project.getTasks(), javaExtension);
         configureBuild(project);
         configurePublishing(project, mainSourceSet);
-    }
-
-    private static void configureSourceSets(JavaPluginExtension pluginExtension, final BuildOutputCleanupRegistry buildOutputCleanupRegistry) {
-        // Register the project's source set output directories
-        pluginExtension.getSourceSets().all(sourceSet -> buildOutputCleanupRegistry.registerOutputs(sourceSet.getOutput()));
     }
 
     private static void configureBuiltInTest(Project project, SourceSet mainSourceSet) {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JvmPluginsHelper.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JvmPluginsHelper.java
@@ -156,7 +156,7 @@ public class JvmPluginsHelper {
         sourceDirectorySet.getDestinationDirectory().convention(target.getLayout().getBuildDirectory().dir(sourceSetChildPath));
 
         DefaultSourceSetOutput sourceSetOutput = Cast.cast(DefaultSourceSetOutput.class, sourceSet.getOutput());
-        sourceSetOutput.getClassesDirs().from(sourceDirectorySet.getDestinationDirectory()).builtBy(compileTask);
+        sourceSetOutput.getClassesDirs().from(sourceDirectorySet.getClassesDirectory());
         sourceSetOutput.getGeneratedSourcesDirs().from(options.flatMap(CompileOptions::getGeneratedSourceOutputDirectory));
         sourceDirectorySet.compiledBy(compileTask, AbstractCompile::getDestinationDirectory);
     }


### PR DESCRIPTION
When updating the destinationDirectory of a JavaCompile task, the destination directory of the SourceDirectorySet which is compiledBy it is not also updated. However, the classesDirectory of the source directory set is updated to remain consistent with the compile task's output diretory.

Here, we update the SourceSet to reference the source directory set's classes directory so that the source set outputs are kept consistent with the compile task's destination directory.
