### PR TITLE
Support JDK 20 (compiling and testing only)

### DIFF
--- a/build-logic/build-platform/build.gradle.kts
+++ b/build-logic/build-platform/build.gradle.kts
@@ -13,7 +13,7 @@ val groovyVersion = GroovySystem.getVersion()
 val isGroovy4 = VersionNumber.parse(groovyVersion).major >= 4
 val codenarcVersion = if (isGroovy4) "3.1.0-groovy-4.0" else "3.1.0"
 val spockVersion = if (isGroovy4) "2.2-groovy-4.0" else "2.2-groovy-3.0"
-val asmVersion = "9.2"
+val asmVersion = "9.4"
 // To try out better kotlin compilation avoidance and incremental compilation
 // with -Pkotlin.incremental.useClasspathSnapshot=true
 val kotlinVersion = providers.gradleProperty("buildKotlinVersion")

--- a/build-logic/dependency-modules/src/main/kotlin/gradlebuild/modules/extension/ExternalModulesExtension.kt
+++ b/build-logic/dependency-modules/src/main/kotlin/gradlebuild/modules/extension/ExternalModulesExtension.kt
@@ -20,7 +20,7 @@ import gradlebuild.modules.model.License
 
 abstract class ExternalModulesExtension(isBundleGroovy4: Boolean) {
 
-    val groovyVersion = if (isBundleGroovy4) "4.0.7" else "3.0.13"
+    val groovyVersion = if (isBundleGroovy4) "4.0.7" else "3.0.15"
     val configurationCacheReportVersion = "1.2"
     val kotlinVersion = "1.8.10"
 

--- a/subprojects/base-services/src/main/java/org/gradle/api/JavaVersion.java
+++ b/subprojects/base-services/src/main/java/org/gradle/api/JavaVersion.java
@@ -94,11 +94,9 @@ public enum JavaVersion {
 
     /**
      * Java 20 major version.
-     * Not officially supported by Gradle. Use at your own risk.
      *
      * @since 7.0
      */
-    @Incubating
     VERSION_20,
 
     /**

--- a/subprojects/distributions-dependencies/build.gradle.kts
+++ b/subprojects/distributions-dependencies/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
 description = "Provides a platform dependency to align all distribution versions"
 
 val antVersion = "1.10.11"
-val asmVersion = "9.3"
+val asmVersion = "9.4"
 val awsS3Version = "1.12.365"
 val bouncycastleVersion = "1.68"
 val jacksonVersion = "2.14.1"

--- a/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
+++ b/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
@@ -36,7 +36,7 @@ import static org.hamcrest.MatcherAssert.assertThat
 
 abstract class DistributionIntegrationSpec extends AbstractIntegrationSpec {
 
-    protected static final THIRD_PARTY_LIB_COUNT = 150
+    protected static final THIRD_PARTY_LIB_COUNT = 149
 
     @Rule public final PreconditionVerifier preconditionVerifier = new PreconditionVerifier()
 

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/util/TestPrecondition.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/util/TestPrecondition.groovy
@@ -148,6 +148,9 @@ enum TestPrecondition implements org.gradle.internal.Factory<Boolean> {
     JDK19_OR_LATER({
         JavaVersion.current() >= JavaVersion.VERSION_19
     }),
+    JDK20_OR_LATER({
+        JavaVersion.current() >= JavaVersion.VERSION_20
+    }),
     JDK_ORACLE({
         System.getProperty('java.vm.vendor') == 'Oracle Corporation'
     }),
@@ -175,6 +178,7 @@ enum TestPrecondition implements org.gradle.internal.Factory<Boolean> {
         WINDOWS.fulfilled && "embedded" != System.getProperty("org.gradle.integtest.executer")
     }),
     SUPPORTS_TARGETING_JAVA6({ !JDK12_OR_LATER.fulfilled }),
+    SUPPORTS_TARGETING_JAVA7({ !JDK20_OR_LATER.fulfilled }),
     // Currently mac agents are not that strong so we avoid running high-concurrency tests on them
     HIGH_PERFORMANCE(NOT_MAC_OS_X),
     NOT_EC2_AGENT({

--- a/subprojects/jacoco/src/testFixtures/groovy/org/gradle/testing/jacoco/plugins/fixtures/JacocoCoverage.groovy
+++ b/subprojects/jacoco/src/testFixtures/groovy/org/gradle/testing/jacoco/plugins/fixtures/JacocoCoverage.groovy
@@ -24,21 +24,23 @@ final class JacocoCoverage {
     private JacocoCoverage() {}
 
     private static final String[] ALL = [JacocoPlugin.DEFAULT_JACOCO_VERSION, '0.7.1.201405082137', '0.7.6.201602180812', '0.8.3'].asImmutable()
+    // Order matters here, as we want to test the latest version first
+    // Relies on Groovy keeping the order of the keys in a map literal
+    private static final Map<JavaVersion, JacocoVersion> JDK_CUTOFFS = [
+        (JavaVersion.VERSION_20): JacocoVersion.SUPPORTS_JDK_20,
+        (JavaVersion.VERSION_18): JacocoVersion.SUPPORTS_JDK_18,
+        (JavaVersion.VERSION_17): JacocoVersion.SUPPORTS_JDK_17,
+        (JavaVersion.VERSION_16): JacocoVersion.SUPPORTS_JDK_16,
+        (JavaVersion.VERSION_15): JacocoVersion.SUPPORTS_JDK_15,
+        (JavaVersion.VERSION_14): JacocoVersion.SUPPORTS_JDK_14,
+        (JavaVersion.VERSION_1_9): JacocoVersion.SUPPORTS_JDK_9,
+    ]
 
-    // Release notes: https://www.jacoco.org/jacoco/trunk/doc/changes.html
     static List<String> getSupportedVersionsByJdk() {
-        if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_18)) {
-            return filter(JacocoVersion.SUPPORTS_JDK_18)
-        } else if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
-            return filter(JacocoVersion.SUPPORTS_JDK_17)
-        } else if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16)) {
-            return filter(JacocoVersion.SUPPORTS_JDK_16)
-        } else if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_15)) {
-            return filter(JacocoVersion.SUPPORTS_JDK_15)
-        } else if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_14)) {
-            return filter(JacocoVersion.SUPPORTS_JDK_14)
-        } else if (JavaVersion.current().isJava9Compatible()) {
-            return filter(JacocoVersion.SUPPORTS_JDK_9)
+        for (def cutoff : JDK_CUTOFFS) {
+            if (JavaVersion.current().isCompatibleWith(cutoff.key)) {
+                return filter(cutoff.value)
+            }
         }
         return filter(JacocoVersion.SUPPORTS_JDK_8)
     }
@@ -48,6 +50,7 @@ final class JacocoCoverage {
     }
 
     private static class JacocoVersion implements Comparable<JacocoVersion> {
+        // Release notes: https://www.jacoco.org/jacoco/trunk/doc/changes.html
         static final SUPPORTS_JDK_8 = new JacocoVersion(0, 7, 0)
         static final SUPPORTS_JDK_9 = new JacocoVersion(0, 7, 8)
         static final SUPPORTS_JDK_14 = new JacocoVersion(0, 8, 5)
@@ -55,6 +58,7 @@ final class JacocoCoverage {
         static final SUPPORTS_JDK_16 = new JacocoVersion(0, 8, 6)
         static final SUPPORTS_JDK_17 = new JacocoVersion(0, 8, 7)
         static final SUPPORTS_JDK_18 = new JacocoVersion(0, 8, 8)
+        static final SUPPORTS_JDK_20 = new JacocoVersion(0, 8, 9)
 
         private final int major
         private final int minor

--- a/subprojects/language-groovy/src/testFixtures/groovy/org/gradle/testing/fixture/GroovyCoverage.groovy
+++ b/subprojects/language-groovy/src/testFixtures/groovy/org/gradle/testing/fixture/GroovyCoverage.groovy
@@ -22,7 +22,7 @@ import org.gradle.util.internal.VersionNumber
 import javax.annotation.Nullable
 
 class GroovyCoverage {
-    private static final String[] PREVIOUS = ['1.5.8', '1.6.9', '1.7.11', '1.8.8', '2.0.5', '2.1.9', '2.2.2', '2.3.10', '2.4.15', '2.5.8', '3.0.13']
+    private static final String[] PREVIOUS = ['1.5.8', '1.6.9', '1.7.11', '1.8.8', '2.0.5', '2.1.9', '2.2.2', '2.3.10', '2.4.15', '2.5.8', '3.0.15']
     private static final String[] FUTURE = ['4.0.7']
 
     static final Set<String> SUPPORTED_BY_JDK

--- a/subprojects/normalization-java/src/test/groovy/org/gradle/internal/normalization/java/ApiClassExtractorTest.groovy
+++ b/subprojects/normalization-java/src/test/groovy/org/gradle/internal/normalization/java/ApiClassExtractorTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.normalization.java
 
+import org.gradle.util.TestPrecondition
 import org.junit.Assume
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassVisitor
@@ -273,7 +274,8 @@ class ApiClassExtractorTest extends ApiClassExtractorTestSupport {
     }
 
     void "target binary compatibility is maintained"() {
-        Assume.assumeFalse(target == "1.6" && !org.gradle.util.TestPrecondition.SUPPORTS_TARGETING_JAVA6.fulfilled)
+        Assume.assumeFalse(target == "1.6" && !TestPrecondition.SUPPORTS_TARGETING_JAVA6.fulfilled)
+        Assume.assumeFalse(target == "1.7" && !TestPrecondition.SUPPORTS_TARGETING_JAVA7.fulfilled)
 
         given:
         def api = toApi(target, [A: 'public class A {}'])

--- a/subprojects/normalization-java/src/test/groovy/org/gradle/internal/normalization/java/ApiClassExtractorTestSupport.groovy
+++ b/subprojects/normalization-java/src/test/groovy/org/gradle/internal/normalization/java/ApiClassExtractorTestSupport.groovy
@@ -106,8 +106,12 @@ class ApiClassExtractorTestSupport extends Specification {
     @Rule
     public final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
+    // The default target version can be updated to a new version when necessary, as long as
+    // you also update `ApiClassExtractorTest#target binary compatibility is maintained` with new assumptions.
+    private static final String DEFAULT_TARGET_VERSION = '8'
+
     protected ApiContainer toApi(Map<String, String> sources) {
-        toApi('1.7', [], sources)
+        toApi(DEFAULT_TARGET_VERSION, [], sources)
     }
 
     protected ApiContainer toApi(String targetVersion, Map<String, String> sources) {
@@ -115,7 +119,7 @@ class ApiClassExtractorTestSupport extends Specification {
     }
 
     protected ApiContainer toApi(List<String> packages, Map<String, String> sources) {
-        toApi('1.7', packages, sources)
+        toApi(DEFAULT_TARGET_VERSION, packages, sources)
     }
 
     protected ApiContainer toApi(String targetVersion, List<String> packages,  Map<String, String> sources) {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/GroovyCompileToolchainIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/GroovyCompileToolchainIntegrationTest.groovy
@@ -27,7 +27,6 @@ import org.gradle.testing.fixture.GroovyCoverage
 import org.gradle.util.internal.TextUtil
 import org.gradle.util.internal.VersionNumber
 import org.junit.Assume
-import spock.lang.Ignore
 
 import static org.gradle.util.internal.GroovyDependencyUtil.groovyModuleDependency
 
@@ -197,7 +196,6 @@ class GroovyCompileToolchainIntegrationTest extends MultiVersionIntegrationSpec 
         'none' | 'none' | '11'      | '11'
     }
 
-    @Ignore("https://github.com/gradle/gradle-private/issues/3729")
     def "can compile source and run tests using Java #javaVersion for Groovy "() {
         def jdk = AvailableJavaHomes.getJdk(javaVersion)
         Assume.assumeTrue(jdk != null)


### PR DESCRIPTION
Fixes #23489.

This includes minor changes to allow us to compile, test, etc. Java and Groovy on JDK 20.