### PR TITLE
Add documentation about temporary compile outputs

### DIFF
--- a/subprojects/docs/src/docs/userguide/jvm/java_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/java_plugin.adoc
@@ -515,7 +515,7 @@ To help you understand how incremental compilation works, the following provides
 * Having a source structure that does not match the package names, while legal for compilation, might end up causing trouble in the toolchain.
     Even more if annotation processing and <<build_cache.adoc#build_cache,caching>> are involved.
 
-Additionally, Gradle might temporary change the output location while running incremental compilation. This might affect some annotation processors that inspect output locations and which allow users to wire some action to file paths (e.g. `-XepExcludedPaths` in Error Prone). You can disable this Gradle behaviour by setting link:{javadocPath}/org/gradle/api/tasks/compile/CompileOptions.html#getIncrementalAfterFailure--[`options.incrementalAfterFailure`] to `false` on the JavaCompile task. Alternatively you can specifying temporary output path to annotation processor. Output location mapping to temporary output locations is listed in the next table:
+Additionally, Gradle might temporary change the output location while running incremental compilation. This might affect some annotation processors that inspect output locations and which allow users to wire some action to file paths (e.g. `-XepExcludedPaths` in Error Prone). You can disable this Gradle behaviour by setting link:{javadocPath}/org/gradle/api/tasks/compile/CompileOptions.html#getIncrementalAfterFailure--[`options.incrementalAfterFailure`] to `false` on the JavaCompile task. Alternatively you can try specify temporary output path to annotation processor. Output location mapping to temporary output locations is listed in the next table:
 
 .Compiler output to temporary output locations mapping
 |===

--- a/subprojects/docs/src/docs/userguide/jvm/java_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/java_plugin.adoc
@@ -515,11 +515,11 @@ To help you understand how incremental compilation works, the following provides
 * Having a source structure that does not match the package names, while legal for compilation, might end up causing trouble in the toolchain.
     Even more if annotation processing and <<build_cache.adoc#build_cache,caching>> are involved.
 
-Additionally, Gradle might temporary change the output location while running incremental compilation.
-This might affect some annotation processors that inspect output locations and which allow users to wire some action to file paths (e.g. `-XepExcludedPaths` in Error Prone).
-You can disable this Gradle behaviour by setting link:{javadocPath}/org/gradle/api/tasks/compile/CompileOptions.html#getIncrementalAfterFailure--[`options.incrementalAfterFailure`] to `false` on the JavaCompile task.
+Additionally, Gradle might temporarily change the output location while running incremental compilation.
+This might affect some annotation processors that inspect output locations or accept file paths as arguments (e.g. `-XepExcludedPaths` in Error Prone).
+You can disable this behaviour by setting link:{javadocPath}/org/gradle/api/tasks/compile/CompileOptions.html#getIncrementalAfterFailure--[`options.incrementalAfterFailure`] to `false` on the JavaCompile task.
 Alternatively, you can try to specify a temporary output path to the annotation processor.
-The next table shows the mapping from output location to temporary output location:
+The following table shows the mapping from default output location to temporary output location:
 
 .Compiler output to temporary output location
 |===

--- a/subprojects/docs/src/docs/userguide/jvm/java_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/java_plugin.adoc
@@ -519,10 +519,10 @@ Additionally, Gradle might temporarily change the output location while running 
 This might affect some annotation processors that inspect output locations or accept file paths as arguments (e.g., `-XepExcludedPaths` in Error Prone).
 There are two options:
 
- - You can disable `incremental after failure` by setting the link:{javadocPath}/org/gradle/api/tasks/compile/CompileOptions.html#getIncrementalAfterFailure--[`options.incrementalAfterFailure`] to `false` on the JavaCompile task.
--  You can keep `incremental after failure` working by passing a temporary output value to the annotation processor as a parameter so the annotation processor is aware of that path. In case of Error Prone, pass a value to `-XepExcludedPaths`. For example:
-Before, you might have had: `-XepExcludedPaths=.\*/build/generated/.*`.
-With the new behavior, they might need to do +
+ - Disable `incremental after failure` by setting link:{javadocPath}/org/gradle/api/tasks/compile/CompileOptions.html#getIncrementalAfterFailure--[`options.incrementalAfterFailure`] to `false` on the JavaCompile task.
+-  Keep `incremental after failure` enabled by instead passing a temporary output value to the annotation processor as a parameter so that the annotation processor is aware of the temporary path. 
+
+In the case of Error Prone, `-XepExcludedPaths` must be set. Given an existing value of `-XepExcludedPaths=.\*/build/generated/.*`, the updated value would be
 `-XepExcludedPaths=.\*/(build/generated|compileJava/compileTransaction/annotation-output)/.*`.
 
 The following table shows the mapping from default output location to temporary output location:

