### PR TITLE
Maximize usage of ImmutableCapabilities to further reduce memory usage and simplify code

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParser.java
@@ -38,7 +38,7 @@ import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
-import org.gradle.internal.component.external.model.DefaultShadowedCapability;
+import org.gradle.internal.component.external.model.ImmutableShadowedCapability;
 import org.gradle.internal.component.external.model.ImmutableCapability;
 import org.gradle.internal.component.external.model.MutableComponentVariant;
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
@@ -135,7 +135,7 @@ public class GradleModuleMetadataParser {
     }
 
     private Capability buildShadowPlatformCapability(ModuleComponentIdentifier componentId) {
-        return new DefaultShadowedCapability(new ImmutableCapability(
+        return new ImmutableShadowedCapability(new ImmutableCapability(
                 componentId.getGroup(),
                 componentId.getModule(),
                 componentId.getVersion()

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializer.java
@@ -43,7 +43,7 @@ import org.gradle.internal.component.external.descriptor.MavenScope;
 import org.gradle.internal.component.external.model.CapabilityInternal;
 import org.gradle.internal.component.external.model.ComponentVariant;
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
-import org.gradle.internal.component.external.model.DefaultShadowedCapability;
+import org.gradle.internal.component.external.model.ImmutableShadowedCapability;
 import org.gradle.internal.component.external.model.ExternalDependencyDescriptor;
 import org.gradle.internal.component.external.model.ImmutableCapability;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
@@ -515,7 +515,7 @@ public class ModuleMetadataSerializer {
                 String appendix = decoder.readNullableString();
                 CapabilityInternal capability = new ImmutableCapability(decoder.readString(), decoder.readString(), decoder.readString());
                 if (appendix != null) {
-                    capability = new DefaultShadowedCapability(capability, appendix);
+                    capability = new ImmutableShadowedCapability(capability, appendix);
                 }
                 variant.addCapability(capability);
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultLocalComponentMetadataBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultLocalComponentMetadataBuilder.java
@@ -72,8 +72,7 @@ public class DefaultLocalComponentMetadataBuilder implements LocalComponentMetad
         ImmutableSet<String> hierarchy = Configurations.getNames(configuration.getHierarchy());
         ImmutableSet<String> extendsFrom = Configurations.getNames(configuration.getExtendsFrom());
         // Presence of capabilities is bound to the definition of a capabilities extension to the project
-        ImmutableCapabilities capabilities =
-            ImmutableCapabilities.copyAsImmutable(Configurations.collectCapabilities(configuration, Sets.newHashSet(), Sets.newHashSet()));
+        ImmutableCapabilities capabilities = ImmutableCapabilities.of(Configurations.collectCapabilities(configuration, Sets.newHashSet(), Sets.newHashSet()));
         return metaData.addConfiguration(configuration.getName(),
             configuration.getDescription(),
             extendsFrom,

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleResolveMetadataSerializationHelper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleResolveMetadataSerializationHelper.java
@@ -191,7 +191,7 @@ public abstract class AbstractRealisedModuleResolveMetadataSerializationHelper {
             String appendix = decoder.readNullableString();
             CapabilityInternal capability = new ImmutableCapability(decoder.readString(), decoder.readString(), decoder.readString());
             if (appendix != null) {
-                capability = new DefaultShadowedCapability(capability, appendix);
+                capability = new ImmutableShadowedCapability(capability, appendix);
             }
             rawCapabilities.add(capability);
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMutableCapabilities.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultMutableCapabilities.java
@@ -20,7 +20,6 @@ import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.capabilities.CapabilitiesMetadata;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.capabilities.MutableCapabilitiesMetadata;
-import org.gradle.internal.Cast;
 
 import java.util.List;
 
@@ -48,8 +47,7 @@ public class DefaultMutableCapabilities implements MutableCapabilitiesMetadata {
 
     @Override
     public CapabilitiesMetadata asImmutable() {
-        ImmutableList<ImmutableCapability> capabilities = Cast.uncheckedCast(getCapabilities());
-        return new ImmutableCapabilities(capabilities);
+        return ImmutableCapabilities.of(getCapabilities());
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ImmutableCapabilities.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ImmutableCapabilities.java
@@ -57,7 +57,22 @@ public class ImmutableCapabilities implements CapabilitiesMetadata {
     }
 
     public ImmutableCapabilities(ImmutableList<? extends Capability> capabilities) {
-        this.capabilities = capabilities;
+        ImmutableList.Builder<CapabilityInternal> builder = ImmutableList.builder();
+
+        for (Capability capability : capabilities) {
+            if (capability instanceof ImmutableCapability) {
+                builder.add((ImmutableCapability) capability);
+            } else if (capability instanceof ImmutableShadowedCapability) {
+                builder.add((ImmutableShadowedCapability) capability);
+            } else if (capability instanceof ShadowedCapability) {
+                ShadowedCapability shadowedCapability = (ShadowedCapability) capability;
+                builder.add(new ImmutableShadowedCapability(shadowedCapability, shadowedCapability.getAppendix()));
+            } else {
+                builder.add(new ImmutableCapability(capability.getGroup(), capability.getName(), capability.getVersion()));
+            }
+        }
+
+        this.capabilities = builder.build();
     }
 
     public static ImmutableCapabilities copyAsImmutable(Collection<? extends Capability> capabilities) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ImmutableCapabilities.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ImmutableCapabilities.java
@@ -30,6 +30,9 @@ import java.util.List;
  * This type will ensure that all contents are immutable upon construction,
  * in order to allow instances of this type to be safely reused whenever possible
  * to avoid unnecessary memory allocations.
+ *
+ * Note that while this class is not itself {@code final}, all fields are private, so
+ * subclassing should not break the immutability contract.
  */
 public class ImmutableCapabilities implements CapabilitiesMetadata {
     public static final ImmutableCapabilities EMPTY = new ImmutableCapabilities(ImmutableList.<ImmutableCapability>of());
@@ -86,7 +89,7 @@ public class ImmutableCapabilities implements CapabilitiesMetadata {
         return capabilities;
     }
 
-    private static class ShadowedSingleImmutableCapabilities extends ImmutableCapabilities implements ShadowedCapabilityOnly {
+    private final static class ShadowedSingleImmutableCapabilities extends ImmutableCapabilities implements ShadowedCapabilityOnly {
         public ShadowedSingleImmutableCapabilities(Capability single) {
             super(ImmutableList.of(single));
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ImmutableCapabilities.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ImmutableCapabilities.java
@@ -43,13 +43,6 @@ public class ImmutableCapabilities implements CapabilitiesMetadata {
         return of(capabilities.getCapabilities());
     }
 
-    public static ImmutableCapabilities of(@Nullable Collection<? extends Capability> capabilities) {
-        if (capabilities == null || capabilities.isEmpty()) {
-            return EMPTY;
-        }
-        return new ImmutableCapabilities(capabilities);
-    }
-
     public static ImmutableCapabilities of(@Nullable Capability capability) {
         if (capability == null) {
             return EMPTY;
@@ -57,7 +50,18 @@ public class ImmutableCapabilities implements CapabilitiesMetadata {
         if (capability instanceof ShadowedCapability) {
             return new ShadowedSingleImmutableCapabilities(capability);
         }
-        return of(Collections.singleton(capability));
+        return new ImmutableCapabilities(Collections.singleton(capability));
+    }
+
+    public static ImmutableCapabilities of(@Nullable Collection<? extends Capability> capabilities) {
+        if (capabilities == null || capabilities.isEmpty()) {
+            return EMPTY;
+        }
+        if (capabilities.size() == 1) {
+            Capability single = capabilities.iterator().next();
+            return of(single);
+        }
+        return new ImmutableCapabilities(capabilities);
     }
 
     private ImmutableCapabilities(Collection<? extends Capability> capabilities) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ImmutableCapability.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ImmutableCapability.java
@@ -21,7 +21,7 @@ import org.gradle.api.capabilities.Capability;
 
 import javax.annotation.Nullable;
 
-public class ImmutableCapability implements CapabilityInternal {
+public final class ImmutableCapability implements CapabilityInternal {
 
     public static ImmutableCapability defaultCapabilityForComponent(ModuleVersionIdentifier identifier) {
         return new ImmutableCapability(identifier.getGroup(), identifier.getName(), identifier.getVersion());

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ImmutableShadowedCapability.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ImmutableShadowedCapability.java
@@ -15,12 +15,21 @@
  */
 package org.gradle.internal.component.external.model;
 
-public class ImmutableShadowedCapability implements ShadowedCapability {
+/**
+ * A capability that is shadowed by another capability, which is deeply immutable.
+ *
+ * Note that despite the name, this is <strong>NOT</strong> an extension of
+ * {@link ImmutableCapability}.  The class hierarchy needs to be adjusted to
+ * expose the relationships here.
+ */
+public final class ImmutableShadowedCapability implements ShadowedCapability {
     private final CapabilityInternal shadowed;
     private final String appendix;
 
     public ImmutableShadowedCapability(CapabilityInternal shadowed, String appendix) {
         if (shadowed instanceof ImmutableShadowedCapability) {
+            this.shadowed = shadowed;
+        } else if (shadowed instanceof ImmutableCapability) {
             this.shadowed = shadowed;
         } else {
             this.shadowed = new ImmutableCapability(shadowed.getGroup(), shadowed.getName(), shadowed.getVersion());

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ImmutableShadowedCapability.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ImmutableShadowedCapability.java
@@ -15,12 +15,16 @@
  */
 package org.gradle.internal.component.external.model;
 
-public class DefaultShadowedCapability implements ShadowedCapability {
+public class ImmutableShadowedCapability implements ShadowedCapability {
     private final CapabilityInternal shadowed;
     private final String appendix;
 
-    public DefaultShadowedCapability(CapabilityInternal shadowed, String appendix) {
-        this.shadowed = shadowed;
+    public ImmutableShadowedCapability(CapabilityInternal shadowed, String appendix) {
+        if (shadowed instanceof ImmutableShadowedCapability) {
+            this.shadowed = shadowed;
+        } else {
+            this.shadowed = new ImmutableCapability(shadowed.getGroup(), shadowed.getName(), shadowed.getVersion());
+        }
         this.appendix = appendix;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/JavaEcosystemVariantDerivationStrategy.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/JavaEcosystemVariantDerivationStrategy.java
@@ -96,7 +96,7 @@ public class JavaEcosystemVariantDerivationStrategy extends AbstractStatelessDer
 
     private ImmutableCapabilities buildShadowPlatformCapability(ModuleComponentIdentifier componentId, boolean enforced) {
         return ImmutableCapabilities.of(Collections.singletonList(
-                new DefaultShadowedCapability(new ImmutableCapability(
+                new ImmutableShadowedCapability(new ImmutableCapability(
                         componentId.getGroup(),
                         componentId.getModule(),
                         componentId.getVersion()

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/DefaultArtifactSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/DefaultArtifactSelector.java
@@ -71,10 +71,9 @@ public class DefaultArtifactSelector implements ArtifactSelector {
     public ArtifactSet resolveArtifacts(ComponentResolveMetadata component, Supplier<Set<? extends VariantResolveMetadata>> allVariants, Set<? extends VariantResolveMetadata> legacyVariants, ExcludeSpec exclusions, ImmutableAttributes overriddenAttributes) {
         ModuleVersionIdentifier moduleVersionId = component.getModuleVersionId();
         ModuleSources sources = component.getSources();
-        ImmutableCapabilities fallbackCapabilities = ImmutableCapabilities.of(ImmutableCapability.defaultCapabilityForComponent(moduleVersionId));
 
-        ImmutableSet<ResolvedVariant> legacyResolvedVariants = buildResolvedVariants(moduleVersionId, fallbackCapabilities, sources, legacyVariants, exclusions);
-        ComponentArtifactResolveVariantState allResolvedVariants = () -> buildResolvedVariants(moduleVersionId, fallbackCapabilities, sources, allVariants.get(), exclusions);
+        ImmutableSet<ResolvedVariant> legacyResolvedVariants = buildResolvedVariants(moduleVersionId, sources, legacyVariants, exclusions);
+        ComponentArtifactResolveVariantState allResolvedVariants = () -> buildResolvedVariants(moduleVersionId, sources, allVariants.get(), exclusions);
 
         for (OriginArtifactSelector selector : selectors) {
             ArtifactSet artifacts = selector.resolveArtifacts(component, allResolvedVariants, legacyResolvedVariants, exclusions, overriddenAttributes);
@@ -85,10 +84,10 @@ public class DefaultArtifactSelector implements ArtifactSelector {
         throw new IllegalStateException("No artifacts selected.");
     }
 
-    private ImmutableSet<ResolvedVariant> buildResolvedVariants(ModuleVersionIdentifier moduleVersionId, ImmutableCapabilities fallbackCapabilities, ModuleSources sources, Set<? extends VariantResolveMetadata> allVariants, ExcludeSpec exclusions) {
+    private ImmutableSet<ResolvedVariant> buildResolvedVariants(ModuleVersionIdentifier moduleVersionId, ModuleSources sources, Set<? extends VariantResolveMetadata> allVariants, ExcludeSpec exclusions) {
         ImmutableSet.Builder<ResolvedVariant> resolvedVariantBuilder = ImmutableSet.builder();
         for (VariantResolveMetadata variant : allVariants) {
-            ResolvedVariant resolvedVariant = toResolvedVariant(variant.getIdentifier(), variant.asDescribable(), variant.getAttributes(), variant.getArtifacts(), withImplicitCapability(variant.getCapabilities().getCapabilities(), fallbackCapabilities), exclusions, moduleVersionId, sources, resolvedVariantCache, variant.isEligibleForCaching());
+            ResolvedVariant resolvedVariant = toResolvedVariant(variant.getIdentifier(), variant.asDescribable(), variant.getAttributes(), variant.getArtifacts(), withImplicitCapability(variant.getCapabilities().getCapabilities(), moduleVersionId), exclusions, moduleVersionId, sources, resolvedVariantCache, variant.isEligibleForCaching());
             resolvedVariantBuilder.add(resolvedVariant);
         }
         return resolvedVariantBuilder.build();
@@ -128,10 +127,10 @@ public class DefaultArtifactSelector implements ArtifactSelector {
         }
     }
 
-    private static ImmutableCapabilities withImplicitCapability(Collection<? extends Capability> capabilities, ImmutableCapabilities fallbackCapabilities) {
+    private static ImmutableCapabilities withImplicitCapability(Collection<? extends Capability> capabilities, ModuleVersionIdentifier moduleVersionId) {
         // TODO: This doesn't seem right. We should know the capability of the variant before we get here instead of assuming that it's the same as the owner
         if (capabilities.isEmpty()) {
-            return fallbackCapabilities;
+            return ImmutableCapabilities.of(ImmutableCapability.defaultCapabilityForComponent(moduleVersionId));
         } else {
             return ImmutableCapabilities.copyAsImmutable(capabilities);
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/DefaultArtifactSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/DefaultArtifactSelector.java
@@ -19,7 +19,7 @@ package org.gradle.internal.resolve.resolver;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
-import org.gradle.api.capabilities.Capability;
+import org.gradle.api.capabilities.CapabilitiesMetadata;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactSetFactory;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.FileDependencyArtifactSet;
@@ -87,7 +87,7 @@ public class DefaultArtifactSelector implements ArtifactSelector {
     private ImmutableSet<ResolvedVariant> buildResolvedVariants(ModuleVersionIdentifier moduleVersionId, ModuleSources sources, Set<? extends VariantResolveMetadata> allVariants, ExcludeSpec exclusions) {
         ImmutableSet.Builder<ResolvedVariant> resolvedVariantBuilder = ImmutableSet.builder();
         for (VariantResolveMetadata variant : allVariants) {
-            ResolvedVariant resolvedVariant = toResolvedVariant(variant.getIdentifier(), variant.asDescribable(), variant.getAttributes(), variant.getArtifacts(), withImplicitCapability(variant.getCapabilities().getCapabilities(), moduleVersionId), exclusions, moduleVersionId, sources, resolvedVariantCache, variant.isEligibleForCaching());
+            ResolvedVariant resolvedVariant = toResolvedVariant(variant.getIdentifier(), variant.asDescribable(), variant.getAttributes(), variant.getArtifacts(), withImplicitCapability(variant.getCapabilities(), moduleVersionId), exclusions, moduleVersionId, sources, resolvedVariantCache, variant.isEligibleForCaching());
             resolvedVariantBuilder.add(resolvedVariant);
         }
         return resolvedVariantBuilder.build();
@@ -127,12 +127,14 @@ public class DefaultArtifactSelector implements ArtifactSelector {
         }
     }
 
-    private static ImmutableCapabilities withImplicitCapability(Collection<? extends Capability> capabilities, ModuleVersionIdentifier moduleVersionId) {
+    private static ImmutableCapabilities withImplicitCapability(CapabilitiesMetadata capabilitiesMetadata, ModuleVersionIdentifier moduleVersionId) {
         // TODO: This doesn't seem right. We should know the capability of the variant before we get here instead of assuming that it's the same as the owner
-        if (capabilities.isEmpty()) {
+        if (capabilitiesMetadata.getCapabilities().isEmpty()) {
             return ImmutableCapabilities.of(ImmutableCapability.defaultCapabilityForComponent(moduleVersionId));
+        } else if (capabilitiesMetadata instanceof ImmutableCapabilities) {
+            return (ImmutableCapabilities) capabilitiesMetadata;
         } else {
-            return ImmutableCapabilities.copyAsImmutable(capabilities);
+            return ImmutableCapabilities.copyAsImmutable(capabilitiesMetadata.getCapabilities());
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/DefaultArtifactSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/DefaultArtifactSelector.java
@@ -134,7 +134,7 @@ public class DefaultArtifactSelector implements ArtifactSelector {
         } else if (capabilitiesMetadata instanceof ImmutableCapabilities) {
             return (ImmutableCapabilities) capabilitiesMetadata;
         } else {
-            return ImmutableCapabilities.copyAsImmutable(capabilitiesMetadata.getCapabilities());
+            return ImmutableCapabilities.of(capabilitiesMetadata.getCapabilities());
         }
     }
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlatformPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlatformPlugin.java
@@ -38,7 +38,7 @@ import org.gradle.api.publish.ivy.internal.publication.IvyPublicationInternal;
 import org.gradle.api.publish.maven.MavenPublication;
 import org.gradle.api.publish.maven.internal.publication.MavenPublicationInternal;
 import org.gradle.api.publish.plugins.PublishingPlugin;
-import org.gradle.internal.component.external.model.DefaultShadowedCapability;
+import org.gradle.internal.component.external.model.ImmutableShadowedCapability;
 import org.gradle.internal.component.external.model.ProjectDerivedCapability;
 
 import javax.inject.Inject;
@@ -117,7 +117,7 @@ public abstract class JavaPlatformPlugin implements Plugin<Project> {
 
     private void createConfigurations(Project project) {
         ConfigurationContainer configurations = project.getConfigurations();
-        Capability enforcedCapability = new DefaultShadowedCapability(new ProjectDerivedCapability(project), "-derived-enforced-platform");
+        Capability enforcedCapability = new ImmutableShadowedCapability(new ProjectDerivedCapability(project), "-derived-enforced-platform");
 
         Configuration api = configurations.create(API_CONFIGURATION_NAME, AS_BUCKET);
         Configuration apiElements = createConsumableApi(project, configurations, api, API_ELEMENTS_CONFIGURATION_NAME, Category.REGULAR_PLATFORM);


### PR DESCRIPTION
Makes `ImmutableCapabilities` class thoroughly immutable by verifying immutability of all contents as they are added.  This add references to already immutable capabilities, and duplicates non-immutable capabilities as immutable types.

Renames `DefaultShadowedCapability` to `ImmutableShadowedCapability` to advertise immutability.  Also check that the shadowed capability is immutable upon construction, or make an immutable copy.

The result of this is to make the `DefaultArtifactSelector` more efficient in two ways.  It can defer creation of a fallback capabilities collection until it is actually needed.  It can also reuse existing immutable capabilities rather than creating new instances, as the immutable types will never change.

This saves 16MB or so during the large sync scenario testing by creating less `ImmutableCapabilities` and `ImmutableCapability` objects which are equivalent. 

The top image shows the new results, the bottom shows the old:

<img width="900" alt="image" src="https://user-images.githubusercontent.com/44197/215287095-b96006a5-7bde-4441-8781-b2330b2a217b.png">

