### PR TITLE
Fix several issues with artifact transforms loaded from configuration cache

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheDependencyResolutionIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheDependencyResolutionIntegrationTest.groovy
@@ -1163,12 +1163,14 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractConf
 
         then:
         configurationCache.assertStateStored() // transform spec is stored
-        output.count("processing") == 2
+        output.count("processing") == 3
         outputContains("processing root.blue")
         outputContains("processing a.jar")
+        outputContains("processing a.blue")
         failure.assertHasFailure("Execution failed for task ':resolve'.") {
             it.assertHasCause("Failed to transform root.blue to match attributes {artifactType=blue, color=green}.")
-            // TODO - should collect all failures rather than stopping on first failure
+            it.assertHasCause("Failed to transform a.jar (project :a) to match attributes {artifactType=jar, color=green}.")
+            it.assertHasCause("Failed to transform a.blue to match attributes {artifactType=blue, color=green}.")
         }
         failure.assertHasFailures(1)
 
@@ -1177,12 +1179,14 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractConf
 
         then:
         configurationCache.assertStateLoaded()
-        output.count("processing") == 2
+        output.count("processing") == 3
         outputContains("processing root.blue")
         outputContains("processing a.jar")
+        outputContains("processing a.blue")
         failure.assertHasFailure("Execution failed for task ':resolve'.") {
             it.assertHasCause("Failed to transform root.blue to match attributes {artifactType=blue, color=green}.")
-            // TODO - should collect all failures rather than stopping on first failure
+            it.assertHasCause("Failed to transform a.jar (project :a) to match attributes {artifactType=jar, color=green}.")
+            it.assertHasCause("Failed to transform a.blue to match attributes {artifactType=blue, color=green}.")
         }
         failure.assertHasFailures(1)
     }
@@ -1275,11 +1279,12 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractConf
 
         then:
         configurationCache.assertStateStored()
-        output.count("processing") == 1
+        output.count("processing") == 2
         outputContains("processing thing1-1.2.jar")
+        outputContains("processing thing2-1.2.jar")
         failure.assertHasFailure("Execution failed for task ':resolve'.") {
             it.assertHasCause("Failed to transform thing1-1.2.jar (group:thing1:1.2) to match attributes {artifactType=jar, color=green, org.gradle.status=release}.")
-            // TODO - should collect all failures rather than stopping on first failure
+            it.assertHasCause("Failed to transform thing2-1.2.jar (group:thing2:1.2) to match attributes {artifactType=jar, color=green, org.gradle.status=release}.")
         }
 
         when:
@@ -1287,11 +1292,12 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractConf
 
         then:
         configurationCache.assertStateLoaded()
-        output.count("processing") == 1
+        output.count("processing") == 2
         outputContains("processing thing1-1.2.jar")
