### PR TITLE
Avoid leaking build operation listeners

### DIFF
--- a/subprojects/build-events/build.gradle.kts
+++ b/subprojects/build-events/build.gradle.kts
@@ -28,8 +28,3 @@ dependencies {
         because("Requires ':toolingApiBuilders': Event handlers are in the wrong place, and should live in this project")
     }
 }
-
-// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
-tasks.configCacheIntegTest {
-    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
-}

--- a/subprojects/build-events/src/main/java/org/gradle/internal/build/event/DefaultBuildEventsListenerRegistry.java
+++ b/subprojects/build-events/src/main/java/org/gradle/internal/build/event/DefaultBuildEventsListenerRegistry.java
@@ -105,6 +105,7 @@ public class DefaultBuildEventsListenerRegistry implements BuildEventsListenerRe
         }
 
         ForwardingBuildOperationListener subscription = new ForwardingBuildOperationListener(listenerProvider, executorFactory);
+        keepAliveIfBuildService(listenerProvider);
         subscriptions.put(listenerProvider, subscription);
         buildOperationListenerManager.addListener(subscription);
         listeners.add(subscription);
@@ -117,9 +118,7 @@ public class DefaultBuildEventsListenerRegistry implements BuildEventsListenerRe
         }
 
         ForwardingBuildEventConsumer subscription = new ForwardingBuildEventConsumer(listenerProvider, executorFactory);
-        if (listenerProvider instanceof RegisteredBuildServiceProvider) {
-            ((RegisteredBuildServiceProvider) listenerProvider).keepAlive();
-        }
+        keepAliveIfBuildService(listenerProvider);
         subscriptions.put(listenerProvider, subscription);
 
         BuildEventSubscriptions eventSubscriptions = new BuildEventSubscriptions(Collections.singleton(OperationType.TASK));
@@ -131,6 +130,12 @@ public class DefaultBuildEventsListenerRegistry implements BuildEventsListenerRe
             if (listener instanceof BuildOperationListener) {
                 buildOperationListenerManager.addListener((BuildOperationListener) listener);
             }
+        }
+    }
+
+    private void keepAliveIfBuildService(Provider<?> listenerProvider) {
+        if (listenerProvider instanceof RegisteredBuildServiceProvider) {
+            ((RegisteredBuildServiceProvider) listenerProvider).keepAlive();
         }
     }
 

--- a/subprojects/resources-gcs/build.gradle.kts
+++ b/subprojects/resources-gcs/build.gradle.kts
@@ -36,8 +36,3 @@ dependencies {
 strictCompile {
     ignoreDeprecations()
 }
-
-// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
-tasks.configCacheIntegTest {
-    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
-}


### PR DESCRIPTION
...when load-after-store=true
