### PR TITLE
Enable load-after-store for composite build tests

### DIFF
--- a/subprojects/composite-builds/build.gradle.kts
+++ b/subprojects/composite-builds/build.gradle.kts
@@ -33,8 +33,3 @@ dependencies {
 }
 
 testFilesCleanup.reportOnly.set(true)
-
-// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
-tasks.configCacheIntegTest {
-    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
-}

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/AbstractCompositeBuildValidationIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/AbstractCompositeBuildValidationIntegrationTest.groovy
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.composite
+
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.gradle.test.fixtures.file.TestFile
+
+abstract class AbstractCompositeBuildValidationIntegrationTest extends AbstractCompositeBuildIntegrationTest {
+    def validationTask(TestFile buildFile, String name, String content) {
+        if (GradleContextualExecuter.configCache) {
+            buildFile << """
+                tasks.register("$name") {
+                    $content
+                    doLast { }
+                }
+            """
+        } else {
+            buildFile << """
+                tasks.register("$name") {
+                    doLast {
+                        $content
+                    }
+                }
+            """
+        }
+    }
+}

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcBuildOperationsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcBuildOperationsIntegrationTest.groovy
@@ -22,9 +22,11 @@ import org.gradle.initialization.ConfigureBuildBuildOperationType
 import org.gradle.initialization.LoadBuildBuildOperationType
 import org.gradle.initialization.buildsrc.BuildBuildSrcBuildOperationType
 import org.gradle.integtests.fixtures.build.BuildTestFile
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType
 import org.gradle.internal.taskgraph.CalculateTreeTaskGraphBuildOperationType
 import org.gradle.launcher.exec.RunBuildBuildOperationType
+import spock.lang.IgnoreIf
 
 import java.util.regex.Pattern
 
@@ -43,6 +45,8 @@ class CompositeBuildBuildSrcBuildOperationsIntegrationTest extends AbstractCompo
         includedBuilds << buildB
     }
 
+    // Also covered by tests in configuration cache project
+    @IgnoreIf({ GradleContextualExecuter.configCache })
     def "generates configure, task graph and run tasks operations for buildSrc of included builds with #display"() {
         given:
         dependency 'org.test:buildB:1.0'
@@ -145,6 +149,8 @@ class CompositeBuildBuildSrcBuildOperationsIntegrationTest extends AbstractCompo
         "rootProject.name='someLib'" | "configured root project name"
     }
 
