### PR TITLE
Hide timestamp in the cache cleanup API for now

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/cache/CacheResourceConfiguration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/cache/CacheResourceConfiguration.java
@@ -17,7 +17,6 @@
 package org.gradle.api.cache;
 
 import org.gradle.api.Incubating;
-import org.gradle.api.provider.Property;
 import org.gradle.internal.HasInternalProtocol;
 
 /**
@@ -28,18 +27,10 @@ import org.gradle.internal.HasInternalProtocol;
 @Incubating
 @HasInternalProtocol
 public interface CacheResourceConfiguration {
-    /**
-     * Configures the timestamp before which an unused entry will be removed from the cache.
-     *
-     * See {@link #setRemoveUnusedEntriesAfterDays(int)}.
-     */
-    Property<Long> getRemoveUnusedEntriesOlderThan();
 
     /**
      * Sets the timestamp before which unused entries will be removed to be calculated exactly
      * the given number of days previous to the current time.
-     *
-     * See {@link #getRemoveUnusedEntriesOlderThan()}
      */
     void setRemoveUnusedEntriesAfterDays(int removeUnusedEntriesAfterDays);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/cache/CacheResourceConfigurationInternal.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/cache/CacheResourceConfigurationInternal.java
@@ -17,8 +17,17 @@
 package org.gradle.api.internal.cache;
 
 import org.gradle.api.cache.CacheResourceConfiguration;
+import org.gradle.api.provider.Property;
+
 import java.util.function.Supplier;
 
 public interface CacheResourceConfigurationInternal extends CacheResourceConfiguration {
     Supplier<Long> getRemoveUnusedEntriesOlderThanAsSupplier();
+
+    /**
+     * Configures the timestamp before which an unused entry will be removed from the cache.
+     *
+     * See {@link #setRemoveUnusedEntriesAfterDays(int)}.
+     */
+    Property<Long> getRemoveUnusedEntriesOlderThan();
 }


### PR DESCRIPTION
Hide the timestamp property from the public API for the moment until we decide whether we want to change it or not.