### PR TITLE
Inject services into all external module dependencies created by DefultJvmComponentDependencies

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyFactory.java
@@ -155,7 +155,9 @@ public class DefaultDependencyFactory implements DependencyFactoryInternal {
 
     @Override
     public ProjectDependency create(Project project) {
-        return dependencyNotationParser.getProjectNotationParser().parseNotation(project);
+        ProjectDependency dependency = dependencyNotationParser.getProjectNotationParser().parseNotation(project);
+        injectServices(dependency);
+        return dependency;
     }
 
     // endregion

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyFactory.java
@@ -130,7 +130,9 @@ public class DefaultDependencyFactory implements DependencyFactoryInternal {
 
     @Override
     public ExternalModuleDependency create(CharSequence dependencyNotation) {
-        return dependencyNotationParser.getStringNotationParser().parseNotation(dependencyNotation.toString());
+        ExternalModuleDependency dependency = dependencyNotationParser.getStringNotationParser().parseNotation(dependencyNotation.toString());
+        injectServices(dependency);
+        return dependency;
     }
 
     @Override
@@ -142,6 +144,7 @@ public class DefaultDependencyFactory implements DependencyFactoryInternal {
     public ExternalModuleDependency create(@Nullable String group, String name, @Nullable String version, @Nullable String classifier, @Nullable String extension) {
         DefaultExternalModuleDependency dependency = instantiator.newInstance(DefaultExternalModuleDependency.class, group, name, version);
         ModuleFactoryHelper.addExplicitArtifactsIfDefined(dependency, extension, classifier);
+        injectServices(dependency);
         return dependency;
     }
 


### PR DESCRIPTION
This fixes an issue where you can decorate a dep with platform and get a runtime failure because an AttributesFactory
has not been injected into the dep.

Fixes #19065