### PR TITLE
Versions catalog: fail fast if an alias contains 'class'

### DIFF
--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/catalog/problems/VersionCatalogErrorMessages.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/catalog/problems/VersionCatalogErrorMessages.groovy
@@ -49,6 +49,10 @@ trait VersionCatalogErrorMessages {
         buildMessage(ReservedAlias, VersionCatalogProblemId.RESERVED_ALIAS_NAME, spec)
     }
 
+    String aliasContainsReservedName(@DelegatesTo(value = ReservedAlias, strategy = Closure.DELEGATE_FIRST) Closure<?> spec) {
+        buildMessage(ReservedAlias, VersionCatalogProblemId.RESERVED_ALIAS_NAME, spec)
+    }
+
     String undefinedVersionRef(@DelegatesTo(value = UndefinedVersionRef, strategy = Closure.DELEGATE_FIRST) Closure<?> spec) {
         buildMessage(UndefinedVersionRef, VersionCatalogProblemId.UNDEFINED_VERSION_REFERENCE, spec)
     }
@@ -234,6 +238,12 @@ trait VersionCatalogErrorMessages {
             this
         }
 
+        ReservedAlias shouldNotContain(String name) {
+            this.alias = name
+            this.message = "Alias '$name' contains a reserved name in Gradle and prevents generation of accessors"
+            this
+        }
+
         ReservedAlias reservedAliasPrefix(String... suffixes) {
             this.solution = "Use a different alias which prefix is not equal to ${oxfordListOf(suffixes as List, 'or')}"
             this
@@ -241,6 +251,11 @@ trait VersionCatalogErrorMessages {
 
         ReservedAlias reservedAliases(String... aliases) {
             this.solution = "Use a different alias which isn't in the reserved names ${oxfordListOf(aliases as List, "or")}"
+            this
+        }
+
+        ReservedAlias reservedNames(String... names) {
+            this.solution = "Use a different alias which doesn't contain any of ${oxfordListOf(names as List, "or")}"
             this
         }
 


### PR DESCRIPTION
Fixes #23106 

I made this a separate case from `extensions` and `convention` because my understanding is that `class` will fail anywhere while it's ok to have an alias end with `-extensions`, like `coroutines-extensions` for an example or anything else.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
