### PR TITLE
allow labels for gradle wrapper task versions

### DIFF
--- a/subprojects/build-init/build.gradle.kts
+++ b/subprojects/build-init/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     implementation(libs.groovy)
     implementation(libs.groovyTemplates)
     implementation(libs.guava)
+    implementation(libs.gson)
     implementation(libs.commonsLang)
     implementation(libs.inject)
     implementation(libs.maven3SettingsBuilder)
@@ -58,4 +59,8 @@ dependencies {
         because("ProjectBuilder tests load services from a Gradle distribution.")
     }
     integTestDistributionRuntimeOnly(project(":distributions-full"))
+}
+
+packageCycles {
+    excludePatterns.add("org/gradle/api/tasks/wrapper/internal/*")
 }

--- a/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/GradleVersionResolver.java
+++ b/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/GradleVersionResolver.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks.wrapper;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.gradle.api.GradleException;
+import org.gradle.api.resources.TextResource;
+import org.gradle.api.tasks.wrapper.internal.DefaultWrapperVersionsResources;
+import org.gradle.util.GradleVersion;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+
+import static org.gradle.api.tasks.wrapper.internal.DefaultWrapperVersionsResources.LATEST;
+import static org.gradle.api.tasks.wrapper.internal.DefaultWrapperVersionsResources.NIGHTLY;
+import static org.gradle.api.tasks.wrapper.internal.DefaultWrapperVersionsResources.RELEASE_CANDIDATE;
+import static org.gradle.api.tasks.wrapper.internal.DefaultWrapperVersionsResources.RELEASE_NIGHTLY;
+
+class GradleVersionResolver {
+
+    private TextResource latest;
+    private TextResource releaseCandidate;
+    private TextResource nightly;
+    private TextResource releaseNightly;
+
+    private GradleVersion gradleVersion;
+    private String gradleVersionString = GradleVersion.current().getVersion();
+
+    void setTextResources(TextResource latest, TextResource releaseCandidate, TextResource nightly, TextResource releaseNightly) {
+        this.latest = latest;
+        this.releaseCandidate = releaseCandidate;
+        this.nightly = nightly;
+        this.releaseNightly = releaseNightly;
+    }
+
+    public String resolve(String version) {
+        if (version == null) {
+            return GradleVersion.current().getVersion();
+        }
+        switch (version) {
+            case LATEST:
+                return getVersion(latest.asString(), version);
+            case NIGHTLY:
+                return getVersion(nightly.asString(), version);
+            case RELEASE_NIGHTLY:
+                return getVersion(releaseNightly.asString(), version);
+            case RELEASE_CANDIDATE:
+                return getVersion(releaseCandidate.asString(), version);
+            default:
+                return version;
+        }
+    }
+
+    static String getVersion(String json, String placeHolder) {
+        Type type = new TypeToken<Map<String, String>>() {}.getType();
+        Map<String, String> map = new Gson().fromJson(json, type);
+        String version = map.get("version");
+        if (version == null) {
+            throw new GradleException("There is currently no version information available for \"" + placeHolder + "\".");
+        }
+        return version;
+    }
+
+    static boolean isPlaceHolder(String version) {
+        return DefaultWrapperVersionsResources.PLACE_HOLDERS.contains(version);
+    }
+
+    public GradleVersion getGradleVersion() {
+        if (gradleVersion == null) {
+            gradleVersion = GradleVersion.version(resolve(gradleVersionString));
+        }
+        return gradleVersion;
+    }
+
+    public void setGradleVersionString(String gradleVersionString) {
+        if (!isPlaceHolder(gradleVersionString)) {
+            this.gradleVersion = GradleVersion.version(gradleVersionString);
+        }
+        if (this.gradleVersionString != gradleVersionString) {
+            this.gradleVersionString = gradleVersionString;
+            this.gradleVersion = null;
+        }
+    }
+}

--- a/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/GradleVersionResolver.java
+++ b/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/GradleVersionResolver.java
@@ -48,7 +48,7 @@ class GradleVersionResolver {
         this.releaseNightly = releaseNightly;
     }
 
