### PR TITLE
Add Jacoco offline instrumentation support

### DIFF
--- a/subprojects/docs/src/docs/dsl/dsl.xml
+++ b/subprojects/docs/src/docs/dsl/dsl.xml
@@ -488,6 +488,9 @@
                 <td>org.gradle.testing.jacoco.tasks.JacocoCoverageVerification</td>
             </tr>
             <tr>
+                <td>org.gradle.testing.jacoco.tasks.JacocoOfflineInstrumentation</td>
+            </tr>
+            <tr>
                 <td>org.gradle.api.tasks.bundling.Jar</td>
             </tr>
             <tr>

--- a/subprojects/docs/src/docs/dsl/org.gradle.testing.jacoco.tasks.JacocoOfflineInstrumentation.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.testing.jacoco.tasks.JacocoOfflineInstrumentation.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2013 the original author or authors.
+  ~ Copyright 2023 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -21,43 +21,16 @@
             <thead>
                 <tr>
                     <td>Name</td>
+                    <td>Default with <literal>jacoco</literal> plugin</td>
                 </tr>
             </thead>
             <tr>
-                <td>destinationFile</td>
+                <td>inputClassDirs</td>
+                <td/>
             </tr>
             <tr>
-                <td>includes</td>
-            </tr>
-            <tr>
-                <td>excludes</td>
-            </tr>
-            <tr>
-                <td>excludeClassLoaders</td>
-            </tr>
-            <tr>
-                <td>sessionId</td>
-            </tr>
-            <tr>
-                <td>dumpOnExit</td>
-            </tr>
-            <tr>
-                <td>output</td>
-            </tr>
-            <tr>
-                <td>address</td>
-            </tr>
-            <tr>
-                <td>port</td>
-            </tr>
-            <tr>
-                <td>classDumpDir</td>
-            </tr>
-            <tr>
-                <td>jmx</td>
-            </tr>
-            <tr>
-                <td>offline</td>
+                <td>outputDir</td>
+                <td/>
             </tr>
         </table>
     </section>
@@ -70,10 +43,7 @@
                 </tr>
             </thead>
             <tr>
-                <td>getAsJvmArg</td>
-            </tr>
-            <tr>
-                <td>asJvmArgs</td>
+                <td>sourceSets</td>
             </tr>
         </table>
     </section>

--- a/subprojects/docs/src/docs/userguide/core-plugins/jacoco_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/core-plugins/jacoco_plugin.adoc
@@ -154,6 +154,21 @@ include::sample[dir="snippets/testing/jacoco-application/groovy",files="build.gr
 ----
 
 
+[[sec:jacoco_offline_instrumentation]]
+== JaCoCo offline instrumentation
+
+By default, JaCoCo instruments classes on-the-fly to measure code coverage. However, there can be situations where on-the-fly instrumentation is not suitable.
+For such scenarios class files can be pre-instrumented with JaCoCo. For more information, see link:https://www.eclemma.org/jacoco/trunk/doc/offline.html[JaCoCo documentation].
+
+JaCoCo offline instrumentation can be enabled on a per task basis. This will modify the test classpath to use pre-instrumented classes instead.
+
+.Enabling offline instrumentation for test task
+====
+include::sample[dir="snippets/testing/jacoco-quickstart/kotlin",files="build.gradle.kts[tags=testtask-configuration-offline]"]
+include::sample[dir="snippets/testing/jacoco-quickstart/groovy",files="build.gradle[tags=testtask-configuration-offline]"]
+====
+
+
 [[sec:jacoco_tasks]]
 == Tasks
 
@@ -166,6 +181,10 @@ Generates code coverage report for the test task.
 `jacocoTestCoverageVerification` — link:{groovyDslPath}/org.gradle.testing.jacoco.tasks.JacocoCoverageVerification.html[JacocoCoverageVerification]::
 +
 Verifies code coverage metrics based on specified rules for the test task.
+
+`jacocoTestOfflineInstrumentation` — link:{groovyDslPath}/org.gradle.testing.jacoco.tasks.JacocoOfflineInstrumentation.html[JacocoOfflineInstrumentation]::
++
+Generates offline instrumented classes.
 
 
 [[sec:jacoco_dependency_management]]

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
@@ -154,6 +154,13 @@ The following method on `Configuration` is deprecated for removal:
 
 Obtain the set of all configurations from the project's `configurations` container instead.
 
+[[get_as_jvm_arg_deprecated]]
+==== Method `link:{javadocPath}/org/gradle/testing/jacoco/plugins/JacocoTaskExtension.html#getAsJvmArg--[JacocoTaskExtension.getAsJvmArg()]` is deprecated
+
+When the Jacoco offline instrumentation feature is enabled, multiple JVM arguments are required to configure Jacoco at runtime.
+The `JacocoTaskExtension.getAsJvmArg()` method can only return one argument and thus is now deprecated for removal.
+The new `JacocoTaskExtension#asJvmArgs()` method should be used instead.
+
 [[changes_8.1]]
 == Upgrading from 8.0 and earlier
 

--- a/subprojects/docs/src/snippets/testing/jacoco-quickstart/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/testing/jacoco-quickstart/groovy/build.gradle
@@ -91,6 +91,15 @@ test {
         address = "localhost"
         port = 6300
         jmx = false
+        offline = false
     }
 }
 // end::testtask-configuration-defaults[]
