### PR TITLE
Remove unnecessary inner interface and improve javadoc on local plugin resolution types

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/plugins/AbstractPluginBuildIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/plugins/AbstractPluginBuildIntegrationTest.groovy
@@ -41,6 +41,10 @@ abstract class AbstractPluginBuildIntegrationTest extends AbstractIntegrationSpe
         final TestFile projectPluginFile
 
         PluginBuildFixture(String buildName, boolean useKotlinDSL) {
+            this(null, buildName, useKotlinDSL)
+        }
+
+        PluginBuildFixture(String rootDir, String buildName, boolean useKotlinDSL) {
             def fileExtension = useKotlinDSL ? '.gradle.kts' : '.gradle'
             def sourceDirectory = useKotlinDSL ? 'kotlin' : 'groovy'
             def pluginPluginId = useKotlinDSL
@@ -50,8 +54,8 @@ abstract class AbstractPluginBuildIntegrationTest extends AbstractIntegrationSpe
             this.buildName = buildName
             this.settingsPluginId = "${buildName}.settings-plugin"
             this.projectPluginId = "${buildName}.project-plugin"
-            this.settingsFile = file("$buildName/settings${fileExtension}")
-            this.buildFile = file("$buildName/build${fileExtension}")
+            this.settingsFile = file("$rootDir/$buildName/settings${fileExtension}")
+            this.buildFile = file("$rootDir/$buildName/build${fileExtension}")
 
             settingsFile << """
                 rootProject.name = "$buildName"
@@ -64,11 +68,11 @@ abstract class AbstractPluginBuildIntegrationTest extends AbstractIntegrationSpe
                     gradlePluginPortal()
                 }
             """
-            settingsPluginFile = file("$buildName/src/main/$sourceDirectory/${settingsPluginId}.settings${fileExtension}")
+            settingsPluginFile = file("$rootDir/$buildName/src/main/$sourceDirectory/${settingsPluginId}.settings${fileExtension}")
             settingsPluginFile << """
                 println("$settingsPluginId applied")
             """
-            projectPluginFile = file("$buildName/src/main/$sourceDirectory/${projectPluginId}${fileExtension}")
+            projectPluginFile = file("$rootDir/$buildName/src/main/$sourceDirectory/${projectPluginId}${fileExtension}")
             projectPluginFile << """
                 println("$projectPluginId applied")
             """

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/plugins/AbstractPluginBuildIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/plugins/AbstractPluginBuildIntegrationTest.groovy
@@ -25,6 +25,10 @@ abstract class AbstractPluginBuildIntegrationTest extends AbstractIntegrationSpe
         return new PluginBuildFixture(buildName, useKotlinDSL)
     }
 
+    PluginBuildFixture pluginBuild(String rootDir, String buildName, boolean useKotlinDSL = false) {
+        return new PluginBuildFixture(rootDir, buildName, useKotlinDSL)
+    }
+
     PluginAndLibraryBuildFixture pluginAndLibraryBuild(String buildName) {
         return new PluginAndLibraryBuildFixture(pluginBuild(buildName))
     }
