### PR TITLE
Emit a bunch of deprecation warnings for Gradle 8.1

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/util/VersionNumber.java
+++ b/subprojects/core/src/main/java/org/gradle/util/VersionNumber.java
@@ -30,10 +30,10 @@ import javax.annotation.Nullable;
 @Deprecated
 public class VersionNumber implements Comparable<VersionNumber> {
 
-    private static void logDeprecation() {
+    private static void logDeprecation(int majorVersion) {
         DeprecationLogger.deprecateType(VersionNumber.class)
             .willBeRemovedInGradle9()
-            .withUpgradeGuideSection(7, "org_gradle_util_reports_deprecations")
+            .withUpgradeGuideSection(majorVersion, "org_gradle_util_reports_deprecations")
             .nagUser();
     }
 
@@ -64,16 +64,15 @@ public class VersionNumber implements Comparable<VersionNumber> {
         this.patch = patch;
         this.qualifier = qualifier;
         this.scheme = scheme;
-        // TODO log deprecation once protobuf/osdetector plugin is fixed
         if (logDeprecation) {
-            logDeprecation();
+            logDeprecation(7);
             deprecationLogged = true;
         }
     }
 
     private void maybeLogDeprecation() {
         if(!deprecationLogged) {
-            logDeprecation();
+            logDeprecation(7);
         }
     }
 
@@ -110,7 +109,7 @@ public class VersionNumber implements Comparable<VersionNumber> {
 
     @Override
     public int compareTo(VersionNumber other) {
-        // TODO log deprecation once protobuf/osdetector plugin is fixed
+        logDeprecation(8);
         if (major != other.major) {
             return major - other.major;
         }
@@ -159,7 +158,7 @@ public class VersionNumber implements Comparable<VersionNumber> {
      * Returns the default MAJOR.MINOR.MICRO-QUALIFIER scheme.
      */
     public static Scheme scheme() {
-        logDeprecation();
+        logDeprecation(7);
         return DEFAULT_SCHEME;
     }
 
@@ -167,12 +166,12 @@ public class VersionNumber implements Comparable<VersionNumber> {
      * Returns the MAJOR.MINOR.MICRO.PATCH-QUALIFIER scheme.
      */
     public static Scheme withPatchNumber() {
-        logDeprecation();
+        logDeprecation(7);
         return PATCH_SCHEME;
     }
 
     public static VersionNumber parse(String versionString) {
-        // TODO log deprecation once protobuf/osdetector plugin is fixed
+        logDeprecation(8);
         return DEFAULT_SCHEME.parse(versionString);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/util/WrapUtil.java
+++ b/subprojects/core/src/main/java/org/gradle/util/WrapUtil.java
@@ -41,7 +41,7 @@ import java.util.TreeSet;
 @Deprecated
 public class WrapUtil {
 
-    private static void logDeprecation() {
+    private static void logDeprecation(int majorVersion) {
         DeprecationLogger.deprecateType(WrapUtil.class)
             .willBeRemovedInGradle9()
             .withUpgradeGuideSection(7, "org_gradle_util_reports_deprecations")
@@ -49,7 +49,7 @@ public class WrapUtil {
     }
 
     public WrapUtil() {
-        logDeprecation();
+        logDeprecation(7);
     }
 
     /**
@@ -58,7 +58,7 @@ public class WrapUtil {
     @SafeVarargs
     @SuppressWarnings("varargs")
     public static <T> Set<T> toSet(T... items) {
-        logDeprecation();
+        logDeprecation(7);
         Set<T> coll = new HashSet<T>();
         Collections.addAll(coll, items);
         return coll;
@@ -70,7 +70,7 @@ public class WrapUtil {
     @SafeVarargs
     @SuppressWarnings("varargs")
     public static <T> DomainObjectSet<T> toDomainObjectSet(Class<T> type, T... items) {
-        // TODO log deprecation when Kotlin plugin is fixed
+        logDeprecation(8);
         DefaultDomainObjectSet<T> set = new DefaultDomainObjectSet<T>(type, CollectionCallbackActionDecorator.NOOP);
         set.addAll(Arrays.asList(items));
         return set;
@@ -82,7 +82,7 @@ public class WrapUtil {
     @SafeVarargs
     @SuppressWarnings("varargs")
     public static <T> Set<T> toLinkedSet(T... items) {
-        logDeprecation();
+        logDeprecation(7);
         Set<T> coll = new LinkedHashSet<T>();
         Collections.addAll(coll, items);
         return coll;
@@ -94,7 +94,7 @@ public class WrapUtil {
     @SafeVarargs
     @SuppressWarnings("varargs")
     public static <T> SortedSet<T> toSortedSet(T... items) {
-        logDeprecation();
+        logDeprecation(7);
         SortedSet<T> coll = new TreeSet<T>();
         Collections.addAll(coll, items);
         return coll;
@@ -106,7 +106,7 @@ public class WrapUtil {
     @SafeVarargs
     @SuppressWarnings("varargs")
     public static <T> SortedSet<T> toSortedSet(Comparator<T> comp, T... items) {
-        logDeprecation();
+        logDeprecation(7);
         SortedSet<T> coll = new TreeSet<T>(comp);
         Collections.addAll(coll, items);
         return coll;
@@ -118,7 +118,7 @@ public class WrapUtil {
     @SafeVarargs
     @SuppressWarnings("varargs")
     public static <T> List<T> toList(T... items) {
-        logDeprecation();
+        logDeprecation(7);
         ArrayList<T> coll = new ArrayList<T>();
         Collections.addAll(coll, items);
         return coll;
@@ -128,7 +128,7 @@ public class WrapUtil {
      * Wraps the given items in a mutable list.
      */
     public static <T> List<T> toList(Iterable<? extends T> items) {
-        logDeprecation();
+        logDeprecation(7);
         ArrayList<T> coll = new ArrayList<T>();
         for (T item : items) {
             coll.add(item);
@@ -140,7 +140,7 @@ public class WrapUtil {
      * Wraps the given key and value in a mutable unordered map.
      */
     public static <K, V> Map<K, V> toMap(K key, V value) {
-        logDeprecation();
+        logDeprecation(7);
         Map<K, V> map = new HashMap<K, V>();
         map.put(key, value);
         return map;
@@ -149,7 +149,7 @@ public class WrapUtil {
     @SafeVarargs
     @SuppressWarnings("varargs")
     public static <T> T[] toArray(T... items) {
-        logDeprecation();
+        logDeprecation(7);
         return items;
     }
 

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
@@ -189,3 +189,8 @@ plugins {
 
 The Java Toolchains plugin is applied automatically by the link:https://docs.gradle.org/current/userguide/java_plugin.html[Java plugin],
 so you can also apply it to your project and it will fix the warning.
+
+[[org_gradle_util_reports_deprecations]]
+==== Deprecated members of the `org.gradle.util` package now report their deprecation
+
+These members will be removed in Gradle 9.0.

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
@@ -200,7 +200,6 @@ These members will be removed in Gradle 9.0.
 * `GUtil.toCamelCase(...)`
 * `GUtil.toLowerCase(...)`
 * `ConfigureUtil.configureByMap(...)`
-* `ConfigureUtil.configure(...)`
 
 [[for_use_at_configuration_time_deprecation]]
 ==== `Provider.forUseAtConfigurationTime()`

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
@@ -200,12 +200,3 @@ These members will be removed in Gradle 9.0.
 * `GUtil.toCamelCase(...)`
 * `GUtil.toLowerCase(...)`
 * `ConfigureUtil.configureByMap(...)`
-
-[[for_use_at_configuration_time_deprecation]]
-==== `Provider.forUseAtConfigurationTime()`
-
-`Provider.forUseAtConfigurationTime()` now report its deprecation.
-It has been a no-operation link:https://docs.gradle.org/current/userguide/upgrading_version_7.html#for_use_at_configuration_time_deprecation[since Gradle 7.4].
-It will be removed in Gradle 9.0.
-
-Simply remove the call.

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
@@ -194,3 +194,5 @@ so you can also apply it to your project and it will fix the warning.
 ==== Deprecated members of the `org.gradle.util` package now report their deprecation
 
 These members will be removed in Gradle 9.0.
+
+* `VersionNumber`

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
@@ -197,3 +197,5 @@ These members will be removed in Gradle 9.0.
 
 * `VersionNumber`
 * `WrapUtil.toDomainObjectSet(...)`
+* `GUtil.toCamelCase(...)`
+* `GUtil.toLowerCase(...)`

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
@@ -201,3 +201,12 @@ These members will be removed in Gradle 9.0.
 * `GUtil.toLowerCase(...)`
 * `ConfigureUtil.configureByMap(...)`
 * `ConfigureUtil.configure(...)`
+
+[[for_use_at_configuration_time_deprecation]]
+==== `Provider.forUseAtConfigurationTime()`
+
+`Provider.forUseAtConfigurationTime()` now report its deprecation.
+It has been a no-operation link:https://docs.gradle.org/current/userguide/upgrading_version_7.html#for_use_at_configuration_time_deprecation[since Gradle 7.4].
+It will be removed in Gradle 9.0.
+
+Simply remove the call.

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
@@ -196,3 +196,4 @@ so you can also apply it to your project and it will fix the warning.
 These members will be removed in Gradle 9.0.
 
 * `VersionNumber`
+* `WrapUtil.toDomainObjectSet(...)`

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
@@ -199,3 +199,5 @@ These members will be removed in Gradle 9.0.
 * `WrapUtil.toDomainObjectSet(...)`
 * `GUtil.toCamelCase(...)`
 * `GUtil.toLowerCase(...)`
+* `ConfigureUtil.configureByMap(...)`
+* `ConfigureUtil.configure(...)`

--- a/subprojects/docs/src/snippets/buildCache/caching-android-projects/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/buildCache/caching-android-projects/kotlin/build.gradle.kts
@@ -1,8 +1,8 @@
 import org.jetbrains.kotlin.gradle.plugin.KaptExtension
 
 plugins {
-    kotlin("jvm") version "1.6.0"
-    kotlin("kapt") version "1.6.0"
+    kotlin("jvm") version "1.8.0"
+    kotlin("kapt") version "1.8.0"
 }
 
 repositories {

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
@@ -239,6 +239,13 @@ class GradleKotlinDslIntegrationTest : AbstractPluginIntegrationTest() {
             """
         )
 
+        executer.expectDocumentedDeprecationWarning(
+            "The org.gradle.util.WrapUtil type has been deprecated. " +
+                "This is scheduled to be removed in Gradle 9.0. " +
+                "Consult the upgrading guide for further information: " +
+                "https://docs.gradle.org/current/userguide/upgrading_version_7.html#org_gradle_util_reports_deprecations"
+        )
+
         assertThat(
             build("print-kotlin-version").output,
             containsString("$expectedKotlinCompilerVersionString[compileKotlin=true, compileTestKotlin=true]")

--- a/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginGradlePluginCrossVersionSmokeTest.kt
+++ b/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginGradlePluginCrossVersionSmokeTest.kt
@@ -21,6 +21,7 @@ import org.gradle.kotlin.dsl.*
 import org.gradle.kotlin.dsl.fixtures.AbstractPluginTest
 import org.gradle.test.fixtures.dsl.GradleDsl
 import org.gradle.test.fixtures.file.LeaksFileHandles
+import org.gradle.util.internal.VersionNumber
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.MatcherAssert.assertThat
@@ -97,8 +98,18 @@ class KotlinDslPluginGradlePluginCrossVersionSmokeTest(
         )
         withFile("src/main/kotlin/SomeSource.kt", "fun main(args: Array<String>) {}")
 
+
         if (kotlinVersion.startsWith("1.6")) {
             executer.expectDocumentedDeprecationWarning("The AbstractCompile.destinationDir property has been deprecated. This is scheduled to be removed in Gradle 9.0. Please use the destinationDirectory property instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#compile_task_wiring")
+        }
+
+        if (VersionNumber.parse(kotlinVersion) < VersionNumber.parse("1.7.20")) {
+            executer.expectDocumentedDeprecationWarning(
+                "The org.gradle.util.WrapUtil type has been deprecated. " +
+                    "This is scheduled to be removed in Gradle 9.0. " +
+                    "Consult the upgrading guide for further information: " +
+                    "https://docs.gradle.org/current/userguide/upgrading_version_7.html#org_gradle_util_reports_deprecations"
+            )
         }
 
         build("classes").apply {

--- a/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProviderTest.kt
+++ b/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProviderTest.kt
@@ -47,19 +47,19 @@ class EmbeddedKotlinProviderTest : AbstractKotlinIntegrationTest() {
             buildscript {
                 $repositoriesBlock
                 dependencies {
-                    classpath("org.jetbrains.kotlin:kotlin-stdlib:1.6.10")
-                    classpath("org.jetbrains.kotlin:kotlin-reflect:1.6.10")
+                    classpath("org.jetbrains.kotlin:kotlin-stdlib:1.7.22")
+                    classpath("org.jetbrains.kotlin:kotlin-reflect:1.7.22")
                 }
             }
             plugins {
-                kotlin("jvm") version "1.6.10"
+                kotlin("jvm") version "1.7.22"
             }
             """
         )
 
         val result = build("buildEnvironment")
         listOf("stdlib", "reflect").forEach { module ->
-            assertThat(result.output, containsString("org.jetbrains.kotlin:kotlin-$module:1.6.10 -> $embeddedKotlinVersion"))
+            assertThat(result.output, containsString("org.jetbrains.kotlin:kotlin-$module:1.7.22 -> $embeddedKotlinVersion"))
         }
     }
 

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
@@ -432,11 +432,16 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
 
         when:
         if (isKotlin1dot6) {
-            executer.beforeExecute {
-                executer.expectDocumentedDeprecationWarning(
-                    "The org.gradle.util.WrapUtil type has been deprecated. " +
-                        "This is scheduled to be removed in Gradle 9.0. " +
-                        "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#org_gradle_util_reports_deprecations")
+            def wrapUtilWarning = "The org.gradle.util.WrapUtil type has been deprecated. " +
+                "This is scheduled to be removed in Gradle 9.0. " +
+                "Consult the upgrading guide for further information: " +
+                "https://docs.gradle.org/current/userguide/upgrading_version_7.html#org_gradle_util_reports_deprecations"
+            if (GradleContextualExecuter.isConfigCache()) {
+                executer.expectDocumentedDeprecationWarning(wrapUtilWarning)
+            } else {
+                executer.beforeExecute {
+                    executer.expectDocumentedDeprecationWarning(wrapUtilWarning)
+                }
             }
             executer.expectDocumentedDeprecationWarning(
                 "The AbstractCompile.destinationDir property has been deprecated. " +

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
@@ -432,6 +432,12 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
 
         when:
         if (isKotlin1dot6) {
+            executer.beforeExecute {
+                executer.expectDocumentedDeprecationWarning(
+                    "The org.gradle.util.WrapUtil type has been deprecated. " +
+                        "This is scheduled to be removed in Gradle 9.0. " +
+                        "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#org_gradle_util_reports_deprecations")
+            }
             executer.expectDocumentedDeprecationWarning(
                 "The AbstractCompile.destinationDir property has been deprecated. " +
                     "This is scheduled to be removed in Gradle 9.0. " +

--- a/subprojects/logging/src/main/java/org/gradle/util/GUtil.java
+++ b/subprojects/logging/src/main/java/org/gradle/util/GUtil.java
@@ -70,7 +70,7 @@ import static java.util.Collections.emptyList;
 @Deprecated
 public class GUtil {
 
-    private static void logDeprecation() {
+    private static void logDeprecation(int majorVersion) {
         DeprecationLogger.deprecateType(GUtil.class)
             .willBeRemovedInGradle9()
             .withUpgradeGuideSection(7, "org_gradle_util_reports_deprecations")
@@ -81,7 +81,7 @@ public class GUtil {
     private static final Pattern UPPER_LOWER = Pattern.compile("(?m)([A-Z]*)([a-z0-9]*)");
 
     public GUtil() {
-        logDeprecation();
+        logDeprecation(7);
     }
 
     public static <T extends Collection<?>> T flatten(Object[] elements, T addTo, boolean flattenMaps) {
@@ -107,7 +107,7 @@ public class GUtil {
     }
 
     public static <T extends Collection<?>> T flatten(Collection<?> elements, T addTo, boolean flattenMaps, boolean flattenArrays) {
-        logDeprecation();
+        logDeprecation(7);
         Iterator<?> iter = elements.iterator();
         while (iter.hasNext()) {
             Object element = iter.next();
@@ -155,12 +155,12 @@ public class GUtil {
     }
 
     public static String asPath(Iterable<?> collection) {
-        logDeprecation();
+        logDeprecation(7);
         return CollectionUtils.join(File.pathSeparator, collection);
     }
 
     public static List<String> prefix(String prefix, Collection<String> strings) {
-        logDeprecation();
+        logDeprecation(7);
         List<String> prefixed = new ArrayList<String>();
         for (String string : strings) {
             prefixed.add(prefix + string);
@@ -169,7 +169,7 @@ public class GUtil {
     }
 
     public static boolean isTrue(@Nullable Object object) {
-        logDeprecation();
+        logDeprecation(7);
         if (object == null) {
             return false;
         }
@@ -196,7 +196,7 @@ public class GUtil {
     }
 
     public static <V, T extends Collection<? super V>> T addToCollection(T dest, boolean failOnNull, Iterable<? extends V> src) {
-        logDeprecation();
+        logDeprecation(7);
         for (V v : src) {
             if (failOnNull && v == null) {
                 throw new IllegalArgumentException("Illegal null value provided in this collection: " + src);
@@ -212,7 +212,7 @@ public class GUtil {
 
     @Deprecated
     public static <V, T extends Collection<? super V>> T addToCollection(T dest, boolean failOnNull, Iterable<? extends V>... srcs) {
-        logDeprecation();
+        logDeprecation(7);
         for (Iterable<? extends V> src : srcs) {
             for (V v : src) {
                 if (failOnNull && v == null) {
@@ -230,7 +230,7 @@ public class GUtil {
     }
 
     public static Comparator<String> caseInsensitive() {
-        logDeprecation();
+        logDeprecation(7);
         return new Comparator<String>() {
             @Override
             public int compare(String o1, String o2) {
@@ -244,7 +244,7 @@ public class GUtil {
     }
 
     public static <K, V> Map<K, V> addMaps(Map<K, V> map1, Map<K, V> map2) {
-        logDeprecation();
+        logDeprecation(7);
         HashMap<K, V> map = new HashMap<K, V>();
         map.putAll(map1);
         map.putAll(map2);
@@ -252,14 +252,14 @@ public class GUtil {
     }
 
     public static void addToMap(Map<String, String> dest, Map<?, ?> src) {
-        logDeprecation();
+        logDeprecation(7);
         for (Map.Entry<?, ?> entry : src.entrySet()) {
             dest.put(entry.getKey().toString(), entry.getValue().toString());
         }
     }
 
     public static Properties loadProperties(File propertyFile) {
-        logDeprecation();
+        logDeprecation(7);
         try {
             FileInputStream inputStream = new FileInputStream(propertyFile);
             try {
@@ -297,7 +297,7 @@ public class GUtil {
     }
 
     public static void saveProperties(Properties properties, File propertyFile) {
-        logDeprecation();
+        logDeprecation(7);
         try {
             FileOutputStream propertiesFileOutputStream = new FileOutputStream(propertyFile);
             try {
@@ -311,7 +311,7 @@ public class GUtil {
     }
 
     public static void saveProperties(Properties properties, OutputStream outputStream) {
-        logDeprecation();
+        logDeprecation(7);
         try {
             try {
                 properties.store(outputStream, null);
@@ -324,7 +324,7 @@ public class GUtil {
     }
 
     public static Map<Object, Object> map(Object... objects) {
-        logDeprecation();
+        logDeprecation(7);
         Map<Object, Object> map = new HashMap<Object, Object>();
         assert objects.length % 2 == 0;
         for (int i = 0; i < objects.length; i += 2) {
@@ -334,7 +334,7 @@ public class GUtil {
     }
 
     public static String toString(Iterable<?> names) {
-        logDeprecation();
+        logDeprecation(7);
         Formatter formatter = new Formatter();
         boolean first = true;
         for (Object name : names) {
@@ -360,9 +360,9 @@ public class GUtil {
     }
 
     private static String toCamelCase(CharSequence string, boolean lower) {
-        // TODO log deprecation once protobuf plugin and idea are fixed
+        logDeprecation(8);
         if (lower) {
-            logDeprecation();
+            logDeprecation(7);
         }
         if (string == null) {
             return null;
@@ -400,7 +400,7 @@ public class GUtil {
      */
     public static String toConstant(CharSequence string) {
         if (string == null) {
-            logDeprecation();
+            logDeprecation(7);
             return null;
         }
         return toWords(string, '_').toUpperCase();
@@ -414,7 +414,7 @@ public class GUtil {
     }
 
     public static String toWords(CharSequence string, char separator) {
-        // TODO log deprecation once android plugin is fixed
+        // TODO log deprecation once android 8.0 stable is released
         if (string == null) {
             return null;
         }
@@ -452,14 +452,14 @@ public class GUtil {
     }
 
     public static byte[] serialize(Object object) {
-        logDeprecation();
+        logDeprecation(7);
         StreamByteBuffer buffer = new StreamByteBuffer();
         serialize(object, buffer.getOutputStream());
         return buffer.readAsByteArray();
     }
 
     public static void serialize(Object object, OutputStream outputStream) {
-        logDeprecation();
+        logDeprecation(7);
         try {
             ObjectOutputStream objectOutputStream = new ObjectOutputStream(outputStream);
             objectOutputStream.writeObject(object);
@@ -470,7 +470,7 @@ public class GUtil {
     }
 
     public static <T> Comparator<T> last(final Comparator<? super T> comparator, final T lastValue) {
-        logDeprecation();
+        logDeprecation(7);
         return new Comparator<T>() {
             @Override
             public int compare(T o1, T o2) {
@@ -499,7 +499,7 @@ public class GUtil {
      */
     @Nullable
     public static <T> T uncheckedCall(Callable<T> callable) {
-        logDeprecation();
+        logDeprecation(7);
         try {
             return callable.call();
         } catch (Exception e) {
@@ -508,7 +508,7 @@ public class GUtil {
     }
 
     public static <T extends Enum<T>> T toEnum(Class<? extends T> enumType, Object value) {
-        logDeprecation();
+        logDeprecation(7);
         if (enumType.isInstance(value)) {
             return enumType.cast(value);
         }
@@ -556,7 +556,7 @@ public class GUtil {
     }
 
     public static <T extends Enum<T>> EnumSet<T> toEnumSet(Class<T> enumType, Iterable<?> values) {
-        logDeprecation();
+        logDeprecation(7);
         EnumSet<T> result = EnumSet.noneOf(enumType);
         for (Object value : values) {
             result.add(toEnum(enumType, value));
@@ -571,7 +571,7 @@ public class GUtil {
      * this check is faster than converting them to Strings and using {@link String#endsWith(String)}.
      */
     public static boolean endsWith(CharSequence longer, CharSequence shorter) {
-        logDeprecation();
+        logDeprecation(7);
         if (longer instanceof String && shorter instanceof String) {
             return ((String) longer).endsWith((String) shorter);
         }
@@ -589,7 +589,7 @@ public class GUtil {
     }
 
     public static URI toSecureUrl(URI scriptUri) {
-        logDeprecation();
+        logDeprecation(7);
         try {
             return new URI("https", null, scriptUri.getHost(), scriptUri.getPort(), scriptUri.getPath(), scriptUri.getQuery(), scriptUri.getFragment());
         } catch (URISyntaxException e) {
@@ -598,7 +598,7 @@ public class GUtil {
     }
 
     public static boolean isSecureUrl(URI url) {
-        logDeprecation();
+        logDeprecation(7);
         /*
          * TL;DR: http://127.0.0.1 will bypass this validation, http://localhost will fail this validation.
          *

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
@@ -22,7 +22,6 @@ import org.gradle.api.provider.Provider;
 import org.gradle.internal.Cast;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
-import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.logging.text.TreeFormatter;
 import org.gradle.internal.state.Managed;
 
@@ -122,11 +121,14 @@ public abstract class AbstractMinimalProvider<T> implements ProviderInternal<T>,
     @Deprecated
     @Override
     public final Provider<T> forUseAtConfigurationTime() {
+        /*
+ TODO:configuration-cache start nagging in Gradle 8.x
         DeprecationLogger.deprecateMethod(Provider.class, "forUseAtConfigurationTime")
             .withAdvice("Simply remove the call.")
             .willBeRemovedInGradle9()
-            .withUpgradeGuideSection(8, "for_use_at_configuration_time_deprecation")
+            .withUpgradeGuideSection(7, "for_use_at_configuration_time_deprecation")
             .nagUser();
+*/
         return this;
     }
 

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
@@ -22,6 +22,7 @@ import org.gradle.api.provider.Provider;
 import org.gradle.internal.Cast;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.logging.text.TreeFormatter;
 import org.gradle.internal.state.Managed;
 
@@ -121,14 +122,11 @@ public abstract class AbstractMinimalProvider<T> implements ProviderInternal<T>,
     @Deprecated
     @Override
     public final Provider<T> forUseAtConfigurationTime() {
-        /*
- TODO:configuration-cache start nagging in Gradle 8.x
         DeprecationLogger.deprecateMethod(Provider.class, "forUseAtConfigurationTime")
             .withAdvice("Simply remove the call.")
             .willBeRemovedInGradle9()
-            .withUpgradeGuideSection(7, "for_use_at_configuration_time_deprecation")
+            .withUpgradeGuideSection(8, "for_use_at_configuration_time_deprecation")
             .nagUser();
-*/
         return this;
     }
 

--- a/subprojects/model-core/src/main/java/org/gradle/util/ConfigureUtil.java
+++ b/subprojects/model-core/src/main/java/org/gradle/util/ConfigureUtil.java
@@ -145,7 +145,7 @@ public class ConfigureUtil {
      * @return The delegate param
      */
     public static <T> T configure(@Nullable Closure configureClosure, T target) {
-        logDeprecation(8);
+        // TODO log deprecation once the shadow plugin is fixed
         if (configureClosure == null) {
             return target;
         }

--- a/subprojects/model-core/src/main/java/org/gradle/util/ConfigureUtil.java
+++ b/subprojects/model-core/src/main/java/org/gradle/util/ConfigureUtil.java
@@ -73,7 +73,7 @@ import static org.gradle.util.internal.CollectionUtils.toStringList;
 public class ConfigureUtil {
 
     public static <T> T configureByMap(Map<?, ?> properties, T delegate) {
-        // TODO log deprecation once idea is fixed
+        logDeprecation(8);
         return configureByMapInternal(properties, delegate);
     }
 
@@ -109,7 +109,7 @@ public class ConfigureUtil {
                 throw new IncompleteInputException("Input configuration map does not contain following mandatory keys: " + missingKeys, missingKeys);
             }
         }
-        logDeprecation();
+        logDeprecation(7);
         return configureByMapInternal(properties, delegate);
     }
 
@@ -123,7 +123,7 @@ public class ConfigureUtil {
         public IncompleteInputException(String message, Collection missingKeys) {
             super(message);
             this.missingKeys = missingKeys;
-            logDeprecation();
+            logDeprecation(7);
         }
 
         public Collection getMissingKeys() {
@@ -145,8 +145,7 @@ public class ConfigureUtil {
      * @return The delegate param
      */
     public static <T> T configure(@Nullable Closure configureClosure, T target) {
-        // TODO log deprecation once the protobuf plugin is fixed
-        // logDeprecation();
+        logDeprecation(8);
         if (configureClosure == null) {
             return target;
         }
@@ -164,7 +163,7 @@ public class ConfigureUtil {
      * Creates an action that uses the given closure to configure objects of type T.
      */
     public static <T> Action<T> configureUsing(@Nullable final Closure configureClosure) {
-        logDeprecation();
+        logDeprecation(7);
         if (configureClosure == null) {
             return Actions.doNothing();
         }
@@ -176,7 +175,7 @@ public class ConfigureUtil {
      * Called from an object's {@link Configurable#configure} method.
      */
     public static <T> T configureSelf(@Nullable Closure configureClosure, T target) {
-        logDeprecation();
+        logDeprecation(7);
         if (configureClosure == null) {
             return target;
         }
@@ -189,7 +188,7 @@ public class ConfigureUtil {
      * Called from an object's {@link Configurable#configure} method.
      */
     public static <T> T configureSelf(@Nullable Closure configureClosure, T target, ConfigureDelegate closureDelegate) {
-        logDeprecation();
+        logDeprecation(7);
         if (configureClosure == null) {
             return target;
         }
@@ -209,10 +208,10 @@ public class ConfigureUtil {
         new ClosureBackedAction<T>(withNewOwner, Closure.OWNER_ONLY, false).execute(target);
     }
 
-    private static void logDeprecation() {
+    private static void logDeprecation(int majorVersion) {
         DeprecationLogger.deprecateType(ConfigureUtil.class)
             .willBeRemovedInGradle9()
-            .withUpgradeGuideSection(7, "org_gradle_util_reports_deprecations")
+            .withUpgradeGuideSection(majorVersion, "org_gradle_util_reports_deprecations")
             .nagUser();
     }
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -126,7 +126,7 @@ abstract class AbstractSmokeTest extends Specification {
         static errorProne = "2.0.2"
 
         // https://plugins.gradle.org/plugin/com.google.protobuf
-        static protobufPlugin = "0.8.19"
+        static protobufPlugin = "0.9.2"
 
         static protobufTools = "3.21.5"
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -118,7 +118,7 @@ abstract class AbstractSmokeTest extends Specification {
         static gradleVersions = "0.42.0"
 
         // https://plugins.gradle.org/plugin/org.gradle.playframework
-        static playframework = "0.12"
+        static playframework = "0.13"
 
         // https://plugins.gradle.org/plugin/net.ltgt.errorprone
         static errorProne = "2.0.2"

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -46,7 +46,6 @@ import static org.gradle.test.fixtures.server.http.MavenHttpPluginRepository.PLU
 abstract class AbstractSmokeTest extends Specification {
 
     protected static final AndroidGradlePluginVersions AGP_VERSIONS = new AndroidGradlePluginVersions()
-    protected static final String AGP_NO_CC_ITERATION_MATCHER = ".*agp=4\\..*"
 
     protected static final KotlinGradlePluginVersions KOTLIN_VERSIONS = new KotlinGradlePluginVersions()
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -107,7 +107,7 @@ abstract class AbstractSmokeTest extends Specification {
 
         // https://plugins.gradle.org/plugin/org.gretty
         static gretty = [
-            [version: "3.0.9", servletContainer: "jetty9.4", javaMinVersion: JavaVersion.VERSION_1_8],
+            [version: "3.1.1", servletContainer: "jetty9.4", javaMinVersion: JavaVersion.VERSION_1_8],
             [version: "4.0.3", servletContainer: "jetty11", javaMinVersion: JavaVersion.VERSION_11]
         ]
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -49,7 +49,6 @@ abstract class AbstractSmokeTest extends Specification {
     protected static final String AGP_NO_CC_ITERATION_MATCHER = ".*agp=4\\..*"
 
     protected static final KotlinGradlePluginVersions KOTLIN_VERSIONS = new KotlinGradlePluginVersions()
-    protected static final String KGP_NO_CC_ITERATION_MATCHER = ".*(kotlin=1\\.3\\.|kotlin=1\\.4\\.[01]).*"
 
     static class TestedVersions {
         /**

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
@@ -75,7 +75,6 @@ class AndroidPluginsSmokeTest extends AbstractPluginValidatingSmokeTest implemen
         ].combinations()
     }
 
-    @UnsupportedWithConfigurationCache(iterationMatchers = AGP_NO_CC_ITERATION_MATCHER)
     def "android library and application APK assembly (agp=#agpVersion, ide=#ide)"() {
 
         given:

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerCachingSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerCachingSmokeTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.smoketests
 
-import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.testkit.runner.BuildResult
 
 import static org.gradle.testkit.runner.TaskOutcome.FROM_CACHE
@@ -27,7 +26,6 @@ import static org.gradle.testkit.runner.TaskOutcome.UP_TO_DATE
 
 class AndroidSantaTrackerCachingSmokeTest extends AbstractAndroidSantaTrackerSmokeTest {
 
-    @UnsupportedWithConfigurationCache(iterationMatchers = AGP_NO_CC_ITERATION_MATCHER)
     def "can cache Santa Tracker Android application (agp=#agpVersion)"() {
 
         given:

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerSmokeTest.groovy
@@ -16,8 +16,6 @@
 
 package org.gradle.smoketests
 
-import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
-
 import java.util.jar.JarOutputStream
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
@@ -26,7 +24,6 @@ abstract class AndroidSantaTrackerSmokeTest extends AbstractAndroidSantaTrackerS
 }
 
 class AndroidSantaTrackerDeprecationSmokeTest extends AndroidSantaTrackerSmokeTest {
-    @UnsupportedWithConfigurationCache(iterationMatchers = [AGP_NO_CC_ITERATION_MATCHER])
     def "check deprecation warnings produced by building Santa Tracker (agp=#agpVersion)"() {
 
         given:
@@ -48,7 +45,6 @@ class AndroidSantaTrackerDeprecationSmokeTest extends AndroidSantaTrackerSmokeTe
 }
 
 class AndroidSantaTrackerIncrementalCompilationSmokeTest extends AndroidSantaTrackerSmokeTest {
-    @UnsupportedWithConfigurationCache(iterationMatchers = [AGP_NO_CC_ITERATION_MATCHER])
     def "incremental Java compilation works for Santa Tracker (agp=#agpVersion)"() {
 
         given:
@@ -94,7 +90,6 @@ class AndroidSantaTrackerIncrementalCompilationSmokeTest extends AndroidSantaTra
 }
 
 class AndroidSantaTrackerLintSmokeTest extends AndroidSantaTrackerSmokeTest {
-    @UnsupportedWithConfigurationCache(iterationMatchers = [AGP_NO_CC_ITERATION_MATCHER])
     def "can lint Santa-Tracker (agp=#agpVersion)"() {
 
         given:

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GrettySmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GrettySmokeTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.smoketests
 
 import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
+import org.gradle.util.GradleVersion
 import org.gradle.util.internal.VersionNumber
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
@@ -60,7 +61,15 @@ class GrettySmokeTest extends AbstractPluginValidatingSmokeTest {
         """
 
         when:
-        def result = runner('checkContainerUp').build()
+        def result = runner('checkContainerUp')
+            .expectDeprecationWarningIf(
+                grettyVersion < VersionNumber.parse('4.0.0'),
+                "The org.gradle.util.VersionNumber type has been deprecated. " +
+                    "This is scheduled to be removed in Gradle 9.0. " +
+                    "Consult the upgrading guide for further information: " +
+                    "https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#org_gradle_util_reports_deprecations",
+                ""
+            ).build()
 
         then:
         result.task(':checkContainerUp').outcome == SUCCESS

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginAndroidGroovyDSLSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginAndroidGroovyDSLSmokeTest.groovy
@@ -24,7 +24,7 @@ import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
 class KotlinPluginAndroidGroovyDSLSmokeTest extends AbstractSmokeTest {
 
-    @UnsupportedWithConfigurationCache(iterationMatchers = [KGP_NO_CC_ITERATION_MATCHER, AGP_NO_CC_ITERATION_MATCHER])
+    @UnsupportedWithConfigurationCache(iterationMatchers = [AGP_NO_CC_ITERATION_MATCHER])
     def "kotlin android on android-kotlin-example (kotlin=#kotlinPluginVersion, agp=#androidPluginVersion, workers=#workers)"(String kotlinPluginVersion, String androidPluginVersion, boolean workers) {
         given:
         AndroidHome.assertIsSet()

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginAndroidGroovyDSLSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginAndroidGroovyDSLSmokeTest.groovy
@@ -67,5 +67,8 @@ class KotlinPluginAndroidGroovyDSLSmokeTest extends AbstractSmokeTest {
 
     private SmokeTestGradleRunner createRunner(boolean workers, String kotlinVersion, String... tasks) {
         return KotlinPluginSmokeTest.runnerFor(this, workers, VersionNumber.parse(kotlinVersion), tasks)
+            .deprecations(KotlinPluginSmokeTest.KotlinDeprecations) {
+                expectOrgGradleUtilWrapUtilDeprecation(kotlinVersion)
+            }
     }
 }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginAndroidGroovyDSLSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginAndroidGroovyDSLSmokeTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.smoketests
 
-import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.integtests.fixtures.android.AndroidHome
 import org.gradle.util.internal.VersionNumber
 
@@ -24,7 +23,6 @@ import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
 class KotlinPluginAndroidGroovyDSLSmokeTest extends AbstractSmokeTest {
 
-    @UnsupportedWithConfigurationCache(iterationMatchers = [AGP_NO_CC_ITERATION_MATCHER])
     def "kotlin android on android-kotlin-example (kotlin=#kotlinPluginVersion, agp=#androidPluginVersion, workers=#workers)"(String kotlinPluginVersion, String androidPluginVersion, boolean workers) {
         given:
         AndroidHome.assertIsSet()

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginAndroidKotlinDSLSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginAndroidKotlinDSLSmokeTest.groovy
@@ -68,5 +68,8 @@ class KotlinPluginAndroidKotlinDSLSmokeTest extends AbstractSmokeTest {
 
     private SmokeTestGradleRunner createRunner(boolean workers, String kotlinVersion, String... tasks) {
         return KotlinPluginSmokeTest.runnerFor(this, workers, VersionNumber.parse(kotlinVersion), tasks)
+            .deprecations(KotlinPluginSmokeTest.KotlinDeprecations) {
+                expectOrgGradleUtilWrapUtilDeprecation(kotlinVersion)
+            }
     }
 }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginAndroidKotlinDSLSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginAndroidKotlinDSLSmokeTest.groovy
@@ -24,7 +24,7 @@ import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
 class KotlinPluginAndroidKotlinDSLSmokeTest extends AbstractSmokeTest {
 
-    @UnsupportedWithConfigurationCache(iterationMatchers = [KGP_NO_CC_ITERATION_MATCHER, AGP_NO_CC_ITERATION_MATCHER])
+    @UnsupportedWithConfigurationCache(iterationMatchers = [AGP_NO_CC_ITERATION_MATCHER])
     def "kotlin android on android-kotlin-example-kotlin-dsl (kotlin=#kotlinPluginVersion, agp=#androidPluginVersion, workers=#workers)"(String kotlinPluginVersion, String androidPluginVersion, boolean workers) {
         given:
         AndroidHome.assertIsSet()

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginAndroidKotlinDSLSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginAndroidKotlinDSLSmokeTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.smoketests
 
-import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.integtests.fixtures.android.AndroidHome
 import org.gradle.util.internal.VersionNumber
 
@@ -24,7 +23,6 @@ import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
 class KotlinPluginAndroidKotlinDSLSmokeTest extends AbstractSmokeTest {
 
-    @UnsupportedWithConfigurationCache(iterationMatchers = [AGP_NO_CC_ITERATION_MATCHER])
     def "kotlin android on android-kotlin-example-kotlin-dsl (kotlin=#kotlinPluginVersion, agp=#androidPluginVersion, workers=#workers)"(String kotlinPluginVersion, String androidPluginVersion, boolean workers) {
         given:
         AndroidHome.assertIsSet()

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.smoketests
 
 import org.gradle.api.JavaVersion
-import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.internal.reflect.validation.ValidationMessageChecker
 import org.gradle.util.GradleVersion
 import org.gradle.util.internal.VersionNumber
@@ -30,7 +29,6 @@ import static org.junit.Assume.assumeTrue
 
 class KotlinPluginSmokeTest extends AbstractPluginValidatingSmokeTest implements ValidationMessageChecker {
 
-    @UnsupportedWithConfigurationCache(iterationMatchers = KGP_NO_CC_ITERATION_MATCHER)
     def 'kotlin jvm (kotlin=#version, workers=#workers)'() {
         given:
         useSample("kotlin-example")
@@ -67,7 +65,6 @@ class KotlinPluginSmokeTest extends AbstractPluginValidatingSmokeTest implements
         ].combinations()
     }
 
-    @UnsupportedWithConfigurationCache(iterationMatchers = KGP_NO_CC_ITERATION_MATCHER)
     def 'kotlin javascript (kotlin=#version, workers=#workers)'() {
 
         // kotlinjs has been removed in Kotlin 1.7 in favor of kotlin-mpp
@@ -100,7 +97,6 @@ class KotlinPluginSmokeTest extends AbstractPluginValidatingSmokeTest implements
         ].combinations()
     }
 
-    @UnsupportedWithConfigurationCache(iterationMatchers = KGP_NO_CC_ITERATION_MATCHER)
     def 'kotlin jvm and groovy plugins combined (kotlin=#kotlinVersion)'() {
         given:
         buildFile << """
@@ -146,7 +142,6 @@ class KotlinPluginSmokeTest extends AbstractPluginValidatingSmokeTest implements
         kotlinVersion << TestedVersions.kotlin.versions
     }
 
-    @UnsupportedWithConfigurationCache(iterationMatchers = KGP_NO_CC_ITERATION_MATCHER)
     def 'kotlin jvm and java-gradle-plugin plugins combined (kotlin=#kotlinVersion)'() {
 
         assumeFalse(kotlinVersion.startsWith("1.3."))

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.smoketests
 
 import org.gradle.api.JavaVersion
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.internal.reflect.validation.ValidationMessageChecker
 import org.gradle.util.GradleVersion
 import org.gradle.util.internal.VersionNumber
@@ -51,7 +52,9 @@ class KotlinPluginSmokeTest extends AbstractPluginValidatingSmokeTest implements
         when:
         result = runner(workers, versionNumber, 'run')
             .deprecations(KotlinDeprecations) {
-                expectOrgGradleUtilWrapUtilDeprecation(version)
+                if (GradleContextualExecuter.isNotConfigCache()) {
+                    expectOrgGradleUtilWrapUtilDeprecation(version)
+                }
             }.build()
 
         then:
@@ -180,7 +183,9 @@ class KotlinPluginSmokeTest extends AbstractPluginValidatingSmokeTest implements
         when:
         result = runner(false, versionNumber, 'build')
             .deprecations(KotlinDeprecations) {
-                expectOrgGradleUtilWrapUtilDeprecation(kotlinVersion)
+                if (GradleContextualExecuter.isNotConfigCache()) {
+                    expectOrgGradleUtilWrapUtilDeprecation(kotlinVersion)
+                }
             }.build()
 
         then:

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/PlayPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/PlayPluginSmokeTest.groovy
@@ -53,8 +53,9 @@ class PlayPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
 
         when:
         def result = runner('build')
-            .expectLegacyDeprecationWarning(orgGradleUtilTypeDeprecation("VersionNumber"))
-            .expectLegacyDeprecationWarning(orgGradleUtilTypeDeprecation("CollectionUtils"))
+            .expectLegacyDeprecationWarning(orgGradleUtilTypeDeprecation("VersionNumber", 7))
+            .expectLegacyDeprecationWarning(orgGradleUtilTypeDeprecation("VersionNumber", 8))
+            .expectLegacyDeprecationWarning(orgGradleUtilTypeDeprecation("CollectionUtils", 7))
             .expectLegacyDeprecationWarning(abstractArchiveTaskArchivePathDeprecation())
             .build()
 
@@ -62,10 +63,10 @@ class PlayPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
         result.task(':build').outcome == SUCCESS
     }
 
-    private String orgGradleUtilTypeDeprecation(String type) {
+    private String orgGradleUtilTypeDeprecation(String type, int major) {
         return "The org.gradle.util.$type type has been deprecated. " +
             "This is scheduled to be removed in Gradle 9.0. " +
-            "Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_7.html#org_gradle_util_reports_deprecations"
+            "Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_${major}.html#org_gradle_util_reports_deprecations"
     }
 
     private String abstractArchiveTaskArchivePathDeprecation() {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyGradleModuleMetadataSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyGradleModuleMetadataSmokeTest.groovy
@@ -137,15 +137,21 @@ class ThirdPartyGradleModuleMetadataSmokeTest extends AbstractSmokeTest {
             // https://youtrack.jetbrains.com/issue/KT-44266#focus=Comments-27-4639508.0-0
             runner.withJvmArguments(runner.jvmArguments + [
                 "-Dkotlin.daemon.jvm.options=" +
-                "--add-exports=java.base/sun.nio.ch=ALL-UNNAMED," +
-                "--add-opens=java.base/java.util=ALL-UNNAMED"
+                    "--add-exports=java.base/sun.nio.ch=ALL-UNNAMED," +
+                    "--add-opens=java.base/java.util=ALL-UNNAMED"
             ])
         }
         return runner
     }
 
+    private static SmokeTestGradleRunner expectingDeprecations(SmokeTestGradleRunner runner, String kotlinVersion, String agpVersion) {
+        return runner.deprecations(KotlinPluginSmokeTest.KotlinDeprecations) {
+            expectOrgGradleUtilWrapUtilDeprecation(kotlinVersion)
+        }
+    }
+
     private BuildResult publish(String kotlinVersion, String agpVersion) {
-        return setIllegalAccessPermitForJDK16KotlinCompilerDaemonOptions(runner('publish'))
+        return setIllegalAccessPermitForJDK16KotlinCompilerDaemonOptions(expectingDeprecations(runner('publish'), kotlinVersion, agpVersion))
             .withProjectDir(new File(testProjectDir, 'producer'))
             .forwardOutput()
             .build()
@@ -186,7 +192,7 @@ class ThirdPartyGradleModuleMetadataSmokeTest extends AbstractSmokeTest {
 
         if (metadataFileName.startsWith('kotlin-multiplatform') && !OperatingSystem.current().isMacOsX()) {
             // MacOS lib cannot be built on other platforms, so kotlin plugin won't add `artifactType` there
-            moduleRoot.variants.findAll { it.attributes["org.jetbrains.kotlin.native.target"] == "macos_x64" }.each { it.attributes.remove("artifactType")}
+            moduleRoot.variants.findAll { it.attributes["org.jetbrains.kotlin.native.target"] == "macos_x64" }.each { it.attributes.remove("artifactType") }
         }
 
         moduleRoot


### PR DESCRIPTION
* Closes https://github.com/gradle/gradle/issues/21902
* Closes https://github.com/gradle/gradle/issues/21882
* Closes https://github.com/gradle/gradle/issues/21900
* Closes https://github.com/gradle/gradle/issues/21914

----

This PR also opportunistically cleans up some smoke tests by removing `@UnsupportedWithConfigurationCache` annotation when it is not applicable anymore.