### PR TITLE
Let Kotlin standalone script compilation show compiler warnings by default

### DIFF
--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
@@ -40,6 +40,13 @@ The previous step will help you identify potential problems by issuing deprecati
 
 === Potential breaking changes
 
+==== Kotlin DSL scripts now emit compilation warnings
+
+Starting with Gradle 8.1 compilation warnings from Kotlin DSL scripts are printed in the console output.
+For example, the usage of deprecated APIs will be reported.
+
+This is potentially breaking if you are consuming the console output of Gradle builds.
+
 === Deprecations
 
 [[custom_configuration_roles]]

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
@@ -45,7 +45,7 @@ The previous step will help you identify potential problems by issuing deprecati
 Starting with Gradle 8.1 compilation warnings from Kotlin DSL scripts are printed in the console output.
 For example, the usage of deprecated APIs will be reported.
 
-This is potentially breaking if you are consuming the console output of Gradle builds.
+This is a potentially breaking change if you are consuming the console output of Gradle builds.
 
 === Deprecations
 

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
@@ -40,7 +40,7 @@ The previous step will help you identify potential problems by issuing deprecati
 
 === Potential breaking changes
 
-==== Kotlin DSL scripts now emit compilation warnings
+==== Kotlin DSL scripts emit compilation warnings
 
 Starting with Gradle 8.1 compilation warnings from Kotlin DSL scripts are printed in the console output.
 For example, the usage of deprecated APIs will be reported.

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
@@ -42,8 +42,8 @@ The previous step will help you identify potential problems by issuing deprecati
 
 ==== Kotlin DSL scripts emit compilation warnings
 
-Starting with Gradle 8.1 compilation warnings from Kotlin DSL scripts are printed in the console output.
-For example, the usage of deprecated APIs will be reported.
+Compilation warnings from Kotlin DSL scripts are printed to the console output.
+For example, the use of deprecated APIs in Kotlin DSL will emit warnings each time the script is compiled.
 
 This is a potentially breaking change if you are consuming the console output of Gradle builds.
 

--- a/subprojects/docs/src/snippets/initScripts/customLogger/groovy/customLogger.init.gradle
+++ b/subprojects/docs/src/snippets/initScripts/customLogger/groovy/customLogger.init.gradle
@@ -1,5 +1,6 @@
 useLogger(new CustomEventLogger())
 
