### PR TITLE
Slightly increase heap size for arch test

### DIFF
--- a/subprojects/architecture-test/build.gradle.kts
+++ b/subprojects/architecture-test/build.gradle.kts
@@ -45,7 +45,7 @@ val sortAcceptedApiChanges = tasks.register<gradlebuild.binarycompatibility.Sort
 
 tasks.test {
     // Looks like loading all the classes requires more than the default 512M
-    maxHeapSize = "900M"
+    maxHeapSize = "1g"
 
     // Only use one fork, so freezing doesn't have concurrency issues
     maxParallelForks = 1


### PR DESCRIPTION
Seems like it needs more.

I just saw another occurrence: https://builds.gradle.org/repository/download/Gradle_Master_Check_Platform_14_bucket5/60497616:id/.teamcity/gradle-logs/report-architecture-test-test.zip!/classes/Gradle%2320Test%2320Executor%232023.html#failed%20to%20execute%20tests