### PR TITLE
Allow lenient configurations to select artifacts even if some are unavailable

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolvePOMIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolvePOMIntegrationTest.groovy
@@ -26,15 +26,15 @@ class ResolvePOMIntegrationTest extends AbstractIntegrationSpec {
         def mainProjectDir = file("main-project")
         def includedLoggingProjectDir = file("included-logging")
 
-        mainProjectDir.file("settings.gradle.kts").text = """
+        mainProjectDir.file("settings.gradle").text = """
             rootProject.name = "main-project"
             include("app")
             includeBuild("../included-logging")
         """
 
-        mainProjectDir.file("app/build.gradle.kts").text = """
+        mainProjectDir.file("app/build.gradle").text = """
             plugins {
-                application
+                id 'application'
             }
 
             dependencies {
@@ -42,14 +42,14 @@ class ResolvePOMIntegrationTest extends AbstractIntegrationSpec {
             }
         """
 
-        includedLoggingProjectDir.file("settings.gradle.kts").text = """
+        includedLoggingProjectDir.file("settings.gradle").text = """
             rootProject.name = "included-logging"
             include("lib")
         """
 
-        includedLoggingProjectDir.file("lib/build.gradle.kts").text = """
+        includedLoggingProjectDir.file("lib/build.gradle").text = """
             plugins {
-                `java-library`
+                id 'java-library'
             }
         """
 
@@ -71,15 +71,15 @@ class ResolvePOMIntegrationTest extends AbstractIntegrationSpec {
         def mainProjectDir = file("main-project")
         def includedLoggingProjectDir = file("included-logging")
 
-        mainProjectDir.file("settings.gradle.kts").text = """
+        mainProjectDir.file("settings.gradle").text = """
             rootProject.name = "main-project"
             include("app")
             includeBuild("../included-logging")
         """
 
-        mainProjectDir.file("app/build.gradle.kts").text = """
+        mainProjectDir.file("app/build.gradle").text = """
             plugins {
-                application
+                id 'application'
             }
 
             dependencies {
@@ -87,29 +87,31 @@ class ResolvePOMIntegrationTest extends AbstractIntegrationSpec {
             }
 
             tasks.register("resolve") {
-                doLast {
-                    val c: Configuration = configurations.getByName("compileClasspath")
-                    c.getResolvedConfiguration()
+                FileCollection artifacts = project.objects.fileCollection()
+                artifacts.from {
+                    configurations.getByName("compileClasspath").getResolvedConfiguration()
                         .getLenientConfiguration()
                         .getAllModuleDependencies()
-                        .map { it.getAllModuleArtifacts() }
-                        .forEach { mas ->
-                            mas.forEach { a ->
-                                println(a.getFile())
-                            }
+                        .collect {
+                            it.getAllModuleArtifacts().collect { mas ->
+                                mas.collect { a -> a.getFile() }
+                            }.flatten()
                         }
+                }
+                doLast {
+                    artifacts.each { a -> println(a.getFile()) }
                 }
             }
         """
 
-        includedLoggingProjectDir.file("settings.gradle.kts").text = """
+        includedLoggingProjectDir.file("settings.gradle").text = """
             rootProject.name = "included-logging"
             include("lib")
         """
 
-        includedLoggingProjectDir.file("lib/build.gradle.kts").text = """
+        includedLoggingProjectDir.file("lib/build.gradle").text = """
             plugins {
-                `java-library`
+                id 'java-library'
             }
         """
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolvePOMIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolvePOMIntegrationTest.groovy
@@ -19,9 +19,9 @@ package org.gradle.integtests.resolve
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import spock.lang.Issue
 
-@Issue("https://github.com/gradle/gradle/pull/23245")
-class ResolvePOMSpec extends AbstractIntegrationSpec {
-    def "resolving a @pom artifact from an included build replacing an external library doesn't fail the build"() {
+@Issue("https://github.com/gradle/gradle/issues/22875")
+class ResolvePOMIntegrationTest extends AbstractIntegrationSpec {
+    def "resolving a @pom artifact from an included build replacing an external library fails the build"() {
         given:
         def mainProjectDir = file("main-project")
         def includedLoggingProjectDir = file("included-logging")
@@ -61,7 +61,9 @@ class ResolvePOMSpec extends AbstractIntegrationSpec {
         executer.inDirectory(mainProjectDir)
 
         expect:
-        succeeds "build"
+        fails "build"
+        failure.assertHasCause("Could not resolve all task dependencies for configuration ':app:runtimeClasspath'")
+        failure.assertHasCause("Could not find lib.pom (project :included-logging:lib)")
     }
 
     def "getting the file for a @pom artifact from an included build replacing an external library doesn't fail the build"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolvePOMSpec.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolvePOMSpec.groovy
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Issue
+
+@Issue("https://github.com/gradle/gradle/pull/23245")
+class ResolvePOMSpec extends AbstractIntegrationSpec {
+    def "resolving a @pom artifact from an included build replacing an external library doesn't fail the build"() {
+        given:
+        def mainProjectDir = file("main-project")
+        def includedLoggingProjectDir = file("included-logging")
+
+        mainProjectDir.file("settings.gradle.kts").text = """
+            rootProject.name = "main-project"
+            include("app")
+            includeBuild("../included-logging")
+        """
+
+        mainProjectDir.file("app/build.gradle.kts").text = """
+            plugins {
+                application
+            }
+
+            dependencies {
+                implementation("org.gradle.repro:lib@pom")
+            }
+        """
+
+        includedLoggingProjectDir.file("settings.gradle.kts").text = """
+            rootProject.name = "included-logging"
+            include("lib")
+        """
+
+        includedLoggingProjectDir.file("lib/build.gradle.kts").text = """
+            plugins {
+                `java-library`
+            }
+        """
+
+        includedLoggingProjectDir.file("gradle.properties").text = """
+            group=org.gradle.repro
+            version=0.1.0-SNAPSHOT
+        """
+
+        executer.inDirectory(mainProjectDir)
+
+        expect:
+        succeeds "build"
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
@@ -110,7 +110,7 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
 
     private SelectedArtifactResults getSelectedArtifacts() {
         if (artifactsForThisConfiguration == null) {
-            artifactsForThisConfiguration = artifactResults.select(Specs.satisfyAll(), artifactTransforms.variantSelector(implicitAttributes, false, selectFromAllVariants, configuration.getDependenciesResolver()));
+            artifactsForThisConfiguration = artifactResults.selectLenient(Specs.satisfyAll(), artifactTransforms.variantSelector(implicitAttributes, false, selectFromAllVariants, configuration.getDependenciesResolver()));
         }
         return artifactsForThisConfiguration;
     }
@@ -126,7 +126,7 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
     @Override
     public SelectedArtifactSet select(final Spec<? super Dependency> dependencySpec, final AttributeContainerInternal requestedAttributes, final Spec<? super ComponentIdentifier> componentSpec, boolean allowNoMatchingVariants, boolean selectFromAllVariants) {
         VariantSelector selector = artifactTransforms.variantSelector(requestedAttributes, allowNoMatchingVariants, selectFromAllVariants, configuration.getDependenciesResolver());
-        SelectedArtifactResults artifactResults = this.artifactResults.select(componentSpec, selector);
+        SelectedArtifactResults artifactResults = this.artifactResults.selectLenient(componentSpec, selector);
 
         return new SelectedArtifactSet() {
             @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/AbstractFailedResolvedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/AbstractFailedResolvedArtifactSet.java
@@ -22,7 +22,10 @@ import org.gradle.internal.UncheckedException;
 import org.gradle.internal.operations.BuildOperationQueue;
 import org.gradle.internal.operations.RunnableBuildOperation;
 
-public class AbstractFailedResolvedArtifactSet implements ResolvedArtifactSet, ResolvedArtifactSet.Artifacts {
+/**
+ * An artifact set that is failed, capturing the failure and rethrowing when visited or transformed.
+ */
+public abstract class AbstractFailedResolvedArtifactSet implements ResolvedArtifactSet, ResolvedArtifactSet.Artifacts {
     protected final Throwable failure;
 
     public AbstractFailedResolvedArtifactSet(Throwable failure) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/AbstractFailedResolvedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/AbstractFailedResolvedArtifactSet.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
+
+import org.gradle.api.Action;
+import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
+import org.gradle.internal.UncheckedException;
+import org.gradle.internal.operations.BuildOperationQueue;
+import org.gradle.internal.operations.RunnableBuildOperation;
+
+public class AbstractFailedResolvedArtifactSet implements ResolvedArtifactSet, ResolvedArtifactSet.Artifacts {
+    protected final Throwable failure;
+
+    public AbstractFailedResolvedArtifactSet(Throwable failure) {
+        this.failure = failure;
+    }
+
+    @Override
+    public void visitDependencies(TaskDependencyResolveContext context) {
+        context.visitFailure(failure);
+    }
+
+    @Override
+    public void visit(Visitor visitor) {
+        visitor.visitArtifacts(this);
+    }
+
+    @Override
+    public void visitTransformSources(TransformSourceVisitor visitor) {
+        throw UncheckedException.throwAsUncheckedException(failure);
+    }
+
+    @Override
+    public void visitExternalArtifacts(Action<ResolvableArtifact> visitor) {
+        throw UncheckedException.throwAsUncheckedException(failure);
+    }
+
+    @Override
+    public void startFinalization(BuildOperationQueue<RunnableBuildOperation> actions, boolean requireFiles) {
+    }
+
+    @Override
+    public void finalizeNow(boolean requireFiles) {
+    }
+
+    @Override
+    public void visit(ArtifactVisitor visitor) {
+        visitor.visitFailure(failure);
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariant.java
@@ -63,7 +63,7 @@ public class ArtifactBackedResolvedVariant implements ResolvedVariant {
             try {
                 artifacts = artifactsSupplier.get();
             } catch (Exception e) {
-                return EMPTY;
+                return new UnavailableResolvedArtifactSet(e);
             }
             if (artifacts.isEmpty()) {
                 return EMPTY;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariant.java
@@ -59,7 +59,12 @@ public class ArtifactBackedResolvedVariant implements ResolvedVariant {
     }
     private static Supplier<ResolvedArtifactSet> supplyResolvedArtifactSet(DisplayName displayName, AttributeContainerInternal attributes, CapabilitiesMetadata capabilities, Supplier<Collection<? extends ResolvableArtifact>> artifactsSupplier) {
         return () -> {
-            Collection<? extends ResolvableArtifact> artifacts = artifactsSupplier.get();
+            Collection<? extends ResolvableArtifact> artifacts;
+            try {
+                artifacts = artifactsSupplier.get();
+            } catch (Exception e) {
+                return EMPTY;
+            }
             if (artifacts.isEmpty()) {
                 return EMPTY;
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultVisitedArtifactResults.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultVisitedArtifactResults.java
@@ -24,10 +24,13 @@ import org.gradle.api.specs.Spec;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
 import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet.EMPTY;
 
 public class DefaultVisitedArtifactResults implements VisitedArtifactsResults {
+    private static final Function<ResolvedArtifactSet, ResolvedArtifactSet> DO_NOTHING = resolvedArtifactSet -> resolvedArtifactSet;
+    private static final Function<ResolvedArtifactSet, ResolvedArtifactSet> ALLOW_UNAVAILABLE = resolvedArtifactSet -> resolvedArtifactSet instanceof UnavailableResolvedArtifactSet ? ResolvedArtifactSet.EMPTY : resolvedArtifactSet;
     private final ResolutionStrategy.SortOrder sortOrder;
     // Index of the artifact set == the id of the artifact set
     private final List<ArtifactSet> artifactsById;
@@ -37,8 +40,7 @@ public class DefaultVisitedArtifactResults implements VisitedArtifactsResults {
         this.artifactsById = artifactsById;
     }
 
-    @Override
-    public SelectedArtifactResults select(Spec<? super ComponentIdentifier> componentFilter, VariantSelector selector) {
+    private SelectedArtifactResults select(Spec<? super ComponentIdentifier> componentFilter, VariantSelector selector, Function<ResolvedArtifactSet, ResolvedArtifactSet> artifactSetHandler) {
         if (artifactsById.isEmpty()) {
             return NoArtifactResults.INSTANCE;
         }
@@ -46,7 +48,7 @@ public class DefaultVisitedArtifactResults implements VisitedArtifactsResults {
         List<ResolvedArtifactSet> resolvedArtifactSets = new ArrayList<>(artifactsById.size());
         for (ArtifactSet artifactSet : artifactsById) {
             ResolvedArtifactSet resolvedArtifacts = artifactSet.select(componentFilter, selector);
-            resolvedArtifactSets.add(resolvedArtifacts);
+            resolvedArtifactSets.add(artifactSetHandler.apply(resolvedArtifacts));
         }
 
         if (sortOrder == ResolutionStrategy.SortOrder.DEPENDENCY_FIRST) {
@@ -55,6 +57,16 @@ public class DefaultVisitedArtifactResults implements VisitedArtifactsResults {
 
         ResolvedArtifactSet composite = CompositeResolvedArtifactSet.of(resolvedArtifactSets);
         return new DefaultSelectedArtifactResults(sortOrder, composite, resolvedArtifactSets);
+    }
+
+    @Override
+    public SelectedArtifactResults select(Spec<? super ComponentIdentifier> componentFilter, VariantSelector selector) {
+        return select(componentFilter, selector, DO_NOTHING);
+    }
+
+    @Override
+    public SelectedArtifactResults selectLenient(Spec<? super ComponentIdentifier> componentFilter, VariantSelector selector) {
+        return select(componentFilter, selector, ALLOW_UNAVAILABLE);
     }
 
     private static class NoArtifactResults implements SelectedArtifactResults {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultVisitedArtifactResults.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultVisitedArtifactResults.java
@@ -30,7 +30,14 @@ import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifac
 
 public class DefaultVisitedArtifactResults implements VisitedArtifactsResults {
     private static final Function<ResolvedArtifactSet, ResolvedArtifactSet> DO_NOTHING = resolvedArtifactSet -> resolvedArtifactSet;
-    private static final Function<ResolvedArtifactSet, ResolvedArtifactSet> ALLOW_UNAVAILABLE = resolvedArtifactSet -> resolvedArtifactSet instanceof UnavailableResolvedArtifactSet ? ResolvedArtifactSet.EMPTY : resolvedArtifactSet;
+    private static final Function<ResolvedArtifactSet, ResolvedArtifactSet> ALLOW_UNAVAILABLE = resolvedArtifactSet -> {
+        if (resolvedArtifactSet instanceof UnavailableResolvedArtifactSet) {
+            return ResolvedArtifactSet.EMPTY;
+        } else {
+            return resolvedArtifactSet;
+        }
+    };
+
     private final ResolutionStrategy.SortOrder sortOrder;
     // Index of the artifact set == the id of the artifact set
     private final List<ArtifactSet> artifactsById;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/UnavailableResolvedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/UnavailableResolvedArtifactSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,10 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
 /**
- * Represents an artifact that failed to resolve, for instance, no variant matched the requested attributes or
- * multiple variants matched the selected artifacts.
+ * Represents artifacts that are successfully resolved, but unavailable for some reason when the artifact was requested.
  */
-public class BrokenResolvedArtifactSet extends AbstractFailedResolvedArtifactSet {
-
-    public BrokenResolvedArtifactSet(Throwable failure) {
+public class UnavailableResolvedArtifactSet extends AbstractFailedResolvedArtifactSet {
+    public UnavailableResolvedArtifactSet(Throwable failure) {
         super(failure);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/VisitedArtifactsResults.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/VisitedArtifactsResults.java
@@ -25,4 +25,9 @@ public interface VisitedArtifactsResults {
      * Selects the artifacts for the matching variant of each node seen during traversal. The implementation should attempt to select artifacts eagerly, but may be lazy where the selection cannot happen until the results are queried.
      */
     SelectedArtifactResults select(Spec<? super ComponentIdentifier> componentFilter, VariantSelector selector);
+
+    /**
+     * Selects the artifacts for the matching variant of each node seen during traversal, ignoring artifacts that are resolved, but unavailable. The implementation should attempt to select artifacts eagerly, but may be lazy where the selection cannot happen until the results are queried.
+     */
+    SelectedArtifactResults selectLenient(Spec<? super ComponentIdentifier> componentFilter, VariantSelector selector);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/MissingLocalArtifactMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/MissingLocalArtifactMetadata.java
@@ -101,6 +101,6 @@ public class MissingLocalArtifactMetadata implements LocalComponentArtifactMetad
 
     @Override
     public boolean isOptionalArtifact() {
-        return true;
+        return false;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/MissingLocalArtifactMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/MissingLocalArtifactMetadata.java
@@ -98,9 +98,4 @@ public class MissingLocalArtifactMetadata implements LocalComponentArtifactMetad
         MissingLocalArtifactMetadata other = (MissingLocalArtifactMetadata) obj;
         return other.componentIdentifier.equals(componentIdentifier) && other.name.equals(name);
     }
-
-    @Override
-    public boolean isOptionalArtifact() {
-        return false;
-    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/MissingLocalArtifactMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/MissingLocalArtifactMetadata.java
@@ -98,4 +98,9 @@ public class MissingLocalArtifactMetadata implements LocalComponentArtifactMetad
         MissingLocalArtifactMetadata other = (MissingLocalArtifactMetadata) obj;
         return other.componentIdentifier.equals(componentIdentifier) && other.name.equals(name);
     }
+
+    @Override
+    public boolean isOptionalArtifact() {
+        return true;
+    }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultVisitedArtifactResultsTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultVisitedArtifactResultsTest.groovy
@@ -46,4 +46,71 @@ class DefaultVisitedArtifactResultsTest extends Specification {
         selected.getArtifactsWithId(1) == variant2Artifacts
     }
 
+    def "lenient selection includes selected variant of each node"() {
+        def artifacts1 = Stub(ArtifactSet)
+        def artifacts2 = Stub(ArtifactSet)
+        def variant1Artifacts = Stub(ResolvedArtifactSet)
+        def variant2Artifacts = Stub(ResolvedArtifactSet)
+
+        def selector = Stub(VariantSelector)
+        def spec = Stub(Spec)
+
+        given:
+        artifacts1.select(spec, selector) >> variant1Artifacts
+        artifacts2.select(spec, selector) >> variant2Artifacts
+
+        def results = new DefaultVisitedArtifactResults(ResolutionStrategy.SortOrder.CONSUMER_FIRST, [artifacts1, artifacts2])
+        def selected = results.selectLenient(spec, selector)
+
+        expect:
+        selected.getArtifacts() instanceof CompositeResolvedArtifactSet
+        selected.getArtifacts().sets == [variant1Artifacts, variant2Artifacts]
+
+        selected.getArtifactsWithId(0) == variant1Artifacts
+        selected.getArtifactsWithId(1) == variant2Artifacts
+    }
+
+    def "lenient selection does not include unavailable selected variant"() {
+        def artifacts1 = Stub(ArtifactSet)
+        def artifacts2 = Stub(ArtifactSet)
+        def variant1Artifacts = new UnavailableResolvedArtifactSet(new Exception())
+        def variant2Artifacts = Stub(ResolvedArtifactSet)
+
+        def selector = Stub(VariantSelector)
+        def spec = Stub(Spec)
+
+        given:
+        artifacts1.select(spec, selector) >> variant1Artifacts
+        artifacts2.select(spec, selector) >> variant2Artifacts
+
+        def results = new DefaultVisitedArtifactResults(ResolutionStrategy.SortOrder.CONSUMER_FIRST, [artifacts1, artifacts2])
+        def selected = results.selectLenient(spec, selector)
+
+        expect:
+        selected.getArtifacts() == variant2Artifacts
+    }
+
+    def "lenient selection includes broken artifacts"() {
+        def artifacts1 = Stub(ArtifactSet)
+        def artifacts2 = Stub(ArtifactSet)
+        def variant1Artifacts = new BrokenResolvedArtifactSet(new Exception())
+        def variant2Artifacts = Stub(ResolvedArtifactSet)
+
+        def selector = Stub(VariantSelector)
+        def spec = Stub(Spec)
+
+        given:
+        artifacts1.select(spec, selector) >> variant1Artifacts
+        artifacts2.select(spec, selector) >> variant2Artifacts
+
+        def results = new DefaultVisitedArtifactResults(ResolutionStrategy.SortOrder.CONSUMER_FIRST, [artifacts1, artifacts2])
+        def selected = results.selectLenient(spec, selector)
+
+        expect:
+        selected.getArtifacts() instanceof CompositeResolvedArtifactSet
+        selected.getArtifacts().sets == [variant1Artifacts, variant2Artifacts]
+
+        selected.getArtifactsWithId(0) == variant1Artifacts
+        selected.getArtifactsWithId(1) == variant2Artifacts
+    }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultVisitedArtifactResultsTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultVisitedArtifactResultsTest.groovy
@@ -22,11 +22,35 @@ import org.gradle.api.specs.Spec
 import spock.lang.Specification
 
 class DefaultVisitedArtifactResultsTest extends Specification {
-    def "selection includes selected variant of each node"() {
+    def "strict selection includes selected variant of each node"() {
         def artifacts1 = Stub(ArtifactSet)
         def artifacts2 = Stub(ArtifactSet)
         def variant1Artifacts = Stub(ResolvedArtifactSet)
         def variant2Artifacts = Stub(ResolvedArtifactSet)
+
+        def selector = Stub(VariantSelector)
+        def spec = Stub(Spec)
+
+        given:
+        artifacts1.select(spec, selector) >> variant1Artifacts
+        artifacts2.select(spec, selector) >> variant2Artifacts
+
+        def results = new DefaultVisitedArtifactResults(ResolutionStrategy.SortOrder.CONSUMER_FIRST, [artifacts1, artifacts2])
+        def selected = results.select(spec, selector)
+
+        expect:
+        selected.getArtifacts() instanceof CompositeResolvedArtifactSet
+        selected.getArtifacts().sets == [variant1Artifacts, variant2Artifacts]
+
+        selected.getArtifactsWithId(0) == variant1Artifacts
+        selected.getArtifactsWithId(1) == variant2Artifacts
+    }
+
+    def "strict selection includes all failed artifacts"() {
+        def artifacts1 = Stub(ArtifactSet)
+        def artifacts2 = Stub(ArtifactSet)
+        def variant1Artifacts = new BrokenResolvedArtifactSet(new Exception())
+        def variant2Artifacts = new UnavailableResolvedArtifactSet(new Exception())
 
         def selector = Stub(VariantSelector)
         def spec = Stub(Spec)


### PR DESCRIPTION
Artifacts can be resolvable, but still be unavailable, such as the pom artifact from an included build substituting for an external library.  This change allows lenient configurations to select a list of resolvable artifacts, ignoring any that may be resolvable but not available.
