### PR TITLE
Add stale action on issues pending reproducer

### DIFF
--- a/.github/workflows/stale-issue.yml
+++ b/.github/workflows/stale-issue.yml
@@ -106,10 +106,8 @@ jobs:
           stale-issue-label: 'pending:reproducer'
           close-issue-label: 'closed:unreproducible'
           close-issue-message: >
-            This issue has been automatically closed due to inactivity. If you can reproduce this on a
-            recent version of Gradle or if you have a good use case for this feature, please feel free
-            to let know so we can reopen the issue. Please try to provide steps to reproduce, a quick
-            explanation of your use case or a high-quality pull request.
+            While we asked for a reproducer, none was provided. If you provide a valid reproducer, we will consider this issue again.
+            In the meantime, closing as unreproducible.
 
           # PULL REQUESTS -----------------------------------------------------
           stale-pr-label: 'pending:reproducer'

--- a/.github/workflows/stale-issue.yml
+++ b/.github/workflows/stale-issue.yml
@@ -91,3 +91,29 @@ jobs:
             If you are still interested in contributing this, please ensure that
             it is rebased against the latest branch (usually `master`), all review
             comments have been addressed and the build is passing.
+  close-pending-reproducer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v6
+        with:
+          # GLOBAL ------------------------------------------------------------
+          operations-per-run: 30
+          exempt-all-milestones: true
+          days-before-stale: -1
+          only-labels: 'pending:reproducer'
+
+          # ISSUES ------------------------------------------------------------
+          stale-issue-label: 'pending:reproducer'
+          close-issue-message: >
+            This issue has been automatically closed due to inactivity. If you can reproduce this on a
+            recent version of Gradle or if you have a good use case for this feature, please feel free
+            to let know so we can reopen the issue. Please try to provide steps to reproduce, a quick
+            explanation of your use case or a high-quality pull request.
+
+          # PULL REQUESTS -----------------------------------------------------
+          stale-pr-label: 'pending:reproducer'
+          close-pr-message: >
+            This pull request has been automatically closed due to inactivity.
+            If you are still interested in contributing this, please ensure that
+            it is rebased against the latest branch (usually `master`), all review
+            comments have been addressed and the build is passing.

--- a/.github/workflows/stale-issue.yml
+++ b/.github/workflows/stale-issue.yml
@@ -113,7 +113,7 @@ jobs:
 
           # PULL REQUESTS -----------------------------------------------------
           stale-pr-label: 'pending:reproducer'
-          close-pr-label: 'closed:unreproducible'
+          close-pr-label: 'closed:not-fixed'
           close-pr-message: >
             This pull request has been automatically closed due to inactivity.
             If you are still interested in contributing this, please ensure that

--- a/.github/workflows/stale-issue.yml
+++ b/.github/workflows/stale-issue.yml
@@ -103,6 +103,7 @@ jobs:
           only-labels: 'pending:reproducer'
 
           # ISSUES ------------------------------------------------------------
+          days-before-issue-close: 7
           stale-issue-label: 'pending:reproducer'
           close-issue-label: 'closed:unreproducible'
           close-issue-message: >

--- a/.github/workflows/stale-issue.yml
+++ b/.github/workflows/stale-issue.yml
@@ -111,9 +111,4 @@ jobs:
 
           # PULL REQUESTS -----------------------------------------------------
           stale-pr-label: 'pending:reproducer'
-          close-pr-label: 'closed:not-fixed'
-          close-pr-message: >
-            This pull request has been automatically closed due to inactivity.
-            If you are still interested in contributing this, please ensure that
-            it is rebased against the latest branch (usually `master`), all review
-            comments have been addressed and the build is passing.
+          days-before-pr-close: -1

--- a/.github/workflows/stale-issue.yml
+++ b/.github/workflows/stale-issue.yml
@@ -104,6 +104,7 @@ jobs:
 
           # ISSUES ------------------------------------------------------------
           stale-issue-label: 'pending:reproducer'
+          close-issue-label: 'closed:unreproducible'
           close-issue-message: >
             This issue has been automatically closed due to inactivity. If you can reproduce this on a
             recent version of Gradle or if you have a good use case for this feature, please feel free
@@ -112,6 +113,7 @@ jobs:
 
           # PULL REQUESTS -----------------------------------------------------
           stale-pr-label: 'pending:reproducer'
+          close-pr-label: 'closed:unreproducible'
           close-pr-message: >
             This pull request has been automatically closed due to inactivity.
             If you are still interested in contributing this, please ensure that


### PR DESCRIPTION
### Context

Issues that are valid but lack of a valid reproducer require a follow up after one week.

This PR adds a stale action on issues manually labelled with `pending:reproducer` so they can be automatically closed after 7 days of inactivity.

The action itself doesn't add any labels.