### PR TITLE
Fix issue with ant builder throwing exception on call()

### DIFF
--- a/subprojects/model-core/src/integTest/groovy/org/gradle/internal/extensibility/CallablePropertyIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/internal/extensibility/CallablePropertyIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.internal.extensibility
 
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Issue
 
 class CallablePropertyIntegrationTest extends AbstractIntegrationSpec {
 
@@ -94,5 +95,20 @@ class CallablePropertyIntegrationTest extends AbstractIntegrationSpec {
         "Top-level call" | "container.foo.prop()"
         "Inside Project.configure" | "configure(container.foo) { prop() }"
         "Inside NDOC.configure" | "container.configure { foo { prop() } }"
+    }
+
+    @Issue('https://github.com/gradle/gradle/issues/23111')
+    def "can configure dynamic property without call method"() {
+        buildFile << """
+            task test {
+                doLast {
+                    ant { echo(message: 'hello world!') }
+                }
+            }
+        """
+
+        expect:
+        args('--stacktrace')
+        succeeds("test")
     }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/extensibility/MixInClosurePropertiesAsMethodsDynamicObject.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/extensibility/MixInClosurePropertiesAsMethodsDynamicObject.java
@@ -56,7 +56,9 @@ public abstract class MixInClosurePropertiesAsMethodsDynamicObject extends Compo
                 return DynamicInvokeResult.found();
             }
             DynamicObject dynamicObject = DynamicObjectUtil.asDynamicObject(property);
-            return dynamicObject.tryInvokeMethod("call", arguments);
+            if (dynamicObject.hasMethod("call", arguments)) {
+                return dynamicObject.tryInvokeMethod("call", arguments);
+            }
         }
         return DynamicInvokeResult.notFound();
     }


### PR DESCRIPTION
Fixes the issue where `call()` is invoked on a dynamic object that does not throw a MethodMissingException on an unknown method (such as `BasicAntBuilder`, that assumes the method call is an incorrect xml element).

Fixes #23111 