### PR TITLE
nested dependency declarations (`DependencyHandler` dynamic methods to return `List<Dependency>`)

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DynamicAddDependencyMethods.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DynamicAddDependencyMethods.java
@@ -23,6 +23,7 @@ import org.gradle.internal.metaobject.DynamicInvokeResult;
 import org.gradle.internal.metaobject.MethodAccess;
 import org.gradle.util.internal.CollectionUtils;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -56,7 +57,7 @@ class DynamicAddDependencyMethods implements MethodAccess {
         } else if (normalizedArgs.size() == 1) {
             return DynamicInvokeResult.found(dependencyAdder.add(configuration, normalizedArgs.get(0), null));
         } else {
-			return DynamicInvokeResult.found(normalizedArgs.stream().map(arg -> dependencyAdder.add(configuration, arg, null)).collect(Collectors.toList()));
+			return DynamicInvokeResult.found(normalizedArgs.stream().map(arg -> dependencyAdder.add(configuration, arg, null)).collect(Collectors.collectingAndThen(Collectors.toList(), Collections::unmodifiableList)));
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DynamicAddDependencyMethods.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DynamicAddDependencyMethods.java
@@ -57,7 +57,7 @@ class DynamicAddDependencyMethods implements MethodAccess {
         } else if (normalizedArgs.size() == 1) {
             return DynamicInvokeResult.found(dependencyAdder.add(configuration, normalizedArgs.get(0), null));
         } else {
-			return DynamicInvokeResult.found(normalizedArgs.stream().map(arg -> dependencyAdder.add(configuration, arg, null)).collect(Collectors.collectingAndThen(Collectors.toList(), Collections::unmodifiableList)));
+            return DynamicInvokeResult.found(normalizedArgs.stream().map(arg -> dependencyAdder.add(configuration, arg, null)).collect(Collectors.collectingAndThen(Collectors.toList(), Collections::unmodifiableList)));
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DynamicAddDependencyMethods.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DynamicAddDependencyMethods.java
@@ -24,6 +24,7 @@ import org.gradle.internal.metaobject.MethodAccess;
 import org.gradle.util.internal.CollectionUtils;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 class DynamicAddDependencyMethods implements MethodAccess {
     private final ConfigurationContainer configurationContainer;
@@ -55,10 +56,7 @@ class DynamicAddDependencyMethods implements MethodAccess {
         } else if (normalizedArgs.size() == 1) {
             return DynamicInvokeResult.found(dependencyAdder.add(configuration, normalizedArgs.get(0), null));
         } else {
-            for (Object arg : normalizedArgs) {
-                dependencyAdder.add(configuration, arg, null);
-            }
-            return DynamicInvokeResult.found();
+			return DynamicInvokeResult.found(normalizedArgs.stream().map(arg -> dependencyAdder.add(configuration, arg, null)).collect(Collectors.toList()));
         }
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyConstraintHandlerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyConstraintHandlerTest.groovy
@@ -144,7 +144,7 @@ class DefaultDependencyConstraintHandlerTest extends Specification {
         def result = dependencyConstraintHandler.someConf("someNotation", "someOther")
 
         then:
-        result == null
+        result == [constraint1, constraint2]
 
         and:
         1 * dependencyFactory.createDependencyConstraint("someNotation") >> constraint1
@@ -161,7 +161,7 @@ class DefaultDependencyConstraintHandlerTest extends Specification {
         def result = dependencyConstraintHandler.someConf([["someNotation"], ["someOther"]])
 
         then:
-        result == null
+        result == [constraint1, constraint2]
 
         and:
         1 * dependencyFactory.createDependencyConstraint("someNotation") >> constraint1

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandlerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandlerTest.groovy
@@ -170,7 +170,7 @@ class DefaultDependencyHandlerTest extends Specification {
         def result = dependencyHandler.someConf("someNotation", "someOther")
 
         then:
-        result == null
+        result == [dependency1, dependency2]
 
         and:
         1 * dependencyFactory.createDependency("someNotation") >> dependency1
@@ -187,7 +187,7 @@ class DefaultDependencyHandlerTest extends Specification {
         def result = dependencyHandler.someConf([["someNotation"], ["someOther"]])
 
         then:
-        result == null
+        result == [dependency1, dependency2]
 
         and:
         1 * dependencyFactory.createDependency("someNotation") >> dependency1


### PR DESCRIPTION
Fixes #23452.

### Context
This set of patches makes dependency declaration expressions that declare multiple dependencies return a list of the declared dependencies instead of `null` in order to allow nesting. This change makes dependency declaration more consistent and allows for cleaner dependency declarations by eliminating repetition.

Being able to configure the dependencies with a trailing `Closure`—albeit not a part of the issue—would be good too.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation

#
The patches raised a few errors while running `:dependency-management:quickTest` so I updated 4 tests. I've also tested
```groovy
testImplementation(
	"org.junit.jupiter:junit-jupiter:latest.release",
	implementation(
		"org.ow2.asm:asm:latest.release",
		"org.ow2.asm:asm-tree:latest.release",
		api(
			"com.google.guava:guava:31.1-jre",
			"com.google.code.gson:gson:latest.release"
		)
	)
)
```
in a separate project and it works without issues.

Should I add tests and documentation?