### PR TITLE
Let `signing` plugin publish signatures with configuration caching

### DIFF
--- a/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningIntegrationSpec.groovy
+++ b/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningIntegrationSpec.groovy
@@ -31,7 +31,8 @@ abstract class SigningIntegrationSpec extends AbstractIntegrationSpec {
         GPG_CMD
     }
 
-    @Rule public final TestResources resources = new TestResources(temporaryFolder, "keys")
+    @Rule
+    public final TestResources resources = new TestResources(temporaryFolder, "keys")
 
     Path gpgHomeSymlink
 
@@ -150,7 +151,6 @@ abstract class SigningIntegrationSpec extends AbstractIntegrationSpec {
     TestFile fileRepoFile(String name) {
         file("build", "fileRepo", name)
     }
-
 
     void jarUploaded(String jarFileName = jarFileName) {
         assert m2RepoFile(jarFileName).exists()

--- a/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningPublicationsIntegrationSpec.groovy
+++ b/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningPublicationsIntegrationSpec.groovy
@@ -256,7 +256,6 @@ class SigningPublicationsIntegrationSpec extends SigningIntegrationSpec {
         succeeds "signMavenPublication"
     }
 
-    @ToBeFixedForConfigurationCache
     def "publishes signature files for Maven publication"() {
         given:
         buildFile << """
@@ -409,7 +408,6 @@ class SigningPublicationsIntegrationSpec extends SigningIntegrationSpec {
         file("build", "publications", "mavenJava", "pom-default.xml.asc").text
     }
 
-    @ToBeFixedForConfigurationCache
     def "publish task takes into account configuration changes"() {
         given:
         buildFile << """
@@ -716,7 +714,6 @@ class SigningPublicationsIntegrationSpec extends SigningIntegrationSpec {
         m2RepoFile("${jarFileName}.asc").assertDoesNotExist()
     }
 
-    @ToBeFixedForConfigurationCache
     @Issue("https://github.com/gradle/gradle/issues/20166")
     def "signs single Maven publication with similar artifacts"() {
         given:

--- a/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningSamplesSpec.groovy
+++ b/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningSamplesSpec.groovy
@@ -18,7 +18,6 @@ package org.gradle.plugins.signing
 
 import org.gradle.integtests.fixtures.AbstractSampleIntegrationTest
 import org.gradle.integtests.fixtures.Sample
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.UsesSample
 import org.gradle.test.fixtures.maven.MavenFileRepository
 import org.gradle.util.Requires
@@ -75,7 +74,6 @@ class SigningSamplesSpec extends AbstractSampleIntegrationTest {
     }
 
     @UsesSample('signing/maven-publish')
-    @ToBeFixedForConfigurationCache
     def "publish attaches signatures with dsl #dsl"() {
         given:
         inDirectory(sample.dir.file(dsl))

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/Sign.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/Sign.java
@@ -109,7 +109,6 @@ public abstract class Sign extends DefaultTask implements SignatureSpec {
 
             signTask((AbstractArchiveTask) task);
         }
-
     }
 
     private void signTask(final AbstractArchiveTask archiveTask) {

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/Signature.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/Signature.java
@@ -95,6 +95,7 @@ public class Signature extends AbstractPublishArtifact {
 
     private Callable<String> classifierGenerator;
 
+    @Nullable
     private Callable<String> nameGenerator;
 
     /**
@@ -176,12 +177,10 @@ public class Signature extends AbstractPublishArtifact {
     public Signature(Callable<File> toSign, Callable<String> classifier, SignatureSpec signatureSpec, Object... tasks) {
         // TODO: find a way to inject a proper task dependency factory without breaking the public API
         super(DefaultTaskDependencyFactory.withNoAssociatedProject(), tasks);
-        this.toSignGenerator = toSign;
-        this.classifierGenerator = classifier;
-        this.signatureSpec = signatureSpec;
+        init(toSign, classifier, null, signatureSpec);
     }
 
-    private void init(Callable<File> toSign, Callable<String> classifier, Callable<String> name, SignatureSpec signatureSpec) {
+    private void init(Callable<File> toSign, Callable<String> classifier, @Nullable Callable<String> name, SignatureSpec signatureSpec) {
         this.toSignGenerator = toSign;
         this.classifierGenerator = classifier;
         this.nameGenerator = name;

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/SigningExtension.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/SigningExtension.java
@@ -545,9 +545,8 @@ public abstract class SigningExtension {
 
         @Override
         public boolean shouldBePublished() {
-            return signTask.isEnabled() &&
-                signTask.getOnlyIf().isSatisfiedBy(signTask) &&
-                create().exists();
+            return signTask.isEnabled()
+                && signTask.getOnlyIf().isSatisfiedBy(signTask);
         }
     }
 }


### PR DESCRIPTION
By not checking if the original file exists too early in the process.