### PR TITLE
Fix optional dependencies mapped to runtime scope

### DIFF
--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishFeaturesJavaPluginIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishFeaturesJavaPluginIntegTest.groovy
@@ -57,10 +57,10 @@ class MavenPublishFeaturesJavaPluginIntegTest extends AbstractMavenPublishFeatur
             dependency('org', 'optionaldep', '1.0')
             noMoreDependencies()
         }
-        javaLibrary.parsedPom.scope('compile') {
+        javaLibrary.parsedPom.scope('runtime') {
             assertOptionalDependencies('org:optionaldep:1.0')
         }
-        javaLibrary.parsedPom.hasNoScope('runtime')
+        javaLibrary.parsedPom.hasNoScope('compile')
 
         and:
         resolveArtifacts(javaLibrary) { expectFiles "publishTest-1.9.jar" }
@@ -119,17 +119,17 @@ class MavenPublishFeaturesJavaPluginIntegTest extends AbstractMavenPublishFeatur
             noMoreDependencies()
         }
         javaLibrary.parsedModuleMetadata.variant("featureApiElements") {
+            assert files*.name == ["${name}-${version}.jar"]
             noMoreDependencies()
         }
         javaLibrary.parsedModuleMetadata.variant("featureRuntimeElements") {
-            assert files*.name == ["${name}-${version}.jar"]
             dependency('org', 'optionaldep', '1.0')
             noMoreDependencies()
         }
-        javaLibrary.parsedPom.scope('compile') {
+        javaLibrary.parsedPom.scope('runtime') {
             assertOptionalDependencies('org:optionaldep:1.0')
         }
-        javaLibrary.parsedPom.hasNoScope('runtime')
+        javaLibrary.parsedPom.hasNoScope('compile')
 
         and:
         resolveArtifacts(javaLibrary) { expectFiles "${name}-${version}.jar" }

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenScopesTestIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenScopesTestIntegTest.groovy
@@ -35,7 +35,7 @@ class MavenScopesTestIntegTest extends AbstractIntegrationSpec {
             configurations {
                 custom {
                     attributes {
-                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, org.gradle.api.internal.artifacts.JavaEcosystemSupport.DEPRECATED_JAVA_RUNTIME_JARS))
+                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, Usage.JAVA_RUNTIME))
                     }
                 }
             }
@@ -96,7 +96,7 @@ class MavenScopesTestIntegTest extends AbstractIntegrationSpec {
             configurations {
                 custom {
                     attributes {
-                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, org.gradle.api.internal.artifacts.JavaEcosystemSupport.DEPRECATED_JAVA_RUNTIME_JARS))
+                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, Usage.JAVA_RUNTIME))
                     }
                 }
             }
@@ -161,7 +161,7 @@ class MavenScopesTestIntegTest extends AbstractIntegrationSpec {
             configurations {
                 custom {
                     attributes {
-                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, org.gradle.api.internal.artifacts.JavaEcosystemSupport.DEPRECATED_JAVA_RUNTIME_JARS))
+                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, Usage.JAVA_RUNTIME))
                     }
                 }
             }
@@ -226,7 +226,7 @@ class MavenScopesTestIntegTest extends AbstractIntegrationSpec {
             configurations {
                 custom {
                     attributes {
-                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, org.gradle.api.internal.artifacts.JavaEcosystemSupport.DEPRECATED_JAVA_RUNTIME_JARS))
+                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, Usage.JAVA_RUNTIME))
                     }
                 }
             }
@@ -295,7 +295,7 @@ class MavenScopesTestIntegTest extends AbstractIntegrationSpec {
             configurations {
                 custom {
                     attributes {
-                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, org.gradle.api.internal.artifacts.JavaEcosystemSupport.DEPRECATED_JAVA_RUNTIME_JARS))
+                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, Usage.JAVA_RUNTIME))
                     }
                 }
             }
