### PR TITLE
Intercept instrumentable classloaders in the agent

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/agents/DefaultClassFileTransformer.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/agents/DefaultClassFileTransformer.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.agents;
+
+import org.gradle.internal.UncheckedException;
+
+import java.lang.instrument.ClassFileTransformer;
+import java.lang.reflect.Method;
+import java.security.ProtectionDomain;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class DefaultClassFileTransformer implements ClassFileTransformer {
+    private static final AtomicBoolean INSTALLED = new AtomicBoolean();
+
+    @Override
+    public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) {
+        if (!(loader instanceof InstrumentingClassLoader)) {
+            return null;
+        }
+        InstrumentingClassLoader instrumentingLoader = (InstrumentingClassLoader) loader;
+        try {
+            return instrumentingLoader.instrumentClass(className, protectionDomain, classfileBuffer);
+        } catch (Throwable th) {
+            // Throwing exception from the ClassFileTransformer has no effect - if it happens, the class is loaded unchanged silently.
+            // This is not something we want, so we notify the class loader about this.
+            instrumentingLoader.transformFailed(th);
+            return null;
+        }
+    }
+
+    @SuppressWarnings("unused")  // Used reflectively
+    public static boolean tryInstall() {
+        // Installing the same transformer multiple times is very problematic, so additional correctness check is worth it.
+        if (!INSTALLED.compareAndSet(false, true)) {
+            throw new IllegalStateException("The transformer is already installed in " + DefaultClassFileTransformer.class.getClassLoader());
+        }
+        return AgentControl.installTransformer(new DefaultClassFileTransformer());
+    }
+
+    public static boolean tryInstallInClassLoader(ClassLoader classLoader) {
+        // Potentially reload this class in the provided class loader.
+        try {
+            Class<?> transformer = classLoader.loadClass(DefaultClassFileTransformer.class.getName());
+            Method tryInstall = transformer.getMethod("tryInstall");
+            tryInstall.setAccessible(true);
+            return (Boolean) tryInstall.invoke(null);
+        } catch (Exception e) {
+            throw UncheckedException.throwAsUncheckedException(e);
+        }
+    }
+}

--- a/subprojects/base-services/src/main/java/org/gradle/internal/agents/InstrumentingClassLoader.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/agents/InstrumentingClassLoader.java
@@ -16,5 +16,12 @@
 
 package org.gradle.internal.agents;
 
