### PR TITLE
Do not discard build services that are build event listeners after storing configuration cache entry

### DIFF
--- a/subprojects/build-events/src/integTest/groovy/org/gradle/build/event/BuildEventsIntegrationTest.groovy
+++ b/subprojects/build-events/src/integTest/groovy/org/gradle/build/event/BuildEventsIntegrationTest.groovy
@@ -17,11 +17,8 @@
 package org.gradle.build.event
 
 import org.gradle.api.services.BuildServiceParameters
-import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheOption
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
-import org.gradle.integtests.fixtures.RequiredFeature
-import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.tooling.events.FinishEvent
@@ -134,8 +131,6 @@ class BuildEventsIntegrationTest extends AbstractIntegrationSpec {
         outputContains("EVENT: finish :b:thing")
     }
 
-    @RequiredFeature(feature = ConfigurationCacheOption.PROPERTY_NAME, value = "false")
-    @UnsupportedWithConfigurationCache
     def "listener receives task completion events from included builds"() {
         settingsFile << """
             includeBuild 'a'
@@ -173,6 +168,42 @@ class BuildEventsIntegrationTest extends AbstractIntegrationSpec {
         outputContains("EVENT: finish :thing")
         outputContains("EVENT: finish :a:thing")
         outputContains("EVENT: finish :b:thing")
+    }
+
+    @IgnoreIf({ GradleContextualExecuter.configCache }) // already covers CC
+    def "listener is not discarded after configuration phase when used with configuration cache"() {
+        listenerReceivedConfigurationTimeData()
+        registeringPlugin()
+        buildFile << """
+            apply plugin: LoggingPlugin
+
+            def listener = gradle.sharedServices.registrations["listener"].service.get()
+            listener.configTime("data")
+
+            task thing {
+                doLast { }
+            }
+        """
+        executer.beforeExecute {
+            withArgument("--configuration-cache")
+            withArgument("-Dorg.gradle.configuration-cache.internal.load-after-store=true")
+        }
+
+        when:
+        run("thing")
+
+        then:
+        output.count("service:") == 2
+        outputContains("service: finish :thing with data=data")
+        outputContains("service: closed with data=data")
+
+        when:
+        run("thing")
+
+        then:
+        output.count("service:") == 2
+        outputContains("service: finish :thing with data=null")
+        outputContains("service: closed with data=null")
     }
 
     def "listener registered from init script can receive task completion events from buildSrc and main build"() {
@@ -294,7 +325,8 @@ class BuildEventsIntegrationTest extends AbstractIntegrationSpec {
         outputContains("EVENT: finish :b")
     }
 
-    @IgnoreIf({ GradleContextualExecuter.embedded }) // Tries to resolve external (api) jars that are not available in the embedded environment
+    @IgnoreIf({ GradleContextualExecuter.embedded })
+    // Tries to resolve external (api) jars that are not available in the embedded environment
     @Issue("https://github.com/gradle/gradle/issues/16774")
     def "can use plugin that registers build event listener with ProjectBuilder"() {
         given:
@@ -337,7 +369,8 @@ class BuildEventsIntegrationTest extends AbstractIntegrationSpec {
         result.testClass('my.MyTest').assertTestCount(1, 0, 0)
     }
 
-    @IgnoreIf({ GradleContextualExecuter.embedded }) // Cannot run TestKit in embedded mode
+    @IgnoreIf({ GradleContextualExecuter.embedded })
+    // Cannot run TestKit in embedded mode
     def "can use plugin that registers build event listener with TestKit"() {
         given:
         def plugin = file('src/main/groovy/my-plugin.gradle')
@@ -472,6 +505,40 @@ class BuildEventsIntegrationTest extends AbstractIntegrationSpec {
                 void onFinish(FinishEvent event) {
                     println("BROKEN: received event")
                     throw new RuntimeException("broken")
+                }
+            }
+        """
+    }
+
+    void listenerReceivedConfigurationTimeData(TestFile file = buildFile) {
+        file << """
+            import ${OperationCompletionListener.name}
+            import ${FinishEvent.name}
+            import ${TaskFinishEvent.name}
+            import ${TaskSuccessResult.name}
+            import ${TaskFailureResult.name}
+            import ${TaskSkippedResult.name}
+            import ${BuildServiceParameters.name}
+
+            abstract class LoggingListener implements OperationCompletionListener, BuildService<BuildServiceParameters.None>, Closeable {
+                String data
+
+                void configTime(String data) {
+                    this.data = data
+                }
+
+                @Override
+                void onFinish(FinishEvent event) {
+                    if (event instanceof TaskFinishEvent) {
+                        println("service: finish \${event.descriptor.taskPath} with data=" + data)
+                    } else {
+                        throw new IllegalArgumentException()
+                    }
+                }
+
+                @Override
+                void close() {
+                    println("service: closed with data=" + data)
                 }
             }
         """

--- a/subprojects/build-events/src/main/java/org/gradle/internal/build/event/BuildEventListenerRegistryInternal.java
+++ b/subprojects/build-events/src/main/java/org/gradle/internal/build/event/BuildEventListenerRegistryInternal.java
@@ -34,9 +34,4 @@ public interface BuildEventListenerRegistryInternal extends BuildEventsListenerR
     void subscribe(Provider<?> provider);
 
     List<Provider<?>> getSubscriptions();
-
-    /**
-     * Discards all subscriptions.
-     */
-    void unsubscribeAll();
 }

