### PR TITLE
Change the logging around cache config to be Lifecycle level instead of Info

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/caching/configuration/internal/BuildCacheConfigurationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/caching/configuration/internal/BuildCacheConfigurationIntegrationTest.groovy
@@ -207,7 +207,7 @@ class BuildCacheConfigurationIntegrationTest extends AbstractIntegrationSpec {
     def "emits a useful message when using the build cache"() {
         when:
         executer.withBuildCacheEnabled()
-        succeeds("help", "--info")
+        succeeds("help")
         then:
         outputContains("Using local directory build cache")
     }
@@ -218,7 +218,7 @@ class BuildCacheConfigurationIntegrationTest extends AbstractIntegrationSpec {
         """
         executer.withArgument("--no-build-cache")
         when:
-        succeeds("help", "--info")
+        succeeds("help")
         then:
         outputDoesNotContain("Using local directory build cache")
     }
@@ -229,7 +229,7 @@ class BuildCacheConfigurationIntegrationTest extends AbstractIntegrationSpec {
         """
         executer.withArgument("--build-cache")
         when:
-        succeeds("help", "--info")
+        succeeds("help")
         then:
         outputContains("Using local directory build cache")
     }
@@ -270,7 +270,7 @@ class BuildCacheConfigurationIntegrationTest extends AbstractIntegrationSpec {
             }
         """
         executer.withBuildCacheEnabled()
-        succeeds("customTask", "--info")
+        succeeds("customTask")
 
         then:
         outputContains("Using local directory build cache for the root build (pull-only, location = ${file("local-cache")}, removeUnusedEntriesAfter = 7 days).")

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/services/BuildCacheControllerFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/services/BuildCacheControllerFactory.java
@@ -21,6 +21,8 @@ import com.google.common.collect.ImmutableSortedMap;
 import org.gradle.api.internal.GeneratedSubclasses;
 import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.api.internal.file.temp.TemporaryFileProvider;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 import org.gradle.caching.BuildCacheService;
 import org.gradle.caching.BuildCacheServiceFactory;
 import org.gradle.caching.configuration.BuildCache;
@@ -43,8 +45,6 @@ import org.gradle.internal.operations.CallableBuildOperation;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.vfs.FileSystemAccess;
 import org.gradle.util.Path;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.util.HashMap;
@@ -56,7 +56,7 @@ public final class BuildCacheControllerFactory {
 
     public static final String REMOTE_CONTINUE_ON_ERROR_PROPERTY = "org.gradle.unsafe.build-cache.remote-continue-on-error";
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(BuildCacheControllerFactory.class);
+    private static final Logger LOGGER = Logging.getLogger(BuildCacheControllerFactory.class);
 
     public enum BuildCacheMode {
         ENABLED, DISABLED
@@ -182,7 +182,7 @@ public final class BuildCacheControllerFactory {
     }
 
     private static void logConfig(Path buildIdentityPath, BuildCacheServiceRole role, BuildCacheDescription description) {
-        if (LOGGER.isInfoEnabled()) {
+        if (LOGGER.isLifecycleEnabled()) {
             StringBuilder config = new StringBuilder();
             boolean pullOnly = !description.isPush();
             if (!description.config.isEmpty() || pullOnly) {
@@ -213,7 +213,7 @@ public final class BuildCacheControllerFactory {
                 buildDescription = "build '" + buildIdentityPath + "'";
             }
 
-            LOGGER.info("Using {} {} build cache for {}{}.",
+            LOGGER.lifecycle("Using {} {} build cache for {}{}.",
                 role.getDisplayName(),
                 description.type == null ? description.className : description.type,
                 buildDescription,


### PR DESCRIPTION
Customers have requested this as part of issue gradle/ge#19109, at least for the hostname of a remote cache. It's possible we may want to make this more granular so we only log certain cache types or certain config entries, but honestly, knowing how the caching is configured seems important enough to local dev experience that it seems worth boosting in its entirety. 

<!--- The issue this PR addresses -->
Fixes gradle/ge#19109.
