### PR TITLE
Fix standalone kts script compilation to not emit a warning at info level about scripts not being standalone

### DIFF
--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslRegressionsTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslRegressionsTest.kt
@@ -156,4 +156,14 @@ class GradleKotlinDslRegressionsTest : AbstractPluginIntegrationTest() {
         }
         result.assertHasErrorOutput("src/main/kotlin/code.kt:6:48 Null can not be a value of a non-null type Nothing")
     }
+
+    @Test
+    @Issue("https://youtrack.jetbrains.com/issue/KT-55880")
+    @Issue("https://github.com/gradle/gradle/issues/23491")
+    fun `compiling standalone scripts does not emit a warning at info level`() {
+        withBuildScript("""println("test")""")
+        build("help", "--info").apply {
+            assertNotOutput("is not supposed to be used along with regular Kotlin sources, and will be ignored in the future versions by default. (Use -Xallow-any-scripts-in-source-roots command line option to opt-in for the old behavior.)")
+        }
+    }
 }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
@@ -363,6 +363,7 @@ fun compilerConfigurationFor(messageCollector: MessageCollector, jvmTarget: Java
         put(SAM_CONVERSIONS, JvmClosureGenerationScheme.CLASS)
         addJvmSdkRoots(PathUtil.getJdkClassesRootsFromCurrentJre())
         put(CommonConfigurationKeys.LANGUAGE_VERSION_SETTINGS, gradleKotlinDslLanguageVersionSettings)
+        put(CommonConfigurationKeys.ALLOW_ANY_SCRIPTS_IN_SOURCE_ROOTS, true)
     }
 
 


### PR DESCRIPTION
The way we use the embedded Kotlin compiler is by creating a compilation unit for a set of files. The Kotlin compiler considers this is a "source root", hence the emitted warning that we route to INFO.

The fix is to configure the compilation unit to specifically not warn about this.

* Fixes https://github.com/gradle/gradle/issues/23491