### PR TITLE
Enable IT config cache

### DIFF
--- a/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainIntegrationTest.groovy
+++ b/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.jvm.toolchain
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AvailableJavaHomes
+import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.jvm.JavaToolchainFixture
 import org.gradle.internal.jvm.Jvm
 
@@ -161,6 +162,7 @@ class JavaToolchainIntegrationTest extends AbstractIntegrationSpec implements Ja
         failure.assertHasCause("The value for property 'languageVersion' is final and cannot be changed any further")
     }
 
+    @ToBeFixedForConfigurationCache(because = "CC toolchain provisioning but we don't have an IBM one on CI")
     def "nag user when toolchain spec is IBM_SEMERU"() {
         given:
         buildScript """
@@ -176,12 +178,11 @@ class JavaToolchainIntegrationTest extends AbstractIntegrationSpec implements Ja
         """
 
         when:
-        executer.withArgument("--no-configuration-cache")
-            .expectDocumentedDeprecationWarning "Requesting JVM vendor IBM_SEMERU. " +
+        executer.expectDocumentedDeprecationWarning "Requesting JVM vendor IBM_SEMERU. " +
             "This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. " +
             "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#ibm_semeru_should_not_be_used"
 
         then:
-        succeeds 'build'
+        succeeds ':build'
     }
 }


### PR DESCRIPTION
Context 
======

Previously [merged PR ](https://github.com/gradle/gradle/pull/23669) had the configuration cache [disabled](https://github.com/gradle/gradle/pull/23669/files#r1098434268) to make an integration [pass on CI](https://ge.gradle.org/s/v5xkzl7zccl3i/tests/:platform-jvm:configCacheIntegTest/org.gradle.jvm.toolchain.JavaToolchainIntegrationTest/nag%20user%20when%20toolchain%20spec%20is%20IBM_SEMERU?top-execution=1).

This PR enables the IT CC and adds the `@ToBeFixedForConfigurationCache` annotation as an attempt to make the test still green on CI but with CC enabled.
