### PR TITLE
Add functional test source set instead of replace

### DIFF
--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/GroovyGradlePluginInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/GroovyGradlePluginInitIntegrationTest.groovy
@@ -116,4 +116,24 @@ class GroovyGradlePluginInitIntegrationTest extends AbstractInitIntegrationSpec 
         where:
         scriptDsl << ScriptDslFixture.SCRIPT_DSLS
     }
+
+    @Issue("https://github.com/gradle/gradle/issues/23298")
+    @IgnoreIf({ GradleContextualExecuter.embedded }) // This test runs a build that itself runs builds in a test worker with 'gradleApi()' dependency, which needs to pick up Gradle modules from a real distribution
+    def "running TestKit functional test in test source set succeeds"() {
+        given:
+        run('init', '--type', 'groovy-gradle-plugin', '--dsl', scriptDsl.id)
+
+        // Copy functional test contents into default source set test
+        def projectTest = subprojectDir.file('src/test/groovy/some/thing/SomeThingPluginTest.groovy')
+        projectTest.text = subprojectDir.file('src/functionalTest/groovy/some/thing/SomeThingPluginFunctionalTest.groovy').text
+
+        when:
+        run('check')
+
+        then:
+        assertTestPassed("some.thing.SomeThingPluginFunctionalTest", "can run task")
+
+        where:
+        scriptDsl << ScriptDslFixture.SCRIPT_DSLS
+    }
 }

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/JvmGradlePluginProjectInitDescriptor.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/JvmGradlePluginProjectInitDescriptor.java
@@ -80,7 +80,7 @@ public abstract class JvmGradlePluginProjectInitDescriptor extends LanguageLibra
             buildScriptBuilder.taskMethodInvocation("Run the functional tests as part of `check`", "check", "Task", "dependsOn", functionalTest);
             buildScriptBuilder.taskMethodInvocation("Use JUnit Jupiter for unit tests.", "test", "Test", "useJUnitPlatform");
         }
-        buildScriptBuilder.methodInvocation(null, "gradlePlugin.testSourceSets", functionalTestSourceSet);
+        buildScriptBuilder.methodInvocation(null, "gradlePlugin.testSourceSets.add", functionalTestSourceSet);
     }
 
     @Override


### PR DESCRIPTION
### Context 

When using TestKit in tests from the default source set, `GradleRunner` is not found in the tests classpath.

This fix allows the generated Gradle Plugin project to have both functional and default test source sets working with TestKit.

Fixes 
  - #23298
