### PR TITLE
Use directory hierarchy to qualify nested included builds

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildPathAssignmentIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildPathAssignmentIntegrationTest.groovy
@@ -91,12 +91,13 @@ class CompositeBuildBuildPathAssignmentIntegrationTest extends AbstractComposite
             }
             includingBuild {
                 nested
+                includeBuild '../includedBuild'
             }
         }
 
 
         def includingBuild = builds.find { it.rootProjectName == 'includingBuild' }
-        builds.each { build ->
+        (builds + new BuildTestFile(file('includingBuild/nested/buildSrc'), 'buildSrc')).each { build ->
             def buildSrc = build.createDir('buildSrc')
             buildSrc.createFile('settings.gradle')
             buildSrc.createFile('build.gradle')
@@ -105,7 +106,9 @@ class CompositeBuildBuildPathAssignmentIntegrationTest extends AbstractComposite
         when:
         succeeds(includingBuild, 'help')
         then:
-        assignedBuildPaths ==~ [':nested', ':nested:buildSrc', ':', ':buildSrc']
+        assignedBuildPaths ==~ [
+            ':includedBuild', ':includedBuild:buildSrc', ':includedBuild:nested', ':includedBuild:nested:buildSrc',
+            ':', ':buildSrc', ':nested', ':nested:buildSrc', ':nested:buildSrc:buildSrc']
     }
 
     private List<Object> getAssignedBuildPaths() {

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildMultipleBuildLogicIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildMultipleBuildLogicIntegrationTest.groovy
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.composite
+
+import org.gradle.integtests.fixtures.build.BuildTestFile
+
+class CompositeBuildMultipleBuildLogicIntegrationTest extends AbstractCompositeBuildIntegrationTest {
+
+    def "can have build-logic build and include build with build-logic build"() {
+        def rootBuildBuildLogic = new BuildTestFile(buildA.file("build-logic"), "build-logic")
+        rootBuildBuildLogic.buildFile """
+            plugins {
+                id 'java-gradle-plugin'
+            }
+        """
+        rootBuildBuildLogic.settingsFile.createFile()
+        buildA.settingsFile << """
+            includeBuild 'build-logic'
+        """
+
+        def includedBuild = multiProjectBuild("buildB", ["project1", "project2"]) {
+            includeBuild(buildA)
+            settingsFile << """
+                includeBuild 'build-logic'
+            """
+        }
+        def includedBuildBuildLogic = new BuildTestFile(includedBuild.file("build-logic"), "build-logic")
+        includedBuildBuildLogic.buildFile """
+            plugins {
+                id 'java-gradle-plugin'
+            }
+        """
+        includedBuildBuildLogic.settingsFile.createFile()
+
+        includeBuild(includedBuild)
+
+        expect:
+        succeeds(buildA, "help")
+
+    }
+}

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
@@ -243,10 +243,10 @@ public class DefaultIncludedBuildRegistry implements BuildStateRegistry, Stoppab
     private Path assignPath(BuildState owner, String name, File dir) {
         // Get the closest ancestor build of the build directory which we are currently adding
         Optional<Map.Entry<File, IncludedBuildState>> parentBuild = includedBuildsByRootDir.entrySet().stream()
-            .filter(entry -> dir.getAbsolutePath().startsWith(entry.getKey().getAbsolutePath()))
-            .reduce((a, b) -> a.getKey().getAbsolutePath().startsWith(b.getKey().getAbsolutePath())
-                ? a
-                : b
+            .filter(entry -> isPrefix(entry.getKey(), dir))
+            .reduce((a, b) -> isPrefix(a.getKey(), b.getKey())
+                ? b
+                : a
             );
         // If there is an ancestor, then we use it to qualify the path of the build we are adding
         Path requestedPath = parentBuild.map(
@@ -259,6 +259,11 @@ public class DefaultIncludedBuildRegistry implements BuildStateRegistry, Stoppab
 
         return requestedPath;
     }
+
+    private static boolean isPrefix(File prefix, File toCheck) {
+        return toCheck.toPath().toAbsolutePath().startsWith(prefix.toPath().toAbsolutePath());
+    }
+
 
     @Override
     public void resetStateForAllBuilds() {

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
@@ -36,6 +36,7 @@ import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.util.Path;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -106,7 +107,12 @@ public class DefaultIncludedBuildRegistry implements BuildStateRegistry, Stoppab
 
     @Override
     public IncludedBuildState addIncludedBuild(BuildDefinition buildDefinition) {
-        return registerBuild(buildDefinition, false);
+        return registerBuild(buildDefinition, false, null);
+    }
+
+    @Override
+    public IncludedBuildState addIncludedBuild(BuildDefinition buildDefinition, Path buildPath) {
+        return registerBuild(buildDefinition, false, buildPath);
     }
 
     @Override
@@ -114,7 +120,7 @@ public class DefaultIncludedBuildRegistry implements BuildStateRegistry, Stoppab
         // TODO: synchronization with other methods
         IncludedBuildState includedBuild = includedBuildsByRootDir.get(buildDefinition.getBuildRootDir());
         if (includedBuild == null) {
-            includedBuild = registerBuild(buildDefinition, true);
+            includedBuild = registerBuild(buildDefinition, true, null);
         }
         return includedBuild;
     }
@@ -197,7 +203,7 @@ public class DefaultIncludedBuildRegistry implements BuildStateRegistry, Stoppab
         }
     }
 
-    private IncludedBuildState registerBuild(BuildDefinition buildDefinition, boolean isImplicit) {
+    private IncludedBuildState registerBuild(BuildDefinition buildDefinition, boolean isImplicit, @Nullable Path buildPath) {
         // TODO: synchronization
         File buildDir = buildDefinition.getBuildRootDir();
         if (buildDir == null) {
@@ -213,7 +219,7 @@ public class DefaultIncludedBuildRegistry implements BuildStateRegistry, Stoppab
                 throw new IllegalStateException("build name is required");
             }
             validateNameIsNotBuildSrc(buildName, buildDir);
-            Path idPath = assignPath(rootBuild, buildDefinition.getName(), buildDir);
+            Path idPath = buildPath != null ? buildPath : assignPath(rootBuild, buildDefinition.getName(), buildDir);
             BuildIdentifier buildIdentifier = idFor(buildName);
 
             includedBuild = includedBuildFactory.createBuild(buildIdentifier, idPath, buildDefinition, isImplicit, rootBuild);

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildTreeStructureIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildTreeStructureIntegrationTest.groovy
@@ -285,19 +285,19 @@ class ConfigurationCacheBuildTreeStructureIntegrationTest extends AbstractConfig
             size() == 3
             it.find { it.details.buildPath == ":" }
             it.find { it.details.buildPath == ":include" }
-            it.find { it.details.buildPath == ":inner-include" }
+            it.find { it.details.buildPath == ":include:inner-include" }
         }
         with(fixture.all(LoadProjectsBuildOperationType)) {
             size() == 3
             it.find { it.details.buildPath == ":" }
             it.find { it.details.buildPath == ":include" }
-            it.find { it.details.buildPath == ":inner-include" }
+            it.find { it.details.buildPath == ":include:inner-include" }
         }
         with(fixture.progress(BuildIdentifiedProgressDetails)) {
             size() == 3
             it.find { it.details.buildPath == ":" }
             it.find { it.details.buildPath == ":include" }
-            it.find { it.details.buildPath == ":inner-include" }
+            it.find { it.details.buildPath == ":include:inner-include" }
         }
         with(fixture.progress(ProjectsIdentifiedProgressDetails)) {
             size() == 3
@@ -307,7 +307,7 @@ class ConfigurationCacheBuildTreeStructureIntegrationTest extends AbstractConfig
             with(it.find { it.details.buildPath == ":include" }) {
                 details.rootProject.children.size() == 1
             }
-            with(it.find { it.details.buildPath == ":inner-include" }) {
+            with(it.find { it.details.buildPath == ":include:inner-include" }) {
                 details.rootProject.children.size() == 1
             }
         }
@@ -324,7 +324,7 @@ class ConfigurationCacheBuildTreeStructureIntegrationTest extends AbstractConfig
             size() == 3
             it.find { it.details.buildPath == ":" }
             it.find { it.details.buildPath == ":include" }
-            it.find { it.details.buildPath == ":inner-include" }
+            it.find { it.details.buildPath == ":include:inner-include" }
         }
         with(fixture.progress(ProjectsIdentifiedProgressDetails)) {
             size() == 3
@@ -334,18 +334,18 @@ class ConfigurationCacheBuildTreeStructureIntegrationTest extends AbstractConfig
             with(it.find { it.details.buildPath == ":include" }) {
                 details.rootProject.children.size() == 1
             }
-            with(it.find { it.details.buildPath == ":inner-include" }) {
+            with(it.find { it.details.buildPath == ":include:inner-include" }) {
                 details.rootProject.children.size() == 1
             }
         }
 
         where:
-        task                         | projects                                        | builds
-        ":thing"                     | [':']                                           | [':']
-        ":child:thing"               | [':', ':child']                                 | [':']
-        ":include:thing"             | [':', ':include']                               | [':', ':include']
-        ":include:child:thing"       | [':', ':include', ':include:child']             | [':', ':include']
-        ":inner-include:thing"       | [':', ':inner-include']                         | [':', ':inner-include']
-        ":inner-include:child:thing" | [':', ':inner-include', ':inner-include:child'] | [':', ':inner-include']
+        task                                 | projects                                                        | builds
+        ":thing"                             | [':']                                                           | [':']
+        ":child:thing"                       | [':', ':child']                                                 | [':']
+        ":include:thing"                     | [':', ':include']                                               | [':', ':include']
+        ":include:child:thing"               | [':', ':include', ':include:child']                             | [':', ':include']
+        ":include:inner-include:thing"       | [':', ':include:inner-include']                                 | [':', ':include:inner-include']
+        ":include:inner-include:child:thing" | [':', ':include:inner-include', ':include:inner-include:child'] | [':', ':include:inner-include']
     }
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheBuild.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheBuild.kt
@@ -40,7 +40,7 @@ interface ConfigurationCacheBuild {
     // Creates all registered projects for this build
     fun createProjects()
 
-    fun addIncludedBuild(buildDefinition: BuildDefinition, settingsFile: File?): ConfigurationCacheBuild
+    fun addIncludedBuild(buildDefinition: BuildDefinition, settingsFile: File?, buildPath: Path): ConfigurationCacheBuild
 
     fun getBuildSrcOf(ownerId: BuildIdentifier): ConfigurationCacheBuild
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheHost.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheHost.kt
@@ -166,8 +166,8 @@ class ConfigurationCacheHost internal constructor(
         override fun getProject(path: String): ProjectInternal =
             state.projects.getProject(Path.path(path)).mutableModel
 
-        override fun addIncludedBuild(buildDefinition: BuildDefinition, settingsFile: File?): ConfigurationCacheBuild {
-            return DefaultConfigurationCacheBuild(buildStateRegistry.addIncludedBuild(buildDefinition), fileResolver, buildStateRegistry, settingsFile)
+        override fun addIncludedBuild(buildDefinition: BuildDefinition, settingsFile: File?, buildPath: Path): ConfigurationCacheBuild {
+            return DefaultConfigurationCacheBuild(buildStateRegistry.addIncludedBuild(buildDefinition, buildPath), fileResolver, buildStateRegistry, settingsFile)
         }
 
         override fun getBuildSrcOf(ownerId: BuildIdentifier): ConfigurationCacheBuild {

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
@@ -281,6 +281,7 @@ class ConfigurationCacheState(
         withGradleIsolate(gradle, userTypesCodec) {
             write(gradle.settings.settingsScript.resource.file)
             writeBuildDefinition(state.buildDefinition)
+            write(state.identityPath)
         }
         // Encode the build state using the contextualized IO service for the nested build
         state.projects.withMutableStateOfAllProjects {
@@ -293,7 +294,8 @@ class ConfigurationCacheState(
         val build = withGradleIsolate(rootBuild.gradle, userTypesCodec) {
             val settingsFile = read() as File?
             val definition = readIncludedBuildDefinition(rootBuild)
-            rootBuild.addIncludedBuild(definition, settingsFile)
+            val buildPath = read() as Path
+            rootBuild.addIncludedBuild(definition, settingsFile, buildPath)
         }
         // Decode the build state using the contextualized IO service for the build
         return build.gradle.serviceOf<ConfigurationCacheIO>().readIncludedBuildStateFrom(stateFileFor((build.state as NestedBuildState).buildDefinition), build)

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/BuildInitializationBuildOperationsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/BuildInitializationBuildOperationsIntegrationTest.groovy
@@ -185,15 +185,15 @@ class BuildInitializationBuildOperationsIntegrationTest extends AbstractIntegrat
         def loadOrder = [
             ":",
             ":nested",
-            ":nested-nested",
+            ":nested:nested-nested",
             ":nested-cli",
-            ":nested-cli-nested",
-            ":nested-nested:buildSrc",
-            ":nested-nested:buildSrc:buildSrc",
+            ":nested-cli:nested-cli-nested",
+            ":nested:nested-nested:buildSrc",
+            ":nested:nested-nested:buildSrc:buildSrc",
             ":nested:buildSrc",
             ":nested:buildSrc:buildSrc",
-            ":nested-cli-nested:buildSrc",
-            ":nested-cli-nested:buildSrc:buildSrc",
+            ":nested-cli:nested-cli-nested:buildSrc",
+            ":nested-cli:nested-cli-nested:buildSrc:buildSrc",
             ":nested-cli:buildSrc",
             ":nested-cli:buildSrc:buildSrc",
             ":buildSrc",
@@ -206,12 +206,12 @@ class BuildInitializationBuildOperationsIntegrationTest extends AbstractIntegrat
             ":nested",
             ":",
             ":nested-cli",
-            ":nested-nested",
-            ":nested-nested:buildSrc",
+            ":nested:nested-nested",
+            ":nested:nested-nested:buildSrc",
             ":nested",
             ":nested:buildSrc",
-            ":nested-cli-nested",
-            ":nested-cli-nested:buildSrc",
+            ":nested-cli:nested-cli-nested",
+            ":nested-cli:nested-cli-nested:buildSrc",
             ":nested-cli",
             ":nested-cli:buildSrc",
             ":",
@@ -219,18 +219,18 @@ class BuildInitializationBuildOperationsIntegrationTest extends AbstractIntegrat
         ]
 
         def buildIdentifiedEvents = buildOperations.progress(BuildIdentifiedProgressDetails)
-        buildIdentifiedEvents*.details.buildPath == [
+        buildIdentifiedEvents*.details.buildPath ==~ [
             ":",
             ":nested",
             ":nested-cli",
-            ":nested-nested",
-            ":nested-cli-nested",
-            ":nested-nested:buildSrc",
-            ":nested-nested:buildSrc:buildSrc",
+            ":nested:nested-nested",
+            ":nested-cli:nested-cli-nested",
+            ":nested:nested-nested:buildSrc",
+            ":nested:nested-nested:buildSrc:buildSrc",
             ":nested:buildSrc",
             ":nested:buildSrc:buildSrc",
-            ":nested-cli-nested:buildSrc",
-            ":nested-cli-nested:buildSrc:buildSrc",
+            ":nested-cli:nested-cli-nested:buildSrc",
+            ":nested-cli:nested-cli-nested:buildSrc:buildSrc",
             ":nested-cli:buildSrc",
             ":nested-cli:buildSrc:buildSrc",
             ":buildSrc",
@@ -242,15 +242,15 @@ class BuildInitializationBuildOperationsIntegrationTest extends AbstractIntegrat
 
         def configureOrder = [
                 ":",
-                ":nested-nested",
-                ":nested-nested:buildSrc",
-                ":nested-nested:buildSrc:buildSrc",
+                ":nested:nested-nested",
+                ":nested:nested-nested:buildSrc",
+                ":nested:nested-nested:buildSrc:buildSrc",
                 ":nested",
                 ":nested:buildSrc",
                 ":nested:buildSrc:buildSrc",
-                ":nested-cli-nested",
-                ":nested-cli-nested:buildSrc",
-                ":nested-cli-nested:buildSrc:buildSrc",
+                ":nested-cli:nested-cli-nested",
+                ":nested-cli:nested-cli-nested:buildSrc",
+                ":nested-cli:nested-cli-nested:buildSrc:buildSrc",
                 ":nested-cli",
                 ":nested-cli:buildSrc",
                 ":nested-cli:buildSrc:buildSrc",
@@ -268,12 +268,10 @@ class BuildInitializationBuildOperationsIntegrationTest extends AbstractIntegrat
         def dirs = configureOrder
             .collect { it.substring(1) } // strip leading :
             .collect { it.replaceAll(":", "/") }
-            .collect { it.replaceAll("nested-nested", "nested/nested-nested") }
-            .collect { it.replaceAll("nested-cli-nested", "nested-cli/nested-cli-nested") }
             .collect { it ? file(it) : testDirectory }
             .collect { it.absolutePath }
 
-        loadProjectsBuildOperations*.result.rootProject.projectDir == dirs
+        loadProjectsBuildOperations*.result.rootProject.projectDir ==~ dirs
     }
 
     def "operations are fired when child build is not used"() {

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildStateRegistry.java
@@ -21,6 +21,7 @@ import org.gradle.api.internal.BuildDefinition;
 import org.gradle.internal.buildtree.NestedBuildTree;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
+import org.gradle.util.Path;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
@@ -74,6 +75,13 @@ public interface BuildStateRegistry {
      * Creates an included build. An included build is-a nested build whose projects and outputs are treated as part of the composite build.
      */
     IncludedBuildState addIncludedBuild(BuildDefinition buildDefinition);
+
+    /**
+     * Creates an included build. An included build is-a nested build whose projects and outputs are treated as part of the composite build.
+     *
+     * This is used when loaded from the Configuration Cache when the path of the build is already known.
+     */
+    IncludedBuildState addIncludedBuild(BuildDefinition buildDefinition, Path buildPath);
 
     /**
      * Creates an implicit included build. An implicit build is-a nested build that is managed by Gradle and whose outputs are used by dependency resolution.

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
@@ -51,11 +51,52 @@ If you are running tasks from the command line in nested included builds, then y
 
 For example, if you have the following hierarchy:
 
+====
+[.multi-language-sample]
+=====
+[source,kotlin]
 ----
-root
-  nested
-    nestedNested
+.
+├── settings.gradle.kts
+└── nested
+    ├── settings.gradle.kts
+    └── nestedNested
+        └── settings.gradle.kts
 ----
+.settings.gradle.kts
+[source,kotlin]
+----
+includeBuild("nested")
+----
+.nested/settings.gradle.kts
+[source,kotlin]
+----
+includeBuild("nestedNested")
+----
+=====
+[.multi-language-sample]
+=====
+[source,groovy]
+----
+.
+├── settings.gradle
+└── nested
+    ├── settings.gradle
+    └── nestedNested
+        └── settings.gradle
+----
+.settings.gradle
+[source,groovy]
+----
+includeBuild("nested")
+----
+.nested/settings.gradle
+[source,groovy]
+----
+includeBuild("nestedNested")
+----
+=====
+====
 
 Before Gradle 8.1, you ran `gradle :nestedNested:compileJava`.
 In Gradle 8.1 the invocation changes to `gradle :nested:nestedNested:compileJava`.

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
@@ -44,6 +44,22 @@ The previous step will help you identify potential problems by issuing deprecati
 
 === Potential breaking changes
 
+==== Changes to paths of included builds
+
+In order to handle conflicts between nested included build names better, Gradle now uses the directory hierarchy of included builds to assign the build path.
+If you are running tasks from the command line in nested included builds, then you may need to adjust your invocation.
+
+For example, if you have the following hierarchy:
+
+----
+root
+  nested
+    nestedNested
+----
+
+Before Gradle 8.1, you did run `gradle :nestedNested:compileJava`.
+In Gradle 8.0 the invocation changes to `gradle :nested:nestedNested:compileJava`.
+
 === Deprecations
 
 [[custom_configuration_roles]]

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
@@ -57,8 +57,8 @@ root
     nestedNested
 ----
 
-Before Gradle 8.1, you did run `gradle :nestedNested:compileJava`.
-In Gradle 8.0 the invocation changes to `gradle :nested:nestedNested:compileJava`.
+Before Gradle 8.1, you ran `gradle :nestedNested:compileJava`.
+In Gradle 8.1 the invocation changes to `gradle :nested:nestedNested:compileJava`.
 
 === Deprecations
 


### PR DESCRIPTION
To allow having composite builds with included build-logic bodies.

This PR goes further, so it should enable folks to have composite builds between builds that themselves use composite builds.

Fixes https://github.com/gradle/gradle/issues/17228