--- a/subprojects/build-events/src/main/java/org/gradle/internal/build/event/DefaultBuildEventsListenerRegistry.java
+++ b/subprojects/build-events/src/main/java/org/gradle/internal/build/event/DefaultBuildEventsListenerRegistry.java
@@ -23,6 +23,7 @@ import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.provider.ProviderInternal;
 import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.services.internal.RegisteredBuildServiceProvider;
 import org.gradle.build.event.BuildEventsListenerRegistry;
 import org.gradle.initialization.BuildEventConsumer;
 import org.gradle.internal.Cast;
@@ -70,8 +71,10 @@ public class DefaultBuildEventsListenerRegistry implements BuildEventsListenerRe
     private final ExecutorFactory executorFactory;
 
     public DefaultBuildEventsListenerRegistry(
-        BuildEventListenerFactory factory, ListenerManager listenerManager,
-        BuildOperationListenerManager buildOperationListenerManager, ExecutorFactory executorFactory
+        BuildEventListenerFactory factory,
+        ListenerManager listenerManager,
+        BuildOperationListenerManager buildOperationListenerManager,
+        ExecutorFactory executorFactory
     ) {
         this.factory = factory;
         this.listenerManager = listenerManager;
@@ -114,6 +117,9 @@ public class DefaultBuildEventsListenerRegistry implements BuildEventsListenerRe
         }
 
         ForwardingBuildEventConsumer subscription = new ForwardingBuildEventConsumer(listenerProvider, executorFactory);
+        if (listenerProvider instanceof RegisteredBuildServiceProvider) {
+            ((RegisteredBuildServiceProvider) listenerProvider).keepAlive();
+        }
         subscriptions.put(listenerProvider, subscription);
 
         BuildEventSubscriptions eventSubscriptions = new BuildEventSubscriptions(Collections.singleton(OperationType.TASK));
@@ -128,8 +134,7 @@ public class DefaultBuildEventsListenerRegistry implements BuildEventsListenerRe
         }
     }
 
