### PR TITLE
Revert workarounds to avoid conflicts between ivy & project layout

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
@@ -362,7 +362,7 @@ public class DefaultIvyArtifactRepository extends AbstractAuthenticationSupporte
         config.execute(layout);
     }
 
-    public AbstractRepositoryLayout getLayout() {
+    public AbstractRepositoryLayout getRepositoryLayout() {
         return layout;
     }
 
@@ -371,7 +371,7 @@ public class DefaultIvyArtifactRepository extends AbstractAuthenticationSupporte
         return metaDataProvider;
     }
 
-    public void setLayout(AbstractRepositoryLayout layout) {
+    public void setRepositoryLayout(AbstractRepositoryLayout layout) {
         this.layout = layout;
     }
 

--- a/subprojects/docs/src/snippets/ivy-publish/conditional-publishing/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/ivy-publish/conditional-publishing/groovy/build.gradle
@@ -24,14 +24,13 @@ publishing {
     }
     repositories {
         // change URLs to point to your repos, e.g. http://my.org/repo
-        def buildDir = layout.buildDirectory
         ivy {
             name "external"
-            url buildDir.dir('repos/external')
+            url layout.buildDirectory.dir('repos/external')
         }
         ivy {
             name "internal"
-            url buildDir.dir('repos/internal')
+            url layout.buildDirectory.dir('repos/internal')
         }
     }
 }

--- a/subprojects/docs/src/snippets/ivy-publish/customize-identity/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/ivy-publish/customize-identity/groovy/build.gradle
@@ -7,9 +7,8 @@ plugins {
 publishing {
 // end::customize-identity[]
     repositories {
-        def repoDir = layout.buildDirectory.dir('repo')
         ivy {
-            url repoDir
+            url layout.buildDirectory.dir('repo')
         }
     }
 // tag::customize-identity[]

--- a/subprojects/docs/src/snippets/ivy-publish/descriptor-customization/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/ivy-publish/descriptor-customization/groovy/build.gradle
@@ -39,10 +39,9 @@ publishing {
 // end::versions-resolved[]
 // end::customize-descriptor[]
     repositories {
-        def buildDir = layout.buildDirectory
         ivy {
             // change to point to your repo, e.g. http://my.org/repo
-            url buildDir.dir('repo')
+            url layout.buildDirectory.dir('repo')
         }
     }
 }

--- a/subprojects/docs/src/snippets/ivy-publish/distribution/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/ivy-publish/distribution/groovy/build.gradle
@@ -37,9 +37,8 @@ publishing {
 
 publishing {
     repositories {
-        def buildDir = layout.buildDirectory
         ivy {
-            url = buildDir.dir('repo')
+            url = layout.buildDirectory.dir('repo')
         }
     }
 }

--- a/subprojects/docs/src/snippets/ivy-publish/publish-artifact/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/ivy-publish/publish-artifact/groovy/build.gradle
@@ -32,10 +32,9 @@ publishing {
     }
 // end::custom-artifact[]
     repositories {
-        def buildDir = layout.buildDirectory
         // change URLs to point to your repo, e.g. http://my.org/repo
         ivy {
-            url = buildDir.dir("repo")
+            url = layout.buildDirectory.dir("repo")
         }
     }
 // tag::custom-artifact[]

--- a/subprojects/docs/src/snippets/ivy-publish/quickstart/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/ivy-publish/quickstart/groovy/build.gradle
@@ -22,10 +22,9 @@ publishing {
 // end::publish-component[]
 // tag::repositories[]
     repositories {
-        def buildDir = layout.buildDirectory
         ivy {
             // change to point to your repo, e.g. http://my.org/repo
-            url = buildDir.dir("repo")
+            url = layout.buildDirectory.dir("repo")
         }
     }
 // tag::publish-component[]

--- a/subprojects/docs/src/snippets/ivy-publish/quickstart/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/ivy-publish/quickstart/kotlin/build.gradle.kts
@@ -22,10 +22,9 @@ publishing {
 // end::publish-component[]
 // tag::repositories[]
     repositories {
-        val buildDirectory = layout.buildDirectory
         ivy {
             // change to point to your repo, e.g. http://my.org/repo
-            url = uri(buildDirectory.dir("repo"))
+            url = uri(layout.buildDirectory.dir("repo"))
         }
     }
 // tag::publish-component[]

--- a/subprojects/docs/src/snippets/plugins/customPlugin/groovy/java-gradle-plugin/build.gradle
+++ b/subprojects/docs/src/snippets/plugins/customPlugin/groovy/java-gradle-plugin/build.gradle
@@ -31,9 +31,8 @@ gradlePlugin {
 
 publishing {
     repositories {
-        def repoDir = layout.buildDirectory.dir("repo")
         maven {
-            url = uri(repoDir)
+            url = uri(layout.buildDirectory.dir("repo"))
         }
     }
 }

--- a/subprojects/docs/src/snippets/plugins/publishing/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/plugins/publishing/groovy/build.gradle
@@ -22,13 +22,12 @@ gradlePlugin {
 }
 
 publishing {
-    def buildDirectory = layout.buildDirectory
     repositories {
         maven {
-            url buildDirectory.dir("maven-repo")
+            url layout.buildDirectory.dir("maven-repo")
         }
         ivy {
-            url buildDirectory.dir("ivy-repo")
+            url layout.buildDirectory.dir("ivy-repo")
         }
     }
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/tasks/PublishToIvyRepository.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/tasks/PublishToIvyRepository.java
@@ -226,7 +226,7 @@ public abstract class PublishToIvyRepository extends DefaultTask {
                     repository.getUrl(),
                     repository.isAllowInsecureProtocol(),
                     credentialsSpec(),
-                    repository.getLayout()
+                    repository.getRepositoryLayout()
                 );
             }
 
@@ -259,7 +259,7 @@ public abstract class PublishToIvyRepository extends DefaultTask {
                 repository.setName(name);
                 repository.setUrl(repositoryUrl);
                 repository.setAllowInsecureProtocol(allowInsecureProtocol);
-                repository.setLayout(layout);
+                repository.setRepositoryLayout(layout);
                 if (credentials != null) {
                     Provider<? extends Credentials> provider = services.get(ProviderFactory.class).credentials(credentials.getType(), name);
                     repository.setConfiguredCredentials(provider.get());


### PR DESCRIPTION
Avoids property name clash between `project.layout` and `ivy.layout`, and reverts workarounds in sample snippets.

Fixes #23305

