### PR TITLE
Undo type check in BSR#registerIfAbsent()

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
@@ -875,8 +875,14 @@ service: closed with value 12
         fails("hello")
 
         then:
-        failureDescriptionContains("An exception occurred applying plugin request [id: 'my.plugin1']")
-        failureCauseContains("java.lang.IllegalArgumentException: Service 'test' has already been registered with type 'MyService', cannot register another with type 'MyService' (same name but from a different classloader).")
+        outputContains """
+> Task :subproject1:hello
+Hello, subproject1
+
+> Task :subproject2:hello FAILED
+"""
+        failureDescriptionContains("Execution failed for task ':subproject2:hello'.")
+        failureCauseContains("assert MyService == myService.type")
     }
 
     def "service provided by a plugin can be shared by subprojects with different classloaders when using by-type service references"() {

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/DefaultBuildServicesRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/DefaultBuildServicesRegistry.java
@@ -187,13 +187,6 @@ public class DefaultBuildServicesRegistry implements BuildServiceRegistryInterna
         return withRegistrations(registrations -> {
             BuildServiceRegistration<?, ?> existing = registrations.findByName(name);
             if (existing != null) {
-                Class existingType = getProvidedType(existing.getService());
-                if (!implementationType.isAssignableFrom(existingType)) {
-                    boolean sameName = existingType.getTypeName().equals(implementationType.getTypeName());
-                    String additionalDetail = sameName ? " (same name but from a different classloader)" : "";
-                    String message = String.format("Service '%s' has already been registered with type '%s', cannot register another with type '%s'%s.", name, existingType.getName(), implementationType.getName(), additionalDetail);
-                    throw new IllegalArgumentException(message);
-                }
                 // TODO - assert same type
                 // TODO - assert same parameters
                 return uncheckedNonnullCast(existing.getService());


### PR DESCRIPTION
Reverts a type check recently added that would throw an error with a descriptive message when an attempt was made to register a build service with a name that was already in use but the types were different.

The message was helpful but it broke scenarios where people wouldn't be affected by ClassCastExceptions due to our classloader model (such as build services that are just event listeners).

Fixes: #23204
