### PR TITLE
Change configuration cache test suite to use load-after-store semantics by default

### DIFF
--- a/subprojects/build-cache-http/build.gradle.kts
+++ b/subprojects/build-cache-http/build.gradle.kts
@@ -26,3 +26,8 @@ dependencies {
 
     integTestDistributionRuntimeOnly(project(":distributions-basics"))
 }
+
+// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
+tasks.configCacheIntegTest {
+    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
+}

--- a/subprojects/build-events/build.gradle.kts
+++ b/subprojects/build-events/build.gradle.kts
@@ -28,3 +28,8 @@ dependencies {
         because("Requires ':toolingApiBuilders': Event handlers are in the wrong place, and should live in this project")
     }
 }
+
+// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
+tasks.configCacheIntegTest {
+    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
+}

--- a/subprojects/composite-builds/build.gradle.kts
+++ b/subprojects/composite-builds/build.gradle.kts
@@ -33,3 +33,8 @@ dependencies {
 }
 
 testFilesCleanup.reportOnly.set(true)
+
+// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
+tasks.configCacheIntegTest {
+    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
+}

--- a/subprojects/core/build.gradle.kts
+++ b/subprojects/core/build.gradle.kts
@@ -202,3 +202,8 @@ tasks.compileTestGroovy {
 
 integTest.usesJavadocCodeSnippets.set(true)
 testFilesCleanup.reportOnly.set(true)
+
+// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
+tasks.configCacheIntegTest {
+    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
+}

--- a/subprojects/dependency-management/build.gradle.kts
+++ b/subprojects/dependency-management/build.gradle.kts
@@ -131,3 +131,8 @@ tasks.clean {
         }.visit { this.file.setWritable(true) }
     }
 }
+
+// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
+tasks.configCacheIntegTest {
+    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
+}

--- a/subprojects/diagnostics/build.gradle.kts
+++ b/subprojects/diagnostics/build.gradle.kts
@@ -54,3 +54,8 @@ packageCycles {
     excludePatterns.add("org/gradle/api/reporting/dependencies/internal/*")
     excludePatterns.add("org/gradle/api/plugins/internal/*")
 }
+
+// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
+tasks.configCacheIntegTest {
+    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
+}

