### PR TITLE
Fix the bad assertion in ClasspathUtil

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/ClasspathUtil.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/ClasspathUtil.java
@@ -133,7 +133,7 @@ public class ClasspathUtil {
                 String schemeSpecificPart = location.getRawSchemeSpecificPart();
                 int pos = schemeSpecificPart.indexOf("!");
                 if (pos > 0) {
-                    assert schemeSpecificPart.substring(pos + 1).equals("/" + name);
+                    assert schemeSpecificPart.substring(pos + 1).endsWith(name);
                     URI jarFile = new URI(schemeSpecificPart.substring(0, pos));
                     if (jarFile.getScheme().equals("file")) {
                         return new File(jarFile.getPath());

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/ClasspathUtil.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/ClasspathUtil.java
@@ -133,7 +133,7 @@ public class ClasspathUtil {
                 String schemeSpecificPart = location.getRawSchemeSpecificPart();
                 int pos = schemeSpecificPart.indexOf("!");
                 if (pos > 0) {
-                    assert schemeSpecificPart.substring(pos + 1).endsWith(name);
+                    assert schemeSpecificPart.substring(pos + 1).endsWith("/" + name);
                     URI jarFile = new URI(schemeSpecificPart.substring(0, pos));
                     if (jarFile.getScheme().equals("file")) {
                         return new File(jarFile.getPath());

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/classloader/ClasspathUtilTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/classloader/ClasspathUtilTest.groovy
@@ -22,7 +22,8 @@ import spock.lang.Specification
 class ClasspathUtilTest extends Specification {
     private static final URL JAR_URL = new URL('jar:file:home/duke/duke.jar!/')
     private static final URL HTTP_URL = new URL('http://www.foo.com/bar/')
-    private static final URL FILE_URL = new File('home/duke/duke.jar').toURI().toURL()
+    private static final File FILE = new File('/home/duke/duke.jar')
+    private static final URL FILE_URL = FILE.toURI().toURL()
     def factory = new DefaultClassLoaderFactory()
 
     def "filters non-file URLs from classpath"() {
@@ -46,7 +47,7 @@ class ClasspathUtilTest extends Specification {
         def file = ClasspathUtil.getClasspathForResource(jarUrlWithResourceName, "Test.class")
 
         then:
-        "/home/duke/duke.jar" == file.getPath()
+        FILE.getPath() == file.getPath()
     }
 
     @Issue("https://github.com/gradle/gradle/issues/23625")
@@ -58,6 +59,6 @@ class ClasspathUtilTest extends Specification {
         def file = ClasspathUtil.getClasspathForResource(jarUrlWithResourceName, "Test.class")
 
         then:
-        "/home/duke/duke.jar" == file.getPath()
+        FILE.getPath() == file.getPath()
     }
 }

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/classloader/ClasspathUtilTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/classloader/ClasspathUtilTest.groovy
@@ -16,6 +16,7 @@
 package org.gradle.internal.classloader
 
 import org.gradle.internal.classpath.DefaultClassPath
+import spock.lang.Issue
 import spock.lang.Specification
 
 class ClasspathUtilTest extends Specification {
@@ -35,5 +36,28 @@ class ClasspathUtilTest extends Specification {
         then:
         !classpath.asURLs.any { it == JAR_URL || it == HTTP_URL }
         classpath.asURLs.any { it == FILE_URL }
+    }
+
+    def "getClasspathForResource for jar scheme with resource name"() {
+        given:
+        def jarUrlWithResourceName = new URL('jar:file:/home/duke/duke.jar!/Test.class')
+
+        when:
+        def file = ClasspathUtil.getClasspathForResource(jarUrlWithResourceName, "Test.class")
+
+        then:
+        "/home/duke/duke.jar" == file.getPath()
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/23625")
+    def "getClasspathForResource for jar scheme with prefix resource name"() {
+        given:
+        def jarUrlWithResourceName = new URL('jar:file:/home/duke/duke.jar!/META-INF/versions/9/Test.class')
+
+        when:
+        def file = ClasspathUtil.getClasspathForResource(jarUrlWithResourceName, "Test.class")
+
+        then:
+        "/home/duke/duke.jar" == file.getPath()
     }
 }


### PR DESCRIPTION
Signed-off-by: Yanshun Li <qqliys@126.com>

<!--- The issue this PR addresses -->
Fixes #23625

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
In the method `ClasspathUtil.getClasspathForResource`,  `equals` is used to assert the resource name, but it will fail if the name is prefixed.
So this pr uses `endsWith` to replace `equals`.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
