### PR TITLE
Add toAttributes to the Transformer

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/transform/DefaultTransformerCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/transform/DefaultTransformerCodec.kt
@@ -47,6 +47,7 @@ class DefaultTransformerCodec(
         encodePreservingSharedIdentityOf(value) {
             writeClass(value.implementationClass)
             write(value.fromAttributes)
+            write(value.toAttributes)
             writeEnum(value.inputArtifactNormalizer as InputNormalizer)
             writeEnum(value.inputArtifactDependenciesNormalizer as InputNormalizer)
             writeBoolean(value.isCacheable)
@@ -63,6 +64,7 @@ class DefaultTransformerCodec(
         return decodePreservingSharedIdentity {
             val implementationClass = readClassOf<TransformAction<*>>()
             val fromAttributes = readNonNull<ImmutableAttributes>()
+            val toAttributes = readNonNull<ImmutableAttributes>()
             val inputArtifactNormalizer = readEnum<InputNormalizer>()
             val inputArtifactDependenciesNormalizer = readEnum<InputNormalizer>()
             val isCacheable = readBoolean()
@@ -75,6 +77,7 @@ class DefaultTransformerCodec(
                 implementationClass,
                 isolatedParameters,
                 fromAttributes,
+                toAttributes,
                 inputArtifactNormalizer,
                 inputArtifactDependenciesNormalizer,
                 isCacheable,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationRegistrationFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationRegistrationFactory.java
@@ -154,6 +154,7 @@ public class DefaultTransformationRegistrationFactory implements TransformationR
             implementation,
             parameterObject,
             from,
+            to,
             FileParameterUtils.normalizerOrDefault(inputArtifactNormalizer),
             FileParameterUtils.normalizerOrDefault(dependenciesNormalizer),
             cacheable,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformer.java
@@ -99,6 +99,7 @@ public class DefaultTransformer implements Transformer {
 
     private final Class<? extends TransformAction<?>> implementationClass;
     private final ImmutableAttributes fromAttributes;
+    private final ImmutableAttributes toAttributes;
     private final FileNormalizer fileNormalizer;
     private final FileNormalizer dependenciesNormalizer;
     private final FileLookup fileLookup;
@@ -117,6 +118,7 @@ public class DefaultTransformer implements Transformer {
         Class<? extends TransformAction<?>> implementationClass,
         @Nullable TransformParameters parameterObject,
         ImmutableAttributes fromAttributes,
+        ImmutableAttributes toAttributes,
         FileNormalizer inputArtifactNormalizer,
         FileNormalizer dependenciesNormalizer,
         boolean cacheable,
@@ -138,6 +140,7 @@ public class DefaultTransformer implements Transformer {
     ) {
         this.implementationClass = implementationClass;
         this.fromAttributes = fromAttributes;
+        this.toAttributes = toAttributes;
         this.fileNormalizer = inputArtifactNormalizer;
         this.dependenciesNormalizer = dependenciesNormalizer;
         this.fileLookup = fileLookup;
@@ -162,6 +165,7 @@ public class DefaultTransformer implements Transformer {
         Class<? extends TransformAction<?>> implementationClass,
         CalculatedValueContainer<IsolatedParameters, IsolateTransformerParameters> isolatedParameters,
         ImmutableAttributes fromAttributes,
+        ImmutableAttributes toAttributes,
         FileNormalizer inputArtifactNormalizer,
         FileNormalizer dependenciesNormalizer,
         boolean cacheable,
@@ -175,6 +179,7 @@ public class DefaultTransformer implements Transformer {
     ) {
         this.implementationClass = implementationClass;
         this.fromAttributes = fromAttributes;
+        this.toAttributes = toAttributes;
         this.fileNormalizer = inputArtifactNormalizer;
         this.dependenciesNormalizer = dependenciesNormalizer;
         this.fileLookup = fileLookup;
@@ -402,6 +407,11 @@ public class DefaultTransformer implements Transformer {
     @Override
     public ImmutableAttributes getFromAttributes() {
         return fromAttributes;
+    }
+
+    @Override
+    public ImmutableAttributes getToAttributes() {
+        return toAttributes;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationStep.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationStep.java
@@ -137,6 +137,10 @@ public class TransformationStep implements Transformation, TaskDependencyContain
         return transformer.getFromAttributes();
     }
 
+    public ImmutableAttributes getToAttributes() {
+        return transformer.getToAttributes();
+    }
+
     @Override
     public String toString() {
         return transformer.getDisplayName();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/Transformer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/Transformer.java
@@ -40,6 +40,8 @@ public interface Transformer extends Describable, TaskDependencyContainer {
 
     ImmutableAttributes getFromAttributes();
 
+    ImmutableAttributes getToAttributes();
+
     /**
      * Whether the transformer requires dependencies of the transformed artifact to be injected.
      */

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactoryTest.groovy
@@ -187,6 +187,11 @@ class DefaultTransformerInvocationFactoryTest extends AbstractProjectBuilderSpec
         }
 
         @Override
+        ImmutableAttributes getToAttributes() {
+            return ImmutableAttributes.EMPTY
+        }
+
+        @Override
         boolean requiresDependencies() {
             return false
         }
@@ -205,7 +210,7 @@ class DefaultTransformerInvocationFactoryTest extends AbstractProjectBuilderSpec
         TransformationResult transform(Provider<FileSystemLocation> inputArtifactProvider, File outputDir, ArtifactTransformDependencies dependencies, InputChanges inputChanges) {
             def builder = TransformationResult.builderFor(inputArtifactProvider.get().asFile, outputDir)
             transformationAction.apply(inputArtifactProvider.get().asFile, outputDir).each {
-                builder.addOutput(it) { }
+                builder.addOutput(it) {}
             }
             return builder.build()
         }


### PR DESCRIPTION
The `toAttributes` of a transform are required for build scans in the follow ups:
- https://github.com/gradle/gradle/pull/23592
- https://github.com/gradle/gradle/pull/23486