### PR TITLE
Fix behavior for nested DeprecationLogger.whileDisabled invocations

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ systemProp.gradle.internal.testdistribution.writeTraceFile=true
 systemProp.gradle.internal.testdistribution.queryResponseTimeout=PT20S
 
 # Default performance baseline
-defaultPerformanceBaselines=8.1-commit-8e5a6ed3fe1
+defaultPerformanceBaselines=8.1-commit-4b3536b593b

--- a/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DeprecationLogger.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DeprecationLogger.java
@@ -54,10 +54,13 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public class DeprecationLogger {
 
-    private static final ThreadLocal<Boolean> ENABLED = new ThreadLocal<Boolean>() {
+    /**
+     * Counts the levels of nested {@code whileDisabled} invocations.
+     */
+    private static final ThreadLocal<Integer> DISABLE_COUNT = new ThreadLocal<Integer>() {
         @Override
-        protected Boolean initialValue() {
-            return true;
+        protected Integer initialValue() {
+            return 0;
         }
     };
 
@@ -250,30 +253,43 @@ public class DeprecationLogger {
 
     @Nullable
     public static <T> T whileDisabled(Factory<T> factory) {
-        ENABLED.set(false);
+        disable();
         try {
             return factory.create();
         } finally {
-            ENABLED.set(true);
+            maybeEnable();
         }
     }
 
     public static void whileDisabled(Runnable action) {
-        ENABLED.set(false);
+        disable();
         try {
             action.run();
         } finally {
-            ENABLED.set(true);
+            maybeEnable();
         }
     }
 
     public static <T, E extends Exception> T whileDisabledThrowing(ThrowingFactory<T, E> factory) {
-        ENABLED.set(false);
+        disable();
         try {
             return toUncheckedThrowingFactory(factory).create();
         } finally {
-            ENABLED.set(true);
+            maybeEnable();
         }
+    }
+
+    private static void disable() {
+        DISABLE_COUNT.set(DISABLE_COUNT.get() + 1);
+    }
+
+    private static void maybeEnable() {
+        DISABLE_COUNT.set(DISABLE_COUNT.get() - 1);
+    }
+
+    private static boolean isEnabled() {
+        // log deprecation messages only after the outermost whileDisabled finished execution
+        return DISABLE_COUNT.get() == 0;
     }
 
     public interface ThrowingFactory<T, E extends Exception> {
@@ -295,10 +311,6 @@ public class DeprecationLogger {
                 return factory.create();
             }
         };
-    }
-
-    private static boolean isEnabled() {
-        return ENABLED.get();
     }
 
     private synchronized static void nagUserWith(DeprecatedFeatureUsage usage) {

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/deprecation/DeprecationLoggerTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/deprecation/DeprecationLoggerTest.groovy
@@ -98,6 +98,18 @@ class DeprecationLoggerTest extends ConcurrentSpec {
         outputEventListener.events.empty
     }
 
+    def "nested whileDisabled call does not enable deprecation log in the outer method"() {
+        when:
+        DeprecationLogger.whileDisabled {
+            DeprecationLogger.whileDisabled {
+            }
+            DeprecationLogger.deprecate("nag").willBeRemovedInGradle9().undocumented().nagUser()
+        }
+
+        then:
+        outputEventListener.events.empty
+    }
+
     def "warnings are disabled for the current thread only"() {
         when:
         async {

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
@@ -51,7 +51,6 @@ import org.gradle.api.reflect.InjectionPointQualifier;
 import org.gradle.api.tasks.Nested;
 import org.gradle.cache.internal.CrossBuildInMemoryCache;
 import org.gradle.internal.Cast;
-import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.extensibility.NoConventionMapping;
 import org.gradle.internal.instantiation.ClassGenerationException;
 import org.gradle.internal.instantiation.InjectAnnotationHandler;
@@ -506,9 +505,7 @@ abstract class AbstractClassGenerator implements ClassGenerator {
 
             @Override
             public Object newInstance(ServiceLookup services, InstanceGenerator nested, @Nullable Describable displayName, Object[] params) throws InvocationTargetException, IllegalAccessException, InstantiationException {
-                return DeprecationLogger.whileDisabledThrowing(
-                    () -> strategy.newInstance(services, nested, displayName, params)
-                );
+                return strategy.newInstance(services, nested, displayName, params);
             }
 
             @Override

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
@@ -222,6 +222,9 @@ class KotlinPluginSmokeTest extends AbstractPluginValidatingSmokeTest implements
         def result = runner(false, versionNumber, ':tasks')
             .expectDeprecationWarning("The TestReport.reportOn(Object...) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Please use the testResults method instead. See https://docs.gradle.org/${GradleVersion.current().version}/dsl/org.gradle.api.tasks.testing.TestReport.html#org.gradle.api.tasks.testing.TestReport:testResults for more details.", '')
             .expectDeprecationWarning("The TestReport.destinationDir property has been deprecated. This is scheduled to be removed in Gradle 9.0. Please use the destinationDirectory property instead. See https://docs.gradle.org/${GradleVersion.current().version}/dsl/org.gradle.api.tasks.testing.TestReport.html#org.gradle.api.tasks.testing.TestReport:destinationDir for more details.", '')
+            .deprecations(KotlinDeprecations) {
+                expectOrgGradleUtilWrapUtilDeprecation(kotlinVersion)
+            }
             .build()
 
         then:


### PR DESCRIPTION
All deprecation warnings should be suppressed in the code executed with  DeprecationLogger.whileDisabled(). However, the current implementation does not handle nested whileDisabled() calls. So, if a build logic has the following pattern

    DeprecationLogger.whileDisabled {
        DeprecationLogger.whileDisabled {
        }
        DeprecationLogger.deprecate("nag")
            .willBeRemovedInGradle9()
            .undocumented()
            .nagUser()
      }

then the nagging message will appear on the console.

This is because the implementation uses a single, static boolean to keep track of whether or not log messages should be suppressed. That boolean will be set to false when the inner whileDisabled() method returns.

This PR fixes this issue by counting how many levels of nested whileDisabled() are there and only disables the suppression after the outermost block finishes.
