### PR TITLE
Use 17 for toolchain tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,4 @@ atlassian-ide-plugin.xml
 
 # Added GE support maven support to the maven build in .teamcity, per the GE docs, this dir is NOT to be committed
 .teamcity/.mvn/.gradle-enterprise/
+/discoclient.properties

--- a/subprojects/soak/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadComplexProjectSoakTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadComplexProjectSoakTest.groovy
@@ -19,11 +19,15 @@ package org.gradle.jvm.toolchain
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import spock.lang.Ignore
 
+import static org.gradle.jvm.toolchain.JavaToolchainDownloadSoakTest.FOOJAY_PLUGIN_SECTION
+import static org.gradle.jvm.toolchain.JavaToolchainDownloadSoakTest.TOOLCHAIN_WITH_VERSION
+import static org.gradle.jvm.toolchain.JavaToolchainDownloadSoakTest.VERSION
+
 class JavaToolchainDownloadComplexProjectSoakTest extends AbstractIntegrationSpec {
 
     def setup() {
         executer.requireOwnGradleUserHomeDir()
-        executer.withToolchainDownloadEnabled()
+            .withToolchainDownloadEnabled()
     }
 
     def "multiple subprojects with identical toolchain definitions"() {
@@ -61,13 +65,10 @@ class JavaToolchainDownloadComplexProjectSoakTest extends AbstractIntegrationSpe
     }
 
     private String settingsForBuildWithSubprojects() {
-        return """
-            plugins {
-                id 'org.gradle.toolchains.foojay-resolver-convention' version '0.4.0'
-            }
+        return """$FOOJAY_PLUGIN_SECTION
 
             rootProject.name = 'main'
-            
+
             include('subproject1')
             include('subproject2')
         """
@@ -78,10 +79,10 @@ class JavaToolchainDownloadComplexProjectSoakTest extends AbstractIntegrationSpe
             plugins {
                 id 'java'
             }
-            
+
             java {
                 toolchain {
-                    languageVersion = JavaLanguageVersion.of(11)
+                    languageVersion = JavaLanguageVersion.of($VERSION)
                     vendor = JvmVendorSpec.${vendorName}
                 }
             }
@@ -112,11 +113,9 @@ class JavaToolchainDownloadComplexProjectSoakTest extends AbstractIntegrationSpe
             pluginManagement {
                 includeBuild 'plugin1'
             }
-            
-            plugins {
-                id 'org.gradle.toolchains.foojay-resolver-convention' version '0.4.0'
-            }
-            
+
+            $FOOJAY_PLUGIN_SECTION
+
             rootProject.name = 'main'
         """
     }
@@ -127,12 +126,8 @@ class JavaToolchainDownloadComplexProjectSoakTest extends AbstractIntegrationSpe
                 id 'java'
                 id 'org.example.plugin1'
             }
-            
-            java {
-                toolchain {
-                    languageVersion = JavaLanguageVersion.of(11)
-                }
-            }
+
+            $TOOLCHAIN_WITH_VERSION
         """
     }
 
@@ -141,19 +136,19 @@ class JavaToolchainDownloadComplexProjectSoakTest extends AbstractIntegrationSpe
             abstract class CustomToolchainResolverPlugin implements Plugin<Settings> {
                 @Inject
                 protected abstract JavaToolchainResolverRegistry getToolchainResolverRegistry();
-            
+
                 void apply(Settings settings) {
                     settings.getPlugins().apply("jvm-toolchain-management");
-            
+
                     JavaToolchainResolverRegistry registry = getToolchainResolverRegistry();
                     registry.register(CustomToolchainResolver.class);
                 }
             }
-            
-            
+
+
             import javax.inject.Inject
             import java.util.Optional;
-            
+
             abstract class CustomToolchainResolver implements JavaToolchainResolver {
                 @Override
                 Optional<JavaToolchainDownload> resolve(JavaToolchainRequest request) {
@@ -161,10 +156,10 @@ class JavaToolchainDownloadComplexProjectSoakTest extends AbstractIntegrationSpe
                     return Optional.of(JavaToolchainDownload.fromUri(uri));
                 }
             }
-            
-            
+
+
             apply plugin: CustomToolchainResolverPlugin
-            
+
             toolchainManagement {
                 jvm {
                     javaRepositories {
@@ -174,27 +169,21 @@ class JavaToolchainDownloadComplexProjectSoakTest extends AbstractIntegrationSpe
                     }
                 }
             }
-            
+
             rootProject.name = 'plugin1'
         """*/ //TODO: atm the included build will use the definition from its own settings file, so if this is the settings we use it won't be able to download toolchains; need to clarify if this ok in the long term
         file("plugin1/settings.gradle") << """
-            plugins {
-                id 'org.gradle.toolchains.foojay-resolver-convention' version '0.4.0'
-            }
-            
+            $FOOJAY_PLUGIN_SECTION
+
             rootProject.name = 'plugin1'
         """
         file("plugin1/build.gradle") << """
             plugins {
                 id 'java-gradle-plugin'
             }
-            
-            java {
-                toolchain {
-                    languageVersion = JavaLanguageVersion.of(11)
-                }
-            }
-            
+
+            $TOOLCHAIN_WITH_VERSION
+
             gradlePlugin {
                 plugins {
                     simplePlugin {
@@ -209,9 +198,9 @@ class JavaToolchainDownloadComplexProjectSoakTest extends AbstractIntegrationSpe
 
             import org.gradle.api.Plugin;
             import org.gradle.api.Project;
-            
+
             public class Plugin1 implements Plugin<Project> {
-            
+
                 @Override
                 public void apply(Project project) {
                     System.out.println("Plugin1 applied!");

--- a/subprojects/soak/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadSoakTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadSoakTest.groovy
@@ -23,26 +23,31 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 
 class JavaToolchainDownloadSoakTest extends AbstractIntegrationSpec {
 
-    private static final int VERSION = 17
+    public static final int VERSION = 17
     private static final String ECLIPSE_DISTRO_NAME = "eclipse_adoptium"
-
-    def setup() {
-        settingsFile << """
+    public static final String FOOJAY_PLUGIN_SECTION = """
             plugins {
                 id 'org.gradle.toolchains.foojay-resolver-convention' version '0.4.0'
             }
         """
