### PR TITLE
Associate test compilations with main source set for all Kotlin libraries

### DIFF
--- a/build-logic/uber-plugins/src/main/kotlin/gradlebuild.kotlin-library.gradle.kts
+++ b/build-logic/uber-plugins/src/main/kotlin/gradlebuild.kotlin-library.gradle.kts
@@ -34,6 +34,20 @@ configurations.transitiveSourcesElements {
     }
 }
 
+kotlin {
+    target.compilations.named("testFixtures") {
+        associateWith(target.compilations["main"])
+    }
+    target.compilations.named("test") {
+        associateWith(target.compilations["main"])
+        associateWith(target.compilations["testFixtures"])
+    }
+    target.compilations.named("integTest") {
+        associateWith(target.compilations["main"])
+        associateWith(target.compilations["testFixtures"])
+    }
+}
+
 tasks {
     withType<KotlinCompile>().configureEach {
         configureKotlinCompilerForGradleBuild()

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
@@ -62,7 +62,7 @@ import java.io.File
 import javax.inject.Inject
 
 
-class ProjectAccessorsClassPathGenerator @Inject constructor(
+class ProjectAccessorsClassPathGenerator @Inject internal constructor(
     private val fileCollectionFactory: FileCollectionFactory,
     private val projectSchemaProvider: ProjectSchemaProvider,
     private val executionEngine: ExecutionEngine,
@@ -104,6 +104,7 @@ class ProjectAccessorsClassPathGenerator @Inject constructor(
 }
 
 
+internal
 class GenerateProjectAccessors(
     private val project: Project,
     private val projectSchema: TypedProjectSchema,
@@ -629,10 +630,12 @@ import org.gradle.kotlin.dsl.accessors.runtime.*
 /**
  * Location of the discontinued project schema snapshot, relative to the root project.
  */
+internal
 const val projectSchemaResourcePath =
     "gradle/project-schema.json"
 
 
+internal
 const val projectSchemaResourceDiscontinuedWarning =
     "Support for $projectSchemaResourcePath was removed in Gradle 5.0. The file is no longer used and it can be safely deleted."
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/KotlinTypeStrings.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/KotlinTypeStrings.kt
@@ -19,6 +19,7 @@ package org.gradle.kotlin.dsl.accessors
 import org.gradle.api.reflect.TypeOf
 
 
+internal
 fun kotlinTypeStringFor(type: TypeOf<*>): String = type.run {
     when {
         isArray ->
@@ -57,4 +58,5 @@ val primitiveTypeStrings =
     )
 
 
+internal
 val primitiveKotlinTypeNames = primitiveTypeStrings.values.toHashSet()

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsClassPath.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsClassPath.kt
@@ -88,7 +88,7 @@ import javax.inject.Inject
  *
  * The accessors provide content-assist for plugin ids and quick navigation to the plugin source code.
  */
-class PluginAccessorClassPathGenerator @Inject constructor(
+class PluginAccessorClassPathGenerator @Inject internal constructor(
     private val classLoaderHierarchyHasher: ClassLoaderHierarchyHasher,
     private val fileCollectionFactory: FileCollectionFactory,
     private val executionEngine: ExecutionEngine,
@@ -115,6 +115,7 @@ class PluginAccessorClassPathGenerator @Inject constructor(
 }
 
 
+internal
 class GeneratePluginAccessors(
     private val rootProject: Project,
     private val buildSrcClassLoaderScope: ClassLoaderScope,

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/tasks/PrintAccessors.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/tasks/PrintAccessors.kt
@@ -48,6 +48,7 @@ abstract class PrintAccessors : DefaultTask() {
 
     @Suppress("unused")
     @TaskAction
+    internal
     fun printExtensions() {
         printAccessorsFor(schema.get())
     }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/cache/KotlinDslWorkspaceProvider.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/cache/KotlinDslWorkspaceProvider.kt
@@ -28,6 +28,7 @@ import org.gradle.internal.hash.ClassLoaderHierarchyHasher
 import java.io.Closeable
 
 
+internal
 class KotlinDslWorkspaceProvider(
     cacheBuilderFactory: GlobalScopedCacheBuilderFactory,
     fileAccessTimeJournal: FileAccessTimeJournal,

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ApiExtensionsJar.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ApiExtensionsJar.kt
@@ -20,14 +20,13 @@ import org.gradle.kotlin.dsl.support.loggerFor
 import org.gradle.kotlin.dsl.support.compileToDirectory
 import org.gradle.kotlin.dsl.support.zipTo
 
-import com.google.common.annotations.VisibleForTesting
 import org.gradle.api.internal.file.temp.TemporaryFileProvider
 import org.gradle.kotlin.dsl.support.bytecode.GradleJvmVersion
 
 import java.io.File
 
 
-@VisibleForTesting
+internal
 fun generateApiExtensionsJar(
     temporaryFileProvider: TemporaryFileProvider,
     outputFile: File,

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ApiTypeProvider.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ApiTypeProvider.kt
@@ -16,8 +16,6 @@
 
 package org.gradle.kotlin.dsl.codegen
 
-import com.google.common.annotations.VisibleForTesting
-
 import org.gradle.api.Incubating
 
 import org.gradle.internal.classanalysis.AsmConstants.ASM_LEVEL
@@ -56,7 +54,7 @@ import java.util.ArrayDeque
 import javax.annotation.Nullable
 
 
-@VisibleForTesting
+internal
 fun apiTypeProviderFor(
     classPath: List<File>,
     classPathDependencies: List<File> = emptyList(),
@@ -70,9 +68,11 @@ private
 typealias ApiTypeSupplier = () -> ApiType
 
 
+internal
 typealias ParameterNamesSupplier = (String) -> List<String>?
 
 
+private
 fun ParameterNamesSupplier.parameterNamesFor(typeName: String, functionName: String, parameterTypeNames: List<String>): List<String>? =
     this("$typeName.$functionName(${parameterTypeNames.joinToString(",")})")
 
@@ -89,7 +89,7 @@ fun ParameterNamesSupplier.parameterNamesFor(typeName: String, functionName: Str
  * - does not support nested Java arrays as method parameters
  * - does not support generics with multiple bounds
  */
-@VisibleForTesting
+internal
 class ApiTypeProvider internal constructor(
     private val repository: ClassBytesRepository,
     parameterNamesSupplier: ParameterNamesSupplier
@@ -156,7 +156,7 @@ class ApiTypeProvider internal constructor(
 }
 
 
-@VisibleForTesting
+internal
 class ApiType internal constructor(
     val sourceName: String,
     private val delegateSupplier: () -> ClassNode,
@@ -253,7 +253,7 @@ class ApiType internal constructor(
 }
 
 
-@VisibleForTesting
+internal
 class ApiFunction internal constructor(
     val owner: ApiType,
     private val delegate: MethodNode,
@@ -295,7 +295,7 @@ class ApiFunction internal constructor(
 }
 
 
-@VisibleForTesting
+internal
 data class ApiTypeUsage internal constructor(
     val sourceName: String,
     val isNullable: Boolean = false,
@@ -309,7 +309,7 @@ data class ApiTypeUsage internal constructor(
 }
 
 
-@VisibleForTesting
+internal
 enum class Variance {
 
     /**
@@ -334,7 +334,7 @@ enum class Variance {
 }
 
 
-@VisibleForTesting
+internal
 data class ApiFunctionParameter internal constructor(
     val index: Int,
     val isVarargs: Boolean,

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/concurrent/IO.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/concurrent/IO.kt
@@ -72,6 +72,7 @@ interface AsyncIOScopeFactory {
 }
 
 
+internal
 fun <T> withAsynchronousIO(
     project: Project,
     action: IO.() -> T

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/concurrent/future.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/concurrent/future.kt
@@ -16,8 +16,6 @@
 
 package org.gradle.kotlin.dsl.concurrent
 
-import com.google.common.annotations.VisibleForTesting
-
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
@@ -34,7 +32,7 @@ import kotlin.coroutines.startCoroutine
  *
  * The [computation] executes synchronously until its first suspension point.
  */
-@VisibleForTesting
+internal
 fun <T> future(context: CoroutineContext = EmptyCoroutineContext, computation: suspend () -> T): Future<T> =
     FutureContinuation<T>(context).also { k ->
         computation.startCoroutine(completion = k)

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/CompiledScript.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/CompiledScript.kt
@@ -19,6 +19,7 @@ package org.gradle.kotlin.dsl.execution
 import org.gradle.internal.classpath.ClassPath
 
 
+internal
 interface CompiledScript {
     val program: Class<*>
     val classPath: ClassPath

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/ExecutableProgram.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/ExecutableProgram.kt
@@ -27,6 +27,7 @@ import org.gradle.kotlin.dsl.support.useToRun
 import org.gradle.plugin.management.internal.PluginRequests
 
 
+internal
 abstract class ExecutableProgram {
 
     abstract fun execute(programHost: Host, scriptHost: KotlinScriptHost<*>)

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/Interpreter.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/Interpreter.kt
@@ -72,6 +72,7 @@ import kotlin.script.experimental.api.KotlinType
  * @see ResidualProgram
  * @see ResidualProgramCompiler
  */
+internal
 class Interpreter(val host: Host) {
 
     interface Host {

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/ProgramParser.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/ProgramParser.kt
@@ -18,10 +18,7 @@ package org.gradle.kotlin.dsl.execution
 
 import org.gradle.kotlin.dsl.support.compilerMessageFor
 
-import com.google.common.annotations.VisibleForTesting
 
-
-@VisibleForTesting
 object ProgramParser {
 
     fun parse(source: ProgramSource, kind: ProgramKind, target: ProgramTarget): Packaged<Program> = try {

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/ProgramSource.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/ProgramSource.kt
@@ -17,7 +17,7 @@
 package org.gradle.kotlin.dsl.execution
 
 
-data class ProgramSource(val path: String, val contents: ProgramText) {
+data class ProgramSource internal constructor(val path: String, val contents: ProgramText) {
 
     constructor(path: String, contents: String) : this(path, text(contents))
 
@@ -36,10 +36,12 @@ data class ProgramText private constructor(val text: String) {
 
     companion object {
 
+        internal
         fun from(string: String) =
             ProgramText(string.replace("\r\n", "\n"))
     }
 
+    internal
     fun erase(ranges: List<IntRange>): ProgramText =
         if (ranges.isEmpty()) this
         else ProgramText(text.erase(ranges))
@@ -47,12 +49,14 @@ data class ProgramText private constructor(val text: String) {
     fun preserve(vararg ranges: IntRange): ProgramText =
         erase(complementOf(ranges))
 
+    internal
     fun preserve(ranges: List<IntRange>): ProgramText =
         preserve(*ranges.toTypedArray())
 
     fun subText(range: IntRange): ProgramText =
         ProgramText(text.substring(range))
 
+    internal
     fun lineNumberOf(index: Int): Int =
         text.lineAndColumnFor(index).first
 
@@ -78,21 +82,25 @@ data class ProgramText private constructor(val text: String) {
 }
 
 
+internal
 fun text(string: String) = ProgramText.from(string)
 
 
+internal
 fun ProgramSource.fragment(identifier: IntRange, block: IntRange) =
     ProgramSourceFragment(this, ScriptSection(identifier, block))
 
 
+internal
 fun ProgramSource.fragment(section: ScriptSection) =
     ProgramSourceFragment(this, section)
 
 
-data class ProgramSourceFragment(
+data class ProgramSourceFragment internal constructor(
     val source: ProgramSource,
-    val section: ScriptSection
+    internal val section: ScriptSection
 ) {
+    internal
     val lineNumber: Int
         get() = source.contents.lineNumberOf(section.identifier.first)
 
@@ -108,6 +116,7 @@ data class ProgramSourceFragment(
 }
 
 
+internal
 data class ScriptSection(
     val identifier: IntRange,
     val block: IntRange

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/normalization/KotlinApiClassExtractor.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/normalization/KotlinApiClassExtractor.kt
@@ -37,6 +37,7 @@ import org.objectweb.asm.ClassVisitor
 import java.util.Optional
 
 
+internal
 class KotlinApiClassExtractor : ApiClassExtractor(
     emptySet(),
     { classWriter -> KotlinApiMemberWriter(MethodStubbingApiMemberAdapter(classWriter)) }
@@ -163,6 +164,7 @@ class KotlinApiMemberWriter(apiMemberAdapter: ClassVisitor) : ApiMemberWriter(ap
 }
 
 
+internal
 class CompileAvoidanceException(message: String) : GradleException(message) {
 
     companion object Factory {

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/normalization/KotlinCompileClasspathFingerprinter.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/normalization/KotlinCompileClasspathFingerprinter.kt
@@ -31,6 +31,7 @@ import org.gradle.internal.snapshot.RegularFileSnapshot
 import org.gradle.kotlin.dsl.support.loggerFor
 
 
+internal
 class KotlinCompileClasspathFingerprinter(
     cacheService: ResourceSnapshotterCacheService,
     fileCollectionSnapshotter: FileCollectionSnapshotter,

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/BuildServices.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/BuildServices.kt
@@ -45,6 +45,7 @@ import org.gradle.plugin.management.internal.autoapply.AutoAppliedPluginHandler
 import org.gradle.plugin.use.internal.PluginRequestApplicator
 
 
+internal
 const val BUILDSCRIPT_COMPILE_AVOIDANCE_ENABLED = true
 
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinCompilerContextDisposer.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinCompilerContextDisposer.kt
@@ -26,6 +26,7 @@ import org.gradle.kotlin.dsl.support.disposeKotlinCompilerContext
 /**
  * Disposes Kotlin compiler environment once all scripts are compiled.
  */
+internal
 class KotlinCompilerContextDisposer(
     private val listenerManager: ListenerManager
 ) : InternalBuildAdapter(), Stoppable {

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinGradleApiSpecProvider.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinGradleApiSpecProvider.kt
@@ -21,8 +21,9 @@ import org.gradle.initialization.GradleApiSpecProvider
 
 class KotlinGradleApiSpecProvider : GradleApiSpecProvider {
 
-    override fun get() = KotlinSpec
+    override fun get(): GradleApiSpecProvider.Spec = KotlinSpec
 
+    private
     object KotlinSpec : GradleApiSpecProvider.SpecAdapter() {
         override fun getExportedPackages() = setOf("kotlin")
     }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProvider.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProvider.kt
@@ -40,7 +40,6 @@ import org.gradle.kotlin.dsl.support.serviceOf
 
 import org.gradle.util.internal.GFileUtils.moveFile
 
-import com.google.common.annotations.VisibleForTesting
 import org.gradle.api.internal.file.temp.TemporaryFileProvider
 
 import java.io.File
@@ -52,6 +51,7 @@ import java.net.URL
 import java.util.concurrent.ConcurrentHashMap
 
 
+internal
 fun gradleKotlinDslOf(project: Project): List<File> =
     kotlinScriptClassPathProviderOf(project).run {
         gradleKotlinDsl.asFiles
@@ -92,19 +92,19 @@ typealias JarsProvider = () -> Collection<File>
 
 
 class KotlinScriptClassPathProvider(
-    val moduleRegistry: ModuleRegistry,
-    val classPathRegistry: ClassPathRegistry,
-    val coreAndPluginsScope: ClassLoaderScope,
-    val gradleApiJarsProvider: JarsProvider,
-    val jarCache: JarCache,
-    val temporaryFileProvider: TemporaryFileProvider,
-    val progressMonitorProvider: JarGenerationProgressMonitorProvider
+    private val moduleRegistry: ModuleRegistry,
+    private val classPathRegistry: ClassPathRegistry,
+    private val coreAndPluginsScope: ClassLoaderScope,
+    private val gradleApiJarsProvider: JarsProvider,
+    private val jarCache: JarCache,
+    private val temporaryFileProvider: TemporaryFileProvider,
+    private val progressMonitorProvider: JarGenerationProgressMonitorProvider
 ) {
 
     /**
      * Generated Gradle API jar plus supporting libraries such as groovy-all.jar and generated API extensions.
      */
-    @VisibleForTesting
+    internal
     val gradleKotlinDsl: ClassPath by lazy {
         gradleApi + gradleApiExtensions + gradleKotlinDslJars
     }
@@ -147,6 +147,7 @@ class KotlinScriptClassPathProvider(
         return gradleKotlinDsl + exportClassPathFromHierarchyOf(scope)
     }
 
+    internal
     fun exportClassPathFromHierarchyOf(scope: ClassLoaderScope): ClassPath {
         require(scope.isLocked) {
             "$scope must be locked before it can be used to compute a classpath!"

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptPlugin.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptPlugin.kt
@@ -21,6 +21,7 @@ import org.gradle.groovy.scripts.ScriptSource
 import org.gradle.kotlin.dsl.support.loggerFor
 
 
+internal
 class KotlinScriptPlugin(
     private val scriptSource: ScriptSource,
     private val script: (Any) -> Unit

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/EditorReports.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/EditorReports.kt
@@ -16,8 +16,6 @@
 
 package org.gradle.kotlin.dsl.resolver
 
-import com.google.common.annotations.VisibleForTesting
-
 
 object EditorReports {
 
@@ -33,10 +31,10 @@ object EditorMessages {
     private
     const val ideLogs = "see IDE logs for more information"
 
-    @VisibleForTesting
+    internal
     const val failure = "Script dependencies resolution failed, $ideLogs"
 
-    @VisibleForTesting
+    internal
     const val failureUsingPrevious = "Script dependencies resolution failed, $usingPrevious, $ideLogs"
 
     private

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/FindGradleSources.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/FindGradleSources.kt
@@ -36,6 +36,7 @@ import java.io.File
  * subdirectories for all subprojects.
  */
 @DisableCachingByDefault(because = "Only filters the input artifact")
+internal
 abstract class FindGradleSources : TransformAction<TransformParameters.None> {
     @get:IgnoreEmptyDirectories
     @get:PathSensitive(PathSensitivity.RELATIVE)
@@ -68,6 +69,7 @@ abstract class FindGradleSources : TransformAction<TransformParameters.None> {
 
 
 @DisableCachingByDefault(because = "Not worth caching")
+internal
 abstract class UnzipDistribution : TransformAction<TransformParameters.None> {
     @get:PathSensitive(PathSensitivity.NONE)
     @get:InputArtifact

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptDependenciesResolver.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptDependenciesResolver.kt
@@ -27,8 +27,6 @@ import org.gradle.kotlin.dsl.tooling.models.KotlinBuildScriptModel
 
 import org.gradle.tooling.BuildException
 
-import com.google.common.annotations.VisibleForTesting
-
 import java.io.File
 import java.security.MessageDigest
 
@@ -79,7 +77,7 @@ fun EditorPosition.toIdePosition(): Position =
     Position(if (line == 0) 0 else line - 1, column)
 
 
-class KotlinBuildScriptDependenciesResolver @VisibleForTesting constructor(
+class KotlinBuildScriptDependenciesResolver internal constructor(
 
     private
     val logger: ResolverEventLogger

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptModelRequest.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptModelRequest.kt
@@ -32,7 +32,7 @@ import java.io.File
 import java.util.function.Function
 
 
-@VisibleForTesting
+internal
 sealed class GradleInstallation {
 
     data class Local(val dir: File) : GradleInstallation()
@@ -47,7 +47,7 @@ sealed class GradleInstallation {
 }
 
 
-@VisibleForTesting
+internal
 data class KotlinBuildScriptModelRequest(
     val projectDir: File,
     val scriptFile: File? = null,

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/ResolverEvent.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/ResolverEvent.kt
@@ -20,16 +20,14 @@ import kotlin.script.dependencies.KotlinScriptExternalDependencies
 
 import org.gradle.kotlin.dsl.tooling.models.KotlinBuildScriptModel
 
-import com.google.common.annotations.VisibleForTesting
-
 import java.io.File
 
 
-@VisibleForTesting
+internal
 sealed class ResolverEvent
 
 
-@VisibleForTesting
+internal
 data class ResolutionRequest internal constructor(
     val correlationId: String,
     val scriptFile: File?,
@@ -38,7 +36,7 @@ data class ResolutionRequest internal constructor(
 ) : ResolverEvent()
 
 
-@VisibleForTesting
+internal
 data class ResolutionFailure internal constructor(
     val correlationId: String,
     val scriptFile: File?,
@@ -46,7 +44,7 @@ data class ResolutionFailure internal constructor(
 ) : ResolverEvent()
 
 
-@VisibleForTesting
+internal
 data class SubmittedModelRequest internal constructor(
     val correlationId: String,
     val scriptFile: File?,
@@ -62,7 +60,7 @@ data class RequestCancelled(
 ) : ResolverEvent()
 
 
-@VisibleForTesting
+internal
 data class ReceivedModelResponse internal constructor(
     val correlationId: String,
     val scriptFile: File?,
@@ -70,7 +68,7 @@ data class ReceivedModelResponse internal constructor(
 ) : ResolverEvent()
 
 
-@VisibleForTesting
+internal
 data class ResolvedDependencies internal constructor(
     val correlationId: String,
     val scriptFile: File?,
@@ -78,7 +76,7 @@ data class ResolvedDependencies internal constructor(
 ) : ResolverEvent()
 
 
-@VisibleForTesting
+internal
 data class ResolvedDependenciesWithErrors internal constructor(
     val correlationId: String,
     val scriptFile: File?,

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/ResolverEventLogger.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/ResolverEventLogger.kt
@@ -23,8 +23,6 @@ import org.gradle.kotlin.dsl.support.userHome
 
 import org.gradle.kotlin.dsl.tooling.models.KotlinBuildScriptModel
 
-import com.google.common.annotations.VisibleForTesting
-
 import java.io.BufferedWriter
 import java.io.File
 import java.io.FileWriter
@@ -39,7 +37,7 @@ import kotlin.reflect.KProperty1
 import kotlin.reflect.full.declaredMemberProperties
 
 
-@VisibleForTesting
+internal
 interface ResolverEventLogger {
     fun log(event: ResolverEvent)
 }
@@ -146,7 +144,7 @@ object DefaultResolverEventLogger : ResolverEventLogger {
 }
 
 
-@VisibleForTesting
+internal
 fun prettyPrint(e: ResolverEvent): String = e.run {
     when (this) {
         is SubmittedModelRequest ->

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/SourceDistributionProvider.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/SourceDistributionProvider.kt
@@ -35,7 +35,7 @@ interface SourceDistributionProvider {
 }
 
 
-class SourceDistributionResolver(val project: Project) : SourceDistributionProvider {
+class SourceDistributionResolver(private val project: Project) : SourceDistributionProvider {
 
     companion object {
         val artifactType = Attribute.of("artifactType", String::class.java)

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/ClassBytesRepository.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/ClassBytesRepository.kt
@@ -20,14 +20,12 @@ import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.classpath.DefaultClassPath
 import org.gradle.util.internal.TextUtil.normaliseFileSeparators
 
-import com.google.common.annotations.VisibleForTesting
-
 import java.io.Closeable
 import java.io.File
 import java.util.jar.JarFile
 
 
-@VisibleForTesting
+internal
 fun classPathBytesRepositoryFor(classPath: List<File>, classPathDependencies: List<File> = emptyList()) =
     ClassBytesRepository(DefaultClassPath.of(classPath), DefaultClassPath.of(classPathDependencies))
 
@@ -46,7 +44,7 @@ typealias ClassBytesIndex = (String) -> ClassBytesSupplier?
  * Follows the one directory per package name segment convention.
  * Keeps JAR files open for fast lookup, must be closed.
  */
-@VisibleForTesting
+internal
 class ClassBytesRepository(classPath: ClassPath, classPathDependencies: ClassPath = ClassPath.EMPTY) : Closeable {
 
     private
@@ -165,7 +163,7 @@ private
 val slashOrDollar = Regex("[/$]")
 
 
-@VisibleForTesting
+internal
 fun kotlinSourceNameOf(classFilePath: String): String =
     classFilePath
         .removeSuffix(classFileExtension)
@@ -173,7 +171,7 @@ fun kotlinSourceNameOf(classFilePath: String): String =
         .replace(slashOrDollar, ".")
 
 
-@VisibleForTesting
+internal
 fun classFilePathCandidatesFor(sourceName: String): Sequence<String> =
     sourceName.replace(".", "/").let { path ->
         candidateClassFiles(path) + nestedClassFilePathCandidatesFor(path)

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProvider.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProvider.kt
@@ -22,7 +22,7 @@ import org.gradle.kotlin.dsl.embeddedKotlinVersion
 import java.util.Properties
 
 
-class EmbeddedKotlinProvider {
+class EmbeddedKotlinProvider internal constructor() {
 
     fun addDependenciesTo(
         dependencies: DependencyHandler,

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/GradleApiMetadata.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/GradleApiMetadata.kt
@@ -24,9 +24,11 @@ import java.util.Properties
 import java.util.jar.JarFile
 
 
+internal
 const val gradleApiMetadataModuleName = "gradle-api-metadata"
 
 
+internal
 data class GradleApiMetadata(
     val includes: List<String>,
     val excludes: List<String>,
@@ -36,6 +38,7 @@ data class GradleApiMetadata(
 }
 
 
+internal
 fun gradleApiMetadataFrom(gradleApiMetadataJar: File, gradleApiJars: Collection<File>): GradleApiMetadata =
     apiDeclarationFrom(gradleApiMetadataJar).let { (includes, excludes) ->
         GradleApiMetadata(includes, excludes, parameterNamesSupplierFor(parameterNamesFrom(gradleApiJars)))

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/IO.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/IO.kt
@@ -32,6 +32,7 @@ inline fun <T : AutoCloseable, U> T.useToRun(action: T.() -> U): U =
  *
  * Always using the same line separator on all systems to allow for reproducible outputs.
  */
+internal
 fun Appendable.appendReproducibleNewLine(value: CharSequence = ""): Appendable {
     assert('\r' !in value) {
         "Unexpected line ending in string."

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/ImplicitImports.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/ImplicitImports.kt
@@ -22,7 +22,7 @@ import org.gradle.configuration.ImportsReader
 /**
  * Holds the list of imports implicitly added to every Kotlin build script.
  */
-class ImplicitImports(
+class ImplicitImports internal constructor(
     @Transient
     private val importsReader: ImportsReader
 ) {

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinScriptHost.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinScriptHost.kt
@@ -42,15 +42,16 @@ import org.gradle.util.internal.ConfigureUtil.configureByMap
 import java.io.File
 
 
-class KotlinScriptHost<out T : Any>(
+class KotlinScriptHost<out T : Any> internal constructor(
     val target: T,
     val scriptSource: ScriptSource,
-    val scriptHandler: ScriptHandler,
-    val targetScope: ClassLoaderScope,
-    val baseScope: ClassLoaderScope,
+    internal val scriptHandler: ScriptHandler,
+    internal val targetScope: ClassLoaderScope,
+    private val baseScope: ClassLoaderScope,
     private val serviceRegistry: ServiceRegistry
 ) {
 
+    internal
     val fileName = scriptSource.fileName!!
 
     internal

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinScriptType.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinScriptType.kt
@@ -28,13 +28,14 @@ enum class KotlinScriptType {
 }
 
 
-data class KotlinScriptTypeMatch(
+data class KotlinScriptTypeMatch private constructor(
     val scriptType: KotlinScriptType,
     val match: Match
 ) {
 
     companion object {
 
+        internal
         fun forFile(file: File): KotlinScriptTypeMatch? =
             forName(file.name)
 
@@ -60,10 +61,12 @@ sealed class Match {
 
     abstract fun matches(candidate: String): Boolean
 
+    internal
     data class Whole(override val value: String) : Match() {
         override fun matches(candidate: String) = candidate == value
     }
 
+    internal
     data class Suffix(override val value: String) : Match() {
         override fun matches(candidate: String) = candidate.endsWith(value)
     }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/PluginAwareScript.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/PluginAwareScript.kt
@@ -24,7 +24,7 @@ import org.gradle.api.plugins.PluginContainer
 import org.gradle.api.plugins.PluginManager
 
 
-open class PluginAwareScript(
+open class PluginAwareScript internal constructor(
     private val host: KotlinScriptHost<PluginAware>
 ) : PluginAware {
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/ProjectExtensions.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/ProjectExtensions.kt
@@ -16,7 +16,6 @@
 
 package org.gradle.kotlin.dsl.support
 
-import com.google.common.annotations.VisibleForTesting
 import org.gradle.api.Project
 
 import org.gradle.api.internal.project.ProjectInternal
@@ -33,7 +32,7 @@ fun serviceRegistryOf(project: Project) =
     (project as ProjectInternal).services
 
 
-@VisibleForTesting
+internal
 fun isGradleKotlinDslJar(file: File) =
     isGradleKotlinDslJarName(file.name)
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/bytecode/GradleJvmVersion.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/bytecode/GradleJvmVersion.kt
@@ -20,6 +20,7 @@ import org.gradle.api.JavaVersion
 import org.objectweb.asm.Opcodes
 
 
+internal
 object GradleJvmVersion {
 
     /**


### PR DESCRIPTION
This PR makes it possible to access Kotlin `internal` members from `testFixtures`, `test` and `integTest` source sets.
This only changes how we build Gradle itself.

It also tightens the visibility of non-Gradle-public-api members of `:kotlin-dsl` that were public only to be used in tests.

See https://kotlinlang.org/docs/gradle-configure-project.html#associate-compiler-tasks