### PR TITLE
Update com.github.ben-manes.versions tested version

### DIFF
--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-settings/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-settings/groovy/settings.gradle
@@ -79,7 +79,7 @@ dependencyResolutionManagement {
 dependencyResolutionManagement {
     versionCatalogs {
         libs {
-            plugin('versions', 'com.github.ben-manes.versions').version('0.44.0')
+            plugin('versions', 'com.github.ben-manes.versions').version('0.45.0')
         }
     }
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-settings/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-settings/kotlin/settings.gradle.kts
@@ -86,7 +86,7 @@ if (providers.systemProperty("create4").getOrNull() != null) {
     dependencyResolutionManagement {
         versionCatalogs {
             create("libs") {
-                plugin("versions", "com.github.ben-manes.versions").version("0.44.0")
+                plugin("versions", "com.github.ben-manes.versions").version("0.45.0")
             }
         }
     }

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-toml/groovy/gradle/libs.versions.toml
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-toml/groovy/gradle/libs.versions.toml
@@ -12,4 +12,4 @@ commons-lang3 = { group = "org.apache.commons", name = "commons-lang3", version 
 groovy = ["groovy-core", "groovy-json", "groovy-nio"]
 
 [plugins]
-versions = { id = "com.github.ben-manes.versions", version = "0.44.0" }
+versions = { id = "com.github.ben-manes.versions", version = "0.45.0" }

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-toml/kotlin/gradle/libs.versions.toml
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-toml/kotlin/gradle/libs.versions.toml
@@ -12,4 +12,4 @@ commons-lang3 = { group = "org.apache.commons", name = "commons-lang3", version 
 groovy = ["groovy-core", "groovy-json", "groovy-nio"]
 
 [plugins]
-versions = { id = "com.github.ben-manes.versions", version = "0.44.0" }
+versions = { id = "com.github.ben-manes.versions", version = "0.45.0" }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -115,7 +115,7 @@ abstract class AbstractSmokeTest extends Specification {
         static grgit = "4.1.1"
 
         // https://plugins.gradle.org/plugin/com.github.ben-manes.versions
-        static gradleVersions = "0.42.0"
+        static gradleVersions = "0.45.0"
 
         // https://plugins.gradle.org/plugin/org.gradle.playframework
         static playframework = "0.13"

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleVersionsPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleVersionsPluginSmokeTest.groovy
@@ -58,14 +58,7 @@ class GradleVersionsPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
             .withJvmArguments("-Dorg.gradle.configuration-cache.internal.task-execution-access-pre-stable=true")
             .forwardOutput()
 
-        def resolvedConfigurations = ["apiElementsCopy", "archivesCopy", "compileOnlyCopy", "defaultCopy", "implementationCopy", "implementationCopy2", "mainSourceElementsCopy", "runtimeElementsCopy", "runtimeOnlyCopy", "testCompileOnlyCopy", "testImplementationCopy", "testResultsElementsForTestCopy", "testRuntimeOnlyCopy"]
-        def declarationConfiguration = ["compileClasspathCopy", "defaultCopy", "runtimeClasspathCopy", "runtimeElementsCopy", "testCompileClasspathCopy", "testRuntimeClasspathCopy"]
-        resolvedConfigurations.each {
-            runner.expectDeprecationWarning(
-                "The $it configuration has been deprecated for resolution. This will fail with an error in Gradle 9.0. Please resolve another configuration instead. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_5.html#dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations",
-                "https://github.com/ben-manes/gradle-versions-plugin/issues/718"
-            )
-        }
+        def declarationConfiguration = ["compileClasspathCopy", "compileClasspathCopy2", "runtimeClasspathCopy", "runtimeClasspathCopy2", "testCompileClasspathCopy", "testCompileClasspathCopy2", "testRuntimeClasspathCopy", "testRuntimeClasspathCopy2"]
         declarationConfiguration.each {
             runner.expectDeprecationWarning(
                 "The $it configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 9.0. Please use another configuration instead. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_5.html#dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations",


### PR DESCRIPTION
Updates to 0.45.0, which includes a fix to not resolve non-resolvable configurations

The updated version still declares depenencies directly on copies of non-declarable configurations, and also seemingly creates multiple copies of the resolvable configurations that it does copy.

The plugin copies configurations in order to re-write their dependencies with dynamic verions with no upper bound, so that when resolved it selects the latest versions of all dependencies. We probably need to provide some kind of API which can solve this use-case so we can eventually remove the configuration copying API.
