### PR TITLE
Reset the buildscript classpath after the classpath files have been assembled

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
@@ -50,6 +50,13 @@ import java.io.File;
 import java.net.URI;
 
 public class DefaultScriptHandler implements ScriptHandler, ScriptHandlerInternal, DynamicObjectAware {
+
+    /**
+     * If set to {@code true}, the buildscript's {@code classpath} configuration will not be reset after the
+     * classpath has been assembled. Defaults to {@code false}.
+     */
+    public static final String DISABLE_RESET_CONFIGURATION_SYSTEM_PROPERTY = "org.gradle.incubating.reset-buildscript-classpath.disabled";
+
     private static final Logger LOGGER = Logging.getLogger(DefaultScriptHandler.class);
 
     private final ResourceLocation scriptResource;
@@ -59,6 +66,7 @@ public class DefaultScriptHandler implements ScriptHandler, ScriptHandlerInterna
     private final NamedObjectInstantiator instantiator;
     private final DependencyLockingHandler dependencyLockingHandler;
     // The following values are relatively expensive to create, so defer creation until required
+    private ClassPath resolvedClasspath;
     private RepositoryHandler repositoryHandler;
     private DependencyHandler dependencyHandler;
     private ConfigurationContainer configContainer;
@@ -93,7 +101,13 @@ public class DefaultScriptHandler implements ScriptHandler, ScriptHandlerInterna
 
     @Override
     public ClassPath getNonInstrumentedScriptClassPath() {
-        return scriptClassPathResolver.resolveClassPath(classpathConfiguration);
+        if (resolvedClasspath == null) {
+            resolvedClasspath = scriptClassPathResolver.resolveClassPath(classpathConfiguration);
+            if (!System.getProperty(DISABLE_RESET_CONFIGURATION_SYSTEM_PROPERTY, "false").equals("true") && classpathConfiguration != null) {
+                ((ResettableConfiguration) classpathConfiguration).resetResolutionState();
+            }
+        }
+        return resolvedClasspath;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/ResettableConfiguration.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/ResettableConfiguration.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.initialization;
+
+import org.gradle.api.artifacts.Configuration;
+
+/**
+ * A {@link Configuration} which can reset its resolution state. This interface is
+ * separate from {@code ConfigurationInternal} since that interface lives in
+ * {@code :dependency-management} and is not accessible from {@code :core}.
+ */
+public interface ResettableConfiguration extends Configuration {
+
+    /**
+     * Reset this Configuration's resolution state to the unresolved state, discarding any
+     * cached resolution results. No other state is reconfigured. The configuration remains
+     * immutable if resolution has already occurred. Any hooks or actions which ran when the
+     * configuration was originally resolved may or may not run again if this configuration
+     * is resolved again. Any side-effects or external caching which occur as a part of or
+     * after this configuration's resolution are not reversed or invalidated.
+     * <p>
+     * <strong>This method should be avoided if at all possible, and should only be used as a last resort.</strong>
+     * This method was originally added in order to release the resources of the {@code classpath}
+     * configurations used for resolving buildscript classpaths, as they consumed a non-negligible
+     * amount of memory even after the buildscript classpath was assembled.
+     * <p>
+     * Future work in this area should remove the need of this method by instead caching resolution
+     * results to disk and therefore freeing the memory used to cache a configuration's
+     * resolution result. This new functionality should be applicable to all configurations -- those
+     * used during buildscript classpath loading and normal configuration-time configurations.
+     * By applying this functionality to all configurations, this method would no longer be required.
+     */
+    void resetResolutionState();
+
+}

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultScriptHandlerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultScriptHandlerTest.groovy
@@ -15,7 +15,7 @@
  */
 package org.gradle.api.internal.initialization
 
-import org.gradle.api.artifacts.Configuration
+
 import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.DependencyConstraintSet
 import org.gradle.api.artifacts.dsl.DependencyConstraintHandler
@@ -40,7 +40,7 @@ class DefaultScriptHandlerTest extends Specification {
     def dependencyConstraintHandler = Mock(DependencyConstraintHandler)
     def dependencyConstraintSet = Mock(DependencyConstraintSet)
     def configurationContainer = Mock(ConfigurationContainer)
-    def configuration = Mock(Configuration)
+    def configuration = Mock(ResettableConfiguration)
     def scriptSource = Stub(ScriptSource)
     def depMgmtServices = Mock(DependencyResolutionServices) {
         getAttributesSchema() >> Stub(AttributesSchemaInternal)

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationDependenciesBuildOperationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationDependenciesBuildOperationIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests.resolve
 
 import org.gradle.api.internal.artifacts.configurations.ResolveConfigurationDependenciesBuildOperationType
+import org.gradle.api.internal.initialization.DefaultScriptHandler
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
 import org.gradle.integtests.fixtures.BuildOperationNotificationsFixture
 import org.gradle.integtests.fixtures.BuildOperationsFixture
@@ -193,19 +194,28 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
         m1.allowAll()
 
         when:
-        run "buildEnvironment"
+        if (resetClasspathConfiguration) {
+            succeeds("buildEnvironment")
+        } else {
+            succeeds("buildEnvironment", "-D${DefaultScriptHandler.DISABLE_RESET_CONFIGURATION_SYSTEM_PROPERTY}=true")
+        }
 
         then:
         def resolveOperations = operations.all(ResolveConfigurationDependenciesBuildOperationType)
-        resolveOperations.size() == 2
-        resolveOperations[0].details.configurationName == "classpath"
-        resolveOperations[0].details.projectPath == null
-        resolveOperations[0].details.buildPath == ":"
-        resolveOperations[0].details.scriptConfiguration == true
-        resolveOperations[0].details.configurationDescription == null
-        resolveOperations[0].details.configurationVisible == true
-        resolveOperations[0].details.configurationTransitive == true
-        resolveOperations[0].result.resolvedDependenciesCount == 2
+        def classpathOperations = resetClasspathConfiguration
+            ? [resolveOperations[0], resolveOperations[2]]
+            : [resolveOperations[0]]
+        resolveOperations.size() == resetClasspathConfiguration ? 3 : 2
+        classpathOperations.each {
+            assert it.details.configurationName == "classpath"
+            assert it.details.projectPath == null
+            assert it.details.buildPath == ":"
+            assert it.details.scriptConfiguration == true
+            assert it.details.configurationDescription == null
+            assert it.details.configurationVisible == true
+            assert it.details.configurationTransitive == true
+            assert it.result.resolvedDependenciesCount == 2
+        }
 
         resolveOperations[1].details.configurationName == "compileClasspath"
         resolveOperations[1].details.projectPath == ":"
@@ -215,6 +225,9 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
         resolveOperations[1].details.configurationVisible == false
         resolveOperations[1].details.configurationTransitive == true
         resolveOperations[1].result.resolvedDependenciesCount == 1
+
+        where:
+        resetClasspathConfiguration << [true, false]
     }
 
     def "#scriptType script classpath configurations are exposed"() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -89,6 +89,7 @@ import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.file.AbstractFileCollection;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileCollectionStructureVisitor;
+import org.gradle.api.internal.initialization.ResettableConfiguration;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectState;
 import org.gradle.api.internal.project.ProjectStateRegistry;
@@ -156,7 +157,7 @@ import static org.gradle.api.internal.artifacts.configurations.ConfigurationInte
 import static org.gradle.util.internal.ConfigureUtil.configure;
 
 @SuppressWarnings("rawtypes")
-public class DefaultConfiguration extends AbstractFileCollection implements ConfigurationInternal, MutationValidator {
+public class DefaultConfiguration extends AbstractFileCollection implements ConfigurationInternal, MutationValidator, ResettableConfiguration {
 
     private static final Action<Throwable> DEFAULT_ERROR_HANDLER = throwable -> {
         throw UncheckedException.throwAsUncheckedException(throwable);
@@ -848,6 +849,11 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
                 });
         }
         return dependenciesResolverFactory;
+    }
+
+    @Override
+    public void resetResolutionState() {
+        currentResolveState.set(ResolveState.NOT_RESOLVED);
     }
 
     private ResolverResults getResultsForBuildDependencies() {


### PR DESCRIPTION
We discard the 'classpath' Configuration's resolve state after we capture the actual files required for the buildscript's
classpath. Otherwise, we would hold onto this resolution state thoughout the build, even though only the final resolved
files are required.

This solution is incredibly hacky, as there may be other code in Gradle which assumes a configuration is never unresolved
or resolved more than once. For example, there may be some caching which is not reset when we reset the configuration's state.
Or, there may be some side-effects which we cannot reverse or hooks which previously only ran once that may run multiple times now.

We have determined that these trade-offs are acceptible for now, given the memory savings this change allows for. This configuration
is very infrequently resolved after its first resolution. We have added a flag to disable this functionality in case this change
interferes with existing functionality, but we do not expect this to be needed for the vast majority of cases.