@@ -357,7 +357,7 @@ class MavenScopesTestIntegTest extends AbstractIntegrationSpec {
             configurations {
                 custom {
                     attributes {
-                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, org.gradle.api.internal.artifacts.JavaEcosystemSupport.DEPRECATED_JAVA_RUNTIME_JARS))
+                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, Usage.JAVA_RUNTIME))
                     }
                 }
             }

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenScopesTestIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenScopesTestIntegTest.groovy
@@ -22,12 +22,13 @@ import org.gradle.test.fixtures.maven.MavenJavaModule
 import org.gradle.test.fixtures.maven.MavenModule
 
 class MavenScopesTestIntegTest extends AbstractIntegrationSpec {
-    def "test adding custom variant with dependency mapped to Maven runtime scope"() {
-        given:
+    def setup() {
         settingsFile << "rootProject.name = 'publishTest'"
         buildFile << """
-            apply plugin: 'maven-publish'
-            apply plugin: 'java-library'
+            plugins {
+                id 'maven-publish'
+                id 'java-library'
+            }
 
             group = 'org.gradle.test'
             version = '1.9'
@@ -39,11 +40,16 @@ class MavenScopesTestIntegTest extends AbstractIntegrationSpec {
                     }
                 }
             }
-
+            
             dependencies {
                 custom 'log4j:log4j:1.2.17'
             }
+        """
+    }
 
+    def "test adding custom variant with dependency mapped to Maven runtime scope"() {
+        given:
+        buildFile << """
             components.java.addVariantsFromConfiguration(configurations.custom) {
                 mapToMavenScope('runtime')
             }
@@ -85,26 +91,7 @@ class MavenScopesTestIntegTest extends AbstractIntegrationSpec {
 
     def "test adding custom variant with dependency mapped to Maven runtime scope, then changed to compile scope"() {
         given:
-        settingsFile << "rootProject.name = 'publishTest'"
         buildFile << """
-            apply plugin: 'maven-publish'
-            apply plugin: 'java-library'
-
-            group = 'org.gradle.test'
-            version = '1.9'
-
-            configurations {
-                custom {
-                    attributes {
-                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, Usage.JAVA_RUNTIME))
-                    }
-                }
-            }
-
-            dependencies {
-                custom 'log4j:log4j:1.2.17'
-            }
-
             components.java.addVariantsFromConfiguration(configurations.custom) {
                 mapToMavenScope('runtime')
             }
@@ -150,26 +137,7 @@ class MavenScopesTestIntegTest extends AbstractIntegrationSpec {
 
     def "test adding custom variant with dependency mapped to Maven compile scope, then changed to runtime scope"() {
         given:
-        settingsFile << "rootProject.name = 'publishTest'"
         buildFile << """
-            apply plugin: 'maven-publish'
-            apply plugin: 'java-library'
-
-            group = 'org.gradle.test'
-            version = '1.9'
-
-            configurations {
-                custom {
-                    attributes {
-                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, Usage.JAVA_RUNTIME))
-                    }
-                }
-            }
-
-            dependencies {
-                custom 'log4j:log4j:1.2.17'
-            }
-
             components.java.addVariantsFromConfiguration(configurations.custom) {
                 mapToMavenScope('compile')
             }
@@ -215,26 +183,7 @@ class MavenScopesTestIntegTest extends AbstractIntegrationSpec {
 
     def "test adding custom variant with dependency mapped to Maven compile scope, then changed to runtime scope, then changed back to compile"() {
         given:
-        settingsFile << "rootProject.name = 'publishTest'"
         buildFile << """
-            apply plugin: 'maven-publish'
-            apply plugin: 'java-library'
-
-            group = 'org.gradle.test'
-            version = '1.9'
-
-            configurations {
-                custom {
-                    attributes {
-                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, Usage.JAVA_RUNTIME))
-                    }
-                }
-            }
-
-            dependencies {
-                custom 'log4j:log4j:1.2.17'
-            }
-
             components.java.addVariantsFromConfiguration(configurations.custom) {
                 mapToMavenScope('compile')
             }
@@ -284,26 +233,7 @@ class MavenScopesTestIntegTest extends AbstractIntegrationSpec {
 
     def "test adding custom variant with dependency mapped to optional Maven runtime scope"() {
         given:
-        settingsFile << "rootProject.name = 'publishTest'"
         buildFile << """
-            apply plugin: 'maven-publish'
-            apply plugin: 'java-library'
-
-            group = 'org.gradle.test'
-            version = '1.9'
-
-            configurations {
-                custom {
-                    attributes {
-                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, Usage.JAVA_RUNTIME))
-                    }
-                }
-            }
-
-            dependencies {
-                custom 'log4j:log4j:1.2.17'
-            }
-
             components.java.addVariantsFromConfiguration(configurations.custom) {
                 mapToMavenScope('runtime')
                 mapToOptional()
@@ -346,26 +276,7 @@ class MavenScopesTestIntegTest extends AbstractIntegrationSpec {
 
     def "test adding custom variant with dependency mapped to optional with no explicit Maven scope"() {
         given:
-        settingsFile << "rootProject.name = 'publishTest'"
         buildFile << """
-            apply plugin: 'maven-publish'
-            apply plugin: 'java-library'
-
-            group = 'org.gradle.test'
-            version = '1.9'
-
-            configurations {
-                custom {
-                    attributes {
-                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, Usage.JAVA_RUNTIME))
-                    }
-                }
-            }
-
-            dependencies {
-                custom 'log4j:log4j:1.2.17'
-            }
-
             components.java.addVariantsFromConfiguration(configurations.custom) {
                 mapToOptional()
             }

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenScopesTestIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenScopesTestIntegTest.groovy
@@ -1,0 +1,411 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.publish.maven
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.test.fixtures.maven.MavenFileModule
+import org.gradle.test.fixtures.maven.MavenJavaModule
+import org.gradle.test.fixtures.maven.MavenModule
+
+class MavenScopesTestIntegTest extends AbstractIntegrationSpec {
+    def "test adding custom variant with dependency mapped to Maven runtime scope"() {
+        given:
+        settingsFile << "rootProject.name = 'publishTest'"
+        buildFile << """
+            apply plugin: 'maven-publish'
+            apply plugin: 'java-library'
+
+            group = 'org.gradle.test'
+            version = '1.9'
+
+            configurations {
+                custom {
+                    attributes {
+                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, org.gradle.api.internal.artifacts.JavaEcosystemSupport.DEPRECATED_JAVA_RUNTIME_JARS))
+                    }
+                }
+            }
+
+            dependencies {
+                custom 'log4j:log4j:1.2.17'
+            }
+
+            components.java.addVariantsFromConfiguration(configurations.custom) {
+                mapToMavenScope('runtime')
+            }
+
+            publishing {
+                publications {
+                    myPub(MavenPublication) {
+                        from components.java
+                    }
+                }
+                repositories {
+                    maven { url "${mavenRepo.uri}" }
+                }
+            }
+            """
+
+        when:
+        succeeds "publishMyPubPublicationToMavenRepository"
+        MavenModule mavenMetadata = mavenRepo.module("org.gradle.test", "publishTest", "1.9")
+        MavenJavaModule gmmMetadata = javaLibrary(mavenMetadata)
+
+        then:
+        gmmMetadata.parsedModuleMetadata.variant("apiElements") {
+            noMoreDependencies()
+        }
+        gmmMetadata.parsedModuleMetadata.variant("runtimeElements") {
+            noMoreDependencies()
+        }
+        gmmMetadata.parsedModuleMetadata.variant("custom") {
+            dependency('log4j:log4j:1.2.17').exists()
+            noMoreDependencies()
+        }
+
+        and:
+        mavenMetadata.assertPublished()
+        mavenMetadata.parsedPom.scopes.size() == 1
+        mavenMetadata.parsedPom.scopes.runtime.assertDependsOn("log4j:log4j:1.2.17")
+    }
+
+    def "test adding custom variant with dependency mapped to Maven runtime scope, then changed to compile scope"() {
+        given:
+        settingsFile << "rootProject.name = 'publishTest'"
+        buildFile << """
+            apply plugin: 'maven-publish'
+            apply plugin: 'java-library'
+
+            group = 'org.gradle.test'
+            version = '1.9'
+
+            configurations {
+                custom {
+                    attributes {
+                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, org.gradle.api.internal.artifacts.JavaEcosystemSupport.DEPRECATED_JAVA_RUNTIME_JARS))
+                    }
+                }
+            }
+
+            dependencies {
+                custom 'log4j:log4j:1.2.17'
+            }
+
+            components.java.addVariantsFromConfiguration(configurations.custom) {
+                mapToMavenScope('runtime')
+            }
+
+            components.java.withVariantsFromConfiguration(configurations.custom) {
+                mapToMavenScope('compile')
+            }
+
+            publishing {
+                publications {
+                    myPub(MavenPublication) {
+                        from components.java
+                    }
+                }
+                repositories {
+                    maven { url "${mavenRepo.uri}" }
+                }
+            }
+            """
+
+        when:
+        succeeds "publishMyPubPublicationToMavenRepository"
+        MavenModule mavenMetadata = mavenRepo.module("org.gradle.test", "publishTest", "1.9")
+        MavenJavaModule gmmMetadata = javaLibrary(mavenMetadata)
+
+        then:
+        gmmMetadata.parsedModuleMetadata.variant("apiElements") {
+            noMoreDependencies()
+        }
+        gmmMetadata.parsedModuleMetadata.variant("runtimeElements") {
+            noMoreDependencies()
+        }
+        gmmMetadata.parsedModuleMetadata.variant("custom") {
+            dependency('log4j:log4j:1.2.17').exists()
+            noMoreDependencies()
+        }
+
+        and:
+        mavenMetadata.assertPublished()
+        mavenMetadata.parsedPom.scopes.size() == 1
+        mavenMetadata.parsedPom.scopes.compile.assertDependsOn("log4j:log4j:1.2.17")
+    }
+
+    def "test adding custom variant with dependency mapped to Maven compile scope, then changed to runtime scope"() {
+        given:
+        settingsFile << "rootProject.name = 'publishTest'"
+        buildFile << """
+            apply plugin: 'maven-publish'
+            apply plugin: 'java-library'
+
+            group = 'org.gradle.test'
+            version = '1.9'
+
+            configurations {
+                custom {
+                    attributes {
+                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, org.gradle.api.internal.artifacts.JavaEcosystemSupport.DEPRECATED_JAVA_RUNTIME_JARS))
+                    }
+                }
+            }
+
+            dependencies {
+                custom 'log4j:log4j:1.2.17'
+            }
+
+            components.java.addVariantsFromConfiguration(configurations.custom) {
+                mapToMavenScope('compile')
+            }
+
+            components.java.withVariantsFromConfiguration(configurations.custom) {
+                mapToMavenScope('runtime')
+            }
+
+            publishing {
+                publications {
+                    myPub(MavenPublication) {
+                        from components.java
+                    }
+                }
+                repositories {
+                    maven { url "${mavenRepo.uri}" }
+                }
+            }
+            """
+
+        when:
+        succeeds "publishMyPubPublicationToMavenRepository"
+        MavenModule mavenMetadata = mavenRepo.module("org.gradle.test", "publishTest", "1.9")
+        MavenJavaModule gmmMetadata = javaLibrary(mavenMetadata)
+
+        then:
+        gmmMetadata.parsedModuleMetadata.variant("apiElements") {
+            noMoreDependencies()
+        }
+        gmmMetadata.parsedModuleMetadata.variant("runtimeElements") {
+            noMoreDependencies()
+        }
+        gmmMetadata.parsedModuleMetadata.variant("custom") {
+            dependency('log4j:log4j:1.2.17').exists()
+            noMoreDependencies()
+        }
+
+        and:
+        mavenMetadata.assertPublished()
+        mavenMetadata.parsedPom.scopes.size() == 1
+        mavenMetadata.parsedPom.scopes.runtime.assertDependsOn("log4j:log4j:1.2.17")
+    }
+
+    def "test adding custom variant with dependency mapped to Maven compile scope, then changed to runtime scope, then changed back to compile"() {
+        given:
+        settingsFile << "rootProject.name = 'publishTest'"
+        buildFile << """
+            apply plugin: 'maven-publish'
+            apply plugin: 'java-library'
+
+            group = 'org.gradle.test'
+            version = '1.9'
+
+            configurations {
+                custom {
+                    attributes {
+                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, org.gradle.api.internal.artifacts.JavaEcosystemSupport.DEPRECATED_JAVA_RUNTIME_JARS))
+                    }
+                }
+            }
+
+            dependencies {
+                custom 'log4j:log4j:1.2.17'
+            }
+
+            components.java.addVariantsFromConfiguration(configurations.custom) {
+                mapToMavenScope('compile')
+            }
+
+            components.java.withVariantsFromConfiguration(configurations.custom) {
+                mapToMavenScope('runtime')
+            }
+
+            components.java.withVariantsFromConfiguration(configurations.custom) {
+                mapToMavenScope('compile')
+            }
+
+            publishing {
+                publications {
+                    myPub(MavenPublication) {
+                        from components.java
+                    }
+                }
+                repositories {
+                    maven { url "${mavenRepo.uri}" }
+                }
+            }
+            """
+
+        when:
+        succeeds "publishMyPubPublicationToMavenRepository"
+        MavenModule mavenMetadata = mavenRepo.module("org.gradle.test", "publishTest", "1.9")
+        MavenJavaModule gmmMetadata = javaLibrary(mavenMetadata)
+
+        then:
+        gmmMetadata.parsedModuleMetadata.variant("apiElements") {
+            noMoreDependencies()
+        }
+        gmmMetadata.parsedModuleMetadata.variant("runtimeElements") {
+            noMoreDependencies()
+        }
+        gmmMetadata.parsedModuleMetadata.variant("custom") {
+            dependency('log4j:log4j:1.2.17').exists()
+            noMoreDependencies()
+        }
+
+        and:
+        mavenMetadata.assertPublished()
+        mavenMetadata.parsedPom.scopes.size() == 1
+        mavenMetadata.parsedPom.scopes.compile.assertDependsOn("log4j:log4j:1.2.17")
+    }
+
+    def "test adding custom variant with dependency mapped to optional Maven runtime scope"() {
+        given:
+        settingsFile << "rootProject.name = 'publishTest'"
+        buildFile << """
+            apply plugin: 'maven-publish'
+            apply plugin: 'java-library'
+
+            group = 'org.gradle.test'
+            version = '1.9'
+
+            configurations {
+                custom {
+                    attributes {
+                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, org.gradle.api.internal.artifacts.JavaEcosystemSupport.DEPRECATED_JAVA_RUNTIME_JARS))
+                    }
+                }
+            }
+
+            dependencies {
+                custom 'log4j:log4j:1.2.17'
+            }
+
+            components.java.addVariantsFromConfiguration(configurations.custom) {
+                mapToMavenScope('runtime')
+                mapToOptional()
+            }
+
+            publishing {
+                publications {
+                    myPub(MavenPublication) {
+                        from components.java
+                    }
+                }
+                repositories {
+                    maven { url "${mavenRepo.uri}" }
+                }
+            }
+            """
+
+        when:
+        succeeds "publishMyPubPublicationToMavenRepository"
+        MavenModule mavenMetadata = mavenRepo.module("org.gradle.test", "publishTest", "1.9")
+        MavenJavaModule gmmMetadata = javaLibrary(mavenMetadata)
+
+        then:
+        gmmMetadata.parsedModuleMetadata.variant("apiElements") {
+            noMoreDependencies()
+        }
+        gmmMetadata.parsedModuleMetadata.variant("runtimeElements") {
+            noMoreDependencies()
+        }
+        gmmMetadata.parsedModuleMetadata.variant("custom") {
+            dependency('log4j:log4j:1.2.17').exists()
+            noMoreDependencies()
+        }
+
+        and:
+        mavenMetadata.assertPublished()
+        mavenMetadata.parsedPom.scopes.size() == 1
+        mavenMetadata.parsedPom.scopes.runtime.assertOptionalDependencies("log4j:log4j:1.2.17")
+    }
+
+    def "test adding custom variant with dependency mapped to optional with no explicit Maven scope"() {
+        given:
+        settingsFile << "rootProject.name = 'publishTest'"
+        buildFile << """
+            apply plugin: 'maven-publish'
+            apply plugin: 'java-library'
+
+            group = 'org.gradle.test'
+            version = '1.9'
+
+            configurations {
+                custom {
+                    attributes {
+                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, org.gradle.api.internal.artifacts.JavaEcosystemSupport.DEPRECATED_JAVA_RUNTIME_JARS))
+                    }
+                }
+            }
+
+            dependencies {
+                custom 'log4j:log4j:1.2.17'
+            }
+
+            components.java.addVariantsFromConfiguration(configurations.custom) {
+                mapToOptional()
+            }
+
+            publishing {
+                publications {
+                    myPub(MavenPublication) {
+                        from components.java
+                    }
+                }
+                repositories {
+                    maven { url "${mavenRepo.uri}" }
+                }
+            }
+            """
+
+        when:
+        succeeds "publishMyPubPublicationToMavenRepository"
+        MavenModule mavenMetadata = mavenRepo.module("org.gradle.test", "publishTest", "1.9")
+        MavenJavaModule gmmMetadata = javaLibrary(mavenMetadata)
+
+        then:
+        gmmMetadata.parsedModuleMetadata.variant("apiElements") {
+            noMoreDependencies()
+        }
+        gmmMetadata.parsedModuleMetadata.variant("runtimeElements") {
+            noMoreDependencies()
+        }
+        gmmMetadata.parsedModuleMetadata.variant("custom") {
+            dependency('log4j:log4j:1.2.17').exists()
+            noMoreDependencies()
+        }
+
+        and:
+        mavenMetadata.assertPublished()
+        mavenMetadata.parsedPom.scopes.size() == 1
+        mavenMetadata.parsedPom.scopes.compile.assertOptionalDependencies("log4j:log4j:1.2.17")
+    }
+
+    private static MavenJavaModule javaLibrary(MavenFileModule mavenFileModule, List<String> features = [MavenJavaModule.MAIN_FEATURE], boolean withDocumentation = false) {
+        return new MavenJavaModule(mavenFileModule, features, withDocumentation)
+    }
+}

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPom.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPom.java
@@ -273,8 +273,13 @@ public class DefaultMavenPom implements MavenPomInternal, MavenPomLicenseSpec, M
     }
 
     @Override
