### PR TITLE
Ensure and prove kts script compilation errors are reported in file order

### DIFF
--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
@@ -643,18 +643,10 @@ class GradleKotlinDslIntegrationTest : AbstractPluginIntegrationTest() {
                     """
                     |  Line 01: println(foo)
                     |                   ^ Unresolved reference: foo
-                    """.trimMargin()
-                ),
-
-                containsString(
-                    """
+                    |
                     |  Line 06: println("foo").bar.bazar
                     |                          ^ Unresolved reference: bar
-                    """.trimMargin()
-                ),
-
-                containsString(
-                    """
+                    |
                     |  Line 10: println(cathedral)
                     |                   ^ Unresolved reference: cathedral
                     """.trimMargin()

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
@@ -464,10 +464,16 @@ data class ScriptCompilationError(val message: String, val location: CompilerMes
 
 
 internal
-data class ScriptCompilationException(val errors: List<ScriptCompilationError>) : RuntimeException() {
+data class ScriptCompilationException(private val scriptCompilationErrors: List<ScriptCompilationError>) : RuntimeException() {
+
+    val errors: List<ScriptCompilationError> by unsafeLazy {
+        scriptCompilationErrors.filter { it.location == null } +
+            scriptCompilationErrors.filter { it.location != null }
+                .sortedBy { it.location!!.line }
+    }
 
     init {
-        require(errors.isNotEmpty())
+        require(scriptCompilationErrors.isNotEmpty())
     }
 
     val firstErrorLine


### PR DESCRIPTION
It happened that the first error presented on the console was not the first one in the file.
This change makes it easier to work with script compilation errors.