### PR TITLE
Deprecate applying precompiled kts plugins published with Gradle < 6.0 

### DIFF
--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
@@ -15,7 +15,8 @@
 [[upgrading_version_8]]
 = Upgrading your build from Gradle 8.x to the latest
 
-This chapter provides the information you need to migrate your Gradle 8.x builds to the latest Gradle release. For migrating from Gradle 4.x, 5.x, 6.x, or 7.x, see the <<upgrading_version_7.adoc#upgrading_version_7, older migration guide>> first.
+This chapter provides the information you need to migrate your Gradle 8.x builds to the latest Gradle release.
+For migrating from Gradle 4.x, 5.x, 6.x, or 7.x, see the <<upgrading_version_7.adoc#upgrading_version_7, older migration guide>> first.
 
 We recommend the following steps for all users:
 
@@ -28,13 +29,14 @@ This is so you can see any deprecation warnings that apply to your build.
 Alternatively, you could run `gradle help --warning-mode=all` to see the deprecations in the console, though it may not report as much detailed information.
 . Update your plugins.
 +
-Some plugins will break with this new version of Gradle, for example because they use internal APIs that have been removed or changed. The previous step will help you identify potential problems by issuing deprecation warnings when a plugin does try to use a deprecated part of the API.
+Some plugins will break with this new version of Gradle, for example because they use internal APIs that have been removed or changed.
+The previous step will help you identify potential problems by issuing deprecation warnings when a plugin does try to use a deprecated part of the API.
 +
 . Run `gradle wrapper --gradle-version {gradleVersion}` to update the project to {gradleVersion}.
 . Try to run the project and debug any errors using the <<troubleshooting.adoc#troubleshooting, Troubleshooting Guide>>.
 
-[[changes_9.0]]
-== Upgrading from 8.x and earlier
+[[changes_8.1]]
+== Upgrading from 8.0 and earlier
 
 === Warnings that are now errors
 
@@ -45,40 +47,46 @@ Some plugins will break with this new version of Gradle, for example because the
 === Deprecations
 
 [[custom_configuration_roles]]
-Custom roles have been deprecated. Use a pre-defined role instead.
+==== Custom configuration roles
 
-[[upgrading_version_8:changes_8.0]]
+Custom roles have been deprecated.
+Use a pre-defined role instead.
 
 [[configurations_allowed_usage]]
-The usage of configurations should be fixed at creation.  Mutating the allowed usage on a configuration is deprecated.
+==== Allowed configurations usage
+
+The usage of configurations should be fixed at creation.
+Mutating the allowed usage on a configuration is deprecated.
 This includes calling any of the following `Configuration` methods:
 
 - `setCanBeConsumed(boolean)`
 - `setCanBeResolved(boolean)`
 
-The ability to change the allowed usage of a configuration after
-creation will be removed in Gradle 9.0.
+The ability to change the allowed usage of a configuration after creation will be removed in Gradle 9.0.
 
 [[gmm_modification_after_publication_populated]]
 ==== Modifying Gradle Module Metadata after a publication has been populated
 
-Altering the link:publishing_gradle_module_metadata.html[GMM] (e.g., changing a component configuration variants) *after* a Maven or Ivy publication has been populated from their components is now deprecated. This feature will be removed in Gradle 9.0.
+Altering the link:publishing_gradle_module_metadata.html[GMM] (e.g., changing a component configuration variants) *after* a Maven or Ivy publication has been populated from their components is now deprecated.
+This feature will be removed in Gradle 9.0.
 
 Eager population of the publication can happen if the following methods are called:
 
-====== Maven
+* Maven
+** link:{javadocPath}/org/gradle/api/publish/maven/MavenPublication.html#getArtifacts--[MavenPublication.getArtifacts()]
+* Ivy
+** link:{javadocPath}/org/gradle/api/publish/ivy/IvyPublication.html#getArtifacts--[IvyPublication.getArtifacts()]
+** link:{javadocPath}/org/gradle/api/publish/ivy/IvyPublication.html#getConfigurations--[IvyPublication.getConfigurations()]
+** link:{javadocPath}/org/gradle/api/publish/ivy/IvyPublication.html#configurations(Action)--[IvyPublication.configurations(Action)]
 
-* link:{javadocPath}/org/gradle/api/publish/maven/MavenPublication.html#getArtifacts--[MavenPublication.getArtifacts()]
+Previously, the following code did not generate warnings, but it created inconsistencies between published artifacts:
 
