### PR TITLE
Consolidate ImmediateIntermediateJavaArtifact class hierarchy

### DIFF
--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild.test-fixtures.gradle.kts
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild.test-fixtures.gradle.kts
@@ -16,7 +16,6 @@
 
 import gradlebuild.basics.accessors.groovy
 
-import org.gradle.api.plugins.internal.JvmPluginsHelper
 import org.gradle.plugins.ide.idea.model.IdeaModel
 
 /**
@@ -67,19 +66,6 @@ if (project.name != "gradle-kotlin-dsl-accessors" && project.name != "test" /* r
         testFixturesRuntimeOnly(libs.bytebuddy)
         testFixturesRuntimeOnly(libs.cglib)
     }
-}
-
-// Add an outgoing variant allowing to select the exploded resources directory
-// as this is required at least by one project (idePlay)
-val processResources = tasks.named<ProcessResources>("processTestFixturesResources")
-testFixturesRuntimeElements.outgoing.variants.maybeCreate("resources").run {
-    attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
-    attributes.attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.LIBRARY))
-    attributes.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements.RESOURCES))
-
-    @Suppress("DEPRECATION")
-    artifact(JvmPluginsHelper.ProviderBasedIntermediateJavaArtifact(
-        ArtifactTypeDefinition.JVM_RESOURCES_DIRECTORY, processResources, processResources.map { it.destinationDir }))
 }
 
 // Do not publish test fixture, we use them only internal for now

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JvmPluginsHelper.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JvmPluginsHelper.java
@@ -35,7 +35,6 @@ import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.internal.ConventionMapping;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.artifacts.dsl.LazyPublishArtifact;
-import org.gradle.api.internal.artifacts.publish.AbstractPublishArtifact;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.FileTreeInternal;
@@ -61,8 +60,6 @@ import org.gradle.internal.jvm.JavaModuleDetector;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
 
 import javax.annotation.Nullable;
-import java.io.File;
-import java.util.Date;
 import java.util.List;
 import java.util.concurrent.Callable;
 
@@ -258,56 +255,5 @@ public class JvmPluginsHelper {
                 attributes.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objectFactory.named(LibraryElements.class, libraryElements));
             }
         };
-    }
-
-    /**
-     * A custom artifact type which allows the getFile call to be done lazily only when the
-     * artifact is actually needed.
-     */
-    public static class LazyJavaDirectoryArtifact extends AbstractPublishArtifact {
-        private final String type;
-        private final Provider<File> fileProvider;
-
-        public LazyJavaDirectoryArtifact(TaskDependencyFactory taskDependencyFactory, String type, Object dependency, Provider<File> fileProvider) {
-            super(taskDependencyFactory, dependency);
-            this.type = type;
-            this.fileProvider = fileProvider;
-        }
-
-        @Override
-        public String getName() {
-            return getFile().getName();
-        }
-
-        @Override
-        public String getExtension() {
-            return "";
-        }
-
-        @Override
-        public String getType() {
-            return type;
-        }
-
-        @Nullable
-        @Override
-        public String getClassifier() {
-            return null;
-        }
-
-        @Override
-        public Date getDate() {
-            return null;
-        }
-
-        @Override
-        public boolean shouldBePublished() {
-            return false;
-        }
-
-        @Override
-        public File getFile() {
-            return fileProvider.get();
-        }
     }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JvmPluginsHelper.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JvmPluginsHelper.java
@@ -41,7 +41,6 @@ import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.FileTreeInternal;
 import org.gradle.api.internal.plugins.DslObject;
 import org.gradle.api.internal.tasks.DefaultSourceSetOutput;
-import org.gradle.api.internal.tasks.DefaultTaskDependencyFactory;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.internal.tasks.compile.CompilationSourceDirs;
 import org.gradle.api.model.ObjectFactory;
