### PR TITLE
Update reference to TeamCity Build Scan plugin.

### DIFF
--- a/subprojects/docs/src/docs/userguide/reference/ci-systems/teamcity.adoc
+++ b/subprojects/docs/src/docs/userguide/reference/ci-systems/teamcity.adoc
@@ -100,7 +100,7 @@ Next, we can set up the project and run a build in TeamCity.
 == Create a TeamCity build
 
 Setting up a new Gradle build in TeamCity requires just a few clicks:
-TeamCity comes bundled with a Gradle plugin, so you do not need to install plugins additionally. However, it is recommended that you install the https://plugins.jetbrains.com/plugin/9326-gradle-build-scan-integration[Gradle Build Scan plugin].
+TeamCity comes bundled with a Gradle plugin, so you do not need to install plugins additionally. However, it is recommended that you install the https://plugins.jetbrains.com/plugin/9326-gradle-build-scan-integration[TeamCity Build Scan plugin].
 
 On the *Administration | Projects* page click _Create project_,
 use the option _From the repository URL_ and enter the URL of the GitHub repository: `https://github.com/gradle/gradle-site-plugin.git`.
@@ -146,7 +146,7 @@ image::ci-systems/teamcity-tests.png[]
 The information on parameters and environment of the build is available
 on the _Parameters_ tab of the build results.
 
-If you installed the https://plugins.jetbrains.com/plugin/9326-gradle-build-scan-integration[Gradle Build Scan plugin], you will see a link to the build scan in the Build Results view:
+If you installed the https://plugins.jetbrains.com/plugin/9326-gradle-build-scan-integration[TeamCity Build Scan plugin], you will see a link to the build scan in the Build Results view:
 
 image::ci-systems/teamcity-build-scan-plugin.png[]
 


### PR DESCRIPTION
This now says "TeamCity Build Scan plugin" since the previous "Gradle Build Scan plugin" could refer to something else.

Signed-off-by: Nelson Osacky <nosacky@gradle.com>

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
