### PR TITLE
Add disambiguation rules for newer codenarc versions

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/codenarc/CodeNarcNonJvmIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/codenarc/CodeNarcNonJvmIntegrationTest.groovy
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.plugins.quality.codenarc
+
+import org.gradle.api.JavaVersion
+import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
+import org.gradle.integtests.fixtures.TargetCoverage
+import org.gradle.quality.integtest.fixtures.CodeNarcCoverage
+import org.gradle.testing.fixture.GroovyCoverage
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
+import spock.lang.Issue
+
+@TargetCoverage({ CodeNarcCoverage.supportedVersionsByJdk })
+@Requires(TestPrecondition.STABLE_GROOVY)
+class CodeNarcNonJvmIntegrationTest extends MultiVersionIntegrationSpec implements CodeNarcTestFixture {
+
+    @Issue("https://github.com/gradle/gradle/issues/23343")
+    def "can apply codenarc plugin to a non-jvm project"() {
+        buildFile << """
+            plugins {
+                id 'base'
+                id 'codenarc'
+            }
+
+            ${mavenCentralRepository()}
+
+            codenarc {
+                toolVersion = '${version}'
+            }
+
+            tasks.register("codenarcGradle", CodeNarc) {
+                source "test.groovy"
+            }
+
+            ${JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_14) ?
+                """
+                    configurations.codenarc {
+                        resolutionStrategy.force 'org.codehaus.groovy:groovy:${GroovyCoverage.MINIMAL_GROOVY_3}' // force latest Groovy 3 when using Java 14+.  Do not use GroovySystem#version as Groovy 4 needs different coordinates
+                    }
+                """ : ""}
+        """
+        writeRuleFile()
+        file('test.groovy').createFile()
+
+        expect:
+        succeeds("codenarcGradle")
+    }
+}

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CodeNarcPlugin.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CodeNarcPlugin.java
@@ -22,8 +22,8 @@ import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.internal.ConventionMapping;
-import org.gradle.api.internal.artifacts.JavaEcosystemSupport;
 import org.gradle.api.plugins.GroovyBasePlugin;
+import org.gradle.api.plugins.JvmEcosystemPlugin;
 import org.gradle.api.plugins.quality.internal.AbstractCodeQualityPlugin;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
@@ -89,7 +89,7 @@ public abstract class CodeNarcPlugin extends AbstractCodeQualityPlugin<CodeNarc>
     @Override
     protected void beforeApply() {
         // Necessary to disambiguate the published variants of newer codenarc versions (including the default version)
-        JavaEcosystemSupport.configureBundling(project.getDependencies().getAttributesSchema());
+        project.getPluginManager().apply(JvmEcosystemPlugin.class);
     }
 
     private void configureDefaultDependencies(Configuration configuration) {

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CodeNarcPlugin.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CodeNarcPlugin.java
@@ -22,6 +22,7 @@ import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.internal.ConventionMapping;
+import org.gradle.api.internal.artifacts.JavaEcosystemSupport;
 import org.gradle.api.plugins.GroovyBasePlugin;
 import org.gradle.api.plugins.quality.internal.AbstractCodeQualityPlugin;
 import org.gradle.api.provider.Provider;
@@ -83,6 +84,12 @@ public abstract class CodeNarcPlugin extends AbstractCodeQualityPlugin<CodeNarc>
         Configuration configuration = project.getConfigurations().getAt(getConfigurationName());
         configureTaskConventionMapping(configuration, task);
         configureReportsConventionMapping(task, baseName);
+    }
+
+    @Override
+    protected void beforeApply() {
+        // Necessary to disambiguate the published variants of newer codenarc versions (including the default version)
+        JavaEcosystemSupport.configureBundling(project.getDependencies().getAttributesSchema());
     }
 
     private void configureDefaultDependencies(Configuration configuration) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/JavaEcosystemSupport.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/JavaEcosystemSupport.java
@@ -129,7 +129,7 @@ public abstract class JavaEcosystemSupport {
         targetEnvironmentSchema.getDisambiguationRules().add(TargetJvmEnvironmentDisambiguationRules.class);
     }
 
-    public static void configureBundling(AttributesSchema attributesSchema) {
+    private static void configureBundling(AttributesSchema attributesSchema) {
         AttributeMatchingStrategy<Bundling> bundlingSchema = attributesSchema.attribute(Bundling.BUNDLING_ATTRIBUTE);
         bundlingSchema.getCompatibilityRules().add(BundlingCompatibilityRules.class);
         bundlingSchema.getDisambiguationRules().add(BundlingDisambiguationRules.class);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/JavaEcosystemSupport.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/JavaEcosystemSupport.java
@@ -129,7 +129,7 @@ public abstract class JavaEcosystemSupport {
         targetEnvironmentSchema.getDisambiguationRules().add(TargetJvmEnvironmentDisambiguationRules.class);
     }
 
-    private static void configureBundling(AttributesSchema attributesSchema) {
+    public static void configureBundling(AttributesSchema attributesSchema) {
         AttributeMatchingStrategy<Bundling> bundlingSchema = attributesSchema.attribute(Bundling.BUNDLING_ATTRIBUTE);
         bundlingSchema.getCompatibilityRules().add(BundlingCompatibilityRules.class);
         bundlingSchema.getDisambiguationRules().add(BundlingDisambiguationRules.class);


### PR DESCRIPTION
The default version of codenarc (3.1.0) has multiple published variants which must be disambiguated in the case where the JVMEcoSystemPlugin has not also been applied.

We could just apply the `JvmEcoSystem` plugin here, but it does pull along a bunch of additional stuff that isn't necessary.  This is the minimum necessary to fix the problem.

Fixes #23343 
