### PR TITLE
Use test retry functionality from Gradle Enterprise plugin

### DIFF
--- a/build-logic/build-platform/build.gradle.kts
+++ b/build-logic/build-platform/build.gradle.kts
@@ -28,7 +28,6 @@ dependencies {
         api("me.champeau.gradle:japicmp-gradle-plugin:0.4.1")
         api("me.champeau.jmh:jmh-gradle-plugin:0.6.8")
         api("org.asciidoctor:asciidoctor-gradle-jvm:3.3.2")
-        api("org.gradle:test-retry-gradle-plugin:1.5.0")
         api("org.jetbrains.kotlin:kotlin-gradle-plugin") { version { strictly(kotlinVersion) } }
         api(kotlin("compiler-embeddable")) { version { strictly(kotlinVersion) } }
         api("org.jlleitschuh.gradle:ktlint-gradle:10.3.0")

--- a/build-logic/jvm/build.gradle.kts
+++ b/build-logic/jvm/build.gradle.kts
@@ -15,7 +15,6 @@ dependencies {
     implementation("org.ow2.asm:asm")
     implementation("org.ow2.asm:asm-commons")
     implementation("com.google.code.gson:gson")
-    implementation("org.gradle:test-retry-gradle-plugin")
     implementation("com.gradle:gradle-enterprise-gradle-plugin")
 
     implementation("com.thoughtworks.qdox:qdox") {

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -15,6 +15,7 @@
  */
 
 import com.gradle.enterprise.gradleplugin.testdistribution.internal.TestDistributionExtensionInternal
+import com.gradle.enterprise.gradleplugin.testretry.retry
 import com.gradle.enterprise.gradleplugin.testselection.internal.PredictiveTestSelectionExtensionInternal
 import gradlebuild.basics.BuildEnvironment
 import gradlebuild.basics.FlakyTestStrategy
@@ -41,7 +42,6 @@ plugins {
     idea // Need to apply the idea plugin, so the extended configuration is taken into account on sync
     id("gradlebuild.module-identity")
     id("gradlebuild.dependency-modules")
-    id("org.gradle.test-retry")
 }
 
 extensions.create<UnitTestAndCompileExtension>("gradlebuildJava", project, tasks)

--- a/build-logic/performance-testing/build.gradle.kts
+++ b/build-logic/performance-testing/build.gradle.kts
@@ -20,7 +20,6 @@ dependencies {
     implementation("commons-io:commons-io")
     implementation("javax.activation:activation")
     implementation("javax.xml.bind:jaxb-api")
-    implementation("org.gradle:test-retry-gradle-plugin")
     implementation("com.gradle:gradle-enterprise-gradle-plugin")
 
     testImplementation("org.junit.jupiter:junit-jupiter")

--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
@@ -17,6 +17,7 @@
 package gradlebuild.performance
 
 import com.google.common.annotations.VisibleForTesting
+import com.gradle.enterprise.gradleplugin.testretry.retry
 import gradlebuild.basics.BuildEnvironment.isIntel
 import gradlebuild.basics.BuildEnvironment.isLinux
 import gradlebuild.basics.BuildEnvironment.isMacOsX

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,6 +24,3 @@ systemProp.gradle.internal.testdistribution.queryResponseTimeout=PT20S
 
 # Default performance baseline
 defaultPerformanceBaselines=8.0-commit-0de52f832f2
-
-# Disable Test Retry in GE plugin as long as Test Retry Gradle plugin is in use
-systemProp.gradle.enterprise.testretry.enabled=false


### PR DESCRIPTION
Instead of using the Test Retry plugin, the build now uses the test
retry functionality that's included in the Gradle Enterprise Gradle
plugin.