-    public Set<MavenDependencyInternal> getOptionalDependencies() {
-        return mavenPublication.getOptionalDependencies();
+    public Set<MavenDependencyInternal> getOptionalRuntimeDependencies() {
+        return mavenPublication.getOptionalRuntimeDependencies();
+    }
+
+    @Override
+    public Set<MavenDependencyInternal> getOptionalApiDependencies() {
+        return mavenPublication.getOptionalApiDependencies();
     }
 
     @Override

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -147,7 +147,8 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
     private final PublicationArtifactSet<MavenArtifact> publishableArtifacts;
     private final Set<MavenDependencyInternal> runtimeDependencies = new LinkedHashSet<>();
     private final Set<MavenDependencyInternal> apiDependencies = new LinkedHashSet<>();
-    private final Set<MavenDependencyInternal> optionalDependencies = new LinkedHashSet<>();
+    private final Set<MavenDependencyInternal> optionalRuntimeDependencies = new LinkedHashSet<>();
+    private final Set<MavenDependencyInternal> optionalApiDependencies = new LinkedHashSet<>();
     private final Set<MavenDependency> runtimeDependencyConstraints = new LinkedHashSet<>();
     private final Set<MavenDependency> apiDependencyConstraints = new LinkedHashSet<>();
     private final Set<MavenDependency> importDependencyConstraints = new LinkedHashSet<>();
@@ -438,9 +439,9 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
                 case runtime:
                     return runtimeDependencies;
                 case compile_optional:
+                    return optionalApiDependencies;
                 case runtime_optional:
-                    // currently single list of optionals
-                    return optionalDependencies;
+                    return optionalRuntimeDependencies;
             }
         }
         // legacy mode for internal APIs
