### PR TITLE
Make JVM base plugins more consistent with eachother

### DIFF
--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/GroovyBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/GroovyBasePlugin.java
@@ -19,15 +19,13 @@ package org.gradle.api.plugins;
 import com.google.common.collect.Sets;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.attributes.LibraryElements;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.internal.classpath.ModuleRegistry;
 import org.gradle.api.internal.plugins.DslObject;
-import org.gradle.api.internal.tasks.DefaultGroovySourceSet;
 import org.gradle.api.internal.tasks.DefaultSourceSet;
-import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.internal.JvmPluginsHelper;
 import org.gradle.api.plugins.jvm.internal.JvmEcosystemUtilities;
@@ -36,16 +34,15 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.reporting.ReportingExtension;
 import org.gradle.api.tasks.GroovyRuntime;
 import org.gradle.api.tasks.GroovySourceDirectorySet;
+import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.compile.GroovyCompile;
 import org.gradle.api.tasks.javadoc.Groovydoc;
 import org.gradle.api.tasks.javadoc.GroovydocAccess;
 import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.jvm.toolchain.JavaToolchainService;
-import org.gradle.jvm.toolchain.JavaToolchainSpec;
 
 import javax.inject.Inject;
-import java.util.function.BiFunction;
 
 import static org.gradle.api.internal.lambdas.SerializableLambdas.spec;
 
