### PR TITLE
Fix `--write-verification-metadata` when configuration cache is enabled

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheDependencyResolutionFeaturesIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheDependencyResolutionFeaturesIntegrationTest.groovy
@@ -740,7 +740,7 @@ class ConfigurationCacheDependencyResolutionFeaturesIntegrationTest extends Abst
 
         then:
         configurationCache.assertStateStored()
-        outputContains("Calculating task graph as configuration cache cannot be reused because file 'gradle/verification-metadata.xml' has changed.")
+        outputContains("Calculating task graph as configuration cache cannot be reused because file 'gradle/verification-metadata.xml' has changed.".replace('/', File.separator))
 
         when:
         configurationCacheRun("resolve1")
@@ -753,16 +753,29 @@ class ConfigurationCacheDependencyResolutionFeaturesIntegrationTest extends Abst
         configurationCacheFails("resolve1")
 
         then:
-        outputContains("Calculating task graph as configuration cache cannot be reused because file 'gradle/verification-metadata.xml' has changed.")
+        outputContains("Calculating task graph as configuration cache cannot be reused because file 'gradle/verification-metadata.xml' has changed.".replace('/', File.separator))
         failure.assertHasCause("Dependency verification failed for configuration ':implementation'")
         configurationCache.assertStateStoreFailed()
+
+        when:
+        verificationFile.replace('<sha256 value="12345"', '<sha256 value="9e44491880e9ca23ab209f9b2e31cf2a7d26cd33841aea9a490c1b8c9bbf27e5"')
+        configurationCacheRun("resolve1")
+
+        then:
+        configurationCache.assertStateStored()
+
+        when:
+        configurationCacheRun("resolve1")
+
+        then:
+        configurationCache.assertStateLoaded()
 
         when:
         verificationFile.delete()
         configurationCacheRun("resolve1")
 
         then:
-        outputContains("Calculating task graph as configuration cache cannot be reused because file 'gradle/verification-metadata.xml' has changed.")
+        outputContains("Calculating task graph as configuration cache cannot be reused because file 'gradle/verification-metadata.xml' has changed.".replace('/', File.separator))
         configurationCache.assertStateStored()
     }
 

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
@@ -88,7 +88,7 @@ class DefaultConfigurationCache internal constructor(
 
     // Have one or more values been successfully written to the entry?
     private
-    var hasSavedValues = false
+    var cacheEntryRequiresCommit = false
 
     private
     lateinit var host: Host
@@ -171,7 +171,8 @@ class DefaultConfigurationCache internal constructor(
             store.useForStore { layout ->
                 layout.fileFor(StateType.Entry).delete()
             }
-        } else if (hasSavedValues) {
+            cacheEntryRequiresCommit = false
+        } else if (cacheEntryRequiresCommit) {
             val reusedProjects = mutableSetOf<Path>()
             val updatedProjects = mutableSetOf<Path>()
             intermediateModels.value.visitProjects(reusedProjects::add, updatedProjects::add)
@@ -181,7 +182,7 @@ class DefaultConfigurationCache internal constructor(
                 cacheIO.writeCacheEntryDetailsTo(buildStateRegistry, intermediateModels.value.values, projectMetadata.value.values, layout.fileFor(StateType.Entry))
             }
             problems.projectStateStats(reusedProjects.size, updatedProjects.size)
-            hasSavedValues = false
+            cacheEntryRequiresCommit = false
         }
     }
 
@@ -334,13 +335,14 @@ class DefaultConfigurationCache internal constructor(
         // can cause the provider value to incorrectly be treated as a task graph input
         Instrumented.discardListener()
 
+        cacheEntryRequiresCommit = true
+
         buildOperationExecutor.withStoreOperation(cacheKey.string) {
             store.useForStore { layout ->
                 try {
                     action(layout.fileFor(stateType))
                 } catch (error: ConfigurationCacheError) {
                     // Invalidate state on serialization errors
-                    hasSavedValues = false
                     problems.failingBuildDueToSerializationError()
                     throw error
                 } finally {
@@ -350,8 +352,6 @@ class DefaultConfigurationCache internal constructor(
         }
 
         crossConfigurationTimeBarrier()
-
-        hasSavedValues = true
     }
 
     private

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheProblems.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheProblems.kt
@@ -81,6 +81,9 @@ class ConfigurationCacheProblems(
             if (cacheAction == LOAD) {
                 return false
             }
+            if (isFailingBuildDueToSerializationError) {
+                return true
+            }
             val summary = summarizer.get()
             return discardStateDueToProblems(summary) || hasTooManyProblems(summary)
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/StartParameterResolutionOverride.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/StartParameterResolutionOverride.java
@@ -108,14 +108,13 @@ public class StartParameterResolutionOverride {
         FileResourceListener fileResourceListener
     ) {
         List<String> checksums = startParameter.getWriteDependencyVerifications();
+        File verificationsFile = DependencyVerificationOverride.dependencyVerificationsFile(gradleDir);
+        fileResourceListener.fileObserved(verificationsFile);
         if (!checksums.isEmpty() || startParameter.isExportKeys()) {
-            File verificationsFile = DependencyVerificationOverride.dependencyVerificationsFile(gradleDir);
             return DisablingVerificationOverride.of(
                 new WriteDependencyVerificationFile(verificationsFile, keyRing.get(), buildOperationExecutor, checksums, checksumService, signatureVerificationServiceFactory, startParameter.isDryRun(), startParameter.isExportKeys())
             );
         } else {
-            File verificationsFile = DependencyVerificationOverride.dependencyVerificationsFile(gradleDir);
-            fileResourceListener.fileObserved(verificationsFile);
             if (verificationsFile.exists()) {
                 if (startParameter.getDependencyVerificationMode() == DependencyVerificationMode.OFF) {
                     return DependencyVerificationOverride.NO_VERIFICATION;


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context

Previously, the verification file was not included in the configuration cache fingerprint when the `--write-verification-metadata` was used. This would mean that later builds run with the same set of tasks would ignore changes to the verification file.

For example:

```
> gradle --write-verification-metadata assemble
> gradle assemble # ignores verification file
```

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
