### PR TITLE
Remove legacy transform tests

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheDependencyResolutionIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheDependencyResolutionIntegrationTest.groovy
@@ -218,16 +218,12 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractConf
         file('out.txt').text == "12,10"
     }
 
-    def setupBuildWithArtifactTransformOfProjectDependencies(boolean legacy) {
+    def setupBuildWithArtifactTransformOfProjectDependencies() {
         settingsFile << """
             include 'a', 'b'
         """
 
-        if (legacy) {
-            setupBuildWithLegacyColorTransformImplementation()
-        } else {
-            setupBuildWithColorTransformImplementation()
-        }
+        setupBuildWithColorTransformImplementation()
 
         buildFile << """
             dependencies {
@@ -240,7 +236,7 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractConf
     def "task input file collection can include the output of artifact transform of project dependencies"() {
         def configurationCache = newConfigurationCacheFixture()
 
-        setupBuildWithArtifactTransformOfProjectDependencies(legacy)
+        setupBuildWithArtifactTransformOfProjectDependencies()
 
         when:
         configurationCacheRun(":resolve")
@@ -272,15 +268,12 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractConf
         result.assertTaskNotSkipped(":a:producer")
         result.assertTaskSkipped(":b:producer")
         outputContains("result = [a.jar.green, b.jar.green]")
-
-        where:
-        legacy << [true, false]
     }
 
     def "task input artifact collection can include the output of artifact transform of project dependencies"() {
         def configurationCache = newConfigurationCacheFixture()
 
-        setupBuildWithArtifactTransformOfProjectDependencies(legacy)
+        setupBuildWithArtifactTransformOfProjectDependencies()
 
         when:
         configurationCacheRun(":resolveArtifacts")
@@ -318,21 +311,14 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractConf
         outputContains("files = [a.jar.green, b.jar.green]")
         outputContains("artifacts = [a.jar.green (project :a), b.jar.green (project :b)]")
         outputContains("variants = [{artifactType=jar, color=green}, {artifactType=jar, color=green}]")
-
-        where:
-        legacy << [true, false]
     }
 
-    def setupBuildWithArtifactTransformsOfExternalDependencies(boolean legacy) {
+    def setupBuildWithArtifactTransformsOfExternalDependencies() {
         httpServer.start()
         withColorVariants(remoteRepo.module("group", "thing1", "1.2")).publish().allowAll()
         withColorVariants(remoteRepo.module("group", "thing2", "1.2")).publish().allowAll()
 
-        if (legacy) {
-            setupBuildWithLegacyColorTransformImplementation()
-        } else {
-            setupBuildWithColorTransformImplementation()
-        }
+        setupBuildWithColorTransformImplementation()
 
         buildFile << """
             repositories {
@@ -351,7 +337,7 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractConf
     def "task input file collection can include the output of artifact transform of external dependencies"() {
         def configurationCache = newConfigurationCacheFixture()
 
-        setupBuildWithArtifactTransformsOfExternalDependencies(legacy)
+        setupBuildWithArtifactTransformsOfExternalDependencies()
 
         when:
         configurationCacheRun(":resolve")
@@ -367,15 +353,12 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractConf
         configurationCache.assertStateLoaded()
         assertTransformed()
         outputContains("result = [thing1-1.2.jar.green, thing2-1.2.jar.green]")
-
-        where:
-        legacy << [true, false]
     }
 
     def "task input artifact collection can include the output of artifact transform of external dependencies"() {
         def configurationCache = newConfigurationCacheFixture()
 
-        setupBuildWithArtifactTransformsOfExternalDependencies(legacy)
+        setupBuildWithArtifactTransformsOfExternalDependencies()
 
         when:
         configurationCacheRun(":resolveArtifacts")
@@ -395,13 +378,10 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractConf
         outputContains("files = [thing1-1.2.jar.green, thing2-1.2.jar.green]")
         outputContains("artifacts = [thing1-1.2.jar.green (group:thing1:1.2), thing2-1.2.jar.green (group:thing2:1.2)]")
         outputContains("variants = [{artifactType=jar, color=green, org.gradle.status=release}, {artifactType=jar, color=green, org.gradle.status=release}]")
-
-        where:
-        legacy << [true, false]
     }
 
     def "many tasks in the same project can consume the output of transform of external dependencies"() {
-        setupBuildWithArtifactTransformsOfExternalDependencies(false)
+        setupBuildWithArtifactTransformsOfExternalDependencies()
         buildFile << """
             for (i in 0..5) {
                 task "resolve\$i" {
@@ -434,12 +414,8 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractConf
         output.count("result = [thing1-1.2.jar.green, thing2-1.2.jar.green]") == 5
     }
 
-    def setupBuildWithArtifactTransformsOfPrebuiltFileDependencies(boolean legacy) {
-        if (legacy) {
-            setupBuildWithLegacyColorTransformImplementation()
-        } else {
-            setupBuildWithColorTransformImplementation()
-        }
+    def setupBuildWithArtifactTransformsOfPrebuiltFileDependencies() {
+        setupBuildWithColorTransformImplementation()
 
         buildFile << """
             dependencies.artifactTypes {
@@ -457,7 +433,7 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractConf
     def "task input file collection can include the output of artifact transforms of prebuilt file dependencies"() {
         def configurationCache = newConfigurationCacheFixture()
 
-        setupBuildWithArtifactTransformsOfPrebuiltFileDependencies(legacy)
+        setupBuildWithArtifactTransformsOfPrebuiltFileDependencies()
 
         when:
         configurationCacheRun(":resolve")
@@ -473,15 +449,12 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractConf
         configurationCache.assertStateLoaded()
         assertTransformed()
         outputContains("result = [root.blue.green]")
-
-        where:
-        legacy << [true, false]
     }
 
     def "task input artifact collection can include the output of artifact transforms of prebuilt file dependencies"() {
         def configurationCache = newConfigurationCacheFixture()
 
-        setupBuildWithArtifactTransformsOfPrebuiltFileDependencies(legacy)
+        setupBuildWithArtifactTransformsOfPrebuiltFileDependencies()
 
         when:
         configurationCacheRun(":resolveArtifacts")
@@ -501,22 +474,15 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractConf
         outputContains("files = [root.blue.green]")
         outputContains("artifacts = [root.blue.green (root.blue)]")
         outputContains("variants = [{artifactType=blue, color=green}]")
-
-        where:
-        legacy << [true, false]
     }
 
-    def setupBuildWithArtifactTransformsOfFileDependenciesThatContainTaskOutputs(boolean legacy) {
+    def setupBuildWithArtifactTransformsOfFileDependenciesThatContainTaskOutputs() {
         settingsFile << """
             rootProject.name = 'root'
             include 'a'
         """
 
-        if (legacy) {
-            setupBuildWithLegacyColorTransformImplementation()
-        } else {
-            setupBuildWithColorTransformImplementation()
-        }
+        setupBuildWithColorTransformImplementation()
 
         buildFile << """
             allprojects {
@@ -546,7 +512,7 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractConf
     def "task input file collection can include the output of artifact transforms of file dependencies that include task outputs"() {
         def configurationCache = newConfigurationCacheFixture()
 
-        setupBuildWithArtifactTransformsOfFileDependenciesThatContainTaskOutputs(legacy)
+        setupBuildWithArtifactTransformsOfFileDependenciesThatContainTaskOutputs()
 
         when:
         configurationCacheRun(":resolve")
@@ -565,16 +531,13 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractConf
         result.assertTaskOrder(":additionalFile", ":resolve")
         assertTransformed()
         outputContains("result = [root.additional.blue.green, root.blue.green, a.jar.green, a.additional.blue.green]")
-
-        where:
-        legacy << [true, false]
     }
 
     @Issue("https://github.com/gradle/gradle/issues/13200")
     def "task input artifact collection can include the output of artifact transforms of file dependencies that include task outputs"() {
         def configurationCache = newConfigurationCacheFixture()
 
-        setupBuildWithArtifactTransformsOfFileDependenciesThatContainTaskOutputs(legacy)
+        setupBuildWithArtifactTransformsOfFileDependenciesThatContainTaskOutputs()
 
         when:
         configurationCacheRun(":resolveArtifacts")
@@ -597,9 +560,6 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractConf
         outputContains("files = [root.additional.blue.green, root.blue.green, a.jar.green, a.additional.blue.green]")
         outputContains("artifacts = [root.additional.blue.green (root.additional.blue), root.blue.green (root.blue), a.jar.green (project :a), a.additional.blue.green (a.additional.blue)]")
         outputContains("variants = [{artifactType=blue, color=green}, {artifactType=blue, color=green}, {artifactType=jar, color=green}, {artifactType=blue, color=green}]")
-
-        where:
-        legacy << [true, false]
     }
 
     def "task input file collection can include the output of chained artifact transform of project dependencies"() {
@@ -941,7 +901,7 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractConf
 
     @Issue("https://github.com/gradle/gradle/issues/14513")
     def "task input file collection can include transformed outputs of file collection containing transform outputs"() {
-        setupBuildWithArtifactTransformOfProjectDependencies(false)
+        setupBuildWithArtifactTransformOfProjectDependencies()
         buildFile << """
             abstract class MakeRed implements TransformAction<TransformParameters.None> {
                 @InputArtifact
@@ -1082,7 +1042,7 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractConf
             include 'producer'
         """
         def buildSrcBuildFile = file("buildSrc/build.gradle")
-        setupBuildWithLegacyColorTransformImplementation(buildSrcBuildFile)
+        setupBuildWithColorTransformImplementation(buildSrcBuildFile)
         buildSrcBuildFile << """
             repositories {
                 maven { url = '${mavenRepo.uri}' }
@@ -1126,7 +1086,7 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractConf
         settingsFile << """
             include 'a'
         """
-        setupBuildWithColorTransformAction()
+        setupBuildWithColorTransform()
         buildFile << """
             abstract class MakeGreen implements TransformAction<TransformParameters.None> {
                 @InputArtifact
@@ -1195,7 +1155,7 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractConf
         settingsFile << """
             include 'a', 'b'
         """
-        setupBuildWithColorTransformAction()
+        setupBuildWithColorTransform()
         buildFile << """
             abstract class MakeGreen implements TransformAction<TransformParameters.None> {
                 @InputArtifact
@@ -1248,7 +1208,7 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractConf
         withColorVariants(remoteRepo.module("group", "thing1", "1.2")).publish().allowAll()
         withColorVariants(remoteRepo.module("group", "thing2", "1.2")).publish().allowAll()
 
-        setupBuildWithColorTransformAction()
+        setupBuildWithColorTransform()
 
         buildFile << """
             abstract class MakeGreen implements TransformAction<TransformParameters.None> {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformInputArtifactIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformInputArtifactIntegrationTest.groovy
@@ -27,7 +27,7 @@ import java.util.regex.Pattern
 class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyResolutionTest implements ArtifactTransformTestFixture, DirectoryBuildCacheFixture {
     def "transform does not execute when project artifact cannot be built"() {
         settingsFile << "include 'a', 'b', 'c'"
-        setupBuildWithColorTransformAction()
+        setupBuildWithColorTransform()
         buildFile << """
             project(':a') {
                 dependencies {
@@ -66,7 +66,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
     // and so when the path changes the outputs are invalidated
     def "can attach #description to input artifact property with project artifact file but it has no effect when not caching"() {
         settingsFile << "include 'a', 'b', 'c'"
-        setupBuildWithColorTransformAction()
+        setupBuildWithColorTransform()
         buildFile << """
             project(':a') {
                 dependencies {
@@ -177,7 +177,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
 
     def "can attach #description to input artifact property with project artifact directory but it has no effect when not caching"() {
         settingsFile << "include 'a', 'b', 'c'"
-        setupBuildWithColorTransformAction {
+        setupBuildWithColorTransform {
             produceDirs()
         }
         buildFile << """
@@ -310,7 +310,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
 
     def "re-runs transform when input artifact file changes from file to missing"() {
         settingsFile << "include 'a', 'b', 'c'"
-        setupBuildWithColorTransformAction()
+        setupBuildWithColorTransform()
         buildFile << """
             project(':a') {
                 dependencies {
@@ -372,7 +372,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
     def "inputs to the build cache key are reported when build cache logging is enabled"() {
         given:
         settingsFile << "include 'a', 'b'"
-        setupBuildWithColorTransformAction()
+        setupBuildWithColorTransform()
         buildFile << """
             project(':a') {
                 dependencies {
@@ -411,7 +411,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
 
     def "honors @PathSensitive(NONE) on input artifact property for project artifact file when caching"() {
         settingsFile << "include 'a', 'b', 'c'"
-        setupBuildWithColorTransformAction()
+        setupBuildWithColorTransform()
         buildFile << """
             project(':a') {
                 dependencies {
@@ -490,7 +490,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
 
     def "honors @PathSensitive(#sensitivity) to input artifact property for project artifact directory when caching"() {
         settingsFile << "include 'a', 'b', 'c'"
-        setupBuildWithColorTransformAction {
+        setupBuildWithColorTransform {
             produceDirs()
         }
         buildFile << """
@@ -583,7 +583,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
 
     def "honors @PathSensitive(#sensitivity) on input artifact property for project artifact file when caching"() {
         settingsFile << "include 'a', 'b', 'c'"
-        setupBuildWithColorTransformAction()
+        setupBuildWithColorTransform()
         buildFile << """
             project(':a') {
                 dependencies {
@@ -665,7 +665,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
 
     def "honors content changes for @PathSensitive(NONE) on input artifact property for project artifact directory when not caching"() {
         settingsFile << "include 'a', 'b', 'c'"
-        setupBuildWithColorTransformAction {
+        setupBuildWithColorTransform {
             produceDirs()
         }
         buildFile << """
@@ -754,7 +754,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
 
     def "honors @PathSensitive(NONE) on input artifact property for project artifact directory when caching"() {
         settingsFile << "include 'a', 'b', 'c'"
-        setupBuildWithColorTransformAction {
+        setupBuildWithColorTransform {
             produceDirs()
         }
         buildFile << """
@@ -843,7 +843,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
     }
 
     def "can attach @PathSensitive(NONE) to input artifact property for external artifact"() {
-        setupBuildWithColorTransformAction()
+        setupBuildWithColorTransform()
         def group1libv10 = mavenRepo.module("group1", "lib", "1.0").adhocVariants().variant('runtime', [color: 'blue']).withModuleMetadata().publish()
         group1libv10.artifactFile.text = "lib"
         def group2libv10 = mavenRepo.module("group2", "lib", "1.0").adhocVariants().variant('runtime', [color: 'blue']).withModuleMetadata().publish()
@@ -926,7 +926,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
     }
 
     def "can attach @PathSensitive(#sensitivity) to input artifact property for external artifact"() {
-        setupBuildWithColorTransformAction()
+        setupBuildWithColorTransform()
         def lib1 = withColorVariants(mavenRepo.module("group1", "lib", "1.0")).publish()
         lib1.artifactFile.text = "lib"
         def lib2 = withColorVariants(mavenRepo.module("group2", "lib", "1.0")).publish()
@@ -1004,7 +1004,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
 
     def "honors content changes with @#annotation on input artifact property with project artifact file when not caching"() {
         settingsFile << "include 'a', 'b', 'c'"
-        setupBuildWithColorTransformAction {
+        setupBuildWithColorTransform {
             produceJars()
         }
         buildFile << """
@@ -1103,7 +1103,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
 
     def "honors @#annotation on input artifact property with project artifact file when caching"() {
         settingsFile << "include 'a', 'b', 'c'"
-        setupBuildWithColorTransformAction {
+        setupBuildWithColorTransform {
             produceJars()
         }
         buildFile << """
@@ -1203,7 +1203,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
 
     def "honors runtime classpath normalization for input artifact"() {
         settingsFile << "include 'a', 'b', 'c'"
-        setupBuildWithColorTransformAction {
+        setupBuildWithColorTransform {
             produceJars()
         }
         buildFile << """
@@ -1255,7 +1255,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
     @Issue("https://github.com/gradle/gradle/issues/19003")
     def "can transform an empty input artifact"() {
         settingsFile << "include 'a', 'b'"
-        setupBuildWithColorTransformAction {
+        setupBuildWithColorTransform {
             produceDirs()
         }
         buildFile << """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
@@ -796,7 +796,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         settingsFile << """
             include 'a', 'b', 'c'
         """
-        setupBuildWithColorTransformAction()
+        setupBuildWithColorTransform()
         buildFile << """
             project(':a') {
                 dependencies {
@@ -880,7 +880,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         settingsFile << """
             include 'a', 'b'
         """
-        setupBuildWithColorTransformAction()
+        setupBuildWithColorTransform()
         def typeName = propertyType instanceof Class ? propertyType.name : propertyType.toString()
         buildFile << """
             project(':a') {
@@ -921,7 +921,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         settingsFile << """
             include 'a', 'b'
         """
-        setupBuildWithColorTransformAction()
+        setupBuildWithColorTransform()
         buildFile << """
             project(':a') {
                 dependencies {
@@ -958,7 +958,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         settingsFile << """
             include 'a', 'b', 'c'
         """
-        setupBuildWithColorTransformAction()
+        setupBuildWithColorTransform()
         buildFile << """
             project(':a') {
                 dependencies {

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformTestFixture.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformTestFixture.groovy
@@ -234,28 +234,6 @@ class JarProducer extends DefaultTask {
      * Each project produces a 'blue' variant, and has a `resolve` task that resolves the 'green' variant and a transform that converts 'blue' to 'green'.
      * By default the 'blue' variant will contain a single file, and the transform will produce a single 'green' file from this.
      */
-    void setupBuildWithLegacyColorTransformImplementation(TestFile buildFile = getBuildFile()) {
-        setupBuildWithColorTransformAction(buildFile)
-        buildFile << """
-            abstract class MakeGreen implements TransformAction<TransformParameters.None> {
-                @InputArtifact
-                abstract Provider<FileSystemLocation> getInputArtifact()
-
-                void transform(TransformOutputs outputs) {
-                    def input = inputArtifact.get().asFile
-                    println "processing [\${input.name}]"
-                    assert input.file
-                    def output = outputs.file(input.name + ".green")
-                    output.text = input.text + ".green"
-                }
-            }
-        """
-    }
-
-    /**
-     * Each project produces a 'blue' variant, and has a `resolve` task that resolves the 'green' variant and a transform that converts 'blue' to 'green'.
-     * By default the 'blue' variant will contain a single file, and the transform will produce a single 'green' file from this.
-     */
     void setupBuildWithColorTransformImplementation(TestFile buildFile = getBuildFile(), boolean lenient = false) {
         setupBuildWithColorTransform(buildFile)
         buildFile << """
@@ -287,7 +265,7 @@ class JarProducer extends DefaultTask {
      * By default the 'blue' variant will contain a single file, and the transform will produce a single 'green' file from this.
      */
     void setupBuildWithColorTransformThatTakesUpstreamArtifacts() {
-        setupBuildWithColorTransformAction()
+        setupBuildWithColorTransform()
         buildFile << """
             abstract class MakeGreen implements TransformAction<TransformParameters.None> {
                 @InputArtifactDependencies
@@ -358,29 +336,6 @@ class JarProducer extends DefaultTask {
                 }
             }
         """
-    }
-
-    /**
-     * Each project produces a 'blue' variant, and has a `resolve` task that resolves the 'green' variant and a 'MakeGreen' transform that converts 'blue' to 'green'.
-     * By default the variant will contain a single file, this can be configured using the supplied {@link Builder}.
-     * Caller will need to provide an implementation of 'MakeGreen' transform action
-     */
-    void setupBuildWithColorTransformAction(TestFile buildFile = getBuildFile(), @DelegatesTo(Builder) Closure cl = {}) {
-        setupBuildWithColorAttributes(buildFile, cl)
-        buildFile << """
-allprojects {
-    dependencies {
-        registerTransform(MakeGreen) {
-            from.attribute(color, 'blue')
-            to.attribute(color, 'green')
-        }
-    }
-}
-"""
-    }
-
-    void setupBuildWithColorTransformAction(@DelegatesTo(Builder) Closure cl) {
-        setupBuildWithColorTransformAction(buildFile, cl)
     }
 
     /**


### PR DESCRIPTION
The legacy API for artifact transforms has been removed. The methods which claim to use the legacy API actually do the same as the ones which use the new API.