### PR TITLE
Test against CodeNarc versions supported by the toolchain JDK

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/codenarc/CodeNarcNonJvmIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/codenarc/CodeNarcNonJvmIntegrationTest.groovy
@@ -25,7 +25,7 @@ import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import spock.lang.Issue
 
-@TargetCoverage({ CodeNarcCoverage.supportedVersionsByJdk })
+@TargetCoverage({ CodeNarcCoverage.supportedVersionsByCurrentJdk })
 @Requires(TestPrecondition.STABLE_GROOVY)
 class CodeNarcNonJvmIntegrationTest extends MultiVersionIntegrationSpec implements CodeNarcTestFixture {
 

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/codenarc/CodeNarcPluginVersionIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/codenarc/CodeNarcPluginVersionIntegrationTest.groovy
@@ -30,7 +30,7 @@ import spock.lang.Issue
 
 import static org.hamcrest.CoreMatchers.startsWith
 
-@TargetCoverage({ CodeNarcCoverage.supportedVersionsByJdk })
+@TargetCoverage({ CodeNarcCoverage.supportedVersionsByCurrentJdk })
 @Requires(TestPrecondition.STABLE_GROOVY)
 class CodeNarcPluginVersionIntegrationTest extends MultiVersionIntegrationSpec implements CodeNarcTestFixture {
     def setup() {

--- a/subprojects/code-quality/src/testFixtures/groovy/org/gradle/quality/integtest/fixtures/CodeNarcCoverage.groovy
+++ b/subprojects/code-quality/src/testFixtures/groovy/org/gradle/quality/integtest/fixtures/CodeNarcCoverage.groovy
@@ -21,21 +21,30 @@ import org.gradle.api.plugins.quality.CodeNarcPlugin
 import org.gradle.util.internal.VersionNumber
 
 class CodeNarcCoverage {
+    public static final List<String> ALL = [CodeNarcPlugin.DEFAULT_CODENARC_VERSION, "0.17", "0.21", "0.23", "0.24.1", "0.25.2", "1.0", "1.6.1", "2.0.0", "2.2.0", "3.0.1"].asImmutable()
+
     private static boolean isAtLeastGroovy4() {
         return VersionNumber.parse(GroovySystem.version).major >= 4
     }
 
-    private static final List<String> ALL = isAtLeastGroovy4() ? [CodeNarcPlugin.DEFAULT_CODENARC_VERSION].asImmutable()
-                                                               : [CodeNarcPlugin.DEFAULT_CODENARC_VERSION, "0.17", "0.21", "0.23", "0.24.1", "0.25.2", "1.0", "1.6.1", "2.0.0", "2.2.0", "3.0.1"].asImmutable()
+    private static final List<String> CURRENT_GROOVY_SUPPORTED = isAtLeastGroovy4() ? [CodeNarcPlugin.DEFAULT_CODENARC_VERSION].asImmutable()
+                                                               : ALL
 
-    private static final List<String> JDK11_SUPPORTED = versionsAboveInclusive(ALL, "0.23")
+    private static final List<String> JDK11_SUPPORTED = versionsAboveInclusive(CURRENT_GROOVY_SUPPORTED, "0.23")
     private static final List<String> JDK14_SUPPORTED = JDK11_SUPPORTED - ['1.6.1', '1.0']
 
-    static List<String> getSupportedVersionsByJdk() {
-        if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_14)) {
+    static List<String> getSupportedVersionsByCurrentJdk() {
+        getSupportedVersionsByJdk(JavaVersion.current())
+    }
+
+    static List<String> getSupportedVersionsByJdk(JavaVersion version) {
+        if (version.isCompatibleWith(JavaVersion.VERSION_14)) {
             return JDK14_SUPPORTED
+        } else if (version.isCompatibleWith(JavaVersion.VERSION_11)) {
+            return JDK11_SUPPORTED
+        } else {
+            return CURRENT_GROOVY_SUPPORTED
         }
-        return JavaVersion.current().java11Compatible ? JDK11_SUPPORTED : ALL
     }
 
     private static List<String> versionsAboveInclusive(List<String> versionsToFilter, String threshold) {


### PR DESCRIPTION
Previously, this tested against the versions suported by the build JDK, which might have worked due to happy coincidence, but could break if the test fixture selected a different JDK to use for the toolchain.

