### PR TITLE
Document incremental change reporting behavior when discarding path information

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/PathSensitivity.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/PathSensitivity.java
@@ -56,6 +56,14 @@ public enum PathSensitivity {
 
     /**
      * Ignore file paths and directories altogether.
+     *
+     * <p>
+     *     When used on an {@literal @}{@link org.gradle.work.Incremental} input, instead of
+     *     {@link org.gradle.work.ChangeType#MODIFIED} events Gradle may produce
+     *     {@link org.gradle.work.ChangeType#ADDED} and {@link org.gradle.work.ChangeType#REMOVED} events.
+     *     This is because by ignoring the path of the individual inputs it cannot identify <em>what</em>
+     *     has been modified.
+     * </p>
      */
     NONE
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/SkipWhenEmpty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/SkipWhenEmpty.java
@@ -29,7 +29,7 @@ import java.lang.annotation.Target;
  *
  * <p>Consider using {@link IgnoreEmptyDirectories} as well, if the task only works on files and not on directories.</p>
  *
- * <p>Inputs annotated with this annotation can be queried for changes via {@link org.gradle.work.InputChanges#getFileChanges(org.gradle.api.file.FileCollection)} or {@link org.gradle.work.InputChanges#getFileChanges(org.gradle.api.provider.Provider)}.</p>
+ * <p>This annotation implies {@link org.gradle.work.Incremental}, and thus inputs annotated with this annotation can also be queried for changes.</p>
  *
  * <p>This annotation should be attached to the getter method in Java or the property in Groovy.
  * Annotations on setters or just the field in Java are ignored.</p>

--- a/subprojects/core-api/src/main/java/org/gradle/work/InputChanges.java
+++ b/subprojects/core-api/src/main/java/org/gradle/work/InputChanges.java
@@ -95,6 +95,11 @@ public interface InputChanges {
      *     Only input file properties annotated with {@literal @}{@link Incremental} or {@literal @}{@link org.gradle.api.tasks.SkipWhenEmpty} can be queried for changes.
      * </p>
      *
+     * <p>
+     *     Note that for inputs with {@link org.gradle.api.tasks.PathSensitivity#NONE}, instead of a {@link ChangeType#MODIFIED} event,
+     *     file modifications can be reported as a pair of an {@link ChangeType#ADDED} and a {@link ChangeType#REMOVED} event.
+     * </p>
+     *
      * @param parameter The value of the parameter to query.
      */
     Iterable<FileChange> getFileChanges(FileCollection parameter);
@@ -111,6 +116,11 @@ public interface InputChanges {
      *
      * <p>
      *     Only input file properties annotated with {@literal @}{@link Incremental} or {@literal @}{@link org.gradle.api.tasks.SkipWhenEmpty} can be queried for changes.
+     * </p>
+     *
+     * <p>
+     *     Note that for inputs with {@link org.gradle.api.tasks.PathSensitivity#NONE}, instead of a {@link ChangeType#MODIFIED} event,
+     *     file modifications can be reported as a pair of an {@link ChangeType#ADDED} and a {@link ChangeType#REMOVED} event.
      * </p>
      *
      * @param parameter The value of the parameter to query.


### PR DESCRIPTION
When using `@PathSensitive(PathSensitivity.NONE)` or `@Classpath` on an incremental input, Gradle will not report `MODIFIED` events, but instead will produce a pair of an `ADDED` and a `REMOVED` event, since there is no identity to connect the old state and the new.

Fixes #17916