### PR TITLE
provider: introduce orElseThrow()

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/Provider.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/Provider.java
@@ -23,6 +23,8 @@ import org.gradle.internal.HasInternalProtocol;
 import javax.annotation.Nullable;
 import java.util.concurrent.Callable;
 import java.util.function.BiFunction;
+import java.util.function.Supplier;
+import java.util.Optional;
 
 /**
  * A container object that provides a value of a specific type. The value can be retrieved using one of the query methods
@@ -99,10 +101,24 @@ public interface Provider<T> {
      * Returns the value of this provider if it has a value present. Returns the given default value if a value is
      * not available.
      *
+     * @param defaultValue the value to return when no provider value is present
      * @return the value or the default value.
      * @since 4.3
      */
     T getOrElse(T defaultValue);
+
+    /**
+     * Returns the value of this provider if it has a value present, otherwise throwing the supplied exception.
+     *
+     * @param exceptionSupplier the function supplying the exception to be thrown when no provider value is present
+     * @return the provider value
+     * @throws X if there is no value present
+     * @since 8.1
+     */
+    default <X extends Throwable> T orElseThrow(Supplier<? extends X> exceptionSupplier) throws X {
+        return Optional.ofNullable(getOrNull())
+                .orElseThrow(exceptionSupplier);
+    }
 
     /**
      * Returns a new {@link Provider} whose value is the value of this provider transformed using the given function.

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -12,7 +12,8 @@ We would like to thank the following community members for their contributions t
 
 [Martin Bonnin](https://github.com/martinbonnin),
 [valery1707](https://github.com/valery1707),
-[Yanshun Li](https://github.com/Chaoba).
+[Yanshun Li](https://github.com/Chaoba),
+[Brandon Richardson](https://github.com/brandon1024).
 
 ## Upgrade instructions
 

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/AbstractMinimalProviderTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/AbstractMinimalProviderTest.groovy
@@ -130,6 +130,21 @@ class AbstractMinimalProviderTest extends ProviderSpec<String> {
         e.message == 'Cannot query the value of this provider because it has no value available.'
     }
 
+    def "does not throw supplied exception when value present"() {
+        expect:
+        provider.value("abc")
+        provider.orElseThrow() == "abc"
+    }
+
+    def "throws supplied exception when value not present"() {
+        when:
+        provider.orElseThrow(() -> new RuntimeException('supplied exception'))
+
+        then:
+        def e = thrown(RuntimeException)
+        e.message == 'supplied exception'
+    }
+
     def "toString() displays nice things"() {
         expect:
         new TestProvider().toString() == "provider(java.lang.String)"


### PR DESCRIPTION
Improve Provider interface by introducing a new default `orElseThrow()` method to better report illegal state or configuration to users.

Signed-off-by: Brandon Richardson <brandon.richardson@siemens.com>

<!--- The issue this PR addresses -->
Fixes #23323

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