+@SuppressWarnings("deprecation")
 class CustomEventLogger extends BuildAdapter implements TaskExecutionListener {
 
     void beforeExecute(Task task) {

--- a/subprojects/docs/src/snippets/initScripts/customLogger/kotlin/customLogger.init.gradle.kts
+++ b/subprojects/docs/src/snippets/initScripts/customLogger/kotlin/customLogger.init.gradle.kts
@@ -1,5 +1,6 @@
 useLogger(CustomEventLogger())
 
+@Suppress("deprecation")
 class CustomEventLogger() : BuildAdapter(), TaskExecutionListener {
 
     override fun beforeExecute(task: Task) {

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
@@ -25,6 +25,7 @@ import org.gradle.kotlin.dsl.embeddedKotlinVersion
 import org.gradle.kotlin.dsl.fixtures.DeepThought
 import org.gradle.kotlin.dsl.fixtures.LightThought
 import org.gradle.kotlin.dsl.fixtures.ZeroThought
+import org.gradle.kotlin.dsl.fixtures.clickableUrlFor
 import org.gradle.kotlin.dsl.fixtures.containsMultiLineString
 import org.gradle.kotlin.dsl.support.normaliseLineSeparators
 import org.gradle.test.fixtures.dsl.GradleDsl
@@ -369,7 +370,7 @@ class GradleKotlinDslIntegrationTest : AbstractPluginIntegrationTest() {
 
         assertThat(
             buildFailureOutput("tasks"),
-            containsString("e: $buildFile:3:44: Unresolved reference: fooBarVersion")
+            containsString("e: ${clickableUrlFor(buildFile)}:3:44: Unresolved reference: fooBarVersion")
         )
     }
 

--- a/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinBuildScriptIntegrationTest.kt
+++ b/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinBuildScriptIntegrationTest.kt
@@ -1,10 +1,10 @@
 package org.gradle.kotlin.dsl.integration
 
 import org.gradle.kotlin.dsl.fixtures.AbstractKotlinIntegrationTest
+import org.gradle.kotlin.dsl.fixtures.clickableUrlFor
 import org.gradle.kotlin.dsl.fixtures.containsMultiLineString
 
 import org.gradle.test.fixtures.file.LeaksFileHandles
-import org.gradle.util.internal.TextUtil.normaliseFileSeparators
 
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.containsString
@@ -353,7 +353,7 @@ class KotlinBuildScriptIntegrationTest : AbstractKotlinIntegrationTest() {
             deprecatedFunction()
         """)
         build("help").apply {
-            assertOutputContains("w: ${normaliseFileSeparators(script.absolutePath)}:4:13: 'deprecatedFunction(): Unit' is deprecated. BECAUSE")
+            assertOutputContains("w: ${clickableUrlFor(script)}:4:13: 'deprecatedFunction(): Unit' is deprecated. BECAUSE")
         }
     }
 }

--- a/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinBuildScriptIntegrationTest.kt
+++ b/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinBuildScriptIntegrationTest.kt
@@ -4,6 +4,7 @@ import org.gradle.kotlin.dsl.fixtures.AbstractKotlinIntegrationTest
 import org.gradle.kotlin.dsl.fixtures.containsMultiLineString
 
 import org.gradle.test.fixtures.file.LeaksFileHandles
+import org.gradle.util.internal.TextUtil.normaliseFileSeparators
 
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.containsString
@@ -342,5 +343,17 @@ class KotlinBuildScriptIntegrationTest : AbstractKotlinIntegrationTest() {
                 """.trimIndent()
             )
         )
+    }
+
+    @Test
+    fun `script compilation warnings are output on the console`() {
+        val script = withBuildScript("""
+            @Deprecated("BECAUSE")
+            fun deprecatedFunction() {}
+            deprecatedFunction()
+        """)
+        build("help").apply {
+            assertOutputContains("w: ${normaliseFileSeparators(script.absolutePath)}:4:13: 'deprecatedFunction(): Unit' is deprecated. BECAUSE")
+        }
     }
 }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
@@ -20,6 +20,7 @@ import org.gradle.api.JavaVersion
 import org.gradle.api.SupportsKotlinAssignmentOverloading
 import org.gradle.internal.SystemProperties
 import org.gradle.internal.io.NullOutputStream
+import org.gradle.internal.logging.ConsoleRenderer
 import org.gradle.kotlin.dsl.assignment.internal.KotlinDslAssignment
 
 import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
@@ -545,7 +546,7 @@ class LoggingMessageCollector(
                 path.let(pathTranslation).let { path ->
                     when {
                         line >= 0 && column >= 0 -> compilerMessageFor(path, line, column, message)
-                        else -> "$path: $message"
+                        else -> "${clickableFileUrlFor(path)}: $message"
                     }
                 }
             } ?: message
@@ -571,4 +572,9 @@ class LoggingMessageCollector(
 
 internal
 fun compilerMessageFor(path: String, line: Int, column: Int, message: String) =
-    "$path:$line:$column: $message"
+    "${clickableFileUrlFor(path)}:$line:$column: $message"
+
+
+private
+fun clickableFileUrlFor(path: String): String =
+    ConsoleRenderer().asClickableFileUrl(File(path))

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
@@ -560,8 +560,8 @@ class LoggingMessageCollector(
             }
 
             in CompilerMessageSeverity.VERBOSE -> log.trace { msg() }
-            CompilerMessageSeverity.STRONG_WARNING -> log.info { taggedMsg() }
-            CompilerMessageSeverity.WARNING -> log.info { taggedMsg() }
+            CompilerMessageSeverity.STRONG_WARNING -> log.warn { taggedMsg() }
+            CompilerMessageSeverity.WARNING -> log.warn { taggedMsg() }
             CompilerMessageSeverity.INFO -> log.info { msg() }
             else -> log.debug { taggedMsg() }
         }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/Logger.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/Logger.kt
@@ -44,6 +44,12 @@ inline fun Logger.info(msg: () -> String) {
 
 
 internal
+inline fun Logger.warn(msg: () -> String) {
+    if (isWarnEnabled) warn(msg())
+}
+
+
+internal
 inline fun Logger.error(msg: () -> String) {
     if (isErrorEnabled) error(msg())
 }

--- a/subprojects/kotlin-dsl/src/testFixtures/kotlin/org/gradle/kotlin/dsl/fixtures/Testing.kt
+++ b/subprojects/kotlin-dsl/src/testFixtures/kotlin/org/gradle/kotlin/dsl/fixtures/Testing.kt
@@ -1,6 +1,7 @@
 package org.gradle.kotlin.dsl.fixtures
 
 import org.gradle.internal.classpath.ClassPath
+import org.gradle.internal.logging.ConsoleRenderer
 import org.gradle.kotlin.dsl.support.normaliseLineSeparators
 import org.gradle.util.internal.TextUtil
 
@@ -82,3 +83,7 @@ fun standardOutputOf(action: () -> Unit): String =
             System.setOut(out)
         }
     }.toString("utf8").normaliseLineSeparators()
+
+
+fun clickableUrlFor(file: File): String =
+    ConsoleRenderer().asClickableFileUrl(file)


### PR DESCRIPTION
They were redirected to the INFO logger before.
This makes e.g. deprecation warnings more visible.

See discussion in this [slack thread](https://gradle.slack.com/archives/C03A0MT6S/p1675068329093239)