### PR TITLE
Use gradle.properties to toggle IDEA/Eclipse download sources and javadoc options

### DIFF
--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/AbstractSourcesAndJavadocJarsIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/AbstractSourcesAndJavadocJarsIntegrationTest.groovy
@@ -468,6 +468,33 @@ dependencies {
     }
 
     @ToBeFixedForConfigurationCache
+    def "does not download localGroovy() sources when sources download is disabled by using gradle.properties"() {
+        given:
+        executer.withEnvironmentVars('GRADLE_LIBS_REPO_OVERRIDE': "$server.uri/")
+
+        file('gradle.properties') << """
+org.gradle.eclipse.sources.download=false
+org.gradle.idea.sources.download=false
+"""
+
+        buildScript """
+            apply plugin: "java"
+            apply plugin: "idea"
+            apply plugin: "eclipse"
+
+            dependencies {
+                implementation localGroovy()
+            }
+            """
+
+        when:
+        succeeds ideTask
+
+        then:
+        ideFileContainsNoSourcesAndJavadocEntry()
+    }
+
+    @ToBeFixedForConfigurationCache
     def "does not download localGroovy() sources when offline"() {
         given:
         executer.withEnvironmentVars('GRADLE_LIBS_REPO_OVERRIDE': "$server.uri/")

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
@@ -144,8 +144,8 @@ import java.util.Set;
  */
 public abstract class EclipseClasspath {
 
-    public static final String DOWNLOAD_SOURCES_PROPERTY = "org.gradle.eclipse.sources.download";
-    public static final String DOWNLOAD_JAVADOC_PROPERTY = "org.gradle.eclipse.javadoc.download";
+    private static final String DOWNLOAD_SOURCES_PROPERTY = "org.gradle.eclipse.sources.download";
+    private static final String DOWNLOAD_JAVADOC_PROPERTY = "org.gradle.eclipse.javadoc.download";
 
     private Iterable<SourceSet> sourceSets;
 

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
@@ -143,6 +143,10 @@ import java.util.Set;
  * </pre>
  */
 public abstract class EclipseClasspath {
+
+    public static final String DOWNLOAD_SOURCES_PROPERTY = "org.gradle.eclipse.sources.download";
+    public static final String DOWNLOAD_JAVADOC_PROPERTY = "org.gradle.eclipse.javadoc.download";
+
     private Iterable<SourceSet> sourceSets;
 
     private Collection<Configuration> plusConfigurations = new ArrayList<Configuration>();
@@ -153,7 +157,7 @@ public abstract class EclipseClasspath {
 
     private File defaultOutputDir;
 
-    private boolean downloadSources = true;
+    private boolean downloadSources;
 
     private boolean downloadJavadoc;
 
@@ -178,6 +182,9 @@ public abstract class EclipseClasspath {
         this.containsTestFixtures = project.getObjects().property(Boolean.class).convention(false);
         this.testSourceSets = project.getObjects().setProperty(SourceSet.class);
         this.testConfigurations = project.getObjects().setProperty(Configuration.class);
+
+        this.downloadSources = getProject().getProviders().gradleProperty(DOWNLOAD_SOURCES_PROPERTY).map(Boolean::parseBoolean).getOrElse(true);
+        this.downloadJavadoc = getProject().getProviders().gradleProperty(DOWNLOAD_JAVADOC_PROPERTY).map(Boolean::parseBoolean).getOrElse(false);
     }
 
     /**

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/IdeaModule.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/IdeaModule.java
@@ -160,6 +160,9 @@ import static org.gradle.util.internal.ConfigureUtil.configure;
  */
 public abstract class IdeaModule {
 
+    public static final String DOWNLOAD_SOURCES_PROPERTY = "org.gradle.idea.sources.download";
+    public static final String DOWNLOAD_JAVADOC_PROPERTY = "org.gradle.idea.javadoc.download";
+
     private String name;
     private Set<File> sourceDirs;
     private Set<File> generatedSourceDirs = Sets.newLinkedHashSet();
@@ -171,7 +174,7 @@ public abstract class IdeaModule {
     private Set<File> testResourceDirs = Sets.newLinkedHashSet();
     private ConfigurableFileCollection testResources;
     private Map<String, Map<String, Collection<Configuration>>> scopes = Maps.newLinkedHashMap();
-    private boolean downloadSources = true;
+    private boolean downloadSources;
     private boolean downloadJavadoc;
     private File contentRoot;
     /**
@@ -201,6 +204,9 @@ public abstract class IdeaModule {
 
         this.testSources = project.getObjects().fileCollection();
         this.testResources = project.getObjects().fileCollection();
+
+        this.downloadSources = getProject().getProviders().gradleProperty(DOWNLOAD_SOURCES_PROPERTY).map(Boolean::parseBoolean).getOrElse(true);
+        this.downloadJavadoc = getProject().getProviders().gradleProperty(DOWNLOAD_JAVADOC_PROPERTY).map(Boolean::parseBoolean).getOrElse(false);
 
         // TODO: remove this whileDisabled wrapping for Gradle 8.1
         testSources.from(project.provider(() -> DeprecationLogger.whileDisabled(() -> getTestSourceDirs())));

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/IdeaModule.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/IdeaModule.java
@@ -160,8 +160,8 @@ import static org.gradle.util.internal.ConfigureUtil.configure;
  */
 public abstract class IdeaModule {
 
-    public static final String DOWNLOAD_SOURCES_PROPERTY = "org.gradle.idea.sources.download";
-    public static final String DOWNLOAD_JAVADOC_PROPERTY = "org.gradle.idea.javadoc.download";
+    private static final String DOWNLOAD_SOURCES_PROPERTY = "org.gradle.idea.sources.download";
+    private static final String DOWNLOAD_JAVADOC_PROPERTY = "org.gradle.idea.javadoc.download";
 
     private String name;
     private Set<File> sourceDirs;

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/GenerateEclipseClasspathTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/GenerateEclipseClasspathTest.groovy
@@ -19,6 +19,7 @@ import org.gradle.api.Project
 import org.gradle.api.internal.ConventionTask
 import org.gradle.api.tasks.AbstractSpockTaskTest
 import org.gradle.plugins.ide.eclipse.model.EclipseClasspath
+import org.gradle.util.TestProviderFactory
 import org.gradle.util.TestUtil
 
 class GenerateEclipseClasspathTest extends AbstractSpockTaskTest {
@@ -32,6 +33,7 @@ class GenerateEclipseClasspathTest extends AbstractSpockTaskTest {
     def setup() {
         def project = Mock(Project)
         project.getObjects() >> TestUtil.objectFactory()
+        project.getProviders() >> new TestProviderFactory()
         eclipseClasspath = createTask(GenerateEclipseClasspath.class)
         eclipseClasspath.classpath = TestUtil.newInstance(EclipseClasspath, project)
     }

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/EclipseModelTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/EclipseModelTest.groovy
@@ -25,6 +25,7 @@ import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.internal.xml.XmlTransformer
 import org.gradle.plugins.ide.api.PropertiesFileContentMerger
 import org.gradle.plugins.ide.api.XmlFileContentMerger
+import org.gradle.util.TestProviderFactory
 import org.gradle.util.TestUtil
 import spock.lang.Specification
 import spock.lang.Subject
@@ -35,6 +36,7 @@ class EclipseModelTest extends Specification {
     EclipseModel model
     def project = Mock(ProjectInternal) {
         getTaskDependencyFactory() >> TestFiles.taskDependencyFactory()
+        getProviders() >> new TestProviderFactory()
     }
 
     def setup() {
@@ -201,4 +203,15 @@ class EclipseModelTest extends Specification {
         then:
         2 * xmlTransformer.addAction(xmlAction)
     }
+
+    def "download sources is true by default"() {
+        expect:
+        model.classpath.downloadSources
+    }
+
+    def "download javadoc is false by default"() {
+        expect:
+        !model.classpath.downloadJavadoc
+    }
+
 }

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/model/IdeaModelTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/model/IdeaModelTest.groovy
@@ -28,6 +28,7 @@ import org.gradle.internal.service.ServiceRegistry
 import org.gradle.internal.xml.XmlTransformer
 import org.gradle.plugins.ide.api.XmlFileContentMerger
 import org.gradle.plugins.ide.internal.IdeArtifactRegistry
+import org.gradle.util.TestProviderFactory
 import org.gradle.util.TestUtil
 import spock.lang.Specification
 
@@ -106,6 +107,7 @@ class IdeaModelTest extends Specification {
 
             getObjects() >> objectFactory
             provider(_) >> Mock(Provider)
+            getProviders() >> new TestProviderFactory()
         }
         def xmlAction = {} as Action<XmlProvider>
         def moduleIml = Spy(IdeaModuleIml, constructorArgs: [xmlTransformer, null])

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/model/IdeaModuleTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/model/IdeaModuleTest.groovy
@@ -76,4 +76,25 @@ class IdeaModuleTest extends AbstractProjectBuilderSpec {
        expect:
        module.targetBytecodeVersion == null
    }
+
+    def "download sources is true by default"() {
+        given:
+        project.getPlugins().apply(JavaPlugin)
+        project.getPlugins().apply(IdeaPlugin)
+        def iml = Mock(IdeaModuleIml)
+        def module = TestUtil.newInstance(IdeaModule, moduleProject, iml)
+        expect:
+        module.downloadSources
+    }
+
+    def "download javadoc is false by default"() {
+        given:
+        project.getPlugins().apply(JavaPlugin)
+        project.getPlugins().apply(IdeaPlugin)
+        def iml = Mock(IdeaModuleIml)
+        def module = TestUtil.newInstance(IdeaModule, moduleProject, iml)
+        expect:
+        !module.downloadJavadoc
+    }
+
 }


### PR DESCRIPTION
Signed-off-by: Alexey Zhokhov [alexey@zhokhov.com](mailto:alexey@zhokhov.com)

The current version of Gradle by default enables downloading sources in IDEA and Eclipse plugins. Most open-source projects who use these plugins are not switched off this setting in their projects by default, which increases the amount of time for new contributors to import a project to IDEA for the first time and wait until it will be ready to provide all IDE good stuff, normally it takes quite a lot of time. One of the approaches is providing PR to the specific project with the ability to toggle this behavior, but can not change the whole world by changing each project independently. That's why I think this ability to set the global default behavior for these plugins directly from `gradle.properties` probably is the best way to solve this problem.

### Context

Disabling automatic downloading of all sources dramatically speeds up importing open-source projects in IDEA/Eclipse, significantly when the project updated quite a lot of dependencies, on top of that it requires less disk space. For those who are not frequent contributors to a particular project, this change is quite helpful as it saves a lot of time during the first import or refreshing the project after pulling a lot of changes for some period of time.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
