### PR TITLE
Replace classes with instrumented copies when loading

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/agents/DefaultClassFileTransformer.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/agents/DefaultClassFileTransformer.java
@@ -37,7 +37,7 @@ public class DefaultClassFileTransformer implements ClassFileTransformer {
         } catch (Throwable th) {
             // Throwing exception from the ClassFileTransformer has no effect - if it happens, the class is loaded unchanged silently.
             // This is not something we want, so we notify the class loader about this.
-            instrumentingLoader.transformFailed(th);
+            instrumentingLoader.transformFailed(className, th);
             return null;
         }
     }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/agents/InstrumentingClassLoader.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/agents/InstrumentingClassLoader.java
@@ -21,7 +21,7 @@ import java.security.ProtectionDomain;
 
 public interface InstrumentingClassLoader {
     @Nullable
-    byte[] instrumentClass(String className, ProtectionDomain protectionDomain, byte[] classfileBuffer);
+    byte[] instrumentClass(@Nullable String className, ProtectionDomain protectionDomain, byte[] classfileBuffer);
 
-    void transformFailed(Throwable th);
+    void transformFailed(@Nullable String className, Throwable th);
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/TransformErrorHandler.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/TransformErrorHandler.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.classloader;
+
+import com.google.common.base.Throwables;
+
+import javax.annotation.Nullable;
+
+/**
+ * A helper to handle transform errors in {@link org.gradle.internal.agents.InstrumentingClassLoader}.
+ */
+public class TransformErrorHandler {
+    private final ThreadLocal<ClassNotFoundException> lastError = new ThreadLocal<ClassNotFoundException>();
+    private final String classLoaderName;
+
+    public TransformErrorHandler(String classLoaderName) {
+        this.classLoaderName = classLoaderName;
+    }
+
+    /**
+     * Marks the beginning of code where a transformation exception may occur.
+     *
+     * @throws ClassNotFoundException if there is a pending exception from outside the scope
+     */
+    public void enterClassLoadingScope(String className) throws ClassNotFoundException {
+        ClassNotFoundException lastError = getLastErrorAndClear();
+        if (lastError != null) {
+            throw new ClassNotFoundException("A pending instrumentation exception prevented loading a class " + className + " in " + classLoaderName, lastError);
+        }
+    }
+
+    public void classLoadingError(@Nullable String className, Throwable cause) {
+        ClassNotFoundException newError = new ClassNotFoundException("Failed to instrument class " + className + " in " + classLoaderName, cause);
+        Throwable prevError = lastError.get();
+        if (prevError == null) {
+            lastError.set(newError);
+        } else {
+            // We've got a chain of exceptions while loading classes.
+            addSuppressedIfAvailable(prevError, newError);
+        }
+    }
+
+    /**
+     * Marks the end of code where a transformation exception may occur.
+     *
+     * @throws ClassNotFoundException if the exception happened during transformation
+     */
+    public void exitClassLoadingScope() throws ClassNotFoundException {
+        ClassNotFoundException lastError = getLastErrorAndClear();
+        if (lastError != null) {
+            throw lastError;
+        }
+    }
+    /**
+     * Marks the end of code where a transformation exception may occur, if this block completed exceptionally.
+     * Rethrows the supplied throwable.
+     *
+     * @return this method never returns, but can be used in a throw expression
+     */
+    public ClassNotFoundException exitClassLoadingScopeWithException(Throwable th) throws ClassNotFoundException {
+        ClassNotFoundException pendingException = getLastErrorAndClear();
+        if (pendingException != null) {
+            addSuppressedIfAvailable(th, pendingException);
+        }
+        Throwables.propagateIfPossible(th, ClassNotFoundException.class);
+        throw new RuntimeException("Unexpected exception type", th);
+    }
+
+    @Nullable
+    private ClassNotFoundException getLastErrorAndClear() {
+        ClassNotFoundException th = lastError.get();
+        lastError.remove();
+        return th;
+    }
+
+    @SuppressWarnings("Since15")
+    private static void addSuppressedIfAvailable(Throwable th, Throwable suppressed) {
+        try {
+            th.addSuppressed(suppressed);
+        } catch (NoSuchMethodError ignored) {
+            // addSuppressed is Java 7+
+        }
+    }
+}

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/TransformReplacer.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/TransformReplacer.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.classloader;
+
+import org.gradle.api.UncheckedIOException;
+import org.gradle.internal.IoActions;
+import org.gradle.internal.classpath.TransformedClassPath;
+import org.gradle.internal.io.StreamByteBuffer;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.security.CodeSource;
+import java.security.ProtectionDomain;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+public class TransformReplacer implements Closeable {
+    private static final Loader SKIP_INSTRUMENTATION = new Loader();
+    private final ConcurrentMap<ProtectionDomain, Loader> loaders;
+    private final TransformedClassPath classPath;
+
+    public TransformReplacer(TransformedClassPath classPath) {
+        this.loaders = new ConcurrentHashMap<ProtectionDomain, Loader>();
+        this.classPath = classPath;
+    }
+
+    @Nullable
+    public byte[] getInstrumentedClass(@Nullable String className, ProtectionDomain protectionDomain) {
+        if (className == null) {
+            // JVM allows to define a class with "null" name through Unsafe. LambdaMetafactory in Java 8 defines a SAM implementation for method handle this way.
+            return null;
+        }
+        try {
+            return getLoader(protectionDomain).loadTransformedClass(className);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private Loader getLoader(@Nullable ProtectionDomain domain) {
+        if (domain == null) {
+            return SKIP_INSTRUMENTATION;
+        }
+        Loader transformLoader = loaders.get(domain);
+        if (transformLoader == null) {
+            File transformedJarPath = findTransformedFile(domain);
+            Loader newLoader = transformedJarPath != null ? new JarLoader(transformedJarPath) : SKIP_INSTRUMENTATION;
+            transformLoader = storeIfAbsent(domain, newLoader);
+        }
+        return transformLoader;
+    }
+
+    private Loader storeIfAbsent(ProtectionDomain domain, Loader newLoader) {
+        Loader oldLoader = loaders.putIfAbsent(domain, newLoader);
+        if (oldLoader != null) {
+            // discard the new loader, someone beat us with storing it
+            return oldLoader;
+        }
+        return newLoader;
+    }
+
+    @Override
+    public void close() {
+        for (Loader value : loaders.values()) {
+            IoActions.closeQuietly(value);
+        }
+    }
+
+    @Nullable
+    private File findTransformedFile(ProtectionDomain protectionDomain) {
+        CodeSource cs = protectionDomain.getCodeSource();
+        URL originalUrl = cs != null ? cs.getLocation() : null;
+        if (originalUrl == null || !"file".equals(originalUrl.getProtocol())) {
+            // Cannot transform classes from anything but files
+            return null;
+        }
+        try {
+            return classPath.findTransformedJarFor(new File(originalUrl.toURI()));
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Cannot parse file URL " + originalUrl, e);
+        }
+    }
+
+    private static class Loader implements Closeable {
+        @CheckForNull
+        public byte[] loadTransformedClass(String className) throws IOException {
+            return null;
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    private static class JarLoader extends Loader {
+        private final File jarFilePath;
+        private JarFile jarFile;
+
+        public JarLoader(File transformedJarFile) {
+            jarFilePath = transformedJarFile;
+        }
+
+        @Override
+        @CheckForNull
+        public synchronized byte[] loadTransformedClass(String className) throws IOException {
+            JarFile jarFile = getJarFileLocked();
+            JarEntry classEntry = jarFile.getJarEntry(classNameToPath(className));
+            if (classEntry == null) {
+                return null;
+            }
+            InputStream classBytes = jarFile.getInputStream(classEntry);
+            try {
+                return StreamByteBuffer.of(classBytes).readAsByteArray();
+            } finally {
+                classBytes.close();
+            }
+        }
+
+        @Override
+        public synchronized void close() {
+            IoActions.closeQuietly(jarFile);
+        }
+
+        private JarFile getJarFileLocked() throws IOException {
+            if (jarFile == null) {
+                jarFile = new JarFile(jarFilePath);
+            }
+            return jarFile;
+        }
+
+        private static String classNameToPath(String className) {
+            return className + ".class";
+        }
+    }
+}

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classpath/TransformedClassPath.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classpath/TransformedClassPath.java
@@ -16,68 +16,121 @@
 
 package org.gradle.internal.classpath;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.gradle.api.specs.Spec;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.net.URI;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.Set;
 
 public class TransformedClassPath implements ClassPath {
-    private final ClassPath transformedClassPath;
+    private final ClassPath originalClassPath;
+    private final ImmutableMap<File, File> transforms;
 
-    public TransformedClassPath(ClassPath transformedClassPath) {
-        this.transformedClassPath = transformedClassPath;
+    private TransformedClassPath(ClassPath originalClassPath, Map<File, File> transforms) {
+        this.originalClassPath = originalClassPath;
+        this.transforms = ImmutableMap.copyOf(transforms);
     }
 
     @Override
     public boolean isEmpty() {
-        return transformedClassPath.isEmpty();
+        return originalClassPath.isEmpty();
     }
 
     @Override
     public List<URI> getAsURIs() {
-        return transformedClassPath.getAsURIs();
+        return originalClassPath.getAsURIs();
     }
 
     @Override
     public List<File> getAsFiles() {
-        return transformedClassPath.getAsFiles();
+        return originalClassPath.getAsFiles();
+    }
+
+    public List<File> getAsTransformedFiles() {
+        List<File> originals = new ArrayList<File>(originalClassPath.getAsFiles());
+        ListIterator<File> iter = originals.listIterator();
+        while (iter.hasNext()) {
+            File original = iter.next();
+            iter.set(transforms.getOrDefault(original, original));
+        }
+        return originals;
     }
 
     @Override
     public List<URL> getAsURLs() {
-        return transformedClassPath.getAsURLs();
+        return originalClassPath.getAsURLs();
     }
 
     @Override
     public URL[] getAsURLArray() {
-        return transformedClassPath.getAsURLArray();
+        return originalClassPath.getAsURLArray();
     }
 
     ClassPath prepend(DefaultClassPath classPath) {
-        return new TransformedClassPath(classPath.plus(transformedClassPath));
+        return new TransformedClassPath(classPath.plus(originalClassPath), transforms);
+    }
+
+    private ClassPath plusWithTransforms(TransformedClassPath classPath) {
+        ClassPath mergedOriginals = originalClassPath.plus(classPath.originalClassPath);
+
+        // Merge transformations, keeping in mind that class paths are searched left-to-right.
+        ImmutableMap.Builder<File, File> mergedTransforms = ImmutableMap.builderWithExpectedSize(transforms.size() + classPath.transforms.size());
+        Set<File> nonTransformedFiles = ImmutableSet.copyOf(originalClassPath.getAsFiles());
+        for (Map.Entry<File, File> appendedTransform : classPath.transforms.entrySet()) {
+            // If we have non-transformed version of the file on this class path, and transformed in the rhs, then the transform is discarded - the original will win.
+            if (!nonTransformedFiles.contains(appendedTransform.getKey())) {
+                mergedTransforms.put(appendedTransform);
+            }
+        }
+        // All transforms that we have win over transforms of the same files in the rhs.
+        mergedTransforms.putAll(transforms);
+
+        return new TransformedClassPath(mergedOriginals, mergedTransforms.buildKeepingLast());
     }
 
     @Override
     public ClassPath plus(Collection<File> classPath) {
-        return new TransformedClassPath(transformedClassPath.plus(classPath));
+        return new TransformedClassPath(originalClassPath.plus(classPath), transforms);
     }
 
     @Override
     public ClassPath plus(ClassPath classPath) {
-        return new TransformedClassPath(transformedClassPath.plus(classPath));
+        if (classPath instanceof TransformedClassPath) {
+            return plusWithTransforms((TransformedClassPath) classPath);
+        }
+        return new TransformedClassPath(originalClassPath.plus(classPath), transforms);
     }
 
     @Override
     public ClassPath removeIf(Spec<? super File> filter) {
-        return new TransformedClassPath(transformedClassPath.removeIf(filter));
+        ClassPath filteredClassPath = originalClassPath.removeIf(filter);
+        Set<File> remainingOriginals = ImmutableSet.copyOf(filteredClassPath.getAsFiles());
+        ImmutableMap.Builder<File, File> remainingTransforms = ImmutableMap.builderWithExpectedSize(Math.min(remainingOriginals.size(), transforms.size()));
+        for (Map.Entry<File, File> remainingEntry : transforms.entrySet()) {
+            if (remainingOriginals.contains(remainingEntry.getKey())) {
+                remainingTransforms.put(remainingEntry);
+            }
+        }
+        return new TransformedClassPath(filteredClassPath, remainingTransforms.build());
+    }
+
+    @Nullable
+    public File findTransformedJarFor(File originalJar) {
+        return transforms.get(originalJar);
     }
 
     @Override
     public int hashCode() {
-        return transformedClassPath.hashCode();
+        return originalClassPath.hashCode();
     }
 
     @Override
@@ -89,6 +142,33 @@ public class TransformedClassPath implements ClassPath {
             return false;
         }
         TransformedClassPath other = (TransformedClassPath) obj;
-        return transformedClassPath.equals(other.transformedClassPath);
+        return originalClassPath.equals(other.originalClassPath);
+    }
+
+    public static class Builder {
+        private final DefaultClassPath.Builder originals;
+        private final ImmutableMap.Builder<File, File> files;
+
+        private Builder(int expectedSize) {
+            originals = DefaultClassPath.builderWithExactSize(expectedSize);
+            files = ImmutableMap.builderWithExpectedSize(expectedSize);
+        }
+
+        public static Builder withExpectedSize(int expectedSize) {
+            return new Builder(expectedSize);
+        }
+
+        public Builder add(File original, File transformed) {
+            originals.add(original);
+            if (!original.equals(transformed)) {
+                files.put(original, transformed);
+            }
+            return this;
+        }
+
+        public TransformedClassPath build() {
+            Map<File, File> transformedMap = files.build();
+            return new TransformedClassPath(originals.build(), transformedMap);
+        }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultCachedClasspathTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultCachedClasspathTransformer.java
@@ -92,10 +92,51 @@ public class DefaultCachedClasspathTransformer implements CachedClasspathTransfo
         if (classPath.isEmpty()) {
             return classPath;
         }
-        return transformFiles(
-            classPath,
-            fileTransformerFor(transform)
-        );
+        return transformPipelineFor(transform).transform(classPath);
+
+    }
+
+    @FunctionalInterface
+    private interface TransformPipeline {
+        ClassPath transform(ClassPath original);
+    }
+
+    private TransformPipeline transformPipelineFor(StandardTransform transform) {
+        switch (transform) {
+            case None:
+                return copyingPipeline();
+            case BuildLogic:
+                if (!AgentControl.isInstrumentationAgentApplied()) {
+                    return instrumentingPipeline(InstrumentingClasspathFileTransformer.instrumentForLoadingWithClassLoader());
+                }
+                return agentInstrumentingPipeline(copyingPipeline(), instrumentingPipeline(InstrumentingClasspathFileTransformer.instrumentForLoadingWithAgent()));
+            default:
+                throw new IllegalArgumentException();
+        }
+    }
+
+    private TransformPipeline copyingPipeline() {
+        return cp -> transformFiles(cp, new CopyingClasspathFileTransformer(globalCacheLocations));
+    }
+
+    private TransformPipeline instrumentingPipeline(InstrumentingClasspathFileTransformer.Policy policy) {
+        return cp -> transformFiles(cp, instrumentingClasspathFileTransformerFor(policy, new InstrumentingTransformer()));
+    }
+
+    private TransformPipeline agentInstrumentingPipeline(TransformPipeline originalsPipeline, TransformPipeline transformedPipeline) {
+        return classPath -> {
+            ClassPath copiedClassPath = originalsPipeline.transform(classPath);
+            ClassPath transformedClassPath = transformedPipeline.transform(classPath);
+            List<File> copiedOriginalJars = copiedClassPath.getAsFiles();
+            List<File> transformedJars = transformedClassPath.getAsFiles();
+            int size = copiedOriginalJars.size();
+            assert size == transformedJars.size();
+            TransformedClassPath.Builder result = TransformedClassPath.Builder.withExpectedSize(size);
+            for (int i = 0; i < size; ++i) {
+                result.add(copiedOriginalJars.get(i), transformedJars.get(i));
+            }
+            return result.build();
+        };
     }
 
     @Override
@@ -106,6 +147,7 @@ public class DefaultCachedClasspathTransformer implements CachedClasspathTransfo
         return transformFiles(
             classPath,
             instrumentingClasspathFileTransformerFor(
+                InstrumentingClasspathFileTransformer.instrumentForLoadingWithClassLoader(),
                 new CompositeTransformer(additional, transformerFor(transform))
             )
         );
@@ -124,16 +166,12 @@ public class DefaultCachedClasspathTransformer implements CachedClasspathTransfo
     }
 
     private ClassPath transformFiles(ClassPath classPath, ClasspathFileTransformer transformer) {
-        ClassPath transformedClassPath = DefaultClassPath.of(
+        return DefaultClassPath.of(
             transformAll(
                 classPath.getAsFiles(),
                 (file, seen) -> cachedFile(file, transformer, seen)
             )
         );
-        if (AgentControl.isInstrumentationAgentApplied()) {
-            return new TransformedClassPath(transformedClassPath);
-        }
-        return transformedClassPath;
     }
 
     private Transform transformerFor(StandardTransform transform) {
@@ -147,7 +185,7 @@ public class DefaultCachedClasspathTransformer implements CachedClasspathTransfo
     private ClasspathFileTransformer fileTransformerFor(StandardTransform transform) {
         switch (transform) {
             case BuildLogic:
-                return instrumentingClasspathFileTransformerFor(new InstrumentingTransformer());
+                return instrumentingClasspathFileTransformerFor(InstrumentingClasspathFileTransformer.instrumentForLoadingWithClassLoader(), new InstrumentingTransformer());
             case None:
                 return new CopyingClasspathFileTransformer(globalCacheLocations);
             default:
@@ -155,8 +193,8 @@ public class DefaultCachedClasspathTransformer implements CachedClasspathTransfo
         }
     }
 
-    private InstrumentingClasspathFileTransformer instrumentingClasspathFileTransformerFor(CachedClasspathTransformer.Transform transform) {
-        return new InstrumentingClasspathFileTransformer(fileLockManager, classpathWalker, classpathBuilder, transform);
+    private InstrumentingClasspathFileTransformer instrumentingClasspathFileTransformerFor(InstrumentingClasspathFileTransformer.Policy policy, Transform transform) {
+        return new InstrumentingClasspathFileTransformer(fileLockManager, classpathWalker, classpathBuilder, policy, transform);
     }
 
     private Optional<Either<URL, Callable<URL>>> cachedURL(URL original, ClasspathFileTransformer transformer, Set<HashCode> seen) {

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingClasspathFileTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingClasspathFileTransformer.java
@@ -50,18 +50,29 @@ class InstrumentingClasspathFileTransformer implements ClasspathFileTransformer 
     private final FileLockManager fileLockManager;
     private final ClasspathWalker classpathWalker;
     private final ClasspathBuilder classpathBuilder;
+    private final Policy policy;
     private final CachedClasspathTransformer.Transform transform;
     private final HashCode configHash;
+
+    public interface Policy {
+        void applyConfigurationTo(Hasher hasher);
+
+        boolean instrumentFile(File file);
+
+        boolean includeEntry(ClasspathEntryVisitor.Entry entry);
+    }
 
     public InstrumentingClasspathFileTransformer(
         FileLockManager fileLockManager,
         ClasspathWalker classpathWalker,
         ClasspathBuilder classpathBuilder,
+        Policy policy,
         CachedClasspathTransformer.Transform transform
     ) {
         this.fileLockManager = fileLockManager;
         this.classpathWalker = classpathWalker;
         this.classpathBuilder = classpathBuilder;
+        this.policy = policy;
         this.transform = transform;
         this.configHash = configHashFor(transform);
     }
@@ -69,6 +80,7 @@ class InstrumentingClasspathFileTransformer implements ClasspathFileTransformer 
     private HashCode configHashFor(CachedClasspathTransformer.Transform transform) {
         Hasher hasher = Hashing.defaultFunction().newHasher();
         hasher.putInt(CACHE_FORMAT);
+        policy.applyConfigurationTo(hasher);
         transform.applyConfigurationTo(hasher);
         return hasher.hash();
     }
@@ -125,11 +137,11 @@ class InstrumentingClasspathFileTransformer implements ClasspathFileTransformer 
     }
 
     private void transform(File source, File dest) {
-        if (isSignedJar(source)) {
+        if (policy.instrumentFile(source)) {
+            instrument(source, dest);
+        } else {
             LOGGER.debug("Signed archive '{}'. Skipping instrumentation.", source.getName());
             GFileUtils.copyFile(source, dest);
-        } else {
-            instrument(source, dest);
         }
     }
 
@@ -147,6 +159,9 @@ class InstrumentingClasspathFileTransformer implements ClasspathFileTransformer 
     private void visitEntries(File source, ClasspathBuilder.EntryBuilder builder) throws IOException, FileException {
         classpathWalker.visit(source, entry -> {
             try {
+                if (!policy.includeEntry(entry)) {
+                    return;
+                }
                 if (entry.getName().endsWith(".class")) {
                     ClassReader reader = new ClassReader(entry.getContent());
                     ClassWriter classWriter = new ClassWriter(ClassWriter.COMPUTE_MAXS);
@@ -163,7 +178,7 @@ class InstrumentingClasspathFileTransformer implements ClasspathFileTransformer 
         });
     }
 
-    private boolean isSignedJar(File source) {
+    private static boolean isSignedJar(File source) {
         if (!source.isFile()) {
             return false;
         }
@@ -180,5 +195,45 @@ class InstrumentingClasspathFileTransformer implements ClasspathFileTransformer 
             throw new UncheckedIOException(e);
         }
         return false;
+    }
+
+    public static Policy instrumentForLoadingWithClassLoader() {
+        return new Policy() {
+            @Override
+            public void applyConfigurationTo(Hasher hasher) {
+                // Do nothing, this is compatible with the old instrumentation
+            }
+
+            @Override
+            public boolean instrumentFile(File file) {
+                return !isSignedJar(file);
+            }
+
+            @Override
+            public boolean includeEntry(ClasspathEntryVisitor.Entry entry) {
+                // include everything
+                return true;
+            }
+        };
+    }
+
+    public static Policy instrumentForLoadingWithAgent() {
+        return new Policy() {
+            @Override
+            public void applyConfigurationTo(Hasher hasher) {
+                hasher.putInt(1);
+            }
+
+            @Override
+            public boolean instrumentFile(File file) {
+                return true;
+            }
+
+            @Override
+            public boolean includeEntry(ClasspathEntryVisitor.Entry entry) {
+                // Only include classes in the result, resources will be loaded from the original JAR by the class loader.
+                return entry.getName().endsWith(".class");
+            }
+        };
     }
 }


### PR DESCRIPTION
This is a final piece of the new instrumentation logic. When the agent is enabled, the cached copies of the original jars are provided to the classloader as the classpath, and the instrumented jars are provided separately. When loading a class, the classloader looks up a corresponding instrumented jar, loads bytecode from it and replaces the original code with the instrumented one.

Fixes #22939

This is part 3/3, previous part is in #23264.