### PR TITLE
Polish JVM base plugins

### DIFF
--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultGroovySourceSet.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultGroovySourceSet.java
@@ -23,6 +23,7 @@ import org.gradle.api.reflect.HasPublicType;
 import org.gradle.api.reflect.TypeOf;
 import org.gradle.api.tasks.GroovySourceDirectorySet;
 import org.gradle.api.tasks.GroovySourceSet;
+import org.gradle.internal.deprecation.DeprecationLogger;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -51,10 +52,19 @@ public abstract class DefaultGroovySourceSet implements GroovySourceSet, HasPubl
 
     @Override
     public GroovySourceDirectorySet getGroovy() {
+        emitDeprecationWarning();
+        return getGroovyInternal();
+    }
+
+    /**
+     * Same as {@link #getGroovy()} except it does not emit a deprecation warning.
+     */
+    public GroovySourceDirectorySet getGroovyInternal() {
         return groovy;
     }
 
     @Override
+    @SuppressWarnings("rawtypes")
     public GroovySourceSet groovy(@Nullable Closure configureClosure) {
         configure(configureClosure, getGroovy());
         return this;
@@ -68,11 +78,22 @@ public abstract class DefaultGroovySourceSet implements GroovySourceSet, HasPubl
 
     @Override
     public SourceDirectorySet getAllGroovy() {
+        emitDeprecationWarning();
         return allGroovy;
     }
 
     @Override
+    @Deprecated
     public TypeOf<?> getPublicType() {
+        emitDeprecationWarning();
         return typeOf(GroovySourceSet.class);
+    }
+
+    private static void emitDeprecationWarning() {
+        DeprecationLogger.deprecate("Configuring Groovy sources via the convention")
+            .withAdvice("Groovy sources should be configured via the extension instead.")
+            .willBeRemovedInGradle9()
+            .withUpgradeGuideSection(7, "custom_source_set_deprecation")
+            .nagUser();
     }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/GroovyBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/GroovyBasePlugin.java
@@ -19,15 +19,13 @@ package org.gradle.api.plugins;
 import com.google.common.collect.Sets;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.attributes.LibraryElements;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.internal.classpath.ModuleRegistry;
 import org.gradle.api.internal.plugins.DslObject;
-import org.gradle.api.internal.tasks.DefaultGroovySourceSet;
 import org.gradle.api.internal.tasks.DefaultSourceSet;
-import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.internal.JvmPluginsHelper;
 import org.gradle.api.plugins.jvm.internal.JvmEcosystemUtilities;
@@ -36,16 +34,15 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.reporting.ReportingExtension;
 import org.gradle.api.tasks.GroovyRuntime;
 import org.gradle.api.tasks.GroovySourceDirectorySet;
+import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.compile.GroovyCompile;
 import org.gradle.api.tasks.javadoc.Groovydoc;
 import org.gradle.api.tasks.javadoc.GroovydocAccess;
 import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.jvm.toolchain.JavaToolchainService;
-import org.gradle.jvm.toolchain.JavaToolchainSpec;
 
 import javax.inject.Inject;
-import java.util.function.BiFunction;
 
 import static org.gradle.api.internal.lambdas.SerializableLambdas.spec;
 
@@ -58,44 +55,33 @@ import static org.gradle.api.internal.lambdas.SerializableLambdas.spec;
 public abstract class GroovyBasePlugin implements Plugin<Project> {
     public static final String GROOVY_RUNTIME_EXTENSION_NAME = "groovyRuntime";
 
-    private final ObjectFactory objectFactory;
     private final ModuleRegistry moduleRegistry;
     private final JvmPluginServices jvmPluginServices;
-    private final TaskDependencyFactory taskDependencyFactory;
-
-    private Project project;
-    private GroovyRuntime groovyRuntime;
 
     @Inject
     public GroovyBasePlugin(
-        ObjectFactory objectFactory,
         ModuleRegistry moduleRegistry,
-        JvmEcosystemUtilities jvmPluginServices,
-        TaskDependencyFactory taskDependencyFactory
+        JvmEcosystemUtilities jvmPluginServices
     ) {
-        this.objectFactory = objectFactory;
         this.moduleRegistry = moduleRegistry;
         this.jvmPluginServices = (JvmPluginServices) jvmPluginServices;
-        this.taskDependencyFactory = taskDependencyFactory;
     }
+
+    @Inject
+    protected abstract ObjectFactory getObjectFactory();
 
     @Override
     public void apply(Project project) {
-        this.project = project;
         project.getPluginManager().apply(JavaBasePlugin.class);
 
-        configureGroovyRuntimeExtension();
-        configureCompileDefaults();
-        configureSourceSetDefaults();
+        GroovyRuntime groovyRuntime = project.getExtensions().create(GROOVY_RUNTIME_EXTENSION_NAME, GroovyRuntime.class, project);
 
-        configureGroovydoc();
+        configureCompileDefaults(project, groovyRuntime);
+        configureSourceSetDefaults(project);
+        configureGroovydoc(project, groovyRuntime);
     }
 
-    private void configureGroovyRuntimeExtension() {
-        groovyRuntime = project.getExtensions().create(GROOVY_RUNTIME_EXTENSION_NAME, GroovyRuntime.class, project);
-    }
-
-    private void configureCompileDefaults() {
+    private static void configureCompileDefaults(Project project, GroovyRuntime groovyRuntime) {
         project.getTasks().withType(GroovyCompile.class).configureEach(compile ->
             compile.getConventionMapping().map(
                 "groovyClasspath",
@@ -104,61 +90,74 @@ public abstract class GroovyBasePlugin implements Plugin<Project> {
         );
     }
 
-    @SuppressWarnings("deprecation")
-    private void configureSourceSetDefaults() {
-        javaPluginExtension().getSourceSets().all(sourceSet -> {
-            final DefaultGroovySourceSet groovySourceSet = objectFactory.newInstance(DefaultGroovySourceSet.class, "groovy", ((DefaultSourceSet) sourceSet).getDisplayName(), objectFactory);
-            addSourceSetExtension(sourceSet, groovySourceSet);
+    private void configureSourceSetDefaults(Project project) {
+        javaPluginExtension(project).getSourceSets().all(sourceSet -> {
 
-            final SourceDirectorySet groovySource = groovySourceSet.getGroovy();
+            GroovySourceDirectorySet groovySource = getGroovySourceDirectorySet(sourceSet);
+            sourceSet.getExtensions().add(GroovySourceDirectorySet.class, "groovy", groovySource);
             groovySource.srcDir("src/" + sourceSet.getName() + "/groovy");
 
             // Explicitly capture only a FileCollection in the lambda below for compatibility with configuration-cache.
-            @SuppressWarnings("UnnecessaryLocalVariable") final FileCollection groovySourceFiles = groovySource;
+            final FileCollection groovySourceFiles = groovySource;
             sourceSet.getResources().getFilter().exclude(
                 spec(element -> groovySourceFiles.contains(element.getFile()))
             );
             sourceSet.getAllJava().source(groovySource);
             sourceSet.getAllSource().source(groovySource);
 
-            final TaskProvider<GroovyCompile> compileTask = project.getTasks().register(sourceSet.getCompileTaskName("groovy"), GroovyCompile.class, compile -> {
-                JvmPluginsHelper.configureForSourceSet(sourceSet, groovySource, compile, compile.getOptions(), project);
-                compile.setDescription("Compiles the " + sourceSet.getName() + " Groovy source.");
-                compile.setSource(groovySource);
-                Provider<JavaLauncher> javaLauncherConvention = getToolchainTool(project, JavaToolchainService::launcherFor);
-                compile.getJavaLauncher().convention(javaLauncherConvention);
-                compile.getGroovyOptions().getDisabledGlobalASTTransformations().convention(Sets.newHashSet("groovy.grape.GrabAnnotationTransformation"));
-            });
+            TaskProvider<GroovyCompile> compileTask = createGroovyCompileTask(project, sourceSet, groovySource);
 
-            String compileClasspathConfigurationName = sourceSet.getCompileClasspathConfigurationName();
-            JvmPluginsHelper.configureOutputDirectoryForSourceSet(sourceSet, groovySource, project, compileTask, compileTask.map(GroovyCompile::getOptions));
-            useDefaultTargetPlatformInference(compileTask, compileClasspathConfigurationName);
-            useDefaultTargetPlatformInference(compileTask, sourceSet.getRuntimeClasspathConfigurationName());
-
-            // TODO: `classes` should be a little more tied to the classesDirs for a SourceSet so every plugin
-            // doesn't need to do this.
-            project.getTasks().named(sourceSet.getClassesTaskName(), task -> task.dependsOn(compileTask));
-
-            // Explain that Groovy, for compile, also needs the resources (#9872)
-            project.getConfigurations().getByName(compileClasspathConfigurationName).attributes(attrs ->
-                attrs.attribute(
-                    LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
-                    project.getObjects().named(LibraryElements.class, LibraryElements.CLASSES_AND_RESOURCES)
-                )
-            );
+            ConfigurationContainer configurations = project.getConfigurations();
+            configureLibraryElements(sourceSet, configurations, project.getObjects());
+            configureTargetPlatform(compileTask, sourceSet, configurations);
         });
     }
 
-    private void addSourceSetExtension(org.gradle.api.tasks.SourceSet sourceSet, DefaultGroovySourceSet groovySourceSet) {
+    /**
+     * In 9.0, once {@link org.gradle.api.internal.tasks.DefaultGroovySourceSet} is removed, we can update this to only construct the source directory
+     * set instead of the entire source set.
+     */
+    @SuppressWarnings("deprecation")
+    private GroovySourceDirectorySet getGroovySourceDirectorySet(SourceSet sourceSet) {
+        final org.gradle.api.internal.tasks.DefaultGroovySourceSet groovySourceSet = getObjectFactory().newInstance(org.gradle.api.internal.tasks.DefaultGroovySourceSet.class, "groovy", ((DefaultSourceSet) sourceSet).getDisplayName(), getObjectFactory());
         new DslObject(sourceSet).getConvention().getPlugins().put("groovy", groovySourceSet);
-        sourceSet.getExtensions().add(GroovySourceDirectorySet.class, "groovy", groovySourceSet.getGroovy());
+        return groovySourceSet.getGroovyInternal();
     }
 
-    private void useDefaultTargetPlatformInference(TaskProvider<GroovyCompile> compileTask, String configurationName) {
-        jvmPluginServices.useDefaultTargetPlatformInference(project.getConfigurations().getByName(configurationName), compileTask);
+    private static void configureLibraryElements(SourceSet sourceSet, ConfigurationContainer configurations, ObjectFactory objectFactory) {
+        // Explain that Groovy, for compile, also needs the resources (#9872)
+        configurations.getByName(sourceSet.getCompileClasspathConfigurationName()).attributes(attrs ->
+            attrs.attribute(
+                LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
+                objectFactory.named(LibraryElements.class, LibraryElements.CLASSES_AND_RESOURCES)
+            )
+        );
     }
 
-    private void configureGroovydoc() {
+    private void configureTargetPlatform(TaskProvider<GroovyCompile> compileTask, SourceSet sourceSet, ConfigurationContainer configurations) {
+        jvmPluginServices.useDefaultTargetPlatformInference(configurations.getByName(sourceSet.getCompileClasspathConfigurationName()), compileTask);
+        jvmPluginServices.useDefaultTargetPlatformInference(configurations.getByName(sourceSet.getRuntimeClasspathConfigurationName()), compileTask);
+    }
+
+    private TaskProvider<GroovyCompile> createGroovyCompileTask(Project project, SourceSet sourceSet, GroovySourceDirectorySet groovySource) {
+        final TaskProvider<GroovyCompile> compileTask = project.getTasks().register(sourceSet.getCompileTaskName("groovy"), GroovyCompile.class, groovyCompile -> {
+            JvmPluginsHelper.compileAgainstJavaOutputs(groovyCompile, sourceSet, getObjectFactory());
+            JvmPluginsHelper.configureAnnotationProcessorPath(sourceSet, groovySource, groovyCompile.getOptions(), project);
+            groovyCompile.setDescription("Compiles the " + groovySource + ".");
+            groovyCompile.setSource(groovySource);
+            groovyCompile.getJavaLauncher().convention(getJavaLauncher(project));
+
+            groovyCompile.getGroovyOptions().getDisabledGlobalASTTransformations().convention(Sets.newHashSet("groovy.grape.GrabAnnotationTransformation"));
+        });
+        JvmPluginsHelper.configureOutputDirectoryForSourceSet(sourceSet, groovySource, project, compileTask, compileTask.map(GroovyCompile::getOptions));
+
+        // TODO: `classes` should be a little more tied to the classesDirs for a SourceSet so every plugin
+        // doesn't need to do this.
+        project.getTasks().named(sourceSet.getClassesTaskName(), task -> task.dependsOn(compileTask));
+
+        return compileTask;
+    }
+    private void configureGroovydoc(Project project, GroovyRuntime groovyRuntime) {
         project.getTasks().withType(Groovydoc.class).configureEach(groovydoc -> {
             groovydoc.getConventionMapping().map("groovyClasspath", () -> {
                 FileCollection groovyClasspath = groovyRuntime.inferGroovyClasspath(groovydoc.getClasspath());
@@ -166,9 +165,9 @@ public abstract class GroovyBasePlugin implements Plugin<Project> {
                 ConfigurableFileCollection jansi = project.getObjects().fileCollection().from(moduleRegistry.getExternalModule("jansi").getImplementationClasspath().getAsFiles());
                 return groovyClasspath.plus(jansi);
             });
-            groovydoc.getConventionMapping().map("destinationDir", () -> javaPluginExtension().getDocsDir().dir("groovydoc").get().getAsFile());
-            groovydoc.getConventionMapping().map("docTitle", () -> projectExtension(ReportingExtension.class).getApiDocTitle());
-            groovydoc.getConventionMapping().map("windowTitle", () -> projectExtension(ReportingExtension.class).getApiDocTitle());
+            groovydoc.getConventionMapping().map("destinationDir", () -> javaPluginExtension(project).getDocsDir().dir("groovydoc").get().getAsFile());
+            groovydoc.getConventionMapping().map("docTitle", () -> extensionOf(project, ReportingExtension.class).getApiDocTitle());
+            groovydoc.getConventionMapping().map("windowTitle", () -> extensionOf(project, ReportingExtension.class).getApiDocTitle());
             groovydoc.getAccess().convention(GroovydocAccess.PROTECTED);
             groovydoc.getIncludeAuthor().convention(false);
             groovydoc.getProcessScripts().convention(true);
@@ -176,18 +175,14 @@ public abstract class GroovyBasePlugin implements Plugin<Project> {
         });
     }
 
-    private static <T> Provider<T> getToolchainTool(Project project, BiFunction<JavaToolchainService, JavaToolchainSpec, Provider<T>> toolMapper) {
-        final JavaPluginExtension extension = extensionOf(project, JavaPluginExtension.class);
+    private static Provider<JavaLauncher> getJavaLauncher(Project project) {
+        final JavaPluginExtension extension = javaPluginExtension(project);
         final JavaToolchainService service = extensionOf(project, JavaToolchainService.class);
-        return toolMapper.apply(service, extension.getToolchain());
+        return service.launcherFor(extension.getToolchain());
     }
 
-    private JavaPluginExtension javaPluginExtension() {
-        return projectExtension(JavaPluginExtension.class);
-    }
-
-    private <T> T projectExtension(Class<T> type) {
-        return extensionOf(project, type);
+    private static JavaPluginExtension javaPluginExtension(Project project) {
+        return extensionOf(project, JavaPluginExtension.class);
     }
 
     private static <T> T extensionOf(ExtensionAware extensionAware, Class<T> type) {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -31,7 +31,6 @@ import org.gradle.api.internal.GeneratedSubclasses;
 import org.gradle.api.internal.IConventionAware;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.plugins.DslObject;
-import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.tasks.DefaultSourceSetOutput;
 import org.gradle.api.internal.tasks.compile.JavaCompileExecutableUtils;
 import org.gradle.api.internal.tasks.testing.TestExecutableUtils;
@@ -118,50 +117,48 @@ public abstract class JavaBasePlugin implements Plugin<Project> {
 
     @Override
     public void apply(final Project project) {
-        ProjectInternal projectInternal = (ProjectInternal) project;
-
         project.getPluginManager().apply(BasePlugin.class);
         project.getPluginManager().apply(JvmEcosystemPlugin.class);
         project.getPluginManager().apply(ReportingBasePlugin.class);
         project.getPluginManager().apply(JvmToolchainsPlugin.class);
 
-        DefaultJavaPluginExtension javaPluginExtension = addExtensions(projectInternal);
+        DefaultJavaPluginExtension javaPluginExtension = addExtensions(project);
 
-        configureSourceSetDefaults(project, javaPluginExtension);
         configureCompileDefaults(project, javaPluginExtension);
-
+        configureSourceSetDefaults(project, javaPluginExtension);
         configureJavaDoc(project, javaPluginExtension);
+
         configureTest(project, javaPluginExtension);
         configureBuildNeeded(project);
         configureBuildDependents(project);
         configureArchiveDefaults(project);
     }
 
-    private DefaultJavaPluginExtension addExtensions(final ProjectInternal project) {
-        DefaultToolchainSpec toolchainSpec = project.getObjects().newInstance(DefaultToolchainSpec.class);
+    @Inject
+    protected abstract ObjectFactory getObjectFactory();
+
+    private DefaultJavaPluginExtension addExtensions(final Project project) {
+        DefaultToolchainSpec toolchainSpec = getObjectFactory().newInstance(DefaultToolchainSpec.class);
         SourceSetContainer sourceSets = (SourceSetContainer) project.getExtensions().getByName("sourceSets");
         DefaultJavaPluginExtension javaPluginExtension = (DefaultJavaPluginExtension) project.getExtensions().create(JavaPluginExtension.class, "java", DefaultJavaPluginExtension.class, project, sourceSets, toolchainSpec, jvmPluginServices);
-        project.getConvention().getPlugins().put("java", project.getObjects().newInstance(DefaultJavaPluginConvention.class, project, javaPluginExtension));
+        project.getConvention().getPlugins().put("java", getObjectFactory().newInstance(DefaultJavaPluginConvention.class, project, javaPluginExtension));
         return javaPluginExtension;
     }
 
     private void configureSourceSetDefaults(Project project, final JavaPluginExtension javaPluginExtension) {
         javaPluginExtension.getSourceSets().all(sourceSet -> {
-            ConventionMapping outputConventionMapping = ((IConventionAware) sourceSet.getOutput()).getConventionMapping();
 
             ConfigurationContainer configurations = project.getConfigurations();
 
             defineConfigurationsForSourceSet(sourceSet, configurations);
-            definePathsForSourceSet(sourceSet, outputConventionMapping, project);
+            definePathsForSourceSet(sourceSet, project);
 
             createProcessResourcesTask(sourceSet, sourceSet.getResources(), project);
             TaskProvider<JavaCompile> compileTask = createCompileJavaTask(sourceSet, sourceSet.getJava(), project);
             createClassesTask(sourceSet, project);
 
-            configureLibraryElements(compileTask, sourceSet, configurations, project.getObjects());
+            configureLibraryElements(compileTask, sourceSet, configurations, getObjectFactory());
             configureTargetPlatform(compileTask, sourceSet, configurations);
-
-            JvmPluginsHelper.configureOutputDirectoryForSourceSet(sourceSet, sourceSet.getJava(), project, compileTask, compileTask.map(JavaCompile::getOptions));
         });
     }
 
@@ -175,22 +172,28 @@ public abstract class JavaBasePlugin implements Plugin<Project> {
         jvmPluginServices.useDefaultTargetPlatformInference(configurations.getByName(sourceSet.getRuntimeClasspathConfigurationName()), compileTask);
     }
 
-    private TaskProvider<JavaCompile> createCompileJavaTask(final SourceSet sourceSet, final SourceDirectorySet sourceDirectorySet, final Project target) {
-        return target.getTasks().register(sourceSet.getCompileJavaTaskName(), JavaCompile.class, compileTask -> {
-            compileTask.setDescription("Compiles " + sourceDirectorySet + ".");
-            compileTask.setSource(sourceDirectorySet);
-            ConventionMapping conventionMapping = compileTask.getConventionMapping();
+    private TaskProvider<JavaCompile> createCompileJavaTask(final SourceSet sourceSet, final SourceDirectorySet javaSource, final Project project) {
+        final TaskProvider<JavaCompile> compileTask = project.getTasks().register(sourceSet.getCompileJavaTaskName(), JavaCompile.class, javaCompile -> {
+            ConventionMapping conventionMapping = javaCompile.getConventionMapping();
             conventionMapping.map("classpath", sourceSet::getCompileClasspath);
-            JvmPluginsHelper.configureAnnotationProcessorPath(sourceSet, sourceDirectorySet, compileTask.getOptions(), target);
-            String generatedHeadersDir = "generated/sources/headers/" + sourceDirectorySet.getName() + "/" + sourceSet.getName();
-            compileTask.getOptions().getHeaderOutputDirectory().convention(target.getLayout().getBuildDirectory().dir(generatedHeadersDir));
-            JavaPluginExtension javaPluginExtension = target.getExtensions().getByType(JavaPluginExtension.class);
-            compileTask.getModularity().getInferModulePath().convention(javaPluginExtension.getModularity().getInferModulePath());
-            ObjectFactory objectFactory = target.getObjects();
-            Provider<JavaToolchainSpec> toolchainOverrideSpec = target.provider(() ->
-                JavaCompileExecutableUtils.getExecutableOverrideToolchainSpec(compileTask, objectFactory));
-            compileTask.getJavaCompiler().convention(getToolchainTool(target, JavaToolchainService::compilerFor, toolchainOverrideSpec));
+
+            JvmPluginsHelper.configureAnnotationProcessorPath(sourceSet, javaSource, javaCompile.getOptions(), project);
+            javaCompile.setDescription("Compiles " + javaSource + ".");
+            javaCompile.setSource(javaSource);
+
+            Provider<JavaToolchainSpec> toolchainOverrideSpec = project.provider(() ->
+                JavaCompileExecutableUtils.getExecutableOverrideToolchainSpec(javaCompile, getObjectFactory()));
+            javaCompile.getJavaCompiler().convention(getToolchainTool(project, JavaToolchainService::compilerFor, toolchainOverrideSpec));
+
+            String generatedHeadersDir = "generated/sources/headers/" + javaSource.getName() + "/" + sourceSet.getName();
+            javaCompile.getOptions().getHeaderOutputDirectory().convention(project.getLayout().getBuildDirectory().dir(generatedHeadersDir));
+
+            JavaPluginExtension javaPluginExtension = project.getExtensions().getByType(JavaPluginExtension.class);
+            javaCompile.getModularity().getInferModulePath().convention(javaPluginExtension.getModularity().getInferModulePath());
         });
+        JvmPluginsHelper.configureOutputDirectoryForSourceSet(sourceSet, javaSource, project, compileTask, compileTask.map(JavaCompile::getOptions));
+
+        return compileTask;
     }
 
     private void createProcessResourcesTask(final SourceSet sourceSet, final SourceDirectorySet resourceSet, final Project target) {
@@ -215,7 +218,8 @@ public abstract class JavaBasePlugin implements Plugin<Project> {
         );
     }
 
-    private void definePathsForSourceSet(final SourceSet sourceSet, ConventionMapping outputConventionMapping, final Project project) {
+    private static void definePathsForSourceSet(final SourceSet sourceSet, final Project project) {
+        ConventionMapping outputConventionMapping = ((IConventionAware) sourceSet.getOutput()).getConventionMapping();
         outputConventionMapping.map("resourcesDir", () -> {
             String classesDirName = "resources/" + sourceSet.getName();
             return new File(project.getBuildDir(), classesDirName);
@@ -331,9 +335,9 @@ public abstract class JavaBasePlugin implements Plugin<Project> {
         project.getTasks().withType(Javadoc.class).configureEach(javadoc -> {
             javadoc.getConventionMapping().map("destinationDir", () -> new File(javaPluginExtension.getDocsDir().get().getAsFile(), "javadoc"));
             javadoc.getConventionMapping().map("title", () -> project.getExtensions().getByType(ReportingExtension.class).getApiDocTitle());
-            ObjectFactory objectFactory = project.getObjects();
+
             Provider<JavaToolchainSpec> toolchainOverrideSpec = project.provider(() ->
-                JavadocExecutableUtils.getExecutableOverrideToolchainSpec(javadoc, objectFactory));
+                JavadocExecutableUtils.getExecutableOverrideToolchainSpec(javadoc, getObjectFactory()));
             javadoc.getJavadocTool().convention(getToolchainTool(project, JavaToolchainService::javadocToolFor, toolchainOverrideSpec));
         });
     }
@@ -376,9 +380,8 @@ public abstract class JavaBasePlugin implements Plugin<Project> {
         test.getBinaryResultsDirectory().convention(javaPluginExtension.getTestResultsDir().dir(test.getName() + "/binary"));
         test.workingDir(project.getProjectDir());
 
-        ObjectFactory objectFactory = project.getObjects();
         Provider<JavaToolchainSpec> toolchainOverrideSpec = project.provider(() ->
-            TestExecutableUtils.getExecutableToolchainSpec(test, objectFactory));
+            TestExecutableUtils.getExecutableToolchainSpec(test, getObjectFactory()));
         test.getJavaLauncher().convention(getToolchainTool(project, JavaToolchainService::launcherFor, toolchainOverrideSpec));
     }
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginConvention.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginConvention.java
@@ -28,6 +28,7 @@ import org.gradle.api.reflect.HasPublicType;
 import org.gradle.api.reflect.TypeOf;
 import org.gradle.api.reporting.ReportingExtension;
 import org.gradle.api.tasks.SourceSetContainer;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.util.internal.RelativePathUtil;
 
 import javax.inject.Inject;
@@ -47,126 +48,152 @@ public abstract class DefaultJavaPluginConvention extends JavaPluginConvention i
     }
 
     @Override
+    @Deprecated
     public TypeOf<?> getPublicType() {
+        emitDeprecationWarning();
         return typeOf(JavaPluginConvention.class);
     }
 
     @Override
     public Object sourceSets(Closure closure) {
+        emitDeprecationWarning();
         return extension.sourceSets(closure);
     }
 
     @Override
     public File getDocsDir() {
+        emitDeprecationWarning();
         return extension.getDocsDir().get().getAsFile();
     }
 
     @Override
     public File getTestResultsDir() {
+        emitDeprecationWarning();
         return extension.getTestResultsDir().get().getAsFile();
     }
 
     @Override
     public File getTestReportDir() {
+        emitDeprecationWarning();
         return extension.getTestReportDir().get().getAsFile();
     }
 
     @Override
     public JavaVersion getSourceCompatibility() {
+        emitDeprecationWarning();
         return extension.getSourceCompatibility();
     }
 
     @Override
     public void setSourceCompatibility(Object value) {
+        emitDeprecationWarning();
         extension.setSourceCompatibility(value);
     }
 
     @Override
     public void setSourceCompatibility(JavaVersion value) {
+        emitDeprecationWarning();
         extension.setSourceCompatibility(value);
     }
 
     @Override
     public JavaVersion getTargetCompatibility() {
+        emitDeprecationWarning();
         return extension.getTargetCompatibility();
     }
 
     @Override
     public void setTargetCompatibility(Object value) {
+        emitDeprecationWarning();
         extension.setTargetCompatibility(value);
     }
 
     @Override
     public void setTargetCompatibility(JavaVersion value) {
+        emitDeprecationWarning();
         extension.setTargetCompatibility(value);
     }
 
     @Override
     public Manifest manifest() {
+        emitDeprecationWarning();
         return extension.manifest();
     }
 
     @Override
     public Manifest manifest(Closure closure) {
+        emitDeprecationWarning();
         return extension.manifest(closure);
     }
 
     @Override
     public Manifest manifest(Action<? super Manifest> action) {
+        emitDeprecationWarning();
         return extension.manifest(action);
     }
 
     @Override
     public String getDocsDirName() {
+        emitDeprecationWarning();
         return relativePath(project.getLayout().getBuildDirectory(), extension.getDocsDir());
     }
 
     @Override
     public void setDocsDirName(String docsDirName) {
+        emitDeprecationWarning();
         extension.getDocsDir().set(project.getLayout().getBuildDirectory().dir(docsDirName));
     }
 
     @Override
     public String getTestResultsDirName() {
+        emitDeprecationWarning();
         return relativePath(project.getLayout().getBuildDirectory(), extension.getTestResultsDir());
     }
 
     @Override
     public void setTestResultsDirName(String testResultsDirName) {
+        emitDeprecationWarning();
         extension.getTestResultsDir().set(project.getLayout().getBuildDirectory().dir(testResultsDirName));
     }
 
     @Override
     public String getTestReportDirName() {
+        emitDeprecationWarning();
         return relativePath(project.getExtensions().getByType(ReportingExtension.class).getBaseDirectory(), extension.getTestReportDir());
     }
 
     @Override
     public void setTestReportDirName(String testReportDirName) {
+        emitDeprecationWarning();
         extension.getTestReportDir().set(project.getExtensions().getByType(ReportingExtension.class).getBaseDirectory().dir(testReportDirName));
     }
 
     @Override
     public SourceSetContainer getSourceSets() {
+        emitDeprecationWarning();
         return extension.getSourceSets();
     }
 
     @Override
     public ProjectInternal getProject() {
+        emitDeprecationWarning();
         return project;
     }
 
     @Override
     public void disableAutoTargetJvm() {
+        emitDeprecationWarning();
         extension.disableAutoTargetJvm();
     }
 
     @Override
     public boolean getAutoTargetJvmDisabled() {
+        emitDeprecationWarning();
         return extension.getAutoTargetJvmDisabled();
     }
 
     File getReportsDir() {
+        emitDeprecationWarning();
         // This became public API by accident as Groovy has access to private methods and we show an example in our docs
         // see subprojects/docs/src/snippets/java/customDirs/groovy/build.gradle
         // and https://docs.gradle.org/current/userguide/java_testing.html#test_reporting
@@ -175,5 +202,13 @@ public abstract class DefaultJavaPluginConvention extends JavaPluginConvention i
 
     private static String relativePath(DirectoryProperty from, DirectoryProperty to) {
         return RelativePathUtil.relativePath(from.get().getAsFile(), to.get().getAsFile());
+    }
+
+    private static void emitDeprecationWarning() {
+        DeprecationLogger.deprecate("Configuring Java defaults via the convention")
+            .withAdvice("Java defaults should be configured via the extension instead.")
+            .willBeRemovedInGradle9()
+            .withUpgradeGuideSection(7, "all_convention_deprecation")
+            .nagUser();
     }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JvmPluginsHelper.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JvmPluginsHelper.java
@@ -109,18 +109,17 @@ public class JvmPluginsHelper {
         return apiConfiguration;
     }
 
-    public static void configureForSourceSet(final SourceSet sourceSet, final SourceDirectorySet sourceDirectorySet, AbstractCompile compile, CompileOptions options, final Project target) {
-        configureForSourceSet(sourceSet, sourceDirectorySet, compile, target);
-        configureAnnotationProcessorPath(sourceSet, sourceDirectorySet, options, target);
-    }
-
-    private static void configureForSourceSet(final SourceSet sourceSet, final SourceDirectorySet sourceDirectorySet, AbstractCompile compile, final Project target) {
-        compile.setDescription("Compiles the " + sourceDirectorySet.getDisplayName() + ".");
-        compile.setSource(sourceSet.getJava());
-
-        ConfigurableFileCollection classpath = compile.getProject().getObjects().fileCollection();
-        classpath.from((Callable<Object>) () -> sourceSet.getCompileClasspath().plus(target.files(sourceSet.getJava().getClassesDirectory())));
-
+    /**
+     * Configures the provided {@code compile} task to compile against the provided {@code sourceSet}'s compile classpath
+     * in addition to the outputs of the java compilation, as specified by {@link SourceSet#getJava()}
+     *
+     * @param compile The task to configure.
+     * @param sourceSet The source set whose output contains the java classes to compile against.
+     * @param objectFactory An {@link ObjectFactory}.
+     */
+    public static void compileAgainstJavaOutputs(AbstractCompile compile, final SourceSet sourceSet, final ObjectFactory objectFactory) {
+        ConfigurableFileCollection classpath = objectFactory.fileCollection();
+        classpath.from((Callable<Object>) () -> sourceSet.getCompileClasspath().plus(objectFactory.fileCollection().from(sourceSet.getJava().getClassesDirectory())));
         compile.getConventionMapping().map("classpath", () -> classpath);
     }
 

--- a/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/DefaultScalaSourceSet.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/DefaultScalaSourceSet.java
@@ -19,9 +19,10 @@ import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.model.ObjectFactory;
-import org.gradle.api.tasks.ScalaSourceDirectorySet;
 import org.gradle.api.reflect.HasPublicType;
 import org.gradle.api.reflect.TypeOf;
+import org.gradle.api.tasks.ScalaSourceDirectorySet;
+import org.gradle.internal.deprecation.DeprecationLogger;
 
 import javax.inject.Inject;
 
@@ -49,6 +50,14 @@ public abstract class DefaultScalaSourceSet implements org.gradle.api.tasks.Scal
 
     @Override
     public ScalaSourceDirectorySet getScala() {
+        emitDeprecationWarning();
+        return getScalaInternal();
+    }
+
+    /**
+     * Same as {@link #getScala()} except it does not emit a deprecation warning.
+     */
+    public ScalaSourceDirectorySet getScalaInternal() {
         return scala;
     }
 
@@ -67,11 +76,22 @@ public abstract class DefaultScalaSourceSet implements org.gradle.api.tasks.Scal
 
     @Override
     public SourceDirectorySet getAllScala() {
+        emitDeprecationWarning();
         return allScala;
     }
 
     @Override
+    @Deprecated
     public TypeOf<?> getPublicType() {
+        emitDeprecationWarning();
         return typeOf(org.gradle.api.tasks.ScalaSourceSet.class);
+    }
+
+    private static void emitDeprecationWarning() {
+        DeprecationLogger.deprecate("Configuring Scala sources via the convention")
+            .withAdvice("Scala sources should be configured via the extension instead.")
+            .willBeRemovedInGradle9()
+            .withUpgradeGuideSection(7, "custom_source_set_deprecation")
+            .nagUser();
     }
 }

--- a/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
@@ -17,14 +17,12 @@ package org.gradle.api.plugins.scala;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
-import org.codehaus.groovy.runtime.InvokerHelper;
-import org.gradle.api.Action;
 import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.attributes.AttributeDisambiguationRule;
@@ -32,12 +30,12 @@ import org.gradle.api.attributes.AttributeMatchingStrategy;
 import org.gradle.api.attributes.MultipleCandidatesDetails;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.internal.ConventionMapping;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
+import org.gradle.api.internal.plugins.DslObject;
+import org.gradle.api.internal.tasks.DefaultSourceSet;
 import org.gradle.api.internal.tasks.scala.DefaultScalaPluginExtension;
 import org.gradle.api.model.ObjectFactory;
-import org.gradle.api.plugins.Convention;
 import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
@@ -46,7 +44,6 @@ import org.gradle.api.plugins.internal.JvmPluginsHelper;
 import org.gradle.api.plugins.jvm.internal.JvmEcosystemUtilities;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.reporting.ReportingExtension;
-import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.ScalaRuntime;
 import org.gradle.api.tasks.ScalaSourceDirectorySet;
 import org.gradle.api.tasks.SourceSet;
@@ -93,14 +90,15 @@ public abstract class ScalaBasePlugin implements Plugin<Project> {
      */
     public static final String SCALA_COMPILER_PLUGINS_CONFIGURATION_NAME = "scalaCompilerPlugins";
 
-    private final ObjectFactory objectFactory;
     private final JvmEcosystemUtilities jvmEcosystemUtilities;
 
     @Inject
-    public ScalaBasePlugin(ObjectFactory objectFactory, JvmEcosystemUtilities jvmEcosystemUtilities) {
-        this.objectFactory = objectFactory;
+    public ScalaBasePlugin(JvmEcosystemUtilities jvmEcosystemUtilities) {
         this.jvmEcosystemUtilities = jvmEcosystemUtilities;
     }
+
+    @Inject
+    protected abstract ObjectFactory getObjectFactory();
 
     @Override
     public void apply(final Project project) {
@@ -109,11 +107,11 @@ public abstract class ScalaBasePlugin implements Plugin<Project> {
         ScalaRuntime scalaRuntime = project.getExtensions().create(SCALA_RUNTIME_EXTENSION_NAME, ScalaRuntime.class, project);
         ScalaPluginExtension scalaPluginExtension = project.getExtensions().create(ScalaPluginExtension.class, "scala", DefaultScalaPluginExtension.class);
 
-        Usage incrementalAnalysisUsage = objectFactory.named(Usage.class, "incremental-analysis");
+        Usage incrementalAnalysisUsage = getObjectFactory().named(Usage.class, "incremental-analysis");
         configureConfigurations(project, incrementalAnalysisUsage, scalaPluginExtension);
 
-        configureCompileDefaults(project, scalaRuntime, (DefaultJavaPluginExtension) extensionOf(project, JavaPluginExtension.class));
-        configureSourceSetDefaults(project, incrementalAnalysisUsage, objectFactory, scalaRuntime);
+        configureCompileDefaults(project, scalaRuntime, (DefaultJavaPluginExtension) javaPluginExtension(project));
+        configureSourceSetDefaults(project, incrementalAnalysisUsage);
         configureScaladoc(project, scalaRuntime);
     }
 
@@ -167,57 +165,63 @@ public abstract class ScalaBasePlugin implements Plugin<Project> {
         AttributeMatchingStrategy<Usage> matchingStrategy = dependencyHandler.getAttributesSchema().attribute(USAGE_ATTRIBUTE);
         matchingStrategy.getDisambiguationRules().add(UsageDisambiguationRules.class, actionConfiguration -> {
             actionConfiguration.params(incrementalAnalysisUsage);
-            actionConfiguration.params(objectFactory.named(Usage.class, Usage.JAVA_API));
-            actionConfiguration.params(objectFactory.named(Usage.class, Usage.JAVA_RUNTIME));
+            actionConfiguration.params(getObjectFactory().named(Usage.class, Usage.JAVA_API));
+            actionConfiguration.params(getObjectFactory().named(Usage.class, Usage.JAVA_RUNTIME));
         });
     }
 
-    @SuppressWarnings("deprecation")
-    private void configureSourceSetDefaults(final Project project, final Usage incrementalAnalysisUsage, final ObjectFactory objectFactory, final ScalaRuntime scalaRuntime) {
-        project.getExtensions().getByType(JavaPluginExtension.class).getSourceSets().all(new Action<SourceSet>() {
-            @Override
-            public void execute(final SourceSet sourceSet) {
-                String displayName = (String) InvokerHelper.invokeMethod(sourceSet, "getDisplayName", null);
-                Convention sourceSetConvention = (Convention) InvokerHelper.getProperty(sourceSet, "convention");
-                org.gradle.api.internal.tasks.DefaultScalaSourceSet scalaSourceSet = objectFactory.newInstance(org.gradle.api.internal.tasks.DefaultScalaSourceSet.class, displayName, objectFactory);
-                sourceSetConvention.getPlugins().put("scala", scalaSourceSet);
-                sourceSet.getExtensions().add(ScalaSourceDirectorySet.class, "scala", scalaSourceSet.getScala());
+    private void configureSourceSetDefaults(final Project project, final Usage incrementalAnalysisUsage) {
+        javaPluginExtension(project).getSourceSets().all(sourceSet -> {
 
-                final SourceDirectorySet scalaDirectorySet = scalaSourceSet.getScala();
-                scalaDirectorySet.srcDir(project.file("src/" + sourceSet.getName() + "/scala"));
-                sourceSet.getAllJava().source(scalaDirectorySet);
-                sourceSet.getAllSource().source(scalaDirectorySet);
+            ScalaSourceDirectorySet scalaSource = getScalaSourceDirectorySet(sourceSet);
+            sourceSet.getExtensions().add(ScalaSourceDirectorySet.class, "scala", scalaSource);
+            scalaSource.srcDir(project.file("src/" + sourceSet.getName() + "/scala"));
 
-                // Explicitly capture only a FileCollection in the lambda below for compatibility with configuration-cache.
-                FileCollection scalaSource = scalaDirectorySet;
-                sourceSet.getResources().getFilter().exclude(
-                    spec(element -> scalaSource.contains(element.getFile()))
-                );
+            // Explicitly capture only a FileCollection in the lambda below for compatibility with configuration-cache.
+            final FileCollection scalaSourceFiles = scalaSource;
+            sourceSet.getResources().getFilter().exclude(
+                spec(element -> scalaSourceFiles.contains(element.getFile()))
+            );
+            sourceSet.getAllJava().source(scalaSource);
+            sourceSet.getAllSource().source(scalaSource);
 
-                Configuration classpath = project.getConfigurations().getByName(sourceSet.getImplementationConfigurationName());
-                Configuration incrementalAnalysis = project.getConfigurations().create("incrementalScalaAnalysisFor" + sourceSet.getName());
-                incrementalAnalysis.setVisible(false);
-                incrementalAnalysis.setDescription("Incremental compilation analysis files for " + displayName);
-                incrementalAnalysis.setCanBeResolved(true);
-                incrementalAnalysis.setCanBeConsumed(false);
-                incrementalAnalysis.extendsFrom(classpath);
-                incrementalAnalysis.getAttributes().attribute(USAGE_ATTRIBUTE, incrementalAnalysisUsage);
+            Configuration incrementalAnalysis = createIncrementalAnalysisConfigurationFor(project.getConfigurations(), incrementalAnalysisUsage, sourceSet);
 
-                configureScalaCompile(project, sourceSet, incrementalAnalysis, incrementalAnalysisUsage, scalaRuntime);
-            }
-
+            createScalaCompileTask(project, sourceSet, scalaSource, incrementalAnalysis);
         });
     }
 
+    /**
+     * In 9.0, once {@link org.gradle.api.internal.tasks.DefaultScalaSourceSet} is removed, we can update this to only construct the source directory
+     * set instead of the entire source set.
+     */
     @SuppressWarnings("deprecation")
-    private void configureScalaCompile(final Project project, final SourceSet sourceSet, final Configuration incrementalAnalysis, final Usage incrementalAnalysisUsage, final ScalaRuntime scalaRuntime) {
-        final ScalaSourceDirectorySet scalaSourceSet = sourceSet.getExtensions().getByType(ScalaSourceDirectorySet.class);
+    private ScalaSourceDirectorySet getScalaSourceDirectorySet(SourceSet sourceSet) {
+        org.gradle.api.internal.tasks.DefaultScalaSourceSet scalaSourceSet = getObjectFactory().newInstance(org.gradle.api.internal.tasks.DefaultScalaSourceSet.class, ((DefaultSourceSet) sourceSet).getDisplayName(), getObjectFactory());
+        new DslObject(sourceSet).getConvention().getPlugins().put("scala", scalaSourceSet);
+        return scalaSourceSet.getScalaInternal();
+    }
 
-        final TaskProvider<ScalaCompile> scalaCompileTask = project.getTasks().register(sourceSet.getCompileTaskName("scala"), ScalaCompile.class, scalaCompile -> {
-            JvmPluginsHelper.configureForSourceSet(sourceSet, scalaSourceSet, scalaCompile, scalaCompile.getOptions(), project);
-            scalaCompile.setDescription("Compiles the " + scalaSourceSet + ".");
-            scalaCompile.setSource(scalaSourceSet);
+    private static Configuration createIncrementalAnalysisConfigurationFor(ConfigurationContainer configurations, Usage incrementalAnalysisUsage, SourceSet sourceSet) {
+        Configuration classpath = configurations.getByName(sourceSet.getImplementationConfigurationName());
+        Configuration incrementalAnalysis = configurations.create("incrementalScalaAnalysisFor" + sourceSet.getName());
+        incrementalAnalysis.setVisible(false);
+        incrementalAnalysis.setDescription("Incremental compilation analysis files for " + ((DefaultSourceSet) sourceSet).getDisplayName());
+        incrementalAnalysis.setCanBeResolved(true);
+        incrementalAnalysis.setCanBeConsumed(false);
+        incrementalAnalysis.extendsFrom(classpath);
+        incrementalAnalysis.getAttributes().attribute(USAGE_ATTRIBUTE, incrementalAnalysisUsage);
+        return incrementalAnalysis;
+    }
+
+    private void createScalaCompileTask(final Project project, final SourceSet sourceSet, ScalaSourceDirectorySet scalaSource, final Configuration incrementalAnalysis) {
+        final TaskProvider<ScalaCompile> compileTask = project.getTasks().register(sourceSet.getCompileTaskName("scala"), ScalaCompile.class, scalaCompile -> {
+            JvmPluginsHelper.compileAgainstJavaOutputs(scalaCompile, sourceSet, getObjectFactory());
+            JvmPluginsHelper.configureAnnotationProcessorPath(sourceSet, scalaSource, scalaCompile.getOptions(), project);
+            scalaCompile.setDescription("Compiles the " + scalaSource + ".");
+            scalaCompile.setSource(scalaSource);
             scalaCompile.getJavaLauncher().convention(getJavaLauncher(project));
+
             scalaCompile.getAnalysisMappingFile().set(project.getLayout().getBuildDirectory().file("tmp/scala/compilerAnalysis/" + scalaCompile.getName() + ".mapping"));
 
             // cannot compute at task execution time because we need association with source set
@@ -236,7 +240,7 @@ public abstract class ScalaBasePlugin implements Plugin<Project> {
             }
             scalaCompile.getAnalysisFiles().from(incrementalAnalysis.getIncoming().artifactView(viewConfiguration -> {
                 viewConfiguration.lenient(true);
-                viewConfiguration.componentFilter(new IsProjectComponent());
+                viewConfiguration.componentFilter(element -> element instanceof ProjectComponentIdentifier);
             }).getFiles());
 
             // See https://github.com/gradle/gradle/issues/14434.  We do this so that the incrementalScalaAnalysisForXXX configuration
@@ -244,9 +248,11 @@ public abstract class ScalaBasePlugin implements Plugin<Project> {
             // it can potentially block trying to resolve project dependencies.
             scalaCompile.dependsOn(scalaCompile.getAnalysisFiles());
         });
-        JvmPluginsHelper.configureOutputDirectoryForSourceSet(sourceSet, scalaSourceSet, project, scalaCompileTask, scalaCompileTask.map(AbstractScalaCompile::getOptions));
+        JvmPluginsHelper.configureOutputDirectoryForSourceSet(sourceSet, scalaSource, project, compileTask, compileTask.map(AbstractScalaCompile::getOptions));
 
-        project.getTasks().named(sourceSet.getClassesTaskName(), task -> task.dependsOn(scalaCompileTask));
+        // TODO: `classes` should be a little more tied to the classesDirs for a SourceSet so every plugin
+        // doesn't need to do this.
+        project.getTasks().named(sourceSet.getClassesTaskName(), task -> task.dependsOn(compileTask));
     }
 
     private static void configureCompileDefaults(final Project project, final ScalaRuntime scalaRuntime, final DefaultJavaPluginExtension javaExtension) {
@@ -279,17 +285,21 @@ public abstract class ScalaBasePlugin implements Plugin<Project> {
 
     private void configureScaladoc(final Project project, final ScalaRuntime scalaRuntime) {
         project.getTasks().withType(ScalaDoc.class).configureEach(scalaDoc -> {
-            scalaDoc.getConventionMapping().map("destinationDir", (Callable<File>) () -> project.getExtensions().getByType(JavaPluginExtension.class).getDocsDir().dir("scaladoc").get().getAsFile());
-            scalaDoc.getConventionMapping().map("title", (Callable<String>) () -> project.getExtensions().getByType(ReportingExtension.class).getApiDocTitle());
             scalaDoc.getConventionMapping().map("scalaClasspath", (Callable<FileCollection>) () -> scalaRuntime.inferScalaClasspath(scalaDoc.getClasspath()));
+            scalaDoc.getConventionMapping().map("destinationDir", (Callable<File>) () -> javaPluginExtension(project).getDocsDir().dir("scaladoc").get().getAsFile());
+            scalaDoc.getConventionMapping().map("title", (Callable<String>) () -> project.getExtensions().getByType(ReportingExtension.class).getApiDocTitle());
             scalaDoc.getJavaLauncher().convention(getJavaLauncher(project));
         });
     }
 
     private static Provider<JavaLauncher> getJavaLauncher(Project project) {
-        final JavaPluginExtension extension = extensionOf(project, JavaPluginExtension.class);
+        final JavaPluginExtension extension = javaPluginExtension(project);
         final JavaToolchainService service = extensionOf(project, JavaToolchainService.class);
         return service.launcherFor(extension.getToolchain());
+    }
+
+    private static JavaPluginExtension javaPluginExtension(Project project) {
+        return extensionOf(project, JavaPluginExtension.class);
     }
 
     private static <T> T extensionOf(ExtensionAware extensionAware, Class<T> type) {
@@ -313,13 +323,6 @@ public abstract class ScalaBasePlugin implements Plugin<Project> {
                     details.closestMatch(javaRuntime);
                 }
             }
-        }
-    }
-
-    private static class IsProjectComponent implements Spec<ComponentIdentifier> {
-        @Override
-        public boolean isSatisfiedBy(ComponentIdentifier element) {
-            return element instanceof ProjectComponentIdentifier;
         }
     }
 }


### PR DESCRIPTION
These plugins often do very similar things. This PR updates the Scala, Java, and Groovy base plugins to use the same names, patterns, initialization order, and method abstractions as each other (for the most part). 

Additionally, any remaining conventions used by these plugins have been updated to emit deprecation warnings if any of their methods are called.
