### PR TITLE
Ensure settings location preserved even if missing

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheHost.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheHost.kt
@@ -37,7 +37,6 @@ import org.gradle.internal.build.BuildStateRegistry
 import org.gradle.internal.build.RootBuildState
 import org.gradle.internal.file.PathToFileResolver
 import org.gradle.internal.reflect.Instantiator
-import org.gradle.internal.resource.StringTextResource
 import org.gradle.internal.resource.TextFileResourceLoader
 import org.gradle.internal.service.ServiceRegistry
 import org.gradle.internal.service.scopes.ServiceRegistryFactory
@@ -178,11 +177,7 @@ class ConfigurationCacheHost internal constructor(
         fun createSettings(): SettingsState {
             val baseClassLoaderScope = gradle.classLoaderScope
             val classLoaderScope = baseClassLoaderScope.createChild("settings", null)
-            val settingsSource = if (settingsFile == null) {
-                TextResourceScriptSource(StringTextResource("settings", ""))
-            } else {
-                TextResourceScriptSource(service<TextFileResourceLoader>().loadFile("settings file", settingsFile))
-            }
+            val settingsSource = TextResourceScriptSource(service<TextFileResourceLoader>().loadFile("settings file", settingsFile))
             lateinit var services: SettingsScopeServices
             val serviceRegistryFactory = object : ServiceRegistryFactory {
                 override fun createFor(domainObject: Any): ServiceRegistry {

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
@@ -189,7 +189,7 @@ class ConfigurationCacheState(
         require(rootBuild.gradle.owner is RootBuildState)
         val gradle = rootBuild.gradle
         withDebugFrame({ "Gradle" }) {
-            write(gradle.settings.settingsScript.resource.file)
+            write(gradle.settings.settingsScript.resource.location.file)
             writeBuildTreeScopedState(gradle)
         }
         val buildEventListeners = buildEventListenersOf(gradle)

--- a/subprojects/core/src/test/groovy/org/gradle/groovy/scripts/TextResourceScriptSourceTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/groovy/scripts/TextResourceScriptSourceTest.java
@@ -97,6 +97,7 @@ public class TextResourceScriptSourceTest {
     public void convenienceMethodReplacesFileThatDoesNotExistWithEmptyScript() {
         ScriptSource source = forFile(scriptFile);
         assertThat(source.getResource(), instanceOf(EmptyFileTextResource.class));
+        // resource file is null, even though resource location file is not
         assertNull(source.getResource().getFile());
         assertNull(source.getResource().getCharset());
         assertThat(source.getResource().getLocation().getFile(), equalTo(scriptFile));

--- a/subprojects/resources/src/main/java/org/gradle/internal/resource/DefaultTextFileResourceLoader.java
+++ b/subprojects/resources/src/main/java/org/gradle/internal/resource/DefaultTextFileResourceLoader.java
@@ -32,9 +32,6 @@ public class DefaultTextFileResourceLoader implements TextFileResourceLoader {
         if (sourceFile == null) {
             return new StringTextResource(description, "");
         }
-        if (sourceFile.exists()) {
-            return new UriTextResource(description, sourceFile, resolver);
-        }
-        return new EmptyFileTextResource(description, sourceFile, resolver);
+        return UriTextResource.from(description, sourceFile, resolver);
     }
 }

--- a/subprojects/resources/src/main/java/org/gradle/internal/resource/EmptyFileTextResource.java
+++ b/subprojects/resources/src/main/java/org/gradle/internal/resource/EmptyFileTextResource.java
@@ -20,15 +20,20 @@ import org.gradle.internal.file.RelativeFilePathResolver;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.hash.Hashing;
 
+import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.Reader;
 import java.io.StringReader;
 import java.nio.charset.Charset;
 
+/**
+ * A {@link UriTextResource} that is empty and maps to an actual (non-null) file location
+ * (which does not actually exist in the file system).
+ */
 public class EmptyFileTextResource extends UriTextResource {
     private static final HashCode SIGNATURE = Hashing.signature(EmptyFileTextResource.class);
 
-    EmptyFileTextResource(String description, File sourceFile, RelativeFilePathResolver resolver) {
+    EmptyFileTextResource(String description, @Nonnull File sourceFile, RelativeFilePathResolver resolver) {
         super(description, sourceFile, resolver);
     }
 
@@ -44,6 +49,8 @@ public class EmptyFileTextResource extends UriTextResource {
 
     @Override
     public File getFile() {
+        // Returns null as there is no file that contains this resource's contents,
+        // however {@link ResourceLocation#getFile()} would still return the given `sourceFile`
         return null;
     }
 

--- a/subprojects/resources/src/main/java/org/gradle/internal/resource/UriTextResource.java
+++ b/subprojects/resources/src/main/java/org/gradle/internal/resource/UriTextResource.java
@@ -30,6 +30,7 @@ import org.gradle.internal.hash.Hashing;
 import org.gradle.internal.hash.PrimitiveHasher;
 import org.gradle.util.GradleVersion;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.File;
 import java.io.FileInputStream;
@@ -72,18 +73,24 @@ public class UriTextResource implements TextResource {
     private final URI sourceUri;
     private final RelativeFilePathResolver resolver;
 
-    public UriTextResource(String description, File sourceFile, RelativeFilePathResolver resolver) {
+    UriTextResource(String description, @Nonnull File sourceFile, RelativeFilePathResolver resolver) {
         this.description = description;
         this.sourceFile = FileUtils.normalize(sourceFile);
         this.sourceUri = sourceFile.toURI();
         this.resolver = resolver;
     }
 
-    public UriTextResource(String description, URI sourceUri, RelativeFilePathResolver resolver) {
+    public UriTextResource(String description, @Nonnull URI sourceUri, RelativeFilePathResolver resolver) {
         this.description = description;
         this.sourceFile = sourceUri.getScheme().equals("file") ? FileUtils.normalize(new File(sourceUri.getPath())) : null;
         this.sourceUri = sourceUri;
         this.resolver = resolver;
+    }
+
+    public static UriTextResource from(String description, File sourceFile, RelativeFilePathResolver resolver) {
+        return sourceFile.exists() ?
+            new UriTextResource(description, sourceFile, resolver) :
+            new EmptyFileTextResource(description, sourceFile, resolver);
     }
 
     @Override

--- a/subprojects/resources/src/test/groovy/org/gradle/internal/resource/UriTextResourceTest.groovy
+++ b/subprojects/resources/src/test/groovy/org/gradle/internal/resource/UriTextResourceTest.groovy
@@ -27,11 +27,6 @@ import spock.lang.Specification
 import java.nio.charset.Charset
 
 import static org.gradle.internal.resource.UriTextResource.extractCharacterEncoding
-import static org.hamcrest.CoreMatchers.equalTo
-import static org.hamcrest.MatcherAssert.assertThat
-import static org.junit.Assert.assertFalse
-import static org.junit.Assert.assertNull
-import static org.junit.Assert.fail
 
 class UriTextResourceTest extends Specification {
     private TestFile testDir
@@ -188,15 +183,14 @@ class UriTextResourceTest extends Specification {
     }
 
     def hasNoContentWhenUsingFileUriAndFileDoesNotExist() {
-        UriTextResource resource = new UriTextResource('<display-name>', fileUri, resolver)
-        assertFalse(resource.exists)
-        assertNull(resource.file)
-        try {
-            resource.text
-            fail()
-        } catch (MissingResourceException e) {
-            assertThat(e.message, equalTo("Could not read <display-name> '$file' as it does not exist." as String))
-        }
+        when:
+        UriTextResource resource = UriTextResource.from('<display-name>', file, resolver)
+
+        then:
+        resource.exists
+        resource.file == null
+        resource.location.file == file
+        resource.text == ""
     }
 
     def readsFileContentUsingJarUriWhenFileExists() {


### PR DESCRIPTION
A script source resource file may be null, even when the location file is not null. One case is when the resource contents don't match the location contents. Another (which caused the problem fixed here) is when a file does not exist at the expected path file system.

This change set changes how we store a root build settings file path to ensure we store the settings script resource location file path.

Issue: #23766
