### PR TITLE
Apply the latest artifactId in pluginMarkerMaven POM.

### DIFF
--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/JavaGradlePluginPluginPublishingIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/JavaGradlePluginPluginPublishingIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.plugin.devel.plugins
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import spock.lang.Issue
 
 import static org.gradle.plugin.use.resolve.internal.ArtifactRepositoriesPluginResolver.PLUGIN_MARKER_SUFFIX
 
@@ -168,6 +169,40 @@ class JavaGradlePluginPluginPublishingIntegrationTest extends AbstractIntegratio
         ivyRepo.module('com.example', 'plugins', '1.0')
             .assertArtifactsPublished("ivy-1.0.xml", "plugins-1.0.module", "plugins-1.0.jar", "plugins-1.0-sources.jar")
         ivyRepo.module('com.example.foo', 'com.example.foo' + PLUGIN_MARKER_SUFFIX, '1.0').assertPublished()
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/23551")
+    def "Can publish maven with changed artifactId"() {
+
+        given:
+        plugin('foo', 'com.example.foo')
+        publishToMaven()
+
+        and:
+        buildFile << """
+            publishing {
+                afterEvaluate {
+                    publications {
+                        getByName("pluginMaven"){
+                            configure{
+                                artifactId = "foo-new"
+                            }
+                        }
+                    }
+                }
+            }
+        """.stripIndent()
+
+        when:
+        succeeds 'publish'
+
+
+        then:
+        mavenRepo.module('com.example', 'foo-new', '1.0').assertPublished()
+
+        def module = mavenRepo.module('com.example.foo', 'com.example.foo' + PLUGIN_MARKER_SUFFIX, '1.0')
+        module.assertPublished()
+        module.getPomFile().text.contains('foo-new')
     }
 
     @ToBeFixedForConfigurationCache(because = "publishing")

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/JavaGradlePluginPluginPublishingIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/JavaGradlePluginPluginPublishingIntegrationTest.groovy
@@ -183,9 +183,11 @@ class JavaGradlePluginPluginPublishingIntegrationTest extends AbstractIntegratio
             publishing {
                 afterEvaluate {
                     publications {
-                        getByName("pluginMaven"){
-                            configure{
+                        getByName("pluginMaven") {
+                            configure {
                                 artifactId = "foo-new"
+                                groupId = "com.example.foo.new"
+                                version = "1.2.3"
                             }
                         }
                     }
@@ -198,11 +200,13 @@ class JavaGradlePluginPluginPublishingIntegrationTest extends AbstractIntegratio
 
 
         then:
-        mavenRepo.module('com.example', 'foo-new', '1.0').assertPublished()
+        mavenRepo.module('com.example.foo.new', 'foo-new', '1.2.3').assertPublished()
 
         def module = mavenRepo.module('com.example.foo', 'com.example.foo' + PLUGIN_MARKER_SUFFIX, '1.0')
         module.assertPublished()
         module.getPomFile().text.contains('foo-new')
+        module.getPomFile().text.contains('com.example.foo.new')
+        module.getPomFile().text.contains('1.2.3')
     }
 
     @ToBeFixedForConfigurationCache(because = "publishing")

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/MavenPluginPublishPlugin.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/MavenPluginPublishPlugin.java
@@ -82,9 +82,6 @@ abstract class MavenPluginPublishPlugin implements Plugin<Project> {
 
     private void createMavenMarkerPublication(PluginDeclaration declaration, final MavenPublication coordinates, PublicationContainer publications) {
         String pluginId = declaration.getId();
-        String pluginGroupId = coordinates.getGroupId();
-        String pluginArtifactId = coordinates.getArtifactId();
-        String pluginVersion = coordinates.getVersion();
         MavenPublicationInternal publication = (MavenPublicationInternal) publications.create(declaration.getName() + "PluginMarkerMaven", MavenPublication.class);
         publication.setAlias(true);
         publication.setArtifactId(pluginId + PLUGIN_MARKER_SUFFIX);
@@ -97,11 +94,11 @@ abstract class MavenPluginPublishPlugin implements Plugin<Project> {
                 Node dependencies = root.appendChild(document.createElement("dependencies"));
                 Node dependency = dependencies.appendChild(document.createElement("dependency"));
                 Node groupId = dependency.appendChild(document.createElement("groupId"));
-                groupId.setTextContent(pluginGroupId);
+                groupId.setTextContent(coordinates.getGroupId());
                 Node artifactId = dependency.appendChild(document.createElement("artifactId"));
-                artifactId.setTextContent(pluginArtifactId);
+                artifactId.setTextContent(coordinates.getArtifactId());
                 Node version = dependency.appendChild(document.createElement("version"));
-                version.setTextContent(pluginVersion);
+                version.setTextContent(coordinates.getVersion());
             }
         });
         publication.getPom().getName().set(declaration.getDisplayName());


### PR DESCRIPTION
Signed-off-by: Yanshun Li <qqliys@126.com>

<!--- The issue this PR addresses -->
Fixes #23551

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
While generating the pom file for maven maker publication,  it will apply the cached values of`pluginGroupId,  pluginArtifactId,  pluginVersion`. However, these values could be changed before executing the generating task.
In this pr, instead of applying the cached values, the latest values will be applied to fix this issue.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
