### PR TITLE
Avoid regression where configurations cannot be declared against

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -1253,11 +1253,11 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         copiedConfiguration.canBeResolved = true;
         copiedConfiguration.canBeDeclaredAgainst = true;
         copiedConfiguration.declarationAlternatives =
-            canBeDeclaredAgainst ? declarationAlternatives : Collections.emptyList();
+            canBeDeclaredAgainst || declarationAlternatives != null ? declarationAlternatives : Collections.emptyList();
         copiedConfiguration.resolutionAlternatives =
-            canBeResolved ? resolutionAlternatives : Collections.emptyList();
+            canBeResolved || resolutionAlternatives != null ? resolutionAlternatives : Collections.emptyList();
         copiedConfiguration.consumptionDeprecation =
-            canBeConsumed ? consumptionDeprecation
+            canBeConsumed || consumptionDeprecation != null ? consumptionDeprecation
                 : DeprecationLogger.deprecateConfiguration(name).forConsumption()
                     .willBecomeAnErrorInGradle9().undocumented();
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -1244,9 +1244,22 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         copiedConfiguration.withDependencyActions = withDependencyActions;
         copiedConfiguration.dependencyResolutionListeners = dependencyResolutionListeners.copy();
 
-        copiedConfiguration.canBeConsumed = canBeConsumed;
-        copiedConfiguration.canBeResolved = canBeResolved;
-        copiedConfiguration.canBeDeclaredAgainst = canBeDeclaredAgainst;
+        // Instead of copying a configuration's roles outright, we allow copied configurations
+        // to assume any role. However, any roles which were previously disabled will become
+        // deprecated in the copied configuration. In 9.0, we will update this to copy
+        // roles and deprecations without modification. Or, better yet, we will remove support
+        // for copying configurations altogether.
+        copiedConfiguration.canBeConsumed = true;
+        copiedConfiguration.canBeResolved = true;
+        copiedConfiguration.canBeDeclaredAgainst = true;
+        copiedConfiguration.declarationAlternatives =
+            canBeDeclaredAgainst ? declarationAlternatives : Collections.emptyList();
+        copiedConfiguration.resolutionAlternatives =
+            canBeResolved ? resolutionAlternatives : Collections.emptyList();
+        copiedConfiguration.consumptionDeprecation =
+            canBeConsumed ? consumptionDeprecation
+                : DeprecationLogger.deprecateConfiguration(name).forConsumption()
+                    .willBecomeAnErrorInGradle9().undocumented();
 
         copiedConfiguration.getArtifacts().addAll(getAllArtifacts());
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -759,27 +759,57 @@ class DefaultConfigurationSpec extends Specification {
         checkCopiedConfiguration(configuration, copied3Configuration, resolutionStrategyCopy, 3)
     }
 