@@ -641,9 +642,15 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
     }
 
     @Override
-    public Set<MavenDependencyInternal> getOptionalDependencies() {
+    public Set<MavenDependencyInternal> getOptionalRuntimeDependencies() {
         populateFromComponent();
-        return optionalDependencies;
+        return optionalRuntimeDependencies;
+    }
+
+    @Override
+    public Set<MavenDependencyInternal> getOptionalApiDependencies() {
+        populateFromComponent();
+        return optionalApiDependencies;
     }
 
     @Override

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/MavenPomInternal.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/MavenPomInternal.java
@@ -67,7 +67,9 @@ public interface MavenPomInternal extends MavenPom {
 
     Set<MavenDependencyInternal> getRuntimeDependencies();
 
-    Set<MavenDependencyInternal> getOptionalDependencies();
+    Set<MavenDependencyInternal> getOptionalApiDependencies();
+
+    Set<MavenDependencyInternal> getOptionalRuntimeDependencies();
 
     Action<XmlProvider> getXmlAction();
 

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/MavenPublicationInternal.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/MavenPublicationInternal.java
@@ -50,7 +50,9 @@ public interface MavenPublicationInternal extends MavenPublication, PublicationI
 
     Set<MavenDependencyInternal> getRuntimeDependencies();
 
-    Set<MavenDependencyInternal> getOptionalDependencies();
+    Set<MavenDependencyInternal> getOptionalApiDependencies();
+
+    Set<MavenDependencyInternal> getOptionalRuntimeDependencies();
 
     MavenNormalizedPublication asNormalisedPublication();
 
@@ -69,4 +71,3 @@ public interface MavenPublicationInternal extends MavenPublication, PublicationI
 
     boolean writeGradleMetadataMarker();
 }
-

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/tasks/MavenPomFileGenerator.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/tasks/MavenPomFileGenerator.java
@@ -271,13 +271,15 @@ public class MavenPomFileGenerator {
         addDependencyManagement((MavenDependencyInternal) dependency, "import");
     }
 
+    public void addOptionalRuntimeDependency(MavenDependencyInternal optionalDependency) {
+        addDependency(optionalDependency, "runtime", true);
+    }
+
     public void addRuntimeDependency(MavenDependencyInternal dependency) {
         addDependency(dependency, "runtime");
     }
 
-    public void addOptionalDependency(MavenDependencyInternal optionalDependency) {
-        // For Maven we don't really know if an optional dependency is required for runtime or compile
-        // so we use the safest: compile
+    public void addOptionalApiDependency(MavenDependencyInternal optionalDependency) {
         addDependency(optionalDependency, "compile", true);
     }
 

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/GenerateMavenPom.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/GenerateMavenPom.java
@@ -155,8 +155,11 @@ public abstract class GenerateMavenPom extends DefaultTask {
         for (MavenDependencyInternal runtimeDependency : pomInternal.getRuntimeDependencies()) {
             pomGenerator.addRuntimeDependency(runtimeDependency);
         }
-        for (MavenDependencyInternal optionalDependency : pomInternal.getOptionalDependencies()) {
-            pomGenerator.addOptionalDependency(optionalDependency);
+        for (MavenDependencyInternal optionalDependency : pomInternal.getOptionalApiDependencies()) {
+            pomGenerator.addOptionalApiDependency(optionalDependency);
+        }
+        for (MavenDependencyInternal optionalDependency : pomInternal.getOptionalRuntimeDependencies()) {
+            pomGenerator.addOptionalRuntimeDependency(optionalDependency);
         }
 
         pomGenerator.withXml(pomInternal.getXmlAction());

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/fixtures/AbstractJavaTestFixturesIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/fixtures/AbstractJavaTestFixturesIntegrationTest.groovy
@@ -290,7 +290,7 @@ hamcrest-core-1.3.jar
 
         and: "appears as optional dependency in Maven POM"
         MavenPom pom = new MavenPom(file("build/repo/com/acme/root/1.3/root-1.3.pom"))
-        pom.scope("compile") {
+        pom.scope("runtime") {
             assertOptionalDependencies(
                 "org.apache.commons:commons-lang3:3.9"
             )

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/android-kotlin-library-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/android-kotlin-library-1.0.pom
@@ -16,7 +16,7 @@
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib</artifactId>
       <version>1.7.10</version>
-      <scope>compile</scope>
+      <scope>runtime</scope>
       <optional>true</optional>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Optional runtime and optional compile scoped dependencies are now kept in separate collections.  Previously there was a single collection of optional dependencies which was always mapped to the compile scope regardless of the specified mapping.  Now the specified mapping is honored.

This changes the scope mapping we use to write **optional** dependencies in a POM to be:

`implementation` dependencies -> `runtime` scope
`api` dependencies -> `compile` scope

The dependencies in GMM files are updated to be consistent with this:

`implementation` -> `RuntimePublication`
`api` -> `ApiPublication` 

Previously, this feature was incomplete/incorrect and mapped all optional deps to maven `compile` scope, regardless of which Gradle configuration contained them.