### PR TITLE
Let `Gradle` expose that it is `ExtensionAware`

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/CrossProjectConfigurationReportingGradle.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/CrossProjectConfigurationReportingGradle.kt
@@ -35,6 +35,7 @@ import org.gradle.api.internal.project.CrossProjectModelAccess
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.project.ProjectRegistry
 import org.gradle.api.invocation.Gradle
+import org.gradle.api.plugins.ExtensionContainer
 import org.gradle.api.plugins.ObjectConfigurationAction
 import org.gradle.api.plugins.PluginContainer
 import org.gradle.api.services.BuildServiceRegistry
@@ -231,6 +232,9 @@ class CrossProjectConfigurationReportingGradle private constructor(
 
     override fun getPluginManager(): PluginManagerInternal =
         delegate.pluginManager
+
+    override fun getExtensions(): ExtensionContainer =
+        delegate.extensions
 
     override fun getGradleVersion(): String =
         delegate.gradleVersion

--- a/subprojects/core-api/src/main/java/org/gradle/api/invocation/Gradle.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/invocation/Gradle.java
@@ -27,6 +27,7 @@ import org.gradle.api.UnknownDomainObjectException;
 import org.gradle.api.execution.TaskExecutionGraph;
 import org.gradle.api.initialization.IncludedBuild;
 import org.gradle.api.initialization.Settings;
+import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.plugins.PluginAware;
 import org.gradle.api.services.BuildServiceRegistry;
 import org.gradle.internal.HasInternalProtocol;
@@ -41,7 +42,7 @@ import java.util.Collection;
  * <p>You can obtain a {@code Gradle} instance by calling {@link Project#getGradle()}.</p>
  */
 @HasInternalProtocol
-public interface Gradle extends PluginAware {
+public interface Gradle extends PluginAware, ExtensionAware {
     /**
      * Returns the current Gradle version.
      *

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/ProjectSchemaAccessorsIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/ProjectSchemaAccessorsIntegrationTest.kt
@@ -1250,7 +1250,7 @@ class ProjectSchemaAccessorsIntegrationTest : AbstractPluginIntegrationTest() {
         withFile(
             "buildSrc/src/main/kotlin/my-plugin.gradle.kts",
             """
-            (dependencies as ExtensionAware).extensions.create<Mine>("mine")
+            dependencies.extensions.create<Mine>("mine")
             """
         )
 

--- a/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinInitScriptIntegrationTest.kt
+++ b/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinInitScriptIntegrationTest.kt
@@ -168,6 +168,10 @@ class KotlinInitScriptIntegrationTest : AbstractKotlinIntegrationTest() {
         withFile("plugin/src/main/kotlin/gradle-plugin.init.gradle.kts", """
             extensions.create<MyExtension>("my")
         """)
+        // https://github.com/gradle/gradle/issues/22091
+        withFile("plugin/gradle.properties", """
+            kotlin.options.suppressFreeCompilerArgsModificationWarning=true
+        """)
         build(rootDir = existing("plugin"), "jar")
 
         val pluginJar = existing("plugin/build/libs/plugin.jar")

--- a/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinInitScriptIntegrationTest.kt
+++ b/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinInitScriptIntegrationTest.kt
@@ -3,9 +3,7 @@ package org.gradle.kotlin.dsl.integration
 import org.gradle.kotlin.dsl.fixtures.AbstractKotlinIntegrationTest
 import org.gradle.kotlin.dsl.fixtures.DeepThought
 import org.gradle.kotlin.dsl.fixtures.withFolders
-import org.gradle.test.fixtures.archive.JarTestFixture
 import org.gradle.util.internal.TextUtil.normaliseFileSeparators
-import org.hamcrest.CoreMatchers
 
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.CoreMatchers.equalTo

--- a/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinSettingsScriptIntegrationTest.kt
+++ b/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinSettingsScriptIntegrationTest.kt
@@ -6,17 +6,13 @@ import org.gradle.test.fixtures.plugin.PluginBuilder
 import org.gradle.test.fixtures.server.http.MavenHttpPluginRepository
 
 import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
-import org.junit.Rule
 
 import org.junit.Test
 
 
 class KotlinSettingsScriptIntegrationTest : AbstractKotlinIntegrationTest() {
-
-    @Rule
-    @JvmField
-    val pluginPortal: MavenHttpPluginRepository = MavenHttpPluginRepository.asGradlePluginPortal(executer, mavenRepo)
 
     @Test
     fun `can apply plugin using ObjectConfigurationAction syntax`() {
@@ -49,23 +45,31 @@ class KotlinSettingsScriptIntegrationTest : AbstractKotlinIntegrationTest() {
     @Test
     fun `can apply plugin using plugins block`() {
 
-        PluginBuilder(file("plugin")).run {
-            addSettingsPlugin("println '*42*'", "test.MySettingsPlugin", "MySettingsPlugin")
-            publishAs("g", "m", "1.0", pluginPortal, createExecuter()).allowAll()
-        }
+        val pluginPortal: MavenHttpPluginRepository = MavenHttpPluginRepository.asGradlePluginPortal(executer, mavenRepo)
+        try {
+            pluginPortal.start()
 
-        withSettings(
-            """
-            plugins {
-                id("test.MySettingsPlugin").version("1.0")
+            PluginBuilder(file("plugin")).run {
+                addSettingsPlugin("println '*42*'", "test.MySettingsPlugin", "MySettingsPlugin")
+                publishAs("g", "m", "1.0", pluginPortal, createExecuter()).allowAll()
             }
-            """
-        )
 
-        assertThat(
-            build().output,
-            containsString("*42*")
-        )
+            withSettings(
+                """
+                plugins {
+                    id("test.MySettingsPlugin").version("1.0")
+                }
+                """
+            )
+
+            assertThat(
+                build().output,
+                containsString("*42*")
+            )
+
+        } finally {
+            pluginPortal.stop()
+        }
     }
 
     @Test
@@ -154,6 +158,43 @@ class KotlinSettingsScriptIntegrationTest : AbstractKotlinIntegrationTest() {
 
         assert(
             build("compute").output.contains("*42*")
+        )
+    }
+
+    @Test
+    fun `can access settings extensions`() {
+        withKotlinDslPluginIn("build-logic")
+        withFile("build-logic/src/main/kotlin/MyExtension.kt", """
+            interface MyExtension {
+                fun some(message: String) { println(message) }
+            }
+        """)
+        withFile("build-logic/src/main/kotlin/my-plugin.settings.gradle.kts", """
+            extensions.create<MyExtension>("my")
+        """)
+        withSettings("""
+            pluginManagement {
+                includeBuild("build-logic")
+            }
+            plugins { id("my-plugin") }
+
+            extensions.getByType(MyExtension::class).some("api.get")
+            extensions.configure<MyExtension> { some("api.configure") }
+            the<MyExtension>().some("kotlin.get")
+            configure<MyExtension> { some("kotlin.configure") }
+        """)
+        withBuildScript("""tasks.register("noop")""")
+
+        assertThat(
+            build("noop", "-q").output.trim(),
+            equalTo(
+                """
+                api.get
+                api.configure
+                kotlin.get
+                kotlin.configure
+                """.trimIndent()
+            )
         )
     }
 }

--- a/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinSettingsScriptIntegrationTest.kt
+++ b/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinSettingsScriptIntegrationTest.kt
@@ -66,7 +66,6 @@ class KotlinSettingsScriptIntegrationTest : AbstractKotlinIntegrationTest() {
                 build().output,
                 containsString("*42*")
             )
-
         } finally {
             pluginPortal.stop()
         }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/GradleDelegate.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/GradleDelegate.kt
@@ -27,6 +27,7 @@ import org.gradle.api.execution.TaskExecutionGraph
 import org.gradle.api.initialization.IncludedBuild
 import org.gradle.api.initialization.Settings
 import org.gradle.api.invocation.Gradle
+import org.gradle.api.plugins.ExtensionContainer
 import org.gradle.api.plugins.ObjectConfigurationAction
 import org.gradle.api.plugins.PluginContainer
 import org.gradle.api.plugins.PluginManager
@@ -155,4 +156,7 @@ abstract class GradleDelegate : Gradle {
 
     override fun getPluginManager(): PluginManager =
         delegate.pluginManager
+
+    override fun getExtensions(): ExtensionContainer =
+        delegate.extensions
 }

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/ExtensionAwareExtensionsTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/ExtensionAwareExtensionsTest.kt
@@ -9,6 +9,7 @@ import com.nhaarman.mockito_kotlin.whenever
 import org.gradle.api.Action
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Task
+import org.gradle.api.invocation.Gradle
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.plugins.ExtensionContainer
 import org.gradle.testing.jacoco.plugins.JacocoTaskExtension
@@ -17,6 +18,32 @@ import org.junit.Test
 
 
 class ExtensionAwareExtensionsTest {
+
+    interface MyExtension
+
+    @Test
+    fun `can access gradle extensions`() {
+
+        val gradle = mock<Gradle>()
+
+        val extensionContainer = mock<ExtensionContainer>()
+        val extension = mock<MyExtension>()
+        val extensionType = typeOf<MyExtension>()
+
+        whenever(gradle.extensions)
+            .thenReturn(extensionContainer)
+        whenever(extensionContainer.getByType(eq(extensionType)))
+            .thenReturn(extension)
+
+        gradle.the<MyExtension>()
+        gradle.configure<MyExtension> {}
+
+        inOrder(extensionContainer) {
+            verify(extensionContainer).getByType(eq(extensionType))
+            verify(extensionContainer).configure(eq(extensionType), any<Action<MyExtension>>())
+            verifyNoMoreInteractions()
+        }
+    }
 
     @Test
     fun `can get task extensions`() {


### PR DESCRIPTION
This allows access to extensions without casting to `ExtensionAware` from statically compiled languages such as Java or Kotlin.

* Fixes #23160 
