### PR TITLE
Run Santa-Tracker smoke tests with Java 17

### DIFF
--- a/.teamcity/src/main/kotlin/common/JvmCategory.kt
+++ b/.teamcity/src/main/kotlin/common/JvmCategory.kt
@@ -25,6 +25,6 @@ enum class JvmCategory(
     MIN_VERSION_WINDOWS(JvmVendor.openjdk, JvmVersion.java8),
     MAX_LTS_VERSION(JvmVendor.openjdk, JvmVersion.java17),
     MAX_VERSION(JvmVendor.openjdk, JvmVersion.java18),
-    SANTA_TRACKER_SMOKE_TEST_VERSION(JvmVendor.openjdk, JvmVersion.java11),
+    SANTA_TRACKER_SMOKE_TEST_VERSION(JvmVendor.openjdk, JvmVersion.java17),
     EXPERIMENTAL_VERSION(JvmVendor.openjdk, JvmVersion.java18)
 }


### PR DESCRIPTION
as AGP 8 now requires Java 17

This is a prerequisite for 
* https://github.com/gradle/gradle/pull/23386