### PR TITLE
Store full build state in configuration cache if it has build services

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/CachedBuildState.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/CachedBuildState.kt
@@ -58,6 +58,9 @@ data class BuildToStore(
     // Does this build have a child build with work scheduled?
     val hasChildren: Boolean
 ) {
+    val id
+        get() = build.state.buildIdentifier!!
+
     fun hasChildren() = BuildToStore(build, hasWork, true)
 }
 

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
@@ -239,7 +239,7 @@ class ConfigurationCacheState(
     private
     suspend fun DefaultWriteContext.writeBuildState(build: BuildToStore, buildTreeState: StoredBuildTreeState, rootBuild: VintageGradleBuild) {
         val state = build.build.state
-        if (!build.hasWork && !build.hasChildren) {
+        if (!build.hasWork && !build.hasChildren && !buildTreeState.hasBuildServicesFor(build.id)) {
             writeEnum(BuildType.BuildWithNoWork)
             writeBuildWithNoWork(state, rootBuild)
         } else if (state is RootBuildState) {
@@ -799,7 +799,9 @@ class ConfigurationCacheState(
 internal
 class StoredBuildTreeState(
     val requiredBuildServicesPerBuild: Map<BuildIdentifier, List<BuildServiceProvider<*, *>>>
-)
+) {
+    fun hasBuildServicesFor(id: BuildIdentifier) = requiredBuildServicesPerBuild.containsKey(id)
+}
 
 
 internal


### PR DESCRIPTION
In 8.0 only included builds that contribute tasks to the work graph are stored in full, others have most of the state discarded, including registered build services. This caused problems if such a service is used as a build operation listeners, as Gradle restores all listeners when running from cache (except for listeners added in the buildSrc build).

This commit restores the behavior we had in 7.6 by saving builds with registered listeners in full.

It is also possible to discard the build listeners of work-free builds, like we do for buildSrc, but this would be a breaking change. Instead, we may want to reconsider our decision to discard buildSrc listeners.

Fixes #23700