@@ -265,12 +264,14 @@ public class JvmPluginsHelper {
      * A custom artifact type which allows the getFile call to be done lazily only when the
      * artifact is actually needed.
      */
-    public abstract static class IntermediateJavaArtifact extends AbstractPublishArtifact {
+    public static class LazyJavaDirectoryArtifact extends AbstractPublishArtifact {
         private final String type;
+        private final Provider<File> fileProvider;
 
-        public IntermediateJavaArtifact(TaskDependencyFactory taskDependencyFactory, String type, Object dependency) {
+        public LazyJavaDirectoryArtifact(TaskDependencyFactory taskDependencyFactory, String type, Object dependency, Provider<File> fileProvider) {
             super(taskDependencyFactory, dependency);
             this.type = type;
+            this.fileProvider = fileProvider;
         }
 
         @Override
@@ -302,32 +303,6 @@ public class JvmPluginsHelper {
         @Override
         public boolean shouldBePublished() {
             return false;
-        }
-    }
-
-    /**
-     * An {@link IntermediateJavaArtifact} which achieves lazy file access via a {@link Provider} instead
-     * of inheritance.
-     */
-    public static class ProviderBasedIntermediateJavaArtifact extends IntermediateJavaArtifact {
-
-        private final Provider<File> fileProvider;
-
-        // Used in the Gradle build;
-        // TODO: remove once the usage in gradlebuild.test-fixtures.gradle.kts is no longer there
-        /**
-         * @deprecated Use the overload accepting a TaskDependencyFactory
-         */
-        @Deprecated
-        public ProviderBasedIntermediateJavaArtifact(
-            String type, Object dependency, Provider<File> fileProvider
-        ) {
-            this(DefaultTaskDependencyFactory.withNoAssociatedProject(), type, dependency, fileProvider);
-        }
-
-        public ProviderBasedIntermediateJavaArtifact(TaskDependencyFactory taskDependencyFactory, String type, Object dependency, Provider<File> fileProvider) {
-            super(taskDependencyFactory, type, dependency);
-            this.fileProvider = fileProvider;
         }
 
         @Override

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JvmPluginsHelper.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JvmPluginsHelper.java
@@ -265,7 +265,7 @@ public class JvmPluginsHelper {
      * A custom artifact type which allows the getFile call to be done lazily only when the
      * artifact is actually needed.
      */
-    private abstract static class IntermediateJavaArtifact extends AbstractPublishArtifact {
+    public abstract static class IntermediateJavaArtifact extends AbstractPublishArtifact {
         private final String type;
 
         public IntermediateJavaArtifact(TaskDependencyFactory taskDependencyFactory, String type, Object dependency) {
@@ -302,24 +302,6 @@ public class JvmPluginsHelper {
         @Override
         public boolean shouldBePublished() {
             return false;
-        }
-    }
-
-    /**
-     * An {@link IntermediateJavaArtifact} with a non-lazy File.
-     */
-    public static class ImmediateIntermediateJavaArtifact extends IntermediateJavaArtifact {
-
-        private final File file;
-
-        public ImmediateIntermediateJavaArtifact(TaskDependencyFactory taskDependencyFactory, String type, Object dependency, File file) {
-            super(taskDependencyFactory, type, dependency);
-            this.file = file;
-        }
-
-        @Override
-        public File getFile() {
-            return file;
         }
     }
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/PluginAuthorServices.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/PluginAuthorServices.java
@@ -22,6 +22,7 @@ import org.gradle.api.internal.tasks.DefaultSourceSetContainer;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.jvm.internal.DefaultJvmPluginServices;
 import org.gradle.api.plugins.jvm.internal.JvmPluginServices;
+import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.internal.Describables;
@@ -54,6 +55,7 @@ public class PluginAuthorServices extends AbstractPluginServiceRegistry {
     private static class ProjectScopeServices {
         JvmPluginServices createJvmPluginServices(ConfigurationContainer configurations,
                                                   ObjectFactory objectFactory,
+                                                  ProviderFactory providerFactory,
                                                   TaskContainer tasks,
                                                   SoftwareComponentContainer components,
                                                   InstantiatorFactory instantiatorFactory) {
@@ -62,6 +64,7 @@ public class PluginAuthorServices extends AbstractPluginServiceRegistry {
                 Describables.of("JVM Plugin Services"),
                 configurations,
                 objectFactory,
+                providerFactory,
                 tasks,
                 components,
                 instantiator);

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmPluginServices.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmPluginServices.java
@@ -59,6 +59,7 @@ import org.gradle.internal.instantiation.InstanceGenerator;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
+import java.io.File;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -197,7 +198,12 @@ public class DefaultJvmPluginServices implements JvmPluginServices {
         variant.artifactsProvider(() ->  {
             FileCollection classesDirs = sourceSet.getOutput().getClassesDirs();
             return classesDirs.getFiles().stream().map(file ->
-                    new JvmPluginsHelper.ImmediateIntermediateJavaArtifact(project.getTaskDependencyFactory(), ArtifactTypeDefinition.JVM_CLASS_DIRECTORY, classesDirs, file))
+                new JvmPluginsHelper.IntermediateJavaArtifact(project.getTaskDependencyFactory(), ArtifactTypeDefinition.JVM_CLASS_DIRECTORY, classesDirs) {
+                    @Override
+                    public File getFile() {
+                        return file;
+                    }
+                })
                 .collect(Collectors.toList());
         });
         return variant;

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/jvm/internal/AbstractJvmPluginServicesTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/jvm/internal/AbstractJvmPluginServicesTest.groovy
@@ -62,6 +62,7 @@ abstract class AbstractJvmPluginServicesTest extends Specification {
     DefaultJvmPluginServices services = new DefaultJvmPluginServices(
         configurations,
         TestUtil.objectFactory(),
+        TestUtil.providerFactory(),
         tasks,
         softwareComponents,
         TestUtil.instantiatorFactory().decorateScheme().instantiator()


### PR DESCRIPTION
Trim static inner types in JvmPluginsHelper

- Remove ImmediateIntermediateJavaArtifact -> replace with anonymous implementation of IntermediateJavaArtifact
- Remove ProviderBasedIntermediateJavaArtifact
  - update IntermediateJavaArtifact to accept a provider
  - update IntermediateJavaArtifact to be non-abstract
  - Inject ProviderFactory into DefaultJvmPluginServices
  - existing usage just calls with simple anonymous provider (becomes lazy)
- rename IntermediateJavaArtifact to LazyJavaDirectoryArtifact (it is only used for classes and resources variants)
- Move to private inner class od DefaultJvmPluginServices

Result = just 1 inner type

Part of consolidating the PublishArtifact type hierarchy