-====== Ivy
-
-* link:{javadocPath}/org/gradle/api/publish/ivy/IvyPublication.html#getArtifacts--[IvyPublication.getArtifacts()]
-* link:{javadocPath}/org/gradle/api/publish/ivy/IvyPublication.html#getConfigurations--[IvyPublication.getConfigurations()]
-* link:{javadocPath}/org/gradle/api/publish/ivy/IvyPublication.html#configurations(Action)--[IvyPublication.configurations(Action)]
-
-Previously, this code block did not generate warnings, but it created inconsistencies between published artifacts:
-
-```kotlin
+====
+[.multi-language-sample]
+=====
+.build.gradle.kts
+[source,kotlin]
+----
 publishing {
     publications {
         create<MavenPublication>("maven") {
@@ -91,13 +99,40 @@ publishing {
 }
 
 // These calls eagerly populate the Maven and Ivy publications
+
 (publishing.publications["maven"] as MavenPublication).artifacts
 (publishing.publications["ivy"] as IvyPublication).artifacts
 
-(components["java"] as AdhocComponentWithVariants).apply {
-  withVariantsFromConfiguration(configurations["apiElements"]) { skip() }
-  withVariantsFromConfiguration(configurations["runtimeElements"]) { skip() }
+val javaComponent = components["java"] as AdhocComponentWithVariants
+javaComponent.withVariantsFromConfiguration(configurations["apiElements"]) { skip() }
+javaComponent.withVariantsFromConfiguration(configurations["runtimeElements"]) { skip() }
+----
+=====
+[.multi-language-sample]
+=====
+.build.gradle
+[source,groovy]
+----
+publishing {
+    publications {
+        maven(MavenPublication) {
+            from components.java
+        }
+        ivy(IvyPublication) {
+            from components.java
+        }
+    }
 }
-```
+
+// These calls eagerly populate the Maven and Ivy publications
+
+publishing.publications.maven.artifacts
+publishing.publications.ivy.artifacts
+
+components.java.withVariantsFromConfiguration(configurations.apiElements) { skip() }
+components.java.withVariantsFromConfiguration(configurations.runtimeElements) { skip() }
+----
+=====
+====
 
 In this example, the Maven and Ivy publications will contain the main JAR artifacts for the project, whereas the GMM link:https://github.com/gradle/gradle/blob/master/subprojects/docs/src/docs/design/gradle-module-metadata-latest-specification.md[module file] will omit them.

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
@@ -136,3 +136,9 @@ components.java.withVariantsFromConfiguration(configurations.runtimeElements) { 
 ====
 
 In this example, the Maven and Ivy publications will contain the main JAR artifacts for the project, whereas the GMM link:https://github.com/gradle/gradle/blob/master/subprojects/docs/src/docs/design/gradle-module-metadata-latest-specification.md[module file] will omit them.
+
+[[kotlin_dsl_precompiled_gradle_lt_6]]
+==== Applying Kotlin DSL precompiled scripts published with Gradle < 6.0
+
+Applying Kotlin DSL precompiled scripts published with Gradle < 6.0 is deprecated.
+Please use a version of the plugin published with Gradle >= 6.0.

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/precompile/PrecompiledInitScript.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/precompile/PrecompiledInitScript.kt
@@ -18,6 +18,7 @@ package org.gradle.kotlin.dsl.precompile
 
 import org.gradle.api.internal.ProcessOperations
 import org.gradle.api.invocation.Gradle
+import org.gradle.internal.deprecation.DeprecationLogger
 import org.gradle.kotlin.dsl.*
 import org.gradle.kotlin.dsl.support.serviceOf
 
@@ -29,6 +30,14 @@ import org.gradle.kotlin.dsl.support.serviceOf
  */
 @Deprecated("Kept for compatibility with precompiled script plugins published with Gradle versions prior to 6.0")
 open class PrecompiledInitScript(target: Gradle) : @Suppress("deprecation") InitScriptApi(target) {
+
+    init {
+        DeprecationLogger.deprecateBehaviour("Applying a Kotlin DSL precompiled script plugin published with Gradle versions < 6.0.")
+            .withAdvice("Use a version of the plugin published with Gradle >= 6.0.")
+            .willBeRemovedInGradle9()
+            .withUpgradeGuideSection(8, "kotlin_dsl_precompiled_gradle_lt_6")
+            .nagUser()
+    }
 
     override val fileOperations by lazy { fileOperationsFor(delegate, null) }
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/precompile/PrecompiledProjectScript.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/precompile/PrecompiledProjectScript.kt
@@ -19,6 +19,7 @@ package org.gradle.kotlin.dsl.precompile
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderConvertible
+import org.gradle.internal.deprecation.DeprecationLogger
 import org.gradle.kotlin.dsl.*
 import org.gradle.kotlin.dsl.support.delegates.ProjectDelegate
 import org.gradle.plugin.use.PluginDependenciesSpec
@@ -33,6 +34,14 @@ import org.gradle.plugin.use.PluginDependencySpec
 open class PrecompiledProjectScript(
     override val delegate: Project
 ) : ProjectDelegate() {
+
+    init {
+        DeprecationLogger.deprecateBehaviour("Applying a Kotlin DSL precompiled script plugin published with Gradle versions < 6.0.")
+            .withAdvice("Use a version of the plugin published with Gradle >= 6.0.")
+            .willBeRemovedInGradle9()
+            .withUpgradeGuideSection(8, "kotlin_dsl_precompiled_gradle_lt_6")
+            .nagUser()
+    }
 
     /**
      * Configures the build script classpath for this project.

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/precompile/PrecompiledSettingsScript.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/precompile/PrecompiledSettingsScript.kt
@@ -18,6 +18,7 @@ package org.gradle.kotlin.dsl.precompile
 
 import org.gradle.api.initialization.Settings
 import org.gradle.api.internal.ProcessOperations
+import org.gradle.internal.deprecation.DeprecationLogger
 import org.gradle.kotlin.dsl.*
 import org.gradle.kotlin.dsl.support.serviceOf
 
@@ -29,6 +30,14 @@ import org.gradle.kotlin.dsl.support.serviceOf
  */
 @Deprecated("Kept for compatibility with precompiled script plugins published with Gradle versions prior to 6.0")
 open class PrecompiledSettingsScript(target: Settings) : @Suppress("deprecation") SettingsScriptApi(target) {
+
+    init {
+        DeprecationLogger.deprecateBehaviour("Applying a Kotlin DSL precompiled script plugin published with Gradle versions < 6.0.")
+            .withAdvice("Use a version of the plugin published with Gradle >= 6.0.")
+            .willBeRemovedInGradle9()
+            .withUpgradeGuideSection(8, "kotlin_dsl_precompiled_gradle_lt_6")
+            .nagUser()
+    }
 
     override val fileOperations by lazy { fileOperationsFor(delegate) }
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPrecompiledScriptPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPrecompiledScriptPluginsSmokeTest.groovy
@@ -103,7 +103,6 @@ class KotlinPrecompiledScriptPluginsSmokeTest extends AbstractSmokeTest {
         result.task(':help').outcome == SUCCESS
 
         where:
-        pluginPublishGradleVersion << ['6.0', '5.6.4']
-
+        pluginPublishGradleVersion << ['7.0', '6.0', '5.6.4']
     }
 }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPrecompiledScriptPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPrecompiledScriptPluginsSmokeTest.groovy
@@ -21,6 +21,8 @@ import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.test.fixtures.dsl.GradleDsl
 import org.gradle.test.fixtures.maven.MavenFileRepository
+import org.gradle.util.GradleVersion
+import org.gradle.util.internal.VersionNumber
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
@@ -88,7 +90,14 @@ class KotlinPrecompiledScriptPluginsSmokeTest extends AbstractSmokeTest {
         """
 
         when:
-        def result = runner('help').forwardOutput().build()
+        def result = runner('help')
+            .expectDeprecationWarningIf(
+                VersionNumber.parse(pluginPublishGradleVersion) < VersionNumber.parse("6.0"),
+                "Applying a Kotlin DSL precompiled script plugin published with Gradle versions < 6.0. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Use a version of the plugin published with Gradle >= 6.0. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#kotlin_dsl_precompiled_gradle_lt_6",
+                "Remove testing of plugins published with Gradle < 6.0"
+            )
+            .forwardOutput()
+            .build()
 
         then:
         result.task(':help').outcome == SUCCESS


### PR DESCRIPTION
* Fixes https://github.com/gradle/gradle/issues/21989
---

This PR also refines the upgrading guide for 8.x and adds coverage for applying precompiled kts plugins published with Gradle 7.0.

The changes in the upgrading guide are noisy and constitute most of this changeset. This PR might be better reviewed per commits.