-    void "copies configuration role"() {
+    void "deprecations are passed to copies when corresponding role is #state"() {
         def configuration = prepareConfigurationForCopyTest()
         def resolutionStrategyCopy = Mock(ResolutionStrategyInternal)
         1 * resolutionStrategy.copy() >> resolutionStrategyCopy
 
         when:
-        configuration.canBeResolved = resolveAllowed
-        configuration.canBeConsumed = consumeAllowed
+        configuration.deprecateForConsumption(x -> x.willBecomeAnErrorInGradle9().undocumented())
+        configuration.deprecateForDeclaration("declaration")
+        configuration.deprecateForResolution("resolution")
+        configuration.canBeConsumed = enabled
+        configuration.canBeResolved = enabled
+        configuration.canBeDeclaredAgainst = enabled
+
         def copy = configuration.copy()
 
-
         then:
-        copy.canBeResolved == configuration.canBeResolved
-        copy.canBeConsumed == configuration.canBeConsumed
+        // This is not desired behavior. Roles should be copied without modification.
+        copy.canBeDeclaredAgainst
+        copy.canBeResolved
+        copy.canBeConsumed
+        copy.consumptionDeprecation != null
+        copy.declarationAlternatives == ["declaration"]
+        copy.resolutionAlternatives == ["resolution"]
 
         where:
-        resolveAllowed | consumeAllowed
-        false          | false
-        true           | false
-        false          | true
-        true           | true
+        state | enabled
+        "enabled" | true
+        "disabled" | false
+    }
+
+    void "copies disabled configuration role as a deprecation"() {
+        def configuration = prepareConfigurationForCopyTest()
+        def resolutionStrategyCopy = Mock(ResolutionStrategyInternal)
+        1 * resolutionStrategy.copy() >> resolutionStrategyCopy
+
+        when:
+        configuration.canBeConsumed = false
+        configuration.canBeResolved = false
+        configuration.canBeDeclaredAgainst = false
+
+
+        def copy = configuration.copy()
+
+        then:
+        // This is not desired behavior. Roles and deprecations should be copied without modification.
+        copy.canBeDeclaredAgainst
+        copy.canBeResolved
+        copy.canBeConsumed
+        copy.consumptionDeprecation != null
+        copy.declarationAlternatives == []
+        copy.resolutionAlternatives == []
     }
 
     def "can copy with spec"() {

--- a/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DeprecationMessageBuilder.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DeprecationMessageBuilder.java
@@ -334,6 +334,9 @@ public class DeprecationMessageBuilder<T extends DeprecationMessageBuilder<T>> {
 
         @Override
         String formatAdvice(List<String> replacements) {
+            if (replacements.isEmpty()) {
+                return "Please " + deprecationType.usage + " another configuration instead.";
+            }
             return String.format("Please %s the %s configuration instead.", deprecationType.usage, Joiner.on(" or ").join(replacements));
         }
     }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -34,6 +34,7 @@ import org.gradle.api.attributes.VerificationType;
 import org.gradle.api.component.AdhocComponentWithVariants;
 import org.gradle.api.component.SoftwareComponentFactory;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.artifacts.dsl.LazyPublishArtifact;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactoryInternal;
 import org.gradle.api.internal.component.BuildableJavaComponent;
@@ -372,6 +373,7 @@ public abstract class JavaPlugin implements Plugin<Project> {
                 .withDescription("Elements of runtime for main.")
                 .extendsFrom(implementationConfiguration, runtimeOnlyConfiguration));
         defaultConfiguration.extendsFrom(runtimeElementsConfiguration);
+        ((ConfigurationInternal) runtimeElementsConfiguration).setCanBeDeclaredAgainst(false);
 
         // Configure variants
         addJarArtifactToConfiguration(runtimeElementsConfiguration, jarArtifact);
@@ -386,6 +388,7 @@ public abstract class JavaPlugin implements Plugin<Project> {
             builder -> builder.fromSourceSet(mainSourceSet)
                 .providesApi()
                 .withDescription("API elements for main."));
+        ((ConfigurationInternal) apiElementsConfiguration).setCanBeDeclaredAgainst(false);
 
         // Configure variants
         addJarArtifactToConfiguration(apiElementsConfiguration, jarArtifact);

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmPluginServices.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmPluginServices.java
@@ -298,7 +298,6 @@ public class DefaultJvmPluginServices implements JvmPluginServices {
             cnf.setVisible(false);
             cnf.setCanBeConsumed(true);
             cnf.setCanBeResolved(false);
-            ((ConfigurationInternal) cnf).setCanBeDeclaredAgainst(false);
             Configuration[] extendsFrom = buildExtendsFrom();
             if (extendsFrom != null) {
                 cnf.extendsFrom(extendsFrom);

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleVersionsPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleVersionsPluginSmokeTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.smoketests
 
+import org.gradle.util.GradleVersion
 import org.gradle.util.internal.VersionNumber
 import org.junit.Assume
 
@@ -52,7 +53,24 @@ class GradleVersionsPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
         """
 
         when:
-        def result = runner('dependencyUpdates', '-DoutputFormatter=txt').forwardOutput().build()
+        def runner = runner('dependencyUpdates', '-DoutputFormatter=txt').forwardOutput()
+
+        def resolvedConfigurations = ["apiElementsCopy", "archivesCopy", "compileOnlyCopy", "defaultCopy", "implementationCopy", "implementationCopy2", "mainSourceElementsCopy", "runtimeElementsCopy", "runtimeOnlyCopy", "testCompileOnlyCopy", "testImplementationCopy", "testResultsElementsForTestCopy", "testRuntimeOnlyCopy"]
+        def declarationConfiguration = ["compileClasspathCopy", "defaultCopy", "runtimeClasspathCopy", "runtimeElementsCopy", "testCompileClasspathCopy", "testRuntimeClasspathCopy"]
+        resolvedConfigurations.each {
+            runner.expectDeprecationWarning(
+                "The $it configuration has been deprecated for resolution. This will fail with an error in Gradle 9.0. Please resolve another configuration instead. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_5.html#dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations",
+                "https://github.com/ben-manes/gradle-versions-plugin/issues/718"
+            )
+        }
+        declarationConfiguration.each {
+            runner.expectDeprecationWarning(
+                "The $it configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 9.0. Please use another configuration instead. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_5.html#dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations",
+                "https://github.com/ben-manes/gradle-versions-plugin/issues/718"
+            )
+        }
+
+        def result = runner.build()
 
         then:
         result.task(':dependencyUpdates').outcome == SUCCESS


### PR DESCRIPTION
Two things were wrong
1. Elements configurations for test fixtures and feature variants suddenly became un-declarable-against
2. Copied configurations never copied a deprecation. This means a copy of a deprecated configuration showed no warnings. Changing those warnings to errors in 8.0 made the copied configurations thow errors without a deprecation log.

To fix this, we:
1. Update the builder which creates elements configuration to not disallow for declaration against. We then update our internal code which uses these to explicitly disable declaration against
2. Update the copy method for a configuration to always enable all roles for the new configuration.
   However, if a role is disabled for the source configuration, we will ensure the new configuration is disabled for that role. This ensures copied configuration whose source configurations had a role disabled will emit warnings when used for a role which was improper for the source configuration.