+
+// tag::testtask-configuration-offline[]
+test {
+    jacoco {
+        offline = true
+    }
+}
+// end::testtask-configuration-offline[]

--- a/subprojects/docs/src/snippets/testing/jacoco-quickstart/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/testing/jacoco-quickstart/kotlin/build.gradle.kts
@@ -90,6 +90,15 @@ tasks.test {
         address = "localhost"
         port = 6300
         isJmx = false
+        offline.set(false)
     }
 }
 // end::testtask-configuration-defaults[]
+
+// tag::testtask-configuration-offline[]
+tasks.test {
+    extensions.configure(JacocoTaskExtension::class) {
+        offine.set(true)
+    }
+}
+// end::testtask-configuration-offline[]

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoOfflineInstrumentationIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoOfflineInstrumentationIntegrationTest.groovy
@@ -61,7 +61,7 @@ class JacocoOfflineInstrumentationIntegrationTest extends JacocoMultiVersionInte
         then:
         executedAndNotSkipped(':jacocoTestOfflineInstrumentation')
         file("build/jacoco/test.exec").assertIsFile()
-        file("build/jacoco/test/instrumented-classes").assertContainsDescendants("org/gradle/Class1.class")
+        file("build/jacoco/instrumented-classes/test").assertContainsDescendants("org/gradle/Class1.class")
     }
 
     def "offline instrumentation with multiple sourceSets"() {
@@ -83,7 +83,7 @@ class JacocoOfflineInstrumentationIntegrationTest extends JacocoMultiVersionInte
         succeeds('jacocoTestOfflineInstrumentation')
 
         then:
-        file("build/jacoco/test/instrumented-classes").assertContainsDescendants("org/gradle/Class1.class", "org/gradle/Class1Extra.class")
+        file("build/jacoco/instrumented-classes/test").assertContainsDescendants("org/gradle/Class1.class", "org/gradle/Class1Extra.class")
     }
 
     def "offline instrumentation with a different output dir"() {

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoOfflineInstrumentationIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoOfflineInstrumentationIntegrationTest.groovy
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing.jacoco.plugins
+
+import org.gradle.integtests.fixtures.TargetCoverage
+import org.gradle.testing.jacoco.plugins.fixtures.JacocoCoverage
+
+@TargetCoverage({ JacocoCoverage.supportedVersionsByJdk })
+class JacocoOfflineInstrumentationIntegrationTest extends JacocoMultiVersionIntegrationTest {
+
+    def setup() {
+        javaProjectUnderTest.writeSourceFiles()
+    }
+
+    def "task jacocoTestOfflineInstrumentation is not executed when jacoco is disabled"() {
+        given:
+        buildFile << """
+            test {
+                jacoco {
+                    enabled = false
+                }
+            }
+        """
+
+        when:
+        succeeds('test')
+
+        then:
+        notExecuted(':jacocoTestOfflineInstrumentation')
+    }
+
+    def "task jacocoTestOfflineInstrumentation is not executed by default"() {
+        when:
+        succeeds('test')
+
+        then:
+        skipped(':jacocoTestOfflineInstrumentation')
+    }
+
+    def "instrumented classes are generated when offline instrumentation is enabled"() {
+        given:
+        javaProjectUnderTest.writeOfflineInstrumentation(true)
+
+        when:
+        succeeds('test')
+
+        then:
+        executedAndNotSkipped(':jacocoTestOfflineInstrumentation')
+        file("build/jacoco/test.exec").assertIsFile()
+        file("build/jacoco/test/instrumented-classes").assertContainsDescendants("org/gradle/Class1.class")
+    }
+
+    def "offline instrumentation with multiple sourceSets"() {
+        given:
+        buildFile << """
+            sourceSets {
+                extra {
+                }
+            }
+
+            jacocoTestOfflineInstrumentation {
+                sourceSets sourceSets.extra
+            }
+        """
+        javaProjectUnderTest.writeOfflineInstrumentation(true)
+        javaProjectUnderTest.writeSourceFiles(1, "extra", "Extra")
+
+        when:
+        succeeds('jacocoTestOfflineInstrumentation')
+
+        then:
+        file("build/jacoco/test/instrumented-classes").assertContainsDescendants("org/gradle/Class1.class", "org/gradle/Class1Extra.class")
+    }
+
+    def "offline instrumentation with a different output dir"() {
+        given:
+        buildFile << """
+            jacocoTestOfflineInstrumentation {
+                outputDir.set(file('build/jacoco/custom-dir'))
+            }
+        """
+        javaProjectUnderTest.writeOfflineInstrumentation(true)
+
+        when:
+        succeeds('jacocoTestOfflineInstrumentation')
+
+        then:
+        file("build/jacoco/custom-dir").assertContainsDescendants("org/gradle/Class1.class")
+    }
+}

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginIntegrationTest.groovy
@@ -62,6 +62,18 @@ class JacocoPluginIntegrationTest extends AbstractIntegrationSpec implements Ins
         succeeds 'help'
     }
 
