### PR TITLE
Update Publishing Samples and Docs 

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
@@ -434,7 +434,7 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
      * Returns all the configurations belonging to the same configuration container as this
      * configuration (including this configuration).
      *
-     * @return All of the configurations belong to the configuration container that this set belongs to.
+     * @return All the configurations belonging to the configuration container that this set belongs to itself.
      */
     Set<Configuration> getAll();
 
@@ -446,9 +446,9 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
     ResolvableDependencies getIncoming();
 
     /**
-     * Returns the outgoing publications object containing artifacts and variants published by this configuration.
+     * Returns the outgoing {@link ConfigurationPublications} instance that advertises and allows configuring the artifacts and variants published by this configuration.
      * <p>
-     * This allows adding additional artifiacts and accessing and configuring variants to publish.
+     * This allows adding additional artifacts and accessing and configuring variants to publish.
      *
      * @return The outgoing publications object containing artifacts and variants published by this configuration.
      * @since 3.4
@@ -456,7 +456,7 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
     ConfigurationPublications getOutgoing();
 
     /**
-     * Configures the outgoing publications object containing the artifacts and variants published by this configuration.
+     * Configures the outgoing {@link ConfigurationPublications} instance that advertises and allows configuring the artifacts and variants published by this configuration.
      *
      * @param action The action to perform the configuration.
      * @since 3.4

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
@@ -446,15 +446,17 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
     ResolvableDependencies getIncoming();
 
     /**
-     * Returns the outgoing artifacts of this configuration.
+     * Returns the outgoing publications object containing artifacts and variants published by this configuration.
+     * <p>
+     * This allows adding additional artifiacts and accessing and configuring variants to publish.
      *
-     * @return The outgoing artifacts of this configuration.
+     * @return The outgoing publications object containing artifacts and variants published by this configuration.
      * @since 3.4
      */
     ConfigurationPublications getOutgoing();
 
     /**
-     * Configures the outgoing artifacts of this configuration.
+     * Configures the outgoing publications object containing the artifacts and variants published by this configuration.
      *
      * @param action The action to perform the configuration.
      * @since 3.4

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ConfigurationPublications.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ConfigurationPublications.java
@@ -27,7 +27,7 @@ import java.util.Collection;
 /**
  * Represents the outgoing artifacts associated with a configuration. These artifacts are used when the configuration is referenced during dependency resolution.
  *
- * <p>You can use this interface associate artifacts with a configuration using the {@link #artifact(Object)} methods. You can also define several <em>variants</em> of the configuration's artifacts. Each variant represents a set of artifacts that form some mutually exclusive usage of the component.</p>
+ * <p>You can use this interface to associate artifacts with a configuration using the {@link #artifact(Object)} methods. You can also define several <em>variants</em> of the configuration's artifacts. Each variant represents a set of artifacts that form some mutually exclusive usage of the component.</p>
  *
  * <p>An implicit variant is defined for a configuration whenever any artifacts are attached directly to this object or inherited from another configuration.</p>
  *

--- a/subprojects/core-api/src/main/java/org/gradle/api/component/AdhocComponentWithVariants.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/component/AdhocComponentWithVariants.java
@@ -16,6 +16,7 @@
 package org.gradle.api.component;
 
 import org.gradle.api.Action;
+import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.Configuration;
 
 /**
@@ -30,19 +31,23 @@ public interface AdhocComponentWithVariants extends SoftwareComponent {
 
     /**
      * Declares an additional variant to publish, corresponding to an additional feature.
+     * <p>
+     * This can be used to determine if the variant should be published or not, and to configure various options specific to the publishing format.
      *
      * @param outgoingConfiguration the configuration corresponding to the variant to use as source of dependencies and artifacts
-     * @param action the action to execute in order to determine if a configuration variant should be published or not
+     * @param action action executed to configure the variant prior to publishing
      */
     void addVariantsFromConfiguration(Configuration outgoingConfiguration, Action<? super ConfigurationVariantDetails> action);
 
     /**
      * Further configure previously declared variants.
+     * <p>
+     * If the specified variant was not already added to this component, an {@link InvalidUserDataException} is thrown.  The action can be used to determine
+     * if the variant should be published or not, and to configure various options specific to the publishing format.  Note that if multiple actions are added,
+     * they are executed in the order they were added.
      *
-     * @param outgoingConfiguration the configuration corresponding to the variant to use as source of dependencies and artifacts
-     * @param action the action to execute in order to determine if a configuration variant should be published or not
-     *
-     * @since 6.0
+     * @param outgoingConfiguration the configuration corresponding to the variant to configure with a given action
+     * @param action an additional action to be executed to configure the variant prior to publishing
      */
     void withVariantsFromConfiguration(Configuration outgoingConfiguration, Action<? super ConfigurationVariantDetails> action);
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/component/AdhocComponentWithVariants.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/component/AdhocComponentWithVariants.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.component;
 
