### PR TITLE
Run nightly promotion build once per week for old release branches

### DIFF
--- a/.teamcity/src/main/kotlin/common/VersionedSettingsBranch.kt
+++ b/.teamcity/src/main/kotlin/common/VersionedSettingsBranch.kt
@@ -2,7 +2,28 @@ package common
 
 import jetbrains.buildServer.configs.kotlin.v2019_2.DslContext
 
-data class VersionedSettingsBranch(val branchName: String, val enableTriggers: Boolean) {
+data class VersionedSettingsBranch(val branchName: String) {
+    /**
+     * Whether the <a href="https://www.jetbrains.com/help/teamcity/configuring-vcs-triggers.html">VCS trigger</a>
+     * should be enabled, i.e. when new commits are pushed to this branch, should a ReadyForNightly job
+     * be triggered automatically?
+     *
+     * Currently, we only enable VCS trigger for `master` and `release` branches.
+     */
+    val enableVcsTriggers: Boolean = mainBranches.contains(branchName.lowercase())
+
+    /**
+     * 0~23.
+     * To avoid nightly promotion jobs running at the same time,
+     * we run each branch on different hours.
+     * master - 0:00
+     * release - 1:00
+     * release6x - 2:00
+     * release7x - 3:00
+     * ...
+     * releaseNx - (N-4):00
+     */
+    val nightlyPromotionTriggerHour: Int? = determineNightlyPromotionTriggerHour(branchName)
 
     companion object {
         private
@@ -15,18 +36,38 @@ data class VersionedSettingsBranch(val branchName: String, val enableTriggers: B
         const val EXPERIMENTAL_BRANCH = "experimental"
 
         private
+        val OLD_RELEASE_PATTERN = "release(\\d+)x".toRegex()
+
+        private
         val mainBranches = setOf(MASTER_BRANCH, RELEASE_BRANCH)
 
         fun fromDslContext(): VersionedSettingsBranch {
             val branch = DslContext.getParameter("Branch")
             // TeamCity uses a dummy name when first running the DSL
             if (branch.contains("placeholder-1")) {
-                return VersionedSettingsBranch(MASTER_BRANCH, true)
+                return VersionedSettingsBranch(MASTER_BRANCH)
             }
-            return VersionedSettingsBranch(branch.lowercase(), mainBranches.contains(branch.lowercase()))
+            return VersionedSettingsBranch(branch)
+        }
+
+        private fun determineNightlyPromotionTriggerHour(branchName: String) = when (branchName) {
+            MASTER_BRANCH -> 0
+            RELEASE_BRANCH -> 1
+            else -> {
+                val matchResult = OLD_RELEASE_PATTERN.find(branchName)
+                if (matchResult == null) {
+                    null
+                } else {
+                    (matchResult.groupValues[1].toInt() - 4).apply {
+                        require(this in 2..23)
+                    }
+                }
+            }
         }
     }
 
+    val isMainBranch: Boolean
+        get() = isMaster || isRelease
     val isMaster: Boolean
         get() = branchName == MASTER_BRANCH
     val isRelease: Boolean

--- a/.teamcity/src/main/kotlin/common/VersionedSettingsBranch.kt
+++ b/.teamcity/src/main/kotlin/common/VersionedSettingsBranch.kt
@@ -4,15 +4,6 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.DslContext
 
 data class VersionedSettingsBranch(val branchName: String) {
     /**
-     * Whether the <a href="https://www.jetbrains.com/help/teamcity/configuring-vcs-triggers.html">VCS trigger</a>
-     * should be enabled, i.e. when new commits are pushed to this branch, should a ReadyForNightly job
-     * be triggered automatically?
-     *
-     * Currently, we only enable VCS trigger for `master` and `release` branches.
-     */
-    val enableVcsTriggers: Boolean = mainBranches.contains(branchName.lowercase())
-
-    /**
      * 0~23.
      * To avoid nightly promotion jobs running at the same time,
      * we run each branch on different hours.
@@ -24,6 +15,15 @@ data class VersionedSettingsBranch(val branchName: String) {
      * releaseNx - (N-4):00
      */
     val nightlyPromotionTriggerHour: Int? = determineNightlyPromotionTriggerHour(branchName)
+
+    /**
+     * Whether the <a href="https://www.jetbrains.com/help/teamcity/configuring-vcs-triggers.html">VCS trigger</a>
+     * should be enabled, i.e. when new commits are pushed to this branch, should a ReadyForNightly job
+     * be triggered automatically?
+     *
+     * Currently, we only enable VCS trigger for `master`/`release`/`releaseNx` branches.
+     */
+    val enableVcsTriggers: Boolean = nightlyPromotionTriggerHour != null
 
     companion object {
         private

--- a/.teamcity/src/main/kotlin/configurations/StagePasses.kt
+++ b/.teamcity/src/main/kotlin/configurations/StagePasses.kt
@@ -29,7 +29,7 @@ class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?, stagePro
         publishBuildStatusToGithub(model)
     }
 
-    val enableTriggers = model.branch.enableTriggers
+    val enableTriggers = model.branch.enableVcsTriggers
     if (stage.trigger == Trigger.eachCommit) {
         triggers.vcs {
             quietPeriodMode = VcsTrigger.QuietPeriodMode.USE_CUSTOM

--- a/.teamcity/src/main/kotlin/model/FunctionalTestBucketGenerator.kt
+++ b/.teamcity/src/main/kotlin/model/FunctionalTestBucketGenerator.kt
@@ -20,7 +20,7 @@ const val MAX_PROJECT_NUMBER_IN_BUCKET = 11
 fun main() {
     val model = CIBuildModel(
         projectId = "Check",
-        branch = VersionedSettingsBranch("master", true),
+        branch = VersionedSettingsBranch("master"),
         buildScanTags = listOf("Check"),
         subprojects = JsonBasedGradleSubprojectProvider(File("./subprojects.json"))
     )

--- a/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshot.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshot.kt
@@ -17,6 +17,7 @@
 package promotion
 
 import common.VersionedSettingsBranch
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.ScheduleTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.schedule
 import vcsroots.gradlePromotionBranches
 
@@ -33,14 +34,21 @@ class PublishNightlySnapshot(branch: VersionedSettingsBranch) : PublishGradleDis
         description = "Promotes the latest successful changes on '${branch.branchName}' from Ready for Nightly as a new nightly snapshot"
 
         triggers {
-            branch.triggeredHour()?.apply {
+            branch.nightlyPromotionTriggerHour?.let { triggerHour ->
                 schedule {
-                    schedulingPolicy = daily {
-                        this.hour = this@apply
+                    if (branch.isMainBranch) {
+                        schedulingPolicy = daily {
+                            this.hour = triggerHour
+                        }
+                    } else {
+                        schedulingPolicy = weekly {
+                            this.dayOfWeek = ScheduleTrigger.DAY.Saturday
+                            this.hour = triggerHour
+                        }
                     }
                     triggerBuild = always()
-                    withPendingChangesOnly = true
-                    enabled = branch.enableTriggers
+                    withPendingChangesOnly = branch.isMainBranch
+                    enabled = branch.enableVcsTriggers
                     // https://www.jetbrains.com/help/teamcity/2022.04/configuring-schedule-triggers.html#general-syntax-1
                     // We want it to be triggered only when there're pending changes in the specific vcs root, i.e. GradleMaster/GradleRelease
                     triggerRules = "+:root=${VersionedSettingsBranch.fromDslContext().vcsRootId()}:."
@@ -50,11 +58,4 @@ class PublishNightlySnapshot(branch: VersionedSettingsBranch) : PublishGradleDis
             }
         }
     }
-}
-
-// Avoid two jobs running at the same time and causing troubles
-private fun VersionedSettingsBranch.triggeredHour() = when {
-    isMaster -> 0
-    isRelease -> 1
-    else -> null
 }

--- a/.teamcity/src/main/kotlin/promotion/SanityCheck.kt
+++ b/.teamcity/src/main/kotlin/promotion/SanityCheck.kt
@@ -28,7 +28,7 @@ object SanityCheck : BuildType({
     triggers {
         vcs {
             branchFilter = ""
-            enabled = VersionedSettingsBranch.fromDslContext().enableTriggers
+            enabled = VersionedSettingsBranch.fromDslContext().enableVcsTriggers
         }
     }
 

--- a/.teamcity/src/main/kotlin/promotion/StartReleaseCycleTest.kt
+++ b/.teamcity/src/main/kotlin/promotion/StartReleaseCycleTest.kt
@@ -37,7 +37,7 @@ object StartReleaseCycleTest : BasePromotionBuildType(vcsRootId = gradlePromotio
             }
         }
 
-        val enableTriggers = VersionedSettingsBranch.fromDslContext().enableTriggers
+        val enableTriggers = VersionedSettingsBranch.fromDslContext().enableVcsTriggers
         triggers {
             vcs {
                 branchFilter = "+:master"

--- a/.teamcity/src/test/kotlin/ApplyDefaultConfigurationTest.kt
+++ b/.teamcity/src/test/kotlin/ApplyDefaultConfigurationTest.kt
@@ -48,7 +48,7 @@ class ApplyDefaultConfigurationTest {
     private
     val buildModel = CIBuildModel(
         projectId = "Gradle_Check",
-        branch = VersionedSettingsBranch("master", true),
+        branch = VersionedSettingsBranch("master"),
         buildScanTags = listOf("Check"),
         subprojects = JsonBasedGradleSubprojectProvider(File("../.teamcity/subprojects.json"))
     )

--- a/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
+++ b/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
@@ -47,7 +47,7 @@ class PerformanceTestBuildTypeTest {
     private
     val buildModel = CIBuildModel(
         projectId = "Gradle_Check",
-        branch = VersionedSettingsBranch("master", true),
+        branch = VersionedSettingsBranch("master"),
         buildScanTags = listOf("Check"),
         subprojects = JsonBasedGradleSubprojectProvider(File("../.teamcity/subprojects.json"))
     )

--- a/.teamcity/src/test/kotlin/PromotionProjectTests.kt
+++ b/.teamcity/src/test/kotlin/PromotionProjectTests.kt
@@ -249,8 +249,7 @@ class PromotionProjectTests {
         // Set the project id here, so we can use methods on the DslContext
         DslContext.projectId = AbsoluteId("Gradle_$branchName")
         DslContext.addParameters("Branch" to branchName)
-        val model = PromotionProject(VersionedSettingsBranch(branchName, true))
-        return model
+        return PromotionProject(VersionedSettingsBranch(branchName))
     }
 
     private fun gradleStep(steps: List<BuildStep>, index: Int): GradleBuildStep {

--- a/.teamcity/src/test/kotlin/VersionedSettingsBranchTest.kt
+++ b/.teamcity/src/test/kotlin/VersionedSettingsBranchTest.kt
@@ -1,0 +1,47 @@
+import common.VersionedSettingsBranch
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+class VersionedSettingsBranchTest {
+    @ParameterizedTest
+    @CsvSource(
+        value = [
+            "master , true, 0",
+            "release, true, 1",
+            "release6x, false, 2",
+            "release7x, false, 3",
+            "release27x, false, 23"
+        ]
+    )
+    fun validBranches(branchName: String, expectedEnableVcsTriggers: Boolean, expectedNightlyPromotionTriggerHour: Int?) {
+        val vsb = VersionedSettingsBranch(branchName)
+        assertEquals(expectedEnableVcsTriggers, vsb.enableVcsTriggers)
+        assertEquals(expectedNightlyPromotionTriggerHour, vsb.nightlyPromotionTriggerHour)
+    }
+
+    @Test
+    fun invalidBranches() {
+        Assertions.assertThrows(Exception::class.java) {
+            VersionedSettingsBranch("release28x")
+        }
+    }
+}

--- a/.teamcity/src/test/kotlin/VersionedSettingsBranchTest.kt
+++ b/.teamcity/src/test/kotlin/VersionedSettingsBranchTest.kt
@@ -1,9 +1,13 @@
 import common.VersionedSettingsBranch
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.ValueSource
 
 /*
  * Copyright 2023 the original author or authors.
@@ -25,17 +29,31 @@ class VersionedSettingsBranchTest {
     @ParameterizedTest
     @CsvSource(
         value = [
-            "master , true, 0",
-            "release, true, 1",
-            "release6x, false, 2",
-            "release7x, false, 3",
-            "release27x, false, 23"
+            "master,    0",
+            "release,   1",
+            "release6x, 2",
+            "release7x, 3",
+            "release27x,23"
         ]
     )
-    fun validBranches(branchName: String, expectedEnableVcsTriggers: Boolean, expectedNightlyPromotionTriggerHour: Int?) {
+    fun branchesWithVcsTriggerEnabled(branchName: String, expectedNightlyPromotionTriggerHour: Int?) {
         val vsb = VersionedSettingsBranch(branchName)
-        assertEquals(expectedEnableVcsTriggers, vsb.enableVcsTriggers)
+        assertTrue(vsb.enableVcsTriggers)
         assertEquals(expectedNightlyPromotionTriggerHour, vsb.nightlyPromotionTriggerHour)
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = [
+            "experimental",
+            "placeholder-1",
+            "whatever",
+        ]
+    )
+    fun branchesWithVcsTriggerDisabled(branchName: String) {
+        val vsb = VersionedSettingsBranch(branchName)
+        assertFalse(vsb.enableVcsTriggers)
+        assertNull(vsb.nightlyPromotionTriggerHour)
     }
 
     @Test


### PR DESCRIPTION
For old release branches, we still want to run nightly promotion job infrequently, like once per week.
