### PR TITLE
Avoid UsageContext

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/component/AbstractSoftwareComponentVariant.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/component/AbstractSoftwareComponentVariant.java
@@ -19,6 +19,7 @@ import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.component.SoftwareComponentVariant;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 
+import java.util.Collections;
 import java.util.Set;
 
 /**
@@ -41,6 +42,6 @@ public abstract class AbstractSoftwareComponentVariant implements UsageContext {
 
     @Override
     public Set<? extends PublishArtifact> getArtifacts() {
-        return artifacts;
+        return Collections.unmodifiableSet(artifacts);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/component/AbstractSoftwareComponentVariant.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/component/AbstractSoftwareComponentVariant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,37 +13,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.api.plugins.internal;
+package org.gradle.api.internal.component;
 
 import org.gradle.api.artifacts.PublishArtifact;
-import org.gradle.api.attributes.AttributeContainer;
-import org.gradle.api.attributes.Usage;
+import org.gradle.api.component.SoftwareComponentVariant;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
-import org.gradle.api.internal.component.UsageContext;
 
 import java.util.Set;
 
-public abstract class AbstractUsageContext implements UsageContext {
+/**
+ * This extends {@link UsageContext} so that we can use it in {@link SoftwareComponentInternal#getUsages()}.
+ * Once we remove {@link UsageContext}, this should implement {@link SoftwareComponentVariant} instead.
+ */
+public abstract class AbstractSoftwareComponentVariant implements UsageContext {
     private final ImmutableAttributes attributes;
-    private final Set<PublishArtifact> artifacts;
+    private final Set<? extends PublishArtifact> artifacts;
 
-    public AbstractUsageContext(ImmutableAttributes attributes, Set<PublishArtifact> artifacts) {
+    public AbstractSoftwareComponentVariant(ImmutableAttributes attributes, Set<? extends PublishArtifact> artifacts) {
         this.attributes = attributes;
         this.artifacts = artifacts;
     }
 
     @Override
-    public Usage getUsage() {
-        throw new UnsupportedOperationException("This method has been deprecated, should never be called");
-    }
-
-    @Override
-    public AttributeContainer getAttributes() {
+    public ImmutableAttributes getAttributes() {
         return attributes;
     }
 
     @Override
-    public Set<PublishArtifact> getArtifacts() {
+    public Set<? extends PublishArtifact> getArtifacts() {
         return artifacts;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/component/DefaultSoftwareComponentVariant.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/component/DefaultSoftwareComponentVariant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,51 +14,56 @@
  * limitations under the License.
  */
 
-package org.gradle.language.cpp.internal;
+package org.gradle.api.internal.component;
 
-import org.gradle.api.Named;
-import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.DependencyConstraint;
 import org.gradle.api.artifacts.ExcludeRule;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.capabilities.Capability;
-import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
-import org.gradle.api.internal.component.UsageContext;
-import org.gradle.api.plugins.internal.AbstractUsageContext;
-import org.gradle.internal.Cast;
 
 import java.util.Collections;
 import java.util.Set;
 
-public class DefaultUsageContext extends AbstractUsageContext implements Named {
+/**
+ * Default implementation of {@link org.gradle.api.component.SoftwareComponentVariant}.
+ */
+public class DefaultSoftwareComponentVariant extends AbstractSoftwareComponentVariant {
     private final String name;
     private final Set<? extends ModuleDependency> dependencies;
     private final Set<? extends DependencyConstraint> dependencyConstraints;
+    private final Set<? extends Capability> capabilities;
     private final Set<ExcludeRule> globalExcludes;
 
-    public DefaultUsageContext(UsageContext usageContext, Set<? extends PublishArtifact> artifacts, Configuration configuration) {
-        this(usageContext.getName(), usageContext.getAttributes(), artifacts, configuration);
+    public DefaultSoftwareComponentVariant(String name, AttributeContainer attributes) {
+        this(name, attributes, Collections.emptySet());
     }
 
-    public DefaultUsageContext(String name, AttributeContainer attributes) {
-        this(name, attributes, null, null);
+    public DefaultSoftwareComponentVariant(String name, AttributeContainer attributes, Set<? extends PublishArtifact> artifacts) {
+        this(name, attributes, artifacts, Collections.emptySet(), Collections.emptySet(), Collections.emptySet(), Collections.emptySet());
     }
 
-    public DefaultUsageContext(String name, AttributeContainer attributes, Set<? extends PublishArtifact> artifacts, Configuration configuration) {
-        super(((AttributeContainerInternal)attributes).asImmutable(), Cast.uncheckedCast(artifacts));
+    public DefaultSoftwareComponentVariant(
+        String name,
+        AttributeContainer attributes,
+        Set<? extends PublishArtifact> artifacts,
+        Set<? extends ModuleDependency> dependencies,
+        Set<? extends DependencyConstraint> dependencyConstraints,
+        Set<? extends Capability> capabilities,
+        Set<ExcludeRule> globalExcludes
+    ) {
+        super(((AttributeContainerInternal)attributes).asImmutable(), artifacts);
+
+        assert dependencies != null;
+        assert dependencyConstraints != null;
+
         this.name = name;
-        if (configuration != null) {
-            this.dependencies = configuration.getAllDependencies().withType(ModuleDependency.class);
-            this.dependencyConstraints = configuration.getAllDependencyConstraints();
-            this.globalExcludes = ((ConfigurationInternal) configuration).getAllExcludeRules();
-        } else {
-            this.dependencies = null;
-            this.dependencyConstraints = null;
-            this.globalExcludes = Collections.emptySet();
-        }
+        this.dependencies = dependencies;
+        this.dependencyConstraints = dependencyConstraints;
+        this.capabilities = capabilities;
+        this.globalExcludes = globalExcludes;
     }
 
     @Override
@@ -68,19 +73,17 @@ public class DefaultUsageContext extends AbstractUsageContext implements Named {
 
     @Override
     public Set<? extends ModuleDependency> getDependencies() {
-        assert dependencies != null;
         return dependencies;
     }
 
     @Override
     public Set<? extends DependencyConstraint> getDependencyConstraints() {
-        assert dependencyConstraints != null;
         return dependencyConstraints;
     }
 
     @Override
     public Set<? extends Capability> getCapabilities() {
-        return Collections.emptySet();
+        return capabilities;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/component/IvyPublishingAwareVariant.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/component/IvyPublishingAwareVariant.java
@@ -13,23 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.gradle.api.internal.component;
 
-public interface MavenPublishingAwareContext extends UsageContext {
-    ScopeMapping getScopeMapping();
+import org.gradle.api.component.SoftwareComponentVariant;
 
-    // Order is important!
-    enum ScopeMapping {
-        compile,
-        runtime,
-        compile_optional,
-        runtime_optional;
+public interface IvyPublishingAwareVariant extends SoftwareComponentVariant {
 
-        public static ScopeMapping of(String scope, boolean optional) {
-            if (optional) {
-                scope += "_optional";
-            }
-            return ScopeMapping.valueOf(scope);
-        }
-    }
+    boolean isOptional();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/component/MavenPublishingAwareVariant.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/component/MavenPublishingAwareVariant.java
@@ -13,10 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.gradle.api.internal.component;
 
-public interface IvyPublishingAwareContext extends UsageContext {
+import org.gradle.api.component.SoftwareComponentVariant;
 
-    boolean isOptional();
+public interface MavenPublishingAwareVariant extends SoftwareComponentVariant {
+    ScopeMapping getScopeMapping();
+
+    // Order is important!
+    enum ScopeMapping {
+        compile,
+        runtime,
+        compile_optional,
+        runtime_optional;
+
+        public static ScopeMapping of(String scope, boolean optional) {
+            if (optional) {
+                scope += "_optional";
+            }
+            return ScopeMapping.valueOf(scope);
+        }
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/component/SoftwareComponentInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/component/SoftwareComponentInternal.java
@@ -24,5 +24,15 @@ import java.util.Set;
  * This will be replaced by {@link org.gradle.api.component.ComponentWithVariants} and other public APIs.
  */
 public interface SoftwareComponentInternal extends SoftwareComponent {
+    /**
+     * This should be called {@code getVariants} and return a set of {@link org.gradle.api.component.SoftwareComponentVariant}s,
+     * though this is currently used by KMP and perhaps AGP due to there being a missing public API. However, renaming is
+     * difficult since {@link org.gradle.api.component.ComponentWithVariants} already defines a {@code getVariants} method.
+     * The existing {@code getVariants} method however is misnamed and should probably be called {@code getChildren}, and its
+     * interface called {@code ComponentWithChildren}. The existing {@code ComponentWithVariants} actually defines an API for
+     * declaring child components, which contribute their variants as defined by this method, as remote variants in GMM.
+     * <p>
+     * This method and {@link UsageContext} should both be deprecated in favor of a new public API.
+     */
     Set<? extends UsageContext> getUsages();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/component/UsageContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/component/UsageContext.java
@@ -19,7 +19,14 @@ package org.gradle.api.internal.component;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.component.SoftwareComponentVariant;
 
+/**
+ * This is a legacy type and should be avoided if possible. Use {@link SoftwareComponentVariant} instead.
+ */
 public interface UsageContext extends SoftwareComponentVariant {
     @Deprecated
-    Usage getUsage(); // kept for backwards compatibility of plugins (like kotlin-multiplatform) using internal APIs
+    default Usage getUsage(){
+        // This method kept for backwards compatibility of plugins (like kotlin-multiplatform) using internal APIs.
+        // KMP has recently stopped using this method, so we should be able to remove it
+        throw new UnsupportedOperationException("This method has been deprecated and should never be called");
+    }
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
@@ -32,6 +32,7 @@ import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.component.SoftwareComponent;
+import org.gradle.api.component.SoftwareComponentVariant;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
@@ -40,9 +41,8 @@ import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDepende
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
-import org.gradle.api.internal.component.IvyPublishingAwareContext;
+import org.gradle.api.internal.component.IvyPublishingAwareVariant;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
-import org.gradle.api.internal.component.UsageContext;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
@@ -274,24 +274,24 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
         PublicationErrorChecker.checkForUnpublishableAttributes(component, documentationRegistry);
 
         PublicationWarningsCollector publicationWarningsCollector = new PublicationWarningsCollector(LOG, UNSUPPORTED_FEATURE, "", PUBLICATION_WARNING_FOOTER, "suppressIvyMetadataWarningsFor");
-        Set<? extends UsageContext> usageContexts = component.getUsages();
+        Set<? extends SoftwareComponentVariant> variants = component.getUsages();
 
-        populateConfigurations(usageContexts);
-        populateArtifacts(usageContexts);
-        populateDependencies(usageContexts, publicationWarningsCollector);
-        populateGlobalExcludes(usageContexts);
+        populateConfigurations(variants);
+        populateArtifacts(variants);
+        populateDependencies(variants, publicationWarningsCollector);
+        populateGlobalExcludes(variants);
 
         if (!silenceAllPublicationWarnings) {
             publicationWarningsCollector.complete(getDisplayName() + " ivy metadata", silencedVariants);
         }
     }
 
-    private void populateConfigurations(Set<? extends UsageContext> usageContexts) {
+    private void populateConfigurations(Set<? extends SoftwareComponentVariant> variants) {
         IvyConfiguration defaultConfiguration = configurations.maybeCreate("default");
-        for (UsageContext usageContext : usageContexts) {
-            String conf = mapUsageNameToIvyConfiguration(usageContext.getName());
+        for (SoftwareComponentVariant variant : variants) {
+            String conf = mapVariantNameToIvyConfiguration(variant.getName());
             configurations.maybeCreate(conf);
-            if (defaultShouldExtend(usageContext)) {
+            if (defaultShouldExtend(variant)) {
                 defaultConfiguration.extend(conf);
             }
         }
@@ -299,36 +299,36 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
 
     /**
      * In general, default extends all configurations such that you get 'everything' when depending on default.
-     * If a usage is optional, however it is not included.
-     * If a usage represents the Java API variant, it is also not included, because the Java Runtime variant already includes everything
+     * If a variant is optional, however it is not included.
+     * If a variant represents the Java API variant, it is also not included, because the Java Runtime variant already includes everything
      * (including both also works but would lead to some duplication, that might break backwards compatibility in certain cases).
      */
-    private static boolean defaultShouldExtend(UsageContext usageContext) {
-        if (!(usageContext instanceof IvyPublishingAwareContext)) {
+    private static boolean defaultShouldExtend(SoftwareComponentVariant variant) {
+        if (!(variant instanceof IvyPublishingAwareVariant)) {
             return true;
         }
-        if (((IvyPublishingAwareContext) usageContext).isOptional()) {
+        if (((IvyPublishingAwareVariant) variant).isOptional()) {
             return false;
         }
-        return !isJavaApiVariant(usageContext.getName());
+        return !isJavaApiVariant(variant.getName());
     }
 
-    private static boolean isJavaRuntimeVariant(String usageName) {
-        return RUNTIME_VARIANT.equals(usageName) || RUNTIME_ELEMENTS_VARIANT.equals(usageName);
+    private static boolean isJavaRuntimeVariant(String variantName) {
+        return RUNTIME_VARIANT.equals(variantName) || RUNTIME_ELEMENTS_VARIANT.equals(variantName);
     }
 
-    private static boolean isJavaApiVariant(String usageName) {
-        return API_VARIANT.equals(usageName) || API_ELEMENTS_VARIANT.equals(usageName);
+    private static boolean isJavaApiVariant(String variantName) {
+        return API_VARIANT.equals(variantName) || API_ELEMENTS_VARIANT.equals(variantName);
     }
 
-    private void populateArtifacts(Set<? extends UsageContext> usageContexts) {
+    private void populateArtifacts(Set<? extends SoftwareComponentVariant> variants) {
         if (artifactsOverridden) {
             return;
         }
         Map<String, IvyArtifact> seenArtifacts = Maps.newHashMap();
-        for (UsageContext usageContext : usageContexts) {
-            String conf = mapUsageNameToIvyConfiguration(usageContext.getName());
-            for (PublishArtifact publishArtifact : usageContext.getArtifacts()) {
+        for (SoftwareComponentVariant variant : variants) {
+            String conf = mapVariantNameToIvyConfiguration(variant.getName());
+            for (PublishArtifact publishArtifact : variant.getArtifacts()) {
                 String key = artifactKey(publishArtifact);
                 IvyArtifact ivyArtifact = seenArtifacts.get(key);
                 if (ivyArtifact == null) {
@@ -346,11 +346,11 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
         return publishArtifact.getName() + ":" + publishArtifact.getType() + ":" + publishArtifact.getExtension() + ":" + publishArtifact.getClassifier();
     }
 
-    private void populateDependencies(Set<? extends UsageContext> usageContexts, PublicationWarningsCollector publicationWarningsCollector) {
-        for (UsageContext usageContext : usageContexts) {
-            publicationWarningsCollector.newContext(usageContext.getName());
-            for (ModuleDependency dependency : usageContext.getDependencies()) {
-                String confMapping = confMappingFor(usageContext, dependency);
+    private void populateDependencies(Set<? extends SoftwareComponentVariant> variants, PublicationWarningsCollector publicationWarningsCollector) {
+        for (SoftwareComponentVariant variant : variants) {
+            publicationWarningsCollector.newContext(variant.getName());
+            for (ModuleDependency dependency : variant.getDependencies()) {
+                String confMapping = confMappingFor(variant, dependency);
                 if (!dependency.getAttributes().isEmpty()) {
                     publicationWarningsCollector.addUnsupported(String.format("%s:%s:%s declared with Gradle attributes", dependency.getGroup(), dependency.getName(), dependency.getVersion()));
                 }
@@ -364,17 +364,17 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
                     if (!versionMappingInUse && externalDependency.getVersion() == null) {
                         publicationWarningsCollector.addUnsupported(String.format("%s:%s declared without version", externalDependency.getGroup(), externalDependency.getName()));
                     }
-                    addExternalDependency(externalDependency, confMapping, ((AttributeContainerInternal) usageContext.getAttributes()).asImmutable());
+                    addExternalDependency(externalDependency, confMapping, ((AttributeContainerInternal) variant.getAttributes()).asImmutable());
                 }
             }
 
-            if (!usageContext.getDependencyConstraints().isEmpty()) {
-                for (DependencyConstraint constraint : usageContext.getDependencyConstraints()) {
+            if (!variant.getDependencyConstraints().isEmpty()) {
+                for (DependencyConstraint constraint : variant.getDependencyConstraints()) {
                     publicationWarningsCollector.addUnsupported(String.format("%s:%s:%s declared as a dependency constraint", constraint.getGroup(), constraint.getName(), constraint.getVersion()));
                 }
             }
-            if (!usageContext.getCapabilities().isEmpty()) {
-                for (Capability capability : usageContext.getCapabilities()) {
+            if (!variant.getCapabilities().isEmpty()) {
+                for (Capability capability : variant.getCapabilities()) {
                     publicationWarningsCollector.addVariantUnsupported(String.format("Declares capability %s:%s:%s which cannot be mapped to Ivy", capability.getGroup(), capability.getName(), capability.getVersion()));
                 }
             }
@@ -382,24 +382,24 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
         }
     }
 
-    private void populateGlobalExcludes(Set<? extends UsageContext> usageContexts) {
-        for (UsageContext usageContext : usageContexts) {
-            String conf = mapUsageNameToIvyConfiguration(usageContext.getName());
-            for (ExcludeRule excludeRule : usageContext.getGlobalExcludes()) {
+    private void populateGlobalExcludes(Set<? extends SoftwareComponentVariant> variants) {
+        for (SoftwareComponentVariant variant : variants) {
+            String conf = mapVariantNameToIvyConfiguration(variant.getName());
+            for (ExcludeRule excludeRule : variant.getGlobalExcludes()) {
                 globalExcludes.add(new DefaultIvyExcludeRule(excludeRule, conf));
             }
         }
     }
 
-    private static String confMappingFor(UsageContext usageContext, ModuleDependency dependency) {
-        String conf = mapUsageNameToIvyConfiguration(usageContext.getName());
-        String confMappingTarget = mapUsageNameToIvyConfiguration(dependency.getTargetConfiguration());
+    private static String confMappingFor(SoftwareComponentVariant variant, ModuleDependency dependency) {
+        String conf = mapVariantNameToIvyConfiguration(variant.getName());
+        String confMappingTarget = mapVariantNameToIvyConfiguration(dependency.getTargetConfiguration());
 
         // If the following code is activated implementation/runtime separation will be published to ivy. This however is a breaking change.
         //
         // if (confMappingTarget == null) {
-        //     if (usageContext instanceof MavenPublishingAwareContext) {
-        //         MavenPublishingAwareContext.ScopeMapping mapping = ((MavenPublishingAwareContext) usageContext).getScopeMapping();
+        //     if (variant instanceof MavenPublishingAwareVariant) {
+        //         MavenPublishingAwareContext.ScopeMapping mapping = ((MavenPublishingAwareVariant) variant).getScopeMapping();
         //         if (mapping == runtime || mapping == runtime_optional) {
         //             confMappingTarget = "runtime";
         //         }
@@ -416,17 +416,17 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
     }
 
     /**
-     * The usage name usually corresponds to the name of the Gradle configuration on which the variant represented by the usage is based on.
+     * The variant name usually corresponds to the name of the Gradle configuration on which the variant is based on.
      * For backward compatibility, the 'apiElements' and 'runtimeElements' configurations/variants of the Java ecosystem are named 'compile' and 'runtime' in the publication.
      */
-    private static String mapUsageNameToIvyConfiguration(String usageName) {
-        if (isJavaApiVariant(usageName)) {
+    private static String mapVariantNameToIvyConfiguration(String variantName) {
+        if (isJavaApiVariant(variantName)) {
             return "compile";
         }
-        if (isJavaRuntimeVariant(usageName)) {
+        if (isJavaRuntimeVariant(variantName)) {
             return "runtime";
         }
-        return usageName;
+        return variantName;
     }
 
     private void addProjectDependency(ProjectDependency dependency, String confMapping) {

--- a/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
+++ b/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
@@ -414,14 +414,14 @@ class DefaultIvyPublicationTest extends Specification {
     }
 
     def createComponent(def artifacts, def dependencies) {
-        def usage = Stub(UsageContext) {
+        def variant = Stub(UsageContext) {
             getName() >> 'runtime'
             getArtifacts() >> artifacts
             getDependencies() >> dependencies
             getAttributes() >> ImmutableAttributes.EMPTY
         }
         def component = Stub(SoftwareComponentInternal) {
-            getUsages() >> [usage]
+            getUsages() >> [variant]
         }
         return component
     }

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppExecutable.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppExecutable.java
@@ -29,6 +29,7 @@ import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.component.UsageContext;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.plugins.internal.ConfigurationSoftwareComponentVariant;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.language.cpp.CppExecutable;
@@ -129,12 +130,12 @@ public class DefaultCppExecutable extends DefaultCppBinary implements CppExecuta
     @Override
     public Set<? extends UsageContext> getUsages() {
         Configuration runtimeElements = runtimeElementsProperty.get();
-        return Collections.singleton(new DefaultUsageContext(getIdentity().getRuntimeUsageContext(), runtimeElements.getAllArtifacts(), runtimeElements));
+        return Collections.singleton(new ConfigurationSoftwareComponentVariant(getIdentity().getRuntimeVariant(), runtimeElements.getAllArtifacts(), runtimeElements));
     }
 
     @Override
     public AttributeContainer getRuntimeAttributes() {
-        return getIdentity().getRuntimeUsageContext().getAttributes();
+        return getIdentity().getRuntimeVariant().getAttributes();
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppLibrary.java
@@ -79,7 +79,7 @@ public class DefaultCppLibrary extends DefaultCppComponent implements CppLibrary
         AttributeContainer publicationAttributes = immutableAttributesFactory.mutable();
         publicationAttributes.attribute(Usage.USAGE_ATTRIBUTE, apiUsage);
         publicationAttributes.attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.ZIP_TYPE);
-        mainVariant = new MainLibraryVariant("api", apiUsage, apiElements, publicationAttributes, objectFactory);
+        mainVariant = new MainLibraryVariant("api", apiElements, publicationAttributes, objectFactory);
     }
 
     public DefaultCppSharedLibrary addSharedLibrary(NativeVariantIdentity identity, CppPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppSharedLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppSharedLibrary.java
@@ -28,6 +28,7 @@ import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.component.UsageContext;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.plugins.internal.ConfigurationSoftwareComponentVariant;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.language.cpp.CppPlatform;
@@ -117,19 +118,19 @@ public class DefaultCppSharedLibrary extends DefaultCppBinary implements CppShar
         Configuration linkElements = getLinkElements().get();
         Configuration runtimeElements = getRuntimeElements().get();
         return Sets.newHashSet(
-            new DefaultUsageContext(getIdentity().getLinkUsageContext(), linkElements.getAllArtifacts(), linkElements),
-            new DefaultUsageContext(getIdentity().getRuntimeUsageContext(), runtimeElements.getAllArtifacts(), runtimeElements)
+            new ConfigurationSoftwareComponentVariant(getIdentity().getLinkVariant(), linkElements.getAllArtifacts(), linkElements),
+            new ConfigurationSoftwareComponentVariant(getIdentity().getRuntimeVariant(), runtimeElements.getAllArtifacts(), runtimeElements)
         );
     }
 
     @Override
     public AttributeContainer getLinkAttributes() {
-        return getIdentity().getLinkUsageContext().getAttributes();
+        return getIdentity().getLinkVariant().getAttributes();
     }
 
     @Override
     public AttributeContainer getRuntimeAttributes() {
-        return getIdentity().getRuntimeUsageContext().getAttributes();
+        return getIdentity().getRuntimeVariant().getAttributes();
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppStaticLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppStaticLibrary.java
@@ -30,6 +30,7 @@ import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.component.UsageContext;
 import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.plugins.internal.ConfigurationSoftwareComponentVariant;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.language.cpp.CppPlatform;
@@ -118,19 +119,19 @@ public class DefaultCppStaticLibrary extends DefaultCppBinary implements CppStat
         Configuration runtimeElements = getRuntimeElements().get();
         // TODO: Does a static library really have any runtime elements?
         return Sets.newHashSet(
-            new DefaultUsageContext(getIdentity().getLinkUsageContext(), linkElements.getAllArtifacts(), linkElements),
-            new DefaultUsageContext(getIdentity().getRuntimeUsageContext(), runtimeElements.getAllArtifacts(), runtimeElements)
+            new ConfigurationSoftwareComponentVariant(getIdentity().getLinkVariant(), linkElements.getAllArtifacts(), linkElements),
+            new ConfigurationSoftwareComponentVariant(getIdentity().getRuntimeVariant(), runtimeElements.getAllArtifacts(), runtimeElements)
         );
     }
 
     @Override
     public AttributeContainer getLinkAttributes() {
-        return getIdentity().getLinkUsageContext().getAttributes();
+        return getIdentity().getLinkVariant().getAttributes();
     }
 
     @Override
     public AttributeContainer getRuntimeAttributes() {
-        return getIdentity().getRuntimeUsageContext().getAttributes();
+        return getIdentity().getRuntimeVariant().getAttributes();
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/MainLibraryVariant.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/MainLibraryVariant.java
@@ -21,27 +21,25 @@ import org.gradle.api.DomainObjectSet;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.attributes.AttributeContainer;
-import org.gradle.api.attributes.Usage;
 import org.gradle.api.component.ComponentWithVariants;
 import org.gradle.api.component.SoftwareComponent;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.component.UsageContext;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.plugins.internal.ConfigurationSoftwareComponentVariant;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
 
 public class MainLibraryVariant implements ComponentWithVariants, SoftwareComponentInternal {
     private final String name;
-    private final Usage usage;
     private final Set<PublishArtifact> artifacts = new LinkedHashSet<PublishArtifact>();
     private final Configuration dependencies;
     private final DomainObjectSet<SoftwareComponent> variants;
     private final AttributeContainer attributeContainer;
 
-    public MainLibraryVariant(String name, Usage usage, Configuration dependencies, AttributeContainer attributeContainer, ObjectFactory objectFactory) {
+    public MainLibraryVariant(String name, Configuration dependencies, AttributeContainer attributeContainer, ObjectFactory objectFactory) {
         this.name = name;
-        this.usage = usage;
         this.dependencies = dependencies;
         this.attributeContainer = attributeContainer;
         this.variants = objectFactory.domainObjectSet(SoftwareComponent.class);
@@ -54,7 +52,7 @@ public class MainLibraryVariant implements ComponentWithVariants, SoftwareCompon
 
     @Override
     public Set<? extends UsageContext> getUsages() {
-        return ImmutableSet.of(new DefaultUsageContext(name, attributeContainer, artifacts, dependencies));
+        return ImmutableSet.of(new ConfigurationSoftwareComponentVariant(name, attributeContainer, artifacts, dependencies));
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/NativeVariantIdentity.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/NativeVariantIdentity.java
@@ -19,6 +19,7 @@ package org.gradle.language.cpp.internal;
 import com.google.common.collect.Sets;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.component.ComponentWithCoordinates;
+import org.gradle.api.component.SoftwareComponentVariant;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.component.UsageContext;
@@ -37,16 +38,16 @@ public class NativeVariantIdentity implements SoftwareComponentInternal, Compone
     private final boolean debuggable;
     private final boolean optimized;
     private final TargetMachine targetMachine;
-    private final UsageContext linkUsage;
-    private final UsageContext runtimeUsage;
+    private final SoftwareComponentVariant linkVariant;
+    private final SoftwareComponentVariant runtimeVariant;
     private final Linkage linkage;
-    private final Set<UsageContext> usageContexts;
+    private final Set<UsageContext> variants;
 
-    public NativeVariantIdentity(String name, Provider<String> baseName, Provider<String> group, Provider<String> version, boolean debuggable, boolean optimized, TargetMachine targetMachine, UsageContext linkUsage, UsageContext runtimeUsage) {
-        this(name, baseName, group, version, debuggable, optimized, targetMachine, linkUsage, runtimeUsage, null);
+    public NativeVariantIdentity(String name, Provider<String> baseName, Provider<String> group, Provider<String> version, boolean debuggable, boolean optimized, TargetMachine targetMachine, UsageContext linkVariant, UsageContext runtimeVariant) {
+        this(name, baseName, group, version, debuggable, optimized, targetMachine, linkVariant, runtimeVariant, null);
     }
 
-    public NativeVariantIdentity(String name, Provider<String> baseName, Provider<String> group, Provider<String> version, boolean debuggable, boolean optimized, TargetMachine targetMachine, UsageContext linkUsage, UsageContext runtimeUsage, Linkage linkage) {
+    public NativeVariantIdentity(String name, Provider<String> baseName, Provider<String> group, Provider<String> version, boolean debuggable, boolean optimized, TargetMachine targetMachine, UsageContext linkVariant, UsageContext runtimeVariant, Linkage linkage) {
         this.name = name;
         this.baseName = baseName;
         this.group = group;
@@ -54,15 +55,15 @@ public class NativeVariantIdentity implements SoftwareComponentInternal, Compone
         this.debuggable = debuggable;
         this.optimized = optimized;
         this.targetMachine = targetMachine;
-        this.linkUsage = linkUsage;
-        this.runtimeUsage = runtimeUsage;
+        this.linkVariant = linkVariant;
+        this.runtimeVariant = runtimeVariant;
         this.linkage = linkage;
-        this.usageContexts = Sets.newLinkedHashSet();
-        if (linkUsage!=null) {
-            usageContexts.add(linkUsage);
+        this.variants = Sets.newLinkedHashSet();
+        if (linkVariant != null) {
+            variants.add(linkVariant);
         }
-        if (runtimeUsage!=null) {
-            usageContexts.add(runtimeUsage);
+        if (runtimeVariant !=null) {
+            variants.add(runtimeVariant);
         }
     }
 
@@ -89,7 +90,7 @@ public class NativeVariantIdentity implements SoftwareComponentInternal, Compone
 
     @Override
     public Set<? extends UsageContext> getUsages() {
-        return usageContexts;
+        return variants;
     }
 
     @Override
@@ -97,11 +98,11 @@ public class NativeVariantIdentity implements SoftwareComponentInternal, Compone
         return name;
     }
 
-    public UsageContext getRuntimeUsageContext() {
-        return runtimeUsage;
+    public SoftwareComponentVariant getRuntimeVariant() {
+        return runtimeVariant;
     }
 
-    public UsageContext getLinkUsageContext() {
-        return linkUsage;
+    public SoftwareComponentVariant getLinkVariant() {
+        return linkVariant;
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/Dimensions.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/Dimensions.java
@@ -23,10 +23,11 @@ import org.gradle.api.Named;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.api.internal.component.DefaultSoftwareComponentVariant;
+import org.gradle.api.internal.component.UsageContext;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.SetProperty;
-import org.gradle.language.cpp.internal.DefaultUsageContext;
 import org.gradle.language.cpp.internal.NativeVariantIdentity;
 import org.gradle.nativeplatform.Linkage;
 import org.gradle.nativeplatform.MachineArchitecture;
@@ -143,15 +144,15 @@ public class Dimensions {
                     addCommonAttributes(buildType, targetMachine, runtimeAttributes);
                     runtimeAttributes.attribute(LINKAGE_ATTRIBUTE, linkage);
 
-                    DefaultUsageContext runtimeUsageContext = new DefaultUsageContext(variantName + "Runtime", runtimeAttributes);
+                    UsageContext runtimeVariant = new DefaultSoftwareComponentVariant(variantName + "Runtime", runtimeAttributes);
 
                     AttributeContainer linkAttributes = attributesFactory.mutable();
                     linkAttributes.attribute(Usage.USAGE_ATTRIBUTE, linkUsage);
                     addCommonAttributes(buildType, targetMachine, linkAttributes);
                     linkAttributes.attribute(LINKAGE_ATTRIBUTE, linkage);
-                    DefaultUsageContext linkUsageContext = new DefaultUsageContext(variantName + "Link", linkAttributes);
+                    UsageContext linkVariant = new DefaultSoftwareComponentVariant(variantName + "Link", linkAttributes);
 
-                    NativeVariantIdentity variantIdentity = new NativeVariantIdentity(variantName, baseName, group, version, buildType.isDebuggable(), buildType.isOptimized(), targetMachine, linkUsageContext, runtimeUsageContext, linkage);
+                    NativeVariantIdentity variantIdentity = new NativeVariantIdentity(variantName, baseName, group, version, buildType.isDebuggable(), buildType.isOptimized(), targetMachine, linkVariant, runtimeVariant, linkage);
 
                     action.execute(variantIdentity);
                 }
@@ -180,11 +181,11 @@ public class Dimensions {
                 runtimeAttributes.attribute(Usage.USAGE_ATTRIBUTE, runtimeUsage);
                 addCommonAttributes(buildType, targetMachine, runtimeAttributes);
 
-                DefaultUsageContext runtimeUsageContext = new DefaultUsageContext(variantName + "Runtime", runtimeAttributes);
+                UsageContext runtimeVariant = new DefaultSoftwareComponentVariant(variantName + "Runtime", runtimeAttributes);
 
-                DefaultUsageContext linkUsageContext = null;
+                UsageContext linkVariant = null;
 
-                NativeVariantIdentity variantIdentity = new NativeVariantIdentity(variantName, baseName, group, version, buildType.isDebuggable(), buildType.isOptimized(), targetMachine, linkUsageContext, runtimeUsageContext, null);
+                NativeVariantIdentity variantIdentity = new NativeVariantIdentity(variantName, baseName, group, version, buildType.isDebuggable(), buildType.isOptimized(), targetMachine, linkVariant, runtimeVariant, null);
 
                 action.execute(variantIdentity);
             }

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftExecutable.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftExecutable.java
@@ -29,9 +29,9 @@ import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.component.UsageContext;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.plugins.internal.ConfigurationSoftwareComponentVariant;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
-import org.gradle.language.cpp.internal.DefaultUsageContext;
 import org.gradle.language.cpp.internal.NativeVariantIdentity;
 import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithExecutable;
 import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithRuntimeUsage;
@@ -131,11 +131,11 @@ public class DefaultSwiftExecutable extends DefaultSwiftBinary implements SwiftE
     @Override
     public Set<? extends UsageContext> getUsages() {
         Configuration runtimeElements = runtimeElementsProperty.get();
-        return Collections.singleton(new DefaultUsageContext(getIdentity().getRuntimeUsageContext(), runtimeElements.getAllArtifacts(), runtimeElements));
+        return Collections.singleton(new ConfigurationSoftwareComponentVariant(getIdentity().getRuntimeVariant(), runtimeElements.getAllArtifacts(), runtimeElements));
     }
 
     @Override
     public AttributeContainer getRuntimeAttributes() {
-        return getIdentity().getRuntimeUsageContext().getAttributes();
+        return getIdentity().getRuntimeVariant().getAttributes();
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftSharedLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftSharedLibrary.java
@@ -28,9 +28,9 @@ import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.component.UsageContext;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.plugins.internal.ConfigurationSoftwareComponentVariant;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
-import org.gradle.language.cpp.internal.DefaultUsageContext;
 import org.gradle.language.cpp.internal.NativeVariantIdentity;
 import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithLinkUsage;
 import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithRuntimeUsage;
@@ -116,12 +116,12 @@ public class DefaultSwiftSharedLibrary extends DefaultSwiftBinary implements Swi
 
     @Override
     public AttributeContainer getLinkAttributes() {
-        return getIdentity().getLinkUsageContext().getAttributes();
+        return getIdentity().getLinkVariant().getAttributes();
     }
 
     @Override
     public AttributeContainer getRuntimeAttributes() {
-        return getIdentity().getRuntimeUsageContext().getAttributes();
+        return getIdentity().getRuntimeVariant().getAttributes();
     }
 
     @Override
@@ -129,8 +129,8 @@ public class DefaultSwiftSharedLibrary extends DefaultSwiftBinary implements Swi
         Configuration linkElements = getLinkElements().get();
         Configuration runtimeElements = getRuntimeElements().get();
         return Sets.newHashSet(
-            new DefaultUsageContext(getIdentity().getLinkUsageContext(), linkElements.getAllArtifacts(), linkElements),
-            new DefaultUsageContext(getIdentity().getRuntimeUsageContext(), runtimeElements.getAllArtifacts(), runtimeElements)
+            new ConfigurationSoftwareComponentVariant(getIdentity().getLinkVariant(), linkElements.getAllArtifacts(), linkElements),
+            new ConfigurationSoftwareComponentVariant(getIdentity().getRuntimeVariant(), runtimeElements.getAllArtifacts(), runtimeElements)
         );
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftStaticLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftStaticLibrary.java
@@ -30,9 +30,9 @@ import org.gradle.api.internal.component.UsageContext;
 import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.plugins.internal.ConfigurationSoftwareComponentVariant;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
-import org.gradle.language.cpp.internal.DefaultUsageContext;
 import org.gradle.language.cpp.internal.NativeVariantIdentity;
 import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithLinkUsage;
 import org.gradle.language.nativeplatform.internal.ConfigurableComponentWithRuntimeUsage;
@@ -116,12 +116,12 @@ public class DefaultSwiftStaticLibrary extends DefaultSwiftBinary implements Swi
 
     @Override
     public AttributeContainer getLinkAttributes() {
-        return getIdentity().getLinkUsageContext().getAttributes();
+        return getIdentity().getLinkVariant().getAttributes();
     }
 
     @Override
     public AttributeContainer getRuntimeAttributes() {
-        return getIdentity().getRuntimeUsageContext().getAttributes();
+        return getIdentity().getRuntimeVariant().getAttributes();
     }
 
     @Override
@@ -129,9 +129,9 @@ public class DefaultSwiftStaticLibrary extends DefaultSwiftBinary implements Swi
         Configuration linkElements = getLinkElements().get();
         Configuration runtimeElements = getRuntimeElements().get();
         return Sets.newHashSet(
-                // TODO: Does a static library have runtime elements?
-                new DefaultUsageContext(getIdentity().getLinkUsageContext(), linkElements.getAllArtifacts(), linkElements),
-                new DefaultUsageContext(getIdentity().getRuntimeUsageContext(), runtimeElements.getAllArtifacts(), runtimeElements)
+            // TODO: Does a static library have runtime elements?
+            new ConfigurationSoftwareComponentVariant(getIdentity().getLinkVariant(), linkElements.getAllArtifacts(), linkElements),
+            new ConfigurationSoftwareComponentVariant(getIdentity().getRuntimeVariant(), runtimeElements.getAllArtifacts(), runtimeElements)
         );
     }
 }

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/plugins/NativeBasePluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/plugins/NativeBasePluginTest.groovy
@@ -411,29 +411,29 @@ class NativeBasePluginTest extends Specification {
     }
 
     def "adds Maven publications for component with main publication"() {
-        def componentVariant1 = Stub(UsageContext)
+        def variant1 = Stub(UsageContext)
         def artifact1 = Stub(PublishArtifact)
         artifact1.getFile() >> projectDir.file("artifact1")
-        componentVariant1.artifacts >> [artifact1]
-        def variant1 = Stub(PublishableVariant)
-        variant1.name >> "debug"
-        variant1.usages >> [componentVariant1]
-        variant1.getCoordinates() >> new DefaultModuleVersionIdentifier("my.group", "test_app_debug", "1.2")
+        variant1.artifacts >> [artifact1]
+        def publishableVariant1 = Stub(PublishableVariant)
+        publishableVariant1.name >> "debug"
+        publishableVariant1.usages >> [variant1]
+        publishableVariant1.getCoordinates() >> new DefaultModuleVersionIdentifier("my.group", "test_app_debug", "1.2")
 
-        def componentVariant2 = Stub(UsageContext)
+        def variant2 = Stub(UsageContext)
         def artifact2 = Stub(PublishArtifact)
         artifact2.getFile() >> projectDir.file("artifact1")
-        componentVariant2.artifacts >> [artifact2]
-        def variant2 = Stub(PublishableVariant)
-        variant2.name >> "release"
-        variant2.usages >> [componentVariant2]
-        variant2.getCoordinates() >> new DefaultModuleVersionIdentifier("my.group", "test_app_release", "1.2")
+        variant2.artifacts >> [artifact2]
+        def publishableVariant2 = Stub(PublishableVariant)
+        publishableVariant2.name >> "release"
+        publishableVariant2.usages >> [variant2]
+        publishableVariant2.getCoordinates() >> new DefaultModuleVersionIdentifier("my.group", "test_app_release", "1.2")
 
         def doNotPublish = Stub(SoftwareComponentInternal)
 
         def mainVariant = Stub(TestVariant)
         mainVariant.name >> "main"
-        mainVariant.variants >> [variant1, variant2, doNotPublish]
+        mainVariant.variants >> [publishableVariant1, publishableVariant2, doNotPublish]
 
         def component = Stub(PublicationAwareComponent)
         component.mainPublication >> mainVariant

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/plugins/NativeBasePluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/plugins/NativeBasePluginTest.groovy
@@ -411,22 +411,22 @@ class NativeBasePluginTest extends Specification {
     }
 
     def "adds Maven publications for component with main publication"() {
-        def usage1 = Stub(UsageContext)
+        def componentVariant1 = Stub(UsageContext)
         def artifact1 = Stub(PublishArtifact)
         artifact1.getFile() >> projectDir.file("artifact1")
-        usage1.artifacts >> [artifact1]
+        componentVariant1.artifacts >> [artifact1]
         def variant1 = Stub(PublishableVariant)
         variant1.name >> "debug"
-        variant1.usages >> [usage1]
+        variant1.usages >> [componentVariant1]
         variant1.getCoordinates() >> new DefaultModuleVersionIdentifier("my.group", "test_app_debug", "1.2")
 
-        def usage2 = Stub(UsageContext)
+        def componentVariant2 = Stub(UsageContext)
         def artifact2 = Stub(PublishArtifact)
         artifact2.getFile() >> projectDir.file("artifact1")
-        usage2.artifacts >> [artifact2]
+        componentVariant2.artifacts >> [artifact2]
         def variant2 = Stub(PublishableVariant)
         variant2.name >> "release"
-        variant2.usages >> [usage2]
+        variant2.usages >> [componentVariant2]
         variant2.getCoordinates() >> new DefaultModuleVersionIdentifier("my.group", "test_app_release", "1.2")
 
         def doNotPublish = Stub(SoftwareComponentInternal)

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftLibraryTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftLibraryTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.language.swift.internal
 
-import org.gradle.language.cpp.internal.DefaultUsageContext
+import org.gradle.api.internal.component.DefaultSoftwareComponentVariant
 import org.gradle.language.cpp.internal.NativeVariantIdentity
 import org.gradle.language.swift.SwiftPlatform
 import org.gradle.nativeplatform.MachineArchitecture
@@ -110,8 +110,8 @@ class DefaultSwiftLibraryTest extends Specification {
 
     private NativeVariantIdentity getIdentity() {
         return new NativeVariantIdentity("test", null, null, null, true, false, targetMachine(OperatingSystemFamily.WINDOWS, MachineArchitecture.X86_64),
-            new DefaultUsageContext("test", AttributeTestUtil.attributesFactory().mutable()),
-            new DefaultUsageContext("test", AttributeTestUtil.attributesFactory().mutable())
+            new DefaultSoftwareComponentVariant("test", AttributeTestUtil.attributesFactory().mutable()),
+            new DefaultSoftwareComponentVariant("test", AttributeTestUtil.attributesFactory().mutable())
         )
     }
 

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -328,7 +328,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
                         if (dependency instanceof ProjectDependency) {
                             addImportDependencyConstraint((ProjectDependency) dependency);
                         } else {
-                            if (isVersionMavenIncompatible(dependency.getVersion())) {
+                            if (isMavenIncompatibleVersionInUse(dependency.getVersion())) {
                                 publicationWarningsCollector.addIncompatible(String.format("%s:%s:%s declared with a Maven incompatible version notation", dependency.getGroup(), dependency.getName(), dependency.getVersion()));
                             }
                             addImportDependencyConstraint(dependency);
@@ -340,7 +340,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
                         if (dependency instanceof ProjectDependency) {
                             addProjectDependency((ProjectDependency) dependency, globalExcludes, dependencies);
                         } else {
-                            if (isVersionMavenIncompatible(dependency.getVersion())) {
+                            if (isMavenIncompatibleVersionInUse(dependency.getVersion())) {
                                 publicationWarningsCollector.addIncompatible(String.format("%s:%s:%s declared with a Maven incompatible version notation", dependency.getGroup(), dependency.getName(), dependency.getVersion()));
                             }
                             addModuleDependency(dependency, globalExcludes, dependencies);
@@ -354,7 +354,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
                     if (dependency instanceof DefaultProjectDependencyConstraint) {
                         addDependencyConstraint((DefaultProjectDependencyConstraint) dependency, dependencyConstraints);
                     } else if (dependency.getVersion() != null) {
-                        if (isVersionMavenIncompatible(dependency.getVersion())) {
+                        if (isMavenIncompatibleVersionInUse(dependency.getVersion())) {
                             publicationWarningsCollector.addIncompatible(String.format("constraint %s:%s:%s declared with a Maven incompatible version notation", dependency.getGroup(), dependency.getName(), dependency.getVersion()));
                         }
                         addDependencyConstraint(dependency, dependencyConstraints);
@@ -392,7 +392,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
         return getCoordinates().getModule().equals(DefaultModuleIdentifier.newId(dependency.getGroup(), dependency.getName()));
     }
 
-    private boolean isVersionMavenIncompatible(String version) {
+    private boolean isMavenIncompatibleVersionInUse(String version) {
         if (versionMappingInUse) {
             return false;
         }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -19,7 +19,6 @@ package org.gradle.api.publish.maven.internal.publication;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Objects;
 import com.google.common.base.Strings;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.gradle.api.Action;
 import org.gradle.api.DomainObjectCollection;
@@ -37,6 +36,7 @@ import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.component.AdhocComponentWithVariants;
 import org.gradle.api.component.SoftwareComponent;
+import org.gradle.api.component.SoftwareComponentVariant;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.CompositeDomainObjectSet;
 import org.gradle.api.internal.DocumentationRegistry;
@@ -51,9 +51,8 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.MavenVer
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyPublicationResolver;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
-import org.gradle.api.internal.component.MavenPublishingAwareContext;
+import org.gradle.api.internal.component.MavenPublishingAwareVariant;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
-import org.gradle.api.internal.component.UsageContext;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
@@ -102,6 +101,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toMap;
 
@@ -305,20 +305,20 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
         Set<ArtifactKey> seenArtifacts = Sets.newHashSet();
         Set<PublishedDependency> seenDependencies = Sets.newHashSet();
         Set<DependencyConstraint> seenConstraints = Sets.newHashSet();
-        for (UsageContext usageContext : getSortedUsageContexts()) {
-            // TODO Need a smarter way to map usage to artifact classifier
-            for (PublishArtifact publishArtifact : usageContext.getArtifacts()) {
+        for (SoftwareComponentVariant variant : getSortedVariants()) {
+            // TODO Need a smarter way to map variant to artifact classifier
+            for (PublishArtifact publishArtifact : variant.getArtifacts()) {
                 ArtifactKey key = new ArtifactKey(publishArtifact.getFile(), publishArtifact.getClassifier(), publishArtifact.getExtension());
                 if (!artifactsOverridden && seenArtifacts.add(key)) {
                     artifact(publishArtifact);
                 }
             }
 
-            Set<ExcludeRule> globalExcludes = usageContext.getGlobalExcludes();
+            Set<ExcludeRule> globalExcludes = variant.getGlobalExcludes();
 
-            publicationWarningsCollector.newContext(usageContext.getName());
-            Set<MavenDependencyInternal> dependencies = dependenciesFor(usageContext);
-            for (ModuleDependency dependency : usageContext.getDependencies()) {
+            publicationWarningsCollector.newContext(variant.getName());
+            Set<MavenDependencyInternal> dependencies = dependenciesFor(variant);
+            for (ModuleDependency dependency : variant.getDependencies()) {
                 if (seenDependencies.add(PublishedDependency.of(dependency))) {
                     if (isDependencyWithDefaultArtifact(dependency) && dependencyMatchesProject(dependency)) {
                         // We skip all self referencing dependency declarations, unless they have custom artifact information
@@ -328,7 +328,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
                         if (dependency instanceof ProjectDependency) {
                             addImportDependencyConstraint((ProjectDependency) dependency);
                         } else {
-                            if (!versionMappingInUse && isVersionMavenIncompatible(dependency.getVersion())) {
+                            if (isVersionMavenIncompatible(dependency.getVersion())) {
                                 publicationWarningsCollector.addIncompatible(String.format("%s:%s:%s declared with a Maven incompatible version notation", dependency.getGroup(), dependency.getName(), dependency.getVersion()));
                             }
                             addImportDependencyConstraint(dependency);
@@ -340,7 +340,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
                         if (dependency instanceof ProjectDependency) {
                             addProjectDependency((ProjectDependency) dependency, globalExcludes, dependencies);
                         } else {
-                            if (!versionMappingInUse && isVersionMavenIncompatible(dependency.getVersion())) {
+                            if (isVersionMavenIncompatible(dependency.getVersion())) {
                                 publicationWarningsCollector.addIncompatible(String.format("%s:%s:%s declared with a Maven incompatible version notation", dependency.getGroup(), dependency.getName(), dependency.getVersion()));
                             }
                             addModuleDependency(dependency, globalExcludes, dependencies);
@@ -348,21 +348,21 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
                     }
                 }
             }
-            Set<MavenDependency> dependencyConstraints = dependencyConstraintsFor(usageContext);
-            for (DependencyConstraint dependency : usageContext.getDependencyConstraints()) {
+            Set<MavenDependency> dependencyConstraints = dependencyConstraintsFor(variant);
+            for (DependencyConstraint dependency : variant.getDependencyConstraints()) {
                 if (seenConstraints.add(dependency)) {
                     if (dependency instanceof DefaultProjectDependencyConstraint) {
                         addDependencyConstraint((DefaultProjectDependencyConstraint) dependency, dependencyConstraints);
                     } else if (dependency.getVersion() != null) {
-                        if (!versionMappingInUse && isVersionMavenIncompatible(dependency.getVersion())) {
+                        if (isVersionMavenIncompatible(dependency.getVersion())) {
                             publicationWarningsCollector.addIncompatible(String.format("constraint %s:%s:%s declared with a Maven incompatible version notation", dependency.getGroup(), dependency.getName(), dependency.getVersion()));
                         }
                         addDependencyConstraint(dependency, dependencyConstraints);
                     }
                 }
             }
-            if (!usageContext.getCapabilities().isEmpty()) {
-                for (Capability capability : usageContext.getCapabilities()) {
+            if (!variant.getCapabilities().isEmpty()) {
+                for (Capability capability : variant.getCapabilities()) {
                     if (isNotDefaultCapability(capability)) {
                         publicationWarningsCollector.addVariantUnsupported(String.format("Declares capability %s:%s:%s which cannot be mapped to Maven", capability.getGroup(), capability.getName(), capability.getVersion()));
                     }
@@ -393,6 +393,10 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
     }
 
     private boolean isVersionMavenIncompatible(String version) {
+        if (versionMappingInUse) {
+            return false;
+        }
+
         if (version == null) {
             return false;
         }
@@ -414,19 +418,17 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
         importDependencyConstraints.add(new DefaultMavenDependency(dependency.getGroup(), dependency.getName(), dependency.getVersion(), "pom"));
     }
 
-    private List<UsageContext> getSortedUsageContexts() {
-        List<UsageContext> usageContexts = Lists.newArrayList(this.component.getUsages());
-        if (component instanceof AdhocComponentWithVariants) {
-            Collections.sort(Cast.uncheckedCast(usageContexts), Comparator.comparing(MavenPublishingAwareContext::getScopeMapping));
-        } else {
-            Collections.sort(usageContexts, (u1, u2) -> VARIANT_ORDERING.compare(u1.getName(), u2.getName()));
-        }
-        return usageContexts;
+    private List<SoftwareComponentVariant> getSortedVariants() {
+        Comparator<SoftwareComponentVariant> comparator = component instanceof AdhocComponentWithVariants
+            ? Comparator.comparing(x -> ((MavenPublishingAwareVariant) x).getScopeMapping())
+            : (u1, u2) -> VARIANT_ORDERING.compare(u1.getName(), u2.getName());
+
+        return this.component.getUsages().stream().sorted(comparator).collect(Collectors.toList());
     }
 
-    private Set<MavenDependencyInternal> dependenciesFor(UsageContext usage) {
-        if (usage instanceof MavenPublishingAwareContext) {
-            MavenPublishingAwareContext.ScopeMapping mapping = ((MavenPublishingAwareContext) usage).getScopeMapping();
+    private Set<MavenDependencyInternal> dependenciesFor(SoftwareComponentVariant variant) {
+        if (variant instanceof MavenPublishingAwareVariant) {
+            MavenPublishingAwareVariant.ScopeMapping mapping = ((MavenPublishingAwareVariant) variant).getScopeMapping();
             switch (mapping) {
                 case compile:
                     return apiDependencies;
@@ -439,16 +441,16 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
             }
         }
         // legacy mode for internal APIs
-        String name = usage.getName();
+        String name = variant.getName();
         if (API_VARIANT.equals(name) || API_ELEMENTS_VARIANT.equals(name)) {
             return apiDependencies;
         }
         return runtimeDependencies;
     }
 
-    private Set<MavenDependency> dependencyConstraintsFor(UsageContext usage) {
-        if (usage instanceof MavenPublishingAwareContext) {
-            MavenPublishingAwareContext.ScopeMapping mapping = ((MavenPublishingAwareContext) usage).getScopeMapping();
+    private Set<MavenDependency> dependencyConstraintsFor(SoftwareComponentVariant variant) {
+        if (variant instanceof MavenPublishingAwareVariant) {
+            MavenPublishingAwareVariant.ScopeMapping mapping = ((MavenPublishingAwareVariant) variant).getScopeMapping();
             switch (mapping) {
                 case compile:
                 case compile_optional:
@@ -459,7 +461,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
             }
         }
         // legacy mode
-        String name = usage.getName();
+        String name = variant.getName();
         if (API_VARIANT.equals(name) || API_ELEMENTS_VARIANT.equals(name)) {
             return apiDependencyConstraints;
         }

--- a/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
@@ -223,12 +223,12 @@ class DefaultMavenPublicationTest extends Specification {
         artifact2.file >> artifactFile
         artifact2.classifier >> ""
         artifact2.extension >> "jar"
-        def usage1 = Stub(UsageContext) { getName() >> 'api' }
-        usage1.artifacts >> [artifact1]
-        def usage2 = Stub(UsageContext) { getName() >> 'runtime' }
-        usage2.artifacts >> [artifact2]
+        def variant1 = Stub(UsageContext) { getName() >> 'api' }
+        variant1.artifacts >> [artifact1]
+        def variant2 = Stub(UsageContext) { getName() >> 'runtime' }
+        variant2.artifacts >> [artifact2]
         def component = Stub(SoftwareComponentInternal)
-        component.usages >> [usage1, usage2]
+        component.usages >> [variant1, variant2]
         def mavenArtifact = Mock(MavenArtifact)
         mavenArtifact.file >> artifactFile
         notationParser.parseNotation(artifact1) >> mavenArtifact
@@ -594,13 +594,13 @@ class DefaultMavenPublicationTest extends Specification {
     }
 
     def createComponent(def artifacts, def dependencies, def scope) {
-        def usage = Stub(UsageContext) {
+        def variant = Stub(UsageContext) {
             getName() >> scope
             getArtifacts() >> artifacts
             getDependencies() >> dependencies
         }
         def component = Stub(SoftwareComponentInternal) {
-            getUsages() >> [usage]
+            getUsages() >> [variant]
         }
         return component
     }

--- a/subprojects/platform-base/src/main/java/org/gradle/api/internal/java/usagecontext/FeatureConfigurationVariant.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/api/internal/java/usagecontext/FeatureConfigurationVariant.java
@@ -18,25 +18,21 @@ package org.gradle.api.internal.java.usagecontext;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationVariant;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
-import org.gradle.api.internal.component.IvyPublishingAwareContext;
-import org.gradle.api.internal.component.MavenPublishingAwareContext;
-import org.gradle.api.plugins.internal.AbstractConfigurationUsageContext;
+import org.gradle.api.internal.component.IvyPublishingAwareVariant;
+import org.gradle.api.internal.component.MavenPublishingAwareVariant;
+import org.gradle.api.plugins.internal.ConfigurationSoftwareComponentVariant;
 
-public class FeatureConfigurationUsageContext extends AbstractConfigurationUsageContext implements MavenPublishingAwareContext, IvyPublishingAwareContext {
-    private final Configuration configuration;
+/**
+ * A {@link ConfigurationSoftwareComponentVariant} which is aware of both Maven and Ivy publishing.
+ */
+public class FeatureConfigurationVariant extends ConfigurationSoftwareComponentVariant implements MavenPublishingAwareVariant, IvyPublishingAwareVariant {
     private final ScopeMapping scopeMapping;
     private final boolean optional;
 
-    public FeatureConfigurationUsageContext(String name, Configuration configuration, ConfigurationVariant variant, String mavenScope, boolean optional) {
-        super(name, ((AttributeContainerInternal)variant.getAttributes()).asImmutable(), variant.getArtifacts());
-        this.configuration = configuration;
+    public FeatureConfigurationVariant(String name, Configuration configuration, ConfigurationVariant variant, String mavenScope, boolean optional) {
+        super(name, ((AttributeContainerInternal)variant.getAttributes()).asImmutable(), variant.getArtifacts(), configuration);
         this.scopeMapping = ScopeMapping.of(mavenScope, optional);
         this.optional = optional;
-    }
-
-    @Override
-    protected Configuration getConfiguration() {
-        return configuration;
     }
 
     @Override

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/java/WebApplication.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/java/WebApplication.java
@@ -16,31 +16,22 @@
 
 package org.gradle.api.internal.java;
 
-import org.gradle.api.artifacts.DependencyConstraint;
-import org.gradle.api.artifacts.ExcludeRule;
-import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.attributes.AttributeContainer;
-import org.gradle.api.capabilities.Capability;
-import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.component.DefaultSoftwareComponentVariant;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.component.UsageContext;
-import org.gradle.api.plugins.internal.AbstractUsageContext;
 
 import javax.inject.Inject;
 import java.util.Collections;
 import java.util.Set;
 
 public class WebApplication implements SoftwareComponentInternal {
-    private final UsageContext webArchiveUsage;
-    private final PublishArtifact warArtifact;
-    private final String variantName;
+    private final UsageContext variant;
 
     @Inject
     public WebApplication(PublishArtifact warArtifact, String variantName, AttributeContainer attributes) {
-        this.warArtifact = warArtifact;
-        this.variantName = variantName;
-        this.webArchiveUsage = new WebArchiveUsageContext(attributes);
+        this.variant = new DefaultSoftwareComponentVariant(variantName, attributes, Collections.singleton(warArtifact));
     }
 
     @Override
@@ -50,37 +41,6 @@ public class WebApplication implements SoftwareComponentInternal {
 
     @Override
     public Set<UsageContext> getUsages() {
-        return Collections.singleton(webArchiveUsage);
-    }
-
-    private class WebArchiveUsageContext extends AbstractUsageContext {
-        public WebArchiveUsageContext(AttributeContainer attributes) {
-            super(((AttributeContainerInternal)attributes).asImmutable(), Collections.singleton(warArtifact));
-        }
-
-        @Override
-        public String getName() {
-            return variantName;
-        }
-
-        @Override
-        public Set<ModuleDependency> getDependencies() {
-            return Collections.emptySet();
-        }
-
-        @Override
-        public Set<? extends DependencyConstraint> getDependencyConstraints() {
-            return Collections.emptySet();
-        }
-
-        @Override
-        public Set<? extends Capability> getCapabilities() {
-            return Collections.emptySet();
-        }
-
-        @Override
-        public Set<ExcludeRule> getGlobalExcludes() {
-            return Collections.emptySet();
-        }
+        return Collections.singleton(variant);
     }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/java/usagecontext/ConfigurationVariantMapping.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/java/usagecontext/ConfigurationVariantMapping.java
@@ -57,7 +57,7 @@ public class ConfigurationVariantMapping {
         this.action = Actions.composite(this.action, action);
     }
 
-    public void collectUsageContexts(final ImmutableCollection.Builder<UsageContext> outgoing) {
+    public void collectVariants(final ImmutableCollection.Builder<UsageContext> outgoing) {
         if (!outgoingConfiguration.isTransitive()) {
             DeprecationLogger.warnOfChangedBehaviour("Publication ignores 'transitive = false' at configuration level", "Consider using 'transitive = false' at the dependency level if you need this to be published.")
                 .withUserManual("publishing_ivy", "configurations_marked_as_non_transitive")
@@ -69,7 +69,7 @@ public class ConfigurationVariantMapping {
         action.execute(details);
         String outgoingConfigurationName = outgoingConfiguration.getName();
         if (details.shouldPublish()) {
-            registerUsageContext(outgoing, seen, defaultConfigurationVariant, outgoingConfigurationName, details.getMavenScope(), details.isOptional());
+            registerVariant(outgoing, seen, defaultConfigurationVariant, outgoingConfigurationName, details.getMavenScope(), details.isOptional());
         }
         NamedDomainObjectContainer<ConfigurationVariant> extraVariants = outgoingConfiguration.getOutgoing().getVariants();
         for (ConfigurationVariant variant : extraVariants) {
@@ -77,14 +77,14 @@ public class ConfigurationVariantMapping {
             action.execute(details);
             if (details.shouldPublish()) {
                 String name = outgoingConfigurationName + StringUtils.capitalize(variant.getName());
-                registerUsageContext(outgoing, seen, variant, name, details.getMavenScope(), details.isOptional());
+                registerVariant(outgoing, seen, variant, name, details.getMavenScope(), details.isOptional());
             }
         }
     }
 
-    private void registerUsageContext(ImmutableCollection.Builder<UsageContext> outgoing, Set<String> seen, ConfigurationVariant variant, String name, String scope, boolean optional) {
+    private void registerVariant(ImmutableCollection.Builder<UsageContext> outgoing, Set<String> seen, ConfigurationVariant variant, String name, String scope, boolean optional) {
         assertNoDuplicateVariant(name, seen);
-        outgoing.add(new FeatureConfigurationUsageContext(name, outgoingConfiguration, variant, scope, optional));
+        outgoing.add(new FeatureConfigurationVariant(name, outgoingConfiguration, variant, scope, optional));
     }
 
     static class DefaultConfigurationVariant implements ConfigurationVariant {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultAdhocSoftwareComponent.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultAdhocSoftwareComponent.java
@@ -63,7 +63,7 @@ public class DefaultAdhocSoftwareComponent implements AdhocComponentWithVariants
     public Set<? extends UsageContext> getUsages() {
         ImmutableSet.Builder<UsageContext> builder = new ImmutableSet.Builder<>();
         for (ConfigurationVariantMapping variant : variants.values()) {
-            variant.collectUsageContexts(builder);
+            variant.collectVariants(builder);
         }
         return builder.build();
     }

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaLibraryPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaLibraryPluginTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.plugins
 
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.ModuleDependency
+import org.gradle.api.internal.component.SoftwareComponentInternal
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 import org.gradle.util.TestUtil
 
@@ -217,22 +218,22 @@ class JavaLibraryPluginTest extends AbstractProjectBuilderSpec {
 
         when:
         def jarTask = project.tasks.getByName(JavaPlugin.JAR_TASK_NAME)
-        def javaLibrary = project.components.getByName("java")
-        def runtimeUsage = javaLibrary.usages.find { it.name == 'runtimeElements' }
-        def apiUsage = javaLibrary.usages.find { it.name == 'apiElements' }
+        SoftwareComponentInternal javaLibrary = project.components.getByName("java")
+        def runtimeVariant = javaLibrary.usages.find { it.name == 'runtimeElements' }
+        def apiVariant = javaLibrary.usages.find { it.name == 'apiElements' }
 
         then:
-        runtimeUsage.artifacts.collect {it.file} == [jarTask.archiveFile.get().asFile]
-        runtimeUsage.dependencies.size() == 2
-        runtimeUsage.dependencies == project.configurations.getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME).allDependencies.withType(ModuleDependency)
-        runtimeUsage.dependencyConstraints.size() == 2
-        runtimeUsage.dependencyConstraints == project.configurations.getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME).allDependencyConstraints
+        runtimeVariant.artifacts.collect {it.file} == [jarTask.archiveFile.get().asFile]
+        runtimeVariant.dependencies.size() == 2
+        runtimeVariant.dependencies == project.configurations.getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME).allDependencies.withType(ModuleDependency)
+        runtimeVariant.dependencyConstraints.size() == 2
+        runtimeVariant.dependencyConstraints == project.configurations.getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME).allDependencyConstraints
 
-        apiUsage.artifacts.collect {it.file} == [jarTask.archiveFile.get().asFile]
-        apiUsage.dependencies.size() == 1
-        apiUsage.dependencies == project.configurations.getByName(JavaPlugin.API_CONFIGURATION_NAME).allDependencies.withType(ModuleDependency)
-        apiUsage.dependencyConstraints.size() == 1
-        apiUsage.dependencyConstraints == project.configurations.getByName(JavaPlugin.API_CONFIGURATION_NAME).allDependencyConstraints
+        apiVariant.artifacts.collect {it.file} == [jarTask.archiveFile.get().asFile]
+        apiVariant.dependencies.size() == 1
+        apiVariant.dependencies == project.configurations.getByName(JavaPlugin.API_CONFIGURATION_NAME).allDependencies.withType(ModuleDependency)
+        apiVariant.dependencyConstraints.size() == 1
+        apiVariant.dependencyConstraints == project.configurations.getByName(JavaPlugin.API_CONFIGURATION_NAME).allDependencyConstraints
     }
 
 }

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPlatformPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPlatformPluginTest.groovy
@@ -21,7 +21,8 @@ import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.attributes.Category
 import org.gradle.api.attributes.LibraryElements
 import org.gradle.api.attributes.Usage
-import org.gradle.api.internal.component.UsageContext
+import org.gradle.api.component.SoftwareComponentVariant
+import org.gradle.api.internal.component.SoftwareComponentInternal
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 import spock.lang.Unroll
 
@@ -114,26 +115,26 @@ class JavaPlatformPluginTest extends AbstractProjectBuilderSpec {
         project.dependencies.constraints.add(JavaPlatformPlugin.RUNTIME_CONFIGURATION_NAME, "org:runtime2:2.0")
 
         when:
-        def javaPlatform = project.components.getByName("javaPlatform")
-        UsageContext apiUsage = javaPlatform.usages[0]
-        UsageContext runtimeUsage = javaPlatform.usages[1]
+        SoftwareComponentInternal javaPlatform = project.components.getByName("javaPlatform")
+        SoftwareComponentVariant apiVariant = javaPlatform.usages[0]
+        SoftwareComponentVariant runtimeVariant = javaPlatform.usages[1]
 
         then:
-        runtimeUsage.dependencies.size() == 2
-        runtimeUsage.dependencies == project.configurations.getByName(JavaPlatformPlugin.RUNTIME_CONFIGURATION_NAME).allDependencies.withType(ModuleDependency)
-        runtimeUsage.dependencyConstraints.size() == 2
-        runtimeUsage.dependencyConstraints == project.configurations.getByName(JavaPlatformPlugin.RUNTIME_CONFIGURATION_NAME).allDependencyConstraints
-        runtimeUsage.attributes.keySet() == [Usage.USAGE_ATTRIBUTE, Category.CATEGORY_ATTRIBUTE] as Set
-        runtimeUsage.attributes.getAttribute(Usage.USAGE_ATTRIBUTE).name == Usage.JAVA_RUNTIME
-        runtimeUsage.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE).name == Category.REGULAR_PLATFORM
+        runtimeVariant.dependencies.size() == 2
+        runtimeVariant.dependencies == project.configurations.getByName(JavaPlatformPlugin.RUNTIME_CONFIGURATION_NAME).allDependencies.withType(ModuleDependency)
+        runtimeVariant.dependencyConstraints.size() == 2
+        runtimeVariant.dependencyConstraints == project.configurations.getByName(JavaPlatformPlugin.RUNTIME_CONFIGURATION_NAME).allDependencyConstraints
+        runtimeVariant.attributes.keySet() == [Usage.USAGE_ATTRIBUTE, Category.CATEGORY_ATTRIBUTE] as Set
+        runtimeVariant.attributes.getAttribute(Usage.USAGE_ATTRIBUTE).name == Usage.JAVA_RUNTIME
+        runtimeVariant.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE).name == Category.REGULAR_PLATFORM
 
-        apiUsage.dependencies.size() == 1
-        apiUsage.dependencies == project.configurations.getByName(JavaPlatformPlugin.API_CONFIGURATION_NAME).allDependencies.withType(ModuleDependency)
-        apiUsage.dependencyConstraints.size() == 1
-        apiUsage.dependencyConstraints == project.configurations.getByName(JavaPlatformPlugin.API_CONFIGURATION_NAME).allDependencyConstraints
-        apiUsage.attributes.keySet() == [Usage.USAGE_ATTRIBUTE, Category.CATEGORY_ATTRIBUTE] as Set
-        apiUsage.attributes.getAttribute(Usage.USAGE_ATTRIBUTE).name == Usage.JAVA_API
-        apiUsage.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE).name == Category.REGULAR_PLATFORM
+        apiVariant.dependencies.size() == 1
+        apiVariant.dependencies == project.configurations.getByName(JavaPlatformPlugin.API_CONFIGURATION_NAME).allDependencies.withType(ModuleDependency)
+        apiVariant.dependencyConstraints.size() == 1
+        apiVariant.dependencyConstraints == project.configurations.getByName(JavaPlatformPlugin.API_CONFIGURATION_NAME).allDependencyConstraints
+        apiVariant.attributes.keySet() == [Usage.USAGE_ATTRIBUTE, Category.CATEGORY_ATTRIBUTE] as Set
+        apiVariant.attributes.getAttribute(Usage.USAGE_ATTRIBUTE).name == Usage.JAVA_API
+        apiVariant.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE).name == Category.REGULAR_PLATFORM
     }
 
     @Unroll("cannot add a dependency to the #configuration configuration by default")

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.plugins
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.Dependency
+import org.gradle.api.internal.component.SoftwareComponentInternal
 import org.gradle.api.reporting.ReportingExtension
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.SourceSet
@@ -196,7 +197,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
 
         when:
         def jarTask = project.tasks.getByName(JavaPlugin.JAR_TASK_NAME)
-        def javaLibrary = project.components.getByName("java")
+        SoftwareComponentInternal javaLibrary = project.components.getByName("java")
 
         then:
         def runtime = javaLibrary.usages.find { it.name == 'runtimeElements' }

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/metadata/ModuleMetadataSpecBuilder.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/metadata/ModuleMetadataSpecBuilder.java
@@ -33,6 +33,7 @@ import org.gradle.api.capabilities.Capability;
 import org.gradle.api.component.ComponentWithCoordinates;
 import org.gradle.api.component.ComponentWithVariants;
 import org.gradle.api.component.SoftwareComponent;
+import org.gradle.api.component.SoftwareComponentVariant;
 import org.gradle.api.internal.artifacts.DefaultExcludeRule;
 import org.gradle.api.internal.artifacts.ImmutableVersionConstraint;
 import org.gradle.api.internal.artifacts.PublishArtifactInternal;
@@ -42,7 +43,6 @@ import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDepende
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
-import org.gradle.api.internal.component.UsageContext;
 import org.gradle.api.publish.internal.PublicationInternal;
 import org.gradle.api.publish.internal.versionmapping.VariantVersionMappingStrategyInternal;
 import org.gradle.api.publish.internal.versionmapping.VersionMappingStrategyInternal;
@@ -120,7 +120,7 @@ class ModuleMetadataSpecBuilder {
 
     private List<ModuleMetadataSpec.Variant> variants() {
         ArrayList<ModuleMetadataSpec.Variant> variants = new ArrayList<>();
-        for (UsageContext variant : component.getUsages()) {
+        for (SoftwareComponentVariant variant : component.getUsages()) {
             checkVariant(variant);
             variants.add(
                 new ModuleMetadataSpec.LocalVariant(
@@ -138,7 +138,7 @@ class ModuleMetadataSpecBuilder {
                 ModuleVersionIdentifier childCoordinates = coordinatesOf(childComponent);
                 assert childCoordinates != null;
                 if (childComponent instanceof SoftwareComponentInternal) {
-                    for (UsageContext variant : ((SoftwareComponentInternal) childComponent).getUsages()) {
+                    for (SoftwareComponentVariant variant : ((SoftwareComponentInternal) childComponent).getUsages()) {
                         checkVariant(variant);
                         variants.add(
                             new ModuleMetadataSpec.RemoteVariant(
@@ -155,7 +155,7 @@ class ModuleMetadataSpecBuilder {
         return variants;
     }
 
-    private List<ModuleMetadataSpec.Artifact> artifactsOf(UsageContext variant) {
+    private List<ModuleMetadataSpec.Artifact> artifactsOf(SoftwareComponentVariant variant) {
         if (variant.getArtifacts().isEmpty()) {
             return emptyList();
         }
@@ -341,7 +341,7 @@ class ModuleMetadataSpecBuilder {
         );
     }
 
-    private List<ModuleMetadataSpec.Dependency> dependenciesOf(UsageContext variant) {
+    private List<ModuleMetadataSpec.Dependency> dependenciesOf(SoftwareComponentVariant variant) {
         if (variant.getDependencies().isEmpty()) {
             return emptyList();
         }
@@ -374,7 +374,7 @@ class ModuleMetadataSpecBuilder {
         return dependencies;
     }
 
-    private List<ModuleMetadataSpec.DependencyConstraint> dependencyConstraintsFor(UsageContext variant) {
+    private List<ModuleMetadataSpec.DependencyConstraint> dependencyConstraintsFor(SoftwareComponentVariant variant) {
         if (variant.getDependencyConstraints().isEmpty()) {
             return emptyList();
         }
@@ -486,11 +486,11 @@ class ModuleMetadataSpecBuilder {
         }
     }
 
-    private void checkVariant(UsageContext usageContext) {
+    private void checkVariant(SoftwareComponentVariant variant) {
         checker.registerVariant(
-            usageContext.getName(),
-            usageContext.getAttributes(),
-            usageContext.getCapabilities()
+            variant.getName(),
+            variant.getAttributes(),
+            variant.getCapabilities()
         );
     }
 
@@ -529,14 +529,14 @@ class ModuleMetadataSpecBuilder {
         return projectDependencyResolver.resolve(ModuleVersionIdentifier.class, projectDependency);
     }
 
-    private VariantVersionMappingStrategyInternal versionMappingStrategyFor(UsageContext variant) {
+    private VariantVersionMappingStrategyInternal versionMappingStrategyFor(SoftwareComponentVariant variant) {
         VersionMappingStrategyInternal versionMappingStrategy = publication.getVersionMappingStrategy();
         return versionMappingStrategy != null
             ? versionMappingStrategy.findStrategyForVariant(immutableAttributesOf(variant))
             : null;
     }
 
-    private ImmutableAttributes immutableAttributesOf(UsageContext variant) {
+    private ImmutableAttributes immutableAttributesOf(SoftwareComponentVariant variant) {
         return ((AttributeContainerInternal) variant.getAttributes()).asImmutable();
     }
 

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/validation/PublicationErrorChecker.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/validation/PublicationErrorChecker.java
@@ -19,9 +19,9 @@ package org.gradle.api.publish.internal.validation;
 import org.gradle.api.artifacts.PublishException;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.Category;
+import org.gradle.api.component.SoftwareComponentVariant;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
-import org.gradle.api.internal.component.UsageContext;
 
 import java.util.Optional;
 
@@ -37,15 +37,15 @@ public abstract class PublicationErrorChecker {
      * @throws PublishException if the component uses attributes invalid for publication
      */
     public static void checkForUnpublishableAttributes(SoftwareComponentInternal component, DocumentationRegistry documentationRegistry) {
-        for (final UsageContext usageContext : component.getUsages()) {
-            Optional<Attribute<?>> category = usageContext.getAttributes().keySet().stream()
+        for (final SoftwareComponentVariant variant : component.getUsages()) {
+            Optional<Attribute<?>> category = variant.getAttributes().keySet().stream()
                 .filter(a -> Category.CATEGORY_ATTRIBUTE.getName().equals(a.getName()))
                 .findFirst();
 
             category.ifPresent(c -> {
-                Object value = usageContext.getAttributes().getAttribute(c);
+                Object value = variant.getAttributes().getAttribute(c);
                 if (value != null && Category.VERIFICATION.equals(value.toString())) {
-                    throw new PublishException("Cannot publish module metadata for component '" + component.getName() + "' which would include a variant '" + usageContext.getName() + "' that contains a '" + Category.CATEGORY_ATTRIBUTE.getName() + "' attribute with a value of '" + Category.VERIFICATION + "'.  This attribute is reserved for test verification output and is not publishable.  See: " + documentationRegistry.getDocumentationFor("variant_attributes.html", "sec:verification_category"));
+                    throw new PublishException("Cannot publish module metadata for component '" + component.getName() + "' which would include a variant '" + variant.getName() + "' that contains a '" + Category.CATEGORY_ATTRIBUTE.getName() + "' attribute with a value of '" + Category.VERIFICATION + "'.  This attribute is reserved for test verification output and is not publishable.  See: " + documentationRegistry.getDocumentationFor("variant_attributes.html", "sec:verification_category"));
                 }
             });
         }

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/tasks/GenerateModuleMetadata.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/tasks/GenerateModuleMetadata.java
@@ -22,11 +22,11 @@ import org.gradle.api.Buildable;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.api.artifacts.PublishArtifact;
+import org.gradle.api.component.SoftwareComponentVariant;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyPublicationResolver;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
-import org.gradle.api.internal.component.UsageContext;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.collections.MinimalFileSet;
 import org.gradle.api.internal.project.ProjectInternal;
@@ -317,8 +317,8 @@ public abstract class GenerateModuleMetadata extends DefaultTask {
         }
 
         private void forEachArtifactOf(SoftwareComponentInternal component, Action<PublishArtifact> action) {
-            for (UsageContext usageContext : component.getUsages()) {
-                for (PublishArtifact publishArtifact : usageContext.getArtifacts()) {
+            for (SoftwareComponentVariant variant : component.getUsages()) {
+                for (PublishArtifact publishArtifact : variant.getArtifacts()) {
                     action.execute(publishArtifact);
                 }
             }


### PR DESCRIPTION
UsageContext is a legacy type. We should be using SoftwareComponentVariant instead. We are still stuck using UsageContext in some places since it is used in SoftwareComponentInternal#getUsages, however this PR removes all other occurances of UsageContext where it is not strictly required to use. This PR will make a future transition to a new public API for defining variants easier.

In general, this PR:
* Updates all terminology from using 'usage' to 'variant'. This includes renaming any implementations of UsageContext to have Variant in their name. Variable and method names are updated where possible
* Remove constructor of DefaultSoftwareComponentVariant which accepts a configuration. Migrate usages to ConfigurationSoftwareComponentVariant.
* Add some documentation describing the state of the component variant-declaring API