### PR TITLE
Remove LGTM file after retirement

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,9 +1,0 @@
-# This is used to configure the LGTM.com website's build of Gradle/Gradle
-# This happens passively without any explict configuration against our repository.
-# See: https://lgtm.com/projects/g/gradle/gradle
-
-extraction:
-  java:
-    index:
-      java_version: "11"
-      build_command: ./gradlew --init-script .github/workflows/codeql-analysis.init.gradle -S -Dorg.gradle.java.home=/usr/lib/jvm/java-11-openjdk-amd64 --max-workers=1 --no-scan testClasses


### PR DESCRIPTION
### Context

LGTM.com has been replaced by [GitHub actions for code scanning](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/setting-up-code-scanning-for-a-repository#setting-up-code-scanning-manually).

Fixes:
 - #23177