--- a/subprojects/docs/build.gradle
+++ b/subprojects/docs/build.gradle
@@ -589,6 +589,8 @@ tasks.named("docsTest") { task ->
     testClassesDirs = sourceSets.docsTest.output.classesDirs
     // 'integTest.samplesdir' is set to an absolute path by the 'org.gradle.samples' plugin
     systemProperties.clear()
+    // Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
+    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
 
     filter {
         // workaround for https://github.com/gradle/dotcom/issues/5958

--- a/subprojects/ear/build.gradle.kts
+++ b/subprojects/ear/build.gradle.kts
@@ -42,3 +42,8 @@ strictCompile {
 packageCycles {
     excludePatterns.add("org/gradle/plugins/ear/internal/*")
 }
+
+// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
+tasks.configCacheIntegTest {
+    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
+}

--- a/subprojects/enterprise/build.gradle.kts
+++ b/subprojects/enterprise/build.gradle.kts
@@ -49,3 +49,8 @@ dependencies {
 
     integTestDistributionRuntimeOnly(project(":distributions-full"))
 }
+
+// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
+tasks.configCacheIntegTest {
+    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
+}

--- a/subprojects/file-collections/build.gradle.kts
+++ b/subprojects/file-collections/build.gradle.kts
@@ -46,3 +46,8 @@ packageCycles {
     // Some cycles have been inherited from the time these classes were in :core
     excludePatterns.add("org/gradle/api/internal/file/collections/**")
 }
+
+// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
+tasks.configCacheIntegTest {
+    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
+}

--- a/subprojects/file-watching/build.gradle.kts
+++ b/subprojects/file-watching/build.gradle.kts
@@ -29,3 +29,8 @@ dependencies {
 
     integTestDistributionRuntimeOnly(project(":distributions-core"))
 }
+
+// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
+tasks.configCacheIntegTest {
+    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
+}

--- a/subprojects/instrumentation-agent/src/integTest/groovy/org/gradle/instrumentation/agent/AgentApplicationTest.groovy
+++ b/subprojects/instrumentation-agent/src/integTest/groovy/org/gradle/instrumentation/agent/AgentApplicationTest.groovy
@@ -74,9 +74,7 @@ class AgentApplicationTest extends AbstractIntegrationSpec {
 
         then:
         agentStatusWas(agentStatus)
-        configurationCache.assertStateStored {
-            loadsOnStore = false
-        }
+        configurationCache.assertStateStored()
 
         when:
         withAgentApplied(agentStatus)
@@ -101,9 +99,7 @@ class AgentApplicationTest extends AbstractIntegrationSpec {
 
         then:
         agentStatusWas(useAgentOnFirstRun)
-        configurationCache.assertStateStored {
-            loadsOnStore = false
-        }
+        configurationCache.assertStateStored()
 
         when:
         withAgentApplied(useAgentOnSecondRun)
@@ -111,9 +107,7 @@ class AgentApplicationTest extends AbstractIntegrationSpec {
 
         then:
         agentStatusWas(useAgentOnSecondRun)
-        configurationCache.assertStateStored {
-            loadsOnStore = false
-        }
+        configurationCache.assertStateStored()
 
         where:
         useAgentOnFirstRun | useAgentOnSecondRun

--- a/subprojects/integ-test/build.gradle.kts
+++ b/subprojects/integ-test/build.gradle.kts
@@ -55,3 +55,8 @@ dependencies {
 }
 
 testFilesCleanup.reportOnly.set(true)
+
+// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
+tasks.configCacheIntegTest {
+    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ConfigurationCacheGradleExecuter.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ConfigurationCacheGradleExecuter.groovy
@@ -29,8 +29,12 @@ class ConfigurationCacheGradleExecuter extends DaemonGradleExecuter {
         "--${ConfigurationCacheOption.LONG_OPTION}",
         "-D${ConfigurationCacheQuietOption.PROPERTY_NAME}=true",
         "-D${ConfigurationCacheMaxProblemsOption.PROPERTY_NAME}=0",
-        "-Dorg.gradle.configuration-cache.internal.load-after-store=false"
+        "-Dorg.gradle.configuration-cache.internal.load-after-store=${testWithLoadAfterStore()}"
     ].collect { it.toString() }
+
+    static boolean testWithLoadAfterStore() {
+        return !System.getProperty("org.gradle.configuration-cache.internal.test-disable-load-after-store")
+    }
 
     ConfigurationCacheGradleExecuter(
         GradleDistribution distribution,

--- a/subprojects/ivy/build.gradle.kts
+++ b/subprojects/ivy/build.gradle.kts
@@ -62,3 +62,8 @@ dependencies {
 }
 
 integTest.usesJavadocCodeSnippets.set(true)
+
+// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
+tasks.configCacheIntegTest {
+    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
+}

--- a/subprojects/kotlin-dsl-integ-tests/build.gradle.kts
+++ b/subprojects/kotlin-dsl-integ-tests/build.gradle.kts
@@ -29,3 +29,8 @@ dependencies {
 }
 
 testFilesCleanup.reportOnly.set(true)
+
+// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
+tasks.configCacheIntegTest {
+    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
+}

--- a/subprojects/kotlin-dsl-plugins/build.gradle.kts
+++ b/subprojects/kotlin-dsl-plugins/build.gradle.kts
@@ -97,3 +97,8 @@ pluginPublish {
         pluginClass = "org.gradle.kotlin.dsl.plugins.precompiled.PrecompiledScriptPlugins"
     )
 }
+
+// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
+tasks.configCacheIntegTest {
+    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
+}

--- a/subprojects/language-java/build.gradle.kts
+++ b/subprojects/language-java/build.gradle.kts
@@ -90,5 +90,9 @@ packageCycles {
     excludePatterns.add("org/gradle/external/javadoc/**")
 }
 
-
 integTest.usesJavadocCodeSnippets.set(true)
+
+// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
+tasks.configCacheIntegTest {
+    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
+}

--- a/subprojects/language-native/build.gradle.kts
+++ b/subprojects/language-native/build.gradle.kts
@@ -72,3 +72,8 @@ packageCycles {
 }
 
 integTest.usesJavadocCodeSnippets.set(true)
+
+// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
+tasks.configCacheIntegTest {
+    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
+}

--- a/subprojects/launcher/build.gradle.kts
+++ b/subprojects/launcher/build.gradle.kts
@@ -85,3 +85,8 @@ strictCompile {
 }
 
 testFilesCleanup.reportOnly.set(true)
+
+// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
+tasks.configCacheIntegTest {
+    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
+}

--- a/subprojects/logging/build.gradle.kts
+++ b/subprojects/logging/build.gradle.kts
@@ -46,3 +46,8 @@ packageCycles {
     excludePatterns.add("org/gradle/internal/featurelifecycle/**")
     excludePatterns.add("org/gradle/util/**")
 }
+
+// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
+tasks.configCacheIntegTest {
+    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
+}

--- a/subprojects/maven/build.gradle.kts
+++ b/subprojects/maven/build.gradle.kts
@@ -68,3 +68,8 @@ packageCycles {
 }
 
 integTest.usesJavadocCodeSnippets.set(true)
+
+// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
+tasks.configCacheIntegTest {
+    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
+}

--- a/subprojects/model-core/build.gradle.kts
+++ b/subprojects/model-core/build.gradle.kts
@@ -68,3 +68,8 @@ packageCycles {
     excludePatterns.add("org/gradle/model/internal/type/**")
     excludePatterns.add("org/gradle/api/internal/plugins/*")
 }
+
+// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
+tasks.configCacheIntegTest {
+    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
+}

--- a/subprojects/platform-jvm/build.gradle.kts
+++ b/subprojects/platform-jvm/build.gradle.kts
@@ -62,3 +62,8 @@ packageCycles {
 integTest.usesJavadocCodeSnippets.set(true)
 
 description = """Extends platform-base with base types and interfaces specific to the Java Virtual Machine, including tasks for obtaining a JDK via toolchains, and for compiling and launching Java applications."""
+
+// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
+tasks.configCacheIntegTest {
+    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
+}

--- a/subprojects/plugin-development/build.gradle.kts
+++ b/subprojects/plugin-development/build.gradle.kts
@@ -61,3 +61,8 @@ integTest.usesJavadocCodeSnippets.set(true)
 strictCompile {
     ignoreDeprecations()
 }
+
+// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
+tasks.configCacheIntegTest {
+    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
+}

--- a/subprojects/plugin-use/build.gradle.kts
+++ b/subprojects/plugin-use/build.gradle.kts
@@ -29,3 +29,8 @@ dependencies {
 testFilesCleanup.reportOnly.set(true)
 
 description = """Provides functionality for resolving and managing plugins during their application to projects."""
+
+// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
+tasks.configCacheIntegTest {
+    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
+}

--- a/subprojects/plugins/build.gradle.kts
+++ b/subprojects/plugins/build.gradle.kts
@@ -84,4 +84,9 @@ packageCycles {
 integTest.usesJavadocCodeSnippets.set(true)
 testFilesCleanup.reportOnly.set(true)
 
+// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
+tasks.configCacheIntegTest {
+    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
+}
+
 description = """Provides core Gradle plugins such as the base plugin and version catalog plugin, as well as JVM-related plugins for building different types of Java and Groovy projects."""

--- a/subprojects/process-services/build.gradle.kts
+++ b/subprojects/process-services/build.gradle.kts
@@ -24,3 +24,8 @@ dependencies {
 packageCycles {
     excludePatterns.add("org/gradle/process/internal/**")
 }
+
+// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
+tasks.configCacheIntegTest {
+    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
+}

--- a/subprojects/resources-gcs/build.gradle.kts
+++ b/subprojects/resources-gcs/build.gradle.kts
@@ -36,3 +36,8 @@ dependencies {
 strictCompile {
     ignoreDeprecations()
 }
+
+// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
+tasks.configCacheIntegTest {
+    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
+}

--- a/subprojects/resources-s3/build.gradle.kts
+++ b/subprojects/resources-s3/build.gradle.kts
@@ -40,3 +40,8 @@ dependencies {
 
     integTestDistributionRuntimeOnly(project(":distributions-basics"))
 }
+
+// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
+tasks.configCacheIntegTest {
+    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
+}

--- a/subprojects/resources-sftp/build.gradle.kts
+++ b/subprojects/resources-sftp/build.gradle.kts
@@ -28,3 +28,8 @@ dependencies {
 
     integTestDistributionRuntimeOnly(project(":distributions-basics"))
 }
+
+// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
+tasks.configCacheIntegTest {
+    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
+}

--- a/subprojects/resources/build.gradle.kts
+++ b/subprojects/resources/build.gradle.kts
@@ -25,3 +25,8 @@ dependencies {
 
     integTestDistributionRuntimeOnly(project(":distributions-core"))
 }
+
+// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
+tasks.configCacheIntegTest {
+    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
+}

--- a/subprojects/samples/build.gradle.kts
+++ b/subprojects/samples/build.gradle.kts
@@ -24,3 +24,8 @@ dependencies {
 }
 
 testFilesCleanup.reportOnly.set(true)
+
+// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
+tasks.configCacheIntegTest {
+    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
+}

--- a/subprojects/scala/build.gradle.kts
+++ b/subprojects/scala/build.gradle.kts
@@ -63,3 +63,8 @@ packageCycles {
 }
 
 integTest.usesJavadocCodeSnippets.set(true)
+
+// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
+tasks.configCacheIntegTest {
+    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
+}

--- a/subprojects/test-kit/build.gradle.kts
+++ b/subprojects/test-kit/build.gradle.kts
@@ -59,3 +59,8 @@ packageCycles {
 tasks.integMultiVersionTest {
     systemProperty("org.gradle.integtest.testkit.compatibility", "all")
 }
+
+// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
+tasks.configCacheIntegTest {
+    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
+}

--- a/subprojects/testing-jvm/build.gradle.kts
+++ b/subprojects/testing-jvm/build.gradle.kts
@@ -54,3 +54,8 @@ packageCycles {
 }
 
 integTest.usesJavadocCodeSnippets.set(true)
+
+// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
+tasks.configCacheIntegTest {
+    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
+}

--- a/subprojects/testing-native/build.gradle.kts
+++ b/subprojects/testing-native/build.gradle.kts
@@ -39,3 +39,8 @@ dependencies {
     }
     integTestDistributionRuntimeOnly(project(":distributions-native"))
 }
+
+// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
+tasks.configCacheIntegTest {
+    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
+}

--- a/subprojects/workers/build.gradle.kts
+++ b/subprojects/workers/build.gradle.kts
@@ -47,3 +47,8 @@ dependencies {
     }
     integTestDistributionRuntimeOnly(project(":distributions-core"))
 }
+
+// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
+tasks.configCacheIntegTest {
+    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
+}

--- a/subprojects/wrapper/build.gradle.kts
+++ b/subprojects/wrapper/build.gradle.kts
@@ -47,3 +47,8 @@ val executableJar by tasks.registering(Jar::class) {
 tasks.jar {
     from(executableJar)
 }
+
+// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
+tasks.configCacheIntegTest {
+    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
+}


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context

Also explicitly disable this for several projects where there are still some tests broken.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
