### PR TITLE
Avoid eager instantiation of shared services

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/AbstractValidatingProperty.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/AbstractValidatingProperty.java
@@ -16,11 +16,16 @@
 
 package org.gradle.api.internal.tasks.properties;
 
+import com.google.common.base.Suppliers;
+import org.gradle.api.provider.Provider;
 import org.gradle.internal.properties.PropertyValue;
 import org.gradle.internal.reflect.problems.ValidationProblemId;
 import org.gradle.internal.reflect.validation.Severity;
 import org.gradle.internal.reflect.validation.TypeValidationContext;
 import org.gradle.util.internal.DeferredUtil;
+
+import javax.annotation.Nullable;
+import java.util.function.Supplier;
 
 public abstract class AbstractValidatingProperty implements ValidatingProperty {
     private final String propertyName;
@@ -50,14 +55,25 @@ public abstract class AbstractValidatingProperty implements ValidatingProperty {
 
     @Override
     public void validate(PropertyValidationContext context) {
-        Object unpacked = DeferredUtil.unpackOrNull(value.call());
-        if (unpacked == null) {
+        // unnest callables without resolving deferred values (providers, factories)
+        Object unnested = DeferredUtil.unpackNestableDeferred(value.call());
+        if (isPresent(unnested)) {
+            // only resolve deferred values if actually required by some action
+            Supplier<Object> valueSupplier = Suppliers.memoize(() -> DeferredUtil.unpack(unnested));
+            validationAction.validate(propertyName, valueSupplier, context);
+        } else {
             if (!optional) {
                 reportValueNotSet(propertyName, context);
             }
-        } else {
-            validationAction.validate(propertyName, unpacked, context);
         }
+    }
+
+    private static boolean isPresent(@Nullable Object value) {
+        if (value instanceof Provider) {
+            // carefully check for presence without necessarily resolving
+            return ((Provider) value).isPresent();
+        }
+        return value != null;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/ValidationAction.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/ValidationAction.java
@@ -15,6 +15,19 @@
  */
 package org.gradle.api.internal.tasks.properties;
 
+import javax.annotation.Nonnull;
+import java.util.function.Supplier;
+
+/**
+ * An action that validates property values.
+ */
 public interface ValidationAction {
-    void validate(String propertyName, Object value, PropertyValidationContext context);
+    /**
+     * Validates the given property value according to some rule.
+     *
+     * @param propertyName
+     * @param value a supplier of a non-null value - side effects are guaranteed to happen only once
+     * @param context
+     */
+    void validate(String propertyName, @Nonnull Supplier<Object> value, PropertyValidationContext context);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceProvider.java
@@ -43,11 +43,6 @@ public abstract class BuildServiceProvider<T extends BuildService<P>, P extends 
     }
 
     @Override
-    public boolean calculatePresence(ValueConsumer consumer) {
-        return true;
-    }
-
-    @Override
     public boolean isImmutable() {
         return true;
     }
@@ -76,6 +71,10 @@ public abstract class BuildServiceProvider<T extends BuildService<P>, P extends 
     public abstract BuildServiceDetails<T, P> getServiceDetails();
 
     public abstract String getName();
+
+    @Override
+    @Nonnull
+    public abstract Class<T> getType();
 
     /**
      * Returns the identifier for the build that owns this service.

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/ConsumedBuildServiceProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/ConsumedBuildServiceProvider.java
@@ -25,6 +25,7 @@ import org.gradle.api.services.BuildServiceRegistry;
 import org.gradle.internal.Cast;
 import org.gradle.internal.service.ServiceRegistry;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -72,7 +73,7 @@ public class ConsumedBuildServiceProvider<T extends BuildService<BuildServicePar
         return resolvedProvider;
     }
 
-    @Nullable
+    @Nonnull
     @Override
     public Class<T> getType() {
         return serviceType;
@@ -97,5 +98,10 @@ public class ConsumedBuildServiceProvider<T extends BuildService<BuildServicePar
     public ProviderInternal<T> withFinalValue(ValueConsumer consumer) {
         RegisteredBuildServiceProvider<T, BuildServiceParameters> resolved = resolve();
         return resolved != null ? resolved.withFinalValue(consumer) : super.withFinalValue(consumer);
+    }
+
+    @Override
+    public boolean calculatePresence(ValueConsumer consumer) {
+        return resolve() != null;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/RegisteredBuildServiceProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/RegisteredBuildServiceProvider.java
@@ -28,6 +28,7 @@ import org.gradle.internal.isolation.IsolatableFactory;
 import org.gradle.internal.service.ServiceLookup;
 import org.gradle.internal.service.ServiceRegistry;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 // TODO:configuration-cache - complain when used at configuration time, except when opted in to this
@@ -88,7 +89,7 @@ public class RegisteredBuildServiceProvider<T extends BuildService<P>, P extends
         return serviceDetails.getParameters();
     }
 
-    @Nullable
+    @Nonnull
     @Override
     public Class<T> getType() {
         return serviceDetails.getImplementationType();
@@ -179,5 +180,10 @@ public class RegisteredBuildServiceProvider<T extends BuildService<P>, P extends
     @Override
     public ProviderInternal<T> withFinalValue(ValueConsumer consumer) {
         return this;
+    }
+
+    @Override
+    public boolean calculatePresence(ValueConsumer consumer) {
+        return true;
     }
 }


### PR DESCRIPTION
...just for the sake of property (value presence) validation.

Originally, we called `unpackOrNull`, which unpacked callables *and* resolved deferreds (provider, factory).  Presence was deemed based on the resolved value being null.

We now do it in two steps - we only do resolution of deferreds if the value is actually present ( presence validation no longer resolves deferreds, at least for Providers), *and* a validation action requires so.

Issue: #22996