### PR TITLE
Make SourceSetOuput getClassesDirs a ConfigurableFileCollection

### DIFF
--- a/subprojects/platform-jvm/src/main/java/org/gradle/api/tasks/SourceSetOutput.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/api/tasks/SourceSetOutput.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.tasks;
 
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 
 import javax.annotation.Nullable;
@@ -90,7 +91,7 @@ public interface SourceSetOutput extends FileCollection {
      * @return The classes directories. Never returns null.
      * @since 4.0
      */
-    FileCollection getClassesDirs();
+    ConfigurableFileCollection getClassesDirs();
 
     /**
      * Returns the output directory for resources


### PR DESCRIPTION
So we have a public API for adding task outputs to the source set output
