### PR TITLE
Reduce overhead of getting console columns

### DIFF
--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/console/DefaultWorkInProgressFormatter.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/console/DefaultWorkInProgressFormatter.java
@@ -61,8 +61,9 @@ public class DefaultWorkInProgressFormatter {
         // Don't write to the right-most column, as on some consoles the cursor will wrap to the next line and currently wrapping causes
         // layout weirdness
         int maxWidth;
-        if (consoleMetaData.getCols() > 0) {
-            maxWidth = consoleMetaData.getCols() - 1;
+        int cols = consoleMetaData.getCols();
+        if (cols > 0) {
+            maxWidth = cols - 1;
         } else {
             // Assume 80 wide. This is to minimize wrapping on console where we don't know the width (eg mintty)
             // It's not intended to be a correct solution, simply a work around


### PR DESCRIPTION
Hi,

I recently noticed during a profiling session that there is some overhead involved when getting the columns of the console in `DefaultWorkInProgressFormatter` on my Macbook. See the following profiling screenshot from `async-profiler`:
<img width="1007" alt="image" src="https://user-images.githubusercontent.com/6304496/210422030-8bd17091-1dfa-4c60-bf4b-3737c24876e3.png">

This PR cuts the overhead in half.

Let me know what you think.
Cheers,
Christoph