@@ -61,41 +58,30 @@ public abstract class GroovyBasePlugin implements Plugin<Project> {
     private final ObjectFactory objectFactory;
     private final ModuleRegistry moduleRegistry;
     private final JvmPluginServices jvmPluginServices;
-    private final TaskDependencyFactory taskDependencyFactory;
-
-    private Project project;
-    private GroovyRuntime groovyRuntime;
 
     @Inject
     public GroovyBasePlugin(
         ObjectFactory objectFactory,
         ModuleRegistry moduleRegistry,
-        JvmEcosystemUtilities jvmPluginServices,
-        TaskDependencyFactory taskDependencyFactory
+        JvmEcosystemUtilities jvmPluginServices
     ) {
         this.objectFactory = objectFactory;
         this.moduleRegistry = moduleRegistry;
         this.jvmPluginServices = (JvmPluginServices) jvmPluginServices;
-        this.taskDependencyFactory = taskDependencyFactory;
     }
 
     @Override
     public void apply(Project project) {
-        this.project = project;
         project.getPluginManager().apply(JavaBasePlugin.class);
 
-        configureGroovyRuntimeExtension();
-        configureCompileDefaults();
-        configureSourceSetDefaults();
+        GroovyRuntime groovyRuntime = project.getExtensions().create(GROOVY_RUNTIME_EXTENSION_NAME, GroovyRuntime.class, project);
 
-        configureGroovydoc();
+        configureCompileDefaults(project, groovyRuntime);
+        configureSourceSetDefaults(project);
+        configureGroovydoc(project, groovyRuntime);
     }
 
-    private void configureGroovyRuntimeExtension() {
-        groovyRuntime = project.getExtensions().create(GROOVY_RUNTIME_EXTENSION_NAME, GroovyRuntime.class, project);
-    }
-
-    private void configureCompileDefaults() {
+    private static void configureCompileDefaults(Project project, GroovyRuntime groovyRuntime) {
         project.getTasks().withType(GroovyCompile.class).configureEach(compile ->
             compile.getConventionMapping().map(
                 "groovyClasspath",
@@ -104,61 +90,74 @@ public abstract class GroovyBasePlugin implements Plugin<Project> {
         );
     }
 
-    @SuppressWarnings("deprecation")
-    private void configureSourceSetDefaults() {
-        javaPluginExtension().getSourceSets().all(sourceSet -> {
-            final DefaultGroovySourceSet groovySourceSet = objectFactory.newInstance(DefaultGroovySourceSet.class, "groovy", ((DefaultSourceSet) sourceSet).getDisplayName(), objectFactory);
-            addSourceSetExtension(sourceSet, groovySourceSet);
+    private void configureSourceSetDefaults(Project project) {
+        javaPluginExtension(project).getSourceSets().all(sourceSet -> {
 
-            final SourceDirectorySet groovySource = groovySourceSet.getGroovy();
+            GroovySourceDirectorySet groovySource = getGroovySourceDirectorySet(sourceSet);
+            sourceSet.getExtensions().add(GroovySourceDirectorySet.class, "groovy", groovySource);
             groovySource.srcDir("src/" + sourceSet.getName() + "/groovy");
 
             // Explicitly capture only a FileCollection in the lambda below for compatibility with configuration-cache.
-            @SuppressWarnings("UnnecessaryLocalVariable") final FileCollection groovySourceFiles = groovySource;
+            final FileCollection groovySourceFiles = groovySource;
             sourceSet.getResources().getFilter().exclude(
                 spec(element -> groovySourceFiles.contains(element.getFile()))
             );
             sourceSet.getAllJava().source(groovySource);
             sourceSet.getAllSource().source(groovySource);
 
-            final TaskProvider<GroovyCompile> compileTask = project.getTasks().register(sourceSet.getCompileTaskName("groovy"), GroovyCompile.class, compile -> {
-                JvmPluginsHelper.configureForSourceSet(sourceSet, groovySource, compile, compile.getOptions(), project);
-                compile.setDescription("Compiles the " + sourceSet.getName() + " Groovy source.");
-                compile.setSource(groovySource);
-                Provider<JavaLauncher> javaLauncherConvention = getToolchainTool(project, JavaToolchainService::launcherFor);
-                compile.getJavaLauncher().convention(javaLauncherConvention);
-                compile.getGroovyOptions().getDisabledGlobalASTTransformations().convention(Sets.newHashSet("groovy.grape.GrabAnnotationTransformation"));
-            });
+            TaskProvider<GroovyCompile> compileTask = createGroovyCompileTask(project, sourceSet, groovySource);
 
-            String compileClasspathConfigurationName = sourceSet.getCompileClasspathConfigurationName();
-            JvmPluginsHelper.configureOutputDirectoryForSourceSet(sourceSet, groovySource, project, compileTask, compileTask.map(GroovyCompile::getOptions));
-            useDefaultTargetPlatformInference(compileTask, compileClasspathConfigurationName);
-            useDefaultTargetPlatformInference(compileTask, sourceSet.getRuntimeClasspathConfigurationName());
-
-            // TODO: `classes` should be a little more tied to the classesDirs for a SourceSet so every plugin
-            // doesn't need to do this.
-            project.getTasks().named(sourceSet.getClassesTaskName(), task -> task.dependsOn(compileTask));
-
-            // Explain that Groovy, for compile, also needs the resources (#9872)
-            project.getConfigurations().getByName(compileClasspathConfigurationName).attributes(attrs ->
-                attrs.attribute(
-                    LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
-                    project.getObjects().named(LibraryElements.class, LibraryElements.CLASSES_AND_RESOURCES)
-                )
-            );
+            ConfigurationContainer configurations = project.getConfigurations();
+            configureLibraryElements(sourceSet, configurations, project.getObjects());
+            configureTargetPlatform(compileTask, sourceSet, configurations);
         });
     }
 
-    private void addSourceSetExtension(org.gradle.api.tasks.SourceSet sourceSet, DefaultGroovySourceSet groovySourceSet) {
+    /**
+     * In 9.0, once {@link org.gradle.api.internal.tasks.DefaultGroovySourceSet} is removed, we can update this to only construct the source directory
+     * set instead of the entire source set.
+     */
+    @SuppressWarnings("deprecation")
+    private GroovySourceDirectorySet getGroovySourceDirectorySet(SourceSet sourceSet) {
+        final org.gradle.api.internal.tasks.DefaultGroovySourceSet groovySourceSet = objectFactory.newInstance(org.gradle.api.internal.tasks.DefaultGroovySourceSet.class, "groovy", ((DefaultSourceSet) sourceSet).getDisplayName(), objectFactory);
         new DslObject(sourceSet).getConvention().getPlugins().put("groovy", groovySourceSet);
-        sourceSet.getExtensions().add(GroovySourceDirectorySet.class, "groovy", groovySourceSet.getGroovy());
+        return groovySourceSet.getGroovy();
     }
 
-    private void useDefaultTargetPlatformInference(TaskProvider<GroovyCompile> compileTask, String configurationName) {
-        jvmPluginServices.useDefaultTargetPlatformInference(project.getConfigurations().getByName(configurationName), compileTask);
+    private static void configureLibraryElements(SourceSet sourceSet, ConfigurationContainer configurations, ObjectFactory objectFactory) {
+        // Explain that Groovy, for compile, also needs the resources (#9872)
+        configurations.getByName(sourceSet.getCompileClasspathConfigurationName()).attributes(attrs ->
+            attrs.attribute(
+                LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
+                objectFactory.named(LibraryElements.class, LibraryElements.CLASSES_AND_RESOURCES)
+            )
+        );
     }
 
-    private void configureGroovydoc() {
+    private void configureTargetPlatform(TaskProvider<GroovyCompile> compileTask, SourceSet sourceSet, ConfigurationContainer configurations) {
+        jvmPluginServices.useDefaultTargetPlatformInference(configurations.getByName(sourceSet.getCompileClasspathConfigurationName()), compileTask);
+        jvmPluginServices.useDefaultTargetPlatformInference(configurations.getByName(sourceSet.getRuntimeClasspathConfigurationName()), compileTask);
+    }
+
+    private TaskProvider<GroovyCompile> createGroovyCompileTask(Project project, SourceSet sourceSet, GroovySourceDirectorySet groovySource) {
+        final TaskProvider<GroovyCompile> compileTask = project.getTasks().register(sourceSet.getCompileTaskName("groovy"), GroovyCompile.class, groovyCompile -> {
+            JvmPluginsHelper.compileAgainstJavaOutputs(groovyCompile, sourceSet, objectFactory);
+            JvmPluginsHelper.configureAnnotationProcessorPath(sourceSet, groovySource, groovyCompile.getOptions(), project);
+            groovyCompile.setDescription("Compiles the " + groovySource + ".");
+            groovyCompile.setSource(groovySource);
+            groovyCompile.getJavaLauncher().convention(getJavaLauncher(project));
+
+            groovyCompile.getGroovyOptions().getDisabledGlobalASTTransformations().convention(Sets.newHashSet("groovy.grape.GrabAnnotationTransformation"));
+        });
+        JvmPluginsHelper.configureOutputDirectoryForSourceSet(sourceSet, groovySource, project, compileTask, compileTask.map(GroovyCompile::getOptions));
+
+        // TODO: `classes` should be a little more tied to the classesDirs for a SourceSet so every plugin
+        // doesn't need to do this.
+        project.getTasks().named(sourceSet.getClassesTaskName(), task -> task.dependsOn(compileTask));
+
+        return compileTask;
+    }
+    private void configureGroovydoc(Project project, GroovyRuntime groovyRuntime) {
         project.getTasks().withType(Groovydoc.class).configureEach(groovydoc -> {
             groovydoc.getConventionMapping().map("groovyClasspath", () -> {
                 FileCollection groovyClasspath = groovyRuntime.inferGroovyClasspath(groovydoc.getClasspath());
@@ -166,9 +165,9 @@ public abstract class GroovyBasePlugin implements Plugin<Project> {
                 ConfigurableFileCollection jansi = project.getObjects().fileCollection().from(moduleRegistry.getExternalModule("jansi").getImplementationClasspath().getAsFiles());
                 return groovyClasspath.plus(jansi);
             });
-            groovydoc.getConventionMapping().map("destinationDir", () -> javaPluginExtension().getDocsDir().dir("groovydoc").get().getAsFile());
-            groovydoc.getConventionMapping().map("docTitle", () -> projectExtension(ReportingExtension.class).getApiDocTitle());
-            groovydoc.getConventionMapping().map("windowTitle", () -> projectExtension(ReportingExtension.class).getApiDocTitle());
+            groovydoc.getConventionMapping().map("destinationDir", () -> javaPluginExtension(project).getDocsDir().dir("groovydoc").get().getAsFile());
+            groovydoc.getConventionMapping().map("docTitle", () -> extensionOf(project, ReportingExtension.class).getApiDocTitle());
+            groovydoc.getConventionMapping().map("windowTitle", () -> extensionOf(project, ReportingExtension.class).getApiDocTitle());
             groovydoc.getAccess().convention(GroovydocAccess.PROTECTED);
             groovydoc.getIncludeAuthor().convention(false);
             groovydoc.getProcessScripts().convention(true);
@@ -176,18 +175,14 @@ public abstract class GroovyBasePlugin implements Plugin<Project> {
         });
     }
 
-    private static <T> Provider<T> getToolchainTool(Project project, BiFunction<JavaToolchainService, JavaToolchainSpec, Provider<T>> toolMapper) {
-        final JavaPluginExtension extension = extensionOf(project, JavaPluginExtension.class);
+    private static Provider<JavaLauncher> getJavaLauncher(Project project) {
+        final JavaPluginExtension extension = javaPluginExtension(project);
         final JavaToolchainService service = extensionOf(project, JavaToolchainService.class);
-        return toolMapper.apply(service, extension.getToolchain());
+        return service.launcherFor(extension.getToolchain());
     }
 
-    private JavaPluginExtension javaPluginExtension() {
-        return projectExtension(JavaPluginExtension.class);
-    }
-
-    private <T> T projectExtension(Class<T> type) {
-        return extensionOf(project, type);
+    private static JavaPluginExtension javaPluginExtension(Project project) {
+        return extensionOf(project, JavaPluginExtension.class);
     }
 
     private static <T> T extensionOf(ExtensionAware extensionAware, Class<T> type) {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -31,7 +31,6 @@ import org.gradle.api.internal.GeneratedSubclasses;
 import org.gradle.api.internal.IConventionAware;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.plugins.DslObject;
-import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.tasks.DefaultSourceSetOutput;
 import org.gradle.api.internal.tasks.compile.JavaCompileExecutableUtils;
 import org.gradle.api.internal.tasks.testing.TestExecutableUtils;
@@ -108,60 +107,57 @@ public abstract class JavaBasePlugin implements Plugin<Project> {
     );
 
     private final boolean javaClasspathPackaging;
+    private final ObjectFactory objectFactory;
     private final JvmPluginServices jvmPluginServices;
 
     @Inject
-    public JavaBasePlugin(JvmEcosystemUtilities jvmPluginServices) {
+    public JavaBasePlugin(ObjectFactory objectFactory, JvmEcosystemUtilities jvmPluginServices) {
+        this.objectFactory = objectFactory;
         this.javaClasspathPackaging = Boolean.getBoolean(COMPILE_CLASSPATH_PACKAGING_SYSTEM_PROPERTY);
         this.jvmPluginServices = (JvmPluginServices) jvmPluginServices;
     }
 
     @Override
     public void apply(final Project project) {
-        ProjectInternal projectInternal = (ProjectInternal) project;
-
         project.getPluginManager().apply(BasePlugin.class);
         project.getPluginManager().apply(JvmEcosystemPlugin.class);
         project.getPluginManager().apply(ReportingBasePlugin.class);
         project.getPluginManager().apply(JvmToolchainsPlugin.class);
 
-        DefaultJavaPluginExtension javaPluginExtension = addExtensions(projectInternal);
+        DefaultJavaPluginExtension javaPluginExtension = addExtensions(project);
 
-        configureSourceSetDefaults(project, javaPluginExtension);
         configureCompileDefaults(project, javaPluginExtension);
-
+        configureSourceSetDefaults(project, javaPluginExtension);
         configureJavaDoc(project, javaPluginExtension);
+
         configureTest(project, javaPluginExtension);
         configureBuildNeeded(project);
         configureBuildDependents(project);
         configureArchiveDefaults(project);
     }
 
-    private DefaultJavaPluginExtension addExtensions(final ProjectInternal project) {
-        DefaultToolchainSpec toolchainSpec = project.getObjects().newInstance(DefaultToolchainSpec.class);
+    private DefaultJavaPluginExtension addExtensions(final Project project) {
+        DefaultToolchainSpec toolchainSpec = objectFactory.newInstance(DefaultToolchainSpec.class);
         SourceSetContainer sourceSets = (SourceSetContainer) project.getExtensions().getByName("sourceSets");
         DefaultJavaPluginExtension javaPluginExtension = (DefaultJavaPluginExtension) project.getExtensions().create(JavaPluginExtension.class, "java", DefaultJavaPluginExtension.class, project, sourceSets, toolchainSpec, jvmPluginServices);
-        project.getConvention().getPlugins().put("java", project.getObjects().newInstance(DefaultJavaPluginConvention.class, project, javaPluginExtension));
+        project.getConvention().getPlugins().put("java", objectFactory.newInstance(DefaultJavaPluginConvention.class, project, javaPluginExtension));
         return javaPluginExtension;
     }
 
     private void configureSourceSetDefaults(Project project, final JavaPluginExtension javaPluginExtension) {
         javaPluginExtension.getSourceSets().all(sourceSet -> {
-            ConventionMapping outputConventionMapping = ((IConventionAware) sourceSet.getOutput()).getConventionMapping();
 
             ConfigurationContainer configurations = project.getConfigurations();
 
             defineConfigurationsForSourceSet(sourceSet, configurations);
-            definePathsForSourceSet(sourceSet, outputConventionMapping, project);
+            definePathsForSourceSet(sourceSet, project);
 
             createProcessResourcesTask(sourceSet, sourceSet.getResources(), project);
             TaskProvider<JavaCompile> compileTask = createCompileJavaTask(sourceSet, sourceSet.getJava(), project);
             createClassesTask(sourceSet, project);
 
-            configureLibraryElements(compileTask, sourceSet, configurations, project.getObjects());
+            configureLibraryElements(compileTask, sourceSet, configurations, objectFactory);
             configureTargetPlatform(compileTask, sourceSet, configurations);
-
-            JvmPluginsHelper.configureOutputDirectoryForSourceSet(sourceSet, sourceSet.getJava(), project, compileTask, compileTask.map(JavaCompile::getOptions));
         });
     }
 
@@ -175,22 +171,28 @@ public abstract class JavaBasePlugin implements Plugin<Project> {
         jvmPluginServices.useDefaultTargetPlatformInference(configurations.getByName(sourceSet.getRuntimeClasspathConfigurationName()), compileTask);
     }
 
-    private TaskProvider<JavaCompile> createCompileJavaTask(final SourceSet sourceSet, final SourceDirectorySet sourceDirectorySet, final Project target) {
-        return target.getTasks().register(sourceSet.getCompileJavaTaskName(), JavaCompile.class, compileTask -> {
-            compileTask.setDescription("Compiles " + sourceDirectorySet + ".");
-            compileTask.setSource(sourceDirectorySet);
-            ConventionMapping conventionMapping = compileTask.getConventionMapping();
+    private TaskProvider<JavaCompile> createCompileJavaTask(final SourceSet sourceSet, final SourceDirectorySet javaSource, final Project project) {
+        final TaskProvider<JavaCompile> compileTask = project.getTasks().register(sourceSet.getCompileJavaTaskName(), JavaCompile.class, javaCompile -> {
+            ConventionMapping conventionMapping = javaCompile.getConventionMapping();
             conventionMapping.map("classpath", sourceSet::getCompileClasspath);
-            JvmPluginsHelper.configureAnnotationProcessorPath(sourceSet, sourceDirectorySet, compileTask.getOptions(), target);
-            String generatedHeadersDir = "generated/sources/headers/" + sourceDirectorySet.getName() + "/" + sourceSet.getName();
-            compileTask.getOptions().getHeaderOutputDirectory().convention(target.getLayout().getBuildDirectory().dir(generatedHeadersDir));
-            JavaPluginExtension javaPluginExtension = target.getExtensions().getByType(JavaPluginExtension.class);
-            compileTask.getModularity().getInferModulePath().convention(javaPluginExtension.getModularity().getInferModulePath());
-            ObjectFactory objectFactory = target.getObjects();
-            Provider<JavaToolchainSpec> toolchainOverrideSpec = target.provider(() ->
-                JavaCompileExecutableUtils.getExecutableOverrideToolchainSpec(compileTask, objectFactory));
-            compileTask.getJavaCompiler().convention(getToolchainTool(target, JavaToolchainService::compilerFor, toolchainOverrideSpec));
+
+            JvmPluginsHelper.configureAnnotationProcessorPath(sourceSet, javaSource, javaCompile.getOptions(), project);
+            javaCompile.setDescription("Compiles " + javaSource + ".");
+            javaCompile.setSource(javaSource);
+
+            Provider<JavaToolchainSpec> toolchainOverrideSpec = project.provider(() ->
+                JavaCompileExecutableUtils.getExecutableOverrideToolchainSpec(javaCompile, objectFactory));
+            javaCompile.getJavaCompiler().convention(getToolchainTool(project, JavaToolchainService::compilerFor, toolchainOverrideSpec));
+
+            String generatedHeadersDir = "generated/sources/headers/" + javaSource.getName() + "/" + sourceSet.getName();
+            javaCompile.getOptions().getHeaderOutputDirectory().convention(project.getLayout().getBuildDirectory().dir(generatedHeadersDir));
+
+            JavaPluginExtension javaPluginExtension = project.getExtensions().getByType(JavaPluginExtension.class);
+            javaCompile.getModularity().getInferModulePath().convention(javaPluginExtension.getModularity().getInferModulePath());
         });
+        JvmPluginsHelper.configureOutputDirectoryForSourceSet(sourceSet, javaSource, project, compileTask, compileTask.map(JavaCompile::getOptions));
+
+        return compileTask;
     }
 
     private void createProcessResourcesTask(final SourceSet sourceSet, final SourceDirectorySet resourceSet, final Project target) {
@@ -215,7 +217,8 @@ public abstract class JavaBasePlugin implements Plugin<Project> {
         );
     }
 
-    private void definePathsForSourceSet(final SourceSet sourceSet, ConventionMapping outputConventionMapping, final Project project) {
+    private void definePathsForSourceSet(final SourceSet sourceSet, final Project project) {
+        ConventionMapping outputConventionMapping = ((IConventionAware) sourceSet.getOutput()).getConventionMapping();
         outputConventionMapping.map("resourcesDir", () -> {
             String classesDirName = "resources/" + sourceSet.getName();
             return new File(project.getBuildDir(), classesDirName);
@@ -331,7 +334,7 @@ public abstract class JavaBasePlugin implements Plugin<Project> {
         project.getTasks().withType(Javadoc.class).configureEach(javadoc -> {
             javadoc.getConventionMapping().map("destinationDir", () -> new File(javaPluginExtension.getDocsDir().get().getAsFile(), "javadoc"));
             javadoc.getConventionMapping().map("title", () -> project.getExtensions().getByType(ReportingExtension.class).getApiDocTitle());
-            ObjectFactory objectFactory = project.getObjects();
+
             Provider<JavaToolchainSpec> toolchainOverrideSpec = project.provider(() ->
                 JavadocExecutableUtils.getExecutableOverrideToolchainSpec(javadoc, objectFactory));
             javadoc.getJavadocTool().convention(getToolchainTool(project, JavaToolchainService::javadocToolFor, toolchainOverrideSpec));
@@ -376,7 +379,6 @@ public abstract class JavaBasePlugin implements Plugin<Project> {
         test.getBinaryResultsDirectory().convention(javaPluginExtension.getTestResultsDir().dir(test.getName() + "/binary"));
         test.workingDir(project.getProjectDir());
 
-        ObjectFactory objectFactory = project.getObjects();
         Provider<JavaToolchainSpec> toolchainOverrideSpec = project.provider(() ->
             TestExecutableUtils.getExecutableToolchainSpec(test, objectFactory));
         test.getJavaLauncher().convention(getToolchainTool(project, JavaToolchainService::launcherFor, toolchainOverrideSpec));

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JvmPluginsHelper.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JvmPluginsHelper.java
@@ -109,19 +109,18 @@ public class JvmPluginsHelper {
         return apiConfiguration;
     }
 
-    public static void configureForSourceSet(final SourceSet sourceSet, final SourceDirectorySet sourceDirectorySet, AbstractCompile compile, CompileOptions options, final Project target) {
-        configureForSourceSet(sourceSet, sourceDirectorySet, compile, target);
-        configureAnnotationProcessorPath(sourceSet, sourceDirectorySet, options, target);
-    }
-
-    private static void configureForSourceSet(final SourceSet sourceSet, final SourceDirectorySet sourceDirectorySet, AbstractCompile compile, final Project target) {
-        compile.setDescription("Compiles the " + sourceDirectorySet.getDisplayName() + ".");
-        compile.setSource(sourceSet.getJava());
-
-        ConfigurableFileCollection classpath = compile.getProject().getObjects().fileCollection();
-        classpath.from((Callable<Object>) () -> sourceSet.getCompileClasspath().plus(target.files(sourceSet.getJava().getClassesDirectory())));
-
-        compile.getConventionMapping().map("classpath", () -> classpath);
+    /**
+     * Configures {@code compileTask} to compile against {@code sourceSet}'s compile classpath
+     * in addition to the outputs of the java compilation, as specified by {@link SourceSet#getJava()}
+     *
+     * @param compileTask The task to configure.
+     * @param sourceSet The source set whose output contains the java classes to compile against.
+     * @param objectFactory An {@link ObjectFactory}.
+     */
+    public static void compileAgainstJavaOutputs(AbstractCompile compileTask, final SourceSet sourceSet, final ObjectFactory objectFactory) {
+        ConfigurableFileCollection classpath = objectFactory.fileCollection();
+        classpath.from((Callable<Object>) () -> sourceSet.getCompileClasspath().plus(objectFactory.fileCollection().from(sourceSet.getJava().getClassesDirectory())));
+        compileTask.getConventionMapping().map("classpath", () -> classpath);
     }
 
     public static void configureAnnotationProcessorPath(final SourceSet sourceSet, SourceDirectorySet sourceDirectorySet, CompileOptions options, final Project target) {


### PR DESCRIPTION
These plugins often do very similar things. This PR updates the Scala, Java, and Groovy base plugins to use the same names, patterns, initialization order, and method abstractions as each other -- for the most part at least. 
