### PR TITLE
Remove exceptional M1 Mac toolchain handling (`release7x`)

### DIFF
--- a/build-logic-commons/gradle-plugin/src/main/kotlin/common.kt
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/common.kt
@@ -20,9 +20,5 @@ import org.gradle.jvm.toolchain.JvmVendorSpec
 fun JavaPluginExtension.configureJavaToolChain() {
     toolchain {
         languageVersion.set(JavaLanguageVersion.of(11))
-        // Do not force Adoptium vendor for M1 Macs
-        if (System.getProperty("os.arch") != "aarch64") {
-            vendor.set(JvmVendorSpec.ADOPTIUM)
-        }
     }
 }

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/m9/M9JavaConfigurabilityCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/m9/M9JavaConfigurabilityCrossVersionSpec.groovy
@@ -17,12 +17,14 @@
 package org.gradle.integtests.tooling.m9
 
 import org.gradle.integtests.fixtures.AvailableJavaHomes
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.TextUtil
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.tooling.model.GradleProject
 import org.gradle.tooling.model.build.BuildEnvironment
 import org.junit.Assume
 
+@TargetGradleVersion(">=3.0")
 class M9JavaConfigurabilityCrossVersionSpec extends ToolingApiSpecification {
 
     def setup() {


### PR DESCRIPTION
Cherry pick of #23020 to `release7x`