--- a/subprojects/docs/src/docs/userguide/jvm/java_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/java_plugin.adoc
@@ -515,7 +515,7 @@ To help you understand how incremental compilation works, the following provides
 * Having a source structure that does not match the package names, while legal for compilation, might end up causing trouble in the toolchain.
     Even more if annotation processing and <<build_cache.adoc#build_cache,caching>> are involved.
 
-Additionally, Gradle might temporary change the output location while running incremental compilation. This might affect some annotation processors that inspect output locations and which allow users to wire some action to file paths (e.g. `-XepExcludedPaths` in Error Prone). You can disable this Gradle behaviour by setting link:{javadocPath}/org/gradle/api/tasks/compile/CompileOptions.html#getIncrementalAfterFailure--[`options.incrementalAfterFailure`] to `false` on the JavaCompile task. Alternatively you can try specify temporary output path to annotation processor. Output location mapping to temporary output locations is listed in the next table:
+Additionally, Gradle might temporary change the output location while running incremental compilation. This might affect some annotation processors that inspect output locations and which allow users to wire some action to file paths (e.g. `-XepExcludedPaths` in Error Prone). You can disable this Gradle behaviour by setting link:{javadocPath}/org/gradle/api/tasks/compile/CompileOptions.html#getIncrementalAfterFailure--[`options.incrementalAfterFailure`] to `false` on the JavaCompile task. Alternatively, you can try to specify a temporary output path to the annotation processor. The next table shows the mapping from output location to temporary output location:
 
 .Compiler output to temporary output location
 |===

--- a/subprojects/docs/src/docs/userguide/jvm/java_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/java_plugin.adoc
@@ -517,9 +517,9 @@ To help you understand how incremental compilation works, the following provides
 
 Additionally, Gradle might temporary change the output location while running incremental compilation. This might affect some annotation processors that inspect output locations and which allow users to wire some action to file paths (e.g. `-XepExcludedPaths` in Error Prone). You can disable this Gradle behaviour by setting link:{javadocPath}/org/gradle/api/tasks/compile/CompileOptions.html#getIncrementalAfterFailure--[`options.incrementalAfterFailure`] to `false` on the JavaCompile task. Alternatively you can try specify temporary output path to annotation processor. Output location mapping to temporary output locations is listed in the next table:
 
-.Compiler output to temporary output locations mapping
+.Compiler output to temporary output location
 |===
-| JavaCompile location property | Example output location | Temporary output location
+| JavaCompile location property | Default output location | Temporary output location
 | `destinationDirectory` | `build/classes/java/main` | `build/tmp/<task-name>/compileTransaction/compile-output`
 | `options.generatedSourceOutputDirectory` | `build/generated/sources/annotationProcessor/java/main` | `build/tmp/<task-name>/compileTransaction/annotation-output`
 | `options.headerOutputDirectory` | `build/generated/sources/headers/java/main` | `build/tmp/<task-name>/compileTransaction/header-output`

--- a/subprojects/docs/src/docs/userguide/jvm/java_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/java_plugin.adoc
@@ -515,6 +515,16 @@ To help you understand how incremental compilation works, the following provides
 * Having a source structure that does not match the package names, while legal for compilation, might end up causing trouble in the toolchain.
     Even more if annotation processing and <<build_cache.adoc#build_cache,caching>> are involved.
 
