### PR TITLE
Copy endorsing and VersionConstraint.branch properties of Dependency

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractModuleDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractModuleDependency.java
@@ -191,6 +191,9 @@ public abstract class AbstractModuleDependency extends AbstractDependency implem
         if (isTransitive() != dependencyRhs.isTransitive()) {
             return false;
         }
+        if (isEndorsingStrictVersions() != dependencyRhs.isEndorsingStrictVersions()) {
+            return false;
+        }
         if (!Objects.equal(getArtifacts(), dependencyRhs.getArtifacts())) {
             return false;
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractModuleDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractModuleDependency.java
@@ -163,6 +163,7 @@ public abstract class AbstractModuleDependency extends AbstractDependency implem
         if (moduleDependencyCapabilities != null) {
             target.moduleDependencyCapabilities = moduleDependencyCapabilities.copy();
         }
+        target.endorsing = endorsing;
     }
 
     protected boolean isKeyEquals(ModuleDependency dependencyRhs) {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/VersionCatalogExtensionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/VersionCatalogExtensionIntegrationTest.groovy
@@ -2368,9 +2368,11 @@ Second: 1.1"""
                 assert original.targetConfiguration == copied.targetConfiguration
                 assert original.attributes == copied.attributes
                 assert original.requestedCapabilities == copied.requestedCapabilities
+                assert original.endorsingStrictVersions == copied.endorsingStrictVersions
 
                 // ExternalDependency + ExternalModuleDependency
                 assert original.changing == copied.changing
+                assert original.versionConstraint == copied.versionConstraint
             }
 
             def getOriginal(dep) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultMutableVersionConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultMutableVersionConstraint.java
@@ -50,6 +50,7 @@ public class DefaultMutableVersionConstraint extends AbstractVersionConstraint i
         for (String reject : rejects) {
             this.rejectedVersions.add(nullToEmpty(reject));
         }
+        this.branch = branch;
     }
 
     private void updateVersions(@Nullable String preferredVersion, @Nullable String requiredVersion, @Nullable String strictVersion) {


### PR DESCRIPTION
These were missing from dependency copying operations

Fixes: [#23286](https://github.com/gradle/gradle/issues/23286)