### PR TITLE
Address issue where initialization fails before cleanup is configured

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
@@ -23,6 +23,7 @@ import org.gradle.api.internal.BuildDefinition
 import org.gradle.api.internal.FeaturePreviews
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.SettingsInternal.BUILD_SRC
+import org.gradle.api.internal.cache.CacheConfigurationsInternal
 import org.gradle.api.provider.Provider
 import org.gradle.api.services.internal.BuildServiceProvider
 import org.gradle.api.services.internal.BuildServiceRegistryInternal
@@ -600,6 +601,9 @@ class ConfigurationCacheState(
             cacheConfigurations.downloadedResources.removeUnusedEntriesOlderThan.value(readNonNull<Provider<Long>>())
             cacheConfigurations.createdResources.removeUnusedEntriesOlderThan.value(readNonNull<Provider<Long>>())
             cacheConfigurations.cleanup.value(readNonNull<Provider<Cleanup>>())
+        }
+        if (gradle.isRootBuild) {
+            gradle.serviceOf<CacheConfigurationsInternal>().setCleanupHasBeenConfigured(true)
         }
     }
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/cache/CacheConfigurationsInternal.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/cache/CacheConfigurationsInternal.java
@@ -21,7 +21,6 @@ import org.gradle.api.cache.Cleanup;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.cache.CleanupFrequency;
-import org.gradle.internal.Factory;
 
 public interface CacheConfigurationsInternal extends CacheConfigurations {
     int DEFAULT_MAX_AGE_IN_DAYS_FOR_RELEASED_DISTS = 30;
@@ -51,5 +50,5 @@ public interface CacheConfigurationsInternal extends CacheConfigurations {
      */
     void synchronize(CacheConfigurationsInternal cacheConfigurationsInternal);
 
-    <T> T allowCleanupOnlyIfSuccessful(Factory<T> factory);
+    void setCleanupHasBeenConfigured(boolean hasBeenConfigured);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/cache/CacheConfigurationsInternal.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/cache/CacheConfigurationsInternal.java
@@ -21,6 +21,7 @@ import org.gradle.api.cache.Cleanup;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.cache.CleanupFrequency;
+import org.gradle.internal.Factory;
 
 public interface CacheConfigurationsInternal extends CacheConfigurations {
     int DEFAULT_MAX_AGE_IN_DAYS_FOR_RELEASED_DISTS = 30;
@@ -49,4 +50,6 @@ public interface CacheConfigurationsInternal extends CacheConfigurations {
      * by setting the provided configuration's properties to be backed by the properties of this configuration.
      */
     void synchronize(CacheConfigurationsInternal cacheConfigurationsInternal);
+
+    <T> T allowCleanupOnlyIfSuccessful(Factory<T> factory);
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/cache/internal/GradleUserHomeCleanupServiceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/cache/internal/GradleUserHomeCleanupServiceIntegrationTest.groovy
@@ -21,9 +21,6 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.GradleVersion
 
-import java.text.SimpleDateFormat
-import java.time.Instant
-
 import static org.gradle.cache.internal.VersionSpecificCacheCleanupFixture.MarkerFileType.USED_TODAY
 
 class GradleUserHomeCleanupServiceIntegrationTest extends AbstractIntegrationSpec implements GradleUserHomeCleanupFixture {
@@ -215,75 +212,6 @@ class GradleUserHomeCleanupServiceIntegrationTest extends AbstractIntegrationSpe
         type              | daysToTriggerCleanup
         DistType.RELEASED | NOT_USED_WITHIN_DEFAULT_MAX_DAYS_FOR_RELEASED_DISTS
         DistType.SNAPSHOT | NOT_USED_WITHIN_DEFAULT_MAX_DAYS_FOR_SNAPSHOT_DISTS
-    }
-
-    private GradleDistDirs versionedDistDirs(String version, MarkerFileType lastUsed, String customDistName) {
-        def distVersion = GradleVersion.version(version)
-        return new GradleDistDirs(
-            createVersionSpecificCacheDir(distVersion, lastUsed),
-            createDistributionChecksumDir(distVersion).parentFile,
-            createCustomDistributionChecksumDir(customDistName, distVersion).parentFile
-        )
-    }
-
-    private static class GradleDistDirs {
-        private final TestFile cacheDir
-        private final TestFile distDir
-        private final TestFile customDistDir
-
-        GradleDistDirs(TestFile cacheDir, TestFile distDir, TestFile customDistDir) {
-            this.cacheDir = cacheDir
-            this.distDir = distDir
-            this.customDistDir = customDistDir
-        }
-
-        void assertAllDirsExist() {
-            cacheDir.assertExists()
-            distDir.assertExists()
-            customDistDir.assertExists()
-        }
-
-        void assertAllDirsDoNotExist() {
-            cacheDir.assertDoesNotExist()
-            distDir.assertDoesNotExist()
-            customDistDir.assertDoesNotExist()
-        }
-    }
-
-    private static enum DistType {
-        RELEASED() {
-            @Override
-            String version(String baseVersion) {
-                return baseVersion
-            }
-
-            @Override
-            String alternateVersion(String baseVersion) {
-                throw new UnsupportedOperationException()
-            }
-        },
-        SNAPSHOT() {
-            def formatter = new SimpleDateFormat("yyyyMMddHHmmssZ")
-            def now = Instant.now()
-
-            @Override
-            String version(String baseVersion) {
-                return baseVersion + '-' + formatter.format(Date.from(now))
-            }
-
-            @Override
-            String alternateVersion(String baseVersion) {
-                return baseVersion + '-' + formatter.format(Date.from(now.plusSeconds(60)))
-            }
-        }
-
-        abstract String version(String baseVersion)
-        abstract String alternateVersion(String baseVersion)
-
-        @Override
-        String toString() {
-            return name().toLowerCase()
-        }
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/cache/DefaultCacheConfigurations.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/cache/DefaultCacheConfigurations.java
@@ -29,7 +29,6 @@ import org.gradle.api.provider.Provider;
 import org.gradle.cache.CleanupFrequency;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
-import org.gradle.internal.Factory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -52,7 +51,7 @@ abstract public class DefaultCacheConfigurations implements CacheConfigurationsI
     private final CacheResourceConfigurationInternal createdResourcesConfiguration;
     private final Property<Cleanup> cleanup;
 
-    private boolean hasBeenConfigured;
+    private boolean cleanupHasBeenConfigured;
 
     @Inject
     public DefaultCacheConfigurations(ObjectFactory objectFactory, PropertyHost propertyHost) {
@@ -117,7 +116,7 @@ abstract public class DefaultCacheConfigurations implements CacheConfigurationsI
     @Override
     public Provider<CleanupFrequency> getCleanupFrequency() {
         return getCleanup().map(cleanup ->
-            lastCleanupTimestamp -> hasBeenConfigured && ((CleanupInternal)cleanup).getCleanupFrequency().requiresCleanup(lastCleanupTimestamp)
+            lastCleanupTimestamp -> cleanupHasBeenConfigured && ((CleanupInternal)cleanup).getCleanupFrequency().requiresCleanup(lastCleanupTimestamp)
         );
     }
 
@@ -139,11 +138,8 @@ abstract public class DefaultCacheConfigurations implements CacheConfigurationsI
     }
 
     @Override
-    public <T> T allowCleanupOnlyIfSuccessful(Factory<T> factory) {
-        hasBeenConfigured = false;
-        T result = factory.create();
-        hasBeenConfigured = true;
-        return result;
+    public void setCleanupHasBeenConfigured(boolean hasBeenConfigured) {
+        this.cleanupHasBeenConfigured = hasBeenConfigured;
     }
 
     private static <T> Provider<T> providerFromSupplier(Supplier<T> supplier) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/CacheConfigurationsHandlingSettingsLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/CacheConfigurationsHandlingSettingsLoader.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.initialization;
+
+import org.gradle.api.internal.GradleInternal;
+import org.gradle.api.internal.cache.CacheConfigurationsInternal;
+import org.gradle.initialization.SettingsLoader;
+import org.gradle.initialization.SettingsState;
+
+public class CacheConfigurationsHandlingSettingsLoader implements SettingsLoader {
+    private final SettingsLoader delegate;
+    private final CacheConfigurationsInternal cacheConfigurations;
+
+    public CacheConfigurationsHandlingSettingsLoader(SettingsLoader delegate, CacheConfigurationsInternal cacheConfigurations) {
+        this.delegate = delegate;
+        this.cacheConfigurations = cacheConfigurations;
+    }
+
+    @Override
+    public SettingsState findAndLoadSettings(GradleInternal gradle) {
+        return cacheConfigurations.allowCleanupOnlyIfSuccessful(() -> delegate.findAndLoadSettings(gradle));
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/CacheConfigurationsHandlingSettingsLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/CacheConfigurationsHandlingSettingsLoader.java
@@ -32,6 +32,9 @@ public class CacheConfigurationsHandlingSettingsLoader implements SettingsLoader
 
     @Override
     public SettingsState findAndLoadSettings(GradleInternal gradle) {
-        return cacheConfigurations.allowCleanupOnlyIfSuccessful(() -> delegate.findAndLoadSettings(gradle));
+        cacheConfigurations.setCleanupHasBeenConfigured(false);
+        SettingsState state = delegate.findAndLoadSettings(gradle);
+        cacheConfigurations.setCleanupHasBeenConfigured(true);
+        return state;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoaderFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoaderFactory.java
@@ -16,6 +16,8 @@
 
 package org.gradle.initialization;
 
+import org.gradle.api.internal.cache.CacheConfigurationsInternal;
+import org.gradle.api.internal.initialization.CacheConfigurationsHandlingSettingsLoader;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.configuration.project.BuiltInCommand;
 import org.gradle.initialization.layout.BuildLayoutFactory;
@@ -36,6 +38,7 @@ public class DefaultSettingsLoaderFactory implements SettingsLoaderFactory {
     private final BuildIncluder buildIncluder;
     private final InitScriptHandler initScriptHandler;
     private final List<BuiltInCommand> builtInCommands;
+    private final CacheConfigurationsInternal cacheConfigurations;
 
     public DefaultSettingsLoaderFactory(
         SettingsProcessor settingsProcessor,
@@ -45,7 +48,8 @@ public class DefaultSettingsLoaderFactory implements SettingsLoaderFactory {
         GradlePropertiesController gradlePropertiesController,
         BuildIncluder buildIncluder,
         InitScriptHandler initScriptHandler,
-        List<BuiltInCommand> builtInCommands
+        List<BuiltInCommand> builtInCommands,
+        CacheConfigurationsInternal cacheConfigurations
     ) {
         this.settingsProcessor = settingsProcessor;
         this.buildRegistry = buildRegistry;
@@ -55,20 +59,27 @@ public class DefaultSettingsLoaderFactory implements SettingsLoaderFactory {
         this.buildIncluder = buildIncluder;
         this.initScriptHandler = initScriptHandler;
         this.builtInCommands = builtInCommands;
+        this.cacheConfigurations = cacheConfigurations;
     }
 
     @Override
     public SettingsLoader forTopLevelBuild() {
         return new GradlePropertiesHandlingSettingsLoader(
-            new InitScriptHandlingSettingsLoader(
-                new CompositeBuildSettingsLoader(
-                    new ChildBuildRegisteringSettingsLoader(
-                        new CommandLineIncludedBuildSettingsLoader(
-                            defaultSettingsLoader()
+            new CacheConfigurationsHandlingSettingsLoader(
+                new InitScriptHandlingSettingsLoader(
+                    new CompositeBuildSettingsLoader(
+                        new ChildBuildRegisteringSettingsLoader(
+                            new CommandLineIncludedBuildSettingsLoader(
+                                defaultSettingsLoader()
+                            ),
+                            buildIncluder
                         ),
-                        buildIncluder),
-                    buildRegistry),
-                initScriptHandler),
+                        buildRegistry
+                    ),
+                    initScriptHandler
+                ),
+                cacheConfigurations
+            ),
             buildLayoutFactory,
             gradlePropertiesController
         );

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/SettingsScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/SettingsScopeServices.java
@@ -78,6 +78,7 @@ public class SettingsScopeServices extends DefaultServiceRegistry {
         CacheConfigurationsInternal cacheConfigurations = objectFactory.newInstance(DefaultCacheConfigurations.class);
         if (gradleInternal.isRootBuild()) {
             cacheConfigurations.synchronize(persistentCacheConfigurations);
+            persistentCacheConfigurations.setCleanupHasBeenConfigured(false);
         }
         return cacheConfigurations;
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/cache/DefaultCacheConfigurationsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/cache/DefaultCacheConfigurationsTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.cache
 
 import org.gradle.api.cache.Cleanup
+import org.gradle.cache.CleanupFrequency
 import org.gradle.util.TestUtil
 import spock.lang.Specification
 
@@ -189,6 +190,25 @@ class DefaultCacheConfigurationsTest extends Specification {
         mutableCacheConfigurations.downloadedResources.removeUnusedEntriesOlderThan.get() == twoDaysAgo
         mutableCacheConfigurations.releasedWrappers.removeUnusedEntriesOlderThan.get() == twoDaysAgo
         mutableCacheConfigurations.snapshotWrappers.removeUnusedEntriesOlderThan.get() == twoDaysAgo
+    }
+
+    def "will not require cleanup unless configured"() {
+        when:
+        def twoDaysAgo = daysAgo(2).get()
+        cacheConfigurations.createdResources.removeUnusedEntriesOlderThan.set(twoDaysAgo)
+        cacheConfigurations.downloadedResources.removeUnusedEntriesOlderThan.set(twoDaysAgo)
+        cacheConfigurations.releasedWrappers.removeUnusedEntriesOlderThan.set(twoDaysAgo)
+        cacheConfigurations.snapshotWrappers.removeUnusedEntriesOlderThan.set(twoDaysAgo)
+        cacheConfigurations.cleanup.set(Cleanup.ALWAYS)
+
+        then:
+        !cacheConfigurations.cleanupFrequency.get().requiresCleanup(CleanupFrequency.NEVER_CLEANED)
+
+        when:
+        cacheConfigurations.allowCleanupOnlyIfSuccessful { return null }
+
+        then:
+        cacheConfigurations.cleanupFrequency.get().requiresCleanup(CleanupFrequency.NEVER_CLEANED)
     }
 
     void assertCannotConfigureErrorIsThrown(Exception e, String name) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/cache/DefaultCacheConfigurationsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/cache/DefaultCacheConfigurationsTest.groovy
@@ -205,7 +205,7 @@ class DefaultCacheConfigurationsTest extends Specification {
         !cacheConfigurations.cleanupFrequency.get().requiresCleanup(CleanupFrequency.NEVER_CLEANED)
 
         when:
-        cacheConfigurations.allowCleanupOnlyIfSuccessful { return null }
+        cacheConfigurations.cleanupHasBeenConfigured = true
 
         then:
         cacheConfigurations.cleanupFrequency.get().requiresCleanup(CleanupFrequency.NEVER_CLEANED)

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/GradleUserHomeCleanupServiceTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/GradleUserHomeCleanupServiceTest.groovy
@@ -30,6 +30,7 @@ import org.gradle.internal.time.TimestampSuppliers
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.GradleVersion
+import org.gradle.util.TestUtil
 import org.junit.Rule
 import spock.lang.Specification
 import spock.lang.Subject
@@ -68,6 +69,7 @@ class GradleUserHomeCleanupServiceTest extends Specification implements GradleUs
     def cacheConfigurations = Stub(CacheConfigurationsInternal) {
         getReleasedWrappers() >> releasedWrappers
         getSnapshotWrappers() >> snapshotWrappers
+        getCleanupFrequency() >> TestUtil.providerFactory().provider { CleanupFrequency.DAILY }
     }
 
     def property(Object value) {

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/GradleUserHomeCleanupFixture.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/GradleUserHomeCleanupFixture.groovy
@@ -23,6 +23,8 @@ import org.gradle.util.GradleVersion
 import org.gradle.util.JarUtils
 import org.gradle.util.internal.DefaultGradleVersion
 
+import java.text.SimpleDateFormat
+import java.time.Instant
 import java.util.concurrent.TimeUnit
 
 import static org.gradle.cache.internal.WrapperDistributionCleanupAction.WRAPPER_DISTRIBUTION_FILE_PATH
@@ -132,6 +134,75 @@ trait GradleUserHomeCleanupFixture implements VersionSpecificCacheCleanupFixture
         @Override
         String toString() {
             return super.toString().toLowerCase()
+        }
+    }
+
+    GradleDistDirs versionedDistDirs(String version, MarkerFileType lastUsed, String customDistName) {
+        def distVersion = GradleVersion.version(version)
+        return new GradleDistDirs(
+            createVersionSpecificCacheDir(distVersion, lastUsed),
+            createDistributionChecksumDir(distVersion).parentFile,
+            createCustomDistributionChecksumDir(customDistName, distVersion).parentFile
+        )
+    }
+
+    static class GradleDistDirs {
+        private final TestFile cacheDir
+        private final TestFile distDir
+        private final TestFile customDistDir
+
+        GradleDistDirs(TestFile cacheDir, TestFile distDir, TestFile customDistDir) {
+            this.cacheDir = cacheDir
+            this.distDir = distDir
+            this.customDistDir = customDistDir
+        }
+
+        void assertAllDirsExist() {
+            cacheDir.assertExists()
+            distDir.assertExists()
+            customDistDir.assertExists()
+        }
+
+        void assertAllDirsDoNotExist() {
+            cacheDir.assertDoesNotExist()
+            distDir.assertDoesNotExist()
+            customDistDir.assertDoesNotExist()
+        }
+    }
+
+    static enum DistType {
+        RELEASED() {
+            @Override
+            String version(String baseVersion) {
+                return baseVersion
+            }
+
+            @Override
+            String alternateVersion(String baseVersion) {
+                throw new UnsupportedOperationException()
+            }
+        },
+        SNAPSHOT() {
+            def formatter = new SimpleDateFormat("yyyyMMddHHmmssZ")
+            def now = Instant.now()
+
+            @Override
+            String version(String baseVersion) {
+                return baseVersion + '-' + formatter.format(Date.from(now))
+            }
+
+            @Override
+            String alternateVersion(String baseVersion) {
+                return baseVersion + '-' + formatter.format(Date.from(now.plusSeconds(60)))
+            }
+        }
+
+        abstract String version(String baseVersion)
+        abstract String alternateVersion(String baseVersion)
+
+        @Override
+        String toString() {
+            return name().toLowerCase()
         }
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractContinuousIntegrationTest.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractContinuousIntegrationTest.groovy
@@ -200,7 +200,7 @@ ${result.error}
             throw new RuntimeException("""Timeout waiting for build to complete. Output:
 $lastOutput
 
-Error: 
+Error:
 ${gradle.errorOutput}
 
 Look for additional thread dump files in the following folder: $temporaryFolder
@@ -314,7 +314,7 @@ Look for additional thread dump files in the following folder: $temporaryFolder
         }
     }
 
-    private waitForNotRunning() {
+    void waitForNotRunning() {
         ConcurrentTestUtil.poll(WAIT_FOR_SHUTDOWN_TIMEOUT_SECONDS) {
             assert !gradle.running
         }

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/CleanupFrequency.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/CleanupFrequency.java
@@ -23,11 +23,13 @@ import java.util.concurrent.TimeUnit;
  *
  * @since 8.0
  */
-public enum CleanupFrequency {
+public interface CleanupFrequency {
+    long NEVER_CLEANED = 0;
+
     /**
      * Trigger cleanup once every 24 hours.
      */
-    DAILY() {
+    CleanupFrequency DAILY = new CleanupFrequency() {
         @Override
         public boolean requiresCleanup(long lastCleanupTimestamp) {
             if (lastCleanupTimestamp == NEVER_CLEANED) {
@@ -38,11 +40,12 @@ public enum CleanupFrequency {
                 return timeInHours >= 24;
             }
         }
-    },
+    };
+
     /**
      * Trigger cleanup after every build session
      */
-    ALWAYS() {
+    CleanupFrequency ALWAYS = new CleanupFrequency() {
         @Override
         public boolean requiresCleanup(long lastCleanupTimestamp) {
             return true;
@@ -52,21 +55,20 @@ public enum CleanupFrequency {
         public boolean shouldCleanupOnEndOfSession() {
             return true;
         }
-    },
+    };
+
     /**
      * Disable cleanup completely
      */
-    NEVER() {
+    CleanupFrequency NEVER = new CleanupFrequency() {
         @Override
         public boolean requiresCleanup(long lastCleanupTimestamp) {
             return false;
         }
     };
 
-    public static final long NEVER_CLEANED = 0;
-
-    public abstract boolean requiresCleanup(long lastCleanupTimestamp);
-    public boolean shouldCleanupOnEndOfSession() {
+    boolean requiresCleanup(long lastCleanupTimestamp);
+    default boolean shouldCleanupOnEndOfSession() {
         return false;
     }
 }


### PR DESCRIPTION
Initialization and settings scripts must now succeed before cache cleanup can occur.  Cache cleanup is disabled until settings are configured.  On subsequent builds, we disable cleanup before evaluating init and settings scripts and only reenable once evaluation has succeeded.

