### PR TITLE
Fix kotlin precompiled scripts support to only consider the kotlin sources and fail with a reasonable error message when script file names are invalid

### DIFF
--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
@@ -932,7 +932,28 @@ class PrecompiledScriptPluginIntegrationTest : AbstractPluginIntegrationTest() {
         compileKotlin()
         val generated = file("build/generated-sources/kotlin-dsl-plugins/kotlin").walkTopDown().filter { it.isFile }.map { it.name }
         assertThat(generated.toList(), equalTo(listOf("CorrectPlugin.kt")))
-    }}
+    }
+
+    @Test
+    @Issue("https://github.com/gradle/gradle/issues/17831")
+    fun `fails with a reasonable error message if init precompiled script has no plugin id`() {
+        withKotlinDslPlugin()
+        val init = withPrecompiledKotlinScript("init.gradle.kts", "")
+        buildAndFail(":compileKotlin").apply {
+            assertHasCause("Precompiled script '${normaliseFileSeparators(init.absolutePath)}' file name is invalid, please rename it to '<plugin-id>.init.gradle.kts'.")
+        }
+    }
+
+    @Test
+    @Issue("https://github.com/gradle/gradle/issues/17831")
+    fun `fails with a reasonable error message if settings precompiled script has no plugin id`() {
+        withKotlinDslPlugin()
+        val settings = withPrecompiledKotlinScript("settings.gradle.kts", "")
+        buildAndFail(":compileKotlin").apply {
+            assertHasCause("Precompiled script '${normaliseFileSeparators(settings.absolutePath)}' file name is invalid, please rename it to '<plugin-id>.settings.gradle.kts'.")
+        }
+    }
+}
 
 
 abstract class MyPlugin : Plugin<Project> {

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
@@ -922,7 +922,17 @@ class PrecompiledScriptPluginIntegrationTest : AbstractPluginIntegrationTest() {
 
         build(":consumer:generatePrecompiledScriptPluginAccessors", "--offline")
     }
-}
+
+    @Test
+    @Issue("https://github.com/gradle/gradle/issues/17831")
+    fun `precompiled script plugins in resources are ignored`() {
+        withKotlinDslPlugin()
+        withPrecompiledKotlinScript("correct.gradle.kts", "")
+        file("src/main/resources/invalid.gradle.kts", "DOES NOT COMPILE")
+        compileKotlin()
+        val generated = file("build/generated-sources/kotlin-dsl-plugins/kotlin").walkTopDown().filter { it.isFile }.map { it.name }
+        assertThat(generated.toList(), equalTo(listOf("CorrectPlugin.kt")))
+    }}
 
 
 abstract class MyPlugin : Plugin<Project> {


### PR DESCRIPTION
* Fixes https://github.com/gradle/gradle/issues/17831