### PR TITLE
Add ExampleSelfLinkProcessor to asciidoctor enabling documentation samples linking

### DIFF
--- a/subprojects/docs-asciidoctor-extensions-base/src/main/java/org/gradle/docs/asciidoctor/ExampleSelfLinkProcessor.java
+++ b/subprojects/docs-asciidoctor-extensions-base/src/main/java/org/gradle/docs/asciidoctor/ExampleSelfLinkProcessor.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.docs.asciidoctor;
+
+import org.asciidoctor.ast.Document;
+import org.asciidoctor.ast.StructuralNode;
+import org.asciidoctor.extension.Treeprocessor;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Adds self-links to example block titles.
+ */
+public class ExampleSelfLinkProcessor extends Treeprocessor {
+
+    private static final Map<Object, Object> EXAMPLE_SELECTOR = new HashMap<>();
+
+    // common ID prefix (to avoid trivial cases of clashes where section name has the same id as the example title)
+    private static final String ID_PREFIX = "ex-";
+
+    static {
+        EXAMPLE_SELECTOR.put("context", ":example");
+    }
+
+    @Override
+    public Document process(Document document) {
+        List<StructuralNode> examples = document.findBy(EXAMPLE_SELECTOR);
+        for (StructuralNode example : examples) {
+            if (example.getTitle() != null) {
+                if (example.getId() == null) {
+                    example.setId(IdGenerator.generateId(ID_PREFIX + example.getTitle()));
+                }
+                example.setTitle(String.format("link:#%s[%s]", example.getId(), example.getTitle()));
+            }
+        }
+        return document;
+    }
+}

--- a/subprojects/docs-asciidoctor-extensions-base/src/main/java/org/gradle/docs/asciidoctor/GradleDocsAsciidoctorExtensionRegistry.java
+++ b/subprojects/docs-asciidoctor-extensions-base/src/main/java/org/gradle/docs/asciidoctor/GradleDocsAsciidoctorExtensionRegistry.java
@@ -32,6 +32,8 @@ public class GradleDocsAsciidoctorExtensionRegistry implements ExtensionRegistry
         registry.includeProcessor(GuidesContributeIncludeProcessor.class);
         registry.includeProcessor(SampleIncludeProcessor.class);
 
+        registry.treeprocessor(ExampleSelfLinkProcessor.class);
+
 //        registry.docinfoProcessor(new LinkingDataDocinfoProcessor(footerOptions));
         // TODO: satisfaction widget processor
 

--- a/subprojects/docs-asciidoctor-extensions-base/src/main/java/org/gradle/docs/asciidoctor/IdGenerator.java
+++ b/subprojects/docs-asciidoctor-extensions-base/src/main/java/org/gradle/docs/asciidoctor/IdGenerator.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.docs.asciidoctor;
+
+import java.util.regex.Pattern;
+
+/**
+ * Generates valid Asciidoctor identifiers from strings.
+ * Tries to mimic original Asciidoctor behaviour.
+ *
+ * @see <a href="https://docs.asciidoctor.org/asciidoc/latest/sections/auto-ids/#how-a-section-id-is-computed">How a section ID is computed</a>
+ */
+public class IdGenerator {
+
+    // Matches invalid ID characters in a section title. (taken from https://www.rubydoc.info/gems/asciidoctor/Asciidoctor)
+    private static final Pattern ID_PATTERN = Pattern.compile("<[^>]+>|&(?:[a-z][a-z]+\\d{0,2}|#\\d\\d\\d{0,4}|#x[\\da-f][\\da-f][\\da-f]{0,3});|[^ a-zA-Z0-9_\\-.]+?");
+    private static final Pattern SEPARATOR_PATTERN = Pattern.compile("[ _.-]+");
+
+    private static final String PART_SEPARATOR = "-";
+
+    static String generateId(String source) {
+        String result = source.toLowerCase();
+
+        // replace invalid characters
+        result = ID_PATTERN.matcher(result).replaceAll("");
+
+        // normalize separators
+        result = SEPARATOR_PATTERN.matcher(result).replaceAll(PART_SEPARATOR);
+
+        // strip separator from the end
+        if (result.endsWith(PART_SEPARATOR)) {
+            result = result.substring(0, result.length() - 1);
+        }
+
+        // string separator from the start
+        if (result.startsWith(PART_SEPARATOR)) {
+            result = result.substring(1);
+        }
+        return result;
+    }
+}

