### PR TITLE
Clarify kotlin dsl plugins block interpreter unsupported syntax

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -121,7 +121,7 @@ plugins {
 2. Plugin specification with version and/or the plugin application flag
 3. Kotlin plugin specification helper
 
-Note that using version catalog aliases for plugins or plugin specification type-safe accessors is not supported by the `plugins {}` block interpreter. This support will be added in a later version.
+Note that using version catalog aliases for plugins (e.g. `plugins { alias(libs.plugins.acme) }`) or plugin specification type-safe accessors (e.g. ``plugins { `acme-plugin` }``) is not supported by the `plugins {}` block interpreter. This support will be added in a later version.
 
 In unsupported cases, Gradle falls back to the Kotlin compiler, providing the same performance as previous Gradle releases.
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -112,9 +112,9 @@ To utilize this performance, ensure you are using the supported formats in the d
 
 ```kotlin
 plugins {
-    id("java-library")                               // <1>
+    id("java-library")                                // <1>
     id("com.acme.example") version "1.0" apply false  // <2>
-    kotlin("jvm") version "1.7.21"                   // <3>
+    kotlin("jvm") version "1.7.21"                    // <3>
 }
 ```
 1. Plugin specification by plugin identifier string


### PR DESCRIPTION
By showing actual examples of what is not supported.

Rendered release notes
https://builds.gradle.org/repository/download/Gradle_Release_Check_BuildDistributions/61086734:id/distributions/gradle-8.0-docs.zip!/gradle-8.0-20230202072942%2B0000/docs/release-notes.html#improved-script-compilation-performance