### PR TITLE
Fix wrong docsTest trigger id

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/DocsTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/DocsTest.kt
@@ -54,8 +54,8 @@ type test-splits\$action-test-classes.properties
 class DocsTestProject(
     model: CIBuildModel,
     stage: Stage,
-    os: Os,
-    testJava: JvmCategory,
+    val os: Os,
+    val testJava: JvmCategory,
     testTypes: List<DocsTestType>
 ) : Project({
     id("${model.projectId}_DocsTest_${testJava.version.name.toCapitalized()}_${os.asName()}")
@@ -85,7 +85,7 @@ class DocsTestProject(
 }
 
 class DocsTestTrigger(model: CIBuildModel, docsTestProject: DocsTestProject) : BaseGradleBuildType(init = {
-    id("${docsTestProject.id}_Trigger")
+    id("${model.projectId}_DocsTest_${docsTestProject.testJava.version.name.toCapitalized()}_${docsTestProject.os.asName()}_Trigger")
     name = docsTestProject.name + " (Trigger)"
     type = Type.COMPOSITE
 


### PR DESCRIPTION
It was mistakenly Gradle_Master_Gradle_Master_Check_DocsTest_Java18_Macos_Trigger, causing `ci-health` builds to fail.

<img width="675" alt="image" src="https://user-images.githubusercontent.com/12689835/211256585-fd6df8ca-728d-4874-bde4-066b6b721766.png">

https://builds.gradle.org/buildConfiguration/Hygiene_AutoUpdateTestSplitJsonOnGradleMaster/59986066?hideProblemsFromDependencies=false&hideTestsFromDependencies=true&expandBuildProblemsSection=true&expandBuildChangesSection=true