### PR TITLE
Fix test flakiness

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
@@ -878,7 +878,8 @@ service: closed with value 12
         outputContains """
 > Task :subproject1:hello
 Hello, subproject1
-
+"""
+        outputContains """
 > Task :subproject2:hello FAILED
 """
         failureDescriptionContains("Execution failed for task ':subproject2:hello'.")


### PR DESCRIPTION
Tests should not rely on order of tasks being executed across subprojects.
