### PR TITLE
Fix the references dispay text

### DIFF
--- a/subprojects/docs/src/docs/userguide/migration/migrating_from_groovy_to_kotlin_dsl.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/migrating_from_groovy_to_kotlin_dsl.adoc
@@ -479,10 +479,10 @@ Utilizing the <<organizing_gradle_projects.adoc#sec:build_sources,_buildSrc_ pro
 
 Depending on your build structure you might be interested in the following user manual chapters:
 
-* The <<writing_build_scripts#writing_build_scripts>> chapter demonstrates the use of `apply(from = "")` to modularize build scripts.
-* The <<multi_project_builds#multi_project_builds>> chapter demonstrates various multi-project build structures.
-* The <<custom_plugins#custom_plugins>> and <<kotlin_dsl#kotlin_dsl>> chapters demonstrate how to develop custom Gradle plugins.
-* The <<composite_builds#composite_builds>> chapter demonstrates how to use Composite Builds.
+* The <<writing_build_scripts#writing_build_scripts,Writing Build Scripts>> chapter demonstrates the use of `apply(from = "")` to modularize build scripts.
+* The <<multi_project_builds#multi_project_builds,Multi-project Builds>> chapter demonstrates various multi-project build structures.
+* The <<custom_plugins#custom_plugins,Developing Custom Gradle Plugins>> and <<kotlin_dsl#kotlin_dsl,Gradle Kotlin DSL Primer>> chapters demonstrate how to develop custom Gradle plugins.
+* The <<composite_builds#composite_builds,Composing builds>> chapter demonstrates how to use Composite Builds.
 
 
 [[interop]]


### PR DESCRIPTION
### Context
Some of the links in [Migrating build logic from Groovy to Kotlin](https://docs.gradle.org/current/userguide/migrating_from_groovy_to_kotlin_dsl.html#kotlin_dsl_build_structure_samples) display raw file names currently:

![image](https://user-images.githubusercontent.com/577360/216673834-b58f368f-2ceb-41ac-9fd5-06a08d5ac2b5.png)

This is an attempt to fix it to:

![image](https://user-images.githubusercontent.com/577360/216673973-62ffa65f-c85f-4030-af95-4280c5039827.png)


### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