+    // Also covered by tests in configuration cache project
+    @IgnoreIf({ GradleContextualExecuter.configCache })
     def "generates configure, task graph and run tasks operations when all builds have buildSrc with #display"() {
         given:
         dependency 'org.test:buildB:1.0'

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildConfigurationAttributesResolveIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildConfigurationAttributesResolveIntegrationTest.groovy
@@ -17,10 +17,15 @@
 package org.gradle.integtests.composite
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 
 class CompositeBuildConfigurationAttributesResolveIntegrationTest extends AbstractIntegrationSpec {
+    def resolve = new ResolveTestFixture(buildFile)
 
-    def setup(){
+    def setup() {
+        settingsFile << """
+            rootProject.name = 'test'
+        """
         using m2
     }
 
@@ -50,17 +55,6 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
                     _compileFreeDebug project(':b')
                     _compileFreeRelease project(':b')
                 }
-                task checkDebug(dependsOn: configurations._compileFreeDebug) {
-                    doLast {
-                       assert configurations._compileFreeDebug.collect { it.name } == ['b-transitive.jar', 'c-foo.jar']
-                    }
-                }
-                task checkRelease(dependsOn: configurations._compileFreeRelease) {
-                    doLast {
-                       assert configurations._compileFreeRelease.collect { it.name } == ['b-transitive.jar', 'c-bar.jar']
-                    }
-                }
-
             }
             project(':b') {
                 configurations.create('default')
@@ -72,6 +66,10 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
                 }
             }
         '''
+        resolve.prepare {
+            config('_compileFreeDebug', 'checkDebug')
+            config('_compileFreeRelease', 'checkRelease')
+        }
 
         file('includedBuild/build.gradle') << """
 
@@ -104,6 +102,16 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
         then:
         executedAndNotSkipped ':includedBuild:fooJar'
         notExecuted ':includedBuild:barJar'
+        resolve.expectGraph {
+            root(':a', 'test:a:') {
+                project(':b', 'test:b:') {
+                    artifact(name: 'b-transitive')
+                    edge('com.acme.external:external:1.0', ':includedBuild', 'com.acme.external:external:2.0-SNAPSHOT') {
+                        artifact(name: 'c-foo', fileName: 'c-foo.jar')
+                    }
+                }
+            }
+        }
 
         when:
         run ':a:checkRelease'
@@ -111,6 +119,16 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
         then:
         executedAndNotSkipped ':includedBuild:barJar'
         notExecuted ':includedBuild:fooJar'
+        resolve.expectGraph {
+            root(':a', 'test:a:') {
+                project(':b', 'test:b:') {
+                    artifact(name: 'b-transitive')
+                    edge('com.acme.external:external:1.0', ':includedBuild', 'com.acme.external:external:2.0-SNAPSHOT') {
+                        artifact(name: 'c-bar', fileName: 'c-bar.jar')
+                    }
+                }
+            }
+        }
     }
 
     def "context travels to transitive dependencies via external components (Maven)"() {
@@ -145,16 +163,6 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
                     _compileFreeDebug project(':b')
                     _compileFreeRelease project(':b')
                 }
-                task checkDebug(dependsOn: configurations._compileFreeDebug) {
-                    doLast {
-                       assert configurations._compileFreeDebug.collect { it.name } == ['b-transitive.jar', 'external-1.2.jar', 'c-foo.jar']
-                    }
-                }
-                task checkRelease(dependsOn: configurations._compileFreeRelease) {
-                    doLast {
-                       assert configurations._compileFreeRelease.collect { it.name } == ['b-transitive.jar', 'external-1.2.jar', 'c-bar.jar']
-                    }
-                }
             }
             project(':b') {
                 configurations.create('default')
@@ -166,6 +174,10 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
                 }
             }
         """
+        resolve.prepare {
+            config('_compileFreeDebug', 'checkDebug')
+            config('_compileFreeRelease', 'checkRelease')
+        }
 
         file('includedBuild/build.gradle') << """
 
@@ -198,6 +210,18 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
         then:
         executedAndNotSkipped ':includedBuild:fooJar'
         notExecuted ':includedBuild:barJar'
+        resolve.expectGraph {
+            root(':a', 'test:a:') {
+                project(':b', 'test:b:') {
+                    artifact(name: 'b-transitive')
+                    module('com.acme.external:external:1.2') {
+                        edge('com.acme.external:c:0.1', ':includedBuild', 'com.acme.external:c:2.0-SNAPSHOT') {
+                            artifact(name: 'c-foo', fileName: 'c-foo.jar')
+                        }
+                    }
+                }
+            }
+        }
 
         when:
         run ':a:checkRelease'
@@ -205,6 +229,18 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
         then:
         executedAndNotSkipped ':includedBuild:barJar'
         notExecuted ':includedBuild:fooJar'
+        resolve.expectGraph {
+            root(':a', 'test:a:') {
+                project(':b', 'test:b:') {
+                    artifact(name: 'b-transitive')
+                    module('com.acme.external:external:1.2') {
+                        edge('com.acme.external:c:0.1', ':includedBuild', 'com.acme.external:c:2.0-SNAPSHOT') {
+                            artifact(name: 'c-bar', fileName: 'c-bar.jar')
+                        }
+                    }
+                }
+            }
+        }
     }
 
     def "context travels to transitive dependencies via external components (Ivy)"() {
@@ -239,16 +275,6 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
                     _compileFreeDebug project(':b')
                     _compileFreeRelease project(':b')
                 }
-                task checkDebug(dependsOn: configurations._compileFreeDebug) {
-                    doLast {
-                       assert configurations._compileFreeDebug.collect { it.name } == ['b-transitive.jar', 'external-1.2.jar', 'c-foo.jar']
-                    }
-                }
-                task checkRelease(dependsOn: configurations._compileFreeRelease) {
-                    doLast {
-                       assert configurations._compileFreeRelease.collect { it.name } == ['b-transitive.jar', 'external-1.2.jar', 'c-bar.jar']
-                    }
-                }
             }
             project(':b') {
                 configurations.create('default')
@@ -260,6 +286,10 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
                 }
             }
         """
+        resolve.prepare {
+            config('_compileFreeDebug', 'checkDebug')
+            config('_compileFreeRelease', 'checkRelease')
+        }
 
         file('includedBuild/build.gradle') << """
 
@@ -288,6 +318,18 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
 
         when:
         run ':a:checkDebug'
+        resolve.expectGraph {
+            root(':a', 'test:a:') {
+                project(':b', 'test:b:') {
+                    artifact(name: 'b-transitive')
+                    module('com.acme.external:external:1.2') {
+                        edge('com.acme.external:c:0.1', ':includedBuild', 'com.acme.external:c:2.0-SNAPSHOT') {
+                            artifact(name: 'c-foo', fileName: 'c-foo.jar')
+                        }
+                    }
+                }
+            }
+        }
 
         then:
         executedAndNotSkipped ':includedBuild:fooJar'
@@ -299,6 +341,18 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
         then:
         executedAndNotSkipped ':includedBuild:barJar'
         notExecuted ':includedBuild:fooJar'
+        resolve.expectGraph {
+            root(':a', 'test:a:') {
+                project(':b', 'test:b:') {
+                    artifact(name: 'b-transitive')
+                    module('com.acme.external:external:1.2') {
+                        edge('com.acme.external:c:0.1', ':includedBuild', 'com.acme.external:c:2.0-SNAPSHOT') {
+                            artifact(name: 'c-bar', fileName: 'c-bar.jar')
+                        }
+                    }
+                }
+            }
+        }
     }
 
     def "attribute values are matched across builds - #type"() {
@@ -330,16 +384,6 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
                     _compileFree project(':b')
                     _compilePaid project(':b')
                 }
-                task checkFree(dependsOn: configurations._compileFree) {
-                    doLast {
-                       assert configurations._compileFree.collect { it.name } == ['b-transitive.jar', 'c-foo.jar']
-                    }
-                }
-                task checkPaid(dependsOn: configurations._compilePaid) {
-                    doLast {
-                       assert configurations._compilePaid.collect { it.name } == ['b-transitive.jar', 'c-bar.jar']
-                    }
-                }
             }
             project(':b') {
                 configurations.create('default')
@@ -351,6 +395,10 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
                 }
             }
         """
+        resolve.prepare {
+            config('_compileFree', 'checkFree')
+            config('_compilePaid', 'checkPaid')
+        }
 
         file('includedBuild/build.gradle') << """
             enum SomeEnum { free, paid }
@@ -385,6 +433,16 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
         then:
         executedAndNotSkipped ':includedBuild:fooJar'
         notExecuted ':includedBuild:barJar'
+        resolve.expectGraph {
+            root(':a', 'test:a:') {
+                project(':b', 'test:b:') {
+                    artifact(name: 'b-transitive')
+                    edge('com.acme.external:external:1.0', ':includedBuild', 'com.acme.external:external:2.0-SNAPSHOT') {
+                        artifact(name: 'c-foo', fileName: 'c-foo.jar')
+                    }
+                }
+            }
+        }
 
         when:
         run ':a:checkPaid'
@@ -392,6 +450,16 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
         then:
         executedAndNotSkipped ':includedBuild:barJar'
         notExecuted ':includedBuild:fooJar'
+        resolve.expectGraph {
+            root(':a', 'test:a:') {
+                project(':b', 'test:b:') {
+                    artifact(name: 'b-transitive')
+                    edge('com.acme.external:external:1.0', ':includedBuild', 'com.acme.external:external:2.0-SNAPSHOT') {
+                        artifact(name: 'c-bar', fileName: 'c-bar.jar')
+                    }
+                }
+            }
+        }
 
         where:
         type         | freeValue                      | paidValue
@@ -448,16 +516,6 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
                     _compileFree project(':b')
                     _compilePaid project(':b')
                 }
-                task checkFree(dependsOn: configurations._compileFree) {
-                    doLast {
-                       assert configurations._compileFree.collect { it.name } == ['b-transitive.jar', 'c-foo.jar']
-                    }
-                }
-                task checkPaid(dependsOn: configurations._compilePaid) {
-                    doLast {
-                       assert configurations._compilePaid.collect { it.name } == ['b-transitive.jar', 'c-bar.jar']
-                    }
-                }
             }
             project(':b') {
                 configurations.create('default')
@@ -469,6 +527,10 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
                 }
             }
         """
+        resolve.prepare {
+            config('_compileFree', 'checkFree')
+            config('_compilePaid', 'checkPaid')
+        }
 
         file('includedBuild/build.gradle') << """
             interface Thing extends Named { }
@@ -500,6 +562,16 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
         then:
         executedAndNotSkipped ':includedBuild:fooJar'
         notExecuted ':includedBuild:barJar'
+        resolve.expectGraph {
+            root(':a', 'test:a:') {
+                project(':b', 'test:b:') {
+                    artifact(name: 'b-transitive')
+                    edge('com.acme.external:external:1.0', ':includedBuild', 'com.acme.external:external:2.0-SNAPSHOT') {
+                        artifact(name: 'c-foo', fileName: 'c-foo.jar')
+                    }
+                }
+            }
+        }
 
         when:
         run ':a:checkPaid'
@@ -507,6 +579,16 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
         then:
         executedAndNotSkipped ':includedBuild:barJar'
         notExecuted ':includedBuild:fooJar'
+        resolve.expectGraph {
+            root(':a', 'test:a:') {
+                project(':b', 'test:b:') {
+                    artifact(name: 'b-transitive')
+                    edge('com.acme.external:external:1.0', ':includedBuild', 'com.acme.external:external:2.0-SNAPSHOT') {
+                        artifact(name: 'c-bar', fileName: 'c-bar.jar')
+                    }
+                }
+            }
+        }
     }
 
     def "reports failure to resolve due to incompatible attribute values"() {
@@ -614,11 +696,13 @@ All of them match the consumer attributes:
     }
 
     def "context travels down to transitive dependencies with typed attributes using plugin"() {
+        def resolve = new ResolveTestFixture(buildFile)
+
         buildTypedAttributesPlugin('1.0')
         buildTypedAttributesPlugin('1.1')
 
         given:
-        file('settings.gradle') << """
+        settingsFile.text = """
             pluginManagement {
                 repositories {
                     maven { url "${mavenRepo.uri}" }
@@ -626,6 +710,7 @@ All of them match the consumer attributes:
             }
             include 'a', 'b'
             includeBuild 'includedBuild'
+            rootProject.name = 'test'
         """
         buildFile << """
             ${usesTypedAttributesPlugin(v1, usePluginsDSL)}
@@ -647,12 +732,12 @@ All of them match the consumer attributes:
                     _compileFreeDebug project(':b')
                     _compileFreeRelease project(':b')
                 }
-                task checkDebug(dependsOn: configurations._compileFreeDebug) {
+                task xcheckDebug(dependsOn: configurations._compileFreeDebug) {
                     doLast {
                        assert configurations._compileFreeDebug.collect { it.name } == ['b-transitive.jar', 'c-foo.jar']
                     }
                 }
-                task checkRelease(dependsOn: configurations._compileFreeRelease) {
+                task xcheckRelease(dependsOn: configurations._compileFreeRelease) {
                     doLast {
                        assert configurations._compileFreeRelease.collect { it.name } == ['b-transitive.jar', 'c-bar.jar']
                     }
@@ -671,6 +756,10 @@ All of them match the consumer attributes:
                 }
             }
         """
+        resolve.prepare {
+            config("_compileFreeDebug", "checkDebug")
+            config("_compileFreeRelease", "checkRelease")
+        }
 
         file('includedBuild/build.gradle') << """
             ${usesTypedAttributesPlugin(v2, usePluginsDSL)}
@@ -708,6 +797,16 @@ All of them match the consumer attributes:
         then:
         executedAndNotSkipped ':includedBuild:fooJar'
         notExecuted ':includedBuild:barJar'
+        resolve.expectGraph {
+            root(':a', 'test:a:') {
+                project(':b', 'test:b:') {
+                    artifact(name: 'b-transitive')
+                    edge('com.acme.external:external:1.0', ':includedBuild', 'com.acme.external:external:2.0-SNAPSHOT') {
+                        artifact(name: 'c-foo', fileName: 'c-foo.jar')
+                    }
+                }
+            }
+        }
 
         when:
         run ':a:checkRelease'
@@ -715,6 +814,16 @@ All of them match the consumer attributes:
         then:
         executedAndNotSkipped ':includedBuild:barJar'
         notExecuted ':includedBuild:fooJar'
+        resolve.expectGraph {
+            root(':a', 'test:a:') {
+                project(':b', 'test:b:') {
+                    artifact(name: 'b-transitive')
+                    edge('com.acme.external:external:1.0', ':includedBuild', 'com.acme.external:external:2.0-SNAPSHOT') {
+                        artifact(name: 'c-bar', fileName: 'c-bar.jar')
+                    }
+                }
+            }
+        }
 
         where:
         v1    | v2    | usePluginsDSL

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildContinueOnSingleFailureIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildContinueOnSingleFailureIntegrationTest.groovy
@@ -38,11 +38,11 @@ class CompositeBuildContinueOnSingleFailureIntegrationTest extends AbstractCompo
                     }
                 }
                 task succeeds {
-                    shouldRunAfter fails
                 }
                 task checkContinueFlag {
+                    def continueFlag = gradle.startParameter.continueOnFailure
                     doLast {
-                        println "continueOnFailure = " + gradle.startParameter.continueOnFailure
+                        println "continueOnFailure = " + continueFlag
                     }
                 }
 """
@@ -63,7 +63,10 @@ class CompositeBuildContinueOnSingleFailureIntegrationTest extends AbstractCompo
         dependsOn gradle.includedBuild('buildB').task(':succeeds')
     }
 """
-
+        buildB.buildFile << """
+    // force sequential execution
+    tasks.succeeds.mustRunAfter tasks.fails
+"""
         fails(buildA, ":delegate")
 
         then:

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildIdentityIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildIdentityIntegrationTest.groovy
@@ -137,29 +137,41 @@ Required by:
 
         buildA.buildFile << """
             def runtimeClasspath = configurations.runtimeClasspath
+            def rootProvider = runtimeClasspath.incoming.resolutionResult.rootComponent
             classes.doLast {
-                def components = runtimeClasspath.incoming.resolutionResult.allComponents.id
-                assert components.size() == 3
-                assert components[0].build.name == ':'
-                assert components[0].build.currentBuild
-                assert components[0].projectPath == ':'
-                assert components[0].projectName == 'buildA'
-                assert components[1].build.name == '${buildName}'
-                assert !components[1].build.currentBuild
-                assert components[1].projectPath == ':'
-                assert components[1].projectName == '${buildName}'
-                assert components[2].build.name == '${buildName}'
-                assert !components[2].build.currentBuild
-                assert components[2].projectPath == ':b1'
-                assert components[2].projectName == 'b1'
+                def rootComponent = rootProvider.get()
+                assert rootComponent.id.build.name == ':'
+                assert rootComponent.id.build.currentBuild
+                assert rootComponent.id.projectPath == ':'
+                assert rootComponent.id.projectName == 'buildA'
 
-                def selectors = configurations.runtimeClasspath.incoming.resolutionResult.allDependencies.requested
-                assert selectors.size() == 2
+                def components = rootComponent.dependencies.selected
+                assert components.size() == 1
+                def buildRootProject = components[0]
+                def componentId = components[0].id
+                assert componentId.build.name == '${buildName}'
+                assert !componentId.build.currentBuild
+                assert componentId.projectPath == ':'
+                assert componentId.projectName == '${buildName}'
+
+                components = buildRootProject.dependencies.selected
+                assert components.size() == 1
+                componentId = components[0].id
+                assert componentId.build.name == '${buildName}'
+                assert !componentId.build.currentBuild
+                assert componentId.projectPath == ':b1'
+                assert componentId.projectName == 'b1'
+
+                def selectors = rootComponent.dependencies.requested
+                assert selectors.size() == 1
                 assert selectors[0].displayName == 'org.test:${dependencyName}:1.0'
-                assert selectors[1].displayName == 'project :${buildName}:b1'
+
+                selectors = buildRootProject.dependencies.requested
+                assert selectors.size() == 1
+                assert selectors[0].displayName == 'project :${buildName}:b1'
                 // TODO - should be build name
-                assert selectors[1].buildName == 'buildB'
-                assert selectors[1].projectPath == ':b1'
+                assert selectors[0].buildName == 'buildB'
+                assert selectors[0].projectPath == ':b1'
             }
         """
 

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildOperationsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildOperationsIntegrationTest.groovy
@@ -22,10 +22,12 @@ import org.gradle.initialization.BuildIdentifiedProgressDetails
 import org.gradle.initialization.ConfigureBuildBuildOperationType
 import org.gradle.initialization.LoadBuildBuildOperationType
 import org.gradle.integtests.fixtures.build.BuildTestFile
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.internal.operations.trace.BuildOperationRecord
 import org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType
 import org.gradle.internal.taskgraph.CalculateTreeTaskGraphBuildOperationType
 import org.gradle.launcher.exec.RunBuildBuildOperationType
+import spock.lang.IgnoreIf
 
 import java.util.regex.Pattern
 
@@ -64,6 +66,8 @@ class CompositeBuildOperationsIntegrationTest extends AbstractCompositeBuildInte
         }
     }
 
+    // Also covered by tests in configuration cache project
+    @IgnoreIf({ GradleContextualExecuter.configCache })
     def "generates build lifecycle operations for included builds with #display"() {
         given:
         dependency "org.test:${dependencyName}:1.0"
@@ -141,6 +145,8 @@ class CompositeBuildOperationsIntegrationTest extends AbstractCompositeBuildInte
         "rootProject.name='someLib'" | "someLib"      | "configured root project name"
     }
 
+    // Also covered by tests in configuration cache project
+    @IgnoreIf({ GradleContextualExecuter.configCache })
     def "generates build lifecycle operations for multiple included builds"() {
         given:
         def buildC = multiProjectBuild("buildC", ["someLib"]) {
@@ -194,6 +200,8 @@ class CompositeBuildOperationsIntegrationTest extends AbstractCompositeBuildInte
         graphNotifyOps[2].parentId == treeTaskGraphOps[0].id
     }
 
+    // Also covered by tests in configuration cache project
+    @IgnoreIf({ GradleContextualExecuter.configCache })
     def "generates build lifecycle operations for multiple included builds used as buildscript dependencies"() {
         given:
         def buildC = multiProjectBuild("buildC", ["someLib"]) {
@@ -257,6 +265,8 @@ class CompositeBuildOperationsIntegrationTest extends AbstractCompositeBuildInte
         graphNotifyOps[2].parentId == treeTaskGraphOps[1].id
     }
 
+    // Also covered by tests in configuration cache project
+    @IgnoreIf({ GradleContextualExecuter.configCache })
     def "generates build lifecycle operations for included build used as buildscript and production dependency"() {
         given:
         buildA.buildFile.text = """

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildTaskExcludeIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildTaskExcludeIntegrationTest.groovy
@@ -256,5 +256,4 @@ class CompositeBuildTaskExcludeIntegrationTest extends AbstractCompositeBuildTas
             result.assertTaskNotExecuted(":app:processResources")
         }
     }
-
 }

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeContinuousBuildIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeContinuousBuildIntegrationTest.groovy
@@ -168,7 +168,7 @@ class CompositeContinuousBuildIntegrationTest extends AbstractContinuousIntegrat
 
         when:
         succeeds("--status")
-        succeeds("tasks", "--debug")
+        succeeds("tasks")
         then:
         outputContains("Hello World")
 

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
@@ -183,6 +183,8 @@ class DefaultConfigurationCache internal constructor(
             }
             problems.projectStateStats(reusedProjects.size, updatedProjects.size)
             cacheEntryRequiresCommit = false
+            // Can reuse the cache entry for the rest of this build invocation
+            cacheAction = ConfigurationCacheAction.LOAD
         }
     }
 

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/AbstractProjectDependencyConflictResolutionIntegrationSpec.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/AbstractProjectDependencyConflictResolutionIntegrationSpec.groovy
@@ -28,7 +28,7 @@ import org.gradle.util.Path
  *  └> myorg.ModuleB(1.0) ────────> myorg.ModuleC($versionExternal)
  *
  * Of myorg.ModuleC...
- * - ...all referenced version exist in a repository as 'module' (see test setup)
+ * - ...all referenced versions exist in a repository as 'module' (see test setup)
  * - ...one version exists as 'project' in the build (either through multi-project or composite)
  *
  * This abstract specification leaves out the concrete implementation of setting up the project structure.
@@ -139,18 +139,19 @@ abstract class AbstractProjectDependencyConflictResolutionIntegrationSpec extend
         "2.1"      | "2.0"         | 'projectId("ModuleC")'                | false                | "substitute module('myorg:ModuleC') using project(':ModuleC')"
     }
 
-
     static String check(String moduleName, String declaredDependencyId, String confName, String winner) { """
         task check${moduleName}_${confName} {
             def result = configurations.${confName}.incoming.resolutionResult.rootComponent
+            def declared = $declaredDependencyId
+            def expected = $winner
             doLast {
                 def deps = result.get().dependencies as List
                 def projectDependency = deps.find {
                     it instanceof org.gradle.api.artifacts.result.ResolvedDependencyResult &&
-                        it.requested.matchesStrictly($declaredDependencyId)
+                        it.requested.matchesStrictly(declared)
                 }
 
-                assert projectDependency && projectDependency.selected.componentId == $winner
+                assert projectDependency && projectDependency.selected.componentId == expected
             }
         }
 """


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context

Also fix a couple of issues for build event listeners and `-x` support for builds in the tree that do not have work scheduled.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
