### PR TITLE
Revert "Delete tests for property which no longer exists"

### DIFF
--- a/subprojects/reporting/src/test/groovy/org/gradle/api/reporting/internal/TaskGeneratedSingleDirectoryReportTest.groovy
+++ b/subprojects/reporting/src/test/groovy/org/gradle/api/reporting/internal/TaskGeneratedSingleDirectoryReportTest.groovy
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.reporting.internal
+
+import org.gradle.api.Task
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.util.TestUtil
+import org.junit.Rule
+import spock.lang.Specification
+
+class TaskGeneratedSingleDirectoryReportTest extends Specification {
+    @Rule
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
+
+    def "can attach a convention mapping for output directory location"() {
+        def report = TestUtil.objectFactory(tmpDir.testDirectory).newInstance(TaskGeneratedSingleDirectoryReport, "report", Stub(Task), "entryPoint")
+        def output = new File("report.dir")
+        def resolvedOutput = tmpDir.file("report.dir")
+
+        expect:
+        !report.outputLocation.isPresent()
+
+        report.conventionMapping.map("destination") { output }
+
+        report.outputLocation.asFile.get() == resolvedOutput
+    }
+}

--- a/subprojects/reporting/src/test/groovy/org/gradle/api/reporting/internal/TaskGeneratedSingleFileReportTest.groovy
+++ b/subprojects/reporting/src/test/groovy/org/gradle/api/reporting/internal/TaskGeneratedSingleFileReportTest.groovy
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.reporting.internal
+
+import org.gradle.api.Task
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.util.TestUtil
+import org.junit.Rule
+import spock.lang.Specification
+
+class TaskGeneratedSingleFileReportTest extends Specification {
+    @Rule
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
+
+    def "can attach a convention mapping for output file location"() {
+        def report = TestUtil.objectFactory(tmpDir.testDirectory).newInstance(TaskGeneratedSingleFileReport, "report", Stub(Task))
+        def output = new File("report.txt")
+        def resolvedOutput = tmpDir.file("report.txt")
+
+        expect:
+        !report.outputLocation.isPresent()
+
+        report.conventionMapping.map("destination") { output }
+
+        report.outputLocation.asFile.get() == resolvedOutput
+    }
+}


### PR DESCRIPTION
These tests are still important as `setDestination` still exists, so these properties could still be wired like this.

This reverts commit 80cafb1d658988f905a5df34f0a545a3c0373d19.