### PR TITLE
Fix "Unable to make progress running work" together with `--continue`

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/AbstractCommandLineOrderTaskIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/AbstractCommandLineOrderTaskIntegrationTest.groovy
@@ -137,6 +137,7 @@ abstract class AbstractCommandLineOrderTaskIntegrationTest extends AbstractInteg
         final Set<String> localState = []
         final Set<String> inputFiles = []
         boolean shouldBlock
+        String failMessage
 
         TaskFixture(ProjectFixture project, String path) {
             this.project = project
@@ -206,6 +207,11 @@ abstract class AbstractCommandLineOrderTaskIntegrationTest extends AbstractInteg
             return this
         }
 
+        TaskFixture fail(String message = 'BOOM') {
+            failMessage = message
+            return this
+        }
+
         String getConfig() {
             return """
                 tasks.register('${name}') {
@@ -219,6 +225,7 @@ abstract class AbstractCommandLineOrderTaskIntegrationTest extends AbstractInteg
                     ${inputFiles.collect { 'inputs.files ' + it }.join('\n\t\t\t\t')}
                     doLast {
                         ${shouldBlock ? server.callFromTaskAction(path) : ''}
+                        ${failMessage ? "throw new RuntimeException('$failMessage')" : ''}
                     }
                 }
             """.stripIndent()

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultFinalizedExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultFinalizedExecutionPlan.java
@@ -515,6 +515,13 @@ public class DefaultFinalizedExecutionPlan implements WorkSource<Node>, Finalize
             // Wait for any dependencies of this node that have not started yet
             for (Node successor : node.getDependencySuccessors()) {
                 if (successor.isRequired()) {
+                    // There may be a dependency of this node which does not have
+                    //   - any dependencies of its own,
+                    //   - and is not part of the initially scheduled nodes.
+                    // We need to check if this node is ready to start, if not it will never start.
+                    // An example of this is a producer node of an ordinal group, when there aren't any producers in the ordinal group.
+                    successor.updateAllDependenciesComplete();
+                    maybeNodeReady(successor);
                     waitingForNode(successor, "other node completed", node);
                 }
             }


### PR DESCRIPTION
We saw some problems with "Unable to make progress running work" in the Gradle build when a task fails on CI. On CI we run with `--continue`. It seems like that exposes some problems in the current scheduling logic.

The PR fixes this by ensuring that we try to run all dependency nodes which are ready to run to the ready to run queue. Before the change, some nodes in ordinal groups (in this case the producer node for ordinal group 0) never checked if they are ready to run.

Fixes https://github.com/gradle/gradle/issues/23293.