### PR TITLE
Make additionalOptions always mutable for Scala compilation

### DIFF
--- a/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
+++ b/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
@@ -1788,6 +1788,14 @@
             ]
         },
         {
+            "type": "org.gradle.language.scala.tasks.BaseScalaCompileOptions",
+            "member": "Method org.gradle.language.scala.tasks.BaseScalaCompileOptions.setAdditionalParameters(java.util.List)",
+            "acceptation": "corresponding getter always returns a non-null value",
+            "changes": [
+                "Parameter 0 from null accepting to non-null accepting breaking change"
+            ]
+        },
+        {
             "type": "org.gradle.language.swift.plugins.SwiftApplicationPlugin",
             "member": "Class org.gradle.language.swift.plugins.SwiftApplicationPlugin",
             "acceptation": "making this class abstract makes it easier to remove boilerplate",

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -669,12 +669,6 @@ In case no toolchains are explicitly configured, the toolchain corresponding to 
 
 Similarly, tasks from the Groovy and Scala plugins also rely on toolchains to determine on which JVM they are executed.
 
-==== Scala compile options `getAdditionalParameters()` returns immutable list
-
-The list of additional parameters for Scala compilation retrieved from the `ScalaCompileOptions` or `BaseScalaCompileOptions` is now immutable.
-
-Previously, the mutability of the list depended on the last assigned value.
-
 [[changes_7.6]]
 == Upgrading from 7.5 and earlier
 

--- a/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/scala/MinimalScalaCompileOptions.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/scala/MinimalScalaCompileOptions.java
@@ -49,7 +49,7 @@ public class MinimalScalaCompileOptions implements Serializable {
         this.optimize = compileOptions.isOptimize();
         this.encoding = compileOptions.getEncoding();
         this.force = compileOptions.isForce();
-        this.additionalParameters = compileOptions.getAdditionalParameters() == null ? null : ImmutableList.copyOf(compileOptions.getAdditionalParameters());
+        this.additionalParameters = ImmutableList.copyOf(compileOptions.getAdditionalParameters());
         this.listFiles = compileOptions.isListFiles();
         this.loggingLevel = compileOptions.getLoggingLevel();
         this.loggingPhases = compileOptions.getLoggingPhases() == null ? null : ImmutableList.copyOf(compileOptions.getLoggingPhases());

--- a/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/internal/ScalaCompileOptionsConfigurer.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/internal/ScalaCompileOptionsConfigurer.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.tasks.scala.internal;
 
-import com.google.common.collect.ImmutableList;
 import org.gradle.api.tasks.scala.ScalaCompileOptions;
 import org.gradle.jvm.toolchain.JavaInstallationMetadata;
 import org.gradle.jvm.toolchain.internal.JavaToolchain;
@@ -24,7 +23,6 @@ import org.gradle.util.internal.VersionNumber;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -69,17 +67,12 @@ public class ScalaCompileOptionsConfigurer {
             return;
         }
 
-        List<String> additionalParameters = scalaCompileOptions.getAdditionalParameters();
-        if (additionalParameters != null && hasTargetDefiningParameter(additionalParameters)) {
+        if (hasTargetDefiningParameter(scalaCompileOptions.getAdditionalParameters())) {
             return;
         }
 
         String targetParameter = determineTargetParameter(scalaVersion, (JavaToolchain) toolchain);
-        if (additionalParameters == null) {
-            scalaCompileOptions.setAdditionalParameters(Collections.singletonList(targetParameter));
-        } else {
-            scalaCompileOptions.setAdditionalParameters(new ImmutableList.Builder<String>().addAll(additionalParameters).add(targetParameter).build());
-        }
+        scalaCompileOptions.getAdditionalParameters().add(targetParameter);
     }
 
     private static boolean hasTargetDefiningParameter(List<String> additionalParameters) {

--- a/subprojects/scala/src/main/java/org/gradle/language/scala/tasks/BaseScalaCompileOptions.java
+++ b/subprojects/scala/src/main/java/org/gradle/language/scala/tasks/BaseScalaCompileOptions.java
@@ -16,7 +16,6 @@
 
 package org.gradle.language.scala.tasks;
 
-import com.google.common.collect.ImmutableList;
 import org.gradle.api.Incubating;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
@@ -30,6 +29,7 @@ import org.gradle.api.tasks.scala.ScalaForkOptions;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -53,7 +53,7 @@ public abstract class BaseScalaCompileOptions extends AbstractOptions {
 
     private boolean force;
 
-    private List<String> additionalParameters;
+    private final List<String> additionalParameters = new ArrayList<>();
 
     private boolean listFiles;
 
@@ -166,17 +166,24 @@ public abstract class BaseScalaCompileOptions extends AbstractOptions {
      * Additional parameters passed to the compiler.
      * Each parameter must start with '-'.
      *
-     * @return The immutable list of additional parameters.
+     * @return The list of additional parameters.
      */
-    @Nullable
     @Optional
     @Input
     public List<String> getAdditionalParameters() {
         return additionalParameters;
     }
 
-    public void setAdditionalParameters(@Nullable List<String> additionalParameters) {
-        this.additionalParameters = additionalParameters == null ? null : ImmutableList.copyOf(additionalParameters);
+    /**
+     * Sets the additional parameters.
+     * <p>
+     * Setting this property will clear any previously set additional parameters.
+     */
+    public void setAdditionalParameters(List<String> additionalParameters) {
+        this.additionalParameters.clear();
+        if (additionalParameters != null) {
+            this.additionalParameters.addAll(additionalParameters);
+        }
     }
 
     /**

--- a/subprojects/scala/src/test/groovy/org/gradle/scala/compile/internal/ScalaCompileOptionsTest.groovy
+++ b/subprojects/scala/src/test/groovy/org/gradle/scala/compile/internal/ScalaCompileOptionsTest.groovy
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.scala.compile.internal
+
+import org.gradle.api.tasks.scala.ScalaCompileOptions
+import org.gradle.util.TestUtil
+import spock.lang.Specification
+import spock.lang.Subject
+
+@Subject(ScalaCompileOptions)
+class ScalaCompileOptionsTest extends Specification {
+
+    def 'additional parameters are empty by default'() {
+        ScalaCompileOptions scalaCompileOptions = TestUtil.newInstance(ScalaCompileOptions)
+
+        expect:
+        scalaCompileOptions.additionalParameters != null
+        scalaCompileOptions.additionalParameters.isEmpty()
+    }
+
+    def 'can append to additional parameters #description'() {
+        ScalaCompileOptions scalaCompileOptions = TestUtil.newInstance(ScalaCompileOptions)
+
+        when:
+        action(scalaCompileOptions)
+        scalaCompileOptions.additionalParameters.add("-some-flag")
+
+        then:
+        scalaCompileOptions.additionalParameters == ["-some-flag"]
+
+        where:
+        description                       | action
+        "by default"                      | {}
+        "after setting to null"           | { it.additionalParameters = null }
+        "after setting to immutable list" | { it.additionalParameters = [].asImmutable() }
+    }
+}


### PR DESCRIPTION
This is effectively a revert of
* https://github.com/gradle/gradle/pull/23198

However, it still improves the behavior by making the list always mutable and non-dependable on the last assigned value.

It makes it safe to always do this without possibility of an NPE:
```
scalaCompileOptions.additionalParameters.add("-some-flag")
```