### PR TITLE
Use targetGradleVersion >=7.3 on new test

### DIFF
--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r81/DependencyArtifactDownloadProgressEventCrossVersionTest.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r81/DependencyArtifactDownloadProgressEventCrossVersionTest.groovy
@@ -72,7 +72,7 @@ class DependencyArtifactDownloadProgressEventCrossVersionTest extends AbstractHt
         [projectFModuleMissing, projectF2]
     }
 
-    @ToolingApiVersion("<8.1 >=7.0")
+    @ToolingApiVersion("<8.1 >=7.3")
     @TargetGradleVersion(">=8.1")
     def "generates"() {
         def (MavenHttpModule projectFModuleMissing, MavenHttpModule projectF2) = prepareTest()


### PR DESCRIPTION
it shouldn't change behaviour from the perspective of an older tooling api version.

- #20850