-    @Override
-    public void unsubscribeAll() {
+    private void unsubscribeAll() {
         try {
             for (Object listener : listeners) {
                 listenerManager.removeListener(listener);

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheAwareBuildTreeWorkController.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheAwareBuildTreeWorkController.kt
@@ -21,7 +21,6 @@ import org.gradle.configurationcache.initialization.ConfigurationCacheStartParam
 import org.gradle.execution.EntryTaskSelector
 import org.gradle.internal.build.BuildStateRegistry
 import org.gradle.internal.build.ExecutionResult
-import org.gradle.internal.build.event.BuildEventListenerRegistryInternal
 import org.gradle.internal.buildtree.BuildTreeWorkController
 import org.gradle.internal.buildtree.BuildTreeWorkExecutor
 import org.gradle.internal.buildtree.BuildTreeWorkPreparer
@@ -33,7 +32,6 @@ class ConfigurationCacheAwareBuildTreeWorkController(
     private val workGraph: BuildTreeWorkGraphController,
     private val cache: BuildTreeConfigurationCache,
     private val buildRegistry: BuildStateRegistry,
-    private val eventListenerRegistry: BuildEventListenerRegistryInternal,
     private val startParameter: ConfigurationCacheStartParameter,
 ) : BuildTreeWorkController {
 
@@ -54,7 +52,6 @@ class ConfigurationCacheAwareBuildTreeWorkController(
         }
 
         cache.finalizeCacheEntry()
-        eventListenerRegistry.unsubscribeAll()
         buildRegistry.resetStateForAllBuilds()
 
         return workGraph.withNewWorkGraph { graph ->

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheBuildTreeLifecycleControllerFactory.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheBuildTreeLifecycleControllerFactory.kt
@@ -21,7 +21,6 @@ import org.gradle.configurationcache.extensions.get
 import org.gradle.configurationcache.initialization.ConfigurationCacheStartParameter
 import org.gradle.internal.build.BuildLifecycleController
 import org.gradle.internal.build.BuildStateRegistry
-import org.gradle.internal.build.event.BuildEventListenerRegistryInternal
 import org.gradle.internal.buildtree.BuildModelParameters
 import org.gradle.internal.buildtree.BuildTreeFinishExecutor
 import org.gradle.internal.buildtree.BuildTreeLifecycleController
@@ -40,7 +39,6 @@ class ConfigurationCacheBuildTreeLifecycleControllerFactory(
     private val cache: BuildTreeConfigurationCache,
     private val taskGraph: BuildTreeWorkGraphController,
     private val stateTransitionControllerFactory: StateTransitionControllerFactory,
-    private val eventListenerRegistry: BuildEventListenerRegistryInternal,
     private val startParameter: ConfigurationCacheStartParameter,
     private val buildStateRegistry: BuildStateRegistry,
 ) : BuildTreeLifecycleControllerFactory {
@@ -68,7 +66,7 @@ class ConfigurationCacheBuildTreeLifecycleControllerFactory(
         }
 
         val workPreparer = vintageFactory.createWorkPreparer(targetBuild)
-        val workController = ConfigurationCacheAwareBuildTreeWorkController(workPreparer, workExecutor, taskGraph, cache, buildStateRegistry, eventListenerRegistry, startParameter)
+        val workController = ConfigurationCacheAwareBuildTreeWorkController(workPreparer, workExecutor, taskGraph, cache, buildStateRegistry, startParameter)
 
         val defaultModelCreator = vintageFactory.createModelCreator(targetBuild)
         val modelCreator = ConfigurationCacheAwareBuildTreeModelCreator(defaultModelCreator, cache)

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceRegistryInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceRegistryInternal.java
@@ -43,11 +43,6 @@ public interface BuildServiceRegistryInternal extends BuildServiceRegistry {
     @Nullable
     SharedResource forService(BuildServiceProvider<?, ?> service);
 
-    /**
-     * Discards all registered services.
-     */
-    void discardAll();
-
     @Nullable
     BuildServiceRegistration<?, ?> findByName(String name);
 

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/RegisteredBuildServiceProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/RegisteredBuildServiceProvider.java
@@ -41,6 +41,7 @@ public class RegisteredBuildServiceProvider<T extends BuildService<P>, P extends
     private final IsolatableFactory isolatableFactory;
     private final Listener listener;
     private Try<T> instance;
+    private boolean keepAlive;
 
     public RegisteredBuildServiceProvider(
         BuildIdentifier buildIdentifier,
@@ -90,6 +91,17 @@ public class RegisteredBuildServiceProvider<T extends BuildService<P>, P extends
     @Override
     public Class<T> getType() {
         return serviceDetails.getImplementationType();
+    }
+
+    /**
+     * When true, this service should be kept alive until the end of the build.
+     */
+    public boolean isKeepAlive() {
+        return keepAlive;
+    }
+
+    public void keepAlive() {
+        keepAlive = true;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/build/AbstractBuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/AbstractBuildState.java
@@ -20,7 +20,6 @@ import org.gradle.api.internal.BuildDefinition;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.project.HoldsProjectState;
 import org.gradle.api.internal.project.ProjectStateRegistry;
-import org.gradle.api.services.internal.BuildServiceRegistryInternal;
 import org.gradle.initialization.IncludedBuildSpec;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
@@ -77,7 +76,6 @@ public abstract class AbstractBuildState implements BuildState, Closeable {
         projectStateRegistry.get().discardProjectsFor(this);
         workGraphController.get().resetState();
         buildLifecycleController.get().resetLifecycle();
-        buildLifecycleController.get().getGradle().getServices().get(BuildServiceRegistryInternal.class).discardAll();
         for (HoldsProjectState service : buildLifecycleController.get().getGradle().getServices().getAll(HoldsProjectState.class)) {
             service.discardAll();
         }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
@@ -30,7 +30,6 @@ import org.gradle.api.internal.plugins.PluginTarget;
 import org.gradle.api.internal.tasks.options.OptionReader;
 import org.gradle.api.services.internal.BuildServiceProvider;
 import org.gradle.api.services.internal.BuildServiceProviderNagger;
-import org.gradle.api.services.internal.BuildServiceRegistryInternal;
 import org.gradle.api.services.internal.DefaultBuildServicesRegistry;
 import org.gradle.cache.GlobalCacheLocations;
 import org.gradle.cache.internal.DefaultFileContentCacheFactory;
@@ -203,7 +202,7 @@ public class GradleScopeServices extends DefaultServiceRegistry {
         );
     }
 
-    BuildServiceRegistryInternal createSharedServiceRegistry(
+    DefaultBuildServicesRegistry createSharedServiceRegistry(
         BuildState buildState,
         Instantiator instantiator,
         DomainObjectCollectionFactory factory,


### PR DESCRIPTION

<!--- The issue this PR addresses -->
Fixes #?

### Context

Build event listeners may also collect configuration time metrics, so do not discard them after configuration time.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
