### PR TITLE
Tweak cache cleanup documentation to use a clear, more consistent pattern

### DIFF
--- a/subprojects/docs/src/docs/userguide/reference/directory_layout.adoc
+++ b/subprojects/docs/src/docs/userguide/reference/directory_layout.adoc
@@ -119,13 +119,18 @@ Beginning with Gradle version 8.0, the cache cleanup settings can be configured 
 - If the retention period is customized for Gradle versions greater than or equal to version 8.0 to use retention periods _longer_ than the previously fixed periods, the older versions of Gradle may clean the shared caches earlier than what is configured.  In this case, if it is desirable to maintain these shared cache entries for newer versions for the longer retention periods, they will not be able to share a Gradle user home directory with older versions and will need to use a separate directory.
 
 Another consideration when sharing the Gradle user home directory with versions of Gradle before version 8.0 is that the DSL elements to configure the cache retention settings are not available in earlier versions, so this must be accounted for in any init script that is shared between versions.
-This can easily be handled in a Groovy init script with a conditional.
-For Kotlin init scripts, this is a little more tricky, due to the statically compiled nature of Kotlin, but it can be accomplished using some of the dynamicity features of the Kotlin DSL.
+This can easily be handled by conditionally applying a version-compliant script.
+Note that the version-compliant script should reside somewhere other than the `init.d` directory (such as a sub-directory) so that it is not automatically applied.
 
 .Configuring cache cleanup in a version-safe manner
 ====
 include::sample[dir="snippets/initScripts/multiVersionCacheRetention/groovy",files="gradleUserHome/init.d/cache-settings.gradle"]
 include::sample[dir="snippets/initScripts/multiVersionCacheRetention/kotlin",files="gradleUserHome/init.d/cache-settings.gradle.kts"]
+====
+.Version-compliant cache configuration script
+====
+include::sample[dir="snippets/initScripts/multiVersionCacheRetention/groovy",files="gradleUserHome/init.d/gradle8/cache-settings.gradle"]
+include::sample[dir="snippets/initScripts/multiVersionCacheRetention/kotlin",files="gradleUserHome/init.d/gradle8/cache-settings.gradle.kts"]
 ====
 
 [[dir:project_root]]

--- a/subprojects/docs/src/snippets/initScripts/multiVersionCacheRetention/groovy/gradleUserHome/init.d/cache-settings.gradle
+++ b/subprojects/docs/src/snippets/initScripts/multiVersionCacheRetention/groovy/gradleUserHome/init.d/cache-settings.gradle
@@ -1,10 +1,3 @@
 if (GradleVersion.current() >= GradleVersion.version('8.0')) {
-    beforeSettings { settings ->
-        settings.caches {
-            releasedWrappers.removeUnusedEntriesAfterDays = 45
-            snapshotWrappers.removeUnusedEntriesAfterDays = 10
-            downloadedResources.removeUnusedEntriesAfterDays = 45
-            createdResources.removeUnusedEntriesAfterDays = 10
-        }
-    }
+    apply from: "gradle8/cache-settings.gradle"
 }

--- a/subprojects/docs/src/snippets/initScripts/multiVersionCacheRetention/groovy/gradleUserHome/init.d/gradle8/cache-settings.gradle
+++ b/subprojects/docs/src/snippets/initScripts/multiVersionCacheRetention/groovy/gradleUserHome/init.d/gradle8/cache-settings.gradle
@@ -1,0 +1,8 @@
+beforeSettings { settings ->
+    settings.caches {
+        releasedWrappers.removeUnusedEntriesAfterDays = 45
+        snapshotWrappers.removeUnusedEntriesAfterDays = 10
+        downloadedResources.removeUnusedEntriesAfterDays = 45
+        createdResources.removeUnusedEntriesAfterDays = 10
+    }
+}

--- a/subprojects/docs/src/snippets/initScripts/multiVersionCacheRetention/kotlin/gradleUserHome/init.d/cache-settings.gradle.kts
+++ b/subprojects/docs/src/snippets/initScripts/multiVersionCacheRetention/kotlin/gradleUserHome/init.d/cache-settings.gradle.kts
@@ -1,13 +1,3 @@
 if (GradleVersion.current() >= GradleVersion.version("8.0")) {
-    beforeSettings {
-        // Use withGroovyBuilder since these model elements are not available in older Gradle versions
-        withGroovyBuilder {
-            "caches" {
-                "releasedWrappers" { "setRemoveUnusedEntriesAfterDays"(45) }
-                "snapshotWrappers" { "setRemoveUnusedEntriesAfterDays"(10) }
-                "downloadedResources" { "setRemoveUnusedEntriesAfterDays"(45) }
-                "createdResources" { "setRemoveUnusedEntriesAfterDays"(10) }
-            }
-        }
-    }
+    apply(from = "gradle8/cache-settings.gradle.kts")
 }

--- a/subprojects/docs/src/snippets/initScripts/multiVersionCacheRetention/kotlin/gradleUserHome/init.d/gradle8/cache-settings.gradle.kts
+++ b/subprojects/docs/src/snippets/initScripts/multiVersionCacheRetention/kotlin/gradleUserHome/init.d/gradle8/cache-settings.gradle.kts
@@ -1,0 +1,8 @@
+beforeSettings {
+    caches {
+        releasedWrappers { setRemoveUnusedEntriesAfterDays(45) }
+        snapshotWrappers { setRemoveUnusedEntriesAfterDays(10) }
+        downloadedResources { setRemoveUnusedEntriesAfterDays(45) }
+        createdResources { setRemoveUnusedEntriesAfterDays(10) }
+    }
+}


### PR DESCRIPTION
Recommend conditionally applying version-compliant scripts instead of trying to handle the dynamic version-specific syntax in the main init script.