+import com.sun.org.apache.xalan.internal.xsltc.compiler.If;
 import org.gradle.api.Action;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.Configuration;
@@ -42,12 +43,12 @@ public interface AdhocComponentWithVariants extends SoftwareComponent {
     /**
      * Further configure previously declared variants.
      * <p>
-     * If the specified variant was not already added to this component, an {@link InvalidUserDataException} is thrown.  The action can be used to determine
-     * if the variant should be published or not, and to configure various options specific to the publishing format.  Note that if multiple actions are added,
-     * they are executed in the order they were added.
+     * The action can be used to determine if the variant should be published or not, and to configure various options specific to the publishing
+     * format.  Note that if multiple actions are added, they are executed in the order they were added.
      *
      * @param outgoingConfiguration the configuration corresponding to the variant to configure with a given action
      * @param action an additional action to be executed to configure the variant prior to publishing
+     * @throws InvalidUserDataException if the specified variant was not already added to this component
      */
     void withVariantsFromConfiguration(Configuration outgoingConfiguration, Action<? super ConfigurationVariantDetails> action);
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/component/AdhocComponentWithVariants.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/component/AdhocComponentWithVariants.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.component;
 
-import com.sun.org.apache.xalan.internal.xsltc.compiler.If;
 import org.gradle.api.Action;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.Configuration;

--- a/subprojects/core-api/src/main/java/org/gradle/api/component/ConfigurationVariantDetails.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/component/ConfigurationVariantDetails.java
@@ -21,6 +21,8 @@ import org.gradle.internal.HasInternalProtocol;
 /**
  * The details object used to determine what to do with a
  * configuration variant when publishing.
+ * <p>
+ * This type also contains Maven specific information used to map the variant to a Maven POM file.
  *
  * @since 5.3
  */

--- a/subprojects/core-api/src/main/java/org/gradle/api/component/SoftwareComponent.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/component/SoftwareComponent.java
@@ -21,14 +21,9 @@ import org.gradle.internal.HasInternalProtocol;
 
 /**
  * A software component produced by a Gradle software project.
- *
- * <p>An implementation of this interface may also implement:</p>
- *
- * <ul>
- *
- * <li>{@link ComponentWithVariants} to provide information about the variants that the component provides.</li>
- *
- * </ul>
+ * <p>
+ * An implementation of this interface may also implement {@link ComponentWithVariants} to provide
+ * information about the variants that the component provides.
  */
 @HasInternalProtocol
 public interface SoftwareComponent extends Named {

--- a/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_setup.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_setup.adoc
@@ -71,7 +71,7 @@ include::sample[dir="snippets/publishing/javaLibrary/kotlin",files="build.gradle
 include::sample[dir="snippets/publishing/javaLibrary/groovy",files="build.gradle[tags=apply-plugins]"]
 ====
 
-Once the appropriate plugin has been applied, you can configure the publications and repositories. For this example, we want to publish the project's production JAR file — the one produced by the `jar` task — to a custom, Maven repository. We do that with the following `publishing {}` block, which is backed by link:{groovyDslPath}/org.gradle.api.publish.PublishingExtension.html[PublishingExtension]:
+Once the appropriate plugin has been applied, you can configure the publications and repositories. For this example, we want to publish the project's production JAR file — the one produced by the `jar` task — to a custom Maven repository. We do that with the following `publishing {}` block, which is backed by link:{groovyDslPath}/org.gradle.api.publish.PublishingExtension.html[PublishingExtension]:
 
 .Configuring a Java library for publishing
 ====

--- a/subprojects/docs/src/samples/groovy/library-publishing/README.adoc
+++ b/subprojects/docs/src/samples/groovy/library-publishing/README.adoc
@@ -46,4 +46,4 @@ build/publishing-repository/
 5 directories, 20 files
 ----
 
-For more information, see link:{userManualPath}/groovy_plugin.html[Groovy Plugin reference chapter].
+For more information, see link:{userManualPath}/publishing_setup.html[Publishing Libraries].

--- a/subprojects/docs/src/samples/java/library-publishing/README.adoc
+++ b/subprojects/docs/src/samples/java/library-publishing/README.adoc
@@ -47,4 +47,4 @@ build/publishing-repository
 5 directories, 20 files
 ----
 
-For more information, see link:{userManualPath}/java_library_plugin.html[Java Library Plugin reference chapter].
+For more information, see link:{userManualPath}/publishing_setup.html[Publishing Libraries].

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPom.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPom.java
@@ -39,7 +39,7 @@ import org.gradle.internal.HasInternalProtocol;
 public interface MavenPom {
 
     /**
-     * Returns the packaging for the publication represented by this POM.
+     * Returns the packaging (for example: jar, war) for the publication represented by this POM.
      */
     String getPackaging();
 
@@ -56,21 +56,21 @@ public interface MavenPom {
     Property<String> getName();
 
     /**
-     * The description for the publication represented by this POM.
+     * A short, human-readable description for the project represented by this POM.
      *
      * @since 4.8
      */
     Property<String> getDescription();
 
     /**
-     * The URL for the publication represented by this POM.
+     * The home page for the project represented by this POM.
      *
      * @since 4.8
      */
     Property<String> getUrl();
 
     /**
-     * The year of the inception for the publication represented by this POM.
+     * The year the project was first created.
      *
      * @since 4.8
      */

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPom.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPom.java
@@ -56,21 +56,21 @@ public interface MavenPom {
     Property<String> getName();
 
     /**
-     * A short, human-readable description for the project represented by this POM.
+     * A short, human-readable description for the publication represented by this POM.
      *
      * @since 4.8
      */
     Property<String> getDescription();
 
     /**
-     * The URL of the home page for the project represented by this POM.
+     * The URL of the home page for the project producing the publication represented by this POM.
      *
      * @since 4.8
      */
     Property<String> getUrl();
 
     /**
-     * The year the project was first created.
+     * The year the project producing the publication represented by this POM was first created.
      *
      * @since 4.8
      */

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPom.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPom.java
@@ -63,7 +63,7 @@ public interface MavenPom {
     Property<String> getDescription();
 
     /**
-     * The home page for the project represented by this POM.
+     * The URL of the home page for the project represented by this POM.
      *
      * @since 4.8
      */

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/PublicationContainer.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/PublicationContainer.java
@@ -45,5 +45,6 @@ import org.gradle.api.ExtensiblePolymorphicDomainObjectContainer;
  * @see Publication
  * @see PublishingExtension
  */
+@SuppressWarnings("JavadocReference")
 public interface PublicationContainer extends ExtensiblePolymorphicDomainObjectContainer<Publication> {
 }


### PR DESCRIPTION
Attempt at some small improvements to javadoc and documentation throughout publishing.
- Link to publishing sections of docs from publishing samples.
- Suppress IDE errors from javadoc links to missing subproject.