### PR TITLE
Increase NoDaemon timeout

### DIFF
--- a/.teamcity/src/main/kotlin/model/CIBuildModel.kt
+++ b/.teamcity/src/main/kotlin/model/CIBuildModel.kt
@@ -286,7 +286,9 @@ enum class TestType(val unitTests: Boolean = true, val functionalTests: Boolean 
     // run integMultiVersionTest with all version to cover
     allVersionsIntegMultiVersion(false, true, false),
     parallel(false, true, false),
-    noDaemon(false, true, false, 300),
+    // FIXME: timeout increased because of https://github.com/gradle/gradle-private/issues/3695
+    //        revert it to 300 after fixed
+    noDaemon(false, true, false, 360),
     configCache(false, true, false),
     soak(false, false, false),
     forceRealizeDependencyManagement(false, true, false)


### PR DESCRIPTION
Band-aid fix to solve issues with the [`NoDaemon Java17 Openjdk Windows Amd64 (platform-native,plugins,plugin-use,logging,integ-test,core,configuration-cache,composite-builds,build-init,architecture-test,execution)`](https://builds.gradle.org/admin/editBuildFailureConditions.html?id=buildType:Gradle_Master_Check_NoDaemon_13_bucket14) pipeline.