### PR TITLE
Fix issue with ALWAYS cache cleanup not firing on session end

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/cache/internal/GradleUserHomeCleanupServiceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/cache/internal/GradleUserHomeCleanupServiceIntegrationTest.groovy
@@ -18,10 +18,12 @@ package org.gradle.cache.internal
 
 import org.gradle.api.internal.cache.CacheConfigurationsInternal
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.GradleVersion
 
 import static org.gradle.cache.internal.VersionSpecificCacheCleanupFixture.MarkerFileType.USED_TODAY
+import static org.gradle.internal.service.scopes.DefaultGradleUserHomeScopeServiceRegistry.REUSE_USER_HOME_SERVICES
 
 class GradleUserHomeCleanupServiceIntegrationTest extends AbstractIntegrationSpec implements GradleUserHomeCleanupFixture {
     private static final int HALF_MAX_AGE_IN_DAYS_FOR_RELEASED_DISTS = Math.max(1, CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_RELEASED_DISTS / 2 as int)
@@ -174,6 +176,12 @@ class GradleUserHomeCleanupServiceIntegrationTest extends AbstractIntegrationSpe
 
     def "always cleans up unused version-specific cache directories and corresponding #type distributions when configured"() {
         given:
+        executer.requireIsolatedDaemons() // because we want to reuse Gradle user home services
+        executer.beforeExecute {
+            if (!GradleContextualExecuter.embedded) {
+                executer.withArgument("-D$REUSE_USER_HOME_SERVICES=true")
+            }
+        }
         requireOwnGradleUserHomeDir() // because we delete caches and distributions
         alwaysCleanupCaches()
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -1633,9 +1633,19 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
 
         when:
         run '--stop' // ensure daemon does not cache file access times in memory
+
+        then:
+        gcFile.assertExists()
+
+        when:
         writeLastTransformationAccessTimeToJournal(outputDir1.parentFile, daysAgo(HALF_DEFAULT_MAX_AGE_IN_DAYS + 1))
 
         and:
+        executer.beforeExecute {
+            if (!GradleContextualExecuter.embedded) {
+                executer.withArgument("-D$REUSE_USER_HOME_SERVICES=true")
+            }
+        }
         // start as new process so journal is not restored from in-memory cache
         executer.withTasks("help").start().waitForFinish()
 


### PR DESCRIPTION
#23244 broke the ALWAYS cleanup frequency such that cleanup was no longer occurring at the end of the build session.  It turns out that our integration tests don't reuse Gradle user home services by default, which meant that the tests that should have caught this didn't because cleanup was still getting called at session end when the GUH caches were being closed.

This change fixes the issue and adjusts the tests that would catch this problem by ensuring that they reuse Gradle user home services and won't introduce a cache close.