+Additionally, Gradle might temporary change the output location while running incremental compilation. This might affect some annotation processors that inspect output locations and which allow users to wire some action to file paths (e.g. `-XepExcludedPaths` in Error Prone). You can disable this Gradle behaviour by setting link:{javadocPath}/org/gradle/api/tasks/compile/CompileOptions.html#getIncrementalAfterFailure--[`options.incrementalAfterFailure`] to `false` on the JavaCompile task. Alternatively you can specifying temporary output path to annotation processor. Output location mapping to temporary output locations is listed in the next table:
+
+.Compiler output to temporary output locations mapping
+|===
+| JavaCompile location property | Example output location | Temporary output location
+| `destinationDirectory` | `build/classes/java/main` | `build/tmp/<task-name>/compileTransaction/compile-output`
+| `options.generatedSourceOutputDirectory` | `build/generated/sources/annotationProcessor/java/main` | `build/tmp/<task-name>/compileTransaction/annotation-output`
+| `options.headerOutputDirectory` | `build/generated/sources/headers/java/main` | `build/tmp/<task-name>/compileTransaction/header-output`
+|===
+
 [[sec:incremental_annotation_processing]]
 == Incremental annotation processing
 

--- a/subprojects/docs/src/docs/userguide/jvm/java_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/java_plugin.adoc
@@ -515,7 +515,11 @@ To help you understand how incremental compilation works, the following provides
 * Having a source structure that does not match the package names, while legal for compilation, might end up causing trouble in the toolchain.
     Even more if annotation processing and <<build_cache.adoc#build_cache,caching>> are involved.
 
-Additionally, Gradle might temporary change the output location while running incremental compilation. This might affect some annotation processors that inspect output locations and which allow users to wire some action to file paths (e.g. `-XepExcludedPaths` in Error Prone). You can disable this Gradle behaviour by setting link:{javadocPath}/org/gradle/api/tasks/compile/CompileOptions.html#getIncrementalAfterFailure--[`options.incrementalAfterFailure`] to `false` on the JavaCompile task. Alternatively, you can try to specify a temporary output path to the annotation processor. The next table shows the mapping from output location to temporary output location:
+Additionally, Gradle might temporary change the output location while running incremental compilation.
+This might affect some annotation processors that inspect output locations and which allow users to wire some action to file paths (e.g. `-XepExcludedPaths` in Error Prone).
+You can disable this Gradle behaviour by setting link:{javadocPath}/org/gradle/api/tasks/compile/CompileOptions.html#getIncrementalAfterFailure--[`options.incrementalAfterFailure`] to `false` on the JavaCompile task.
+Alternatively, you can try to specify a temporary output path to the annotation processor.
+The next table shows the mapping from output location to temporary output location:
 
 .Compiler output to temporary output location
 |===

--- a/subprojects/docs/src/docs/userguide/jvm/java_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/java_plugin.adoc
@@ -516,9 +516,15 @@ To help you understand how incremental compilation works, the following provides
     Even more if annotation processing and <<build_cache.adoc#build_cache,caching>> are involved.
 
 Additionally, Gradle might temporarily change the output location while running incremental compilation.
-This might affect some annotation processors that inspect output locations or accept file paths as arguments (e.g. `-XepExcludedPaths` in Error Prone).
-You can disable this behaviour by setting link:{javadocPath}/org/gradle/api/tasks/compile/CompileOptions.html#getIncrementalAfterFailure--[`options.incrementalAfterFailure`] to `false` on the JavaCompile task.
-Alternatively, you can try to specify a temporary output path to the annotation processor.
+This might affect some annotation processors that inspect output locations or accept file paths as arguments (e.g., `-XepExcludedPaths` in Error Prone).
+There are two options:
+
+ - You can disable `incremental after failure` by setting the link:{javadocPath}/org/gradle/api/tasks/compile/CompileOptions.html#getIncrementalAfterFailure--[`options.incrementalAfterFailure`] to `false` on the JavaCompile task.
+-  You can keep `incremental after failure` working by passing a temporary output value to the annotation processor as a parameter so the annotation processor is aware of that path. In case of Error Prone, pass a value to `-XepExcludedPaths`. For example:
+Before, you might have had: `-XepExcludedPaths=.\*/build/generated/.*`.
+With the new behavior, they might need to do +
+`-XepExcludedPaths=.\*/(build/generated|compileJava/compileTransaction/annotation-output)/.*`.
+
 The following table shows the mapping from default output location to temporary output location:
 
 .Compiler output to temporary output location

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -744,7 +744,7 @@ For more information, see the updated <<jvm_test_suite_plugin.adoc#sec:declare_a
 
 ==== Incremental compilation temporarily changes the output location
 
