### PR TITLE
Do not fail the build scan performance test if there is a regression

### DIFF
--- a/subprojects/build-scan-performance/src/performanceTest/groovy/org/gradle/performance/BuildScanPluginPerformanceTest.groovy
+++ b/subprojects/build-scan-performance/src/performanceTest/groovy/org/gradle/performance/BuildScanPluginPerformanceTest.groovy
@@ -87,11 +87,6 @@ class BuildScanPluginPerformanceTest extends AbstractBuildScanPluginPerformanceT
         def speedStats = withoutResults.getSpeedStatsAgainst(withResults.name, withResults)
         println(speedStats)
 
-        def shiftedResults = buildShiftedResults(results, WITHOUT_PLUGIN_LABEL, MEDIAN_PERCENTAGES_SHIFT)
-        if (shiftedResults.significantlyFasterThan(withResults)) {
-            throw new AssertionError(speedStats)
-        }
-
         where:
         scenario                                                | expectedMedianPercentageShift | tasks                              | withFailure | scenarioArgs                                                  | manageCacheState
         "clean build - 50 projects"                             | MEDIAN_PERCENTAGES_SHIFT      | ['clean', 'build']                 | true        | ['--build-cache']                                             | true


### PR DESCRIPTION
We want to mute these tests as we are not actively monitoring these and want to still verify the performance builds used to run the performance tests and to store the runs in our performance database for later when we resurrect these tests.