### PR TITLE
Cherry-pick #23165 to Gradle 8.0

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildPathAssignmentIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildPathAssignmentIntegrationTest.groovy
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.composite
+
+import org.gradle.initialization.BuildIdentifiedProgressDetails
+import org.gradle.integtests.fixtures.BuildOperationsFixture
+import org.gradle.integtests.fixtures.build.BuildTestFile
+import org.gradle.integtests.fixtures.build.BuildTestFixture
+import org.gradle.test.fixtures.file.TestDirectoryProvider
+
+class CompositeBuildBuildPathAssignmentIntegrationTest extends AbstractCompositeBuildIntegrationTest {
+
+    BuildOperationsFixture fixture = new BuildOperationsFixture(executer, temporaryFolder)
+
+    def "can have buildLogic build and include build with buildLogic build"() {
+        def builds = nestedBuilds {
+            includedBuild {
+                buildLogic
+            }
+            includingBuild {
+                buildLogic
+                includeBuild '../includedBuild'
+            }
+        }
+        def includingBuild = builds.find { it.rootProjectName == 'includingBuild' }
+
+        when:
+        succeeds(includingBuild, "help")
+        then:
+        assignedBuildPaths ==~ [
+            ':includedBuild',
+            ':includedBuild:buildLogic',
+            ':',
+            ':buildLogic'
+        ]
+    }
+
+    def "build paths are selected based on the directory hierarchy"() {
+        def builds = nestedBuilds {
+            includedBuild {
+                buildLogic
+                nested {
+                    buildLogic
+                    includeBuild '../buildLogic'
+                }
+            }
+            includingBuild {
+                includeBuild '../includedBuild'
+                buildLogic
+                nested {
+                    includeBuild '../buildLogic'
+                    buildLogic
+                }
+            }
+        }
+        def includingBuild = builds.find { it.rootProjectName == 'includingBuild' }
+
+        when:
+        succeeds(includingBuild, 'help')
+        then:
+        assignedBuildPaths ==~ [
+            ':includedBuild',
+            ':includedBuild:buildLogic',
+            ':includedBuild:nested',
+            ':includedBuild:nested:buildLogic',
+            ':',
+            ':buildLogic',
+            ':nested',
+            ':nested:buildLogic'
+        ]
+    }
+
+    def "buildSrc is relative to its including build"() {
+        def builds = nestedBuilds {
+            includedBuild {
+                nested
+            }
+            includingBuild {
+                nested
+                includeBuild '../includedBuild'
+            }
+        }
+
+
+        def includingBuild = builds.find { it.rootProjectName == 'includingBuild' }
+        (builds + new BuildTestFile(file('includingBuild/nested/buildSrc'), 'buildSrc')).each { build ->
+            def buildSrc = build.createDir('buildSrc')
+            buildSrc.createFile('settings.gradle')
+            buildSrc.createFile('build.gradle')
+        }
+
+        when:
+        succeeds(includingBuild, 'help')
+        then:
+        assignedBuildPaths ==~ [
+            ':includedBuild', ':includedBuild:buildSrc', ':includedBuild:nested', ':includedBuild:nested:buildSrc',
+            ':', ':buildSrc', ':nested', ':nested:buildSrc', ':nested:buildSrc:buildSrc']
+    }
+
+    def "uses the directory hierarchy to determine the build path when the builds are not nested"() {
+        def builds = nestedBuilds {
+            includedBuildA {
+                includeBuild '../includedBuildB/nested'
+            }
+            includedBuildB
+            nested
+            includingBuild {
+                includeBuild '../includedBuildB'
+                includeBuild '../includedBuildA'
+                includeBuild '../nested'
+            }
+        }
+        def includingBuild = builds.find { it.rootProjectName == 'includingBuild' }
+        def includedBuildBNested = createDir('includedBuildB/nested')
+        new BuildTestFixture(includedBuildBNested).multiProjectBuild('includedBuildB', ['project1', 'project2'])
+
+        when:
+        succeeds(includingBuild, 'help')
+        then:
+        assignedBuildPaths ==~ [':', ':includedBuildB', ':includedBuildA', ':nested', ':includedBuildB:nested']
+    }
+
+    def "does not resolve the path conflict when the parent build is included #laterDescription"() {
+        def builds = nestedBuilds {
+            includedBuildA {
+                includeBuild '../includedBuildB/nested'
+            }
+            includedBuildB
+
+        }
+
+        if (includeFromNestedBuild) {
+            builds.addAll(nestedBuilds {
+                nested {
+                    includeBuild '../includedBuildB'
+                }
+                includingBuild {
+                    includeBuild '../includedBuildA'
+                    includeBuild '../nested'
+                }
+            })
+        } else {
+            builds.addAll(nestedBuilds {
+                nested
+                includingBuild {
+                    includeBuild '../includedBuildA'
+                    includeBuild '../includedBuildB'
+                    includeBuild '../nested'
+                }
+            })
+        }
+        def includingBuild = builds.find { it.rootProjectName == 'includingBuild' }
+        def includedBuildBNested = createDir('includedBuildB/nested')
+        new BuildTestFixture(includedBuildBNested).multiProjectBuild('includedBuildB', ['project1', 'project2'])
+
+        when:
+        fails(includingBuild, 'help')
+        then:
+        failure.assertHasDescription("Included build ${file('nested')} has build path :nested which is the same as included build ${file('includedBuildB/nested')}")
+
+        where:
+        laterDescription             | includeFromNestedBuild
+        'later from nested build'    | true
+        'later from including build' | false
+    }
+
+    private List<Object> getAssignedBuildPaths() {
+        fixture.progress(BuildIdentifiedProgressDetails).findAll { it.details.buildPath }*.details*.buildPath
+    }
+
+    private void configureBuildConfigurationOutput(List<BuildTestFile> builds) {
+        builds.each {
+            it.buildFile << """
+                    subprojects {
+                        // The Java plugin forces the configuration of the included builds
+                        apply plugin: 'java'
+                    }
+                """
+        }
+    }
+
+    List<BuildTestFile> nestedBuilds(Closure configuration) {
+        def rootSpec = new RootNestedBuildSpec(temporaryFolder)
+        rootSpec.with(configuration)
+        def builds = rootSpec.nestedBuilds
+        configureBuildConfigurationOutput(builds)
+        builds
+    }
+
+    class RootNestedBuildSpec {
+        private final TestDirectoryProvider temporaryFolder
+        List<BuildTestFile> nestedBuilds = []
+
+        RootNestedBuildSpec(TestDirectoryProvider temporaryFolder) {
+            this.temporaryFolder = temporaryFolder
+        }
+
+        def propertyMissing(String name) {
+            createBuild(name)
+        }
+
+        def methodMissing(String name, def args) {
+            BuildTestFile build = createBuild(name)
+
+            def nestedBuildSpec = new NestedBuildSpec(build, nestedBuilds)
+            if (args.length == 1 && args[0] instanceof Closure) {
+                nestedBuildSpec.with(args[0])
+            } else {
+                throw new MissingMethodException(name, getClass(), args)
+            }
+            return nestedBuildSpec
+        }
+
+        private BuildTestFile createBuild(String name) {
+            def build = new BuildTestFile(temporaryFolder.testDirectory.file(name), name)
+            new BuildTestFixture(build).multiProjectBuild(name, ["project1", "project2"])
+            nestedBuilds.add(build)
+            build
+        }
+    }
+
+    class NestedBuildSpec {
+        private final BuildTestFile build
+        private final List<BuildTestFile> nestedBuilds
+
+        NestedBuildSpec(BuildTestFile build, nestedBuilds) {
+            this.nestedBuilds = nestedBuilds
+            this.build = build
+        }
+
+        def includeBuild(String path) {
+            build.settingsFile << """
+                includeBuild '$path'
+            """
+        }
+
+        def propertyMissing(String name) {
+            createNestedBuild(name)
+        }
+
+        def methodMissing(String name, def args) {
+            if (args.length == 1 && args[0] instanceof Closure) {
+                return createNestedBuild(name, args[0])
+            } else {
+                throw new MissingMethodException(name, getClass(), args)
+            }
+        }
+
+        BuildTestFile createNestedBuild(String name, Closure configuration = {}) {
+            includeBuild(name)
+            def nestedBuild = new BuildTestFile(build.file(name), name)
+            nestedBuilds.add(nestedBuild)
+            new BuildTestFixture(nestedBuild).multiProjectBuild(name, ["project1", "project2"])
+            def nestedBuildSpec = new NestedBuildSpec(nestedBuild, nestedBuilds)
+            nestedBuildSpec.with(configuration)
+            return nestedBuild
+        }
+    }
+}
+
+

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildTreeStructureIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildTreeStructureIntegrationTest.groovy
@@ -285,19 +285,19 @@ class ConfigurationCacheBuildTreeStructureIntegrationTest extends AbstractConfig
             size() == 3
             it.find { it.details.buildPath == ":" }
             it.find { it.details.buildPath == ":include" }
