### PR TITLE
bugfix(#21967): Additional API to easily include/exclude groups and their subgroups

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/InclusiveRepositoryContentDescriptor.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/InclusiveRepositoryContentDescriptor.java
@@ -16,6 +16,7 @@
 package org.gradle.api.artifacts.repositories;
 
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 
 /**
  * <p>Descriptor of a repository content, used to avoid reaching to
@@ -39,11 +40,22 @@ public interface InclusiveRepositoryContentDescriptor {
     void includeGroup(String group);
 
     /**
+     * Declares that an entire group and subgroups should be searched for in this repository.
+     *
+     * @since 8.1
+     *
+     * @param group the group name
+     */
+    @Incubating
+    void includeGroupAndSubGroups(String group);
+
+    /**
      * Declares that an entire group should be searched for in this repository.
      *
      * @param groupRegex a regular expression of the group name
      */
     void includeGroupByRegex(String groupRegex);
+
 
     /**
      * Declares that an entire module should be searched for in this repository.

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/RepositoryContentDescriptor.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/RepositoryContentDescriptor.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.artifacts.repositories;
 
+import org.gradle.api.Incubating;
 import org.gradle.api.attributes.Attribute;
 
 /**
@@ -36,6 +37,14 @@ public interface RepositoryContentDescriptor extends InclusiveRepositoryContentD
      */
     @Override
     void includeGroup(String group);
+
+    /**
+     * Declares that an entire group and subgroups should be searched for in this repository.
+     *
+     * @param group the group name
+     */
+    @Override
+    void includeGroupAndSubGroups(String group);
 
     /**
      * Declares that an entire group should be searched for in this repository.
@@ -93,6 +102,16 @@ public interface RepositoryContentDescriptor extends InclusiveRepositoryContentD
      * @param group the group name
      */
     void excludeGroup(String group);
+
+    /**
+     * Declares that an entire group and subgroups shouldn't be searched for in this repository.
+     *
+     * @since 8.1
+     *
+     * @param group the group name
+     */
+    @Incubating
+    void excludeGroupAndSubGroups(String group);
 
     /**
      * Declares that an entire group shouldn't be searched for in this repository.

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultRepositoryHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultRepositoryHandler.java
@@ -198,6 +198,11 @@ public class DefaultRepositoryHandler extends DefaultArtifactRepositoryContainer
             }
 
             @Override
+            public void includeGroupAndSubGroups(String group) {
+                desc.includeGroupAndSubGroups(group);
+            }
+
+            @Override
             public void includeGroupByRegex(String groupRegex) {
                 desc.excludeGroupByRegex(groupRegex);
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultRepositoryContentDescriptor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultRepositoryContentDescriptor.java
@@ -132,6 +132,12 @@ class DefaultRepositoryContentDescriptor implements RepositoryContentDescriptorI
         addInclude(group, null, null, false);
     }
 
+    @Override
+    public void includeGroupAndSubGroups(String group) {
+        checkNotNull(group, "Group cannot be null");
+        addInclude(createSubGroupRegex(group), null, null, true);
+    }
+
     private static void checkNotNull(@Nullable String value, String message) {
         if (value == null) {
             throw new IllegalArgumentException(message);
@@ -182,10 +188,20 @@ class DefaultRepositoryContentDescriptor implements RepositoryContentDescriptorI
         includeSpecs.add(new ContentSpec(regex, group, moduleName, version, versionSelectorScheme, versionSelectors, true));
     }
 
+    private String createSubGroupRegex(String group) {
+        return group.replaceAll("\\.", "\\\\.") + "(?:\\..+|\\Z|:.+)";
+    }
+
     @Override
     public void excludeGroup(String group) {
         checkNotNull(group, "Group cannot be null");
         addExclude(group, null, null, false);
+    }
+
+    @Override
+    public void excludeGroupAndSubGroups(String group) {
+        checkNotNull(group, "Group cannot be null");
+        addExclude(createSubGroupRegex(group), null, null, true);
     }
 
     @Override

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultRepositoryContentDescriptorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultRepositoryContentDescriptorTest.groovy
@@ -242,14 +242,17 @@ class DefaultRepositoryContentDescriptorTest extends Specification {
         }
 
         where:
-        method         | expr     | group   | module | version | excluded
-        'Group'        | 'org'    | 'org'   | 'foo'  | '1.0'   | true
-        'Group'        | 'org'    | 'other' | 'foo'  | '1.0'   | false
-        'GroupByRegex' | 'org'    | 'org'   | 'foo'  | '1.0'   | true
-        'GroupByRegex' | 'org'    | 'other' | 'foo'  | '1.0'   | false
-        'GroupByRegex' | 'bar'    | 'org'   | 'foo'  | '1.0'   | false
-        'GroupByRegex' | '[org]+' | 'org'   | 'foo'  | '1.0'   | true
-        'GroupByRegex' | '[org]+' | 'other' | 'foo'  | '1.0'   | false
+        method              | expr     | group        | module | version | excluded
+        'Group'             | 'org'    | 'org'        | 'foo'  | '1.0'   | true
+        'Group'             | 'org'    | 'other'      | 'foo'  | '1.0'   | false
+        'GroupByRegex'      | 'org'    | 'org'        | 'foo'  | '1.0'   | true
+        'GroupByRegex'      | 'org'    | 'other'      | 'foo'  | '1.0'   | false
+        'GroupByRegex'      | 'bar'    | 'org'        | 'foo'  | '1.0'   | false
+        'GroupByRegex'      | '[org]+' | 'org'        | 'foo'  | '1.0'   | true
+        'GroupByRegex'      | '[org]+' | 'other'      | 'foo'  | '1.0'   | false
+        'GroupAndSubGroups' | 'org'    | 'org'        | 'foo'  | '1.0'   | true
+        'GroupAndSubGroups' | 'org'    | 'org.other'  | 'foo'  | '1.0'   | true
+        'GroupAndSubGroups' | 'org'    | 'org1.other' | 'foo'  | '1.0'   | false
     }
 
     def "can exclude or include whole modules using #method(#expr)"() {


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #21967

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
This provides a new option (happy to rename) which makes it easier and safer to include/exclude a group and it's sub groups rather than inadvertently configuring the includes in an insecure way via includeByGroupRegex as documented in #21967.

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [X] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [X] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [X] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
