### PR TITLE
[Junit] Allow to omit  SystemOutLog & SystemErrLog in XML report #23229

### DIFF
--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -163,7 +163,7 @@ The new [`includeSystemOutLog` and `includeSystemErrLog` options](userguide/java
 Disabling these options can be useful when running a test task results in a large amount of standard output or standard error data that is not relevant for testing, or to preserve disk space when running jobs on CI.
 
 Set these options by configuring the
-link:{javadocPath}/org/gradle/api/tasks/testing/JUnitXmlReport.html[JUnitXmlReport] options block.
+[JUnitXmlReport](javadoc/org/gradle/api/tasks/testing/JUnitXmlReport.html) options block.
 
 ```kotlin
 tasks.test {
@@ -174,7 +174,6 @@ tasks.test {
     }
 }
 ```
-
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ADD RELEASE FEATURES ABOVE
 ==========================================================

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -147,11 +147,21 @@ Previously, the display name could be obtained only by parsing the operation dis
 Additionally, for JUnit5 and Spock, we updated the test descriptor for dynamic and parameterized tests to include information about the class name and method name containing the test.
 These enhancements enable IDEs to offer improved navigation and reporting capabilities for dynamic and parameterized tests.
 
+#### Fix IDE performance issues with large projects
+
+A performance issue in the Tooling API causing delays at the end of task execution in large projects has been identified and fixed by a community member.
+This problem occurred while transmitting task information for executed tasks to the IDE.
+
+After executing approximately 15,000 tasks, the IDE would encounter a delay of several seconds.
+The root cause was that much more information than needed was serialized via the Tooling API.
+We added a test to the fix to ensure there will be no future regression, demonstrating a performance improvement of around 12%.
+The environments that benefit from this fix are Android Studio, IntelliJ IDEA, Eclipse, and other Tooling API clients.
+
 #### Filter standard output and error output in XML test reports
 
 The new [`includeSystemOutLog` and `includeSystemErrLog` options](userguide/java_testing.html#junit_xml_configuration_output_filtering) control whether or not output written to standard output and standard error output during testing is included in XML test reports.
 This report format is used by JUnit 4, JUnit Jupiter, and TestNG, despite the name of the report format, and can be configured when using any of these test frameworks.
-Disabling these options can be useful when running a test task results in a large amount of standard output or standard error data that is irrelevant for testing.  
+Disabling these options can be useful when running a test task results in a large amount of standard output or standard error data that is irrelevant for testing.
 It is also useful for preserving disk space when running jobs on CI.
 
 Set these options by configuring the [JUnitXmlReport](javadoc/org/gradle/api/tasks/testing/JUnitXmlReport.html) options block.

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -147,27 +147,16 @@ Previously, the display name could be obtained only by parsing the operation dis
 Additionally, for JUnit5 and Spock, we updated the test descriptor for dynamic and parameterized tests to include information about the class name and method name containing the test.
 These enhancements enable IDEs to offer improved navigation and reporting capabilities for dynamic and parameterized tests.
 
-#### Fix IDE performance issues with large projects
+#### Filter standard output and error output in XML test reports
 
-A performance issue in the Tooling API causing delays at the end of task execution in large projects has been identified and fixed by a community member.
-This problem occurred while transmitting task information for executed tasks to the IDE. 
-
-After executing approximately 15,000 tasks, the IDE would encounter a delay of several seconds. 
-The root cause was that much more information than needed was serialized via the Tooling API.
-We added a test to the fix to ensure there will be no future regression, demonstrating a performance improvement of around 12%.
-The environments that benefit from this fix are Android Studio, IntelliJ IDEA, Eclipse, and other Tooling API clients.
-
-#### Filter output in JUnit XML test reports
-
-The new [`includeSystemOutLog` and `includeSystemErrLog` options](userguide/java_testing.html#junit_xml_configuration_output_filtering) allow for controlling whether or not output written to standard output and standard error output during testing is included in JUnit's XML test reports.
+The new [`includeSystemOutLog` and `includeSystemErrLog` options](userguide/java_testing.html#junit_xml_configuration_output_filtering) control whether or not output written to standard output and standard error output during testing is included in XML test reports.
+This report format is used by the JUnit 4, JUnit Jupiter, and TestNG, despite the name of the report format, and can be configured when using any of these test frameworks.
 Disabling these options can be useful when running a test task results in a large amount of standard output or standard error data that is not relevant for testing, or to preserve disk space when running jobs on CI.
 
-Set these options by configuring the
-[JUnitXmlReport](javadoc/org/gradle/api/tasks/testing/JUnitXmlReport.html) options block.
+Set these options by configuring the [JUnitXmlReport](javadoc/org/gradle/api/tasks/testing/JUnitXmlReport.html) options block.
 
 ```kotlin
 tasks.test {
-    useJUnit()
     reports.junitXml {
         includeSystemOutLog = false
         includeSystemErrLog = true

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -2,7 +2,7 @@ The Gradle team is excited to announce Gradle @version@.
 
 This release features [1](), [2](), ... [n](), and more.
 
-<!-- 
+<!--
 Include only their name, impactful features should be called out separately below.
  [Some person](https://github.com/some-person)
 
@@ -20,7 +20,7 @@ Switch your build to use Gradle @version@ by updating your wrapper:
 
 See the [Gradle 8.x upgrade guide](userguide/upgrading_version_8.html#changes_@baseVersion@) to learn about deprecations, breaking changes, and other considerations when upgrading to Gradle @version@.
 
-For Java, Groovy, Kotlin, and Android compatibility, see the [full compatibility notes](userguide/compatibility.html).   
+For Java, Groovy, Kotlin, and Android compatibility, see the [full compatibility notes](userguide/compatibility.html).
 
 ## New features and usability improvements
 
@@ -60,10 +60,10 @@ vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv -->
 
 Plugin-provided tasks often expose file collections that are meant to be customizable by build engineers (for instance, the classpath for the JavaCompile task).
 Up until now, for plugin authors to define default values for file collections, they have had to resort to configuring those defaults as initial values.
-Conventions provide a better model for that: plugin authors recommend default values via conventions, and users choose to accept, add on top, or completely 
+Conventions provide a better model for that: plugin authors recommend default values via conventions, and users choose to accept, add on top, or completely
 replace them when defining their actual value.
 
-This release introduces a  pair of [`convention(...)`](javadoc/org/gradle/api/file/ConfigurableFileCollection.html#convention-java.lang.Object...-) methods 
+This release introduces a  pair of [`convention(...)`](javadoc/org/gradle/api/file/ConfigurableFileCollection.html#convention-java.lang.Object...-) methods
 on `ConfigurableFileCollection` that define the default value of a file collection if no explicit value is previously set via `setFrom(...)` or `from(...)`.
 
 ```kotlin
@@ -73,7 +73,7 @@ files.from("dir2")
 println(files.elements.get()) // [.../dir1, .../dir2]
 ```
 
-`#from(...)` will honor the convention if one is configured when invoked, so the order of operations will matter. 
+`#from(...)` will honor the convention if one is configured when invoked, so the order of operations will matter.
 
 To forcefully override or prevent a convention (i.e., regardless of the order of those operations), one should use `#setFrom()` instead:
 
@@ -122,7 +122,7 @@ Refer to the Javadoc for [`Property.replace(Transformer<>)`](javadoc/org/gradle/
 
 When attempting to download Java toolchains from the configured resolvers, errors will be better handled now, and all resolvers will be tried.
 
-While mapping toolchain specs to download URLs, resolvers aren't supposed to throw exceptions. 
+While mapping toolchain specs to download URLs, resolvers aren't supposed to throw exceptions.
 But it is possible for them to do that, and when it happens, Gradle should try to use other configured resolvers in their stead.
 However, it wasn't the case before this fix.
 
@@ -156,6 +156,24 @@ After executing approximately 15,000 tasks, the IDE would encounter a delay of s
 The root cause was that much more information than needed was serialized via the Tooling API.
 We added a test to the fix to ensure there will be no future regression, demonstrating a performance improvement of around 12%.
 The environments that benefit from this fix are Android Studio, IntelliJ IDEA, Eclipse, and other Tooling API clients.
+
+#### Filter output in JUnit XML test reports
+
+The new [`includeSystemOutLog` and `includeSystemErrLog` options](userguide/java_testing.html#junit_xml_configuration_output_filtering) allow for controlling whether or not output written to standard output and standard error output during testing is included in JUnit's XML test reports.
+Disabling these options can be useful when running a test task results in a large amount of standard output or standard error data that is not relevant for testing, or to preserve disk space when running jobs on CI.
+
+Set these options by configuring the
+link:{javadocPath}/org/gradle/api/tasks/testing/JUnitXmlReport.html[JUnitXmlReport] options block.
+
+```kotlin
+tasks.test {
+    useJUnit()
+    reports.junitXml {
+        includeSystemOutLog = false
+        includeSystemErrLog = true
+    }
+}
+```
 
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ADD RELEASE FEATURES ABOVE

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -151,7 +151,8 @@ These enhancements enable IDEs to offer improved navigation and reporting capabi
 
 The new [`includeSystemOutLog` and `includeSystemErrLog` options](userguide/java_testing.html#junit_xml_configuration_output_filtering) control whether or not output written to standard output and standard error output during testing is included in XML test reports.
 This report format is used by the JUnit 4, JUnit Jupiter, and TestNG, despite the name of the report format, and can be configured when using any of these test frameworks.
-Disabling these options can be useful when running a test task results in a large amount of standard output or standard error data that is not relevant for testing, or to preserve disk space when running jobs on CI.
+Disabling these options can be useful when running a test task results in a large amount of standard output or standard error data that is irrelevant for testing.  
+It is also useful for preserving disk space when running jobs on CI.
 
 Set these options by configuring the [JUnitXmlReport](javadoc/org/gradle/api/tasks/testing/JUnitXmlReport.html) options block.
 

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -150,7 +150,7 @@ These enhancements enable IDEs to offer improved navigation and reporting capabi
 #### Filter standard output and error output in XML test reports
 
 The new [`includeSystemOutLog` and `includeSystemErrLog` options](userguide/java_testing.html#junit_xml_configuration_output_filtering) control whether or not output written to standard output and standard error output during testing is included in XML test reports.
-This report format is used by the JUnit 4, JUnit Jupiter, and TestNG, despite the name of the report format, and can be configured when using any of these test frameworks.
+This report format is used by JUnit 4, JUnit Jupiter, and TestNG, despite the name of the report format, and can be configured when using any of these test frameworks.
 Disabling these options can be useful when running a test task results in a large amount of standard output or standard error data that is irrelevant for testing.  
 It is also useful for preserving disk space when running jobs on CI.
 

--- a/platforms/documentation/docs/src/docs/userguide/jvm/java_testing.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/jvm/java_testing.adoc
@@ -283,7 +283,7 @@ The `includeSystemOutLog` option allows configuring whether or not test output w
 The `includeSystemErrLog` option allows configuring whether or not test error output written to standard error is exported to the XML report file.
 
 These options affect both test-suite level output (such as `@BeforeClass`/`@BeforeAll` output) and test class and method-specific output (`@Before`/`@BeforeEach` and `@Test`).
-If either option is disabled, the element that would normally contain that content will be omitted from the XML report file.
+If either option is disabled, the element that normally contains that content will be excluded from the XML report file.
 
 The default for each option is `true`.
 

--- a/platforms/documentation/docs/src/docs/userguide/jvm/java_testing.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/jvm/java_testing.adoc
@@ -275,11 +275,16 @@ include::sample[dir="snippets/testing/junit-xml-results/kotlin",files="build.gra
 include::sample[dir="snippets/testing/junit-xml-results/groovy",files="build.gradle[tags=configure-content]"]
 ====
 
+[[junit_xml_configuration_output_filtering]]
 ===== includeSystemOutLog & includeSystemErrLog
 
-The `includeSystemOutLog` option allows configuring whether or not test output is exported to the XML report file.
-The `includeSystemErrLog` option allows configuring whether or not test error output is exported to the XML report file.
+The `includeSystemOutLog` option allows configuring whether or not test output writen to standard out is exported to the XML report file.
+The `includeSystemErrLog` option allows configuring whether or not test error output written to standard error is exported to the XML report file.
 
+These options affect both test-suite level output (such as `@BeforeClass` output in JUnit 4), and test class and method specific output (`@Before` and `@Test` output in JUnit 4).
+If either option is disabled, the element that would normally contain that content will be omitted from the XML report file.
+
+These options are available when testing with JUnit 4.
 The default for each option is `true`.
 
 ===== outputPerTestCase

--- a/platforms/documentation/docs/src/docs/userguide/jvm/java_testing.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/jvm/java_testing.adoc
@@ -279,7 +279,7 @@ include::sample[dir="snippets/testing/junit-xml-results/groovy",files="build.gra
 [[junit_xml_configuration_output_filtering]]
 ===== includeSystemOutLog & includeSystemErrLog
 
-The `includeSystemOutLog` option allows configuring whether or not test output writen to standard out is exported to the XML report file.
+The `includeSystemOutLog` option allows configuring whether or not test output written to standard out is exported to the XML report file.
 The `includeSystemErrLog` option allows configuring whether or not test error output written to standard error is exported to the XML report file.
 
 These options affect both test-suite level output (such as `@BeforeClass`/`@BeforeAll` output), and test class and method specific output (`@Before`/`@BeforeEach` and `@Test`).

--- a/platforms/documentation/docs/src/docs/userguide/jvm/java_testing.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/jvm/java_testing.adoc
@@ -277,7 +277,8 @@ include::sample[dir="snippets/testing/junit-xml-results/groovy",files="build.gra
 
 ===== omitSystemOutLog & omitSystemErrLog
 
-Allows configuring XML exporter to omit the system error and system out logs in the result file.
+When enabled, the `omitSystemErrLog` option allows configuring XML exporter to omit the system error in the result file. 
+While the `omitSystemErrLog` option allows configuring XML exporter to omit the system out logs in the result file.
 
 ===== outputPerTestCase
 

--- a/platforms/documentation/docs/src/docs/userguide/jvm/java_testing.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/jvm/java_testing.adoc
@@ -275,6 +275,10 @@ include::sample[dir="snippets/testing/junit-xml-results/kotlin",files="build.gra
 include::sample[dir="snippets/testing/junit-xml-results/groovy",files="build.gradle[tags=configure-content]"]
 ====
 
+===== omitSystemOutLog & omitSystemErrLog
+
+Allows configuring XML exporter to omit the system error and system out logs in the result file.
+
 ===== outputPerTestCase
 
 The `outputPerTestCase` option, when enabled, associates any output logging generated during a test case to that test case in the results.

--- a/platforms/documentation/docs/src/docs/userguide/jvm/java_testing.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/jvm/java_testing.adoc
@@ -241,6 +241,7 @@ You should note that the `TestReport` type combines the results from multiple te
 === Communicating test results to CI servers and other tools via XML files
 
 The Test tasks creates XML files describing the test results, in the “JUnit XML” pseudo standard.
+This standard is used by the JUnit 4, JUnit Jupiter, and TestNG test frameworks, and is configured using the same DSL block for each of these.
 It is common for CI servers and other tooling to observe test results via these XML files.
 
 By default, the files are written to `layout.buildDirectory.dir("test-results/$testTaskName")` with a file per test class.
@@ -281,10 +282,9 @@ include::sample[dir="snippets/testing/junit-xml-results/groovy",files="build.gra
 The `includeSystemOutLog` option allows configuring whether or not test output writen to standard out is exported to the XML report file.
 The `includeSystemErrLog` option allows configuring whether or not test error output written to standard error is exported to the XML report file.
 
-These options affect both test-suite level output (such as `@BeforeClass` output in JUnit 4), and test class and method specific output (`@Before` and `@Test` output in JUnit 4).
+These options affect both test-suite level output (such as `@BeforeClass`/`@BeforeAll` output), and test class and method specific output (`@Before`/`@BeforeEach` and `@Test`).
 If either option is disabled, the element that would normally contain that content will be omitted from the XML report file.
 
-These options are available when testing with JUnit 4.
 The default for each option is `true`.
 
 ===== outputPerTestCase

--- a/platforms/documentation/docs/src/docs/userguide/jvm/java_testing.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/jvm/java_testing.adoc
@@ -275,10 +275,12 @@ include::sample[dir="snippets/testing/junit-xml-results/kotlin",files="build.gra
 include::sample[dir="snippets/testing/junit-xml-results/groovy",files="build.gradle[tags=configure-content]"]
 ====
 
-===== omitSystemOutLog & omitSystemErrLog
+===== includeSystemOutLog & includeSystemErrLog
 
-When enabled, the `omitSystemErrLog` option allows configuring XML exporter to omit the system error in the result file. 
-While the `omitSystemErrLog` option allows configuring XML exporter to omit the system out logs in the result file.
+The `includeSystemOutLog` option allows configuring whether or not test output is exported to the XML report file.
+The `includeSystemErrLog` option allows configuring whether or not test error output is exported to the XML report file.
+
+The default for each option is `true`.
 
 ===== outputPerTestCase
 

--- a/platforms/documentation/docs/src/docs/userguide/jvm/java_testing.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/jvm/java_testing.adoc
@@ -282,7 +282,7 @@ include::sample[dir="snippets/testing/junit-xml-results/groovy",files="build.gra
 The `includeSystemOutLog` option allows configuring whether or not test output written to standard out is exported to the XML report file.
 The `includeSystemErrLog` option allows configuring whether or not test error output written to standard error is exported to the XML report file.
 
-These options affect both test-suite level output (such as `@BeforeClass`/`@BeforeAll` output), and test class and method specific output (`@Before`/`@BeforeEach` and `@Test`).
+These options affect both test-suite level output (such as `@BeforeClass`/`@BeforeAll` output) and test class and method-specific output (`@Before`/`@BeforeEach` and `@Test`).
 If either option is disabled, the element that would normally contain that content will be omitted from the XML report file.
 
 The default for each option is `true`.

--- a/platforms/documentation/docs/src/snippets/testing/junit-xml-results/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/testing/junit-xml-results/groovy/build.gradle
@@ -26,6 +26,8 @@ java.testResultsDir = layout.buildDirectory.dir("junit-xml")
 test {
     reports {
         junitXml {
+            omitSystemErrLog = true // defaults to false
+            omitSystemOutLog = true // defaults to false
             outputPerTestCase = true // defaults to false
             mergeReruns = true // defaults to false
         }

--- a/platforms/documentation/docs/src/snippets/testing/junit-xml-results/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/testing/junit-xml-results/groovy/build.gradle
@@ -26,8 +26,8 @@ java.testResultsDir = layout.buildDirectory.dir("junit-xml")
 test {
     reports {
         junitXml {
-            omitSystemErrLog = true // defaults to false
-            omitSystemOutLog = true // defaults to false
+            includeSystemOutLog = false // defaults to true
+            includeSystemErrLog = false // defaults to true
             outputPerTestCase = true // defaults to false
             mergeReruns = true // defaults to false
         }

--- a/platforms/documentation/docs/src/snippets/testing/junit-xml-results/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/testing/junit-xml-results/kotlin/build.gradle.kts
@@ -26,6 +26,8 @@ java.testResultsDir = layout.buildDirectory.dir("junit-xml")
 tasks.test {
     reports {
         junitXml.apply {
+            includeSystemOutLog = false // defaults to true
+            includeSystemErrLog = false // defaults to true
             isOutputPerTestCase = true // defaults to false
             mergeReruns = true // defaults to false
         }

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/junit4/JUnit4LoggingOutputCaptureIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/junit4/JUnit4LoggingOutputCaptureIntegrationTest.groovy
@@ -59,15 +59,15 @@ class JUnit4LoggingOutputCaptureIntegrationTest extends AbstractJUnit4LoggingOut
             assert junitResult.getSuiteStandardOutput("OkTest").isPresent()
             assert junitResult.getTestCaseStandardOutput("OkTest", "isOk").isPresent()
         } else {
-            assert junitResult.getSuiteStandardOutput("OkTest").isEmpty()
-            assert junitResult.getTestCaseStandardOutput("OkTest", "isOk").isEmpty()
+            assert !junitResult.getSuiteStandardOutput("OkTest").isPresent() // isEmpty not available in Java 8
+            assert !junitResult.getTestCaseStandardOutput("OkTest", "isOk").isPresent()
         }
         if (standardErrIncluded) {
             assert junitResult.getSuiteStandardError("OkTest").isPresent()
             assert junitResult.getTestCaseStandardError("OkTest", "isOk").isPresent()
         } else {
-            assert junitResult.getSuiteStandardError("OkTest").isEmpty()
-            assert junitResult.getTestCaseStandardError("OkTest", "isOk").isEmpty()
+            assert !junitResult.getSuiteStandardError("OkTest").isPresent()
+            assert !junitResult.getTestCaseStandardError("OkTest", "isOk").isPresent()
         }
 
         and: "all output appeared in the console when running tests"

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/junit4/JUnit4LoggingOutputCaptureIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/junit4/JUnit4LoggingOutputCaptureIntegrationTest.groovy
@@ -16,10 +16,76 @@
 
 package org.gradle.testing.junit.junit4
 
+import groovy.xml.XmlParser
 import org.gradle.integtests.fixtures.TargetCoverage
 
 import static org.gradle.testing.fixture.JUnitCoverage.JUNIT_4
 
 @TargetCoverage({ JUNIT_4 })
 class JUnit4LoggingOutputCaptureIntegrationTest extends AbstractJUnit4LoggingOutputCaptureIntegrationTest implements JUnit4MultiVersionTest {
+    def "can configure logging output inclusion in xml reports"() {
+        given:
+        buildFile.text = buildFile.text.replace("reports.junitXml.outputPerTestCase = true", """reports.junitXml {
+            outputPerTestCase = true
+            $includeSystemOut
+            $includeSystemErr
+        }""".stripIndent())
+
+        file("src/test/java/OkTest.java") << """
+            ${testFrameworkImports}
+
+            public class OkTest {
+                @BeforeClass
+                public static void init() {
+                    System.out.println("before class output");
+                    System.err.println("before class error");
+                }
+
+                @Test
+                public void isOk() {
+                    System.out.println("test method output");
+                    System.err.println("test method error");
+                }
+            }
+        """
+
+        expect:
+        executer.withTestConsoleAttached()
+        succeeds("test")
+
+        and:
+        def xmlResult = file("build/test-results/test/TEST-OkTest.xml")
+        def doc = new XmlParser().parseText(xmlResult.text)
+
+        and: "suite level output (before/after class) is included/excluded in the xml report as configured"
+        def testSuiteOutput = doc.tap {
+            assert it.name() == 'testsuite'
+            assert it["@name"] == 'OkTest'
+        }
+        def suiteStandardOut = testSuiteOutput.'system-out'.text()
+        def suiteStandardErr = testSuiteOutput.'system-err'.text()
+        suiteStandardOut.isEmpty() == !standardOutIncluded
+        suiteStandardErr.isEmpty() == !standardErrIncluded
+
+        and: "test method output (includes setup/teardown) is included/excluded in the xml report as configured"
+        def testMethodOutput = testSuiteOutput.'testcase'.find { it.@classname = 'OkTest' && it.@name == 'isOk' }
+        def testStandardOut = testMethodOutput.'system-out'.text()
+        def testStandardErr = testMethodOutput.'system-err'.text()
+        testStandardOut.isEmpty() == !standardOutIncluded
+        testStandardErr.isEmpty() == !standardErrIncluded
+
+        and: "all output appeared in the console when running tests"
+        result.assertOutputContains("before class output")
+        result.assertOutputContains("test method output")
+        result.assertHasErrorOutput("before class error")
+        result.assertHasErrorOutput("test method error")
+
+        where:
+        includeSystemOut                    | includeSystemErr                  || standardOutIncluded || standardErrIncluded
+        "// default includeSystemOutLog"    | "// default includeSystemErrLog"  || true                || true
+        "includeSystemOutLog = true"        | "includeSystemErrLog = true"      || true                || true
+        "includeSystemOutLog = false"       | "includeSystemErrLog = true"      || false               || true
+        "includeSystemOutLog = true"        | "includeSystemErrLog = false"     || true                || false
+        "includeSystemOutLog = false"       | "includeSystemErrLog = false"     || false               || false
+    }
 }

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/junit4/JUnit4LoggingOutputCaptureIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/junit4/JUnit4LoggingOutputCaptureIntegrationTest.groovy
@@ -75,8 +75,8 @@ class JUnit4LoggingOutputCaptureIntegrationTest extends AbstractJUnit4LoggingOut
         testStandardErr.isEmpty() == !standardErrIncluded
 
         and: "all output appeared in the console when running tests"
-        result.assertOutputContains("before class output")
-        result.assertOutputContains("test method output")
+        outputContains("before class output")
+        outputContains("test method output")
         result.assertHasErrorOutput("before class error")
         result.assertHasErrorOutput("test method error")
 

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/jupiter/JUnitJupiterLoggingOutputCaptureIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/jupiter/JUnitJupiterLoggingOutputCaptureIntegrationTest.groovy
@@ -157,4 +157,66 @@ class JUnitJupiterLoggingOutputCaptureIntegrationTest extends AbstractJUnitLoggi
             "after class err\n"
         ))
     }
+
+    def "can configure logging output inclusion in xml reports"() {
+        given:
+        buildFile.text = buildFile.text.replace("reports.junitXml.outputPerTestCase = true", """reports.junitXml {
+            outputPerTestCase = true
+            $includeSystemOutConf
+            $includeSystemErrConf
+        }""".stripIndent())
+
+        file("src/test/java/OkTest.java") << """
+            ${testFrameworkImports}
+
+            public class OkTest {
+                @BeforeAll
+                public static void init() {
+                    System.out.println("before class output");
+                    System.err.println("before class error");
+                }
+
+                @Test
+                public void isOk() {
+                    System.out.println("test method output");
+                    System.err.println("test method error");
+                }
+            }
+        """
+
+        expect:
+        executer.withTestConsoleAttached()
+        succeeds("test")
+
+        and: "all output is included/excluded in the xml report as configured"
+        def junitResult = new JUnitXmlTestExecutionResult(testDirectory)
+        if (standardOutIncluded) {
+            assert junitResult.getSuiteStandardOutput("OkTest").isPresent()
+            assert junitResult.getTestCaseStandardOutput("OkTest", "isOk()").isPresent()
+        } else {
+            assert !junitResult.getSuiteStandardOutput("OkTest").isPresent() // isEmpty not available in Java 8
+            assert !junitResult.getTestCaseStandardOutput("OkTest", "isOk()").isPresent()
+        }
+        if (standardErrIncluded) {
+            assert junitResult.getSuiteStandardError("OkTest").isPresent()
+            assert junitResult.getTestCaseStandardError("OkTest", "isOk()").isPresent()
+        } else {
+            assert !junitResult.getSuiteStandardError("OkTest").isPresent()
+            assert !junitResult.getTestCaseStandardError("OkTest", "isOk()").isPresent()
+        }
+
+        and: "all output appeared in the console when running tests"
+        outputContains("before class output")
+        outputContains("test method output")
+        result.assertHasErrorOutput("before class error")
+        result.assertHasErrorOutput("test method error")
+
+        where:
+        includeSystemOutConf                | includeSystemErrConf              || standardOutIncluded || standardErrIncluded
+        "// default includeSystemOutLog"    | "// default includeSystemErrLog"  || true                || true
+        "includeSystemOutLog = true"        | "includeSystemErrLog = true"      || true                || true
+        "includeSystemOutLog = false"       | "includeSystemErrLog = true"      || false               || true
+        "includeSystemOutLog = true"        | "includeSystemErrLog = false"     || true                || false
+        "includeSystemOutLog = false"       | "includeSystemErrLog = false"     || false               || false
+    }
 }

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/vintage/JUnitVintageLoggingOutputCaptureIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/vintage/JUnitVintageLoggingOutputCaptureIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.testing.junit.vintage
 
+import org.gradle.integtests.fixtures.JUnitXmlTestExecutionResult
 import org.gradle.integtests.fixtures.TargetCoverage
 import org.gradle.testing.junit.junit4.AbstractJUnit4LoggingOutputCaptureIntegrationTest
 
@@ -24,4 +25,65 @@ import static org.gradle.testing.fixture.JUnitCoverage.JUNIT_VINTAGE
 // https://github.com/junit-team/junit5/issues/1285
 @TargetCoverage({ JUNIT_VINTAGE })
 class JUnitVintageLoggingOutputCaptureIntegrationTest extends AbstractJUnit4LoggingOutputCaptureIntegrationTest implements JUnitVintageMultiVersionTest {
+    def "can configure logging output inclusion in xml reports"() {
+        given:
+        buildFile.text = buildFile.text.replace("reports.junitXml.outputPerTestCase = true", """reports.junitXml {
+            outputPerTestCase = true
+            $includeSystemOutConf
+            $includeSystemErrConf
+        }""".stripIndent())
+
+        file("src/test/java/OkTest.java") << """
+            ${testFrameworkImports}
+
+            public class OkTest {
+                @BeforeClass
+                public static void init() {
+                    System.out.println("before class output");
+                    System.err.println("before class error");
+                }
+
+                @Test
+                public void isOk() {
+                    System.out.println("test method output");
+                    System.err.println("test method error");
+                }
+            }
+        """
+
+        expect:
+        executer.withTestConsoleAttached()
+        succeeds("test")
+
+        and: "all output is included/excluded in the xml report as configured"
+        def junitResult = new JUnitXmlTestExecutionResult(testDirectory)
+        if (standardOutIncluded) {
+            assert junitResult.getSuiteStandardOutput("OkTest").isPresent()
+            assert junitResult.getTestCaseStandardOutput("OkTest", "isOk").isPresent()
+        } else {
+            assert !junitResult.getSuiteStandardOutput("OkTest").isPresent() // isEmpty not available in Java 8
+            assert !junitResult.getTestCaseStandardOutput("OkTest", "isOk").isPresent()
+        }
+        if (standardErrIncluded) {
+            assert junitResult.getSuiteStandardError("OkTest").isPresent()
+            assert junitResult.getTestCaseStandardError("OkTest", "isOk").isPresent()
+        } else {
+            assert !junitResult.getSuiteStandardError("OkTest").isPresent()
+            assert !junitResult.getTestCaseStandardError("OkTest", "isOk").isPresent()
+        }
+
+        and: "all output appeared in the console when running tests"
+        outputContains("before class output")
+        outputContains("test method output")
+        result.assertHasErrorOutput("before class error")
+        result.assertHasErrorOutput("test method error")
+
+        where:
+        includeSystemOutConf                | includeSystemErrConf              || standardOutIncluded || standardErrIncluded
+        "// default includeSystemOutLog"    | "// default includeSystemErrLog"  || true                || true
+        "includeSystemOutLog = true"        | "includeSystemErrLog = true"      || true                || true
+        "includeSystemOutLog = false"       | "includeSystemErrLog = true"      || false               || true
+        "includeSystemOutLog = true"        | "includeSystemErrLog = false"     || true                || false
+        "includeSystemOutLog = false"       | "includeSystemErrLog = false"     || false               || false
+    }
 }

--- a/platforms/software/reporting/src/main/java/org/gradle/api/reporting/internal/TaskGeneratedSingleDirectoryReport.java
+++ b/platforms/software/reporting/src/main/java/org/gradle/api/reporting/internal/TaskGeneratedSingleDirectoryReport.java
@@ -22,14 +22,16 @@ import org.gradle.api.internal.IConventionAware;
 import org.gradle.api.internal.provider.DefaultProvider;
 import org.gradle.api.reporting.DirectoryReport;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.io.File;
 
 public abstract class TaskGeneratedSingleDirectoryReport extends TaskGeneratedReport implements DirectoryReport {
+    @Nullable
     private final String relativeEntryPath;
 
     @Inject
-    public TaskGeneratedSingleDirectoryReport(String name, Task task, String relativeEntryPath) {
+    public TaskGeneratedSingleDirectoryReport(String name, Task task, @Nullable String relativeEntryPath) {
         super(name, OutputType.DIRECTORY, task);
         this.relativeEntryPath = relativeEntryPath;
         getOutputLocation().convention(getProjectLayout().dir(new DefaultProvider<>(() -> {

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DefaultJUnitXmlReport.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DefaultJUnitXmlReport.java
@@ -23,17 +23,13 @@ import org.gradle.api.reporting.internal.TaskGeneratedSingleDirectoryReport;
 import org.gradle.api.tasks.testing.JUnitXmlReport;
 
 public abstract class DefaultJUnitXmlReport extends TaskGeneratedSingleDirectoryReport implements JUnitXmlReport {
-
     private boolean outputPerTestCase;
-    private final Property<Boolean> mergeReruns;
-    private final Property<Boolean> includeSystemOutLog;
-    private final Property<Boolean> includeSystemErrLog;
 
     public DefaultJUnitXmlReport(String name, Task task, ObjectFactory objectFactory) {
         super(name, task, null);
-        this.mergeReruns = objectFactory.property(Boolean.class).convention(false);
-        this.includeSystemOutLog = objectFactory.property(Boolean.class).convention(true);
-        this.includeSystemErrLog = objectFactory.property(Boolean.class).convention(true);
+        this.getMergeReruns().convention(false);
+        this.getIncludeSystemOutLog().convention(true);
+        this.getIncludeSystemErrLog().convention(true);
     }
 
     @Override
@@ -47,17 +43,11 @@ public abstract class DefaultJUnitXmlReport extends TaskGeneratedSingleDirectory
     }
 
     @Override
-    public Property<Boolean> getMergeReruns() {
-        return mergeReruns;
-    }
+    public abstract Property<Boolean> getMergeReruns();
 
     @Override
-    public Property<Boolean> getIncludeSystemOutLog() {
-        return includeSystemOutLog;
-    }
+    public abstract Property<Boolean> getIncludeSystemOutLog();
 
     @Override
-    public Property<Boolean> getIncludeSystemErrLog() {
-        return includeSystemErrLog;
-    }
+    public abstract Property<Boolean> getIncludeSystemErrLog();
 }

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DefaultJUnitXmlReport.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DefaultJUnitXmlReport.java
@@ -26,12 +26,14 @@ public abstract class DefaultJUnitXmlReport extends TaskGeneratedSingleDirectory
 
     private boolean outputPerTestCase;
     private final Property<Boolean> mergeReruns;
-    private boolean omitSystemOutLog;
-    private boolean omitSystemErrLog;
+    private final Property<Boolean> includeSystemOutLog;
+    private final Property<Boolean> includeSystemErrLog;
 
     public DefaultJUnitXmlReport(String name, Task task, ObjectFactory objectFactory) {
         super(name, task, null);
         this.mergeReruns = objectFactory.property(Boolean.class).convention(false);
+        this.includeSystemOutLog = objectFactory.property(Boolean.class).convention(true);
+        this.includeSystemErrLog = objectFactory.property(Boolean.class).convention(true);
     }
 
     @Override
@@ -50,22 +52,12 @@ public abstract class DefaultJUnitXmlReport extends TaskGeneratedSingleDirectory
     }
 
     @Override
-    public void setOmitSystemOutLog(boolean omitSystemOutLog) {
-        this.omitSystemOutLog = omitSystemOutLog;
+    public Property<Boolean> getIncludeSystemOutLog() {
+        return includeSystemOutLog;
     }
 
     @Override
-    public boolean isOmitSystemOutLog() {
-        return this.omitSystemOutLog;
-    }
-
-    @Override
-    public void setOmitSystemErrLog(boolean omitSystemErrLog) {
-        this.omitSystemErrLog = omitSystemErrLog;
-    }
-
-    @Override
-    public boolean isOmitSystemErrLog() {
-        return this.omitSystemErrLog;
+    public Property<Boolean> getIncludeSystemErrLog() {
+        return includeSystemErrLog;
     }
 }

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DefaultJUnitXmlReport.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DefaultJUnitXmlReport.java
@@ -26,6 +26,8 @@ public abstract class DefaultJUnitXmlReport extends TaskGeneratedSingleDirectory
 
     private boolean outputPerTestCase;
     private final Property<Boolean> mergeReruns;
+    private boolean omitSystemOutLog;
+    private boolean omitSystemErrLog;
 
     public DefaultJUnitXmlReport(String name, Task task, ObjectFactory objectFactory) {
         super(name, task, null);
@@ -45,5 +47,25 @@ public abstract class DefaultJUnitXmlReport extends TaskGeneratedSingleDirectory
     @Override
     public Property<Boolean> getMergeReruns() {
         return mergeReruns;
+    }
+
+    @Override
+    public void setOmitSystemOutLog(boolean omitSystemOutLog) {
+        this.omitSystemOutLog = omitSystemOutLog;
+    }
+
+    @Override
+    public boolean isOmitSystemOutLog() {
+        return this.omitSystemOutLog;
+    }
+
+    @Override
+    public void setOmitSystemErrLog(boolean omitSystemErrLog) {
+        this.omitSystemErrLog = omitSystemErrLog;
+    }
+
+    @Override
+    public boolean isOmitSystemErrLog() {
+        return this.omitSystemErrLog;
     }
 }

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultOptions.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultOptions.java
@@ -20,13 +20,13 @@ public class JUnitXmlResultOptions {
 
     public final boolean outputPerTestCase;
     public final boolean mergeReruns;
-    public final boolean omitSystemOutLog;
-    public final boolean omitSystemErrLog;
+    public final boolean includeSystemOutLog;
+    public final boolean includeSystemErrLog;
 
-    public JUnitXmlResultOptions(boolean outputPerTestCase, boolean mergeReruns, boolean omitSystemOutLog, boolean omitSystemErrLog) {
+    public JUnitXmlResultOptions(boolean outputPerTestCase, boolean mergeReruns, boolean includeSystemOutLog, boolean includeSystemErrLog) {
         this.outputPerTestCase = outputPerTestCase;
         this.mergeReruns = mergeReruns;
-        this.omitSystemOutLog = omitSystemOutLog;
-        this.omitSystemErrLog = omitSystemErrLog;
+        this.includeSystemOutLog = includeSystemOutLog;
+        this.includeSystemErrLog = includeSystemErrLog;
     }
 }

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultOptions.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultOptions.java
@@ -20,9 +20,13 @@ public class JUnitXmlResultOptions {
 
     public final boolean outputPerTestCase;
     public final boolean mergeReruns;
+    public final boolean omitSystemOutLog;
+    public final boolean omitSystemErrLog;
 
-    public JUnitXmlResultOptions(boolean outputPerTestCase, boolean mergeReruns) {
+    public JUnitXmlResultOptions(boolean outputPerTestCase, boolean mergeReruns, boolean omitSystemOutLog, boolean omitSystemErrLog) {
         this.outputPerTestCase = outputPerTestCase;
         this.mergeReruns = mergeReruns;
+        this.omitSystemOutLog = omitSystemOutLog;
+        this.omitSystemErrLog = omitSystemErrLog;
     }
 }

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultWriter.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultWriter.java
@@ -75,12 +75,17 @@ public class JUnitXmlResultWriter {
                 writeTestCasesWithDiscreteRerunHandling(writer, methodResults, className, classId);
             }
 
-            writer.startElement("system-out");
-            writeOutputs(writer, classId, !options.outputPerTestCase, TestOutputEvent.Destination.StdOut);
-            writer.endElement();
-            writer.startElement("system-err");
-            writeOutputs(writer, classId, !options.outputPerTestCase, TestOutputEvent.Destination.StdErr);
-            writer.endElement();
+            if (!options.omitSystemOutLog) {
+                writer.startElement("system-out");
+                writeOutputs(writer, classId, !options.outputPerTestCase, TestOutputEvent.Destination.StdOut);
+                writer.endElement();
+            }
+
+            if (!options.omitSystemErrLog) {
+                writer.startElement("system-err");
+                writeOutputs(writer, classId, !options.outputPerTestCase, TestOutputEvent.Destination.StdErr);
+                writer.endElement();
+            }
 
             writer.endElement();
         } catch (IOException e) {

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultWriter.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultWriter.java
@@ -75,13 +75,13 @@ public class JUnitXmlResultWriter {
                 writeTestCasesWithDiscreteRerunHandling(writer, methodResults, className, classId);
             }
 
-            if (!options.omitSystemOutLog) {
+            if (options.includeSystemOutLog) {
                 writer.startElement("system-out");
                 writeOutputs(writer, classId, !options.outputPerTestCase, TestOutputEvent.Destination.StdOut);
                 writer.endElement();
             }
 
-            if (!options.omitSystemErrLog) {
+            if (options.includeSystemErrLog) {
                 writer.startElement("system-err");
                 writeOutputs(writer, classId, !options.outputPerTestCase, TestOutputEvent.Destination.StdErr);
                 writer.endElement();

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultWriter.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultWriter.java
@@ -240,17 +240,18 @@ public class JUnitXmlResultWriter {
     }
 
     abstract static class TestCaseExecution {
-
         private final OutputProvider outputProvider;
+        private final JUnitXmlResultOptions options;
 
-        TestCaseExecution(OutputProvider outputProvider) {
+        TestCaseExecution(OutputProvider outputProvider, JUnitXmlResultOptions options) {
             this.outputProvider = outputProvider;
+            this.options = options;
         }
 
         abstract void write(SimpleXmlWriter writer) throws IOException;
 
         protected void writeOutput(SimpleXmlWriter writer) throws IOException {
-            if (outputProvider.has(TestOutputEvent.Destination.StdOut)) {
+            if (options.includeSystemOutLog && outputProvider.has(TestOutputEvent.Destination.StdOut)) {
                 writer.startElement("system-out");
                 writer.startCDATA();
                 outputProvider.write(TestOutputEvent.Destination.StdOut, writer);
@@ -258,7 +259,7 @@ public class JUnitXmlResultWriter {
                 writer.endElement();
             }
 
-            if (outputProvider.has(TestOutputEvent.Destination.StdErr)) {
+            if (options.includeSystemErrLog && outputProvider.has(TestOutputEvent.Destination.StdErr)) {
                 writer.startElement("system-err");
                 writer.startCDATA();
                 outputProvider.write(TestOutputEvent.Destination.StdErr, writer);
@@ -283,8 +284,8 @@ public class JUnitXmlResultWriter {
     }
 
     private static class TestCaseExecutionSuccess extends TestCaseExecution {
-        TestCaseExecutionSuccess(OutputProvider outputProvider) {
-            super(outputProvider);
+        TestCaseExecutionSuccess(OutputProvider outputProvider, JUnitXmlResultOptions options) {
+            super(outputProvider, options);
         }
 
         @Override
@@ -295,8 +296,8 @@ public class JUnitXmlResultWriter {
 
 
     private static class TestCaseExecutionSkipped extends TestCaseExecution {
-        TestCaseExecutionSkipped(OutputProvider outputProvider) {
-            super(outputProvider);
+        TestCaseExecutionSkipped(OutputProvider outputProvider, JUnitXmlResultOptions options) {
+            super(outputProvider, options);
         }
 
         @Override
@@ -324,8 +325,8 @@ public class JUnitXmlResultWriter {
         private final TestFailure failure;
         private final FailureType type;
 
-        TestCaseExecutionFailure(OutputProvider outputProvider, FailureType type, TestFailure failure) {
-            super(outputProvider);
+        TestCaseExecutionFailure(OutputProvider outputProvider, JUnitXmlResultOptions options, FailureType type, TestFailure failure) {
+            super(outputProvider, options);
             this.failure = failure;
             this.type = type;
         }
@@ -351,17 +352,17 @@ public class JUnitXmlResultWriter {
     }
 
     private TestCaseExecution success(long classId, long id) {
-        return new TestCaseExecutionSuccess(outputProvider(classId, id));
+        return new TestCaseExecutionSuccess(outputProvider(classId, id), options);
     }
 
     private TestCaseExecution skipped(long classId, long id) {
-        return new TestCaseExecutionSkipped(outputProvider(classId, id));
+        return new TestCaseExecutionSkipped(outputProvider(classId, id), options);
     }
 
     private Iterable<TestCaseExecution> failures(final long classId, final TestMethodResult methodResult, final FailureType failureType) {
         List<TestFailure> failures = methodResult.getFailures();
         if (failures.isEmpty()) {
-            // This can happen with a failing engine. For now we just ignore this.
+            // This can happen with a failing engine. For now, we just ignore this.
             return Collections.emptyList();
         }
         final TestFailure firstFailure = failures.get(0);
@@ -370,7 +371,7 @@ public class JUnitXmlResultWriter {
             public TestCaseExecution apply(final TestFailure failure) {
                 boolean isFirst = failure == firstFailure;
                 OutputProvider outputProvider = isFirst ? outputProvider(classId, methodResult.getId()) : NullOutputProvider.INSTANCE;
-                return new TestCaseExecutionFailure(outputProvider, failureType, failure);
+                return new TestCaseExecutionFailure(outputProvider, options, failureType, failure);
             }
         });
     }

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
@@ -602,7 +602,9 @@ public abstract class AbstractTestTask extends ConventionTask implements Verific
             if (junitXml.getRequired().get()) {
                 JUnitXmlResultOptions xmlResultOptions = new JUnitXmlResultOptions(
                     junitXml.isOutputPerTestCase(),
-                    junitXml.getMergeReruns().get()
+                    junitXml.getMergeReruns().get(),
+                    junitXml.isOmitSystemOutLog(),
+                    junitXml.isOmitSystemErrLog()
                 );
                 Binary2JUnitXmlReportGenerator binary2JUnitXmlReportGenerator = new Binary2JUnitXmlReportGenerator(
                     junitXml.getOutputLocation().getAsFile().get(),

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
@@ -603,8 +603,8 @@ public abstract class AbstractTestTask extends ConventionTask implements Verific
                 JUnitXmlResultOptions xmlResultOptions = new JUnitXmlResultOptions(
                     junitXml.isOutputPerTestCase(),
                     junitXml.getMergeReruns().get(),
-                    junitXml.isOmitSystemOutLog(),
-                    junitXml.isOmitSystemErrLog()
+                    junitXml.getIncludeSystemOutLog().get(),
+                    junitXml.getIncludeSystemErrLog().get()
                 );
                 Binary2JUnitXmlReportGenerator binary2JUnitXmlReportGenerator = new Binary2JUnitXmlReportGenerator(
                     junitXml.getOutputLocation().getAsFile().get(),

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/JUnitXmlReport.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/JUnitXmlReport.java
@@ -57,4 +57,25 @@ public interface JUnitXmlReport extends DirectoryReport {
     @Input
     Property<Boolean> getMergeReruns();
 
+    /**
+      * Should omit system out log
+     */
+    void setOmitSystemOutLog(boolean omitSystemOutLog);
+
+    /**
+     * Should omit system out log
+     */
+    @Input
+    boolean isOmitSystemOutLog();
+
+    /**
+     * Should omit system err log
+     */
+    void setOmitSystemErrLog(boolean omitSystemErrLog);
+
+    /**
+     * Should omit system err log
+     */
+    @Input
+    boolean isOmitSystemErrLog();
 }

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/JUnitXmlReport.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/JUnitXmlReport.java
@@ -61,7 +61,7 @@ public interface JUnitXmlReport extends DirectoryReport {
     /**
      * Decide to include or omit the system out log in the XML report. The default behavior is to have it.
      *
-     * @since 8.1
+     * @since 8.8
      */
     @Input
     @Incubating
@@ -70,7 +70,7 @@ public interface JUnitXmlReport extends DirectoryReport {
     /**
      * Decide to include or omit the system err log in the XML report. The default behavior is to have it.
      *
-     * @since 8.1
+     * @since 8.8
      */
     @Input
     @Incubating

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/JUnitXmlReport.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/JUnitXmlReport.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.tasks.testing;
 
+import org.gradle.api.Incubating;
 import org.gradle.api.provider.Property;
 import org.gradle.api.reporting.DirectoryReport;
 import org.gradle.api.tasks.Input;
@@ -58,24 +59,20 @@ public interface JUnitXmlReport extends DirectoryReport {
     Property<Boolean> getMergeReruns();
 
     /**
-      * Should omit system out log
-     */
-    void setOmitSystemOutLog(boolean omitSystemOutLog);
-
-    /**
-     * Should omit system out log
+     * Decide to include or omit the system out log in the XML report. The default behavior is to have it.
+     *
+     * @since 8.1
      */
     @Input
-    boolean isOmitSystemOutLog();
+    @Incubating
+    Property<Boolean> getIncludeSystemOutLog();
 
     /**
-     * Should omit system err log
-     */
-    void setOmitSystemErrLog(boolean omitSystemErrLog);
-
-    /**
-     * Should omit system err log
+     * Decide to include or omit the system err log in the XML report. The default behavior is to have it.
+     *
+     * @since 8.1
      */
     @Input
-    boolean isOmitSystemErrLog();
+    @Incubating
+    Property<Boolean> getIncludeSystemErrLog();
 }

--- a/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/Binary2JUnitXmlReportGeneratorSpec.groovy
+++ b/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/Binary2JUnitXmlReportGeneratorSpec.groovy
@@ -17,13 +17,13 @@
 package org.gradle.api.internal.tasks.testing.junit.result
 
 import org.gradle.api.Action
-import org.gradle.internal.concurrent.DefaultExecutorFactory
-import org.gradle.internal.concurrent.DefaultParallelismConfiguration
 import org.gradle.internal.operations.BuildOperationExecutor
-import org.gradle.internal.operations.BuildOperationExecutorSupport
-import org.gradle.internal.operations.BuildOperationRunner
+import org.gradle.internal.operations.DefaultBuildOperationExecutor
+import org.gradle.internal.operations.DefaultBuildOperationIdFactory
+import org.gradle.internal.operations.DefaultBuildOperationQueueFactory
 import org.gradle.internal.operations.MultipleBuildOperationFailures
-import org.gradle.internal.operations.TestBuildOperationRunner
+import org.gradle.internal.progress.NoOpProgressLoggerFactory
+import org.gradle.internal.work.WorkerLeaseService
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
 import spock.lang.Specification
@@ -44,7 +44,7 @@ class Binary2JUnitXmlReportGeneratorSpec extends Specification {
         Binary2JUnitXmlReportGenerator reportGenerator = new Binary2JUnitXmlReportGenerator(
             temp.testDirectory,
             resultsProvider,
-            new JUnitXmlResultOptions(false, false),
+            new JUnitXmlResultOptions(false, false, true, true),
             buildOperationRunner,
             buildOperationExecutor,
             "localhost")

--- a/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/Binary2JUnitXmlReportGeneratorSpec.groovy
+++ b/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/Binary2JUnitXmlReportGeneratorSpec.groovy
@@ -17,6 +17,8 @@
 package org.gradle.api.internal.tasks.testing.junit.result
 
 import org.gradle.api.Action
+import org.gradle.internal.concurrent.DefaultExecutorFactory
+import org.gradle.internal.concurrent.DefaultParallelismConfiguration
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.operations.BuildOperationExecutorSupport
 import org.gradle.internal.operations.BuildOperationRunner

--- a/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/Binary2JUnitXmlReportGeneratorSpec.groovy
+++ b/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/Binary2JUnitXmlReportGeneratorSpec.groovy
@@ -18,12 +18,10 @@ package org.gradle.api.internal.tasks.testing.junit.result
 
 import org.gradle.api.Action
 import org.gradle.internal.operations.BuildOperationExecutor
-import org.gradle.internal.operations.DefaultBuildOperationExecutor
-import org.gradle.internal.operations.DefaultBuildOperationIdFactory
-import org.gradle.internal.operations.DefaultBuildOperationQueueFactory
+import org.gradle.internal.operations.BuildOperationExecutorSupport
+import org.gradle.internal.operations.BuildOperationRunner
 import org.gradle.internal.operations.MultipleBuildOperationFailures
-import org.gradle.internal.progress.NoOpProgressLoggerFactory
-import org.gradle.internal.work.WorkerLeaseService
+import org.gradle.internal.operations.TestBuildOperationRunner
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
 import spock.lang.Specification

--- a/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultWriterMergeRerunSpec.groovy
+++ b/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultWriterMergeRerunSpec.groovy
@@ -26,7 +26,7 @@ class JUnitXmlResultWriterMergeRerunSpec extends Specification {
     def outputPerTestCase = true
 
     protected JUnitXmlResultWriter getGenerator() {
-        new JUnitXmlResultWriter("localhost", provider, new JUnitXmlResultOptions(outputPerTestCase, true))
+        new JUnitXmlResultWriter("localhost", provider, new JUnitXmlResultOptions(outputPerTestCase, true, false, false))
     }
 
     def "merges for simple case - output per testcase"() {

--- a/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultWriterMergeRerunSpec.groovy
+++ b/platforms/software/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/result/JUnitXmlResultWriterMergeRerunSpec.groovy
@@ -26,7 +26,7 @@ class JUnitXmlResultWriterMergeRerunSpec extends Specification {
     def outputPerTestCase = true
 
     protected JUnitXmlResultWriter getGenerator() {
-        new JUnitXmlResultWriter("localhost", provider, new JUnitXmlResultOptions(outputPerTestCase, true, false, false))
+        new JUnitXmlResultWriter("localhost", provider, new JUnitXmlResultOptions(outputPerTestCase, true, true, true))
     }
 
     def "merges for simple case - output per testcase"() {


### PR DESCRIPTION
### Overview
The feature was requested by the community: https://github.com/gradle/gradle/issues/23229

### Current Behavior
In the XML report generated by the Gradle (junit) all data can be discovered: 
- results
- systemOut
- systemErr

### Expected behavior
In some cases, you're only interested to see the test results, not SystemOut and SystemErr (your tooling analyzes only if the test failed). 

The improvement may be useful, especially when you have many tests which are run in debug mode and may produce a lot of logs (eg. spring boot in debug, testcontainers). Omitting them lowers the memory required to parse the file and consumes less HDD space.
