### PR TITLE
Fix sorting of accepted api changes to work on Chrome

### DIFF
--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/EnrichedReportRenderer.groovy
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/EnrichedReportRenderer.groovy
@@ -71,7 +71,8 @@ class EnrichedReportRenderer extends GroovyReportRenderer {
                     });
                     // Sort the array in place by type, then member
                     // Note that Firefox is fine with a sort function returning any positive or negative number, but Chrome 
-                    // requires 1 or -1 specifically and ignores higher or lower values
+                    // requires 1 or -1 specifically and ignores higher or lower values.  This sort ought to remain consistent
+                    // with the sort used by AbstractAcceptedApiChangesMaintenanceTask.
                     result.acceptedApiChanges.sort((a, b) => { 
                         if ((a.type +'#' + a.member) > (b.type + '#' + b.member)) {
                             return 1; 

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/EnrichedReportRenderer.groovy
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/EnrichedReportRenderer.groovy
@@ -70,7 +70,15 @@ class EnrichedReportRenderer extends GroovyReportRenderer {
                         result.acceptedApiChanges.push(correction);
                     });
                     // Sort the array in place by type, then member
-                    result.acceptedApiChanges = result.acceptedApiChanges.sort((a, b) => (a.type +'#' + a.member) > (b.type + '#' + b.member));
+                    // Note that Firefox is fine with a sort function returning any positive or negative number, but Chrome 
+                    // requires 1 or -1 specifically and ignores higher or lower values
+                    result.acceptedApiChanges = result.acceptedApiChanges.sort((a, b) => { 
+                        if ((a.type +'#' + a.member) > (b.type + '#' + b.member)) {
+                            return 1; 
+                        } else {
+                            return -1;
+                        }
+                    });
                     // Remove duplicates (equal adjacent elements) - a new, un@Incubating type will be here twice, as 2 errors are reported; use stringified JSON to compare
                     // Filtering an array is NOT in place
                     result.acceptedApiChanges = result.acceptedApiChanges.filter((item, pos, ary) => (!pos || (JSON.stringify(item) != JSON.stringify(ary[pos - 1]))));

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/EnrichedReportRenderer.groovy
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/EnrichedReportRenderer.groovy
@@ -72,7 +72,7 @@ class EnrichedReportRenderer extends GroovyReportRenderer {
                     // Sort the array in place by type, then member
                     // Note that Firefox is fine with a sort function returning any positive or negative number, but Chrome 
                     // requires 1 or -1 specifically and ignores higher or lower values
-                    result.acceptedApiChanges = result.acceptedApiChanges.sort((a, b) => { 
+                    result.acceptedApiChanges.sort((a, b) => { 
                         if ((a.type +'#' + a.member) > (b.type + '#' + b.member)) {
                             return 1; 
                         } else {

--- a/build-logic/binary-compatibility/src/main/kotlin/gradlebuild/binarycompatibility/AbstractAcceptedApiChangesMaintenanceTask.kt
+++ b/build-logic/binary-compatibility/src/main/kotlin/gradlebuild/binarycompatibility/AbstractAcceptedApiChangesMaintenanceTask.kt
@@ -42,6 +42,12 @@ abstract class AbstractAcceptedApiChangesMaintenanceTask : DefaultTask() {
         return json.acceptedApiChanges!!
     }
 
+    /**
+     * Sorts the given list of [AcceptedApiChange]s by type and member.
+     * <p>
+     * This sort ought to remain consistent with the sort used by the [EnrichedReportRenderer].
+     */
+    @Suppress("KDocUnresolvedReference")
     protected
     fun sortChanges(originalChanges: List<AcceptedApiChange>) = originalChanges.toMutableList().sortedBy { it.type + '#' + it.member }
 


### PR DESCRIPTION
Chrome doesn't swap elements unless a 1 or -1 is returned from the sort function, other positive or negative values are ignored.