-            it.find { it.details.buildPath == ":inner-include" }
+            it.find { it.details.buildPath == ":include:inner-include" }
         }
         with(fixture.all(LoadProjectsBuildOperationType)) {
             size() == 3
             it.find { it.details.buildPath == ":" }
             it.find { it.details.buildPath == ":include" }
-            it.find { it.details.buildPath == ":inner-include" }
+            it.find { it.details.buildPath == ":include:inner-include" }
         }
         with(fixture.progress(BuildIdentifiedProgressDetails)) {
             size() == 3
             it.find { it.details.buildPath == ":" }
             it.find { it.details.buildPath == ":include" }
-            it.find { it.details.buildPath == ":inner-include" }
+            it.find { it.details.buildPath == ":include:inner-include" }
         }
         with(fixture.progress(ProjectsIdentifiedProgressDetails)) {
             size() == 3
@@ -307,7 +307,7 @@ class ConfigurationCacheBuildTreeStructureIntegrationTest extends AbstractConfig
             with(it.find { it.details.buildPath == ":include" }) {
                 details.rootProject.children.size() == 1
             }
-            with(it.find { it.details.buildPath == ":inner-include" }) {
+            with(it.find { it.details.buildPath == ":include:inner-include" }) {
                 details.rootProject.children.size() == 1
             }
         }
@@ -324,7 +324,7 @@ class ConfigurationCacheBuildTreeStructureIntegrationTest extends AbstractConfig
             size() == 3
             it.find { it.details.buildPath == ":" }
             it.find { it.details.buildPath == ":include" }
-            it.find { it.details.buildPath == ":inner-include" }
+            it.find { it.details.buildPath == ":include:inner-include" }
         }
         with(fixture.progress(ProjectsIdentifiedProgressDetails)) {
             size() == 3
@@ -334,18 +334,18 @@ class ConfigurationCacheBuildTreeStructureIntegrationTest extends AbstractConfig
             with(it.find { it.details.buildPath == ":include" }) {
                 details.rootProject.children.size() == 1
             }
-            with(it.find { it.details.buildPath == ":inner-include" }) {
+            with(it.find { it.details.buildPath == ":include:inner-include" }) {
                 details.rootProject.children.size() == 1
             }
         }
 
         where:
-        task                         | projects                                        | builds
-        ":thing"                     | [':']                                           | [':']
-        ":child:thing"               | [':', ':child']                                 | [':']
-        ":include:thing"             | [':', ':include']                               | [':', ':include']
-        ":include:child:thing"       | [':', ':include', ':include:child']             | [':', ':include']
-        ":inner-include:thing"       | [':', ':inner-include']                         | [':', ':inner-include']
-        ":inner-include:child:thing" | [':', ':inner-include', ':inner-include:child'] | [':', ':inner-include']
+        task                                 | projects                                                        | builds
+        ":thing"                             | [':']                                                           | [':']
+        ":child:thing"                       | [':', ':child']                                                 | [':']
+        ":include:thing"                     | [':', ':include']                                               | [':', ':include']
+        ":include:child:thing"               | [':', ':include', ':include:child']                             | [':', ':include']
+        ":include:inner-include:thing"       | [':', ':include:inner-include']                                 | [':', ':include:inner-include']
+        ":include:inner-include:child:thing" | [':', ':include:inner-include', ':include:inner-include:child'] | [':', ':include:inner-include']
     }
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheBuild.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheBuild.kt
@@ -40,7 +40,7 @@ interface ConfigurationCacheBuild {
     // Creates all registered projects for this build
     fun createProjects()
 
-    fun addIncludedBuild(buildDefinition: BuildDefinition, settingsFile: File?): ConfigurationCacheBuild
+    fun addIncludedBuild(buildDefinition: BuildDefinition, settingsFile: File?, buildPath: Path): ConfigurationCacheBuild
 
     fun getBuildSrcOf(ownerId: BuildIdentifier): ConfigurationCacheBuild
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheHost.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheHost.kt
@@ -166,8 +166,8 @@ class ConfigurationCacheHost internal constructor(
         override fun getProject(path: String): ProjectInternal =
             state.projects.getProject(Path.path(path)).mutableModel
 
-        override fun addIncludedBuild(buildDefinition: BuildDefinition, settingsFile: File?): ConfigurationCacheBuild {
-            return DefaultConfigurationCacheBuild(buildStateRegistry.addIncludedBuild(buildDefinition), fileResolver, buildStateRegistry, settingsFile)
+        override fun addIncludedBuild(buildDefinition: BuildDefinition, settingsFile: File?, buildPath: Path): ConfigurationCacheBuild {
+            return DefaultConfigurationCacheBuild(buildStateRegistry.addIncludedBuild(buildDefinition, buildPath), fileResolver, buildStateRegistry, settingsFile)
         }
 
         override fun getBuildSrcOf(ownerId: BuildIdentifier): ConfigurationCacheBuild {

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
@@ -273,6 +273,7 @@ class ConfigurationCacheState(
         withGradleIsolate(gradle, userTypesCodec) {
             write(gradle.settings.settingsScript.resource.file)
             writeBuildDefinition(state.buildDefinition)
+            write(state.identityPath)
         }
         // Encode the build state using the contextualized IO service for the nested build
         state.projects.withMutableStateOfAllProjects {
@@ -285,7 +286,8 @@ class ConfigurationCacheState(
         val build = withGradleIsolate(rootBuild.gradle, userTypesCodec) {
             val settingsFile = read() as File?
             val definition = readIncludedBuildDefinition(rootBuild)
-            rootBuild.addIncludedBuild(definition, settingsFile)
+            val buildPath = read() as Path
+            rootBuild.addIncludedBuild(definition, settingsFile, buildPath)
         }
         // Decode the build state using the contextualized IO service for the build
         return build.gradle.serviceOf<ConfigurationCacheIO>().readIncludedBuildStateFrom(stateFileFor((build.state as NestedBuildState).buildDefinition), build)

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/BuildInitializationBuildOperationsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/BuildInitializationBuildOperationsIntegrationTest.groovy
@@ -185,15 +185,15 @@ class BuildInitializationBuildOperationsIntegrationTest extends AbstractIntegrat
         def loadOrder = [
             ":",
             ":nested",
-            ":nested-nested",
+            ":nested:nested-nested",
             ":nested-cli",
-            ":nested-cli-nested",
-            ":nested-nested:buildSrc",
-            ":nested-nested:buildSrc:buildSrc",
+            ":nested-cli:nested-cli-nested",
+            ":nested:nested-nested:buildSrc",
+            ":nested:nested-nested:buildSrc:buildSrc",
             ":nested:buildSrc",
             ":nested:buildSrc:buildSrc",
-            ":nested-cli-nested:buildSrc",
-            ":nested-cli-nested:buildSrc:buildSrc",
+            ":nested-cli:nested-cli-nested:buildSrc",
+            ":nested-cli:nested-cli-nested:buildSrc:buildSrc",
             ":nested-cli:buildSrc",
             ":nested-cli:buildSrc:buildSrc",
             ":buildSrc",
@@ -206,12 +206,12 @@ class BuildInitializationBuildOperationsIntegrationTest extends AbstractIntegrat
             ":nested",
             ":",
             ":nested-cli",
-            ":nested-nested",
-            ":nested-nested:buildSrc",
+            ":nested:nested-nested",
+            ":nested:nested-nested:buildSrc",
             ":nested",
             ":nested:buildSrc",
-            ":nested-cli-nested",
-            ":nested-cli-nested:buildSrc",
+            ":nested-cli:nested-cli-nested",
+            ":nested-cli:nested-cli-nested:buildSrc",
             ":nested-cli",
             ":nested-cli:buildSrc",
             ":",
@@ -219,18 +219,18 @@ class BuildInitializationBuildOperationsIntegrationTest extends AbstractIntegrat
         ]
 
         def buildIdentifiedEvents = buildOperations.progress(BuildIdentifiedProgressDetails)
-        buildIdentifiedEvents*.details.buildPath == [
+        buildIdentifiedEvents*.details.buildPath ==~ [
             ":",
             ":nested",
             ":nested-cli",
-            ":nested-nested",
-            ":nested-cli-nested",
-            ":nested-nested:buildSrc",
-            ":nested-nested:buildSrc:buildSrc",
+            ":nested:nested-nested",
+            ":nested-cli:nested-cli-nested",
+            ":nested:nested-nested:buildSrc",
+            ":nested:nested-nested:buildSrc:buildSrc",
             ":nested:buildSrc",
             ":nested:buildSrc:buildSrc",
-            ":nested-cli-nested:buildSrc",
-            ":nested-cli-nested:buildSrc:buildSrc",
+            ":nested-cli:nested-cli-nested:buildSrc",
+            ":nested-cli:nested-cli-nested:buildSrc:buildSrc",
             ":nested-cli:buildSrc",
             ":nested-cli:buildSrc:buildSrc",
             ":buildSrc",
@@ -242,15 +242,15 @@ class BuildInitializationBuildOperationsIntegrationTest extends AbstractIntegrat
 
         def configureOrder = [
                 ":",
-                ":nested-nested",
-                ":nested-nested:buildSrc",
-                ":nested-nested:buildSrc:buildSrc",
+                ":nested:nested-nested",
+                ":nested:nested-nested:buildSrc",
+                ":nested:nested-nested:buildSrc:buildSrc",
                 ":nested",
                 ":nested:buildSrc",
                 ":nested:buildSrc:buildSrc",
-                ":nested-cli-nested",
-                ":nested-cli-nested:buildSrc",
-                ":nested-cli-nested:buildSrc:buildSrc",
+                ":nested-cli:nested-cli-nested",
+                ":nested-cli:nested-cli-nested:buildSrc",
+                ":nested-cli:nested-cli-nested:buildSrc:buildSrc",
                 ":nested-cli",
                 ":nested-cli:buildSrc",
                 ":nested-cli:buildSrc:buildSrc",
@@ -268,12 +268,10 @@ class BuildInitializationBuildOperationsIntegrationTest extends AbstractIntegrat
         def dirs = configureOrder
             .collect { it.substring(1) } // strip leading :
             .collect { it.replaceAll(":", "/") }
-            .collect { it.replaceAll("nested-nested", "nested/nested-nested") }
-            .collect { it.replaceAll("nested-cli-nested", "nested-cli/nested-cli-nested") }
             .collect { it ? file(it) : testDirectory }
             .collect { it.absolutePath }
 
-        loadProjectsBuildOperations*.result.rootProject.projectDir == dirs
+        loadProjectsBuildOperations*.result.rootProject.projectDir ==~ dirs
     }
 
     def "operations are fired when child build is not used"() {

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildStateRegistry.java
@@ -21,6 +21,7 @@ import org.gradle.api.internal.BuildDefinition;
 import org.gradle.internal.buildtree.NestedBuildTree;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
+import org.gradle.util.Path;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
@@ -74,6 +75,13 @@ public interface BuildStateRegistry {
      * Creates an included build. An included build is-a nested build whose projects and outputs are treated as part of the composite build.
      */
     IncludedBuildState addIncludedBuild(BuildDefinition buildDefinition);
+
+    /**
+     * Creates an included build. An included build is-a nested build whose projects and outputs are treated as part of the composite build.
+     *
+     * This is used when loaded from the Configuration Cache when the path of the build is already known.
+     */
+    IncludedBuildState addIncludedBuild(BuildDefinition buildDefinition, Path buildPath);
 
     /**
      * Creates an implicit included build. An implicit build is-a nested build that is managed by Gradle and whose outputs are used by dependency resolution.

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -444,6 +444,63 @@ the tasks for `buildSrc` completed and before any requested tasks started.
 
 This behavior is now consistent for `buildSrc` and included builds.
 
+==== Changes to paths of included builds
+
+In order to handle conflicts between nested included build names better, Gradle now uses the directory hierarchy of included builds to assign the build path.
+If you are running tasks from the command line in nested included builds, then you may need to adjust your invocation.
+
+For example, if you have the following hierarchy:
+
+====
+[.multi-language-sample]
+=====
+[source,kotlin]
+----
+.
+├── settings.gradle.kts
+└── nested
+    ├── settings.gradle.kts
+    └── nestedNested
+        └── settings.gradle.kts
+----
+.settings.gradle.kts
+[source,kotlin]
+----
+includeBuild("nested")
+----
+.nested/settings.gradle.kts
+[source,kotlin]
+----
+includeBuild("nestedNested")
+----
+=====
+[.multi-language-sample]
+=====
+[source,groovy]
+----
+.
+├── settings.gradle
+└── nested
+    ├── settings.gradle
+    └── nestedNested
+        └── settings.gradle
+----
+.settings.gradle
+[source,groovy]
+----
+includeBuild("nested")
+----
+.nested/settings.gradle
+[source,groovy]
+----
+includeBuild("nestedNested")
+----
+=====
+====
+
+Before Gradle 8.1, you ran `gradle :nestedNested:compileJava`.
+In Gradle 8.1 the invocation changes to `gradle :nested:nestedNested:compileJava`.
+
 ==== Adding `jst.ejb` with the `eclipse wtp' plugin now removes the `jst.utility` facet
 
 The `eclipse wtp` plugin adds the `jst.utility` facet to java projects.


### PR DESCRIPTION
Use directory hierarchy to qualify nested included builds to allow having composite builds with included build-logic bodies.

Fixes https://github.com/gradle/gradle/issues/17228