### PR TITLE
Fix HTML rendering of example headers that are wrapped into links

### DIFF
--- a/subprojects/docs-asciidoctor-extensions-base/src/main/java/org/gradle/docs/asciidoctor/ExampleSelfLinkProcessor.java
+++ b/subprojects/docs-asciidoctor-extensions-base/src/main/java/org/gradle/docs/asciidoctor/ExampleSelfLinkProcessor.java
@@ -42,11 +42,16 @@ public class ExampleSelfLinkProcessor extends Treeprocessor {
     public Document process(Document document) {
         List<StructuralNode> examples = document.findBy(EXAMPLE_SELECTOR);
         for (StructuralNode example : examples) {
-            if (example.getTitle() != null) {
-                if (example.getId() == null) {
-                    example.setId(IdGenerator.generateId(ID_PREFIX + example.getTitle()));
+            if (example.hasAttribute("title")) {
+                // Using attribute value, since it contains Asciidoc markup, as opposed to getTitle() that returns rendered html
+                String title = example.getAttribute("title").toString();
+                String exampleId = example.getId();
+                if (exampleId == null) {
+                    exampleId = IdGenerator.generateId(ID_PREFIX + title);
+                    example.setId(exampleId);
                 }
-                example.setTitle(String.format("link:#%s[%s]", example.getId(), example.getTitle()));
+                // Using setTitle() instead of setAttribute(), because the latter has no effect
+                example.setTitle(String.format("link:#%s[%s]", exampleId, title));
             }
         }
         return document;

--- a/subprojects/docs-asciidoctor-extensions-base/src/main/java/org/gradle/docs/asciidoctor/GradleDocsAsciidoctorExtensionRegistry.java
+++ b/subprojects/docs-asciidoctor-extensions-base/src/main/java/org/gradle/docs/asciidoctor/GradleDocsAsciidoctorExtensionRegistry.java
@@ -23,7 +23,6 @@ public class GradleDocsAsciidoctorExtensionRegistry implements ExtensionRegistry
 
     @Override
     public void register(Asciidoctor asciidoctor) {
-
         JavaExtensionRegistry registry = asciidoctor.javaExtensionRegistry();
 
         registry.docinfoProcessor(MetadataDocinfoProcessor.class);
@@ -33,13 +32,5 @@ public class GradleDocsAsciidoctorExtensionRegistry implements ExtensionRegistry
         registry.includeProcessor(SampleIncludeProcessor.class);
 
         registry.treeprocessor(ExampleSelfLinkProcessor.class);
-
-//        registry.docinfoProcessor(new LinkingDataDocinfoProcessor(footerOptions));
-        // TODO: satisfaction widget processor
-
-//        registry.inlineMacro("javadoc", JavadocLinkInlineMacroProcessor.class);
-//        registry.blockMacro("sample", IncludeSampleBlockMacroProcessor.class);
-
-        // TODO: consider project layout macro inspired by https://github.com/gradle/gradle/pull/6006/files#diff-8c02799b6a73d6394741c4e2933273ae
     }
 }

--- a/subprojects/docs-asciidoctor-extensions-base/src/test/groovy/org/gradle/docs/asciidoctor/ExampleSelfLinkProcessorTest.groovy
+++ b/subprojects/docs-asciidoctor-extensions-base/src/test/groovy/org/gradle/docs/asciidoctor/ExampleSelfLinkProcessorTest.groovy
@@ -16,7 +16,6 @@
 package org.gradle.docs.asciidoctor
 
 import org.asciidoctor.Asciidoctor
-import org.asciidoctor.extension.JavaExtensionRegistry
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
@@ -30,14 +29,12 @@ class ExampleSelfLinkProcessorTest extends Specification {
     def setup() {
         tmpDir.newFolder("src", "samples")
         asciidoctor = Asciidoctor.Factory.create()
-        JavaExtensionRegistry extensionRegistry = asciidoctor.javaExtensionRegistry()
-        extensionRegistry.treeprocessor(ExampleSelfLinkProcessor.class)
     }
 
     def "renders example with title adding link to self"() {
         given:
         String asciidocContent = """
-.Example Title
+.Example Title `with code`
 ====
 some text
 ====
@@ -47,8 +44,8 @@ some text
         String content = asciidoctor.convert(asciidocContent, [:])
 
         then:
-        content.contains("""<div id="ex-example-title" class="exampleblock">
-<div class="title">Example 1. <a href="#ex-example-title">&lt;a href="#ex-example-title"&gt;Example Title&lt;/a&gt;</a></div>
+        content.contains("""<div id="ex-example-title-with-code" class="exampleblock">
+<div class="title">Example 1. <a href="#ex-example-title-with-code">Example Title <code>with code</code></a></div>
 <div class="content">
 <div class="paragraph">
 <p>some text</p>


### PR DESCRIPTION
Fixes:
* https://github.com/gradle/gradle/issues/23861

## Result
<img width="693" alt="image" src="https://user-images.githubusercontent.com/2759152/218096671-b7e0f751-f3d2-46e6-91f7-323ef427fda6.png">