+    def "jacoco plugin adds offline instrumentation for test task when java plugin applied"() {
+        given:
+        buildFile << '''
+            assert project.jacocoTestOfflineInstrumentation instanceof JacocoOfflineInstrumentation
+            assert project.jacocoTestOfflineInstrumentation.inputClassDirs*.absolutePath == project.sourceSets.main.output.classesDirs*.absolutePath
+            assert project.jacocoTestOfflineInstrumentation.outputDir.get() == project.layout.buildDirectory.dir("jacoco/test/instrumented-classes").get()
+        '''.stripIndent()
+
+        expect:
+        succeeds 'help'
+    }
+
     def "dependencies report shows default jacoco dependencies"() {
         when:
         succeeds("dependencies", "--configuration", "jacocoAgent")

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginIntegrationTest.groovy
@@ -67,7 +67,7 @@ class JacocoPluginIntegrationTest extends AbstractIntegrationSpec implements Ins
         buildFile << '''
             assert project.jacocoTestOfflineInstrumentation instanceof JacocoOfflineInstrumentation
             assert project.jacocoTestOfflineInstrumentation.inputClassDirs*.absolutePath == project.sourceSets.main.output.classesDirs*.absolutePath
-            assert project.jacocoTestOfflineInstrumentation.outputDir.get() == project.layout.buildDirectory.dir("jacoco/test/instrumented-classes").get()
+            assert project.jacocoTestOfflineInstrumentation.outputDir.get() == project.layout.buildDirectory.dir("jacoco/instrumented-classes/test").get()
         '''.stripIndent()
 
         expect:

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoVersionCompatibilityIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoVersionCompatibilityIntegrationTest.groovy
@@ -23,9 +23,10 @@ import org.gradle.testing.jacoco.plugins.fixtures.JacocoReportFixture
 @TargetCoverage({ JacocoCoverage.supportedVersionsByJdk })
 class JacocoVersionCompatibilityIntegrationTest extends JacocoMultiVersionIntegrationTest {
 
-    def "can run versions"() {
+    def "can run versions (offline: #offline)"() {
         given:
         javaProjectUnderTest.writeSourceFiles()
+        javaProjectUnderTest.writeOfflineInstrumentation(offline)
 
         when:
         succeeds('test', 'jacocoTestReport')
@@ -34,6 +35,9 @@ class JacocoVersionCompatibilityIntegrationTest extends JacocoMultiVersionIntegr
         def report = htmlReport()
         report.totalCoverage() == 100
         report.assertVersion(version)
+
+        where:
+        offline << [false, true]
     }
 
     private JacocoReportFixture htmlReport(String basedir = "build/reports/jacoco/test/html") {

--- a/subprojects/jacoco/src/main/java/org/gradle/internal/jacoco/AntJacocoInstrument.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/internal/jacoco/AntJacocoInstrument.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.jacoco;
+
+import com.google.common.collect.ImmutableMap;
+import groovy.lang.Closure;
+import groovy.lang.GroovyObjectSupport;
+import org.gradle.api.file.Directory;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.project.IsolatedAntBuilder;
+
+import java.util.Map;
+
+public class AntJacocoInstrument {
+    private final IsolatedAntBuilder ant;
+
+    public AntJacocoInstrument(IsolatedAntBuilder ant) {
+        this.ant = ant;
+    }
+
+    public void execute(final FileCollection classpath, final FileCollection inputClassesDirs, final Directory outputDir) {
+        ant.withClasspath(classpath).execute(new Closure<Object>(this, this) {
+            @SuppressWarnings({"UnusedDeclaration"})
+            public Object doCall(Object it) {
+                GroovyObjectSupport antBuilder = (GroovyObjectSupport) it;
+                antBuilder.invokeMethod("taskdef", ImmutableMap.of(
+                        "name", "jacocoInstrument",
+                        "classname", "org.jacoco.ant.InstrumentTask"
+                ));
+
+                final Map<String, Object> instrumentArgs = ImmutableMap.of("destdir", outputDir.getAsFile());
+                antBuilder.invokeMethod("jacocoInstrument", new Object[]{instrumentArgs, new Closure<Object>(this, this) {
+                    @SuppressWarnings("UnusedDeclaration")
+                    public Object doCall(Object ignore) {
+                        inputClassesDirs.getAsFileTree().addToAntBuilder(antBuilder, "resources");
+                        return null;
+                    }
+                }});
+                return null;
+            }
+        });
+    }
+}

--- a/subprojects/jacoco/src/main/java/org/gradle/internal/jacoco/AntJacocoInstrument.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/internal/jacoco/AntJacocoInstrument.java
@@ -25,6 +25,9 @@ import org.gradle.api.internal.project.IsolatedAntBuilder;
 
 import java.util.Map;
 
+/**
+ * Runs Jacoco offline instrumentation task using Ant.
+ */
 public class AntJacocoInstrument {
     private final IsolatedAntBuilder ant;
 

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPlugin.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPlugin.java
@@ -17,6 +17,7 @@ package org.gradle.testing.jacoco.plugins;
 
 import org.apache.commons.lang.StringUtils;
 import org.gradle.api.ExtensiblePolymorphicDomainObjectContainer;
+import org.gradle.api.Incubating;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
@@ -72,6 +73,15 @@ public abstract class JacocoPlugin implements Plugin<Project> {
      * @since 3.4
      */
     public static final String DEFAULT_JACOCO_VERSION = "0.8.8";
+
+    /**
+     * The default directory where offline instrumented classes are generated.
+     *
+     * @since 8.2
+     */
+    @Incubating
+    public static final String DEFAULT_OFFLINE_INSTRUMENTED_CLASSES_DIR = "jacoco/instrumented-classes/";
+
     public static final String AGENT_CONFIGURATION_NAME = "jacocoAgent";
     public static final String ANT_CONFIGURATION_NAME = "jacocoAnt";
     public static final String PLUGIN_EXTENSION_NAME = "jacoco";
@@ -228,7 +238,7 @@ public abstract class JacocoPlugin implements Plugin<Project> {
                 instrumentationTask.setGroup(LifecycleBasePlugin.VERIFICATION_GROUP);
                 instrumentationTask.setDescription(String.format("Generates offline instrumented classes for the %s task.", testTaskProvider.getName()));
                 instrumentationTask.sourceSets(project.getExtensions().getByType(SourceSetContainer.class).getByName("main"));
-                instrumentationTask.getOutputDir().set(project.getLayout().getBuildDirectory().dir("jacoco/" + testTaskProvider.getName() + "/instrumented-classes"));
+                instrumentationTask.getOutputDir().convention(project.getLayout().getBuildDirectory().dir(DEFAULT_OFFLINE_INSTRUMENTED_CLASSES_DIR + testTaskProvider.getName()));
                 instrumentationTask.onlyIf(t -> testTaskProvider.get().getExtensions().getByType(JacocoTaskExtension.class).getOffline().get());
             });
 

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPlugin.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPlugin.java
@@ -52,6 +52,7 @@ import org.gradle.testing.base.TestSuite;
 import org.gradle.testing.base.TestingExtension;
 import org.gradle.testing.jacoco.tasks.JacocoBase;
 import org.gradle.testing.jacoco.tasks.JacocoCoverageVerification;
+import org.gradle.testing.jacoco.tasks.JacocoOfflineInstrumentation;
 import org.gradle.testing.jacoco.tasks.JacocoReport;
 
 import javax.inject.Inject;
@@ -97,9 +98,9 @@ public abstract class JacocoPlugin implements Plugin<Project> {
 
         configureAgentDependencies(agent, extension);
         configureTaskClasspathDefaults(extension);
-        applyToDefaultTasks(extension);
+        applyToTestTasks(extension);
         configureJacocoReportsDefaults(extension);
-        addDefaultReportAndCoverageVerificationTasks(extension);
+        addDefaultJacocoTasks(extension);
         configureCoverageDataElementsVariants(project);
     }
 
@@ -179,7 +180,7 @@ public abstract class JacocoPlugin implements Plugin<Project> {
      *
      * @param extension the extension to apply Jacoco with
      */
-    private void applyToDefaultTasks(final JacocoPluginExtension extension) {
+    private void applyToTestTasks(final JacocoPluginExtension extension) {
         project.getTasks().withType(Test.class).configureEach(extension::applyTo);
     }
 
@@ -206,16 +207,32 @@ public abstract class JacocoPlugin implements Plugin<Project> {
      *
      * @param extension the extension describing the test task names
      */
-    private void addDefaultReportAndCoverageVerificationTasks(final JacocoPluginExtension extension) {
+    private void addDefaultJacocoTasks(final JacocoPluginExtension extension) {
         project.getPlugins().withType(JavaPlugin.class, javaPlugin -> {
             TestingExtension testing = project.getExtensions().getByType(TestingExtension.class);
             JvmTestSuite defaultTestSuite = testing.getSuites().withType(JvmTestSuite.class).getByName(JvmTestSuitePlugin.DEFAULT_TEST_SUITE_NAME);
             defaultTestSuite.getTargets().configureEach(target -> {
                 TaskProvider<Test> testTask = target.getTestTask();
+                addDefaultOfflineInstrumentationTask(testTask);
                 addDefaultReportTask(extension, testTask);
                 addDefaultCoverageVerificationTask(testTask);
             });
         });
+    }
+
+    private void addDefaultOfflineInstrumentationTask(final TaskProvider<? extends Task> testTaskProvider) {
+        TaskProvider<JacocoOfflineInstrumentation> instrumentationTaskProvider = project.getTasks().register(
+            "jacoco" + StringUtils.capitalize(testTaskProvider.getName()) + "OfflineInstrumentation",
+            JacocoOfflineInstrumentation.class,
+            instrumentationTask -> {
+                instrumentationTask.setGroup(LifecycleBasePlugin.VERIFICATION_GROUP);
+                instrumentationTask.setDescription(String.format("Generates offline instrumented classes for the %s task.", testTaskProvider.getName()));
+                instrumentationTask.sourceSets(project.getExtensions().getByType(SourceSetContainer.class).getByName("main"));
+                instrumentationTask.getOutputDir().set(project.getLayout().getBuildDirectory().dir("jacoco/" + testTaskProvider.getName() + "/instrumented-classes"));
+                instrumentationTask.onlyIf(t -> testTaskProvider.get().getExtensions().getByType(JacocoTaskExtension.class).getOffline().get());
+            });
+
+        testTaskProvider.configure(testTask -> testTask.getExtensions().getByType(JacocoTaskExtension.class).getOfflineInstrumentedClasses().from(instrumentationTaskProvider));
     }
 
     private void addDefaultReportTask(final JacocoPluginExtension extension, final TaskProvider<? extends Task> testTaskProvider) {

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPluginExtension.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPluginExtension.java
@@ -130,6 +130,11 @@ public abstract class JacocoPluginExtension {
         );
     }
 
+    /**
+     * Prepares a task before it is about to be executed.
+     * The coverage file from the last execution is deleted.
+     * When offline instrumentation is enabled, the classpath is modified to use the instrumented classes.
+     */
     private static class JacocoPrepareTestTaskAction implements Action<Task> {
         private final JacocoTaskExtension extension;
         private final JacocoAgentJar agent;

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoTaskExtension.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoTaskExtension.java
@@ -34,6 +34,7 @@ import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.jacoco.JacocoAgentJar;
 import org.gradle.process.JavaForkOptions;
 import org.gradle.util.internal.RelativePathUtil;
@@ -120,7 +121,7 @@ public abstract class JacocoTaskExtension {
     /**
      * Whether offline instrumentation will be used. Defaults to {@code false}.
      *
-     * @since 8.1
+     * @since 8.2
      */
     @Incubating
     @Input
@@ -131,7 +132,7 @@ public abstract class JacocoTaskExtension {
     /**
      * The collection of offline instrumented classes that will be added to the test runtime classpath.
      *
-     * @since 8.1
+     * @since 8.2
      */
     @Incubating
     @IgnoreEmptyDirectories
@@ -341,14 +342,23 @@ public abstract class JacocoTaskExtension {
     @Deprecated
     @Internal
     public String getAsJvmArg() {
+        DeprecationLogger.deprecateMethod(JacocoTaskExtension.class, "getAsJvmArg()")
+            .replaceWith("asJvmArgs()")
+            .willBeRemovedInGradle9()
+            .withUpgradeGuideSection(8, "get_as_jvm_arg_deprecated")
+            .nagUser();
+
         return getJavaAgentArg();
     }
 
     /**
-     * Gets all agent properties as JVM arguments.
+     * Gets all Jacoco options as JVM arguments.
+     * These arguments are used to configure Jacoco at runtime.
+     * When offline instrumentation is disabled, a single argument contains the path of the agent and all its options.
+     * When offline instrumentation is enabled, each Jacoco option is passed in its own JVM property.
      *
      * @return state of extension as JVM arguments
-     * @since 8.1
+     * @since 8.2
      */
     @Incubating
     public List<String> asJvmArgs() {
@@ -410,7 +420,7 @@ public abstract class JacocoTaskExtension {
                 return;
             }
 
-            final @Nullable String formatted;
+            final String formatted;
             if (value instanceof Collection) {
                 formatted = ((Collection<?>) value).isEmpty() ? null : Joiner.on(':').join((Collection<?>) value);
             } else if (value instanceof File) {

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoOfflineInstrumentation.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoOfflineInstrumentation.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing.jacoco.tasks;
+
+import org.gradle.api.Incubating;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.Directory;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.internal.project.IsolatedAntBuilder;
+import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.IgnoreEmptyDirectories;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.internal.jacoco.AntJacocoInstrument;
+
+import javax.inject.Inject;
+import java.io.File;
+
+/**
+ * Task for applying Jacoco offline instrumentation to a collection of classes.
+ *
+ * @since 8.1
+ */
+@Incubating
+@CacheableTask
+public abstract class JacocoOfflineInstrumentation extends JacocoBase {
+
+    @IgnoreEmptyDirectories
+    @PathSensitive(PathSensitivity.RELATIVE)
+    @InputFiles
+    public abstract ConfigurableFileCollection getInputClassDirs();
+
+    public void sourceSets(final SourceSet... sourceSets) {
+        for (final SourceSet sourceSet : sourceSets) {
+            getInputClassDirs().from(sourceSet.getOutput().getClassesDirs());
+        }
+    }
+
+    @OutputDirectory
+    public abstract DirectoryProperty getOutputDir();
+
+    @Inject
+    protected abstract IsolatedAntBuilder getAntBuilder();
+
+    @TaskAction
+    public void generate() {
+        Directory outputDir = getOutputDir().get();
+        getProject().delete(outputDir);
+
+        new AntJacocoInstrument(getAntBuilder()).execute(
+            getJacocoClasspath(),
+            getInputClassDirs().filter(File::exists),
+            outputDir
+        );
+    }
+}

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoOfflineInstrumentation.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoOfflineInstrumentation.java
@@ -43,17 +43,28 @@ import java.io.File;
 @CacheableTask
 public abstract class JacocoOfflineInstrumentation extends JacocoBase {
 
+    /**
+     * The directories containing the classes that will be instrumented.
+     */
     @IgnoreEmptyDirectories
     @PathSensitive(PathSensitivity.RELATIVE)
     @InputFiles
     public abstract ConfigurableFileCollection getInputClassDirs();
 
+    /**
+     * Adds a source set to the list to be instrumented. The output of this source set will be used as classes to be instrumented.
+     *
+     * @param sourceSets one or more source sets to instrument
+     */
     public void sourceSets(final SourceSet... sourceSets) {
         for (final SourceSet sourceSet : sourceSets) {
             getInputClassDirs().from(sourceSet.getOutput().getClassesDirs());
         }
     }
 
+    /**
+     * The directory where instrumented classes will be generated.
+     */
     @OutputDirectory
     public abstract DirectoryProperty getOutputDir();
 

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoOfflineInstrumentation.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoOfflineInstrumentation.java
@@ -37,7 +37,7 @@ import java.io.File;
 /**
  * Task for applying Jacoco offline instrumentation to a collection of classes.
  *
- * @since 8.1
+ * @since 8.2
  */
 @Incubating
 @CacheableTask

--- a/subprojects/jacoco/src/test/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginSpec.groovy
+++ b/subprojects/jacoco/src/test/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginSpec.groovy
@@ -102,9 +102,12 @@ class JacocoPluginSpec extends AbstractProjectBuilderSpec {
         expect:
         def jacocoTestReportTask = project.tasks.getByName('jacocoTestReport')
         def jacocoTestCoverageVerificationTask = project.tasks.getByName('jacocoTestCoverageVerification')
+        def jacocoTestOfflineInstrumentationTask = project.tasks.getByName('jacocoTestOfflineInstrumentation')
         jacocoTestReportTask.group == LifecycleBasePlugin.VERIFICATION_GROUP
         jacocoTestCoverageVerificationTask.group == LifecycleBasePlugin.VERIFICATION_GROUP
+        jacocoTestOfflineInstrumentationTask.group == LifecycleBasePlugin.VERIFICATION_GROUP
         jacocoTestReportTask.description == 'Generates code coverage report for the test task.'
         jacocoTestCoverageVerificationTask.description == 'Verifies code coverage metrics based on specified rules for the test task.'
+        jacocoTestOfflineInstrumentationTask.description == 'Generates offline instrumented classes for the test task.'
     }
 }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #2429

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
Jacoco offline instrumentation is necessary on some projects to measure coverage properly. Examples are listed in [Jacoco documentation](https://www.eclemma.org/jacoco/trunk/doc/offline.html). From issue #2429, we can see that many people are looking for this possibility. Some have found a workaround, but not everyone can get it to work and it doesn't integrate well with the existing plugin.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
