### PR TITLE
Update tested AGP versions

### DIFF
--- a/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
@@ -409,7 +409,7 @@ performanceTest.registerAndroidTestProject("largeAndroidBuild2", RemoteProject) 
 performanceTest.registerAndroidTestProject("santaTrackerAndroidBuild", RemoteProject) {
     remoteUri = 'https://github.com/gradle/santa-tracker-android.git'
     // Pinned from main branch
-    ref = '37a7d12c40f36657a0cb0181979c401c752bd328'
+    ref = '180b7a91054d5fe5b617543bb2f74a3819537b7b'
     doLast {
         addGoogleServicesJson(outputDirectory)
     }

--- a/gradle/dependency-management/agp-versions.properties
+++ b/gradle/dependency-management/agp-versions.properties
@@ -1,2 +1,2 @@
 # Generated - Update by running `./gradlew updateAgpVersions`
-latests=7.3.1,7.4.0-rc01,8.0.0-alpha09
+latests=7.3.1,7.4.0-rc03,8.0.0-alpha10

--- a/gradle/dependency-management/agp-versions.properties
+++ b/gradle/dependency-management/agp-versions.properties
@@ -1,2 +1,2 @@
 # Generated - Update by running `./gradlew updateAgpVersions`
-latests=7.3.1,7.4.0-rc03,8.0.0-alpha10
+latests=7.3.1,7.4.0-rc03,8.0.0-alpha11

--- a/subprojects/smoke-test/build.gradle.kts
+++ b/subprojects/smoke-test/build.gradle.kts
@@ -57,7 +57,7 @@ tasks {
     val santaTracker by registering(RemoteProject::class) {
         remoteUri.set(santaGitUri)
         // Pinned from branch main
-        ref.set("37a7d12c40f36657a0cb0181979c401c752bd328")
+        ref.set("180b7a91054d5fe5b617543bb2f74a3819537b7b")
     }
 
     val gradleBuildCurrent by registering(RemoteProject::class) {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractAndroidSantaTrackerSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractAndroidSantaTrackerSmokeTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.smoketests
 
 import org.gradle.api.JavaVersion
-import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.integtests.fixtures.daemon.DaemonLogsAnalyzer
 import org.gradle.internal.scan.config.fixtures.ApplyGradleEnterprisePluginFixture
 import org.gradle.test.fixtures.file.TestFile
@@ -74,14 +73,6 @@ class AbstractAndroidSantaTrackerSmokeTest extends AbstractSmokeTest {
 
     protected SmokeTestGradleRunner runnerForLocation(File projectDir, String agpVersion, String... tasks) {
         def runnerArgs = [["-DagpVersion=$agpVersion", "-DkotlinVersion=$kotlinVersion", "--stacktrace"], tasks].flatten()
-        if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16)) {
-            // fall back to using Java 11 (LTS) for Android tests
-            // Kapt is not compatible with JDK 16+, https://youtrack.jetbrains.com/issue/KT-45545,
-            // or Java 17 for now: https://youtrack.jetbrains.com/issue/KT-47583
-            // perhaps we should always run Android tests on Java 11 instead of having some of them skipped by a precondition
-            def jdk = AvailableJavaHomes.getJdk(JavaVersion.VERSION_11)
-            runnerArgs += "-Dorg.gradle.java.home=${jdk.javaHome}"
-        }
         def runner = runner(*runnerArgs)
             .withProjectDir(projectDir)
             .withTestKitDir(homeDir)


### PR DESCRIPTION
from 7.4.0-rc01 to 7.4.0-rc03
from 8.0.0-alpha09 to 8.0.0-alpha11

This PR
* is blocked by https://github.com/gradle/gradle/pull/23407
* lets Santa Tracker smoke tests run with Java 17 because AGP >= 8 requires Java 17
* updates Santa Tracker tracked commit with https://github.com/gradle/santa-tracker-android/pull/24