### PR TITLE
Trim common indent when rendering snippets in docs

### DIFF
--- a/subprojects/docs-asciidoctor-extensions-base/src/main/java/org/gradle/docs/asciidoctor/SampleIncludeProcessor.java
+++ b/subprojects/docs-asciidoctor-extensions-base/src/main/java/org/gradle/docs/asciidoctor/SampleIncludeProcessor.java
@@ -97,6 +97,7 @@ public class SampleIncludeProcessor extends IncludeProcessor {
             if (!tags.isEmpty()) {
                 source = filterByTag(source, sourceSyntax, tags);
             }
+            source = trimIndent(source);
             builder.append(String.format(".%s%n[source,%s]%n----%n%s%n----%n", sourceRelativeLocation, sourceSyntax, source));
         }
 
@@ -152,7 +153,7 @@ public class SampleIncludeProcessor extends IncludeProcessor {
         } else {
             String activeTag = null;
             Pattern tagPattern = Pattern.compile(regex);
-            try(BufferedReader reader = new BufferedReader(new StringReader(source))) {
+            try (BufferedReader reader = new BufferedReader(new StringReader(source))) {
                 String line;
                 while ((line = reader.readLine()) != null) {
                     if (activeTag != null) {
@@ -181,4 +182,37 @@ public class SampleIncludeProcessor extends IncludeProcessor {
         }
         return null;
     }
+
+    private static String trimIndent(String source) {
+        String[] lines = source.split("\r\n|\r|\n");
+        int minIndent = Integer.MAX_VALUE;
+        for (String line : lines) {
+            if (line.trim().length() == 0) {
+                continue;
+            }
+
+            int indent = 0;
+            while (indent < line.length() && Character.isWhitespace(line.charAt(indent))) {
+                indent++;
+            }
+            if (indent < line.length()) {
+                minIndent = Math.min(minIndent, indent);
+            }
+        }
+
+        if (minIndent != Integer.MAX_VALUE && minIndent > 0) {
+            StringBuilder sb = new StringBuilder();
+            String newline = String.format("%n");
+            for (String line : lines) {
+                if (line.trim().length() > 0) {
+                    sb.append(line.substring(minIndent));
+                }
+                sb.append(newline);
+            }
+            return sb.toString();
+        }
+
+        return source;
+    }
+
 }

--- a/subprojects/docs-asciidoctor-extensions-base/src/main/java/org/gradle/docs/asciidoctor/SampleIncludeProcessor.java
+++ b/subprojects/docs-asciidoctor-extensions-base/src/main/java/org/gradle/docs/asciidoctor/SampleIncludeProcessor.java
@@ -185,9 +185,27 @@ public class SampleIncludeProcessor extends IncludeProcessor {
 
     private static String trimIndent(String source) {
         String[] lines = source.split("\r\n|\r|\n");
+
+        int minIndent = getMinIndent(lines);
+        if (minIndent == 0) {
+            return source;
+        }
+
+        StringBuilder sb = new StringBuilder();
+        String newline = String.format("%n");
+        for (String line : lines) {
+            if (!line.trim().isEmpty()) {
+                sb.append(line.substring(minIndent));
+            }
+            sb.append(newline);
+        }
+        return sb.toString();
+    }
+
+    private static int getMinIndent(String[] lines) {
         int minIndent = Integer.MAX_VALUE;
         for (String line : lines) {
-            if (line.trim().length() == 0) {
+            if (line.trim().isEmpty()) {
                 continue;
             }
 
@@ -199,20 +217,6 @@ public class SampleIncludeProcessor extends IncludeProcessor {
                 minIndent = Math.min(minIndent, indent);
             }
         }
-
-        if (minIndent != Integer.MAX_VALUE && minIndent > 0) {
-            StringBuilder sb = new StringBuilder();
-            String newline = String.format("%n");
-            for (String line : lines) {
-                if (line.trim().length() > 0) {
-                    sb.append(line.substring(minIndent));
-                }
-                sb.append(newline);
-            }
-            return sb.toString();
-        }
-
-        return source;
+        return minIndent == Integer.MAX_VALUE ? 0 : minIndent;
     }
-
 }

--- a/subprojects/docs-asciidoctor-extensions-base/src/test/groovy/org/gradle/docs/asciidoctor/SampleIncludeProcessorTest.groovy
+++ b/subprojects/docs-asciidoctor-extensions-base/src/test/groovy/org/gradle/docs/asciidoctor/SampleIncludeProcessorTest.groovy
@@ -227,50 +227,64 @@ include::sample[dir="src/samples",files="foo.xml[tag=bar]"]
     def "trims indentation in samples"() {
         given:
         tmpDir.newFile("src/samples/build.gradle") << """
-                // Comment
-                doLast {
-                    println "hello world"
-                }
-"""
+            |    // Comment
+            |    doLast {
+            |        println "hello world"
+            |    }
+        """.trim().stripMargin()
 
         String asciidocContent = """
-= Doctitle
-:samples-dir: ${tmpDir.root.canonicalPath}
-
-include::sample[dir="src/samples",files="build.gradle[]"]
-"""
+            |= Doctitle
+            |:samples-dir: ${tmpDir.root.canonicalPath}
+            |
+            |include::sample[dir="src/samples",files="build.gradle[]"]
+        """.trim().stripMargin()
 
         when:
         String content = asciidoctor.convert(asciidocContent, [:])
 
+        def expectedContent = '''
+            |// Comment
+            |doLast {
+            |    println "hello world"
+            |}
+        '''.trim().stripMargin()
+
         then:
-        content.contains('// Comment\ndoLast {\n    println "hello world"\n}')
+        content.contains(expectedContent)
     }
 
     def "trims indentation in samples with tags"() {
         given:
         tmpDir.newFile("src/samples/build.gradle") << """
-    // tag::foo[]
-                // Comment
-                doLast {
-    // end::foo[]
-                    println "hello world"
-    // tag::foo[]
-                }
-    // end::foo[]
-"""
+            |// No-indent comment outside of tag
+            |// tag::foo[]
+            |    // Comment
+            |    doLast {
+            |// end::foo[]
+            |        println "hello world"
+            |// tag::foo[]
+            |    }
+            |// end::foo[]
+        """.trim().stripMargin()
 
         String asciidocContent = """
-= Doctitle
-:samples-dir: ${tmpDir.root.canonicalPath}
-
-include::sample[dir="src/samples",files="build.gradle[tags=foo]"]
-"""
+            |= Doctitle
+            |:samples-dir: ${tmpDir.root.canonicalPath}
+            |
+            |include::sample[dir="src/samples",files="build.gradle[tags=foo]"]
+        """.trim().stripMargin()
 
         when:
         String content = asciidoctor.convert(asciidocContent, [:])
 
+        def expectedContent = """
+            |// Comment
+            |doLast {
+            |}
+        """.trim().stripMargin()
+
         then:
-        content.contains('// Comment\ndoLast {\n}')
+        content.contains(expectedContent)
     }
 }


### PR DESCRIPTION
Build DSL snippets used in the user manual often use only parts of the actual testable build script samples. Due the DSL differences between Groovy and Kotlin, sometimes the snippets selected to be displayed in the docs have different indentation. This may be due to Kotlin requiring an extra context being explicitly introduced. Some snippets actually select indented code from the sample project.

The problem is that these implementation details leak into the manual intended for the user and the indentation does not make any sense in the context of the manual.

This PR strips any common indentation (max number of whitespace characters leading each line) of code snippets at the stage of embedding them into the rendered docs.

Before:
<img width="625" alt="image" src="https://user-images.githubusercontent.com/2759152/209925015-b52b5a74-88ca-485a-8112-c0d345b9c4a2.png">

After:
<img width="639" alt="image" src="https://user-images.githubusercontent.com/2759152/209924961-04e53b12-9309-4011-9db2-6adf21ab1ccd.png">

Fixes issues described in:
- https://github.com/gradle/gradle/pull/23105
