### PR TITLE
Capture output while collecting accessors schema for Kotlin precompiled script plugins

### DIFF
--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
@@ -532,7 +532,7 @@ class PrecompiledScriptPluginIntegrationTest : AbstractPluginIntegrationTest() {
             // then:
             assertThat(
                 output.count("*version 1*"),
-                equalTo(2)
+                equalTo(1)
             )
         }
 
@@ -544,7 +544,7 @@ class PrecompiledScriptPluginIntegrationTest : AbstractPluginIntegrationTest() {
             // then:
             assertThat(
                 output.count("*version 2*"),
-                equalTo(2)
+                equalTo(1)
             )
         }
     }

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
@@ -958,6 +958,11 @@ class PrecompiledScriptPluginIntegrationTest : AbstractPluginIntegrationTest() {
     @Issue("https://github.com/gradle/gradle/issues/12955")
     fun `logs output from schema collection on errors only`() {
 
+        // TODO: the Kotlin compile tasks check for cacheability using Task.getProject
+        executer.beforeExecute {
+            it.withBuildJvmOpts("-Dorg.gradle.configuration-cache.internal.task-execution-access-pre-stable=true")
+        }
+
         fun outputFrom(origin: String, logger: Boolean = true) = buildString {
             appendLine("""println("STDOUT from $origin")""")
             appendLine("""System.err.println("STDERR from $origin")""")
@@ -998,13 +1003,13 @@ class PrecompiledScriptPluginIntegrationTest : AbstractPluginIntegrationTest() {
             plugins {
                 ${outputFrom("plugins block", logger = false)}
                 id("applied-output")
-                TODO("BOOM") // Fail in the plugins block
+                TODO("some plugins block failure")
             }
         """)
         buildAndFail(":compileKotlin").apply {
             assertHasFailure("Execution failed for task ':generatePrecompiledScriptPluginAccessors'.") {
                 assertHasCause("Failed to collect plugin requests of 'src/main/kotlin/some.gradle.kts'")
-                assertHasCause("An operation is not implemented: BOOM")
+                assertHasCause("An operation is not implemented: some plugins block failure")
             }
             assertHasErrorOutput("STDOUT from plugins block")
             assertHasErrorOutput("STDERR from plugins block")

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
@@ -958,13 +958,12 @@ class PrecompiledScriptPluginIntegrationTest : AbstractPluginIntegrationTest() {
     @Test
     @Issue("https://github.com/gradle/gradle/issues/12955")
     @ToBeFixedForConfigurationCache(because = "KGP uses project at execution time")
-    fun `logs output from schema collection on errors only`() {
+    fun `captures output of schema collection and displays it on errors`() {
 
         fun outputFrom(origin: String, logger: Boolean = true) = buildString {
             appendLine("""println("STDOUT from $origin")""")
             appendLine("""System.err.println("STDERR from $origin")""")
             if (logger) {
-                appendLine("""logger.info("INFO log from $origin")""")
                 appendLine("""logger.lifecycle("LIFECYCLE log from $origin")""")
                 appendLine("""logger.warn("WARN log from $origin")""")
                 appendLine("""logger.error("ERROR log from $origin")""")
@@ -990,9 +989,9 @@ class PrecompiledScriptPluginIntegrationTest : AbstractPluginIntegrationTest() {
         build(":compileKotlin").apply {
             assertNotOutput("STDOUT")
             assertNotOutput("STDERR")
-            assertNotOutput("INFO")
-            assertNotOutput("LIFECYCLE")
-            assertNotOutput("WARN")
+            // TODO logging is not captured yet
+            assertOutputContains("LIFECYCLE")
+            assertOutputContains("WARN")
             assertHasErrorOutput("ERROR")
         }
 
@@ -1030,9 +1029,9 @@ class PrecompiledScriptPluginIntegrationTest : AbstractPluginIntegrationTest() {
             assertHasErrorOutput("STDERR from applied-output-fails plugin")
             assertNotOutput("STDOUT from plugins block")
             assertNotOutput("STDERR from plugins block")
-            assertNotOutput("INFO")
-            assertNotOutput("LIFECYCLE")
-            assertNotOutput("WARN")
+            // TODO logging is not captured yet
+            assertOutputContains("LIFECYCLE")
+            assertOutputContains("WARN")
             assertHasErrorOutput("ERROR")
         }
     }

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
@@ -6,6 +6,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskAction
 import org.gradle.integtests.fixtures.RepoScriptBlockUtil
+import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.kotlin.dsl.fixtures.classEntriesFor
 import org.gradle.kotlin.dsl.fixtures.normalisedPath
 import org.gradle.test.fixtures.dsl.GradleDsl
@@ -956,12 +957,8 @@ class PrecompiledScriptPluginIntegrationTest : AbstractPluginIntegrationTest() {
 
     @Test
     @Issue("https://github.com/gradle/gradle/issues/12955")
+    @ToBeFixedForConfigurationCache(because = "KGP uses project at execution time")
     fun `logs output from schema collection on errors only`() {
-
-        // TODO: the Kotlin compile tasks check for cacheability using Task.getProject
-        executer.beforeExecute {
-            it.withBuildJvmOpts("-Dorg.gradle.configuration-cache.internal.task-execution-access-pre-stable=true")
-        }
 
         fun outputFrom(origin: String, logger: Boolean = true) = buildString {
             appendLine("""println("STDOUT from $origin")""")

--- a/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/DefaultPrecompiledScriptPluginsSupport.kt
+++ b/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/DefaultPrecompiledScriptPluginsSupport.kt
@@ -16,7 +16,6 @@
 package org.gradle.kotlin.dsl.provider.plugins.precompiled
 
 
-import org.gradle.api.GradleException
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -461,7 +460,7 @@ private
 fun Project.validateScriptPlugin(scriptPlugin: PrecompiledScriptPlugin) {
 
     if (scriptPlugin.id == DefaultPluginManager.CORE_PLUGIN_NAMESPACE || scriptPlugin.id.startsWith(DefaultPluginManager.CORE_PLUGIN_PREFIX)) {
-        throw GradleException(
+        throw PrecompiledScriptException(
             String.format(
                 "The precompiled plugin (%s) cannot start with '%s' or be in the '%s' package.\n\n%s", this.relativePath(scriptPlugin.scriptFile),
                 DefaultPluginManager.CORE_PLUGIN_NAMESPACE, DefaultPluginManager.CORE_PLUGIN_NAMESPACE,
@@ -471,7 +470,7 @@ fun Project.validateScriptPlugin(scriptPlugin: PrecompiledScriptPlugin) {
     }
     val existingPlugin = plugins.findPlugin(scriptPlugin.id)
     if (existingPlugin != null && existingPlugin.javaClass.getPackage().name.startsWith(DefaultPluginManager.CORE_PLUGIN_PREFIX)) {
-        throw GradleException(
+        throw PrecompiledScriptException(
             String.format(
                 "The precompiled plugin (%s) conflicts with the core plugin '%s'. Rename your plugin.\n\n%s", this.relativePath(scriptPlugin.scriptFile), scriptPlugin.id, PRECOMPILED_SCRIPT_MANUAL.consultDocumentationMessage()
             )

--- a/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/PrecompiledScriptException.kt
+++ b/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/PrecompiledScriptException.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.provider.plugins.precompiled
+
+import org.gradle.api.GradleException
+import org.gradle.internal.exceptions.Contextual
+import org.gradle.internal.exceptions.LocationAwareException
+import java.lang.reflect.InvocationTargetException
+
+
+@Contextual
+class PrecompiledScriptException
+internal constructor(message: String, cause: Throwable? = null) : GradleException(message, reduceCause(cause))
+
+
+private
+fun reduceCause(cause: Throwable?): Throwable? =
+    when (cause) {
+        is InvocationTargetException -> reduceCause(cause.targetException)
+        is LocationAwareException -> if (cause.location == null && cause.cause != null) reduceCause(cause.cause!!) else cause
+        else -> cause
+    }

--- a/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/GeneratePrecompiledScriptPluginAccessors.kt
+++ b/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/GeneratePrecompiledScriptPluginAccessors.kt
@@ -72,6 +72,7 @@ import org.gradle.plugin.management.internal.PluginRequests
 import org.gradle.plugin.use.PluginDependenciesSpec
 import org.gradle.plugin.use.internal.PluginRequestApplicator
 import org.gradle.plugin.use.internal.PluginRequestCollector
+import org.gradle.util.internal.TextUtil.normaliseFileSeparators
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.PrintStream
@@ -464,7 +465,7 @@ abstract class GeneratePrecompiledScriptPluginAccessors @Inject internal constru
 
     private
     fun projectRelativePathOf(scriptPlugin: PrecompiledScriptPlugin) =
-        scriptPlugin.scriptFile.toRelativeString(projectLayout.projectDirectory.asFile)
+        normaliseFileSeparators(scriptPlugin.scriptFile.toRelativeString(projectLayout.projectDirectory.asFile))
 
     private
     fun IO.writeTypeSafeAccessorsFor(hashedSchema: HashedProjectSchema) {

--- a/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/GeneratePrecompiledScriptPluginAccessors.kt
+++ b/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/GeneratePrecompiledScriptPluginAccessors.kt
@@ -17,7 +17,6 @@
 package org.gradle.kotlin.dsl.provider.plugins.precompiled.tasks
 
 import org.gradle.StartParameter
-import org.gradle.api.GradleException
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.ProjectLayout
@@ -61,6 +60,7 @@ import org.gradle.kotlin.dsl.concurrent.AsyncIOScopeFactory
 import org.gradle.kotlin.dsl.concurrent.IO
 import org.gradle.kotlin.dsl.concurrent.writeFile
 import org.gradle.kotlin.dsl.precompile.PrecompiledScriptDependenciesResolver
+import org.gradle.kotlin.dsl.provider.plugins.precompiled.PrecompiledScriptException
 import org.gradle.kotlin.dsl.provider.plugins.precompiled.PrecompiledScriptPlugin
 import org.gradle.kotlin.dsl.provider.plugins.precompiled.scriptPluginFilesOf
 import org.gradle.kotlin.dsl.support.KotlinScriptType
@@ -422,7 +422,7 @@ abstract class GeneratePrecompiledScriptPluginAccessors @Inject internal constru
     private
     fun reportProjectSchemaError(plugins: List<PrecompiledScriptPlugin>, error: Throwable) {
         @Suppress("DEPRECATION")
-        if (strict.get()) throw GradleException(failedToGenerateAccessorsFor(plugins), error)
+        if (strict.get()) throw PrecompiledScriptException(failedToGenerateAccessorsFor(plugins), error)
         else logger.warn(failedToGenerateAccessorsFor(plugins), error)
     }
 

--- a/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/GeneratePrecompiledScriptPluginAccessors.kt
+++ b/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/GeneratePrecompiledScriptPluginAccessors.kt
@@ -23,8 +23,6 @@ import org.gradle.api.file.ProjectLayout
 import org.gradle.api.internal.StartParameterInternal
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.project.ProjectStateRegistry
-import org.gradle.api.invocation.Gradle
-import org.gradle.api.logging.LogLevel
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Classpath
@@ -49,7 +47,6 @@ import org.gradle.internal.classpath.DefaultClassPath
 import org.gradle.internal.concurrent.CompositeStoppable.stoppable
 import org.gradle.internal.exceptions.LocationAwareException
 import org.gradle.internal.hash.HashCode
-import org.gradle.internal.logging.LoggingManagerInternal
 import org.gradle.internal.resource.TextFileResourceLoader
 import org.gradle.kotlin.dsl.accessors.AccessorFormats
 import org.gradle.kotlin.dsl.accessors.ProjectSchemaProvider
@@ -366,9 +363,7 @@ abstract class GeneratePrecompiledScriptPluginAccessors @Inject internal constru
                     gradle.rootProject = rootProject
                     gradle.defaultProject = rootProject
                     rootProject.run {
-                        gradle.withLogLevel(LogLevel.QUIET) {
-                            applyPlugins(plugins)
-                        }
+                        applyPlugins(plugins)
                         serviceOf<ProjectSchemaProvider>().schemaFor(this)
                     }
                 }
@@ -520,19 +515,6 @@ fun ProjectInternal.applyPlugins(pluginRequests: PluginRequests) {
         pluginManager,
         classLoaderScope
     )
-}
-
-
-private
-fun <T> Gradle.withLogLevel(logLevel: LogLevel, block: () -> T): T {
-    val loggingManager = serviceOf<LoggingManagerInternal>()
-    val previousLevel = loggingManager.level
-    return try {
-        loggingManager.setLevelInternal(logLevel)
-        block()
-    } finally {
-        loggingManager.setLevelInternal(previousLevel)
-    }
 }
 
 


### PR DESCRIPTION
* Fixes https://github.com/gradle/gradle/issues/12955

This PR only handles stdout/stderr output.
There currently isn't any way to configure the log level just for the nested build.
