### PR TITLE
Make additionalOptions immutable for Scala compilation

### DIFF
--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -585,6 +585,12 @@ In case no toolchains are explicitly configured, the toolchain corresponding to 
 
 Similarly, tasks from the Groovy and Scala plugins also rely on toolchains to determine on which JVM they are executed.
 
+==== Scala compile options `getAdditionalParameters()` returns immutable list
+
+The list of additional parameters for Scala compilation retrieved from the `ScalaCompileOptions` or `BaseScalaCompileOptions` is now immutable.
+
+Previously, the mutability of the list depended on the last assigned value.
+
 [[changes_7.6]]
 == Upgrading from 7.5 and earlier
 

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/ScalaCompileIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/ScalaCompileIntegrationTest.groovy
@@ -72,4 +72,28 @@ class Person {
         }
     }
 
+    def "can assign #value to additional parameters"() {
+        file("src/main/scala/ScalaHall.scala") << "class ScalaHall(name: String)"
+
+        buildFile << """
+            tasks.withType(ScalaCompile) {
+              scalaCompileOptions.additionalParameters = $expression
+            }
+        """
+
+        when:
+        run ":compileScala"
+
+        then:
+        executedAndNotSkipped(":compileScala")
+        outputDoesNotContain("[Warn]")
+        JavaVersion.forClass(scalaClassFile("ScalaHall.class").bytes) == JavaVersion.VERSION_1_8
+
+        where:
+        value            | expression
+        "null"           | "null"
+        "mutable list"   | "[]"
+        "immutable list" | "[].asImmutable()"
+    }
+
 }

--- a/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/internal/ScalaCompileOptionsConfigurer.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/internal/ScalaCompileOptionsConfigurer.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.tasks.scala.internal;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.tasks.scala.ScalaCompileOptions;
 import org.gradle.jvm.toolchain.JavaInstallationMetadata;
 import org.gradle.jvm.toolchain.internal.JavaToolchain;
@@ -77,7 +78,7 @@ public class ScalaCompileOptionsConfigurer {
         if (additionalParameters == null) {
             scalaCompileOptions.setAdditionalParameters(Collections.singletonList(targetParameter));
         } else {
-            additionalParameters.add(targetParameter);
+            scalaCompileOptions.setAdditionalParameters(new ImmutableList.Builder<String>().addAll(additionalParameters).add(targetParameter).build());
         }
     }
 

--- a/subprojects/scala/src/main/java/org/gradle/language/scala/tasks/BaseScalaCompileOptions.java
+++ b/subprojects/scala/src/main/java/org/gradle/language/scala/tasks/BaseScalaCompileOptions.java
@@ -16,6 +16,7 @@
 
 package org.gradle.language.scala.tasks;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.Incubating;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
@@ -164,14 +165,18 @@ public abstract class BaseScalaCompileOptions extends AbstractOptions {
     /**
      * Additional parameters passed to the compiler.
      * Each parameter must start with '-'.
+     *
+     * @return The immutable list of additional parameters.
      */
-    @Nullable @Optional @Input
+    @Nullable
+    @Optional
+    @Input
     public List<String> getAdditionalParameters() {
         return additionalParameters;
     }
 
     public void setAdditionalParameters(@Nullable List<String> additionalParameters) {
-        this.additionalParameters = additionalParameters;
+        this.additionalParameters = additionalParameters == null ? null : ImmutableList.copyOf(additionalParameters);
     }
 
     /**

--- a/subprojects/scala/src/test/groovy/org/gradle/scala/compile/internal/ScalaCompileOptionsConfigurerTest.groovy
+++ b/subprojects/scala/src/test/groovy/org/gradle/scala/compile/internal/ScalaCompileOptionsConfigurerTest.groovy
@@ -30,6 +30,7 @@ class ScalaCompileOptionsConfigurerTest extends Specification {
     def 'using Java #toolchain and Scala #scalaLibraryVersion results in #expectedTarget'() {
         given:
         ScalaCompileOptions scalaCompileOptions = TestUtil.newInstance(ScalaCompileOptions)
+        scalaCompileOptions.additionalParameters = ["-some-other-flag"].asImmutable()
         def isScala3 = scalaLibraryVersion.startsWith("3.")
         File scalaLibrary = new File(isScala3 ? "scala3-library_3-${scalaLibraryVersion}.jar" : "scala-library-${scalaLibraryVersion}.jar")
         Set<File> classpath = [scalaLibrary]


### PR DESCRIPTION
The list of additional parameters for Scala compilation retrieved from the `ScalaCompileOptions` or `BaseScalaCompileOptions` is now immutable.

Previously, the mutability of the list depended on the last assigned value.

Fixes #23193