### PR TITLE
Remove usage of `org.jetbrains.kotlin.android.extensions` plugin in snippets

### DIFF
--- a/subprojects/docs/src/snippets/kotlinDsl/androidBuild/kotlin/app/build.gradle.kts
+++ b/subprojects/docs/src/snippets/kotlinDsl/androidBuild/kotlin/app/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
     id("com.android.application")
 // end::android[]
     kotlin("android")
-    kotlin("android.extensions")
 // tag::android[]
 }
 

--- a/subprojects/docs/src/snippets/kotlinDsl/androidBuild/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/kotlinDsl/androidBuild/kotlin/build.gradle.kts
@@ -3,7 +3,6 @@ plugins {
     id("com.android.application") version "7.3.0" apply false
 // end::android[]
     kotlin("android") version "1.8.10" apply false
-    kotlin("android.extensions") version "1.8.10" apply false
 // tag::android[]
 }
 // end::android[]

--- a/subprojects/docs/src/snippets/kotlinDsl/androidSingleBuild/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/kotlinDsl/androidSingleBuild/kotlin/build.gradle.kts
@@ -3,7 +3,6 @@ plugins {
     id("com.android.application") version "7.3.0"
 // end::android[]
     kotlin("android") version "1.8.10"
-    kotlin("android.extensions") version "1.8.10"
 // tag::android[]
 }
 


### PR DESCRIPTION

It is deprecated since Kotlin 1.4.20