+import javax.annotation.Nullable;
+import java.security.ProtectionDomain;
+
 public interface InstrumentingClassLoader {
+    @Nullable
+    byte[] instrumentClass(String className, ProtectionDomain protectionDomain, byte[] classfileBuffer);
+
+    void transformFailed(Throwable th);
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/agents/InstrumentingClassLoader.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/agents/InstrumentingClassLoader.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.agents;
+
+public interface InstrumentingClassLoader {
+}

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/DefaultClassLoaderFactory.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/DefaultClassLoaderFactory.java
@@ -84,7 +84,7 @@ public class DefaultClassLoaderFactory implements ClassLoaderFactory {
     }
 
     protected ClassLoader doCreateClassLoader(String name, ClassLoader parent, ClassPath classPath) {
-        return new VisitableURLClassLoader(name, parent, classPath);
+        return VisitableURLClassLoader.fromClassPath(name, parent, classPath);
     }
 
     protected ClassLoader doCreateFilteringClassLoader(ClassLoader parent, FilteringClassLoader.Spec spec) {

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classpath/DefaultClassPath.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classpath/DefaultClassPath.java
@@ -148,6 +148,10 @@ public class DefaultClassPath implements ClassPath, Serializable {
         if (other.isEmpty()) {
             return this;
         }
+        if (other instanceof TransformedClassPath) {
+            // Any combination of TransformedClassPath and other ClassPath has to remain transformed.
+            return ((TransformedClassPath) other).prepend(this);
+        }
         return new DefaultClassPath(concat(files, other.getAsFiles()));
     }
 

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classpath/TransformedClassPath.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classpath/TransformedClassPath.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.classpath;
+
+import org.gradle.api.specs.Spec;
+
+import java.io.File;
+import java.net.URI;
+import java.net.URL;
+import java.util.Collection;
+import java.util.List;
+
+public class TransformedClassPath implements ClassPath {
+    private final ClassPath transformedClassPath;
+
+    public TransformedClassPath(ClassPath transformedClassPath) {
+        this.transformedClassPath = transformedClassPath;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return transformedClassPath.isEmpty();
+    }
+
+    @Override
+    public List<URI> getAsURIs() {
+        return transformedClassPath.getAsURIs();
+    }
+
+    @Override
+    public List<File> getAsFiles() {
+        return transformedClassPath.getAsFiles();
+    }
+
+    @Override
+    public List<URL> getAsURLs() {
+        return transformedClassPath.getAsURLs();
+    }
+
+    @Override
+    public URL[] getAsURLArray() {
+        return transformedClassPath.getAsURLArray();
+    }
+
+    ClassPath prepend(DefaultClassPath classPath) {
+        return new TransformedClassPath(classPath.plus(transformedClassPath));
+    }
+
+    @Override
+    public ClassPath plus(Collection<File> classPath) {
+        return new TransformedClassPath(transformedClassPath.plus(classPath));
+    }
+
+    @Override
+    public ClassPath plus(ClassPath classPath) {
+        return new TransformedClassPath(transformedClassPath.plus(classPath));
+    }
+
+    @Override
+    public ClassPath removeIf(Spec<? super File> filter) {
+        return new TransformedClassPath(transformedClassPath.removeIf(filter));
+    }
+
+    @Override
+    public int hashCode() {
+        return transformedClassPath.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null || obj.getClass() != getClass()) {
+            return false;
+        }
+        TransformedClassPath other = (TransformedClassPath) obj;
+        return transformedClassPath.equals(other.transformedClassPath);
+    }
+}

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprint.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprint.kt
@@ -29,7 +29,12 @@ sealed class ConfigurationCacheFingerprint {
     data class GradleEnvironment(
         val gradleUserHomeDir: File,
         val jvm: String,
-        val startParameterProperties: Map<String, Any?>
+        val startParameterProperties: Map<String, Any?>,
+        /**
+         * Whether the instrumentation agent was used when computing the cache.
+         * With the agent, the class paths may be stored differently, making the caches incompatible with one another.
+         */
+        val instrumentationAgentUsed: Boolean
     ) : ConfigurationCacheFingerprint()
 
     data class InitScripts(

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintChecker.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintChecker.kt
@@ -45,6 +45,7 @@ class ConfigurationCacheFingerprintChecker(private val host: Host) {
         val startParameterProperties: Map<String, Any?>
         val buildStartTime: Long
         val invalidateCoupledProjects: Boolean
+        val instrumentationAgentUsed: Boolean
         fun gradleProperty(propertyName: String): String?
         fun fingerprintOf(fileCollection: FileCollectionInternal): HashCode
         fun hashCodeOf(file: File): HashCode?
@@ -184,6 +185,13 @@ class ConfigurationCacheFingerprintChecker(private val host: Host) {
                 }
                 if (host.startParameterProperties != startParameterProperties) {
                     return "the set of Gradle properties has changed"
+                }
+                if (host.instrumentationAgentUsed != instrumentationAgentUsed) {
+                    val statusChangeString = when (instrumentationAgentUsed) {
+                        true -> "is no longer available"
+                        false -> "is now applied"
+                    }
+                    return "the instrumentation Java agent $statusChangeString"
                 }
             }
             is ConfigurationCacheFingerprint.EnvironmentVariablesPrefixedBy -> input.run {

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintController.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintController.kt
@@ -35,6 +35,7 @@ import org.gradle.configurationcache.problems.location
 import org.gradle.configurationcache.serialization.DefaultWriteContext
 import org.gradle.configurationcache.serialization.ReadContext
 import org.gradle.configurationcache.services.EnvironmentChangeTracker
+import org.gradle.internal.agents.AgentControl
 import org.gradle.internal.buildtree.BuildModelParameters
 import org.gradle.internal.concurrent.Stoppable
 import org.gradle.internal.event.ListenerManager
@@ -293,6 +294,9 @@ class ConfigurationCacheFingerprintController internal constructor(
         override val cacheIntermediateModels: Boolean
             get() = modelParameters.isIntermediateModelCache
 
+        override val instrumentationAgentUsed: Boolean
+            get() = AgentControl.isInstrumentationAgentApplied()
+
         override fun hashCodeOf(file: File) =
             fileSystemAccess.hashCodeOf(file)
 
@@ -331,6 +335,9 @@ class ConfigurationCacheFingerprintController internal constructor(
 
         override val invalidateCoupledProjects: Boolean
             get() = modelParameters.isInvalidateCoupledProjects
+
+        override val instrumentationAgentUsed: Boolean
+            get() = AgentControl.isInstrumentationAgentApplied()
 
         override fun gradleProperty(propertyName: String): String? =
             gradleProperties.find(propertyName)?.uncheckedCast()

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintWriter.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintWriter.kt
@@ -108,6 +108,7 @@ class ConfigurationCacheFingerprintWriter(
         val startParameterProperties: Map<String, Any?>
         val buildStartTime: Long
         val cacheIntermediateModels: Boolean
+        val instrumentationAgentUsed: Boolean
         fun fingerprintOf(fileCollection: FileCollectionInternal): HashCode
         fun hashCodeOf(file: File): HashCode?
         fun displayNameOf(file: File): String
@@ -161,7 +162,8 @@ class ConfigurationCacheFingerprintWriter(
             ConfigurationCacheFingerprint.GradleEnvironment(
                 host.gradleUserHomeDir,
                 jvmFingerprint(),
-                host.startParameterProperties
+                host.startParameterProperties,
+                host.instrumentationAgentUsed
             )
         )
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/antbuilder/DefaultIsolatedAntBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/antbuilder/DefaultIsolatedAntBuilder.java
@@ -101,7 +101,7 @@ public class DefaultIsolatedAntBuilder implements IsolatedAntBuilder, Stoppable 
 
         // Need Transformer (part of AntBuilder API) from base services
         gradleCoreUrls = gradleCoreUrls.plus(moduleRegistry.getModule("gradle-base-services").getImplementationClasspath());
-        this.antAdapterLoader = new VisitableURLClassLoader("gradle-core-loader", baseAntLoader, gradleCoreUrls);
+        this.antAdapterLoader = VisitableURLClassLoader.fromClassPath("gradle-core-loader", baseAntLoader, gradleCoreUrls);
 
         gradleApiGroovyLoader = groovySystemLoaderFactory.forClassLoader(this.getClass().getClassLoader());
         antAdapterGroovyLoader = groovySystemLoaderFactory.forClassLoader(antAdapterLoader);
@@ -138,7 +138,7 @@ public class DefaultIsolatedAntBuilder implements IsolatedAntBuilder, Stoppable 
             new Factory<ClassLoader>() {
                 @Override
                 public ClassLoader create() {
-                    return new VisitableURLClassLoader("ant-lib-loader", baseAntLoader, libClasspath);
+                    return VisitableURLClassLoader.fromClassPath("ant-lib-loader", baseAntLoader, libClasspath);
                 }
             }, new Action<CachedClassLoader>() {
                 @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultCachedClasspathTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultCachedClasspathTransformer.java
@@ -22,6 +22,7 @@ import org.gradle.cache.GlobalCacheLocations;
 import org.gradle.cache.PersistentCache;
 import org.gradle.cache.scopes.GlobalScopedCache;
 import org.gradle.internal.Either;
+import org.gradle.internal.agents.AgentControl;
 import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.concurrent.ManagedExecutor;
@@ -123,12 +124,16 @@ public class DefaultCachedClasspathTransformer implements CachedClasspathTransfo
     }
 
     private ClassPath transformFiles(ClassPath classPath, ClasspathFileTransformer transformer) {
-        return DefaultClassPath.of(
+        ClassPath transformedClassPath = DefaultClassPath.of(
             transformAll(
                 classPath.getAsFiles(),
                 (file, seen) -> cachedFile(file, transformer, seen)
             )
         );
+        if (AgentControl.isInstrumentationAgentApplied()) {
+            return new TransformedClassPath(transformedClassPath);
+        }
+        return transformedClassPath;
     }
 
     private Transform transformerFor(StandardTransform transform) {

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/MixInLegacyTypesClassLoaderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/MixInLegacyTypesClassLoaderTest.groovy
@@ -243,7 +243,7 @@ class MixInLegacyTypesClassLoaderTest extends Specification {
         def fileManager = compiler.getStandardFileManager(null, null, null)
         def task = compiler.getTask(null, fileManager, null, ["-d", classesDir.path], null, fileManager.getJavaFileObjects(srcFile))
         task.call()
-        def cl = new VisitableURLClassLoader("groovy-loader", groovyClassLoader, DefaultClassPath.of(classesDir))
+        def cl = VisitableURLClassLoader.fromClassPath("groovy-loader", groovyClassLoader, DefaultClassPath.of(classesDir))
         cl.loadClass(className)
     }
 }

--- a/subprojects/instrumentation-agent/src/main/java/org/gradle/instrumentation/agent/Agent.java
+++ b/subprojects/instrumentation-agent/src/main/java/org/gradle/instrumentation/agent/Agent.java
@@ -16,13 +16,14 @@
 
 package org.gradle.instrumentation.agent;
 
+import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.Instrumentation;
 
 /**
  * An entry point for the on-the-fly bytecode instrumentation agent.
  */
 public class Agent {
-    private static boolean isApplied;
+    private static volatile Instrumentation instrumentation;
 
     public static void premain(String agentArgs, Instrumentation inst) {
         doMain(inst);
@@ -33,11 +34,21 @@ public class Agent {
     }
 
     static void doMain(Instrumentation inst) {
-        isApplied = true;
+        instrumentation = inst;
     }
 
     @SuppressWarnings("unused")  // Used reflectively.
     public static boolean isApplied() {
-        return isApplied;
+        return instrumentation != null;
+    }
+
+    @SuppressWarnings("unused")  // Used reflectively.
+    public static boolean installTransformer(ClassFileTransformer transformer) {
+        Instrumentation inst = instrumentation;
+        if (inst != null) {
+            inst.addTransformer(transformer);
+            return true;
+        }
+        return false;
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkTools.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkTools.java
@@ -81,7 +81,7 @@ public class JdkTools {
             isolatedToolsLoader = new VisitableURLClassLoader("jdk-tools", filteringClassLoader, defaultClassPath.getAsURLs());
             isJava9Compatible = false;
         } else {
-            isolatedToolsLoader = new VisitableURLClassLoader("jdk-tools", filteringClassLoader, DefaultClassPath.of(compilerPlugins));
+            isolatedToolsLoader = VisitableURLClassLoader.fromClassPath("jdk-tools", filteringClassLoader, DefaultClassPath.of(compilerPlugins));
             isJava9Compatible = true;
         }
     }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/bootstrap/ProcessBootstrap.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/bootstrap/ProcessBootstrap.java
@@ -48,7 +48,7 @@ public class ProcessBootstrap {
         ClassPath antClasspath = classPathRegistry.getClassPath("ANT");
         ClassPath runtimeClasspath = classPathRegistry.getClassPath("GRADLE_RUNTIME");
         ClassLoader antClassLoader = classLoaderFactory.createIsolatedClassLoader("ant-loader", antClasspath);
-        ClassLoader runtimeClassLoader = new VisitableURLClassLoader("ant-and-gradle-loader", antClassLoader, runtimeClasspath);
+        ClassLoader runtimeClassLoader = VisitableURLClassLoader.fromClassPath("ant-and-gradle-loader", antClassLoader, runtimeClasspath);
 
         ClassLoader oldClassLoader = Thread.currentThread().getContextClassLoader();
         Thread.currentThread().setContextClassLoader(runtimeClassLoader);

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/bootstrap/ProcessBootstrap.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/bootstrap/ProcessBootstrap.java
@@ -19,6 +19,7 @@ import org.gradle.api.internal.ClassPathRegistry;
 import org.gradle.api.internal.DefaultClassPathProvider;
 import org.gradle.api.internal.DefaultClassPathRegistry;
 import org.gradle.api.internal.classpath.DefaultModuleRegistry;
+import org.gradle.internal.agents.DefaultClassFileTransformer;
 import org.gradle.internal.classloader.ClassLoaderFactory;
 import org.gradle.internal.classloader.ClassLoaderUtils;
 import org.gradle.internal.classloader.DefaultClassLoaderFactory;
@@ -54,6 +55,7 @@ public class ProcessBootstrap {
         Thread.currentThread().setContextClassLoader(runtimeClassLoader);
 
         try {
+            DefaultClassFileTransformer.tryInstallInClassLoader(runtimeClassLoader);
             Class<?> mainClass = runtimeClassLoader.loadClass(mainClassName);
             Object entryPoint = mainClass.getConstructor().newInstance();
             Method mainMethod = mainClass.getMethod("run", String[].class);

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/loader/DefaultToolingImplementationLoader.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/loader/DefaultToolingImplementationLoader.java
@@ -115,6 +115,6 @@ public class DefaultToolingImplementationLoader implements ToolingImplementation
         filterSpec.allowPackage("org.gradle.tooling.internal.protocol");
         filterSpec.allowClass(JavaVersion.class);
         FilteringClassLoader filteringClassLoader = new FilteringClassLoader(classLoader, filterSpec);
-        return new VisitableURLClassLoader("tooling-implementation-loader", filteringClassLoader, implementationClasspath);
+        return VisitableURLClassLoader.fromClassPath("tooling-implementation-loader", filteringClassLoader, implementationClasspath);
     }
 }


### PR DESCRIPTION
This PR tags all classloaders that are intended for the configuration cache instrumentation with the `InstrumentedClassLoader` interface. The `DefaultClassFileTransformer` hooks into the Java Agent at the daemon start, looks for classes loaded with the classloader implementing the marker interface, and asks the class loaders to further instrument the classes.

How to decide if the classloader should become instrumentable? We wrap all `ClassPath` returned from the instrumentation facility with `TransformedClassPath`, and all operations (except converting `ClassPath` to the list of files and assembling back) keep the `transformed` status. When turning the `TransformedClassPath` into the class loader, the proper class loader type is used.

The feature is under the opt-in feature flag, so no changes of behavior unless you explicitly opt in.

Part of #22939 

This is part 2/3. The prev part is #23123. The next part is #23278.