### PR TITLE
Fix invalid serialization of dependency management results

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ModuleVersionIdentifierSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ModuleVersionIdentifierSerializer.java
@@ -23,6 +23,10 @@ import org.gradle.internal.serialize.Serializer;
 
 import java.io.IOException;
 
+/**
+ * A thread-safe and reusable serializer for {@link ModuleVersionIdentifier} if and only if the passed in
+ * {@link ImmutableModuleIdentifierFactory} is itself thread-safe.
+ */
 public class ModuleVersionIdentifierSerializer implements Serializer<ModuleVersionIdentifier> {
     private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/BuildIdentifierSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/BuildIdentifierSerializer.java
@@ -25,6 +25,9 @@ import org.gradle.internal.serialize.Encoder;
 
 import java.io.IOException;
 
+/**
+ * A thread-safe and reusable serializer for {@link BuildIdentifier}.
+ */
 public class BuildIdentifierSerializer extends AbstractSerializer<BuildIdentifier> {
     private static final byte ROOT = 0;
     private static final byte LOCAL = 1;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/CapabilitySerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/CapabilitySerializer.java
@@ -24,6 +24,9 @@ import org.gradle.internal.serialize.Serializer;
 
 import java.io.IOException;
 
+/**
+ * A thread-safe and reusable serializer for {@link Capability}.
+ */
 public class CapabilitySerializer implements Serializer<Capability> {
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentIdentifierSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentIdentifierSerializer.java
@@ -39,6 +39,9 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 
+/**
+ * A thread-safe and reusable serializer for {@link ComponentIdentifier}.
+ */
 public class ComponentIdentifierSerializer extends AbstractSerializer<ComponentIdentifier> {
     private final BuildIdentifierSerializer buildIdentifierSerializer = new BuildIdentifierSerializer();
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectionDescriptorSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectionDescriptorSerializer.java
@@ -24,6 +24,10 @@ import org.gradle.internal.serialize.Serializer;
 
 import java.io.IOException;
 
+/**
+ * A thread-safe and reusable serializer for {@link ComponentSelectionDescriptor} if and only if the passed in
+ * {@link ComponentSelectionDescriptorFactory} is thread-safe and reusable.
+ */
 public class ComponentSelectionDescriptorSerializer implements Serializer<ComponentSelectionDescriptor> {
 
     private final ComponentSelectionDescriptorFactory componentSelectionDescriptorFactory;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectionReasonSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectionReasonSerializer.java
@@ -22,11 +22,13 @@ import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
 import org.gradle.internal.serialize.Serializer;
 
-import javax.annotation.concurrent.NotThreadSafe;
 import java.io.IOException;
 import java.util.List;
 
-@NotThreadSafe
+/**
+ * A thread-safe and reusable serializer for {@link ComponentSelectionReason} if and only if the passed in
+ * {@link ComponentSelectionDescriptorFactory} is thread-safe and reusable.
+ */
 public class ComponentSelectionReasonSerializer implements Serializer<ComponentSelectionReason> {
 
     private final ComponentSelectionDescriptorSerializer componentSelectionDescriptorSerializer;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializer.java
@@ -39,12 +39,17 @@ import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
 import org.gradle.util.Path;
 
+import javax.annotation.concurrent.NotThreadSafe;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * A serializer for {@link ComponentSelector} that is not thread-safe and not reusable.
+ */
+@NotThreadSafe
 public class ComponentSelectorSerializer extends AbstractSerializer<ComponentSelector> {
     private final OptimizingAttributeContainerSerializer attributeContainerSerializer;
     private final BuildIdentifierSerializer buildIdentifierSerializer;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ResolvedComponentResultSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ResolvedComponentResultSerializer.java
@@ -32,12 +32,17 @@ import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
 import org.gradle.internal.serialize.Serializer;
 
+import javax.annotation.concurrent.NotThreadSafe;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * A serializer for {@link ResolvedComponentResult} that is not thread-safe and not reusable.
+ */
+@NotThreadSafe
 public class ResolvedComponentResultSerializer implements Serializer<ResolvedComponentResult> {
     private final Serializer<ModuleVersionIdentifier> moduleVersionIdSerializer;
     private final Serializer<ComponentIdentifier> componentIdSerializer;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ResolvedVariantResultSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ResolvedVariantResultSerializer.java
@@ -28,10 +28,15 @@ import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
 import org.gradle.internal.serialize.Serializer;
 
+import javax.annotation.concurrent.NotThreadSafe;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * A serializer for {@link ResolvedVariantResult} that is not thread safe and not reusable.
+ */
+@NotThreadSafe
 public class ResolvedVariantResultSerializer implements Serializer<ResolvedVariantResult> {
     private final Map<ResolvedVariantResult, Integer> written = Maps.newHashMap();
     private final List<ResolvedVariantResult> read = Lists.newArrayList();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/store/DefaultBinaryStore.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/store/DefaultBinaryStore.java
@@ -106,6 +106,10 @@ class DefaultBinaryStore implements BinaryStore, Closeable {
         return file.length();
     }
 
+    public boolean isInUse() {
+        return offset != -1;
+    }
+
     private static class SimpleBinaryData implements BinaryStore.BinaryData {
         private final long offset;
         private final File inputFile;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/store/ResolutionResultsStoreFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/store/ResolutionResultsStoreFactory.java
@@ -62,7 +62,7 @@ public class ResolutionResultsStoreFactory implements Closeable {
 
     private synchronized DefaultBinaryStore createBinaryStore(String storeKey) {
         DefaultBinaryStore store = stores.get(storeKey);
-        if (store == null || isFull(store)) {
+        if (store == null || isFull(store) || store.isInUse()) {
             File storeFile = temp.createTemporaryFile("gradle", ".bin");
             storeFile.deleteOnExit();
             store = new DefaultBinaryStore(storeFile);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/metadata/ComponentArtifactIdentifierSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/metadata/ComponentArtifactIdentifierSerializer.java
@@ -24,6 +24,9 @@ import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
 import org.gradle.internal.serialize.Serializer;
 
+/**
+ * A thread-safe and reusable serializer for {@link DefaultModuleComponentArtifactIdentifier}.
+ */
 public class ComponentArtifactIdentifierSerializer implements Serializer<DefaultModuleComponentArtifactIdentifier> {
     private final ComponentIdentifierSerializer componentIdentifierSerializer = new ComponentIdentifierSerializer();
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/metadata/ComponentFileArtifactIdentifierSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/metadata/ComponentFileArtifactIdentifierSerializer.java
@@ -25,6 +25,9 @@ import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
 import org.gradle.internal.serialize.Serializer;
 
+/**
+ * A thread-safe and reusable serializer for {@link ComponentFileArtifactIdentifier}.
+ */
 public class ComponentFileArtifactIdentifierSerializer implements Serializer<ComponentFileArtifactIdentifier> {
     private final ComponentIdentifierSerializer componentIdentifierSerializer = new ComponentIdentifierSerializer();
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/metadata/ModuleComponentFileArtifactIdentifierSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/metadata/ModuleComponentFileArtifactIdentifierSerializer.java
@@ -23,6 +23,9 @@ import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
 import org.gradle.internal.serialize.Serializer;
 
+/**
+ * A thread-safe and reusable serializer for {@link ModuleComponentFileArtifactIdentifier}.
+ */
 public class ModuleComponentFileArtifactIdentifierSerializer implements Serializer<ModuleComponentFileArtifactIdentifier> {
     private final ComponentIdentifierSerializer componentIdentifierSerializer = new ComponentIdentifierSerializer();
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/metadata/PublishArtifactLocalArtifactMetadataSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/metadata/PublishArtifactLocalArtifactMetadataSerializer.java
@@ -27,6 +27,9 @@ import org.gradle.internal.serialize.Serializer;
 
 import java.io.File;
 
+/**
+ * A thread-safe and reusable serializer for {@link PublishArtifactLocalArtifactMetadata}.
+ */
 public class PublishArtifactLocalArtifactMetadataSerializer implements Serializer<PublishArtifactLocalArtifactMetadata> {
 
     private final ComponentIdentifierSerializer componentIdentifierSerializer;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/caching/DesugaringAttributeContainerSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/caching/DesugaringAttributeContainerSerializer.java
@@ -29,7 +29,7 @@ import org.gradle.internal.snapshot.impl.CoercingStringValueSnapshot;
 import java.io.IOException;
 
 /**
- * An attribute container serializer that will desugar typed attributes.
+ * A thread-safe and reusable attribute container serializer that will desugar typed attributes.
  *
  * Attributes that are of types different than {@code String} or {@code boolean} will be desugared
  * before serialization. The process requires the attribute type to implement {@link Named}.

--- a/subprojects/messaging/src/main/java/org/gradle/internal/serialize/SerializerRegistry.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/serialize/SerializerRegistry.java
@@ -19,6 +19,8 @@ package org.gradle.internal.serialize;
 public interface SerializerRegistry {
     /**
      * Use the given serializer for objects of the given type.
+     * <p>
+     * The provided serializer must be thread-safe and reusable.
      */
     <T> void register(Class<T> implementationType, Serializer<T> serializer);
 


### PR DESCRIPTION
* Prevents re-entry for metadata stores
* Prevents reuse of serializers for dependency results used as inputs