### PR TITLE
Add DelegatingDependencyMetadata

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -74,7 +74,7 @@ import org.gradle.api.internal.artifacts.ivyservice.modulecache.dynamicversions.
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.dynamicversions.InMemoryModuleVersionsCache;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.dynamicversions.ReadOnlyModuleVersionsCache;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.dynamicversions.TwoStageModuleVersionsCache;
-import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.DependencyDescriptorFactory;
+import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.DependencyMetadataFactory;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.DefaultProjectLocalComponentProvider;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.DefaultProjectPublicationRegistry;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.LocalComponentRegistry;
@@ -535,7 +535,7 @@ class DependencyManagementBuildScopeServices {
     }
 
     ArtifactDependencyResolver createArtifactDependencyResolver(ResolveIvyFactory resolveIvyFactory,
-                                                                DependencyDescriptorFactory dependencyDescriptorFactory,
+                                                                DependencyMetadataFactory dependencyMetadataFactory,
                                                                 VersionComparator versionComparator,
                                                                 List<ResolverProviderFactory> resolverFactories,
                                                                 ModuleExclusions moduleExclusions,
@@ -553,7 +553,7 @@ class DependencyManagementBuildScopeServices {
             buildOperationExecutor,
             resolverFactories,
             resolveIvyFactory,
-            dependencyDescriptorFactory,
+            dependencyMetadataFactory,
             versionComparator,
             moduleExclusions,
             componentSelectorConverter,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGlobalScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGlobalScopeServices.java
@@ -26,14 +26,14 @@ import org.gradle.api.internal.artifacts.ivyservice.DefaultIvyContextManager;
 import org.gradle.api.internal.artifacts.ivyservice.IvyContextManager;
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.ModuleSelectorStringNotationConverter;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
-import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.DefaultDependencyDescriptorFactory;
+import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.DefaultDependencyMetadataFactory;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.DefaultExcludeRuleConverter;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.DefaultLocalConfigurationMetadataBuilder;
-import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.DependencyDescriptorFactory;
+import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.DependencyMetadataFactory;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.ExcludeRuleConverter;
-import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.ExternalModuleIvyDependencyDescriptorFactory;
+import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.ExternalModuleDependencyMetadataConverter;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.LocalConfigurationMetadataBuilder;
-import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.ProjectIvyDependencyDescriptorFactory;
+import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.ProjectDependencyMetadataConverter;
 import org.gradle.api.internal.artifacts.transform.ArtifactTransformActionScheme;
 import org.gradle.api.internal.artifacts.transform.ArtifactTransformParameterScheme;
 import org.gradle.api.internal.artifacts.transform.CacheableTransformTypeAnnotationHandler;
@@ -100,18 +100,17 @@ class DependencyManagementGlobalScopeServices {
         return new DefaultExcludeRuleConverter(moduleIdentifierFactory);
     }
 
-    ExternalModuleIvyDependencyDescriptorFactory createExternalModuleDependencyDescriptorFactory(ExcludeRuleConverter excludeRuleConverter) {
-        return new ExternalModuleIvyDependencyDescriptorFactory(excludeRuleConverter);
+    DependencyMetadataFactory createDependencyMetadataFactory(ExcludeRuleConverter excludeRuleConverter) {
+        return new DefaultDependencyMetadataFactory(
+            new ProjectDependencyMetadataConverter(excludeRuleConverter),
+            new ExternalModuleDependencyMetadataConverter(excludeRuleConverter)
+        );
     }
 
-    DependencyDescriptorFactory createDependencyDescriptorFactory(ExcludeRuleConverter excludeRuleConverter, ExternalModuleIvyDependencyDescriptorFactory descriptorFactory) {
-        return new DefaultDependencyDescriptorFactory(
-            new ProjectIvyDependencyDescriptorFactory(excludeRuleConverter),
-            descriptorFactory);
-    }
-
-    LocalConfigurationMetadataBuilder createLocalConfigurationMetadataBuilder(DependencyDescriptorFactory dependencyDescriptorFactory,
-                                                                              ExcludeRuleConverter excludeRuleConverter) {
+    LocalConfigurationMetadataBuilder createLocalConfigurationMetadataBuilder(
+        DependencyMetadataFactory dependencyDescriptorFactory,
+        ExcludeRuleConverter excludeRuleConverter
+    ) {
         return new DefaultLocalConfigurationMetadataBuilder(dependencyDescriptorFactory, excludeRuleConverter);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/clientmodule/ClientModuleResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/clientmodule/ClientModuleResolver.java
@@ -27,7 +27,7 @@ import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
-import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.DependencyDescriptorFactory;
+import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.DependencyMetadataFactory;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.external.model.DefaultConfigurationMetadata;
@@ -56,11 +56,11 @@ import java.util.Set;
 @NonNullApi
 public class ClientModuleResolver implements ComponentMetaDataResolver {
     private final ComponentMetaDataResolver resolver;
-    private final DependencyDescriptorFactory dependencyDescriptorFactory;
+    private final DependencyMetadataFactory dependencyMetadataFactory;
 
-    public ClientModuleResolver(ComponentMetaDataResolver resolver, DependencyDescriptorFactory dependencyDescriptorFactory) {
+    public ClientModuleResolver(ComponentMetaDataResolver resolver, DependencyMetadataFactory dependencyMetadataFactory) {
         this.resolver = resolver;
-        this.dependencyDescriptorFactory = dependencyDescriptorFactory;
+        this.dependencyMetadataFactory = dependencyMetadataFactory;
     }
 
     @Override
@@ -100,7 +100,7 @@ public class ClientModuleResolver implements ComponentMetaDataResolver {
     }
 
     private ModuleDependencyMetadata createDependencyMetadata(ComponentIdentifier identifier, ModuleDependency moduleDependency) {
-        LocalOriginDependencyMetadata dependencyMetadata = dependencyDescriptorFactory.createDependencyDescriptor(identifier, moduleDependency.getTargetConfiguration(), null, moduleDependency);
+        LocalOriginDependencyMetadata dependencyMetadata = dependencyMetadataFactory.createDependencyMetadata(identifier, moduleDependency.getTargetConfiguration(), null, moduleDependency);
         if (dependencyMetadata instanceof DslOriginDependencyMetadata) {
             return new ClientModuleDependencyMetadataWrapper((DslOriginDependencyMetadata) dependencyMetadata);
         }
@@ -208,11 +208,6 @@ public class ClientModuleResolver implements ComponentMetaDataResolver {
         @Override
         public Dependency getSource() {
             return delegate.getSource();
-        }
-
-        @Override
-        public String getReason() {
-            return delegate.getReason();
         }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/AbstractDependencyMetadataConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/AbstractDependencyMetadataConverter.java
@@ -28,10 +28,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-public abstract class AbstractIvyDependencyDescriptorFactory implements IvyDependencyDescriptorFactory {
+public abstract class AbstractDependencyMetadataConverter implements DependencyMetadataConverter {
     private final ExcludeRuleConverter excludeRuleConverter;
 
-    public AbstractIvyDependencyDescriptorFactory(ExcludeRuleConverter excludeRuleConverter) {
+    public AbstractDependencyMetadataConverter(ExcludeRuleConverter excludeRuleConverter) {
         this.excludeRuleConverter = excludeRuleConverter;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultDependencyMetadataFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultDependencyMetadataFactory.java
@@ -36,21 +36,21 @@ import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 
-public class DefaultDependencyDescriptorFactory implements DependencyDescriptorFactory {
-    private final List<IvyDependencyDescriptorFactory> dependencyDescriptorFactories;
+public class DefaultDependencyMetadataFactory implements DependencyMetadataFactory {
+    private final List<DependencyMetadataConverter> dependencyDescriptorFactories;
 
-    public DefaultDependencyDescriptorFactory(IvyDependencyDescriptorFactory... dependencyDescriptorFactories) {
+    public DefaultDependencyMetadataFactory(DependencyMetadataConverter... dependencyDescriptorFactories) {
         this.dependencyDescriptorFactories = WrapUtil.toList(dependencyDescriptorFactories);
     }
 
     @Override
-    public LocalOriginDependencyMetadata createDependencyDescriptor(ComponentIdentifier componentId, @Nullable String clientConfiguration, @Nullable AttributeContainer attributes, ModuleDependency dependency) {
-        IvyDependencyDescriptorFactory factoryInternal = findFactoryForDependency(dependency);
-        return factoryInternal.createDependencyDescriptor(componentId, clientConfiguration, attributes, dependency);
+    public LocalOriginDependencyMetadata createDependencyMetadata(ComponentIdentifier componentId, @Nullable String clientConfiguration, @Nullable AttributeContainer attributes, ModuleDependency dependency) {
+        DependencyMetadataConverter factoryInternal = findFactoryForDependency(dependency);
+        return factoryInternal.createDependencyMetadata(componentId, clientConfiguration, attributes, dependency);
     }
 
     @Override
-    public LocalOriginDependencyMetadata createDependencyConstraintDescriptor(ComponentIdentifier componentId, String clientConfiguration, AttributeContainer attributes, DependencyConstraint dependencyConstraint) {
+    public LocalOriginDependencyMetadata createDependencyConstraintMetadata(ComponentIdentifier componentId, String clientConfiguration, AttributeContainer attributes, DependencyConstraint dependencyConstraint) {
         ComponentSelector selector = createSelector(dependencyConstraint);
         return new LocalComponentDependencyMetadata(componentId, selector, clientConfiguration, attributes, dependencyConstraint.getAttributes(), null,
                 Collections.emptyList(), Collections.emptyList(), ((DependencyConstraintInternal)dependencyConstraint).isForce(), false, false, true, false, dependencyConstraint.getReason());
@@ -64,10 +64,10 @@ public class DefaultDependencyDescriptorFactory implements DependencyDescriptorF
             DefaultModuleIdentifier.newId(nullToEmpty(dependencyConstraint.getGroup()), nullToEmpty(dependencyConstraint.getName())), dependencyConstraint.getVersionConstraint(), dependencyConstraint.getAttributes(), ImmutableList.of());
     }
 
-    private IvyDependencyDescriptorFactory findFactoryForDependency(ModuleDependency dependency) {
-        for (IvyDependencyDescriptorFactory ivyDependencyDescriptorFactory : dependencyDescriptorFactories) {
-            if (ivyDependencyDescriptorFactory.canConvert(dependency)) {
-                return ivyDependencyDescriptorFactory;
+    private DependencyMetadataConverter findFactoryForDependency(ModuleDependency dependency) {
+        for (DependencyMetadataConverter dependencyMetadataConverter : dependencyDescriptorFactories) {
+            if (dependencyMetadataConverter.canConvert(dependency)) {
+                return dependencyMetadataConverter;
             }
         }
         throw new InvalidUserDataException("Can't map dependency of type: " + dependency.getClass());

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalConfigurationMetadataBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalConfigurationMetadataBuilder.java
@@ -58,12 +58,14 @@ import java.util.Collection;
  * between DSL and internal metadata types.
  */
 public class DefaultLocalConfigurationMetadataBuilder implements LocalConfigurationMetadataBuilder {
-    private final DependencyDescriptorFactory dependencyDescriptorFactory;
+    private final DependencyMetadataFactory dependencyMetadataFactory;
     private final ExcludeRuleConverter excludeRuleConverter;
 
-    public DefaultLocalConfigurationMetadataBuilder(DependencyDescriptorFactory dependencyDescriptorFactory,
-                                                    ExcludeRuleConverter excludeRuleConverter) {
-        this.dependencyDescriptorFactory = dependencyDescriptorFactory;
+    public DefaultLocalConfigurationMetadataBuilder(
+        DependencyMetadataFactory dependencyMetadataFactory,
+        ExcludeRuleConverter excludeRuleConverter
+    ) {
+        this.dependencyMetadataFactory = dependencyMetadataFactory;
         this.excludeRuleConverter = excludeRuleConverter;
     }
 
@@ -176,7 +178,7 @@ public class DefaultLocalConfigurationMetadataBuilder implements LocalConfigurat
         for (Dependency dependency : configuration.getDependencies()) {
             if (dependency instanceof ModuleDependency) {
                 ModuleDependency moduleDependency = (ModuleDependency) dependency;
-                dependencyBuilder.add(dependencyDescriptorFactory.createDependencyDescriptor(
+                dependencyBuilder.add(dependencyMetadataFactory.createDependencyMetadata(
                     componentId, configuration.getName(), attributes, moduleDependency
                 ));
             } else if (dependency instanceof FileCollectionDependency) {
@@ -188,7 +190,7 @@ public class DefaultLocalConfigurationMetadataBuilder implements LocalConfigurat
         }
 
         for (DependencyConstraint dependencyConstraint : configuration.getDependencyConstraints()) {
-            dependencyBuilder.add(dependencyDescriptorFactory.createDependencyConstraintDescriptor(
+            dependencyBuilder.add(dependencyMetadataFactory.createDependencyConstraintMetadata(
                 componentId, configuration.getName(), attributes, dependencyConstraint)
             );
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DependencyMetadataConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DependencyMetadataConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2007-2008 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies;
 
-import org.gradle.api.artifacts.DependencyConstraint;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
@@ -23,7 +22,8 @@ import org.gradle.internal.component.model.LocalOriginDependencyMetadata;
 
 import javax.annotation.Nullable;
 
-public interface DependencyDescriptorFactory {
-    LocalOriginDependencyMetadata createDependencyDescriptor(ComponentIdentifier componentId, @Nullable String clientConfiguration, @Nullable AttributeContainer attributes, ModuleDependency dependency);
-    LocalOriginDependencyMetadata createDependencyConstraintDescriptor(ComponentIdentifier componentId, String clientConfiguration, AttributeContainer attributes, DependencyConstraint dependencyConstraint);
+public interface DependencyMetadataConverter {
+    LocalOriginDependencyMetadata createDependencyMetadata(ComponentIdentifier componentId, @Nullable String clientConfiguration, @Nullable AttributeContainer attributes, ModuleDependency dependency);
+
+    boolean canConvert(ModuleDependency dependency);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DependencyMetadataFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DependencyMetadataFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2007-2008 the original author or authors.
+ * Copyright 2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies;
 
+import org.gradle.api.artifacts.DependencyConstraint;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
@@ -22,8 +23,7 @@ import org.gradle.internal.component.model.LocalOriginDependencyMetadata;
 
 import javax.annotation.Nullable;
 
-public interface IvyDependencyDescriptorFactory {
-    LocalOriginDependencyMetadata createDependencyDescriptor(ComponentIdentifier componentId, @Nullable String clientConfiguration, @Nullable AttributeContainer attributes, ModuleDependency dependency);
-
-    boolean canConvert(ModuleDependency dependency);
+public interface DependencyMetadataFactory {
+    LocalOriginDependencyMetadata createDependencyMetadata(ComponentIdentifier componentId, @Nullable String clientConfiguration, @Nullable AttributeContainer attributes, ModuleDependency dependency);
+    LocalOriginDependencyMetadata createDependencyConstraintMetadata(ComponentIdentifier componentId, String clientConfiguration, AttributeContainer attributes, DependencyConstraint dependencyConstraint);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ExternalModuleDependencyMetadataConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ExternalModuleDependencyMetadataConverter.java
@@ -31,13 +31,13 @@ import org.gradle.internal.component.model.LocalOriginDependencyMetadata;
 import javax.annotation.Nullable;
 import java.util.List;
 
-public class ExternalModuleIvyDependencyDescriptorFactory extends AbstractIvyDependencyDescriptorFactory {
-    public ExternalModuleIvyDependencyDescriptorFactory(ExcludeRuleConverter excludeRuleConverter) {
+public class ExternalModuleDependencyMetadataConverter extends AbstractDependencyMetadataConverter {
+    public ExternalModuleDependencyMetadataConverter(ExcludeRuleConverter excludeRuleConverter) {
         super(excludeRuleConverter);
     }
 
     @Override
-    public LocalOriginDependencyMetadata createDependencyDescriptor(ComponentIdentifier componentId, @Nullable String clientConfiguration, @Nullable AttributeContainer clientAttributes, ModuleDependency dependency) {
+    public LocalOriginDependencyMetadata createDependencyMetadata(ComponentIdentifier componentId, @Nullable String clientConfiguration, @Nullable AttributeContainer clientAttributes, ModuleDependency dependency) {
         ExternalModuleDependency externalModuleDependency = (ExternalModuleDependency) dependency;
         boolean force = externalModuleDependency.isForce();
         boolean changing = externalModuleDependency.isChanging();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectDependencyMetadataConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectDependencyMetadataConverter.java
@@ -31,14 +31,14 @@ import org.gradle.internal.component.model.LocalOriginDependencyMetadata;
 import javax.annotation.Nullable;
 import java.util.List;
 
-public class ProjectIvyDependencyDescriptorFactory extends AbstractIvyDependencyDescriptorFactory {
+public class ProjectDependencyMetadataConverter extends AbstractDependencyMetadataConverter {
 
-    public ProjectIvyDependencyDescriptorFactory(ExcludeRuleConverter excludeRuleConverter) {
+    public ProjectDependencyMetadataConverter(ExcludeRuleConverter excludeRuleConverter) {
         super(excludeRuleConverter);
     }
 
     @Override
-    public LocalOriginDependencyMetadata createDependencyDescriptor(ComponentIdentifier componentId, @Nullable String clientConfiguration, AttributeContainer clientAttributes, ModuleDependency dependency) {
+    public LocalOriginDependencyMetadata createDependencyMetadata(ComponentIdentifier componentId, @Nullable String clientConfiguration, AttributeContainer clientAttributes, ModuleDependency dependency) {
         ProjectDependencyInternal projectDependency = (ProjectDependencyInternal) dependency;
         ComponentSelector selector = DefaultProjectComponentSelector.newSelector(projectDependency.getDependencyProject(),
                 ((AttributeContainerInternal)projectDependency.getAttributes()).asImmutable(),

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultArtifactDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultArtifactDependencyResolver.java
@@ -36,7 +36,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ResolverProviderF
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionComparator;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
-import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.DependencyDescriptorFactory;
+import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.DependencyMetadataFactory;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyResolver;
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.CapabilitiesResolutionInternal;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.DependencyArtifactsVisitor;
@@ -77,7 +77,7 @@ import static org.gradle.api.internal.artifacts.ivyservice.dependencysubstitutio
 
 public class DefaultArtifactDependencyResolver implements ArtifactDependencyResolver {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultArtifactDependencyResolver.class);
-    private final DependencyDescriptorFactory dependencyDescriptorFactory;
+    private final DependencyMetadataFactory dependencyMetadataFactory;
     private final List<ResolverProviderFactory> resolverFactories;
     private final ResolveIvyFactory ivyFactory;
     private final VersionComparator versionComparator;
@@ -97,7 +97,7 @@ public class DefaultArtifactDependencyResolver implements ArtifactDependencyReso
         BuildOperationExecutor buildOperationExecutor,
         List<ResolverProviderFactory> resolverFactories,
         ResolveIvyFactory ivyFactory,
-        DependencyDescriptorFactory dependencyDescriptorFactory,
+        DependencyMetadataFactory dependencyMetadataFactory,
         VersionComparator versionComparator,
         ModuleExclusions moduleExclusions,
         ComponentSelectorConverter componentSelectorConverter,
@@ -112,7 +112,7 @@ public class DefaultArtifactDependencyResolver implements ArtifactDependencyReso
     ) {
         this.resolverFactories = resolverFactories;
         this.ivyFactory = ivyFactory;
-        this.dependencyDescriptorFactory = dependencyDescriptorFactory;
+        this.dependencyMetadataFactory = dependencyMetadataFactory;
         this.versionComparator = versionComparator;
         this.moduleExclusions = moduleExclusions;
         this.buildOperationExecutor = buildOperationExecutor;
@@ -167,7 +167,7 @@ public class DefaultArtifactDependencyResolver implements ArtifactDependencyReso
     ) {
 
         DependencyToComponentIdResolver componentIdResolver = componentSource.getComponentIdResolver();
-        ComponentMetaDataResolver componentMetaDataResolver = new ClientModuleResolver(componentSource.getComponentResolver(), dependencyDescriptorFactory);
+        ComponentMetaDataResolver componentMetaDataResolver = new ClientModuleResolver(componentSource.getComponentResolver(), dependencyMetadataFactory);
 
         ModuleConflictHandler conflictHandler = createModuleConflictHandler(resolutionStrategy, globalRules);
         DefaultCapabilitiesConflictHandler capabilitiesConflictHandler = createCapabilitiesConflictHandler(resolutionStrategy.getCapabilitiesResolutionRules());

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -43,7 +43,6 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.Dependen
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.CapabilitiesConflictHandler;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.strict.StrictVersionConstraints;
 import org.gradle.api.internal.artifacts.result.DefaultResolvedVariantResult;
-import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.Describables;
@@ -54,11 +53,10 @@ import org.gradle.internal.component.external.model.VirtualComponentIdentifier;
 import org.gradle.internal.component.local.model.LocalConfigurationGraphResolveMetadata;
 import org.gradle.internal.component.local.model.LocalFileDependencyMetadata;
 import org.gradle.internal.component.model.ComponentGraphResolveState;
+import org.gradle.internal.component.model.DelegatingDependencyMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
-import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.component.model.VariantGraphResolveMetadata;
-import org.gradle.internal.component.model.VariantSelectionResult;
 import org.gradle.internal.logging.text.TreeFormatter;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 import org.slf4j.Logger;
@@ -1336,31 +1334,12 @@ public class NodeState implements DependencyGraphNode {
         }
     }
 
-    private static class NonTransitiveVariantDependencyMetadata implements DependencyMetadata {
+    private static class NonTransitiveVariantDependencyMetadata extends DelegatingDependencyMetadata {
         private final DependencyMetadata dependencyMetadata;
 
         public NonTransitiveVariantDependencyMetadata(DependencyMetadata dependencyMetadata) {
+            super(dependencyMetadata);
             this.dependencyMetadata = dependencyMetadata;
-        }
-
-        @Override
-        public ComponentSelector getSelector() {
-            return dependencyMetadata.getSelector();
-        }
-
-        @Override
-        public VariantSelectionResult selectVariants(ImmutableAttributes consumerAttributes, ComponentGraphResolveState targetComponentState, AttributesSchemaInternal consumerSchema, Collection<? extends Capability> explicitRequestedCapabilities) {
-            return dependencyMetadata.selectVariants(consumerAttributes, targetComponentState, consumerSchema, explicitRequestedCapabilities);
-        }
-
-        @Override
-        public List<ExcludeMetadata> getExcludes() {
-            return dependencyMetadata.getExcludes();
-        }
-
-        @Override
-        public List<IvyArtifactName> getArtifacts() {
-            return dependencyMetadata.getArtifacts();
         }
 
         @Override
@@ -1374,28 +1353,8 @@ public class NodeState implements DependencyGraphNode {
         }
 
         @Override
-        public boolean isChanging() {
-            return dependencyMetadata.isChanging();
-        }
-
-        @Override
         public boolean isTransitive() {
             return false;
-        }
-
-        @Override
-        public boolean isConstraint() {
-            return dependencyMetadata.isConstraint();
-        }
-
-        @Override
-        public boolean isEndorsingStrictVersions() {
-            return dependencyMetadata.isEndorsingStrictVersions();
-        }
-
-        @Override
-        public String getReason() {
-            return dependencyMetadata.getReason();
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ForcedDependencyMetadataWrapper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ForcedDependencyMetadataWrapper.java
@@ -18,24 +18,19 @@ package org.gradle.internal.component.external.model;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
-import org.gradle.api.capabilities.Capability;
-import org.gradle.api.internal.attributes.AttributesSchemaInternal;
-import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.local.model.DefaultProjectDependencyMetadata;
-import org.gradle.internal.component.model.ComponentGraphResolveState;
+import org.gradle.internal.component.model.DelegatingDependencyMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
-import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.ForcingDependencyMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
-import org.gradle.internal.component.model.VariantSelectionResult;
 
-import java.util.Collection;
 import java.util.List;
 
-public class ForcedDependencyMetadataWrapper implements ForcingDependencyMetadata, ModuleDependencyMetadata {
+public class ForcedDependencyMetadataWrapper extends DelegatingDependencyMetadata implements ForcingDependencyMetadata, ModuleDependencyMetadata {
     private final ModuleDependencyMetadata delegate;
 
     public ForcedDependencyMetadataWrapper(ModuleDependencyMetadata delegate) {
+        super(delegate);
         this.delegate = delegate;
     }
 
@@ -60,21 +55,6 @@ public class ForcedDependencyMetadataWrapper implements ForcingDependencyMetadat
     }
 
     @Override
-    public VariantSelectionResult selectVariants(ImmutableAttributes consumerAttributes, ComponentGraphResolveState targetComponentState, AttributesSchemaInternal consumerSchema, Collection<? extends Capability> explicitRequestedCapabilities) {
-        return delegate.selectVariants(consumerAttributes, targetComponentState, consumerSchema, explicitRequestedCapabilities);
-    }
-
-    @Override
-    public List<ExcludeMetadata> getExcludes() {
-        return delegate.getExcludes();
-    }
-
-    @Override
-    public List<IvyArtifactName> getArtifacts() {
-        return delegate.getArtifacts();
-    }
-
-    @Override
     public DependencyMetadata withTarget(ComponentSelector target) {
         DependencyMetadata dependencyMetadata = delegate.withTarget(target);
         if (dependencyMetadata instanceof DefaultProjectDependencyMetadata) {
@@ -90,31 +70,6 @@ public class ForcedDependencyMetadataWrapper implements ForcingDependencyMetadat
             return ((DefaultProjectDependencyMetadata) dependencyMetadata).forced();
         }
         return new ForcedDependencyMetadataWrapper((ModuleDependencyMetadata) dependencyMetadata);
-    }
-
-    @Override
-    public boolean isChanging() {
-        return delegate.isChanging();
-    }
-
-    @Override
-    public boolean isTransitive() {
-        return delegate.isTransitive();
-    }
-
-    @Override
-    public boolean isConstraint() {
-        return delegate.isConstraint();
-    }
-
-    @Override
-    public boolean isEndorsingStrictVersions() {
-        return delegate.isEndorsingStrictVersions();
-    }
-
-    @Override
-    public String getReason() {
-        return delegate.getReason();
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleDependencyMetadataWrapper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleDependencyMetadataWrapper.java
@@ -16,32 +16,16 @@
 package org.gradle.internal.component.external.model;
 
 import org.gradle.api.artifacts.VersionConstraint;
-import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
-import org.gradle.api.capabilities.Capability;
-import org.gradle.api.internal.attributes.AttributesSchemaInternal;
-import org.gradle.api.internal.attributes.ImmutableAttributes;
-import org.gradle.internal.component.model.ComponentGraphResolveState;
+import org.gradle.internal.component.model.DelegatingDependencyMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
-import org.gradle.internal.component.model.ExcludeMetadata;
-import org.gradle.internal.component.model.IvyArtifactName;
-import org.gradle.internal.component.model.VariantSelectionResult;
 
-import java.util.Collection;
-import java.util.List;
-
-public class ModuleDependencyMetadataWrapper implements ModuleDependencyMetadata {
+public class ModuleDependencyMetadataWrapper extends DelegatingDependencyMetadata implements ModuleDependencyMetadata {
     private final DependencyMetadata delegate;
-    private final boolean isTransitive;
 
     public ModuleDependencyMetadataWrapper(DependencyMetadata delegate) {
+        super(delegate);
         this.delegate = delegate;
-        this.isTransitive = delegate.isTransitive();
-    }
-
-    @Override
-    public List<IvyArtifactName> getArtifacts() {
-        return delegate.getArtifacts();
     }
 
     @Override
@@ -65,52 +49,7 @@ public class ModuleDependencyMetadataWrapper implements ModuleDependencyMetadata
     }
 
     @Override
-    public DependencyMetadata withTarget(ComponentSelector target) {
-        return delegate.withTarget(target);
-    }
-
-    @Override
-    public DependencyMetadata withTargetAndArtifacts(ComponentSelector target, List<IvyArtifactName> artifacts) {
-        return delegate.withTargetAndArtifacts(target, artifacts);
-    }
-
-    @Override
     public ModuleComponentSelector getSelector() {
         return (ModuleComponentSelector) delegate.getSelector();
-    }
-
-    @Override
-    public List<ExcludeMetadata> getExcludes() {
-        return delegate.getExcludes();
-    }
-
-    @Override
-    public VariantSelectionResult selectVariants(ImmutableAttributes consumerAttributes, ComponentGraphResolveState targetComponentState, AttributesSchemaInternal consumerSchema, Collection<? extends Capability> explicitRequestedCapabilities) {
-        return delegate.selectVariants(consumerAttributes, targetComponentState, consumerSchema, explicitRequestedCapabilities);
-    }
-
-    @Override
-    public boolean isChanging() {
-        return delegate.isChanging();
-    }
-
-    @Override
-    public boolean isTransitive() {
-        return isTransitive;
-    }
-
-    @Override
-    public boolean isConstraint() {
-        return delegate.isConstraint();
-    }
-
-    @Override
-    public boolean isEndorsingStrictVersions() {
-        return delegate.isEndorsingStrictVersions();
-    }
-
-    @Override
-    public String getReason() {
-        return delegate.getReason();
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectDependencyMetadata.java
@@ -18,29 +18,23 @@ package org.gradle.internal.component.local.model;
 
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ProjectComponentSelector;
-import org.gradle.api.capabilities.Capability;
-import org.gradle.api.internal.attributes.AttributesSchemaInternal;
-import org.gradle.api.internal.attributes.ImmutableAttributes;
-import org.gradle.internal.component.model.ComponentGraphResolveState;
+import org.gradle.internal.component.model.DelegatingDependencyMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.ForcingDependencyMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
-import org.gradle.internal.component.model.VariantSelectionResult;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-public class DefaultProjectDependencyMetadata implements ForcingDependencyMetadata {
+public class DefaultProjectDependencyMetadata extends DelegatingDependencyMetadata implements ForcingDependencyMetadata {
     private final ProjectComponentSelector selector;
     private final DependencyMetadata delegate;
-    private final boolean isTransitive;
 
     public DefaultProjectDependencyMetadata(ProjectComponentSelector selector, DependencyMetadata delegate) {
+        super(delegate);
         this.selector = selector;
         this.delegate = delegate;
-        this.isTransitive = delegate.isTransitive();
     }
 
     @Override
@@ -67,46 +61,6 @@ public class DefaultProjectDependencyMetadata implements ForcingDependencyMetada
             return this;
         }
         return delegate.withTargetAndArtifacts(target, artifacts);
-    }
-
-    @Override
-    public boolean isChanging() {
-        return delegate.isChanging();
-    }
-
-    @Override
-    public boolean isConstraint() {
-        return delegate.isConstraint();
-    }
-
-    @Override
-    public boolean isEndorsingStrictVersions() {
-        return delegate.isEndorsingStrictVersions();
-    }
-
-    @Override
-    public String getReason() {
-        return delegate.getReason();
-    }
-
-    @Override
-    public boolean isTransitive() {
-        return isTransitive;
-    }
-
-    @Override
-    public VariantSelectionResult selectVariants(ImmutableAttributes consumerAttributes, ComponentGraphResolveState targetComponentState, AttributesSchemaInternal consumerSchema, Collection<? extends Capability> explicitRequestedCapabilities) {
-        return delegate.selectVariants(consumerAttributes, targetComponentState, consumerSchema, explicitRequestedCapabilities);
-    }
-
-    @Override
-    public List<IvyArtifactName> getArtifacts() {
-        return delegate.getArtifacts();
-    }
-
-    @Override
-    public DependencyMetadata withReason(String reason) {
-        return delegate.withReason(reason);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DslOriginDependencyMetadataWrapper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DslOriginDependencyMetadataWrapper.java
@@ -18,36 +18,28 @@ package org.gradle.internal.component.local.model;
 
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.component.ComponentSelector;
-import org.gradle.api.capabilities.Capability;
-import org.gradle.api.internal.attributes.AttributesSchemaInternal;
-import org.gradle.api.internal.attributes.ImmutableAttributes;
-import org.gradle.internal.component.model.ComponentGraphResolveState;
-import org.gradle.internal.component.model.DependencyMetadata;
-import org.gradle.internal.component.model.ExcludeMetadata;
+import org.gradle.internal.component.model.DelegatingDependencyMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.component.model.LocalOriginDependencyMetadata;
-import org.gradle.internal.component.model.VariantSelectionResult;
 
-import java.util.Collection;
 import java.util.List;
 
-public class DslOriginDependencyMetadataWrapper implements DslOriginDependencyMetadata, LocalOriginDependencyMetadata {
+public class DslOriginDependencyMetadataWrapper extends DelegatingDependencyMetadata implements DslOriginDependencyMetadata, LocalOriginDependencyMetadata {
     private final LocalOriginDependencyMetadata delegate;
     private final Dependency source;
-    private final boolean isTransitive;
-    private List<IvyArtifactName> artifacts;
+    private final List<IvyArtifactName> artifacts;
 
     public DslOriginDependencyMetadataWrapper(LocalOriginDependencyMetadata delegate, Dependency source) {
+        super(delegate);
         this.delegate = delegate;
         this.source = source;
-        this.isTransitive = delegate.isTransitive();
         this.artifacts = delegate.getArtifacts();
     }
 
     private DslOriginDependencyMetadataWrapper(LocalOriginDependencyMetadata delegate, Dependency source, List<IvyArtifactName> artifacts) {
+        super(delegate);
         this.delegate = delegate;
         this.source = source;
-        this.isTransitive = delegate.isTransitive();
         this.artifacts = artifacts;
     }
 
@@ -67,28 +59,8 @@ public class DslOriginDependencyMetadataWrapper implements DslOriginDependencyMe
     }
 
     @Override
-    public VariantSelectionResult selectVariants(ImmutableAttributes consumerAttributes, ComponentGraphResolveState targetComponentState, AttributesSchemaInternal consumerSchema, Collection<? extends Capability> explicitRequestedCapabilities) {
-        return delegate.selectVariants(consumerAttributes, targetComponentState, consumerSchema, explicitRequestedCapabilities);
-    }
-
-    @Override
     public String getDependencyConfiguration() {
         return delegate.getDependencyConfiguration();
-    }
-
-    @Override
-    public List<ExcludeMetadata> getExcludes() {
-        return delegate.getExcludes();
-    }
-
-    @Override
-    public boolean isChanging() {
-        return delegate.isChanging();
-    }
-
-    @Override
-    public boolean isTransitive() {
-        return isTransitive;
     }
 
     @Override
@@ -97,27 +69,8 @@ public class DslOriginDependencyMetadataWrapper implements DslOriginDependencyMe
     }
 
     @Override
-    public boolean isConstraint() {
-        return delegate.isConstraint();
-    }
-
-    @Override
-    public boolean isEndorsingStrictVersions() {
-        return delegate.isEndorsingStrictVersions();
-    }
-
-    private boolean isExternalVariant() {
-        return false;
-    }
-
-    @Override
     public boolean isFromLock() {
         return delegate.isFromLock();
-    }
-
-    @Override
-    public String getReason() {
-        return delegate.getReason();
     }
 
     @Override
@@ -133,16 +86,6 @@ public class DslOriginDependencyMetadataWrapper implements DslOriginDependencyMe
     @Override
     public LocalOriginDependencyMetadata withTargetAndArtifacts(ComponentSelector target, List<IvyArtifactName> artifacts) {
         return new DslOriginDependencyMetadataWrapper(delegate.withTarget(target), source, artifacts);
-    }
-
-    @Override
-    public DependencyMetadata withReason(String reason) {
-        return delegate.withReason(reason);
-    }
-
-    @Override
-    public ComponentSelector getSelector() {
-        return delegate.getSelector();
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DelegatingDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DelegatingDependencyMetadata.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.component.model;
+
+import org.gradle.api.artifacts.component.ComponentSelector;
+import org.gradle.api.capabilities.Capability;
+import org.gradle.api.internal.attributes.AttributesSchemaInternal;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * A {@link DependencyMetadata} implementation which delegates all method calls to a provided {@code delegate}.
+ */
+public abstract class DelegatingDependencyMetadata implements DependencyMetadata {
+
+    private final DependencyMetadata delegate;
+
+    public DelegatingDependencyMetadata(DependencyMetadata delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public ComponentSelector getSelector() {
+        return delegate.getSelector();
+    }
+
+    @Override
+    public VariantSelectionResult selectVariants(ImmutableAttributes consumerAttributes, ComponentGraphResolveState targetComponentState, AttributesSchemaInternal consumerSchema, Collection<? extends Capability> explicitRequestedCapabilities) {
+        return delegate.selectVariants(consumerAttributes, targetComponentState, consumerSchema, explicitRequestedCapabilities);
+    }
+
+    @Override
+    public List<ExcludeMetadata> getExcludes() {
+        return delegate.getExcludes();
+    }
+
+    @Override
+    public List<IvyArtifactName> getArtifacts() {
+        return delegate.getArtifacts();
+    }
+
+    @Override
+    public DependencyMetadata withTarget(ComponentSelector target) {
+        return delegate.withTarget(target);
+    }
+
+    @Override
+    public DependencyMetadata withTargetAndArtifacts(ComponentSelector target, List<IvyArtifactName> artifacts) {
+        return delegate.withTargetAndArtifacts(target, artifacts);
+    }
+
+    @Override
+    public boolean isChanging() {
+        return delegate.isChanging();
+    }
+
+    @Override
+    public boolean isTransitive() {
+        return delegate.isTransitive();
+    }
+
+    @Override
+    public boolean isConstraint() {
+        return delegate.isConstraint();
+    }
+
+    @Override
+    public boolean isEndorsingStrictVersions() {
+        return delegate.isEndorsingStrictVersions();
+    }
+
+    @Nullable
+    @Override
+    public String getReason() {
+        return delegate.getReason();
+    }
+
+    @Override
+    public DependencyMetadata withReason(String reason) {
+        return delegate.withReason(reason);
+    }
+
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultDependencyMetadataFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultDependencyMetadataFactoryTest.groovy
@@ -23,7 +23,7 @@ import org.gradle.api.internal.artifacts.dependencies.DefaultDependencyConstrain
 import org.gradle.internal.component.model.LocalOriginDependencyMetadata
 import spock.lang.Specification
 
-class DefaultDependencyDescriptorFactoryTest extends Specification {
+class DefaultDependencyMetadataFactoryTest extends Specification {
     def configurationName = "conf"
     def projectDependency = Stub(ProjectDependency)
     def componentId = new ComponentIdentifier() {
@@ -35,36 +35,32 @@ class DefaultDependencyDescriptorFactoryTest extends Specification {
 
     def "delegates to internal factory"() {
         given:
-        def ivyDependencyDescriptorFactory1 = Mock(IvyDependencyDescriptorFactory)
-        def ivyDependencyDescriptorFactory2 = Mock(IvyDependencyDescriptorFactory)
+        def converter1 = Mock(DependencyMetadataConverter)
+        def converter2 = Mock(DependencyMetadataConverter)
         def result = Stub(LocalOriginDependencyMetadata)
 
         when:
-        def dependencyDescriptorFactory = new DefaultDependencyDescriptorFactory(
-                ivyDependencyDescriptorFactory1, ivyDependencyDescriptorFactory2
-        )
-        def created = dependencyDescriptorFactory.createDependencyDescriptor(componentId, configurationName, null, projectDependency)
+        def dependencyDescriptorFactory = new DefaultDependencyMetadataFactory(converter1, converter2)
+        def created = dependencyDescriptorFactory.createDependencyMetadata(componentId, configurationName, null, projectDependency)
 
         then:
         created == result
 
         and:
-        1 * ivyDependencyDescriptorFactory1.canConvert(projectDependency) >> false
-        1 * ivyDependencyDescriptorFactory2.canConvert(projectDependency) >> true
-        1 * ivyDependencyDescriptorFactory2.createDependencyDescriptor(componentId, configurationName, null, projectDependency) >> result
+        1 * converter1.canConvert(projectDependency) >> false
+        1 * converter2.canConvert(projectDependency) >> true
+        1 * converter2.createDependencyMetadata(componentId, configurationName, null, projectDependency) >> result
     }
 
     def "fails where no internal factory can handle dependency type"() {
-        def ivyDependencyDescriptorFactory1 = Mock(IvyDependencyDescriptorFactory);
+        def converter = Mock(DependencyMetadataConverter);
 
         when:
-        ivyDependencyDescriptorFactory1.canConvert(projectDependency) >> false
+        converter.canConvert(projectDependency) >> false
 
         and:
-        def dependencyDescriptorFactory = new DefaultDependencyDescriptorFactory(
-                ivyDependencyDescriptorFactory1
-        )
-        dependencyDescriptorFactory.createDependencyDescriptor(componentId, configurationName, null, projectDependency)
+        def dependencyDescriptorFactory = new DefaultDependencyMetadataFactory(converter)
+        dependencyDescriptorFactory.createDependencyMetadata(componentId, configurationName, null, projectDependency)
 
         then:
         thrown InvalidUserDataException
@@ -75,8 +71,8 @@ class DefaultDependencyDescriptorFactoryTest extends Specification {
         def dependencyConstraint = new DefaultDependencyConstraint("g", "m", "1")
 
         when:
-        def dependencyDescriptorFactory = new DefaultDependencyDescriptorFactory()
-        def created = dependencyDescriptorFactory.createDependencyConstraintDescriptor(componentId, configurationName, null, dependencyConstraint)
+        def dependencyDescriptorFactory = new DefaultDependencyMetadataFactory()
+        def created = dependencyDescriptorFactory.createDependencyConstraintMetadata(componentId, configurationName, null, dependencyConstraint)
         def selector = created.selector as ModuleComponentSelector
 
         then:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalConfigurationMetadataBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalConfigurationMetadataBuilderTest.groovy
@@ -39,9 +39,9 @@ import spock.lang.Specification
  * Tests {@link DefaultLocalConfigurationMetadataBuilder}
  */
 class DefaultLocalConfigurationMetadataBuilderTest extends Specification {
-    def dependencyDescriptorFactory = Mock(DependencyDescriptorFactory)
+    def dependencyMetadataFactory = Mock(DependencyMetadataFactory)
     def excludeRuleConverter = Mock(ExcludeRuleConverter)
-    def converter = new DefaultLocalConfigurationMetadataBuilder(dependencyDescriptorFactory, excludeRuleConverter)
+    def converter = new DefaultLocalConfigurationMetadataBuilder(dependencyMetadataFactory, excludeRuleConverter)
 
     def configuration = Mock(ConfigurationInternal)
     def dependencySet = Mock(DependencySet)
@@ -96,8 +96,8 @@ class DefaultLocalConfigurationMetadataBuilderTest extends Specification {
         then:
         1 * configuration.runDependencyActions()
         1 * dependencySet.iterator() >> [dependency1, dependency2].iterator()
-        1 * dependencyDescriptorFactory.createDependencyDescriptor(componentId, "config", _, dependency1) >> dependencyDescriptor1
-        1 * dependencyDescriptorFactory.createDependencyDescriptor(componentId, "config", _, dependency2) >> dependencyDescriptor2
+        1 * dependencyMetadataFactory.createDependencyMetadata(componentId, "config", _, dependency1) >> dependencyDescriptor1
+        1 * dependencyMetadataFactory.createDependencyMetadata(componentId, "config", _, dependency2) >> dependencyDescriptor2
 
         metaData.dependencies == [dependencyDescriptor1, dependencyDescriptor2]
     }
@@ -114,8 +114,8 @@ class DefaultLocalConfigurationMetadataBuilderTest extends Specification {
         then:
         1 * configuration.runDependencyActions()
         1 * dependencyConstraintSet.iterator() >> [dependencyConstraint1, dependencyConstraint2].iterator()
-        1 * dependencyDescriptorFactory.createDependencyConstraintDescriptor(componentId, "config", _, dependencyConstraint1) >> dependencyDescriptor1
-        1 * dependencyDescriptorFactory.createDependencyConstraintDescriptor(componentId, "config", _, dependencyConstraint2) >> dependencyDescriptor2
+        1 * dependencyMetadataFactory.createDependencyConstraintMetadata(componentId, "config", _, dependencyConstraint1) >> dependencyDescriptor1
+        1 * dependencyMetadataFactory.createDependencyConstraintMetadata(componentId, "config", _, dependencyConstraint2) >> dependencyDescriptor2
 
         metaData.dependencies == [dependencyDescriptor1, dependencyDescriptor2]
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ExternalModuleDependencyMetadataConverterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ExternalModuleDependencyMetadataConverterTest.groovy
@@ -25,10 +25,9 @@ import org.gradle.api.internal.artifacts.VersionConstraintInternal
 import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency
 import org.gradle.internal.component.model.LocalOriginDependencyMetadata
 
-class ExternalModuleDependencyDescriptorFactoryTest extends AbstractDependencyDescriptorFactoryInternalSpec {
+class ExternalModuleDependencyMetadataConverterTest extends AbstractDependencyDescriptorFactoryInternalSpec {
 
-    ExternalModuleIvyDependencyDescriptorFactory externalModuleDependencyDescriptorFactory =
-            new ExternalModuleIvyDependencyDescriptorFactory(excludeRuleConverterStub)
+    ExternalModuleDependencyMetadataConverter converter = new ExternalModuleDependencyMetadataConverter(excludeRuleConverterStub)
     private final ComponentIdentifier componentId = new ComponentIdentifier() {
         @Override
         String getDisplayName() {
@@ -38,14 +37,14 @@ class ExternalModuleDependencyDescriptorFactoryTest extends AbstractDependencyDe
 
     def canConvert() {
         expect:
-        !externalModuleDependencyDescriptorFactory.canConvert(Mock(ProjectDependency))
-        externalModuleDependencyDescriptorFactory.canConvert(Mock(ExternalModuleDependency))
+        !converter.canConvert(Mock(ProjectDependency))
+        converter.canConvert(Mock(ExternalModuleDependency))
     }
 
     def testAddWithNullGroupAndNullVersionShouldHaveEmptyStringModuleRevisionValues() {
         when:
         ModuleDependency dependency = new DefaultExternalModuleDependency(null, "gradle-core", null, TEST_DEP_CONF)
-        LocalOriginDependencyMetadata dependencyMetaData = externalModuleDependencyDescriptorFactory.createDependencyDescriptor(componentId, TEST_CONF, null, dependency)
+        LocalOriginDependencyMetadata dependencyMetaData = converter.createDependencyMetadata(componentId, TEST_CONF, null, dependency)
         ModuleComponentSelector selector = (ModuleComponentSelector) dependencyMetaData.getSelector()
 
         then:
@@ -61,7 +60,7 @@ class ExternalModuleDependencyDescriptorFactoryTest extends AbstractDependencyDe
         DefaultExternalModuleDependency moduleDependency = new DefaultExternalModuleDependency("org.gradle", "gradle-core", "1.0", configuration)
         setUpDependency(moduleDependency, withArtifacts)
 
-        LocalOriginDependencyMetadata dependencyMetaData = externalModuleDependencyDescriptorFactory.createDependencyDescriptor(componentId, TEST_CONF, null, moduleDependency)
+        LocalOriginDependencyMetadata dependencyMetaData = converter.createDependencyMetadata(componentId, TEST_CONF, null, moduleDependency)
 
         then:
         moduleDependency.changing == dependencyMetaData.changing

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectDependencyMetadataConverterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectDependencyMetadataConverterTest.groovy
@@ -30,9 +30,9 @@ import org.gradle.util.Path
 import org.gradle.util.TestUtil
 import org.junit.Rule
 
-class ProjectDependencyDescriptorFactoryTest extends AbstractDependencyDescriptorFactoryInternalSpec {
+class ProjectDependencyMetadataConverterTest extends AbstractDependencyDescriptorFactoryInternalSpec {
 
-    private ProjectIvyDependencyDescriptorFactory projectDependencyDescriptorFactory = new ProjectIvyDependencyDescriptorFactory(excludeRuleConverterStub)
+    private ProjectDependencyMetadataConverter converter = new ProjectDependencyMetadataConverter(excludeRuleConverterStub)
     private final ComponentIdentifier componentId = new ComponentIdentifier() {
         @Override
         String getDisplayName() {
@@ -45,8 +45,8 @@ class ProjectDependencyDescriptorFactoryTest extends AbstractDependencyDescripto
 
     def canConvert() {
         expect:
-        projectDependencyDescriptorFactory.canConvert(Mock(ProjectDependency))
-        !projectDependencyDescriptorFactory.canConvert(Mock(ExternalModuleDependency))
+        converter.canConvert(Mock(ProjectDependency))
+        !converter.canConvert(Mock(ExternalModuleDependency))
     }
 
     def "test create from project dependency"() {
@@ -54,7 +54,7 @@ class ProjectDependencyDescriptorFactoryTest extends AbstractDependencyDescripto
         def configuration = withArtifacts ? null : TEST_DEP_CONF
         ProjectDependency projectDependency = createProjectDependency(configuration)
         setUpDependency(projectDependency, withArtifacts)
-        LocalOriginDependencyMetadata dependencyMetaData = projectDependencyDescriptorFactory.createDependencyDescriptor(componentId, TEST_CONF, null, projectDependency)
+        LocalOriginDependencyMetadata dependencyMetaData = converter.createDependencyMetadata(componentId, TEST_CONF, null, projectDependency)
 
         then:
         assertDependencyDescriptorHasCommonFixtureValues(dependencyMetaData, withArtifacts)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultLocalComponentMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultLocalComponentMetadataTest.groovy
@@ -40,7 +40,7 @@ import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal
 import org.gradle.api.internal.artifacts.configurations.ConfigurationsProvider
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.DefaultExcludeRuleConverter
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.DefaultLocalConfigurationMetadataBuilder
-import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.DependencyDescriptorFactory
+import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.DependencyMetadataFactory
 import org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact
 import org.gradle.api.internal.attributes.AttributesSchemaInternal
 import org.gradle.api.internal.attributes.ImmutableAttributes
@@ -438,14 +438,14 @@ class DefaultLocalComponentMetadataTest extends Specification {
         return new DslOriginDependencyMetadataWrapper(Mock(LocalOriginDependencyMetadata), dependency)
     }
 
-    class TestDependencyMetadataFactory implements DependencyDescriptorFactory {
+    class TestDependencyMetadataFactory implements DependencyMetadataFactory {
         @Override
-        LocalOriginDependencyMetadata createDependencyDescriptor(ComponentIdentifier componentId, String clientConfiguration, AttributeContainer attributes, ModuleDependency dependency) {
+        LocalOriginDependencyMetadata createDependencyMetadata(ComponentIdentifier componentId, String clientConfiguration, AttributeContainer attributes, ModuleDependency dependency) {
             return dependencyMetadata(dependency)
         }
 
         @Override
-        LocalOriginDependencyMetadata createDependencyConstraintDescriptor(ComponentIdentifier componentId, String clientConfiguration, AttributeContainer attributes, DependencyConstraint dependencyConstraint) {
+        LocalOriginDependencyMetadata createDependencyConstraintMetadata(ComponentIdentifier componentId, String clientConfiguration, AttributeContainer attributes, DependencyConstraint dependencyConstraint) {
             throw new UnsupportedOperationException()
         }
     }


### PR DESCRIPTION
Many implementations of DepenendencyMetadata delegate to another instance. We create a base delegating implementation which other implementations may extend from to reduce duplication

We also rename some classes related to create DependencyMetadatas by removing Ivy from the names and using the DependencyMetadata term instead of DepenendencyDescriptor to reduce overloading of the term which is already used by ExternalDependencyDescriptor
