### PR TITLE
JUnit 5 Dynamic tests not showing with their displayName

### DIFF
--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/AbstractTestLogger.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/AbstractTestLogger.java
@@ -70,7 +70,7 @@ public abstract class AbstractTestLogger {
                 // but we nevertheless want to see the class name. We use "." rather than
                 // " > " as a separator to make it clear that the class is not a separate
                 // level. This matters when configuring granularity.
-                names.add(current.getClassName() + "." + current.getName());
+                names.add(current.getClassName() + "." + current.getDisplayName());
             } else {
                 names.add(current.getDisplayName());
             }

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/AbstractTestLoggerTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/logging/AbstractTestLoggerTest.groovy
@@ -138,7 +138,7 @@ class AbstractTestLoggerTest extends Specification {
         textOutputFactory.toString() == "{TestEventLogger}{INFO}${sep}a test {failure}FAILED{normal}${sep}"
     }
 
-    def "logging of atomic test whose parent isn't the test class includes test class name"() {
+    def "logging of atomic test whose parent isn't the test class"() {
         createLogger(LogLevel.INFO)
         methodDescriptor.parent = innerSuiteDescriptor
 
@@ -146,7 +146,7 @@ class AbstractTestLoggerTest extends Specification {
         logger.logEvent(methodDescriptor, TestLogEvent.STARTED)
 
         then:
-        textOutputFactory.toString() == "{TestEventLogger}{INFO}${sep}OuterSuiteClass > InnerSuiteClass > foo.bar.TestClass.testMethod STARTED${sep}"
+        textOutputFactory.toString() == "{TestEventLogger}{INFO}${sep}OuterSuiteClass > InnerSuiteClass > foo.bar.TestClass.a test STARTED${sep}"
     }
 
     def "logs header just once per batch of events with same type and for same test"() {

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformLoggingIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformLoggingIntegrationTest.groovy
@@ -16,7 +16,9 @@
 
 package org.gradle.testing.junitplatform
 
-class JUnitPlatformLoggingIntegrationTest extends JUnitPlatformIntegrationSpec  {
+import spock.lang.Issue
+
+class JUnitPlatformLoggingIntegrationTest extends JUnitPlatformIntegrationSpec {
 
     @Override
     def setup() {
@@ -31,7 +33,7 @@ class JUnitPlatformLoggingIntegrationTest extends JUnitPlatformIntegrationSpec  
 
     def "should log display names if present"() {
         given:
-        file("src/test/java/pkg/TopLevelClass.java")  << """
+        file("src/test/java/pkg/TopLevelClass.java") << """
             package pkg;
             import org.junit.jupiter.api.DisplayName;
             import org.junit.jupiter.api.Nested;
@@ -67,7 +69,7 @@ class JUnitPlatformLoggingIntegrationTest extends JUnitPlatformIntegrationSpec  
 
     def "should fall back to plain name if no display names present"() {
         given:
-        file("src/test/java/pkg/TopLevelClass.java")  << """
+        file("src/test/java/pkg/TopLevelClass.java") << """
             package pkg;
 
             import org.junit.jupiter.api.DisplayName;
@@ -98,4 +100,33 @@ class JUnitPlatformLoggingIntegrationTest extends JUnitPlatformIntegrationSpec  
         outputContains("TopLevelClass > NestedClass > nestedTestMethod()")
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/5975")
+    def "should log display names for dynamically created tests"() {
+        given:
+        file("src/test/java/org/gradle/JUnitJupiterDynamicTest.java") << """
+            package org.gradle;
+            import org.junit.jupiter.api.DynamicTest;
+            import org.junit.jupiter.api.TestFactory;
+            import java.util.stream.IntStream;
+            import java.util.stream.Stream;
+            import static org.junit.jupiter.api.Assertions.*;
+            import static org.junit.jupiter.api.DynamicTest.dynamicTest;
+            public class JUnitJupiterDynamicTest {
+                @TestFactory
+                Stream<DynamicTest> streamOfTests() {
+                    return IntStream.of(2, 4, 5)
+                        .mapToObj(v -> dynamicTest(v + " is even", () -> assertEquals(0, v % 2)));
+                }
+            }
+        """
+
+        when:
+        runAndFail("test")
+
+        then:
+        def prefix = "JUnitJupiterDynamicTest > streamOfTests() > org.gradle.JUnitJupiterDynamicTest"
+        outputContains("${prefix}.2 is even PASSED")
+        outputContains("${prefix}.4 is even PASSED")
+        outputContains("${prefix}.5 is even FAILED")
+    }
 }


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

Resurrection of https://github.com/gradle/gradle/pull/21361 made by @uberto, which is for https://github.com/gradle/gradle/issues/5975
- The fix is from @uberto
- Applied the suggestions from @6hundreds for the test

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

(Checklist notes: No docs changes necessary. The added test in `JUnitPlatformLoggingIntegrationTest` proves that there is a bug, hence no unit test changes other than updating `AbstractTestLoggerTest`.)

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