+
+    public static final String TOOLCHAIN_WITH_VERSION = """
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of($VERSION)
+                }
+            }
+        """
+
+    def setup() {
+        settingsFile << FOOJAY_PLUGIN_SECTION
 
         buildFile << """
             plugins {
                 id "java"
             }
 
-            java {
-                toolchain {
-                    languageVersion = JavaLanguageVersion.of($VERSION)
-                }
-            }
+            $TOOLCHAIN_WITH_VERSION
         """
 
         file("src/main/java/Foo.java") << "public class Foo {}"

--- a/subprojects/soak/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadSoakTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadSoakTest.groovy
@@ -23,6 +23,9 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 
 class JavaToolchainDownloadSoakTest extends AbstractIntegrationSpec {
 
+    private static final int VERSION = 17
+    private static final String ECLIPSE_DISTRO_NAME = "eclipse_adoptium"
+
     def setup() {
         settingsFile << """
             plugins {
@@ -37,7 +40,7 @@ class JavaToolchainDownloadSoakTest extends AbstractIntegrationSpec {
 
             java {
                 toolchain {
-                    languageVersion = JavaLanguageVersion.of(16)
+                    languageVersion = JavaLanguageVersion.of($VERSION)
                 }
             }
         """
@@ -45,7 +48,6 @@ class JavaToolchainDownloadSoakTest extends AbstractIntegrationSpec {
         file("src/main/java/Foo.java") << "public class Foo {}"
 
         executer.requireOwnGradleUserHomeDir()
-        executer
             .withToolchainDownloadEnabled()
     }
 
@@ -57,7 +59,7 @@ class JavaToolchainDownloadSoakTest extends AbstractIntegrationSpec {
 
         then:
         javaClassFile("Foo.class").assertExists()
-        assertJdkWasDownloaded("eclipse_foundation")
+        assertJdkWasDownloaded(ECLIPSE_DISTRO_NAME)
     }
 
     def "can download missing j9 jdk automatically"() {
@@ -87,7 +89,7 @@ class JavaToolchainDownloadSoakTest extends AbstractIntegrationSpec {
 
         then: "suitable JDK gets auto-provisioned"
         javaClassFile("Foo.class").assertExists()
-        assertJdkWasDownloaded("eclipse_foundation")
+        assertJdkWasDownloaded(ECLIPSE_DISTRO_NAME)
 
         when: "the marker file of the auto-provisioned JDK is deleted, making the JDK not detectable"
         //delete marker file to make the previously downloaded installation undetectable
@@ -112,7 +114,7 @@ class JavaToolchainDownloadSoakTest extends AbstractIntegrationSpec {
 
         then: "suitable JDK gets auto-provisioned"
         javaClassFile("Foo.class").assertExists()
-        assertJdkWasDownloaded("eclipse_foundation")
+        assertJdkWasDownloaded(ECLIPSE_DISTRO_NAME)
 
         when: "build has no toolchain repositories configured"
         settingsFile.text = ''
@@ -128,7 +130,7 @@ class JavaToolchainDownloadSoakTest extends AbstractIntegrationSpec {
 
     private void assertJdkWasDownloaded(String implementation) {
         assert executer.gradleUserHomeDir.file("jdks").listFiles({ file ->
-            file.name.contains("-16-") && file.name.contains(implementation)
+            file.name.contains("-$VERSION-") && file.name.contains(implementation)
         } as FileFilter)
     }
 


### PR DESCRIPTION
This version is available on every architecture and OS we test. Specifically MacOS aarch64 was causing a problem here.

- #23554
