### PR TITLE
Better handling of cache configuration mutability

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
@@ -17,12 +17,12 @@
 package org.gradle.configurationcache
 
 import org.gradle.api.artifacts.component.BuildIdentifier
+import org.gradle.api.cache.Cleanup
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.BuildDefinition
 import org.gradle.api.internal.FeaturePreviews
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.SettingsInternal.BUILD_SRC
-import org.gradle.api.internal.cache.CacheConfigurationsInternal.UnlockableProperty
 import org.gradle.api.provider.Provider
 import org.gradle.api.services.internal.BuildServiceProvider
 import org.gradle.api.services.internal.BuildServiceRegistryInternal
@@ -595,19 +595,12 @@ class ConfigurationCacheState(
     private
     suspend fun DefaultReadContext.readCacheConfigurations(gradle: GradleInternal) {
         gradle.settings.caches.let { cacheConfigurations ->
-            readAndSetUnlockableProperty(cacheConfigurations.releasedWrappers.removeUnusedEntriesOlderThan)
-            readAndSetUnlockableProperty(cacheConfigurations.snapshotWrappers.removeUnusedEntriesOlderThan)
-            readAndSetUnlockableProperty(cacheConfigurations.downloadedResources.removeUnusedEntriesOlderThan)
-            readAndSetUnlockableProperty(cacheConfigurations.createdResources.removeUnusedEntriesOlderThan)
-            readAndSetUnlockableProperty(cacheConfigurations.cleanup)
+            cacheConfigurations.releasedWrappers.removeUnusedEntriesOlderThan.value(readNonNull<Provider<Long>>())
+            cacheConfigurations.snapshotWrappers.removeUnusedEntriesOlderThan.value(readNonNull<Provider<Long>>())
+            cacheConfigurations.downloadedResources.removeUnusedEntriesOlderThan.value(readNonNull<Provider<Long>>())
+            cacheConfigurations.createdResources.removeUnusedEntriesOlderThan.value(readNonNull<Provider<Long>>())
+            cacheConfigurations.cleanup.value(readNonNull<Provider<Cleanup>>())
         }
-    }
-
-    private
-    suspend fun <T : Any> DefaultReadContext.readAndSetUnlockableProperty(property: UnlockableProperty<T>) {
-        property.unlock()
-        property.value(readNonNull<Provider<T>>())
-        property.lock()
     }
 
     private

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/cache/CacheConfigurationsInternal.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/cache/CacheConfigurationsInternal.java
@@ -38,30 +38,15 @@ public interface CacheConfigurationsInternal extends CacheConfigurations {
     CacheResourceConfigurationInternal getCreatedResources();
 
     @Override
-    UnlockableProperty<Cleanup> getCleanup();
-
-    /**
-     * Execute the provided runnable with all cache configuration properties unlocked and mutable.
-     */
-    void withMutableValues(Runnable runnable);
+    Property<Cleanup> getCleanup();
 
     Provider<CleanupFrequency> getCleanupFrequency();
 
-    /**
-     * Represents a property that can be locked, preventing any changes that mutate the value.
-     * As opposed to finalization, the expectation is that the property may be unlocked
-     * again in the future.  This allows properties that can only be changed during a certain
-     * window of time.
-     */
-    interface UnlockableProperty<T> extends Property<T> {
-        /**
-         * Lock the property, preventing changes that mutate the value.
-         */
-        void lock();
+    void finalizeConfigurationValues();
 
-        /**
-         * Unlock the property, allowing changes that mutate the value.
-         */
-        void unlock();
-    }
+    /**
+     * Synchronizes the property values of the provided cache configurations with those of this cache configuration
+     * by setting the provided configuration's properties to be backed by the properties of this configuration.
+     */
+    void synchronize(CacheConfigurationsInternal cacheConfigurationsInternal);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/cache/CacheResourceConfigurationInternal.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/cache/CacheResourceConfigurationInternal.java
@@ -21,7 +21,4 @@ import java.util.function.Supplier;
 
 public interface CacheResourceConfigurationInternal extends CacheResourceConfiguration {
     Supplier<Long> getRemoveUnusedEntriesOlderThanAsSupplier();
-
-    @Override
-    CacheConfigurationsInternal.UnlockableProperty<Long> getRemoveUnusedEntriesOlderThan();
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/cache/CacheConfigurationsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/cache/CacheConfigurationsIntegrationTest.groovy
@@ -100,7 +100,7 @@ class CacheConfigurationsIntegrationTest extends AbstractIntegrationSpec {
 
         expect:
         fails("help")
-        failureCauseContains(String.format(DefaultCacheConfigurations.ILLEGAL_MODIFICATION_ERROR, errorProperty))
+        failureCauseContains(String.format(DefaultCacheConfigurations.UNSAFE_MODIFICATION_ERROR, errorProperty))
 
         where:
         property                                           | errorProperty                  | value

--- a/subprojects/core/src/main/java/org/gradle/initialization/ScriptEvaluatingSettingsProcessor.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/ScriptEvaluatingSettingsProcessor.java
@@ -63,7 +63,8 @@ public class ScriptEvaluatingSettingsProcessor implements SettingsProcessor {
         SettingsState state = settingsFactory.createSettings(gradle, settingsLocation.getSettingsDir(), settingsScript, gradleProperties, startParameter, baseClassLoaderScope);
 
         SettingsInternal settings = state.getSettings();
-        settings.getCaches().withMutableValues(() -> gradle.getBuildListenerBroadcaster().beforeSettings(settings));
+        gradle.getBuildListenerBroadcaster().beforeSettings(settings);
+        settings.getCaches().finalizeConfigurationValues();
         applySettingsScript(settingsScript, settings);
         LOGGER.debug("Timing: Processing settings took: {}", settingsProcessingClock.getElapsed());
         return state;

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/SettingsScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/SettingsScopeServices.java
@@ -19,6 +19,8 @@ package org.gradle.internal.service.scopes;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
+import org.gradle.api.internal.cache.CacheConfigurationsInternal;
+import org.gradle.api.internal.cache.DefaultCacheConfigurations;
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.file.FileLookup;
 import org.gradle.api.internal.file.FileResolver;
@@ -27,6 +29,7 @@ import org.gradle.api.internal.plugins.ImperativeOnlyPluginTarget;
 import org.gradle.api.internal.plugins.PluginManagerInternal;
 import org.gradle.api.internal.plugins.PluginRegistry;
 import org.gradle.api.internal.plugins.PluginTarget;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.configuration.ConfigurationTargetIdentifier;
 import org.gradle.configuration.internal.UserCodeApplicationContext;
 import org.gradle.initialization.DefaultProjectDescriptorRegistry;
@@ -69,5 +72,13 @@ public class SettingsScopeServices extends DefaultServiceRegistry {
 
     protected GradleInternal createGradleInternal() {
         return settings.getGradle();
+    }
+
+    protected CacheConfigurationsInternal createCacheConfigurations(ObjectFactory objectFactory, CacheConfigurationsInternal persistentCacheConfigurations, GradleInternal gradleInternal) {
+        CacheConfigurationsInternal cacheConfigurations = objectFactory.newInstance(DefaultCacheConfigurations.class);
+        if (gradleInternal.isRootBuild()) {
+            cacheConfigurations.synchronize(persistentCacheConfigurations);
+        }
+        return cacheConfigurations;
     }
 }


### PR DESCRIPTION
This removes the awkward UnlockableProperty and uses normal property finalization to prevent further mutation of the cache configurations.  It does this by creating two `CacheConfigurations` objects, one build-session-persistent and always mutable object which all of the caches are wired to, and one available through the `Settings` DSL, which is finalized once the hook from init scripts has run.  The build-session persistent `CacheConfigurations` object always reflects the DSL object, so changes  in between builds are always reflected.