### PR TITLE
Ensure ordinal nodes are scheduled if there are nodes in their group

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultFinalizedExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultFinalizedExecutionPlan.java
@@ -515,13 +515,6 @@ public class DefaultFinalizedExecutionPlan implements WorkSource<Node>, Finalize
             // Wait for any dependencies of this node that have not started yet
             for (Node successor : node.getDependencySuccessors()) {
                 if (successor.isRequired()) {
-                    // There may be a dependency of this node which does not have
-                    //   - any dependencies of its own,
-                    //   - and is not part of the initially scheduled nodes.
-                    // We need to check if this node is ready to start, if not it will never start.
-                    // An example of this is a producer node of an ordinal group, when there aren't any producers in the ordinal group.
-                    successor.updateAllDependenciesComplete();
-                    maybeNodeReady(successor);
                     waitingForNode(successor, "other node completed", node);
                 }
             }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/OrdinalNodeAccess.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/OrdinalNodeAccess.java
@@ -35,25 +35,29 @@ public class OrdinalNodeAccess {
 
     void addDestroyerNode(OrdinalGroup ordinal, LocalTaskNode destroyer, Consumer<Node> ordinalNodeConsumer) {
         // Create (or get) a destroyer ordinal node that depends on the output locations of this task node
-        ordinal.getDestroyerLocationsNode().addDependenciesFrom(destroyer);
+        OrdinalNode destroyerLocations = ordinal.getDestroyerLocationsNode();
+        destroyerLocations.addDependenciesFrom(destroyer);
+        maybeSchedule(ordinalNodeConsumer, destroyerLocations);
 
         // Depend on any previous producer ordinal nodes (i.e. any producer ordinal nodes with a lower ordinal)
         if (ordinal.getPrevious() != null) {
-            OrdinalNode producerLocations = ordinal.getPrevious().getProducerLocationsNode();
-            maybeSchedule(ordinalNodeConsumer, producerLocations);
-            destroyer.addDependencySuccessor(producerLocations);
+            OrdinalNode previousProducerLocations = ordinal.getPrevious().getProducerLocationsNode();
+            maybeSchedule(ordinalNodeConsumer, previousProducerLocations);
+            destroyer.addDependencySuccessor(previousProducerLocations);
         }
     }
 
     void addProducerNode(OrdinalGroup ordinal, LocalTaskNode producer, Consumer<Node> ordinalNodeConsumer) {
         // Create (or get) a producer ordinal node that depends on the dependencies of this task node
-        ordinal.getProducerLocationsNode().addDependenciesFrom(producer);
+        OrdinalNode producerLocations = ordinal.getProducerLocationsNode();
+        producerLocations.addDependenciesFrom(producer);
+        maybeSchedule(ordinalNodeConsumer, producerLocations);
 
         // Depend on any previous destroyer ordinal nodes (i.e. any destroyer ordinal nodes with a lower ordinal)
         if (ordinal.getPrevious() != null) {
-            OrdinalNode destroyerLocations = ordinal.getPrevious().getDestroyerLocationsNode();
-            maybeSchedule(ordinalNodeConsumer, destroyerLocations);
-            producer.addDependencySuccessor(destroyerLocations);
+            OrdinalNode previousDestroyerLocations = ordinal.getPrevious().getDestroyerLocationsNode();
+            maybeSchedule(ordinalNodeConsumer, previousDestroyerLocations);
+            producer.addDependencySuccessor(previousDestroyerLocations);
         }
     }
 


### PR DESCRIPTION
We have been seeing some issues with the task execution plan not being able to make progress.  Looking at [the reproducer](https://github.com/gradle/gradle/blob/e5cc0915b12e88bfaf97b4065352cd48642af51c/subprojects/core/src/integTest/groovy/org/gradle/api/DestroyerTaskCommandLineOrderIntegrationTest.groovy#L451) from @wolfs, it appears the following is happening:
- we are adding producers to ordinal group 1
- this causes the destroyer ordinals from the previous group (ordinal group 0) [to be scheduled](https://github.com/gradle/gradle/blob/901ba375e5bab6cceb48820a69a1858f8128b5b7/subprojects/core/src/main/java/org/gradle/execution/plan/OrdinalNodeAccess.java#L59) but not the producer ordinal from group 1 (or any of its dependencies)
-  when we update the dependencies complete for the _passing_ producer node from ordinal group 1, we [mark his dependents as ready](https://github.com/gradle/gradle/blob/901ba375e5bab6cceb48820a69a1858f8128b5b7/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultFinalizedExecutionPlan.java#L364) which includes the producer node from group 1.
- the producer node from group 1 is added to the ready group, completes, but then, because we have `--continue`, it adds its dependencies (including the producer node from ordinal group 0) to the waiting list.
- Now we are waiting on the producer node from group 0, but it is not scheduled, so no progress.

This change addresses the problem by always scheduling the producer node for an ordinal group (and its predecessors) when a producer is added to the group.  Same for destroyers.  This means that the producer node will be scheduled and will run even if there are no succeeding groups that depend on it.

Another approach here might be to change the initial state of ordinal nodes to something other than SHOULD_RUN, so that the producer node from ordinal group 0 never gets added to the waiting nodes (and possibly that the producer node from ordinal group 1 does not get added to ready nodes).

This effectively reverts the changes from #23292. 