### PR TITLE
Fix ordering of cross process close and file lock release

### DIFF
--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheAccess.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheAccess.java
@@ -177,10 +177,10 @@ public class DefaultCacheAccess implements CacheCoordinator {
 
         withOwnershipNow(() -> {
             try {
-                crossProcessCacheAccess.close();
                 if (fileLockHeldByOwner != null) {
                     fileLockHeldByOwner.run();
                 }
+                crossProcessCacheAccess.close();
 
                 // If cleanup is required, but has not already been invoked (e.g. at the end of the build session)
                 // perform cleanup on close.


### PR DESCRIPTION
We have been seeing some file lock timeout failures when opening the journal cache.  This may be because these two operations were inadvertently reordered while making other changes.