+        outputContains("processing thing2-1.2.jar")
         failure.assertHasFailure("Execution failed for task ':resolve'.") {
             it.assertHasCause("Failed to transform thing1-1.2.jar (group:thing1:1.2) to match attributes {artifactType=jar, color=green, org.gradle.status=release}.")
-            // TODO - should collect all failures rather than stopping on first failure
+            it.assertHasCause("Failed to transform thing2-1.2.jar (group:thing2:1.2) to match attributes {artifactType=jar, color=green, org.gradle.status=release}.")
         }
     }
 

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/ArtifactCollectionCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/ArtifactCollectionCodec.kt
@@ -67,7 +67,7 @@ class ArtifactCollectionCodec(
             elements.map { element ->
                 when (element) {
                     is FixedFileArtifactSpec -> element.file
-                    is ResolvedArtifactSet -> artifactSetConverter.asFileCollection("unknown configuration", element)
+                    is ResolvedArtifactSet -> artifactSetConverter.asFileCollection("unknown configuration", false, element)
                     else -> throw IllegalArgumentException("Unexpected element $element in artifact collection")
                 }
             }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/ArtifactCollectionCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/ArtifactCollectionCodec.kt
@@ -67,7 +67,7 @@ class ArtifactCollectionCodec(
             elements.map { element ->
                 when (element) {
                     is FixedFileArtifactSpec -> element.file
-                    is ResolvedArtifactSet -> artifactSetConverter.asFileCollection("unknown configuration", false, element)
+                    is ResolvedArtifactSet -> artifactSetConverter.asFileCollection("unknown configuration", false, listOf(element))
                     else -> throw IllegalArgumentException("Unexpected element $element in artifact collection")
                 }
             }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/ArtifactCollectionCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/ArtifactCollectionCodec.kt
@@ -67,7 +67,7 @@ class ArtifactCollectionCodec(
             elements.map { element ->
                 when (element) {
                     is FixedFileArtifactSpec -> element.file
-                    is ResolvedArtifactSet -> artifactSetConverter.asFileCollection(element)
+                    is ResolvedArtifactSet -> artifactSetConverter.asFileCollection("unknown configuration", element)
                     else -> throw IllegalArgumentException("Unexpected element $element in artifact collection")
                 }
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -564,7 +564,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
 
     @Override
     protected void visitContents(FileCollectionStructureVisitor visitor) {
-        intrinsicFiles.visitContents(visitor);
+        intrinsicFiles.visitStructure(visitor);
     }
 
     @Override
@@ -2436,6 +2436,11 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     }
 
     private class DefaultResolutionHost implements ResolutionHost {
+        @Override
+        public String getDisplayName() {
+            return DefaultConfiguration.this.getDisplayName();
+        }
+
         @Override
         public DisplayName displayName(String type) {
             return Describables.of(DefaultConfiguration.this, type);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionBackedFileCollection.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionBackedFileCollection.java
@@ -43,6 +43,10 @@ public class ResolutionBackedFileCollection extends AbstractFileCollection {
         this.resolutionHost = resolutionHost;
     }
 
+    public ResolutionHost getResolutionHost() {
+        return resolutionHost;
+    }
+
     @Override
     public void visitDependencies(TaskDependencyResolveContext context) {
         SelectedArtifactSet selected = resultProvider.getTaskDependencyValue();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionBackedFileCollection.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionBackedFileCollection.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.configurations;
+
+import org.gradle.api.internal.artifacts.ivyservice.ResolvedFileCollectionVisitor;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.SelectedArtifactSet;
+import org.gradle.api.internal.file.AbstractFileCollection;
+import org.gradle.api.internal.file.FileCollectionStructureVisitor;
+import org.gradle.api.internal.tasks.FailureCollectingTaskDependencyResolveContext;
+import org.gradle.api.internal.tasks.TaskDependencyFactory;
+import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
+import org.gradle.internal.logging.text.TreeFormatter;
+
+public class ResolutionBackedFileCollection extends AbstractFileCollection {
+    private final ResolutionResultProvider<SelectedArtifactSet> resultProvider;
+    private final boolean lenient;
+    private final ResolutionHost resolutionHost;
+    private SelectedArtifactSet selectedArtifacts;
+
+    public ResolutionBackedFileCollection(
+        ResolutionResultProvider<SelectedArtifactSet> resultProvider,
+        boolean lenient,
+        ResolutionHost resolutionHost,
+        TaskDependencyFactory taskDependencyFactory
+    ) {
+        super(taskDependencyFactory);
+        this.resultProvider = resultProvider;
+        this.lenient = lenient;
+        this.resolutionHost = resolutionHost;
+    }
+
+    @Override
+    public void visitDependencies(TaskDependencyResolveContext context) {
+        SelectedArtifactSet selected = resultProvider.getTaskDependencyValue();
+        FailureCollectingTaskDependencyResolveContext collectingContext = new FailureCollectingTaskDependencyResolveContext(context);
+        selected.visitDependencies(collectingContext);
+        if (!lenient) {
+            resolutionHost.mapFailure("task dependencies", collectingContext.getFailures()).ifPresent(context::visitFailure);
+        }
+    }
+
+    @Override
+    public String getDisplayName() {
+        return resolutionHost.displayName("files").getDisplayName();
+    }
+
+    @Override
+    protected void visitContents(FileCollectionStructureVisitor visitor) {
+        ResolvedFileCollectionVisitor collectingVisitor = new ResolvedFileCollectionVisitor(visitor);
+        getSelectedArtifacts().visitArtifacts(collectingVisitor, lenient);
+        if (!lenient) {
+            resolutionHost.rethrowFailure("files", collectingVisitor.getFailures());
+        }
+    }
+
+    @Override
+    protected void appendContents(TreeFormatter formatter) {
+        formatter.node("contains: " + getDisplayName());
+    }
+
+    SelectedArtifactSet getSelectedArtifacts() {
+        if (selectedArtifacts == null) {
+            selectedArtifacts = resultProvider.getValue();
+        }
+        return selectedArtifacts;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionBackedFileCollection.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionBackedFileCollection.java
@@ -47,6 +47,10 @@ public class ResolutionBackedFileCollection extends AbstractFileCollection {
         return resolutionHost;
     }
 
+    public boolean isLenient() {
+        return lenient;
+    }
+
     @Override
     public void visitDependencies(TaskDependencyResolveContext context) {
         SelectedArtifactSet selected = resultProvider.getTaskDependencyValue();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionBackedFileCollection.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionBackedFileCollection.java
@@ -69,7 +69,7 @@ public class ResolutionBackedFileCollection extends AbstractFileCollection {
     @Override
     protected void visitContents(FileCollectionStructureVisitor visitor) {
         ResolvedFileCollectionVisitor collectingVisitor = new ResolvedFileCollectionVisitor(visitor);
-        getSelectedArtifacts().visitArtifacts(collectingVisitor, lenient);
+        getSelectedArtifacts().visitFiles(collectingVisitor, lenient);
         if (!lenient) {
             resolutionHost.rethrowFailure("files", collectingVisitor.getFailures());
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionHost.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionHost.java
@@ -22,6 +22,8 @@ import java.util.Collection;
 import java.util.Optional;
 
 public interface ResolutionHost {
+    String getDisplayName();
+
     DisplayName displayName(String type);
 
     default void rethrowFailure(String type, Collection<Throwable> failures) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionHost.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionHost.java
@@ -24,7 +24,11 @@ import java.util.Optional;
 public interface ResolutionHost {
     DisplayName displayName(String type);
 
-    void rethrowFailure(String type, Collection<Throwable> failures);
+    default void rethrowFailure(String type, Collection<Throwable> failures) {
+        mapFailure(type, failures).ifPresent(e -> {
+            throw e;
+        });
+    }
 
     Optional<? extends RuntimeException> mapFailure(String type, Collection<Throwable> failures);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedFileCollectionVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedFileCollectionVisitor.java
@@ -32,11 +32,6 @@ public class ResolvedFileCollectionVisitor extends ResolvedFilesCollectingVisito
     }
 
     @Override
-    public void visitSpec(FileCollectionInternal spec) {
-        spec.visitStructure(visitor);
-    }
-
-    @Override
     public void endVisitCollection(FileCollectionInternal.Source source) {
         visitor.visitCollection(source, getFiles());
         getFiles().clear();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactSetToFileCollectionFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactSetToFileCollectionFactory.java
@@ -52,7 +52,7 @@ public class ArtifactSetToFileCollectionFactory {
      * <p>This produces only a minimal implementation to use for artifact sets loaded from the configuration cache
      * Over time, this should be merged with the FileCollection implementation in DefaultConfiguration
      */
-    public FileCollectionInternal asFileCollection(ResolvedArtifactSet artifacts) {
+    public FileCollectionInternal asFileCollection(String displayName, ResolvedArtifactSet artifacts) {
         // TODO - merge these file collections for all transforms so that non-scheduled transforms are executed in parallel
         return new ResolutionBackedFileCollection(
             new ResolutionResultProvider<SelectedArtifactSet>() {
@@ -79,8 +79,13 @@ public class ArtifactSetToFileCollectionFactory {
             false,
             new ResolutionHost() {
                 @Override
+                public String getDisplayName() {
+                    return displayName;
+                }
+
+                @Override
                 public DisplayName displayName(String type) {
-                    return Describables.of("unknown configuration");
+                    return Describables.of(getDisplayName(), type);
                 }
 
                 @Override
@@ -88,7 +93,7 @@ public class ArtifactSetToFileCollectionFactory {
                     if (failures.isEmpty()) {
                         return Optional.empty();
                     } else {
-                        return Optional.of(new DefaultLenientConfiguration.ArtifactResolveException(type, "??", displayName(type).getDisplayName(), failures));
+                        return Optional.of(new DefaultLenientConfiguration.ArtifactResolveException(type, type, getDisplayName(), failures));
                     }
                 }
             }, taskDependencyFactory

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactSetToFileCollectionFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactSetToFileCollectionFactory.java
@@ -71,7 +71,7 @@ public class ArtifactSetToFileCollectionFactory {
 
                         @Override
                         public void visitDependencies(TaskDependencyResolveContext context) {
-                            throw new IllegalStateException();
+                            // No dependencies
                         }
                     };
                 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactSetToFileCollectionFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactSetToFileCollectionFactory.java
@@ -52,7 +52,7 @@ public class ArtifactSetToFileCollectionFactory {
      * <p>This produces only a minimal implementation to use for artifact sets loaded from the configuration cache
      * Over time, this should be merged with the FileCollection implementation in DefaultConfiguration
      */
-    public FileCollectionInternal asFileCollection(String displayName, ResolvedArtifactSet artifacts) {
+    public FileCollectionInternal asFileCollection(String displayName, boolean lenient, ResolvedArtifactSet artifacts) {
         // TODO - merge these file collections for all transforms so that non-scheduled transforms are executed in parallel
         return new ResolutionBackedFileCollection(
             new ResolutionResultProvider<SelectedArtifactSet>() {
@@ -76,7 +76,7 @@ public class ArtifactSetToFileCollectionFactory {
                     };
                 }
             },
-            false,
+            lenient,
             new ResolutionHost() {
                 @Override
                 public String getDisplayName() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactVisitor.java
@@ -43,7 +43,7 @@ public interface ArtifactVisitor {
     void visitArtifact(DisplayName variantName, AttributeContainer variantAttributes, List<? extends Capability> capabilities, ResolvableArtifact artifact);
 
     /**
-     * Should the file for each artifacts be made available prior to calling {@link #visitArtifact(DisplayName, AttributeContainer, List, ResolvableArtifact)}?
+     * Should the file for each artifact be made available prior to calling {@link #visitArtifact(DisplayName, AttributeContainer, List, ResolvableArtifact)}?
      *
      * Returns true here allows the collection to preemptively resolve the files in parallel.
      */

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactVisitor.java
@@ -55,12 +55,6 @@ public interface ArtifactVisitor {
     void visitFailure(Throwable failure);
 
     /**
-     * Called for a set that may be backed by a file collection, when {@link #prepareForVisit(FileCollectionInternal.Source)} return {@link FileCollectionStructureVisitor.VisitType#Spec}.
-     */
-    default void visitSpec(FileCollectionInternal spec) {
-    }
-
-    /**
      * Called after a set of artifacts has been visited.
      */
     default void endVisitCollection(FileCollectionInternal.Source source) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactVisitorToResolvedFileVisitorAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactVisitorToResolvedFileVisitorAdapter.java
@@ -22,6 +22,7 @@ import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.file.FileCollectionStructureVisitor;
 import org.gradle.internal.DisplayName;
 
+import java.io.File;
 import java.util.List;
 
 public class ArtifactVisitorToResolvedFileVisitorAdapter implements ArtifactVisitor {
@@ -34,6 +35,10 @@ public class ArtifactVisitorToResolvedFileVisitorAdapter implements ArtifactVisi
     @Override
     public FileCollectionStructureVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source) {
         return visitor.prepareForVisit(source);
+    }
+
+    public void visitFile(File file) {
+        visitor.visitFile(file);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactVisitorToResolvedFileVisitorAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactVisitorToResolvedFileVisitorAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,27 +14,21 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.artifacts.ivyservice;
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
-import com.google.common.collect.Sets;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedFileVisitor;
+import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.file.FileCollectionStructureVisitor;
+import org.gradle.internal.DisplayName;
 
-import java.io.File;
-import java.util.Set;
+import java.util.List;
 
-public class ResolvedFileCollectionVisitor implements ResolvedFileVisitor {
-    private final FileCollectionStructureVisitor visitor;
-    private final Set<File> files = Sets.newLinkedHashSet();
-    private final Set<Throwable> failures = Sets.newLinkedHashSet();
+public class ArtifactVisitorToResolvedFileVisitorAdapter implements ArtifactVisitor {
+    private final ResolvedFileVisitor visitor;
 
-    public ResolvedFileCollectionVisitor(FileCollectionStructureVisitor visitor) {
+    public ArtifactVisitorToResolvedFileVisitorAdapter(ResolvedFileVisitor visitor) {
         this.visitor = visitor;
-    }
-
-    public Set<Throwable> getFailures() {
-        return failures;
     }
 
     @Override
@@ -43,18 +37,22 @@ public class ResolvedFileCollectionVisitor implements ResolvedFileVisitor {
     }
 
     @Override
-    public void visitFile(File file) {
-        files.add(file);
+    public void visitArtifact(DisplayName variantName, AttributeContainer variantAttributes, List<? extends Capability> capabilities, ResolvableArtifact artifact) {
+        visitor.visitFile(artifact.getFile());
     }
 
     @Override
     public void visitFailure(Throwable failure) {
-        failures.add(failure);
+        visitor.visitFailure(failure);
     }
 
     @Override
     public void endVisitCollection(FileCollectionInternal.Source source) {
-        visitor.visitCollection(source, files);
-        files.clear();
+        visitor.endVisitCollection(source);
+    }
+
+    @Override
+    public boolean requireArtifactFiles() {
+        return true;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
@@ -127,9 +127,6 @@ public class LocalFileDependencyBackedArtifactSet implements TransformedArtifact
             selectedArtifacts.add(selector.select(variant, this));
         }
         CompositeResolvedArtifactSet.of(selectedArtifacts.build()).visit(listener);
-        if (visitType == FileCollectionStructureVisitor.VisitType.Spec) {
-            listener.visitArtifacts(new CollectionSpec(fileCollection));
-        }
     }
 
     @Override
@@ -273,31 +270,6 @@ public class LocalFileDependencyBackedArtifactSet implements TransformedArtifact
                                                CalculatedValueContainerFactory calculatedValueContainerFactory) {
             super(delegate.getComponentId(), delegate, attributes, Collections.emptyList(), transformation, dependenciesResolver, calculatedValueContainerFactory);
             this.delegate = delegate;
-        }
-
-        public ComponentIdentifier getOwnerId() {
-            return delegate.getComponentId();
-        }
-
-        public File getFile() {
-            return delegate.getFile();
-        }
-    }
-
-    private static class CollectionSpec implements Artifacts {
-        private final FileCollectionInternal fileCollection;
-
-        public CollectionSpec(FileCollectionInternal fileCollection) {
-            this.fileCollection = fileCollection;
-        }
-
-        @Override
-        public void startFinalization(BuildOperationQueue<RunnableBuildOperation> actions, boolean requireFiles) {
-        }
-
-        @Override
-        public void visit(ArtifactVisitor visitor) {
-            visitor.visitSpec(fileCollection);
         }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
@@ -25,6 +25,7 @@ import org.gradle.api.internal.artifacts.DefaultResolvableArtifact;
 import org.gradle.api.internal.artifacts.transform.AbstractTransformedArtifactSet;
 import org.gradle.api.internal.artifacts.transform.ExtraExecutionGraphDependenciesResolverFactory;
 import org.gradle.api.internal.artifacts.transform.Transformation;
+import org.gradle.api.internal.artifacts.transform.TransformedArtifactSet;
 import org.gradle.api.internal.artifacts.transform.TransformedVariantFactory;
 import org.gradle.api.internal.artifacts.transform.VariantDefinition;
 import org.gradle.api.internal.artifacts.transform.VariantSelector;
@@ -53,7 +54,7 @@ import java.io.File;
 import java.util.Collections;
 import java.util.Set;
 
-public class LocalFileDependencyBackedArtifactSet implements ResolvedArtifactSet, LocalDependencyFiles, VariantSelector.Factory {
+public class LocalFileDependencyBackedArtifactSet implements TransformedArtifactSet, LocalDependencyFiles, VariantSelector.Factory {
     private static final DisplayName LOCAL_FILE = Describables.of("local file");
 
     private final LocalFileDependencyMetadata dependencyMetadata;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedFileVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedFileVisitor.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
+
+import org.gradle.api.internal.file.FileCollectionInternal;
+import org.gradle.api.internal.file.FileCollectionStructureVisitor;
+
+import java.io.File;
+
+public interface ResolvedFileVisitor {
+    /**
+     * Called prior to scheduling resolution of a set of artifacts. Should be called in result order.
+     */
+    default FileCollectionStructureVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source) {
+        return FileCollectionStructureVisitor.VisitType.Visit;
+    }
+
+    /**
+     * Visits an artifact file.
+     *
+     * <p>Note that a given artifact may be visited multiple times. The implementation is required to filter out duplicates.</p>
+     */
+    void visitFile(File file);
+
+    /**
+     * Called when some problem occurs visiting some element of the set. Visiting may continue.
+     */
+    void visitFailure(Throwable failure);
+
+    /**
+     * Called after a set of artifacts has been visited.
+     */
+    default void endVisitCollection(FileCollectionInternal.Source source) {
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/SelectedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/SelectedArtifactSet.java
@@ -23,8 +23,14 @@ import org.gradle.api.internal.tasks.TaskDependencyContainer;
  */
 public interface SelectedArtifactSet extends TaskDependencyContainer {
     /**
-     * Visits the files and artifacts of this set. Does not include any files or artifacts which could not be selected. Failures to select or resolve artifacts are supplied to the visitor.
+     * Visits the artifacts of this set. Does not include any artifacts that could not be selected. Failures to select or resolve artifacts are supplied to the visitor.
      */
     void visitArtifacts(ArtifactVisitor visitor, boolean continueOnSelectionFailure);
 
+    /**
+     * Visits the files of this set. Does not include any files that could not be selected. Failures to select or resolve artifacts are supplied to the visitor.
+     */
+    default void visitFiles(ResolvedFileVisitor visitor, boolean continueOnSelectionFailure) {
+        visitArtifacts(new ArtifactVisitorToResolvedFileVisitorAdapter(visitor), continueOnSelectionFailure);
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AbstractTransformedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AbstractTransformedArtifactSet.java
@@ -38,7 +38,7 @@ import java.util.List;
 /**
  * Transformed artifact set that performs the transformation itself when visited.
  */
-public abstract class AbstractTransformedArtifactSet implements ResolvedArtifactSet, FileCollectionInternal.Source {
+public abstract class AbstractTransformedArtifactSet implements TransformedArtifactSet, FileCollectionInternal.Source {
     private final CalculatedValueContainer<ImmutableList<ResolvedArtifactSet.Artifacts>, CalculateArtifacts> result;
 
     public AbstractTransformedArtifactSet(

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformedArtifactSet.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.transform;
+
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet;
+
+public interface TransformedArtifactSet extends ResolvedArtifactSet {
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformedProjectArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformedProjectArtifactSet.java
@@ -40,7 +40,7 @@ import java.util.List;
 /**
  * An artifact set containing transformed project artifacts.
  */
-public class TransformedProjectArtifactSet implements ResolvedArtifactSet, FileCollectionInternal.Source, ResolvedArtifactSet.Artifacts {
+public class TransformedProjectArtifactSet implements TransformedArtifactSet, FileCollectionInternal.Source, ResolvedArtifactSet.Artifacts {
     private final ComponentIdentifier componentIdentifier;
     private final ImmutableAttributes targetAttributes;
     private final List<? extends Capability> capabilities;

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -389,8 +389,8 @@ class DefaultConfigurationSpec extends Specification {
         def fileCollection = configuration.fileCollection(dependency1)
 
         then:
-        fileCollection.dependencySpec.isSatisfiedBy(dependency1)
-        !fileCollection.dependencySpec.isSatisfiedBy(dependency2)
+        fileCollection.resultProvider.dependencySpec.isSatisfiedBy(dependency1)
+        !fileCollection.resultProvider.dependencySpec.isSatisfiedBy(dependency2)
     }
 
     def fileCollectionWithSpec() {
@@ -401,7 +401,7 @@ class DefaultConfigurationSpec extends Specification {
         def fileCollection = configuration.fileCollection(spec)
 
         then:
-        fileCollection.dependencySpec == spec
+        fileCollection.resultProvider.dependencySpec == spec
     }
 
     def fileCollectionWithClosureSpec() {
@@ -412,8 +412,8 @@ class DefaultConfigurationSpec extends Specification {
         def fileCollection = configuration.fileCollection(closure)
 
         then:
-        fileCollection.dependencySpec.isSatisfiedBy(dependency("group1", "name", "version"))
-        !fileCollection.dependencySpec.isSatisfiedBy(dependency("group2", "name", "version"))
+        fileCollection.resultProvider.dependencySpec.isSatisfiedBy(dependency("group1", "name", "version"))
+        !fileCollection.resultProvider.dependencySpec.isSatisfiedBy(dependency("group2", "name", "version"))
     }
 
     def filesWithDependencies() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -52,8 +52,7 @@ import org.gradle.api.internal.artifacts.dsl.PublishArtifactNotationParserFactor
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider
 import org.gradle.api.internal.artifacts.ivyservice.DefaultLenientConfiguration
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.RootComponentMetadataBuilder
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedFileVisitor
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.SelectedArtifactSet
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.VisitedArtifactSet
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.projectresult.ResolvedLocalComponentsResult
@@ -477,11 +476,9 @@ class DefaultConfigurationSpec extends Specification {
         def visitedArtifactSet = Stub(VisitedArtifactSet)
 
         _ * visitedArtifactSet.select(_, _, _, _, _) >> Stub(SelectedArtifactSet) {
-            visitArtifacts(_, _) >> { ArtifactVisitor visitor, boolean l ->
+            visitFiles(_, _) >> { ResolvedFileVisitor visitor, boolean l ->
                 files.each {
-                    def artifact = Stub(ResolvableArtifact)
-                    _ * artifact.file >> it
-                    visitor.visitArtifact(null, null, [], artifact)
+                    visitor.visitFile(it)
                 }
                 visitor.endVisitCollection(null)
             }
@@ -514,7 +511,7 @@ class DefaultConfigurationSpec extends Specification {
         def resolvedConfiguration = Stub(ResolvedConfiguration)
 
         _ * visitedArtifactSet.select(_, _, _, _, _) >> Stub(SelectedArtifactSet) {
-            visitArtifacts(_, _) >> { ArtifactVisitor v, boolean l -> v.visitFailure(failure) }
+            visitFiles(_, _) >> { ResolvedFileVisitor v, boolean l -> v.visitFailure(failure) }
         }
         _ * resolvedConfiguration.hasError() >> true
 

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionStructureVisitor.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionStructureVisitor.java
@@ -31,13 +31,7 @@ public interface FileCollectionStructureVisitor {
         // Visitor is interested in the contents of the collection
         Visit,
         // Visitor is not interested in the contents of the collection, but would like to receive the source and other metadata
-        NoContents,
-        // Visitor is interested in the spec of the collection - that is, the files that the collection <em>might</em> include in the future
-        // For most collections, this will be the same as the elements of the collection. However, for a collection that includes
-        // all of the files from a directory, the spec for the collection would be the directory + the patterns it matches files with
-        // Or, for a collection that contains some transformation of another collection, the spec for the collection would include the spec
-        // for the original collection
-        Spec
+        NoContents
     }
 
     /**


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context

Improve the error handling for artifact transforms in `FileCollection` instances loaded from the configuration cache, so that the behavior is consistent with transforms that are not loaded from cache:

- Wrap failures in a contextual exception to explain where the failure happened.
- Run non-scheduled transforms in parallel.
- Collect all transform failures instead of stopping on the first failed transform.
- Honor `lenient` flag

This PR also extracts a resuable `FileCollection` implementation that is reused for dependency resolution backed `FileCollection` instances, regardless of whether loaded from cache or not, for consistent behavior. Also, `FileCollectionStructureVisitor` is slightly simplified.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
