### PR TITLE
Revert exposing internal APIs

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/TaskNodeCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/TaskNodeCodec.kt
@@ -24,6 +24,7 @@ import org.gradle.api.internal.TaskInternal
 import org.gradle.api.internal.TaskOutputsInternal
 import org.gradle.api.internal.provider.Providers
 import org.gradle.api.internal.tasks.TaskDestroyablesInternal
+import org.gradle.api.internal.tasks.TaskInputFilePropertyBuilderInternal
 import org.gradle.api.internal.tasks.TaskLocalStateInternal
 import org.gradle.api.internal.tasks.properties.InputParameterUtils
 import org.gradle.api.specs.Spec
@@ -421,13 +422,13 @@ suspend fun ReadContext.readInputPropertiesOf(task: Task) =
                     val normalizer = readEnum<InputNormalizer>()
                     val directorySensitivity = readEnum<DirectorySensitivity>()
                     val lineEndingNormalization = readEnum<LineEndingSensitivity>()
-                    (task as TaskInternal).inputs.run {
+                    ((task as TaskInternal).inputs.run {
                         when (filePropertyType) {
                             InputFilePropertyType.FILE -> file(pack(propertyValue))
                             InputFilePropertyType.DIRECTORY -> dir(pack(propertyValue))
                             InputFilePropertyType.FILES -> files(pack(propertyValue))
                         }
-                    }.run {
+                    } as TaskInputFilePropertyBuilderInternal).run {
                         withPropertyName(propertyName)
                         optional(optional)
                         skipWhenEmpty(inputBehavior.shouldSkipWhenEmpty())

--- a/subprojects/core/src/main/java/org/gradle/api/internal/TaskInputsInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/TaskInputsInternal.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal;
 
 import org.gradle.api.internal.tasks.TaskDependencyContainer;
-import org.gradle.api.internal.tasks.TaskInputFilePropertyBuilderInternal;
 import org.gradle.api.tasks.TaskInputs;
 import org.gradle.internal.properties.PropertyVisitor;
 
@@ -27,13 +26,4 @@ public interface TaskInputsInternal extends TaskInputs, TaskDependencyContainer 
      * Calls the corresponding visitor methods for all inputs added via the runtime API.
      */
     void visitRegisteredProperties(PropertyVisitor visitor);
-
-    @Override
-    TaskInputFilePropertyBuilderInternal files(Object... paths);
-
-    @Override
-    TaskInputFilePropertyBuilderInternal file(Object path);
-
-    @Override
-    TaskInputFilePropertyBuilderInternal dir(Object dirPath);
 }

--- a/subprojects/integ-test/src/crossVersionTest/groovy/org/gradle/integtests/TaskSubclassingBinaryBackwardsCompatibilityCrossVersionSpec.groovy
+++ b/subprojects/integ-test/src/crossVersionTest/groovy/org/gradle/integtests/TaskSubclassingBinaryBackwardsCompatibilityCrossVersionSpec.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.integtests
+
+import org.gradle.integtests.fixtures.TargetVersions
+
+/**
+ * Tests that task classes compiled with the current version of Gradle are compatible with previous versions.
+ */
+@TargetVersions("7.0+")
+class TaskSubclassingBinaryBackwardsCompatibilityCrossVersionSpec extends AbstractTaskSubclassingBinaryCompatibilityCrossVersionSpec {
+    def "can use task subclass using previous Gradle version"() {
+        given:
+        prepareSubclassingTest(current.version)
+
+        expect:
+        version current withTasks 'assemble' inDirectory(file("producer")) run()
+        version previous withTasks 'tasks' requireDaemon() requireIsolatedDaemons() run()
+    }
+
+    def "task can use all methods declared by Task interface that AbstractTask specialises"() {
+        given:
+        prepareMethodUseTest(current.version)
+
+        expect:
+        version current withTasks 'assemble' inDirectory(file("producer")) run()
+        version previous requireDaemon() requireIsolatedDaemons() withTasks 't' run()
+    }
+}

--- a/subprojects/integ-test/src/crossVersionTest/groovy/org/gradle/integtests/TaskSubclassingBinaryForwardCompatibilityCrossVersionSpec.groovy
+++ b/subprojects/integ-test/src/crossVersionTest/groovy/org/gradle/integtests/TaskSubclassingBinaryForwardCompatibilityCrossVersionSpec.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.integtests
+
+import org.gradle.integtests.fixtures.TargetVersions
+
+/**
+ * Tests that task classes compiled against earlier versions of Gradle are still compatible.
+ */
+@TargetVersions("3.0+")
+class TaskSubclassingBinaryForwardCompatibilityCrossVersionSpec extends AbstractTaskSubclassingBinaryCompatibilityCrossVersionSpec {
+    def "can use task subclass compiled using previous Gradle version"() {
+        given:
+        prepareSubclassingTest(previous.version)
+
+        expect:
+        version previous withTasks 'assemble' inDirectory(file("producer")) run()
+        version current withTasks 'tasks' requireDaemon() requireIsolatedDaemons() run()
+    }
+
+    def "task can use all methods declared by Task interface that AbstractTask specialises"() {
+        given:
+        prepareMethodUseTest(previous.version)
+
+        expect:
+        version previous withTasks 'assemble' inDirectory(file("producer")) run()
+        version current requireDaemon() requireIsolatedDaemons() withTasks 't' run()
+    }
+}


### PR DESCRIPTION
Because DefaultTask.getInputs() exposes internal APIs (see , we ended up accidentally exposing more internal APIs that caused plugins compiled against Gradle 8.0 to fail to load with earlier versions. This reverts the change to fix the immediate issue.

Fixes #23440
