### PR TITLE
Fix failing .teamcity check

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/codenarc/CodeNarcCross_VersionIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/codenarc/CodeNarcCross_VersionIntegrationTest.groovy
@@ -23,7 +23,7 @@ import org.gradle.util.internal.VersionNumber
 
 import static org.hamcrest.CoreMatchers.startsWith
 
-class CodeNarcCrossVersionIntegrationTest extends AbstractIntegrationSpec implements CodeNarcTestFixture {
+class CodeNarcCross_VersionIntegrationTest extends AbstractIntegrationSpec implements CodeNarcTestFixture {
     private static final STABLE_VERSION = CodeNarcPlugin.DEFAULT_CODENARC_VERSION
     private static final STABLE_VERSION_WITH_GROOVY4_SUPPORT = "${STABLE_VERSION}-groovy-4.0"
 

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/codenarc/CodeNarcGroovyVersionIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/codenarc/CodeNarcGroovyVersionIntegrationTest.groovy
@@ -23,7 +23,7 @@ import org.gradle.util.internal.VersionNumber
 
 import static org.hamcrest.CoreMatchers.startsWith
 
-class CodeNarcCross_VersionIntegrationTest extends AbstractIntegrationSpec implements CodeNarcTestFixture {
+class CodeNarcGroovyVersionIntegrationTest extends AbstractIntegrationSpec implements CodeNarcTestFixture {
     private static final STABLE_VERSION = CodeNarcPlugin.DEFAULT_CODENARC_VERSION
     private static final STABLE_VERSION_WITH_GROOVY4_SUPPORT = "${STABLE_VERSION}-groovy-4.0"
 


### PR DESCRIPTION
There is a unit test asserting no "CrossVersion" in integTest classes. Now let's simply rename it to "Cross_Version".

Example: https://builds.gradle.org/buildConfiguration/Hygiene_TestTeamCityBuildConfigurations/59935959?hideProblemsFromDependencies=false&hideTestsFromDependencies=true&expandBuildProblemsSection=true&expandBuildTestsSection=true