@@ -45,6 +49,7 @@ abstract class AbstractPluginBuildIntegrationTest extends AbstractIntegrationSpe
         }
 
         PluginBuildFixture(String rootDir, String buildName, boolean useKotlinDSL) {
+            def rootPath = rootDir == null ? '' : "$rootDir/"
             def fileExtension = useKotlinDSL ? '.gradle.kts' : '.gradle'
             def sourceDirectory = useKotlinDSL ? 'kotlin' : 'groovy'
             def pluginPluginId = useKotlinDSL
@@ -54,8 +59,8 @@ abstract class AbstractPluginBuildIntegrationTest extends AbstractIntegrationSpe
             this.buildName = buildName
             this.settingsPluginId = "${buildName}.settings-plugin"
             this.projectPluginId = "${buildName}.project-plugin"
-            this.settingsFile = file("$rootDir/$buildName/settings${fileExtension}")
-            this.buildFile = file("$rootDir/$buildName/build${fileExtension}")
+            this.settingsFile = file("$rootPath$buildName/settings${fileExtension}")
+            this.buildFile = file("$rootPath$buildName/build${fileExtension}")
 
             settingsFile << """
                 rootProject.name = "$buildName"
@@ -68,11 +73,11 @@ abstract class AbstractPluginBuildIntegrationTest extends AbstractIntegrationSpe
                     gradlePluginPortal()
                 }
             """
-            settingsPluginFile = file("$rootDir/$buildName/src/main/$sourceDirectory/${settingsPluginId}.settings${fileExtension}")
+            settingsPluginFile = file("$rootPath$buildName/src/main/$sourceDirectory/${settingsPluginId}.settings${fileExtension}")
             settingsPluginFile << """
                 println("$settingsPluginId applied")
             """
-            projectPluginFile = file("$rootDir/$buildName/src/main/$sourceDirectory/${projectPluginId}${fileExtension}")
+            projectPluginFile = file("$rootPath$buildName/src/main/$sourceDirectory/${projectPluginId}${fileExtension}")
             projectPluginFile << """
                 println("$projectPluginId applied")
             """

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultProjectDependencyPublicationResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultProjectDependencyPublicationResolver.java
@@ -62,7 +62,7 @@ public class DefaultProjectDependencyPublicationResolver implements ProjectDepen
         projectConfigurer.configureFully(project);
 
         List<ProjectComponentPublication> publications = new ArrayList<>();
-        for (ProjectComponentPublication publication : publicationRegistry.getPublications(ProjectComponentPublication.class, project.getIdentityPath())) {
+        for (ProjectComponentPublication publication : publicationRegistry.getPublications(ProjectComponentPublication.class, project.getPath())) {
             if (!publication.isLegacy() && publication.getCoordinates(coordsType) != null) {
                 publications.add(publication);
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultProjectPublicationRegistry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultProjectPublicationRegistry.java
@@ -20,28 +20,37 @@ import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.SetMultimap;
 import org.gradle.api.internal.project.HoldsProjectState;
 import org.gradle.api.internal.project.ProjectInternal;
-import org.gradle.internal.Cast;
+import org.gradle.api.internal.project.ProjectRegistry;
 import org.gradle.util.Path;
 
+import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class DefaultProjectPublicationRegistry implements ProjectPublicationRegistry, HoldsProjectState {
-    private final SetMultimap<Path, Reference<?>> publicationsByProject = LinkedHashMultimap.create();
+    private final SetMultimap<Path, ProjectPublication> publicationsByProject = LinkedHashMultimap.create();
+    ProjectRegistry<ProjectInternal> projectRegistry;
+
+    @Inject
+    public DefaultProjectPublicationRegistry(ProjectRegistry<ProjectInternal> projectRegistry) {
+        this.projectRegistry = projectRegistry;
+    }
 
     @Override
     public <T extends ProjectPublication> Collection<T> getPublications(Class<T> type, Path projectIdentityPath) {
         synchronized (publicationsByProject) {
-            Collection<Reference<?>> projectPublications = publicationsByProject.get(projectIdentityPath);
+            Collection<ProjectPublication> projectPublications = publicationsByProject.get(projectIdentityPath);
             if (projectPublications.isEmpty()) {
                 return Collections.emptyList();
             }
             List<T> result = new ArrayList<>(projectPublications.size());
-            for (Reference<?> reference : projectPublications) {
-                if (type.isInstance(reference.get())) {
-                    result.add(type.cast(reference.get()));
+            for (ProjectPublication publication : projectPublications) {
+                if (type.isInstance(publication)) {
+                    result.add(type.cast(publication));
                 }
             }
             return result;
@@ -49,18 +58,23 @@ public class DefaultProjectPublicationRegistry implements ProjectPublicationRegi
     }
 
     @Override
-    public <T extends ProjectPublication> Collection<Reference<T>> getPublications(Class<T> type) {
+    public <T extends ProjectPublication> Map<ProjectInternal, Collection<T>> getPublicationsByProject(Class<T> type) {
         synchronized (publicationsByProject) {
-            Collection<Reference<?>> allPublications = publicationsByProject.values();
+            Collection<ProjectPublication> allPublications = publicationsByProject.values();
             if (allPublications.isEmpty()) {
-                return Collections.emptyList();
+                return Collections.emptyMap();
             }
-            List<Reference<T>> result = new ArrayList<>(allPublications.size());
-            for (Reference<?> reference : allPublications) {
-                if (type.isInstance(reference.get())) {
-                    result.add(Cast.uncheckedCast(reference));
+
+            Map<ProjectInternal, Collection<T>> result = new HashMap<>(allPublications.size());
+            publicationsByProject.entries().forEach(entry -> {
+                ProjectPublication publication = entry.getValue();
+                if (type.isInstance(publication)) {
+                    ProjectInternal project = projectRegistry.getProject(entry.getKey().getPath());
+                    Collection<T> publications = result.computeIfAbsent(project, p -> new ArrayList<>());
+                    publications.add(type.cast(publication));
                 }
-            }
+            });
+
             return result;
         }
     }
@@ -68,32 +82,12 @@ public class DefaultProjectPublicationRegistry implements ProjectPublicationRegi
     @Override
     public void registerPublication(ProjectInternal project, ProjectPublication publication) {
         synchronized (publicationsByProject) {
-            publicationsByProject.put(project.getIdentityPath(), new ReferenceImpl(publication, project));
+            publicationsByProject.put(project.getIdentityPath(), publication);
         }
     }
 
     @Override
     public void discardAll() {
         publicationsByProject.clear();
-    }
-
-    private static class ReferenceImpl implements Reference<ProjectPublication> {
-        private final ProjectPublication publication;
-        private final ProjectInternal project;
-
-        ReferenceImpl(ProjectPublication publication, ProjectInternal project) {
-            this.publication = publication;
-            this.project = project;
-        }
-
-        @Override
-        public ProjectPublication get() {
-            return publication;
-        }
-
-        @Override
-        public ProjectInternal getProducingProject() {
-            return project;
-        }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectPublicationRegistry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectPublicationRegistry.java
@@ -21,6 +21,7 @@ import org.gradle.util.Path;
 
 import javax.annotation.concurrent.ThreadSafe;
 import java.util.Collection;
+import java.util.Map;
 
 /**
  * A build scoped service that collects information on the local "publications" of each project within a build. A "publication" here means some buildable thing that the project produces that can be consumed outside of the project.
@@ -37,14 +38,10 @@ public interface ProjectPublicationRegistry {
     <T extends ProjectPublication> Collection<T> getPublications(Class<T> type, Path projectIdentityPath);
 
     /**
-     * Returns all known publications.
+     * Returns all known publications, grouped by the project that produced it.
+     *
+     * This is used for resolving plugins in local composite builds.  See {@link org.gradle.composite.internal.plugins.LocalPluginResolution LocalPluginResolution}.
      */
-    <T extends ProjectPublication> Collection<Reference<T>> getPublications(Class<T> type);
-
-    interface Reference<T> {
-        T get();
-
-        // Should use ProjectState instead
-        ProjectInternal getProducingProject();
-    }
+    @SuppressWarnings("JavadocReference")
+    <T extends ProjectPublication> Map<ProjectInternal, Collection<T>> getPublicationsByProject(Class<T> type);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectPublicationRegistry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectPublicationRegistry.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.artifacts.ivyservice.projectmodule;
 
 import org.gradle.api.internal.project.ProjectInternal;
-import org.gradle.util.Path;
 
 import javax.annotation.concurrent.ThreadSafe;
 import java.util.Collection;
@@ -35,7 +34,7 @@ public interface ProjectPublicationRegistry {
     /**
      * Returns the known publications for the given project.
      */
-    <T extends ProjectPublication> Collection<T> getPublications(Class<T> type, Path projectIdentityPath);
+    <T extends ProjectPublication> Collection<T> getPublications(Class<T> type, String projectPath);
 
     /**
      * Returns all known publications, grouped by the project that produced it.

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultProjectDependencyPublicationResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultProjectDependencyPublicationResolverTest.groovy
@@ -222,7 +222,7 @@ Found the following publications in <project>:
     private void dependentProjectHasPublications(ProjectComponentPublication... added) {
         projectDependency.dependencyProject >> project
         projectConfigurer.configureFully(project)
-        publicationRegistry.getPublications(ProjectComponentPublication, Path.path(":path")) >> (added as LinkedHashSet)
+        publicationRegistry.getPublications(ProjectComponentPublication, ":path") >> (added as LinkedHashSet)
     }
 
     private ProjectComponentPublication pub(def name, def group, def module, def version) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultProjectDependencyPublicationResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultProjectDependencyPublicationResolverTest.groovy
@@ -23,7 +23,6 @@ import org.gradle.api.internal.component.SoftwareComponentInternal
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.execution.ProjectConfigurer
 import org.gradle.internal.Describables
-import org.gradle.util.Path
 import org.gradle.util.internal.TextUtil
 import spock.lang.Specification
 
@@ -34,7 +33,7 @@ class DefaultProjectDependencyPublicationResolverTest extends Specification {
     def projectConfigurer = Mock(ProjectConfigurer)
 
     def setup() {
-        project.identityPath >> Path.path(":path")
+        project.path >> ":path"
         project.displayName >> "<project>"
     }
 

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/PublicationsBuilder.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/PublicationsBuilder.java
@@ -51,7 +51,7 @@ class PublicationsBuilder implements ToolingModelBuilder {
     private List<DefaultGradlePublication> publications(ProjectInternal project, DefaultProjectIdentifier projectIdentifier) {
         List<DefaultGradlePublication> gradlePublications = Lists.newArrayList();
 
-        for (ProjectComponentPublication projectPublication : publicationRegistry.getPublications(ProjectComponentPublication.class, project.getIdentityPath())) {
+        for (ProjectComponentPublication projectPublication : publicationRegistry.getPublications(ProjectComponentPublication.class, project.getPath())) {
             ModuleVersionIdentifier id = projectPublication.getCoordinates(ModuleVersionIdentifier.class);
             if (id != null) {
                 gradlePublications.add(new DefaultGradlePublication()

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/ProjectPublicationsBuilderTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/ProjectPublicationsBuilderTest.groovy
@@ -27,7 +27,7 @@ import org.gradle.util.Path
 class ProjectPublicationsBuilderTest extends AbstractProjectBuilderSpec {
 
     def publicationRegistry = Stub(ProjectPublicationRegistry) {
-        getPublications(ProjectComponentPublication, Path.ROOT) >> [Stub(ProjectComponentPublication) {
+        getPublications(ProjectComponentPublication, Path.ROOT.getPath()) >> [Stub(ProjectComponentPublication) {
             getCoordinates(ModuleVersionIdentifier) >> Stub(ModuleVersionIdentifier) {
                 getGroup() >> "group"
                 getName() >> "name"

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/plugins/CppBasePluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/plugins/CppBasePluginTest.groovy
@@ -146,7 +146,7 @@ class CppBasePluginTest extends Specification {
         project.evaluate()
 
         then:
-        def publications = project.services.get(ProjectPublicationRegistry).getPublications(NativeProjectPublication, project.identityPath)
+        def publications = project.services.get(ProjectPublicationRegistry).getPublications(NativeProjectPublication, project.path)
         publications.size() == 1
         publications.first().getCoordinates(SwiftPmTarget).targetName == "SomeApp"
     }

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/swift/plugins/SwiftBasePluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/swift/plugins/SwiftBasePluginTest.groovy
@@ -153,7 +153,7 @@ class SwiftBasePluginTest extends Specification {
         project.evaluate()
 
         then:
-        def publications = project.services.get(ProjectPublicationRegistry).getPublications(NativeProjectPublication, project.identityPath)
+        def publications = project.services.get(ProjectPublicationRegistry).getPublications(NativeProjectPublication, project.path)
         publications.size() == 1
         publications.first().getCoordinates(SwiftPmTarget).targetName == "SomeApp"
     }

--- a/subprojects/plugin-development/src/test/groovy/org/gradle/plugin/devel/plugins/JavaGradlePluginPluginTest.groovy
+++ b/subprojects/plugin-development/src/test/groovy/org/gradle/plugin/devel/plugins/JavaGradlePluginPluginTest.groovy
@@ -217,7 +217,7 @@ class JavaGradlePluginPluginTest extends AbstractProjectBuilderSpec {
         }
 
         then:
-        def publications = project.services.get(ProjectPublicationRegistry).getPublications(PluginPublication, project.identityPath)
+        def publications = project.services.get(ProjectPublicationRegistry).getPublications(PluginPublication, project.path)
         publications.size() == 2
         publications[0].pluginId == DefaultPluginId.of("a.plugin")
         publications[1].pluginId == DefaultPluginId.of("b.plugin")


### PR DESCRIPTION
The inner `Reference` type and its implementation seem to be unnecessary.  This PR simplifies the `ProjectPublicationRegistry` slightly by removing them.

I added tests to demonstrate the behavior when multiple plugin builds are included reusing the same project name within the build tree.  This does not appear to be a problem.