-    public String resolve(String version) {
+    String resolve(String version) {
         if (version == null) {
             return GradleVersion.current().getVersion();
         }
@@ -71,7 +71,7 @@ class GradleVersionResolver {
         Map<String, String> map = new Gson().fromJson(json, type);
         String version = map.get("version");
         if (version == null) {
-            throw new GradleException("There is currently no version information available for \"" + placeHolder + "\".");
+            throw new GradleException("There is currently no version information available for '" + placeHolder + "'.");
         }
         return version;
     }
@@ -80,14 +80,14 @@ class GradleVersionResolver {
         return DefaultWrapperVersionsResources.PLACE_HOLDERS.contains(version);
     }
 
-    public GradleVersion getGradleVersion() {
+    GradleVersion getGradleVersion() {
         if (gradleVersion == null) {
             gradleVersion = GradleVersion.version(resolve(gradleVersionString));
         }
         return gradleVersion;
     }
 
-    public void setGradleVersionString(String gradleVersionString) {
+    void setGradleVersionString(String gradleVersionString) {
         if (!isPlaceHolder(gradleVersionString)) {
             this.gradleVersion = GradleVersion.version(gradleVersionString);
         }

--- a/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
+++ b/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
@@ -33,6 +33,7 @@ import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
 import org.gradle.api.tasks.options.OptionValues;
+import org.gradle.api.tasks.wrapper.internal.DefaultWrapperVersionsResources;
 import org.gradle.internal.util.PropertiesUtils;
 import org.gradle.util.GradleVersion;
 import org.gradle.util.internal.DistributionLocator;
@@ -72,6 +73,7 @@ import java.util.Properties;
 public abstract class Wrapper extends DefaultTask {
     public static final String DEFAULT_DISTRIBUTION_PARENT_NAME = Install.DEFAULT_DISTRIBUTION_PATH;
 
+
     /**
      * Specifies the Gradle distribution type.
      */
@@ -99,7 +101,7 @@ public abstract class Wrapper extends DefaultTask {
     private PathBase distributionBase = PathBase.GRADLE_USER_HOME;
     private String distributionUrl;
     private String distributionSha256Sum;
-    private GradleVersion gradleVersion;
+    private final GradleVersionResolver gradleVersionResolver = new GradleVersionResolver();
     private DistributionType distributionType = DistributionType.BIN;
     private String archivePath;
     private PathBase archiveBase = PathBase.GRADLE_USER_HOME;
@@ -111,7 +113,6 @@ public abstract class Wrapper extends DefaultTask {
         jarFile = "gradle/wrapper/gradle-wrapper.jar";
         distributionPath = DEFAULT_DISTRIBUTION_PARENT_NAME;
         archivePath = DEFAULT_DISTRIBUTION_PARENT_NAME;
-        gradleVersion = GradleVersion.current();
     }
 
     @Inject
@@ -150,7 +151,7 @@ public abstract class Wrapper extends DefaultTask {
             ? existingProperties.getProperty(WrapperExecutor.DISTRIBUTION_SHA_256_SUM, null)
             : null;
 
-        if (GradleVersion.current() != gradleVersion &&
+        if (!isCurrentVersion() &&
             distributionSha256Sum == null &&
             checksumProperty != null) {
             throw new GradleException("gradle-wrapper.properties contains distributionSha256Sum property, but the wrapper configuration does not have one. Specify one in the wrapped task configuration or with the --gradle-distribution-sha256-sum task option");
@@ -193,11 +194,15 @@ public abstract class Wrapper extends DefaultTask {
     private String getDistributionSha256Sum(Properties existingProperties) {
         if (distributionSha256Sum != null) {
             return distributionSha256Sum;
-        } else if (GradleVersion.current() == gradleVersion && existingProperties != null) {
+        } else if (isCurrentVersion() && existingProperties != null) {
             return existingProperties.getProperty(WrapperExecutor.DISTRIBUTION_SHA_256_SUM, null);
         } else {
             return null;
         }
+    }
+
+    private boolean isCurrentVersion() {
+        return GradleVersion.current().equals(gradleVersionResolver.getGradleVersion());
     }
 
     /**
@@ -295,7 +300,22 @@ public abstract class Wrapper extends DefaultTask {
      */
     @Input
     public String getGradleVersion() {
-        return gradleVersion.getVersion();
+        return gradleVersionResolver.getGradleVersion().getVersion();
+    }
+
+    /**
+     * Set Wrapper versions resources.
+     *
+     * @since 8.1
+     */
+    @Incubating
+    public void setDefaultWrapperVersionsResources(WrapperVersionsResources wrapperVersionsResources) {
+
+        DefaultWrapperVersionsResources defaultWrapperVersionsResources = (DefaultWrapperVersionsResources) wrapperVersionsResources;
+        gradleVersionResolver.setTextResources(defaultWrapperVersionsResources.getLatest(),
+            defaultWrapperVersionsResources.getReleaseCandidate(),
+            defaultWrapperVersionsResources.getNightly(),
+            defaultWrapperVersionsResources.getReleaseNightly());
     }
 
     /**
@@ -304,7 +324,7 @@ public abstract class Wrapper extends DefaultTask {
      */
     @Option(option = "gradle-version", description = "The version of the Gradle distribution required by the wrapper.")
     public void setGradleVersion(String gradleVersion) {
-        this.gradleVersion = GradleVersion.version(gradleVersion);
+        this.gradleVersionResolver.setGradleVersionString(gradleVersion);
     }
 
     /**
@@ -352,8 +372,8 @@ public abstract class Wrapper extends DefaultTask {
     public String getDistributionUrl() {
         if (distributionUrl != null) {
             return distributionUrl;
-        } else if (gradleVersion != null) {
-            return locator.getDistributionFor(gradleVersion, distributionType.name().toLowerCase(Locale.ENGLISH)).toString();
+        } else if (gradleVersionResolver.getGradleVersion() != null) {
+            return locator.getDistributionFor(gradleVersionResolver.getGradleVersion(), distributionType.name().toLowerCase(Locale.ENGLISH)).toString();
         } else {
             return null;
         }

--- a/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
+++ b/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
@@ -294,16 +294,6 @@ public abstract class Wrapper extends DefaultTask {
     }
 
     /**
-     * Returns the gradle version for the wrapper.
-     *
-     * @see #setGradleVersion(String)
-     */
-    @Input
-    public String getGradleVersion() {
-        return gradleVersionResolver.getGradleVersion().getVersion();
-    }
-
-    /**
      * Set Wrapper versions resources.
      *
      * @since 8.1
@@ -318,10 +308,24 @@ public abstract class Wrapper extends DefaultTask {
     }
 
     /**
-     * The version of the gradle distribution required by the wrapper. This is usually the same version of Gradle you
-     * use for building your project.
+     * Returns the gradle version for the wrapper.
+     * This may throw if the label that can be provided via #setGradleVersion(String) can not be resolved at the moment
+     * e.g. there is not a `release-candidate` available at all times.
+     *
+     * @see #setGradleVersion(String)
      */
-    @Option(option = "gradle-version", description = "The version of the Gradle distribution required by the wrapper.")
+    @Input
+    public String getGradleVersion() {
+        return gradleVersionResolver.getGradleVersion().getVersion();
+    }
+
+    /**
+     * The version of the gradle distribution required by the wrapper.
+     * This is usually the same version of Gradle you use for building your project.
+     * The are labels allowed to specify a version: latest, release-candidate, nightly, and release-nightly
+     */
+    @Option(option = "gradle-version", description = "The version of the Gradle distribution required by the wrapper. " +
+        "The following labels are allowed: latest, release-candidate, nightly, and release-nightly")
     public void setGradleVersion(String gradleVersion) {
         this.gradleVersionResolver.setGradleVersionString(gradleVersion);
     }

--- a/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
+++ b/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
@@ -309,8 +309,7 @@ public abstract class Wrapper extends DefaultTask {
      * @since 8.1
      */
     @Incubating
-    public void setDefaultWrapperVersionsResources(WrapperVersionsResources wrapperVersionsResources) {
-
+    public void setWrapperVersionsResources(WrapperVersionsResources wrapperVersionsResources) {
         DefaultWrapperVersionsResources defaultWrapperVersionsResources = (DefaultWrapperVersionsResources) wrapperVersionsResources;
         gradleVersionResolver.setTextResources(defaultWrapperVersionsResources.getLatest(),
             defaultWrapperVersionsResources.getReleaseCandidate(),

--- a/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
+++ b/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
@@ -313,6 +313,8 @@ public abstract class Wrapper extends DefaultTask {
      * e.g. there is not a `release-candidate` available at all times.
      *
      * @see #setGradleVersion(String)
+     *
+     * @throws GradleException if the label that can be provided via {@link #setGradleVersion(String)} can not be resolved at the moment. For example, there is not a `release-candidate` available at all times.
      */
     @Input
     public String getGradleVersion() {
@@ -322,10 +324,10 @@ public abstract class Wrapper extends DefaultTask {
     /**
      * The version of the gradle distribution required by the wrapper.
      * This is usually the same version of Gradle you use for building your project.
-     * The are labels allowed to specify a version: latest, release-candidate, nightly, and release-nightly
+     * The following labels are allowed to specify a version: {@code latest}, {@code release-candidate}, {@code nightly}, and {@code release-nightly}
      */
     @Option(option = "gradle-version", description = "The version of the Gradle distribution required by the wrapper. " +
-        "The following labels are allowed: latest, release-candidate, nightly, and release-nightly")
+        "The following labels are allowed: latest, release-candidate, nightly, and release-nightly.")
     public void setGradleVersion(String gradleVersion) {
         this.gradleVersionResolver.setGradleVersionString(gradleVersion);
     }

--- a/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
+++ b/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
@@ -309,8 +309,6 @@ public abstract class Wrapper extends DefaultTask {
 
     /**
      * Returns the gradle version for the wrapper.
-     * This may throw if the label that can be provided via #setGradleVersion(String) can not be resolved at the moment
-     * e.g. there is not a `release-candidate` available at all times.
      *
      * @see #setGradleVersion(String)
      *

--- a/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/WrapperVersionsResources.java
+++ b/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/WrapperVersionsResources.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks.wrapper;
+
+import org.gradle.api.Incubating;
+import org.gradle.internal.HasInternalProtocol;
+
+/**
+ * Wrapper versions resources.
+ *
+ * @since 8.1
+ */
+@Incubating
+@HasInternalProtocol
+public interface WrapperVersionsResources {
+}

--- a/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/internal/DefaultWrapperVersionsResources.java
+++ b/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/internal/DefaultWrapperVersionsResources.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks.wrapper.internal;
+
+import org.gradle.api.resources.TextResource;
+import org.gradle.api.tasks.wrapper.WrapperVersionsResources;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class DefaultWrapperVersionsResources implements WrapperVersionsResources {
+    public static final String LATEST = "latest";
+    public static final String NIGHTLY = "nightly";
+    public static final String RELEASE_NIGHTLY = "release-nightly";
+    public static final String RELEASE_CANDIDATE = "release-candidate";
+    public static final List<String> PLACE_HOLDERS = Arrays.asList(LATEST, NIGHTLY, RELEASE_NIGHTLY, RELEASE_CANDIDATE);
+    private final TextResource latest;
+    private final TextResource releaseCandidate;
+    private final TextResource nightly;
+    private final TextResource releaseNightly;
+
+    public DefaultWrapperVersionsResources(TextResource latest, TextResource releaseCandidate, TextResource nightly, TextResource releaseNightly) {
+
+        this.latest = latest;
+        this.releaseCandidate = releaseCandidate;
+        this.nightly = nightly;
+        this.releaseNightly = releaseNightly;
+    }
+
+    public TextResource getLatest() {
+        return latest;
+    }
+
+    public TextResource getReleaseCandidate() {
+        return releaseCandidate;
+    }
+
+    public TextResource getNightly() {
+        return nightly;
+    }
+
+    public TextResource getReleaseNightly() {
+        return releaseNightly;
+    }
+
+}

--- a/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/internal/package-info.java
+++ b/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/internal/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2008 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The Gradle wrapper internals.
+ */
+@NonNullApi
+package org.gradle.api.tasks.wrapper.internal;
+
+import org.gradle.api.NonNullApi;

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/WrapperPlugin.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/WrapperPlugin.java
@@ -23,7 +23,6 @@ import org.gradle.api.tasks.wrapper.Wrapper;
 import org.gradle.api.tasks.wrapper.internal.DefaultWrapperVersionsResources;
 import org.gradle.util.internal.DistributionLocator;
 
-import static org.gradle.api.tasks.wrapper.internal.DefaultWrapperVersionsResources.LATEST;
 import static org.gradle.api.tasks.wrapper.internal.DefaultWrapperVersionsResources.NIGHTLY;
 import static org.gradle.api.tasks.wrapper.internal.DefaultWrapperVersionsResources.RELEASE_CANDIDATE;
 import static org.gradle.api.tasks.wrapper.internal.DefaultWrapperVersionsResources.RELEASE_NIGHTLY;
@@ -41,7 +40,7 @@ public abstract class WrapperPlugin implements Plugin<Project> {
     public void apply(Project project) {
         if (project.getParent() == null) {
             String versionUrl = getVersionUrl();
-            TextResource latest = project.getResources().getText().fromUri(versionUrl + "/" + LATEST);
+            TextResource latest = project.getResources().getText().fromUri(versionUrl + "/current");
             TextResource releaseCandidate = project.getResources().getText().fromUri(versionUrl + "/" + RELEASE_CANDIDATE);
             TextResource nightly = project.getResources().getText().fromUri(versionUrl + "/" + NIGHTLY);
             TextResource releaseNightly = project.getResources().getText().fromUri(versionUrl + "/" + RELEASE_NIGHTLY);

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/WrapperPlugin.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/WrapperPlugin.java
@@ -18,7 +18,15 @@ package org.gradle.buildinit.plugins;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.resources.TextResource;
 import org.gradle.api.tasks.wrapper.Wrapper;
+import org.gradle.api.tasks.wrapper.internal.DefaultWrapperVersionsResources;
+import org.gradle.util.internal.DistributionLocator;
+
+import static org.gradle.api.tasks.wrapper.internal.DefaultWrapperVersionsResources.LATEST;
+import static org.gradle.api.tasks.wrapper.internal.DefaultWrapperVersionsResources.NIGHTLY;
+import static org.gradle.api.tasks.wrapper.internal.DefaultWrapperVersionsResources.RELEASE_CANDIDATE;
+import static org.gradle.api.tasks.wrapper.internal.DefaultWrapperVersionsResources.RELEASE_NIGHTLY;
 
 /**
  * The wrapper plugin.
@@ -26,14 +34,31 @@ import org.gradle.api.tasks.wrapper.Wrapper;
  * @see <a href="https://docs.gradle.org/current/userguide/gradle_wrapper.html">Gradle Wrapper reference</a>
  */
 public abstract class WrapperPlugin implements Plugin<Project> {
+
+    private static String servicesGraldeOrgVersionsOverrideUrlProperty = "org.gradle.internal.services.version.url.override";
+
     @Override
     public void apply(Project project) {
         if (project.getParent() == null) {
+            String versionUrl = getVersionUrl();
+            TextResource latest = project.getResources().getText().fromUri(versionUrl + "/" + LATEST);
+            TextResource releaseCandidate = project.getResources().getText().fromUri(versionUrl + "/" + RELEASE_CANDIDATE);
+            TextResource nightly = project.getResources().getText().fromUri(versionUrl + "/" + NIGHTLY);
+            TextResource releaseNightly = project.getResources().getText().fromUri(versionUrl + "/" + RELEASE_NIGHTLY);
+
             project.getTasks().register("wrapper", Wrapper.class, wrapper -> {
                 wrapper.setGroup("Build Setup");
                 wrapper.setDescription("Generates Gradle wrapper files.");
                 wrapper.getNetworkTimeout().convention(10000);
+                wrapper.setDefaultWrapperVersionsResources(new DefaultWrapperVersionsResources(latest, releaseCandidate, nightly, releaseNightly));
             });
         }
     }
+
+    private static String getVersionUrl() {
+        String baseUrl = System.getProperty(servicesGraldeOrgVersionsOverrideUrlProperty,
+            DistributionLocator.SERVICES_GRADLE_BASE_URL);
+        return baseUrl + "/versions";
+    }
+
 }

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/WrapperPlugin.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/WrapperPlugin.java
@@ -19,6 +19,7 @@ package org.gradle.buildinit.plugins;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.resources.TextResource;
+import org.gradle.api.resources.TextResourceFactory;
 import org.gradle.api.tasks.wrapper.Wrapper;
 import org.gradle.api.tasks.wrapper.internal.DefaultWrapperVersionsResources;
 import org.gradle.util.internal.DistributionLocator;
@@ -34,28 +35,29 @@ import static org.gradle.api.tasks.wrapper.internal.DefaultWrapperVersionsResour
  */
 public abstract class WrapperPlugin implements Plugin<Project> {
 
-    private static String servicesGraldeOrgVersionsOverrideUrlProperty = "org.gradle.internal.services.version.url.override";
+    private static final String SERVICES_GRADLE_ORG_VERSIONS_OVERRIDE_URL_PROPERTY = "org.gradle.internal.services.version.url.override";
 
     @Override
     public void apply(Project project) {
         if (project.getParent() == null) {
             String versionUrl = getVersionUrl();
-            TextResource latest = project.getResources().getText().fromUri(versionUrl + "/current");
-            TextResource releaseCandidate = project.getResources().getText().fromUri(versionUrl + "/" + RELEASE_CANDIDATE);
-            TextResource nightly = project.getResources().getText().fromUri(versionUrl + "/" + NIGHTLY);
-            TextResource releaseNightly = project.getResources().getText().fromUri(versionUrl + "/" + RELEASE_NIGHTLY);
+            TextResourceFactory textFactory = project.getResources().getText();
+            TextResource latest = textFactory.fromUri(versionUrl + "/current");
+            TextResource releaseCandidate = textFactory.fromUri(versionUrl + "/" + RELEASE_CANDIDATE);
+            TextResource nightly = textFactory.fromUri(versionUrl + "/" + NIGHTLY);
+            TextResource releaseNightly = textFactory.fromUri(versionUrl + "/" + RELEASE_NIGHTLY);
 
             project.getTasks().register("wrapper", Wrapper.class, wrapper -> {
                 wrapper.setGroup("Build Setup");
                 wrapper.setDescription("Generates Gradle wrapper files.");
                 wrapper.getNetworkTimeout().convention(10000);
-                wrapper.setDefaultWrapperVersionsResources(new DefaultWrapperVersionsResources(latest, releaseCandidate, nightly, releaseNightly));
+                wrapper.setWrapperVersionsResources(new DefaultWrapperVersionsResources(latest, releaseCandidate, nightly, releaseNightly));
             });
         }
     }
 
     private static String getVersionUrl() {
-        String baseUrl = System.getProperty(servicesGraldeOrgVersionsOverrideUrlProperty,
+        String baseUrl = System.getProperty(SERVICES_GRADLE_ORG_VERSIONS_OVERRIDE_URL_PROPERTY,
             DistributionLocator.SERVICES_GRADLE_BASE_URL);
         return baseUrl + "/versions";
     }

--- a/subprojects/build-init/src/test/groovy/org/gradle/api/tasks/wrapper/GradleVersionResolverTest.groovy
+++ b/subprojects/build-init/src/test/groovy/org/gradle/api/tasks/wrapper/GradleVersionResolverTest.groovy
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks.wrapper
+
+import org.gradle.api.GradleException
+import spock.lang.Specification
+
+class GradleVersionResolverTest extends Specification {
+    def "get version from json"() {
+        when:
+        def version = GradleVersionResolver.getVersion("""{ "version" : "7.6" }""", "latest")
+
+        then:
+        version == "7.6"
+    }
+
+    def "get version from empty json"() {
+        when:
+        def version = GradleVersionResolver.getVersion("{ }", "latest")
+
+        then:
+        def e = thrown(GradleException)
+        e.message == "There is currently no version information available for \"latest\"."
+    }
+}

--- a/subprojects/build-init/src/test/groovy/org/gradle/api/tasks/wrapper/GradleVersionResolverTest.groovy
+++ b/subprojects/build-init/src/test/groovy/org/gradle/api/tasks/wrapper/GradleVersionResolverTest.groovy
@@ -34,6 +34,6 @@ class GradleVersionResolverTest extends Specification {
 
         then:
         def e = thrown(GradleException)
-        e.message == "There is currently no version information available for \"latest\"."
+        e.message == "There is currently no version information available for 'latest'."
     }
 }

--- a/subprojects/build-init/src/test/groovy/org/gradle/api/tasks/wrapper/WrapperTest.groovy
+++ b/subprojects/build-init/src/test/groovy/org/gradle/api/tasks/wrapper/WrapperTest.groovy
@@ -18,23 +18,38 @@ package org.gradle.api.tasks.wrapper
 
 import org.gradle.api.tasks.AbstractTaskTest
 import org.gradle.api.tasks.TaskPropertyTestUtils
+import org.gradle.api.tasks.wrapper.internal.DefaultWrapperVersionsResources
 import org.gradle.test.fixtures.file.TestFile
-import org.gradle.util.internal.GUtil
 import org.gradle.util.GradleVersion
+import org.gradle.util.internal.DistributionLocator
+import org.gradle.util.internal.GUtil
 import org.gradle.util.internal.WrapUtil
 import org.gradle.wrapper.GradleWrapperMain
 import org.gradle.wrapper.WrapperExecutor
 
 class WrapperTest extends AbstractTaskTest {
+    private static final String RELEASE = "7.6"
+    private static final String RELEASE_CANDIDATE = "7.7-rc-5"
+    private static final String NIGHTLY = "8.1-20221207164726+0000"
+    private static final String RELEASE_NIGHTLY = "8.0-20221207164726+0000"
     private Wrapper wrapper
-    private String targetWrapperJarPath
+    private String targetWrapperJarPath = "gradle/wrapper"
     private TestFile expectedTargetWrapperJar
     private File expectedTargetWrapperProperties
 
+    def createVersionTextResource(String version) {
+        wrapper.getProject().getResources().text.fromString("""{ "version" : "${version}" }""")
+    }
+
     def setup() {
         wrapper = createTask(Wrapper.class)
+
+        def latest = createVersionTextResource(RELEASE)
+        def releaseCandidate = createVersionTextResource(RELEASE_CANDIDATE)
+        def nightly = createVersionTextResource(NIGHTLY)
+        def releaseNightly = createVersionTextResource(RELEASE_NIGHTLY)
+        wrapper.setDefaultWrapperVersionsResources(new DefaultWrapperVersionsResources(latest, releaseCandidate, nightly, releaseNightly))
         wrapper.setGradleVersion("1.0")
-        targetWrapperJarPath = "gradle/wrapper"
         expectedTargetWrapperJar = new TestFile(getProject().getProjectDir(),
                 targetWrapperJarPath + "/gradle-wrapper.jar")
         expectedTargetWrapperProperties = new File(getProject().getProjectDir(),
@@ -53,7 +68,7 @@ class WrapperTest extends AbstractTaskTest {
         wrapper = createTask(Wrapper.class)
 
         expect:
-        new File(getProject().getProjectDir(), "gradle/wrapper/gradle-wrapper.jar") == wrapper.getJarFile()
+        new File(getProject().getProjectDir(), targetWrapperJarPath + "/gradle-wrapper.jar") == wrapper.getJarFile()
         new File(getProject().getProjectDir(), "gradlew") == wrapper.getScriptFile()
         new File(getProject().getProjectDir(), "gradlew.bat") == wrapper.getBatchScript()
         GradleVersion.current().getVersion() == wrapper.getGradleVersion()
@@ -66,18 +81,17 @@ class WrapperTest extends AbstractTaskTest {
         !wrapper.getNetworkTimeout().isPresent()
     }
 
-    def "determines Windows script path from unix script path"() {
-        given:
-        wrapper.setScriptFile("build/gradle.sh")
-
-        expect:
-        getProject().file("build/gradle.bat") == wrapper.getBatchScript()
-
+    def "determines Windows script path from unix script path with #inName"() {
         when:
-        wrapper.setScriptFile("build/gradle-wrapper")
+        wrapper.setScriptFile("build/$inName")
 
         then:
-        getProject().file("build/gradle-wrapper.bat") == wrapper.getBatchScript()
+        getProject().file("build/$outName") == wrapper.getBatchScript()
+
+        where:
+        inName           | outName
+        "gradle.sh"      | "gradle.bat"
+        "gradle-wrapper" | "gradle-wrapper.bat"
     }
 
     def "determines properties file path from jar path"() {
@@ -88,28 +102,22 @@ class WrapperTest extends AbstractTaskTest {
         getProject().file("build/gradle-wrapper.properties") == wrapper.getPropertiesFile()
     }
 
-    def "downloads from release repository for release versions"() {
-        given:
-        wrapper.setGradleVersion("0.9.1")
+    def "downloads for \"#version\" from repository "() {
+        when:
+        wrapper.setGradleVersion(version)
 
-        expect:
-        "https://services.gradle.org/distributions/gradle-0.9.1-bin.zip" == wrapper.getDistributionUrl()
-    }
+        then:
+        "$DistributionLocator.RELEASE_REPOSITORY$snapshot/gradle-$out-bin.zip" == wrapper.getDistributionUrl()
 
-    def "downloads from release repository for preview release versions"() {
-        given:
-        wrapper.setGradleVersion("1.0-milestone-1")
-
-        expect:
-        "https://services.gradle.org/distributions/gradle-1.0-milestone-1-bin.zip" == wrapper.getDistributionUrl()
-    }
-
-    def "downloads from snapshot repository for snapshot versions"() {
-        given:
-        wrapper.setGradleVersion("0.9.1-20101224110000+1100")
-
-        expect:
-        "https://services.gradle.org/distributions-snapshots/gradle-0.9.1-20101224110000+1100-bin.zip" == wrapper.getDistributionUrl()
+        where:
+        version                     | out               | snapshot
+        "1.0-milestone-1"           | "1.0-milestone-1"           | ""
+        "0.9.1-20101224110000+1100" | "0.9.1-20101224110000+1100" | "-snapshots"
+        "0.9.1"                     | "0.9.1"                     | ""
+        "latest"                    | RELEASE                     | ""
+        "release-candidate"         | RELEASE_CANDIDATE           | ""
+        "nightly"                   | NIGHTLY                     | "-snapshots"
+        "release-nightly"           | RELEASE_NIGHTLY             | "-snapshots"
     }
 
     def "uses explicitly defined distribution url"() {

--- a/subprojects/build-init/src/test/groovy/org/gradle/api/tasks/wrapper/WrapperTest.groovy
+++ b/subprojects/build-init/src/test/groovy/org/gradle/api/tasks/wrapper/WrapperTest.groovy
@@ -32,8 +32,8 @@ class WrapperTest extends AbstractTaskTest {
     private static final String RELEASE_CANDIDATE = "7.7-rc-5"
     private static final String NIGHTLY = "8.1-20221207164726+0000"
     private static final String RELEASE_NIGHTLY = "8.0-20221207164726+0000"
+    private static final String TARGET_WRAPPER_FINAL = "gradle/wrapper"
     private Wrapper wrapper
-    private String targetWrapperJarPath = "gradle/wrapper"
     private TestFile expectedTargetWrapperJar
     private File expectedTargetWrapperProperties
 
@@ -48,13 +48,13 @@ class WrapperTest extends AbstractTaskTest {
         def releaseCandidate = createVersionTextResource(RELEASE_CANDIDATE)
         def nightly = createVersionTextResource(NIGHTLY)
         def releaseNightly = createVersionTextResource(RELEASE_NIGHTLY)
-        wrapper.setDefaultWrapperVersionsResources(new DefaultWrapperVersionsResources(latest, releaseCandidate, nightly, releaseNightly))
+        wrapper.setWrapperVersionsResources(new DefaultWrapperVersionsResources(latest, releaseCandidate, nightly, releaseNightly))
         wrapper.setGradleVersion("1.0")
         expectedTargetWrapperJar = new TestFile(getProject().getProjectDir(),
-                targetWrapperJarPath + "/gradle-wrapper.jar")
+                TARGET_WRAPPER_FINAL + "/gradle-wrapper.jar")
         expectedTargetWrapperProperties = new File(getProject().getProjectDir(),
-                targetWrapperJarPath + "/gradle-wrapper.properties")
-        new File(getProject().getProjectDir(), targetWrapperJarPath).mkdirs()
+                TARGET_WRAPPER_FINAL + "/gradle-wrapper.properties")
+        new File(getProject().getProjectDir(), TARGET_WRAPPER_FINAL).mkdirs()
         wrapper.setDistributionPath("somepath")
         wrapper.setDistributionSha256Sum("somehash")
     }
@@ -68,7 +68,7 @@ class WrapperTest extends AbstractTaskTest {
         wrapper = createTask(Wrapper.class)
 
         expect:
-        new File(getProject().getProjectDir(), targetWrapperJarPath + "/gradle-wrapper.jar") == wrapper.getJarFile()
+        new File(getProject().getProjectDir(), TARGET_WRAPPER_FINAL + "/gradle-wrapper.jar") == wrapper.getJarFile()
         new File(getProject().getProjectDir(), "gradlew") == wrapper.getScriptFile()
         new File(getProject().getProjectDir(), "gradlew.bat") == wrapper.getBatchScript()
         GradleVersion.current().getVersion() == wrapper.getGradleVersion()
@@ -102,7 +102,7 @@ class WrapperTest extends AbstractTaskTest {
         getProject().file("build/gradle-wrapper.properties") == wrapper.getPropertiesFile()
     }
 
-    def "downloads for \"#version\" from repository "() {
+    def "downloads for '#version' from repository "() {
         when:
         wrapper.setGradleVersion(version)
 
@@ -110,7 +110,7 @@ class WrapperTest extends AbstractTaskTest {
         "$DistributionLocator.RELEASE_REPOSITORY$snapshot/gradle-$out-bin.zip" == wrapper.getDistributionUrl()
 
         where:
-        version                     | out               | snapshot
+        version                     | out                         | snapshot
         "1.0-milestone-1"           | "1.0-milestone-1"           | ""
         "0.9.1-20101224110000+1100" | "0.9.1-20101224110000+1100" | "-snapshots"
         "0.9.1"                     | "0.9.1"                     | ""

--- a/subprojects/core/src/main/java/org/gradle/util/internal/DistributionLocator.java
+++ b/subprojects/core/src/main/java/org/gradle/util/internal/DistributionLocator.java
@@ -22,8 +22,11 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 public class DistributionLocator {
-    private static final String RELEASE_REPOSITORY = "https://services.gradle.org/distributions";
-    private static final String SNAPSHOT_REPOSITORY = "https://services.gradle.org/distributions-snapshots";
+
+    public static final String SERVICES_GRADLE_BASE_URL = "https://services.gradle.org";
+
+    public static final String RELEASE_REPOSITORY = SERVICES_GRADLE_BASE_URL + "/distributions";
+    private static final String SNAPSHOT_REPOSITORY = SERVICES_GRADLE_BASE_URL + "/distributions-snapshots";
 
     public URI getDistributionFor(GradleVersion version) {
         return getDistributionFor(version, "bin");
@@ -41,8 +44,10 @@ public class DistributionLocator {
         }
     }
 
-    private URI getDistribution(String repositoryUrl, GradleVersion version, String archiveName,
-                                   String archiveClassifier) {
+    private URI getDistribution(
+        String repositoryUrl, GradleVersion version, String archiveName,
+        String archiveClassifier
+    ) {
         try {
             return new URI(repositoryUrl + "/" + archiveName + "-" + version.getVersion() + "-" + archiveClassifier + ".zip");
         } catch (URISyntaxException e) {

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -37,7 +37,7 @@ The allowed labels are:
 - `nightly`
 - `release-nightly`
 
-More Details can be found in the [Gradle Wrapper](userguide/gradle_wrapper.html#sec:adding_wrapper) section.
+More details can be found in the [Gradle Wrapper](userguide/gradle_wrapper.html#sec:adding_wrapper) section.
 
 <!--
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -24,6 +24,21 @@ For Java, Groovy, Kotlin and Android compatibility, see the [full compatibility 
 
 <!-- Do not add breaking changes or deprecations here! Add them to the upgrade guide instead. -->
 
+### Gradle Wrapper
+
+#### Introduced labels for selecting the version 
+
+The [`--gradle-version`](userguide/gradle_wrapper.html#sec:adding_wrapper) parameter for the wrapper plugin 
+now supports using predefined labels to select a version.
+
+The allowed labels are:
+- `latest`
+- `release-candidate`
+- `nightly`
+- `release-nightly`
+
+More Details can be found in the [Gradle Wrapper](userguide/gradle_wrapper.html#sec:adding_wrapper) section.
+
 <!--
 
 ================== TEMPLATE ==============================

--- a/subprojects/docs/src/docs/userguide/reference/command_line_interface.adoc
+++ b/subprojects/docs/src/docs/userguide/reference/command_line_interface.adoc
@@ -680,10 +680,11 @@ $ gradle init --type java-library
 The built-in `gradle wrapper` task generates a script, `gradlew`, that invokes a declared version of Gradle, downloading it beforehand if necessary.
 
 ----
-$ gradle wrapper --gradle-version=4.4
+$ gradle wrapper --gradle-version=8.1
 ----
 
-You can also specify `--distribution-type=(bin|all)`, `--gradle-distribution-url`, `--gradle-distribution-sha256-sum` in addition to `--gradle-version`. Full details on how to use these options are documented in the <<gradle_wrapper.adoc#gradle_wrapper,Gradle wrapper section>>.
+You can also specify `--distribution-type=(bin|all)`, `--gradle-distribution-url`, `--gradle-distribution-sha256-sum` in addition to `--gradle-version`.
+Full details on how to use these options are documented in the <<gradle_wrapper.adoc#gradle_wrapper,Gradle wrapper section>>.
 
 [[sec:continuous_build]]
 == Continuous Build

--- a/subprojects/docs/src/docs/userguide/reference/gradle_wrapper.adoc
+++ b/subprojects/docs/src/docs/userguide/reference/gradle_wrapper.adoc
@@ -203,7 +203,7 @@ If you nevertheless want *all* the wrapper files to be completely up-to-date, yo
 
 Use the Gradle `wrapper` task to generate the wrapper, specifying a version. The default is the current version. Once you have upgraded the wrapper, you can check that it's the version you expect by executing `./gradlew --version`.
 
-.Example: Upgrading the Wrapper the `latest` version
+.Example: Upgrading the Wrapper to the `latest` version
 [listing,subs=+attributes]
 ----
 $ ./gradlew wrapper --gradle-version latest

--- a/subprojects/docs/src/docs/userguide/reference/gradle_wrapper.adoc
+++ b/subprojects/docs/src/docs/userguide/reference/gradle_wrapper.adoc
@@ -203,12 +203,21 @@ If you nevertheless want *all* the wrapper files to be completely up-to-date, yo
 
 Use the Gradle `wrapper` task to generate the wrapper, specifying a version. The default is the current version. Once you have upgraded the wrapper, you can check that it's the version you expect by executing `./gradlew --version`.
 
-.Example: Upgrading the Wrapper version
+.Example: Upgrading the Wrapper the `latest` version
+[listing,subs=+attributes]
+----
+$ ./gradlew wrapper --gradle-version latest
+include::{snippetsPath}/wrapper/simple/tests/wrapperGradleVersionUpgrade.out[]
+----
+
+.Example: Upgrading the Wrapper to a specific version
 [listing,subs=+attributes]
 ----
 $ ./gradlew wrapper --gradle-version {gradleVersion}
 include::{snippetsPath}/wrapper/simple/tests/wrapperGradleVersionUpgrade.out[]
 ----
+
+
 
 [[customizing_wrapper]]
 == Customizing the Gradle Wrapper

--- a/subprojects/docs/src/docs/userguide/reference/gradle_wrapper.adoc
+++ b/subprojects/docs/src/docs/userguide/reference/gradle_wrapper.adoc
@@ -15,7 +15,9 @@
 [[gradle_wrapper]]
 = The Gradle Wrapper
 
-The recommended way to execute any Gradle build is with the help of the Gradle Wrapper (in short just “Wrapper”). The Wrapper is a script that invokes a declared version of Gradle, downloading it beforehand if necessary. As a result, developers can get up and running with a Gradle project quickly without having to follow manual installation processes saving your company time and money.
+The recommended way to execute any Gradle build is with the help of the Gradle Wrapper (in short just “Wrapper”).
+The Wrapper is a script that invokes a declared version of Gradle, downloading it beforehand if necessary.
+As a result, developers can get up and running with a Gradle project quickly without having to follow manual installation processes saving your company time and money.
 
 .The Wrapper workflow
 image::wrapper-workflow.png[]
@@ -38,7 +40,9 @@ The following sections explain each of these use cases in more detail.
 
 Generating the Wrapper files requires an installed version of the Gradle runtime on your machine as described in <<installation.adoc#installation,Installation>>. Thankfully, generating the initial Wrapper files is a one-time process.
 
-Every vanilla Gradle build comes with a built-in task called `wrapper`. You’ll be able to find the task listed under the group "Build Setup tasks" when <<command_line_interface.adoc#sec:listing_tasks,listing the tasks>>. Executing the `wrapper` task generates the necessary Wrapper files in the project directory.
+Every vanilla Gradle build comes with a built-in task called `wrapper`.
+You’ll be able to find the task listed under the group "Build Setup tasks" when <<command_line_interface.adoc#sec:listing_tasks,listing the tasks>>.
+Executing the `wrapper` task generates the necessary Wrapper files in the project directory.
 
 .Running the Wrapper task
 ----
@@ -48,7 +52,10 @@ include::{snippetsPath}/wrapper/simple/tests/wrapperCommandLine.out[]
 
 [NOTE]
 ====
-To make the Wrapper files available to other developers and execution environments you’ll need to check them into version control. All Wrapper files including the JAR file are very small in size. Adding the JAR file to version control is expected. Some organizations do not allow projects to submit binary files to version control. At the moment there are no alternative options to the approach.
+To make the Wrapper files available to other developers and execution environments you’ll need to check them into version control.
+All Wrapper files including the JAR file are very small in size. Adding the JAR file to version control is expected.
+Some organizations do not allow projects to submit binary files to version control.
+At the moment there are no alternative options to the approach.
 ====
 
 The generated Wrapper properties file, `gradle/wrapper/gradle-wrapper.properties`, stores the information about the Gradle distribution.
@@ -79,10 +86,14 @@ The following labels are allowed:
 * `link:https://gradle.org/release-nightly[release-nightly]`
 
 `--distribution-type`::
-The Gradle distribution type used for the Wrapper. Available options are `bin` and `all`. The default value is `bin`.
+The Gradle distribution type used for the Wrapper.
+Available options are `bin` and `all`.
+The default value is `bin`.
 
 `--gradle-distribution-url`::
-The full URL pointing to Gradle distribution ZIP file. Using this option makes `--gradle-version` and `--distribution-type` obsolete as the URL already contains this information. This option is extremely valuable if you want to host the Gradle distribution inside your company’s network.
+The full URL pointing to Gradle distribution ZIP file.
+Using this option makes `--gradle-version` and `--distribution-type` obsolete as the URL already contains this information.
+This option is extremely valuable if you want to host the Gradle distribution inside your company’s network.
 
 `--gradle-distribution-sha256-sum`::
 The SHA256 hash sum used for <<#sec:verification,verifying the downloaded Gradle distribution>>.
@@ -180,9 +191,15 @@ The Wrapper shell script and batch file reside in the root directory of a single
 [[sec:upgrading_wrapper]]
 == Upgrading the Gradle Wrapper
 
-Projects will typically want to keep up with the times and upgrade their Gradle version to benefit from new features and improvements. One way to upgrade the Gradle version is manually change the `distributionUrl` property in the Wrapper's `gradle-wrapper.properties` file. The better and recommended option is to run the `wrapper` task and provide the target Gradle version as described in <<#sec:adding_wrapper,Adding the Gradle Wrapper>>. Using the `wrapper` task ensures that any optimizations made to the Wrapper shell script or batch file with that specific Gradle version are applied to the project. As usual, you should commit the changes to the Wrapper files to version control.
+Projects will typically want to keep up with the times and upgrade their Gradle version to benefit from new features and improvements.
+One way to upgrade the Gradle version is manually change the `distributionUrl` property in the Wrapper's `gradle-wrapper.properties` file.
+The better and recommended option is to run the `wrapper` task and provide the target Gradle version as described in <<#sec:adding_wrapper,Adding the Gradle Wrapper>>.
+Using the `wrapper` task ensures that any optimizations made to the Wrapper shell script or batch file with that specific Gradle version are applied to the project.
+As usual, you should commit the changes to the Wrapper files to version control.
 
-Note that running the wrapper task once will update `gradle-wrapper.properties` only, but leave the wrapper itself in `gradle-wrapper.jar` untouched. This is usually fine as new versions of Gradle can be run even with ancient wrapper files. If you nevertheless want *all* the wrapper files to be completely up-to-date, you'll need to run the `wrapper` task a second time.
+Note that running the wrapper task once will update `gradle-wrapper.properties` only, but leave the wrapper itself in `gradle-wrapper.jar` untouched.
+This is usually fine as new versions of Gradle can be run even with ancient wrapper files.
+If you nevertheless want *all* the wrapper files to be completely up-to-date, you'll need to run the `wrapper` task a second time.
 
 Use the Gradle `wrapper` task to generate the wrapper, specifying a version. The default is the current version. Once you have upgraded the wrapper, you can check that it's the version you expect by executing `./gradlew --version`.
 
@@ -196,9 +213,13 @@ include::{snippetsPath}/wrapper/simple/tests/wrapperGradleVersionUpgrade.out[]
 [[customizing_wrapper]]
 == Customizing the Gradle Wrapper
 
-Most users of Gradle are happy with the default runtime behavior of the Wrapper. However, organizational policies, security constraints or personal preferences might require you to dive deeper into customizing the Wrapper. Thankfully, the built-in `wrapper` task exposes numerous options to bend the runtime behavior to your needs. Most configuration options are exposed by the underlying task type link:{groovyDslPath}/org.gradle.api.tasks.wrapper.Wrapper.html[Wrapper].
+Most users of Gradle are happy with the default runtime behavior of the Wrapper.
+However, organizational policies, security constraints or personal preferences might require you to dive deeper into customizing the Wrapper.
+Thankfully, the built-in `wrapper` task exposes numerous options to bend the runtime behavior to your needs.
+Most configuration options are exposed by the underlying task type link:{groovyDslPath}/org.gradle.api.tasks.wrapper.Wrapper.html[Wrapper].
 
-Let’s assume you grew tired of defining the `-all` distribution type on the command line every time you upgrade the Wrapper. You can save yourself some keyboard strokes by re-configuring the `wrapper` task.
+Let’s assume you grew tired of defining the `-all` distribution type on the command line every time you upgrade the Wrapper.
+You can save yourself some keyboard strokes by re-configuring the `wrapper` task.
 
 .Customizing the Wrapper task
 ====
@@ -219,12 +240,16 @@ Check out the API documentation for more detail descriptions of the available co
 [[sec:authenticated_download]]
 === Authenticated Gradle distribution download
 
-The Gradle `Wrapper` can download Gradle distributions from servers using HTTP Basic Authentication. This enables you to host the Gradle distribution on a private protected server. You can specify a username and password in two different ways depending on your use case: as system properties or directly embedded in the `distributionUrl`. Credentials in system properties take precedence over the ones embedded in `distributionUrl`.
+The Gradle `Wrapper` can download Gradle distributions from servers using HTTP Basic Authentication.
+This enables you to host the Gradle distribution on a private protected server.
+You can specify a username and password in two different ways depending on your use case: as system properties or directly embedded in the `distributionUrl`.
+Credentials in system properties take precedence over the ones embedded in `distributionUrl`.
 
 [TIP]
 .Security Warning
 ====
-HTTP Basic Authentication should only be used with `HTTPS` URLs and not plain `HTTP` ones. With Basic Authentication, the user credentials are sent in clear text.
+HTTP Basic Authentication should only be used with `HTTPS` URLs and not plain `HTTP` ones.
+With Basic Authentication, the user credentials are sent in clear text.
 ====
 
 Using system properties can be done in the `.gradle/gradle.properties` file in the user's home directory, or by other means, see <<build_environment.adoc#sec:gradle_configuration_properties,Gradle Configuration Properties>>.
@@ -236,7 +261,8 @@ systemProp.gradle.wrapperUser=username
 systemProp.gradle.wrapperPassword=password
 ----
 
-Embedding credentials in the `distributionUrl` in the `gradle/wrapper/gradle-wrapper.properties` file also works. Please note that this file is to be committed into your source control system. Shared credentials embedded in `distributionUrl` should only be used in a controlled environment.
+Embedding credentials in the `distributionUrl` in the `gradle/wrapper/gradle-wrapper.properties` file also works.
+Please note that this file is to be committed into your source control system. Shared credentials embedded in `distributionUrl` should only be used in a controlled environment.
 
 [listing]
 .Specifying the HTTP Basic Authentication credentials in `distributionUrl`
@@ -244,18 +270,21 @@ Embedding credentials in the `distributionUrl` in the `gradle/wrapper/gradle-wra
 distributionUrl=https://username:password@somehost/path/to/gradle-distribution.zip
 ----
 
-This can be used in conjunction with a proxy, authenticated or not. See <<build_environment.adoc#sec:accessing_the_web_via_a_proxy,Accessing the web via a proxy>> for more information on how to configure the `Wrapper` to use a proxy.
+This can be used in conjunction with a proxy, authenticated or not.
+See <<build_environment.adoc#sec:accessing_the_web_via_a_proxy,Accessing the web via a proxy>> for more information on how to configure the `Wrapper` to use a proxy.
 
 [[sec:verification]]
 === Verification of downloaded Gradle distributions
 
-The Gradle Wrapper allows for verification of the downloaded Gradle distribution via SHA-256 hash sum comparison. This increases security against targeted attacks by preventing a man-in-the-middle attacker from tampering with the downloaded Gradle distribution.
+The Gradle Wrapper allows for verification of the downloaded Gradle distribution via SHA-256 hash sum comparison.
+This increases security against targeted attacks by preventing a man-in-the-middle attacker from tampering with the downloaded Gradle distribution.
 
 To enable this feature, download the `.sha256` file associated with the Gradle distribution you want to verify.
 
 ==== Downloading the SHA-256 file
 
-You can download the `.sha256` file from the link:https://services.gradle.org/distributions/[stable releases] or link:https://services.gradle.org/distributions-snapshots/[release candidate and nightly releases]. The format of the file is a single line of text that is the SHA-256 hash of the corresponding zip file.
+You can download the `.sha256` file from the link:https://services.gradle.org/distributions/[stable releases] or link:https://services.gradle.org/distributions-snapshots/[release candidate and nightly releases].
+The format of the file is a single line of text that is the SHA-256 hash of the corresponding zip file.
 
 You can also reference the link:https://gradle.org/release-checksums/[list of Gradle distribution checksums].
 
@@ -269,7 +298,8 @@ Add the downloaded hash sum to `gradle-wrapper.properties` using the `distributi
 distributionSha256Sum=371cb9fbebbe9880d147f59bab36d61eee122854ef8c9ee1ecf12b82368bcf10
 ----
 
-Gradle will report a build failure in case the configured checksum does not match the checksum found on the server for hosting the distribution. Checksum Verification is only performed if the configured Wrapper distribution hasn't been downloaded yet.
+Gradle will report a build failure in case the configured checksum does not match the checksum found on the server for hosting the distribution.
+Checksum Verification is only performed if the configured Wrapper distribution hasn't been downloaded yet.
 
 [NOTE]
 ====

--- a/subprojects/docs/src/docs/userguide/reference/gradle_wrapper.adoc
+++ b/subprojects/docs/src/docs/userguide/reference/gradle_wrapper.adoc
@@ -70,6 +70,13 @@ All of those aspects are configurable at the time of generating the Wrapper file
 
 `--gradle-version`::
 The Gradle version used for downloading and executing the Wrapper.
++
+The following labels are allowed:
++
+* `link:https://gradle.org/releases[latest]`
+* `link:https://gradle.org/release-candidate[release-candidate]`
+* `link:https://gradle.org/nightly[nightly]`
+* `link:https://gradle.org/release-nightly[release-nightly]`
 
 `--distribution-type`::
 The Gradle distribution type used for the Wrapper. Available options are `bin` and `all`. The default value is `bin`.

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperHttpIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperHttpIntegrationTest.groovy
@@ -33,6 +33,16 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
     @Rule TestProxyServer proxyServer = new TestProxyServer()
     @Rule TestResources resources = new TestResources(temporaryFolder)
 
+    public static final String TEST_DISTRIBUTION_URL = "gradlew/dist"
+
+    private String getDefaultBaseUrl() {
+        "http://localhost:${server.port}"
+    }
+
+    private String getDefaultAuthenticatedBaseUrl() {
+        "http://jdoe:changeit@localhost:${server.port}"
+    }
+
     def setup() {
         server.start()
         file("build.gradle") << """
@@ -51,14 +61,14 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
     }
 
     private prepareWrapper(String baseUrl) {
-        prepareWrapper(new URI("${baseUrl}/gradlew/dist"))
+        prepareWrapper(new URI("${baseUrl}/$TEST_DISTRIBUTION_URL"))
     }
 
     @Issue('https://github.com/gradle/gradle-private/issues/1537')
     def "downloads wrapper from http server and caches"() {
         given:
-        prepareWrapper("http://localhost:${server.port}")
-        server.expect(server.get("/gradlew/dist").sendFile(distribution.binDistribution))
+        prepareWrapper(getDefaultBaseUrl())
+        server.expect(server.get("/$TEST_DISTRIBUTION_URL").sendFile(distribution.binDistribution))
 
         when:
         def result = wrapperExecuter.withTasks('hello').run()
@@ -76,8 +86,8 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
     @Issue('https://github.com/gradle/gradle-private/issues/1537')
     def "recovers from failed download"() {
         given:
-        prepareWrapper("http://localhost:${server.port}")
-        server.expect(server.get("/gradlew/dist").broken())
+        prepareWrapper(getDefaultBaseUrl())
+        server.expect(server.get("/$TEST_DISTRIBUTION_URL").broken())
 
         when:
         wrapperExecuter.withStackTraceChecksDisabled()
@@ -87,7 +97,7 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
         failure.error.contains('Server returned HTTP response code: 500')
 
         when:
-        server.expect(server.get("/gradlew/dist").sendFile(distribution.binDistribution))
+        server.expect(server.get("/$TEST_DISTRIBUTION_URL").sendFile(distribution.binDistribution))
 
         and:
         wrapperExecuter.run()
@@ -99,15 +109,15 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
     @Issue('https://github.com/gradle/gradle-private/issues/3032')
     def "fails with reasonable message when download times out"() {
         given:
-        prepareWrapper("http://localhost:${server.port}")
-        server.expectAndBlock(server.get("/gradlew/dist"))
+        prepareWrapper(getDefaultBaseUrl())
+        server.expectAndBlock(server.get("/$TEST_DISTRIBUTION_URL"))
 
         when:
         wrapperExecuter.withStackTraceChecksDisabled()
         def failure = wrapperExecuter.runWithFailure()
 
         then:
-        failure.assertHasErrorOutput("Downloading from http://localhost:${server.port}/gradlew/dist failed: timeout (10000ms)")
+        failure.assertHasErrorOutput("Downloading from ${getDefaultBaseUrl()}/$TEST_DISTRIBUTION_URL failed: timeout (10000ms)")
         failure.assertHasErrorOutput('Read timed out')
     }
 
@@ -115,14 +125,14 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
     def "does not leak credentials when download times out"() {
         given:
         prepareWrapper("http://username:password@localhost:${server.port}")
-        server.expectAndBlock(server.get("/gradlew/dist"))
+        server.expectAndBlock(server.get("/$TEST_DISTRIBUTION_URL"))
 
         when:
         wrapperExecuter.withStackTraceChecksDisabled()
         def failure = wrapperExecuter.runWithFailure()
 
         then:
-        failure.assertHasErrorOutput("Downloading from http://localhost:${server.port}/gradlew/dist failed: timeout (10000ms)")
+        failure.assertHasErrorOutput("Downloading from http://localhost:${server.port}/$TEST_DISTRIBUTION_URL failed: timeout (10000ms)")
         failure.assertHasErrorOutput('Read timed out')
         failure.assertNotOutput("username")
         failure.assertNotOutput("password")
@@ -130,8 +140,8 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
 
     def "reads timeout from wrapper properties"() {
         given:
-        prepareWrapper("http://localhost:${server.port}")
-        server.expectAndBlock(server.get("/gradlew/dist"))
+        prepareWrapper(getDefaultBaseUrl())
+        server.expectAndBlock(server.get("/$TEST_DISTRIBUTION_URL"))
 
         and:
         file('gradle/wrapper/gradle-wrapper.properties') << "networkTimeout=5000"
@@ -141,7 +151,7 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
         def failure = wrapperExecuter.runWithFailure()
 
         then:
-        failure.assertHasErrorOutput("Downloading from http://localhost:${server.port}/gradlew/dist failed: timeout (5000ms)")
+        failure.assertHasErrorOutput("Downloading from http://localhost:${server.port}/$TEST_DISTRIBUTION_URL failed: timeout (5000ms)")
     }
 
     def "downloads wrapper via proxy"() {
@@ -153,7 +163,7 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
     systemProp.http.proxyPort=${proxyServer.port}
     systemProp.http.nonProxyHosts=
 """
-        server.expect(server.get("/gradlew/dist").sendFile(distribution.binDistribution))
+        server.expect(server.get("/$TEST_DISTRIBUTION_URL").sendFile(distribution.binDistribution))
 
         when:
         def result = wrapperExecuter.withTasks('hello').run()
@@ -171,7 +181,7 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
 
         and:
         prepareWrapper(server.uri.toString())
-        server.expect(server.get("/gradlew/dist").sendFile(distribution.binDistribution))
+        server.expect(server.get("/$TEST_DISTRIBUTION_URL").sendFile(distribution.binDistribution))
         file("gradle.properties") << """
     systemProp.http.proxyHost=localhost
     systemProp.http.proxyPort=${proxyServer.port}
@@ -192,9 +202,9 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
 
     def "downloads wrapper from basic authenticated server and caches"() {
         given:
-        prepareWrapper("http://jdoe:changeit@localhost:${server.port}")
+        prepareWrapper(getDefaultAuthenticatedBaseUrl())
         server.withBasicAuthentication("jdoe", "changeit")
-        server.expect(server.get("/gradlew/dist").sendFile(distribution.binDistribution))
+        server.expect(server.get("/$TEST_DISTRIBUTION_URL").sendFile(distribution.binDistribution))
 
         when:
         result = wrapperExecuter.withTasks('hello').run()
@@ -217,9 +227,9 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
         '''.stripIndent()
 
         and:
-        prepareWrapper("http://localhost:${server.port}")
+        prepareWrapper(getDefaultBaseUrl())
         server.withBasicAuthentication("jdoe", "changeit")
-        server.expect(server.get("/gradlew/dist").sendFile(distribution.binDistribution))
+        server.expect(server.get("/$TEST_DISTRIBUTION_URL").sendFile(distribution.binDistribution))
 
         when:
         result = wrapperExecuter.withTasks('hello').run()
@@ -230,9 +240,9 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
 
     def "warns about using basic authentication over insecure connection"() {
         given:
-        prepareWrapper("http://jdoe:changeit@localhost:${server.port}")
+        prepareWrapper(getDefaultAuthenticatedBaseUrl())
         server.withBasicAuthentication("jdoe", "changeit")
-        server.expect(server.get("/gradlew/dist").sendFile(distribution.binDistribution))
+        server.expect(server.get("/$TEST_DISTRIBUTION_URL").sendFile(distribution.binDistribution))
 
         when:
         result = wrapperExecuter.withTasks('hello').run()
@@ -243,9 +253,9 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
 
     def "does not leak basic authentication credentials in output"() {
         given:
-        prepareWrapper("http://jdoe:changeit@localhost:${server.port}")
+        prepareWrapper(getDefaultAuthenticatedBaseUrl())
         server.withBasicAuthentication("jdoe", "changeit")
-        server.expect(server.get("/gradlew/dist").sendFile(distribution.binDistribution))
+        server.expect(server.get("/$TEST_DISTRIBUTION_URL").sendFile(distribution.binDistribution))
 
         when:
         def result = wrapperExecuter.withTasks('hello').run()
@@ -256,8 +266,8 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
 
     def "does not leak basic authentication credentials in exception messages"() {
         given:
-        prepareWrapper("http://jdoe:changeit@localhost:${server.port}")
-        server.expect(server.get("/gradlew/dist").broken())
+        prepareWrapper(getDefaultAuthenticatedBaseUrl())
+        server.expect(server.get("/$TEST_DISTRIBUTION_URL").broken())
 
         when:
         wrapperExecuter.withTasks('hello').run()
@@ -281,16 +291,16 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
         )
 
         and:
-        prepareWrapper("http://jdoe:changeit@localhost:${server.port}")
+        prepareWrapper(getDefaultAuthenticatedBaseUrl())
         server.withBasicAuthentication("jdoe", "changeit")
-        server.expect(server.get("/gradlew/dist").sendFile(distribution.binDistribution))
+        server.expect(server.get("/$TEST_DISTRIBUTION_URL").sendFile(distribution.binDistribution))
 
         when:
         result = wrapperExecuter.withTasks('hello').run()
 
         then:
         outputContains('hello')
-
+        
         and:
         proxyServer.requestCount == 1
     }

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperHttpsIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperHttpsIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests
 
 import org.gradle.integtests.fixtures.TestResources
+import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.fixtures.keystore.TestKeyStore
 import org.gradle.test.fixtures.server.http.BlockingHttpsServer
@@ -26,24 +27,32 @@ import org.junit.Rule
 import spock.lang.IgnoreIf
 import spock.lang.Issue
 
+import static org.gradle.integtests.WrapperHttpIntegrationTest.TEST_DISTRIBUTION_URL
 import static org.gradle.test.matchers.UserAgentMatcher.matchesNameAndVersion
 import static org.hamcrest.CoreMatchers.containsString
 import static org.hamcrest.MatcherAssert.assertThat
 
-@IgnoreIf({ GradleContextualExecuter.embedded }) // wrapperExecuter requires a real distribution
+// wrapperExecuter requires a real distribution
+@IgnoreIf({ GradleContextualExecuter.embedded })
 class WrapperHttpsIntegrationTest extends AbstractWrapperIntegrationSpec {
-    @Rule BlockingHttpsServer server = new BlockingHttpsServer()
-    @Rule TestProxyServer proxyServer = new TestProxyServer()
-    @Rule TestResources resources = new TestResources(temporaryFolder)
+    public static final String DEFAULT_USER = "jdoe"
+    public static final String DEFAULT_PASSWORD = "changeit"
+    @Rule
+    BlockingHttpsServer server = new BlockingHttpsServer()
+    @Rule
+    TestProxyServer proxyServer = new TestProxyServer()
+    @Rule
+    TestResources resources = new TestResources(temporaryFolder)
+    TestKeyStore keyStore
 
     def setup() {
-        TestKeyStore keyStore = TestKeyStore.init(resources.dir)
+        keyStore = TestKeyStore.init(resources.dir)
         // We need to set the SSL properties as arguments here even for non-embedded test mode
         // because we want them to be set on the wrapper client JVM, not the daemon one
-        wrapperExecuter.withArgument("-Djavax.net.ssl.trustStore=$keyStore.keyStore.path")
-        wrapperExecuter.withArgument("-Djavax.net.ssl.trustStorePassword=$keyStore.keyStorePassword")
+        wrapperExecuter.withArguments("-Djavax.net.ssl.trustStore=$keyStore.keyStore.path",
+            "-Djavax.net.ssl.trustStorePassword=$keyStore.keyStorePassword")
         server.configure(keyStore)
-        server.withBasicAuthentication("jdoe", "changeit")
+        server.withBasicAuthentication(DEFAULT_USER, DEFAULT_PASSWORD)
         server.start()
 
         file("build.gradle") << """
@@ -62,16 +71,15 @@ class WrapperHttpsIntegrationTest extends AbstractWrapperIntegrationSpec {
     }
 
     private prepareWrapper(String baseUrl) {
-        prepareWrapper(new URI("${baseUrl}/gradlew/dist"))
+        prepareWrapper(new URI("${baseUrl}/$TEST_DISTRIBUTION_URL"))
     }
 
     def "does not warn about using basic authentication over secure connection"() {
         given:
-        prepareWrapper("https://jdoe:changeit@localhost:${server.port}")
-        server.expect(server.get("/gradlew/dist")
-                .expectUserAgent(matchesNameAndVersion("gradlew", Download.UNKNOWN_VERSION))
-                .sendFile(distribution.binDistribution))
-
+        prepareWrapper(getAuthenticatedBaseUrl())
+        server.expect(server.get("/$TEST_DISTRIBUTION_URL")
+            .expectUserAgent(matchesNameAndVersion("gradlew", Download.UNKNOWN_VERSION))
+            .sendFile(distribution.binDistribution))
 
         when:
         result = wrapperExecuter.withTasks('hello').run()
@@ -83,7 +91,7 @@ class WrapperHttpsIntegrationTest extends AbstractWrapperIntegrationSpec {
     def "downloads wrapper via proxy"() {
         given:
         proxyServer.start()
-        prepareWrapper("https://jdoe:changeit@localhost:${server.port}")
+        prepareWrapper(getAuthenticatedBaseUrl())
 
         // Note that the HTTPS protocol handler uses the same nonProxyHosts property as the HTTP protocol.
         file("gradle.properties") << """
@@ -91,7 +99,7 @@ class WrapperHttpsIntegrationTest extends AbstractWrapperIntegrationSpec {
     systemProp.https.proxyPort=${proxyServer.port}
     systemProp.http.nonProxyHosts=
 """
-        server.expect(server.get("/gradlew/dist").sendFile(distribution.binDistribution))
+        server.expect(server.get("/$TEST_DISTRIBUTION_URL").sendFile(distribution.binDistribution))
 
         when:
         def result = wrapperExecuter.withTasks('hello').run()
@@ -109,8 +117,8 @@ class WrapperHttpsIntegrationTest extends AbstractWrapperIntegrationSpec {
         proxyServer.start('my_user', 'my_password')
 
         and:
-        prepareWrapper("https://jdoe:changeit@localhost:${server.port}")
-        server.expect(server.get("/gradlew/dist").sendFile(distribution.binDistribution))
+        prepareWrapper(getAuthenticatedBaseUrl())
+        server.expect(server.get("/$TEST_DISTRIBUTION_URL").sendFile(distribution.binDistribution))
 
         // Note that the HTTPS protocol handler uses the same nonProxyHosts property as the HTTP protocol.
         file("gradle.properties") << """
@@ -131,4 +139,52 @@ class WrapperHttpsIntegrationTest extends AbstractWrapperIntegrationSpec {
         and:
         proxyServer.requestCount == 1
     }
+
+    private String getAuthenticatedBaseUrl() {
+        "https://$DEFAULT_USER:$DEFAULT_PASSWORD@localhost:${server.port}"
+    }
+
+    def "validate properties file content for latest"() {
+        given:
+        def baseUrl = getAuthenticatedBaseUrl()
+        prepareWrapper(baseUrl)
+        server.expect(server.get("/$TEST_DISTRIBUTION_URL")
+            .sendFile(distribution.binDistribution))
+        server.expect(server.get("/versions/current").send("""{ "version" : "7.6" }"""))
+
+        when:
+        result = runWithVersion(baseUrl, "latest")
+
+        then:
+        validateDistributionUrl("7.6")
+    }
+
+    def "validate properties file content for any version"() {
+        given:
+        def baseUrl = getAuthenticatedBaseUrl()
+        prepareWrapper(baseUrl)
+        server.expect(server.get("/$TEST_DISTRIBUTION_URL").sendFile(distribution.binDistribution))
+
+
+        def version = "7.6"
+        when:
+        runWithVersion(baseUrl, version)
+
+        then:
+        validateDistributionUrl(version)
+    }
+
+    private boolean validateDistributionUrl(String version) {
+        file("gradle/wrapper/gradle-wrapper.properties")
+            .text.contains("distributionUrl=https\\://services.gradle.org/distributions/gradle-$version-bin.zip")
+    }
+
+    private ExecutionResult runWithVersion(String baseUrl, String version) {
+        result = wrapperExecuter.withCommandLineGradleOpts("-Dorg.gradle.internal.services.version.url.override=$baseUrl",
+            "-Djavax.net.ssl.trustStore=$keyStore.keyStore.path",
+            "-Djavax.net.ssl.trustStorePassword=$keyStore.keyStorePassword")
+            .withArguments("wrapper", "--gradle-version", version)
+            .run()
+    }
+
 }

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperHttpsIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperHttpsIntegrationTest.groovy
@@ -35,8 +35,8 @@ import static org.hamcrest.MatcherAssert.assertThat
 // wrapperExecuter requires a real distribution
 @IgnoreIf({ GradleContextualExecuter.embedded })
 class WrapperHttpsIntegrationTest extends AbstractWrapperIntegrationSpec {
-    public static final String DEFAULT_USER = "jdoe"
-    public static final String DEFAULT_PASSWORD = "changeit"
+    private static final String DEFAULT_USER = "jdoe"
+    private static final String DEFAULT_PASSWORD = "changeit"
     @Rule
     BlockingHttpsServer server = new BlockingHttpsServer()
     @Rule


### PR DESCRIPTION
permitted labels:
- "latest"
- "release-candidate"
- "nightly"
- "release-nightly"

- Implements: #13504

Signed-off-by: Reinhold Degenfellner <rdegenfellner@gradle.com>