--- a/subprojects/docs-asciidoctor-extensions-base/src/test/groovy/org/gradle/docs/asciidoctor/ExampleSelfLinkProcessorTest.groovy
+++ b/subprojects/docs-asciidoctor-extensions-base/src/test/groovy/org/gradle/docs/asciidoctor/ExampleSelfLinkProcessorTest.groovy
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.docs.asciidoctor
+
+import org.asciidoctor.Asciidoctor
+import org.asciidoctor.extension.JavaExtensionRegistry
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+class ExampleSelfLinkProcessorTest extends Specification {
+    @Rule
+    TemporaryFolder tmpDir = new TemporaryFolder()
+
+    Asciidoctor asciidoctor
+
+    def setup() {
+        tmpDir.newFolder("src", "samples")
+        asciidoctor = Asciidoctor.Factory.create()
+        JavaExtensionRegistry extensionRegistry = asciidoctor.javaExtensionRegistry()
+        extensionRegistry.treeprocessor(ExampleSelfLinkProcessor.class)
+    }
+
+    def "renders example with title adding link to self"() {
+        given:
+        String asciidocContent = """
+.Example Title
+====
+some text
+====
+"""
+
+        when:
+        String content = asciidoctor.convert(asciidocContent, [:])
+
+        then:
+        content.contains("""<div id="ex-example-title" class="exampleblock">
+<div class="title">Example 1. <a href="#ex-example-title">&lt;a href="#ex-example-title"&gt;Example Title&lt;/a&gt;</a></div>
+<div class="content">
+<div class="paragraph">
+<p>some text</p>
+</div>
+</div>
+</div>""")
+    }
+
+    def "renders example without title"() {
+        given:
+        String asciidocContent = """
+====
+some text
+====
+"""
+
+        when:
+        String content = asciidoctor.convert(asciidocContent, [:])
+
+        then:
+        content.contains("""<div class="exampleblock">
+<div class="content">
+<div class="paragraph">
+<p>some text</p>
+</div>
+</div>
+</div>""")
+    }
+}

--- a/subprojects/docs-asciidoctor-extensions-base/src/test/groovy/org/gradle/docs/asciidoctor/IdGeneratorTest.groovy
+++ b/subprojects/docs-asciidoctor-extensions-base/src/test/groovy/org/gradle/docs/asciidoctor/IdGeneratorTest.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.docs.asciidoctor
+
+import spock.lang.Specification
+
+class IdGeneratorTest extends Specification {
+
+    def "converts string to identifier"(String source, String id) {
+        expect:
+        IdGenerator.generateId(source) == id
+
+        where:
+        source                   | id
+        "Publish a java library" | "publish-a-java-library"
+        "dash-dash"              | "dash-dash"
+        " space prefix"          | "space-prefix"
+        "invalid char ąść"       | "invalid-char"
+        "many  separators -- "   | "many-separators"
+        "--"                     | ""
+    }
+}

--- a/subprojects/docs/src/docs/css/manual.css
+++ b/subprojects/docs/src/docs/css/manual.css
@@ -1119,6 +1119,11 @@ body.book #header > h1 {
     padding: 1em 1em 0;
 }
 
+.exampleblock > .title > a {
+    text-decoration: none;
+    color: rgba(0, 0, 0, 0.8);
+}
+
 .exampleblock .listingblock {
     margin: 0;
 }
@@ -1666,7 +1671,7 @@ div.screenshot {
 }
 
 .docs-navigation a.active {
-    color: #06A0CE; 
+    color: #06A0CE;
     outline: 0;
     border: none;
     -moz-outline-style: none;


### PR DESCRIPTION
Added asciidoctor processor that automatically creates self-links to named example blocks. This allows sharing URLs pointing directly at a particular example.