-Java and Groovy compilation changes the compiler output location.
+Incremental Java and Groovy compilation may now change the compiler output location.
 This might affect some annotation processors that allow users to wire some action to file paths (e.g. `-XepExcludedPaths` in Error Prone).
 This behaviour can be disabled by setting `options.incrementalAfterFailure` to `false`.
 Please refer to the <<java_plugin#sec:incremental_compilation_known_issues, userguide section about known incremental compilation issues>> for more details.

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -742,6 +742,12 @@ Use `implementation.bundle(libs.bundles.testing)` instead.
 
 For more information, see the updated <<jvm_test_suite_plugin.adoc#sec:declare_an_additional_test_suite, declare an additional test suite>> example in the JVM Test Suite Plugin section of the user guide and the link:{groovyDslPath}/org.gradle.api.artifacts.dsl.DependencyAdder.html[`DependencyAdder`] page in the DSL reference.
 
+==== Incremental compilation temporarily changes the output location
+
+Java and Groovy compilation changes the compiler output location. This might affect some annotation processors that allow users to wire some action to file paths (e.g. `-XepExcludedPaths` in Error Prone).
+This behaviour can be disabled by setting `options.incrementalAfterFailure` to `false`.
+Please refer to the <<java_plugin#sec:incremental_compilation_known_issues, userguide section about known incremental compilation issues>> for more details.
+
 === Deprecations
 
 [[invalid_toolchain_specification_deprecation]]

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -744,7 +744,8 @@ For more information, see the updated <<jvm_test_suite_plugin.adoc#sec:declare_a
 
 ==== Incremental compilation temporarily changes the output location
 
-Java and Groovy compilation changes the compiler output location. This might affect some annotation processors that allow users to wire some action to file paths (e.g. `-XepExcludedPaths` in Error Prone).
+Java and Groovy compilation changes the compiler output location.
+This might affect some annotation processors that allow users to wire some action to file paths (e.g. `-XepExcludedPaths` in Error Prone).
 This behaviour can be disabled by setting `options.incrementalAfterFailure` to `false`.
 Please refer to the <<java_plugin#sec:incremental_compilation_known_issues, userguide section about known incremental compilation issues>> for more details.
 

--- a/subprojects/docs/src/main/resources/header.html
+++ b/subprojects/docs/src/main/resources/header.html
@@ -225,7 +225,6 @@
             <li><a href="../userguide/dependency_management_for_java_projects.html">Managing Dependencies</a></li>
             <li><a class="nav-dropdown" data-toggle="collapse" href="#jvm-plugins" aria-expanded="false" aria-controls="jvm-plugins">JVM Plugins</a>
                 <ul id="jvm-plugins">
-                    <li><a href="../userguide/java_plugin.html">Java Plugin</a></li>
                     <li><a href="../userguide/java_library_plugin.html">Java Library Plugin</a></li>
                     <li><a href="../userguide/application_plugin.html">Java Application Plugin</a></li>
                     <li><a href="../userguide/java_platform_plugin.html">Java Platform Plugin</a></li>

--- a/subprojects/docs/src/main/resources/header.html
+++ b/subprojects/docs/src/main/resources/header.html
@@ -225,6 +225,7 @@
             <li><a href="../userguide/dependency_management_for_java_projects.html">Managing Dependencies</a></li>
             <li><a class="nav-dropdown" data-toggle="collapse" href="#jvm-plugins" aria-expanded="false" aria-controls="jvm-plugins">JVM Plugins</a>
                 <ul id="jvm-plugins">
+                    <li><a href="../userguide/java_plugin.html">Java Plugin</a></li>
                     <li><a href="../userguide/java_library_plugin.html">Java Library Plugin</a></li>
                     <li><a href="../userguide/application_plugin.html">Java Application Plugin</a></li>
                     <li><a href="../userguide/java_platform_plugin.html">Java Platform Plugin</a></li>


### PR DESCRIPTION
Documentation for https://github.com/gradle/gradle/issues/23066.

We might add improvements that remove the behaviour in 8.1.