### PR TITLE
Make SoftwareComponentContainer extensible

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ProblemReportingCrossProjectModelAccess.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ProblemReportingCrossProjectModelAccess.kt
@@ -771,6 +771,11 @@ class ProblemReportingCrossProjectModelAccess(
             return delegate.components
         }
 
+        override fun components(configuration: Action<in SoftwareComponentContainer>) {
+            onAccess()
+            delegate.components(configuration)
+        }
+
         override fun getNormalization(): InputNormalizationHandlerInternal {
             onAccess()
             return delegate.normalization

--- a/subprojects/core-api/src/main/java/org/gradle/api/Project.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Project.java
@@ -1765,6 +1765,16 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
     SoftwareComponentContainer getComponents();
 
     /**
+     * Configures software components.
+     *
+     * @param configuration Action to configure the software components.
+     *
+     * @since 8.1
+     */
+    @Incubating
+    void components(Action<? super SoftwareComponentContainer> configuration);
+
+    /**
      * Provides access to configuring input normalization.
      *
      * @since 4.0

--- a/subprojects/core-api/src/main/java/org/gradle/api/component/SoftwareComponentContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/component/SoftwareComponentContainer.java
@@ -16,10 +16,10 @@
 
 package org.gradle.api.component;
 
-import org.gradle.api.NamedDomainObjectSet;
+import org.gradle.api.ExtensiblePolymorphicDomainObjectContainer;
 
 /**
  * A Container that contains all of the Software Components produced by a Project.
  */
-public interface SoftwareComponentContainer extends NamedDomainObjectSet<SoftwareComponent> {
+public interface SoftwareComponentContainer extends ExtensiblePolymorphicDomainObjectContainer<SoftwareComponent> {
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/component/DefaultSoftwareComponentContainerIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/component/DefaultSoftwareComponentContainerIntegrationTest.groovy
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.component
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+/**
+ * Tests {@link DefaultSoftwareComponentContainer}.
+ */
+class DefaultSoftwareComponentContainerIntegrationTest extends AbstractIntegrationSpec {
+
+    def "can instantiate and configure single element with closure"() {
+        given:
+        buildFile << """
+            ${customComponentWithName("DefaultComponent")}
+
+            components {
+                registerBinding(SoftwareComponent, DefaultComponent)
+                first {
+                    value = 1
+                }
+            }
+
+            components {
+                first {
+                    value = 20
+                }
+            }
+
+            task verify {
+                assert components.first.name == "first"
+                assert components.first.value.get() == 20
+                assert components.first instanceof DefaultComponent
+            }
+        """
+
+        expect:
+        succeeds "verify"
+    }
+
+    def "can instantiate and configure single element with configure method"() {
+        given:
+        buildFile << """
+            ${customComponentWithName("DefaultComponent")}
+
+            components.configure {
+                registerBinding(SoftwareComponent, DefaultComponent)
+                first {
+                    value = 1
+                }
+            }
+
+            components.configure {
+                first {
+                    value = 20
+                }
+            }
+
+            task verify {
+                assert components.first.name == "first"
+                assert components.first.value.get() == 20
+                assert components.first instanceof DefaultComponent
+            }
+        """
+
+        expect:
+        succeeds "verify"
+    }
+
+    def "can instantiate multiple components"() {
+        given:
+        buildFile << """
+            ${customComponentWithName("DefaultComponent")}
+            ${customComponentWithName("CustomComponent")}
+
+            components {
+                registerBinding(SoftwareComponent, DefaultComponent)
+                registerBinding(CustomComponent, CustomComponent)
+                first {
+                    value = 1
+                }
+                second(SoftwareComponent) {
+                    value = 2
+                }
+                third(CustomComponent) {
+                    value = 3
+                }
+            }
+
+            task verify {
+                assert components.first.name == "first"
+                assert components.first.value.get() == 1
+                assert components.first instanceof DefaultComponent
+
+                assert components.second.name == "second"
+                assert components.second.value.get() == 2
+                assert components.second instanceof DefaultComponent
+
+                assert components.third.name == "third"
+                assert components.third.value.get() == 3
+                assert components.third instanceof CustomComponent
+            }
+        """
+
+        expect:
+        succeeds "verify"
+    }
+
+    def "can configure multiple elements"() {
+        given:
+        buildFile << """
+            ${customComponentWithName("DefaultComponent")}
+
+            components {
+                registerBinding(SoftwareComponent, DefaultComponent)
+                comp1 {
+                    value = 1
+                }
+                comp2 {
+                    value = 10
+                }
+            }
+
+            components.comp1 {
+                value = 2
+            }
+
+            components {
+                comp2 {
+                    value = 20
+                }
+            }
+
+            task verify {
+                assert components.comp1.name == "comp1"
+                assert components.comp1.value.get() == 2
+                assert components.comp1 instanceof DefaultComponent
+
+                assert components.comp2.name == "comp2"
+                assert components.comp2.value.get() == 20
+                assert components.comp2 instanceof DefaultComponent
+            }
+        """
+
+        expect:
+        succeeds "verify"
+    }
+
+    private static String customComponentWithName(String name) {
+        """
+            abstract class ${name} implements SoftwareComponent {
+
+                private final String name
+
+                @Inject
+                public ${name}(String name) {
+                    this.name = name
+                }
+
+                public String getName() {
+                    return name
+                }
+
+                public abstract Property<Integer> getValue()
+            }
+        """
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/component/DefaultSoftwareComponentContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/component/DefaultSoftwareComponentContainer.java
@@ -17,23 +17,31 @@
 package org.gradle.api.internal.component;
 
 import org.gradle.api.component.SoftwareComponent;
+import org.gradle.api.component.SoftwareComponentContainer;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
-import org.gradle.api.internal.DefaultNamedDomainObjectSet;
-import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.internal.DefaultPolymorphicDomainObjectContainer;
 import org.gradle.api.provider.Property;
+import org.gradle.api.reflect.HasPublicType;
+import org.gradle.api.reflect.TypeOf;
 import org.gradle.internal.reflect.Instantiator;
 
-public class DefaultSoftwareComponentContainer extends DefaultNamedDomainObjectSet<SoftwareComponent> implements SoftwareComponentContainerInternal {
+import javax.inject.Inject;
 
-    private final Property<SoftwareComponent> mainComponent;
+/**
+ * Default implementation of {@link SoftwareComponentContainer}.
+ */
+public abstract class DefaultSoftwareComponentContainer extends DefaultPolymorphicDomainObjectContainer<SoftwareComponent> implements SoftwareComponentContainerInternal, HasPublicType {
 
-    public DefaultSoftwareComponentContainer(Instantiator instantiator, CollectionCallbackActionDecorator decorator, ObjectFactory objectFactory) {
-        super(SoftwareComponentInternal.class, instantiator, decorator);
-        mainComponent = objectFactory.property(SoftwareComponent.class);
+    @Inject
+    public DefaultSoftwareComponentContainer(Instantiator instantiator, CollectionCallbackActionDecorator decorator) {
+        super(SoftwareComponent.class, instantiator, instantiator, decorator);
     }
 
     @Override
-    public Property<SoftwareComponent> getMainComponent() {
-        return mainComponent;
+    public abstract Property<SoftwareComponent> getMainComponent();
+
+    @Override
+    public TypeOf<?> getPublicType() {
+        return TypeOf.typeOf(SoftwareComponentContainer.class);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/component/DefaultSoftwareComponentContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/component/DefaultSoftwareComponentContainer.java
@@ -21,8 +21,6 @@ import org.gradle.api.component.SoftwareComponentContainer;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DefaultPolymorphicDomainObjectContainer;
 import org.gradle.api.provider.Property;
-import org.gradle.api.reflect.HasPublicType;
-import org.gradle.api.reflect.TypeOf;
 import org.gradle.internal.reflect.Instantiator;
 
 import javax.inject.Inject;
@@ -30,7 +28,7 @@ import javax.inject.Inject;
 /**
  * Default implementation of {@link SoftwareComponentContainer}.
  */
-public abstract class DefaultSoftwareComponentContainer extends DefaultPolymorphicDomainObjectContainer<SoftwareComponent> implements SoftwareComponentContainerInternal, HasPublicType {
+public abstract class DefaultSoftwareComponentContainer extends DefaultPolymorphicDomainObjectContainer<SoftwareComponent> implements SoftwareComponentContainerInternal {
 
     @Inject
     public DefaultSoftwareComponentContainer(Instantiator instantiator, Instantiator elementInstantiator, CollectionCallbackActionDecorator decorator) {
@@ -39,9 +37,4 @@ public abstract class DefaultSoftwareComponentContainer extends DefaultPolymorph
 
     @Override
     public abstract Property<SoftwareComponent> getMainComponent();
-
-    @Override
-    public TypeOf<?> getPublicType() {
-        return TypeOf.typeOf(SoftwareComponentContainer.class);
-    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/component/DefaultSoftwareComponentContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/component/DefaultSoftwareComponentContainer.java
@@ -33,8 +33,8 @@ import javax.inject.Inject;
 public abstract class DefaultSoftwareComponentContainer extends DefaultPolymorphicDomainObjectContainer<SoftwareComponent> implements SoftwareComponentContainerInternal, HasPublicType {
 
     @Inject
-    public DefaultSoftwareComponentContainer(Instantiator instantiator, CollectionCallbackActionDecorator decorator) {
-        super(SoftwareComponent.class, instantiator, instantiator, decorator);
+    public DefaultSoftwareComponentContainer(Instantiator instantiator, Instantiator elementInstantiator, CollectionCallbackActionDecorator decorator) {
+        super(SoftwareComponent.class, instantiator, elementInstantiator, decorator);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -260,6 +260,7 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
             extensibleDynamicObject.setParent(parentInherited);
         }
         extensibleDynamicObject.addObject(taskContainer.getTasksAsDynamicObject(), ExtensibleDynamicObject.Location.AfterConvention);
+        getExtensions().add("components", getComponents());
 
         evaluationListener.add(gradle.getProjectEvaluationBroadcaster());
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -260,7 +260,6 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
             extensibleDynamicObject.setParent(parentInherited);
         }
         extensibleDynamicObject.addObject(taskContainer.getTasksAsDynamicObject(), ExtensibleDynamicObject.Location.AfterConvention);
-        getExtensions().add("components", getComponents());
 
         evaluationListener.add(gradle.getProjectEvaluationBroadcaster());
 
@@ -1116,6 +1115,11 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
     @Inject
     @Override
     public abstract SoftwareComponentContainer getComponents();
+
+    @Override
+    public void components(Action<? super SoftwareComponentContainer> configuration) {
+        configuration.execute(getComponents());
+    }
 
     /**
      * This is an implementation of the {@link groovy.lang.GroovyObject}'s corresponding method.

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -207,9 +207,9 @@ public class ProjectScopeServices extends DefaultServiceRegistry {
         ).create();
     }
 
-    protected SoftwareComponentContainer createSoftwareComponentContainer(CollectionCallbackActionDecorator decorator, ObjectFactory objectFactory) {
-        Instantiator instantiator = get(Instantiator.class);
-        return instantiator.newInstance(DefaultSoftwareComponentContainer.class, instantiator, decorator, objectFactory);
+    protected SoftwareComponentContainer createSoftwareComponentContainer(InstantiatorFactory instantiatorFactory, ServiceRegistry services, CollectionCallbackActionDecorator decorator) {
+        Instantiator instantiator = instantiatorFactory.decorate(services);
+        return instantiator.newInstance(DefaultSoftwareComponentContainer.class, instantiator, decorator);
     }
 
     protected ProjectFinder createProjectFinder() {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -207,9 +207,9 @@ public class ProjectScopeServices extends DefaultServiceRegistry {
         ).create();
     }
 
-    protected SoftwareComponentContainer createSoftwareComponentContainer(InstantiatorFactory instantiatorFactory, ServiceRegistry services, CollectionCallbackActionDecorator decorator) {
-        Instantiator instantiator = instantiatorFactory.decorate(services);
-        return instantiator.newInstance(DefaultSoftwareComponentContainer.class, instantiator, decorator);
+    protected SoftwareComponentContainer createSoftwareComponentContainer(Instantiator instantiator, InstantiatorFactory instantiatorFactory, ServiceRegistry services, CollectionCallbackActionDecorator decorator) {
+        Instantiator elementInstantiator = instantiatorFactory.decorate(services);
+        return elementInstantiator.newInstance(DefaultSoftwareComponentContainer.class, instantiator, elementInstantiator, decorator);
     }
 
     protected ProjectFinder createProjectFinder() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
@@ -20,8 +20,10 @@ import org.gradle.api.Action
 import org.gradle.api.AntBuilder
 import org.gradle.api.artifacts.dsl.ArtifactHandler
 import org.gradle.api.attributes.AttributesSchema
+import org.gradle.api.component.SoftwareComponentContainer
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.ConfigurableFileTree
+import org.gradle.api.initialization.ProjectDescriptor
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.file.FileOperations
 import org.gradle.api.internal.file.TestFiles
@@ -31,14 +33,17 @@ import org.gradle.api.internal.provider.DefaultPropertyFactory
 import org.gradle.api.internal.provider.PropertyHost
 import org.gradle.api.internal.tasks.TaskContainerInternal
 import org.gradle.api.model.ObjectFactory
-import org.gradle.groovy.scripts.ScriptSource
+import org.gradle.configuration.internal.ListenerBuildOperationDecorator
+import org.gradle.internal.Factory
 import org.gradle.internal.instantiation.InstantiatorFactory
 import org.gradle.internal.management.DependencyResolutionManagementInternal
-import org.gradle.internal.service.ServiceRegistry
+import org.gradle.internal.resource.DefaultTextFileResourceLoader
+import org.gradle.internal.service.DefaultServiceRegistry
 import org.gradle.internal.service.scopes.ServiceRegistryFactory
 import org.gradle.model.internal.registry.ModelRegistry
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.Path
+import org.gradle.util.TestUtil
 import org.gradle.util.UsesNativeServices
 import org.junit.Rule
 import spock.lang.Specification
@@ -75,27 +80,23 @@ class DefaultProjectSpec extends Specification {
     def "can configure ant tasks with an Action"() {
         given:
         def project = project('root', null, Stub(GradleInternal))
-        def antBuilder = Mock(AntBuilder)
-        project.ant >> antBuilder
 
         when:
         project.ant({ AntBuilder ant -> ant.importBuild('someAntBuild') } as Action<AntBuilder>)
 
         then:
-        1 * antBuilder.importBuild('someAntBuild')
+        1 * project.ant.importBuild('someAntBuild')
     }
 
     def "can configure artifacts with an Action"() {
         given:
         def project = project('root', null, Stub(GradleInternal))
-        def artifactHandler = Mock(ArtifactHandler)
-        project.artifacts >> artifactHandler
 
         when:
         project.artifacts({ artifacts -> artifacts.add('foo', 'bar') } as Action<ArtifactHandler>)
 
         then:
-        1 * artifactHandler.add('foo', 'bar')
+        1 * project.artifacts.add('foo', 'bar')
     }
 
     def "has useful toString and displayName and paths"() {
@@ -150,34 +151,54 @@ class DefaultProjectSpec extends Specification {
     }
 
     ProjectInternal project(String name, ProjectInternal parent, GradleInternal build) {
-        def serviceRegistryFactory = Stub(ServiceRegistryFactory)
-        def serviceRegistry = Stub(ServiceRegistry)
-
-        _ * serviceRegistryFactory.createFor(_) >> serviceRegistry
-        _ * serviceRegistry.get(TaskContainerInternal) >> Stub(TaskContainerInternal)
-        _ * serviceRegistry.get(InstantiatorFactory) >> Stub(InstantiatorFactory)
-        _ * serviceRegistry.get(AttributesSchema) >> Stub(AttributesSchema)
-        _ * serviceRegistry.get(ModelRegistry) >> Stub(ModelRegistry)
-        _ * serviceRegistry.get(CrossProjectModelAccess) >> Stub(CrossProjectModelAccess)
-        _ * serviceRegistry.get(DependencyResolutionManagementInternal) >> Stub(DependencyResolutionManagementInternal)
-        _ * serviceRegistry.get(DynamicLookupRoutine) >> Stub(DynamicLookupRoutine)
-
-        def fileOperations = Stub(FileOperations)
-        fileOperations.fileTree(_) >> TestFiles.fileOperations(tmpDir.testDirectory, new DefaultTemporaryFileProvider(() -> new File(tmpDir.testDirectory, "cache"))).fileTree('tree')
-        def projectDir = new File("project")
-        def objectFactory = Stub(ObjectFactory)
-        objectFactory.fileCollection() >> TestFiles.fileCollectionFactory().configurableFiles()
+        def fileOperations = Stub(FileOperations) {
+            fileTree(_) >> TestFiles.fileOperations(tmpDir.testDirectory, new DefaultTemporaryFileProvider(() -> new File(tmpDir.testDirectory, "cache"))).fileTree('tree')
+        }
         def propertyFactory = new DefaultPropertyFactory(Stub(PropertyHost))
-        objectFactory.property(Object) >> propertyFactory.property(Object)
+        def objectFactory = Stub(ObjectFactory) {
+            fileCollection() >> TestFiles.fileCollectionFactory().configurableFiles()
+            property(Object) >> propertyFactory.property(Object)
+        }
+
+        def serviceRegistry = new DefaultServiceRegistry()
+
+        serviceRegistry.add(FileOperations, fileOperations)
+        serviceRegistry.add(ObjectFactory, objectFactory)
+        serviceRegistry.add(TaskContainerInternal, Stub(TaskContainerInternal))
+        serviceRegistry.add(InstantiatorFactory, Stub(InstantiatorFactory))
+        serviceRegistry.add(AttributesSchema, Stub(AttributesSchema))
+        serviceRegistry.add(ModelRegistry, Stub(ModelRegistry))
+        serviceRegistry.add(CrossProjectModelAccess, Stub(CrossProjectModelAccess))
+        serviceRegistry.add(DependencyResolutionManagementInternal, Stub(DependencyResolutionManagementInternal))
+        serviceRegistry.add(DynamicLookupRoutine, new DefaultDynamicLookupRoutine())
+        serviceRegistry.add(SoftwareComponentContainer, Mock(SoftwareComponentContainer))
+        serviceRegistry.add(CrossProjectConfigurator, Mock(CrossProjectConfigurator))
+        serviceRegistry.add(ListenerBuildOperationDecorator, Mock(ListenerBuildOperationDecorator))
+        serviceRegistry.add(ArtifactHandler, Mock(ArtifactHandler))
+
+        def antBuilder = Mock(AntBuilder)
+        serviceRegistry.addProvider(new Object() {
+            Factory<AntBuilder> createAntBuilder() {
+                return () -> antBuilder
+            }
+        })
+
+        def serviceRegistryFactory = Stub(ServiceRegistryFactory) {
+            createFor(_) >> serviceRegistry
+        }
 
         def container = Mock(ProjectState)
         _ * container.projectPath >> (parent == null ? Path.ROOT : parent.projectPath.child(name))
         _ * container.identityPath >> (parent == null ? build.identityPath : build.identityPath.append(parent.projectPath).child(name))
 
-        return Spy(DefaultProject, constructorArgs: [name, parent, projectDir, new File("build file"), Stub(ScriptSource), build, container, serviceRegistryFactory, Stub(ClassLoaderScope), Stub(ClassLoaderScope)]) {
-            getFileOperations() >> fileOperations
-            getObjects() >> objectFactory
-            getCrossProjectModelAccess() >> Stub(CrossProjectModelAccess)
+        def descriptor = Mock(ProjectDescriptor) {
+            getName() >> name
+            getProjectDir() >> new File("project")
+            getBuildFile() >> new File("build file")
         }
+
+        def instantiator = TestUtil.instantiatorFactory().decorateLenient(serviceRegistry)
+        def factory = new ProjectFactory(instantiator, new DefaultTextFileResourceLoader(null))
+        return factory.createProject(build, descriptor, container, parent, serviceRegistryFactory, Stub(ClassLoaderScope), Stub(ClassLoaderScope))
     }
 }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/ProjectDelegate.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/ProjectDelegate.kt
@@ -239,6 +239,9 @@ abstract class ProjectDelegate : Project {
     override fun getComponents(): SoftwareComponentContainer =
         delegate.components
 
+    override fun components(configuration: Action<in SoftwareComponentContainer>) =
+        delegate.components(configuration)
+
     override fun setBuildDir(path: File) {
         delegate.buildDir = path
     }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/api/internal/tasks/JvmConstants.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/api/internal/tasks/JvmConstants.java
@@ -197,6 +197,11 @@ public final class JvmConstants {
      */
     public static final String TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME = "testRuntimeClasspath";
 
+    /**
+     * The name of the component added by the Java plugin.
+     */
+    public static final String JAVA_COMPONENT_NAME = "java";
+
     private JvmConstants() {
         // Private to prevent instantiation.
     }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/jvm/component/internal/DefaultJvmSoftwareComponentIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/jvm/component/internal/DefaultJvmSoftwareComponentIntegrationTest.groovy
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm.component.internal
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+/**
+ * Tests {@link DefaultJvmSoftwareComponent}.
+ */
+class DefaultJvmSoftwareComponentIntegrationTest extends AbstractIntegrationSpec {
+
+    def "cannot instantiate component instances without the java base plugin applied"() {
+        given:
+        buildFile << """
+            ${factoryRegistration()}
+
+            components {
+                comp(JvmSoftwareComponentInternal)
+            }
+        """
+
+        expect:
+        fails "help"
+        result.assertHasErrorOutput("The java-base plugin must be applied in order to create instances of DefaultJvmSoftwareComponent.")
+    }
+
+    def "can instantiate component instances with java-base plugin applied"() {
+        given:
+        buildFile << """
+            plugins {
+                id('java-base')
+            }
+
+            ${factoryRegistration()}
+
+            components {
+                thing(JvmSoftwareComponentInternal)
+                feature(JvmSoftwareComponentInternal)
+            }
+
+            task verify {
+                assert components.thing instanceof DefaultJvmSoftwareComponent
+                assert sourceSets.thing
+
+                assert components.feature instanceof DefaultJvmSoftwareComponent
+                assert sourceSets.feature
+            }
+        """
+
+        expect:
+        succeeds "verify"
+    }
+
+    def "can instantiate component instances adjacent to java component with java-library plugin applied"() {
+        given:
+        buildFile << """
+            plugins {
+                id('java-library')
+            }
+
+            ${factoryRegistration()}
+
+            components {
+                comp(JvmSoftwareComponentInternal)
+            }
+
+            task verify {
+                assert components.java instanceof DefaultJvmSoftwareComponent
+                assert sourceSets.main
+
+                assert components.comp instanceof DefaultJvmSoftwareComponent
+                assert sourceSets.comp
+            }
+        """
+
+        expect:
+        succeeds "verify"
+    }
+
+    private static final String factoryRegistration() {
+        """
+            import org.gradle.jvm.component.internal.JvmSoftwareComponentInternal
+            import org.gradle.jvm.component.internal.DefaultJvmSoftwareComponent
+
+            components {
+                registerFactory(JvmSoftwareComponentInternal) {
+                    objects.newInstance(DefaultJvmSoftwareComponent, it, it)
+                }
+            }
+        """
+    }
+}

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -245,7 +245,10 @@ public abstract class JavaPlugin implements Plugin<Project> {
         project.getPluginManager().apply("org.gradle.jvm-test-suite");
 
         // Create the 'java' component.
-        JvmSoftwareComponentInternal component = objectFactory.newInstance(DefaultJvmSoftwareComponent.class, "java", "main");
+        JvmSoftwareComponentInternal component = objectFactory.newInstance(
+            DefaultJvmSoftwareComponent.class,
+            JvmConstants.JAVA_COMPONENT_NAME, SourceSet.MAIN_SOURCE_SET_NAME
+        );
         project.getComponents().add(component);
 
         // Set the 'java' component as the project's default.

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -247,7 +247,7 @@ public abstract class JavaPlugin implements Plugin<Project> {
         JavaPluginExtension javaExtension = project.getExtensions().getByType(JavaPluginExtension.class);
 
         // Create the 'java' component.
-        JvmSoftwareComponentInternal component = objectFactory.newInstance(DefaultJvmSoftwareComponent.class, "java", javaExtension);
+        JvmSoftwareComponentInternal component = objectFactory.newInstance(DefaultJvmSoftwareComponent.class, "java", "main", javaExtension);
         project.getComponents().add(component);
 
         // Set the 'java' component as the project's default.

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -244,10 +244,8 @@ public abstract class JavaPlugin implements Plugin<Project> {
         project.getPluginManager().apply(JavaBasePlugin.class);
         project.getPluginManager().apply("org.gradle.jvm-test-suite");
 
-        JavaPluginExtension javaExtension = project.getExtensions().getByType(JavaPluginExtension.class);
-
         // Create the 'java' component.
-        JvmSoftwareComponentInternal component = objectFactory.newInstance(DefaultJvmSoftwareComponent.class, "java", "main", javaExtension);
+        JvmSoftwareComponentInternal component = objectFactory.newInstance(DefaultJvmSoftwareComponent.class, "java", "main");
         project.getComponents().add(component);
 
         // Set the 'java' component as the project's default.
@@ -255,6 +253,7 @@ public abstract class JavaPlugin implements Plugin<Project> {
         defaultConfiguration.extendsFrom(component.getRuntimeElementsConfiguration());
         ((SoftwareComponentContainerInternal) project.getComponents()).getMainComponent().convention(component);
 
+        JavaPluginExtension javaExtension = project.getExtensions().getByType(JavaPluginExtension.class);
         BuildOutputCleanupRegistry buildOutputCleanupRegistry = projectInternal.getServices().get(BuildOutputCleanupRegistry.class);
 
         configureBuiltInTest(project, component);

--- a/subprojects/plugins/src/main/java/org/gradle/jvm/component/internal/DefaultJvmSoftwareComponent.java
+++ b/subprojects/plugins/src/main/java/org/gradle/jvm/component/internal/DefaultJvmSoftwareComponent.java
@@ -32,7 +32,6 @@ import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.artifacts.dsl.LazyPublishArtifact;
 import org.gradle.api.internal.plugins.DefaultArtifactPublicationSet;
 import org.gradle.api.internal.project.ProjectInternal;
-import org.gradle.api.internal.tasks.JvmConstants;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.plugins.ExtensionContainer;
@@ -65,21 +64,16 @@ import javax.inject.Inject;
 
 import static org.gradle.api.attributes.DocsType.JAVADOC;
 import static org.gradle.api.attributes.DocsType.SOURCES;
-import static org.gradle.api.plugins.JavaPlugin.JAVADOC_ELEMENTS_CONFIGURATION_NAME;
-import static org.gradle.api.plugins.JavaPlugin.SOURCES_ELEMENTS_CONFIGURATION_NAME;
 
 /**
  * The software component created by the Java plugin. This component owns the consumable configurations which contribute to
- * this component's variants. Additionally, this component also owns the {@link SourceSet#MAIN_SOURCE_SET_NAME main} {@link SourceSet}
- * and transitively any domain objects which are created by the {@link BasePlugin} on the main source set's behalf. This includes the
- * source set's resolvable configurations and buckets, as well as any associated tasks.
- * <p>
- * This component was written assuming it will only be instantiated once, and therefore it hard-codes the names of the
- * domain objects it creates. However, future iterations of this component should allow it to be more generic.
+ * this component's variants. Additionally, this component also owns its base {@link SourceSet} and transitively any domain
+ * objects which are created by the {@link BasePlugin} on the source set's behalf. This includes the source set's resolvable
+ * configurations and buckets, as well as any associated tasks.
  */
 public class DefaultJvmSoftwareComponent extends DefaultAdhocSoftwareComponent implements JvmSoftwareComponentInternal {
 
-    private static final String SOURCE_ELEMENTS_VARIANT_NAME = "mainSourceElements";
+    private static final String SOURCE_ELEMENTS_VARIANT_NAME_SUFFIX = "SourceElements";
 
     private final Project project;
 
@@ -102,6 +96,7 @@ public class DefaultJvmSoftwareComponent extends DefaultAdhocSoftwareComponent i
     @Inject
     public DefaultJvmSoftwareComponent(
         String componentName,
+        String sourceSetName,
         JavaPluginExtension javaExtension,
         Project project,
         JvmPluginServices jvmPluginServices,
@@ -120,7 +115,7 @@ public class DefaultJvmSoftwareComponent extends DefaultAdhocSoftwareComponent i
         ExtensionContainer extensions = project.getExtensions();
 
         assert project.getPlugins().hasPlugin(JavaBasePlugin.class);
-        this.sourceSet = createMainSourceSet(javaExtension.getSourceSets());
+        this.sourceSet = createSourceSet(sourceSetName, javaExtension.getSourceSets());
 
         this.compileJava = tasks.named(sourceSet.getCompileJavaTaskName(), JavaCompile.class);
         this.jar = registerJarTask(tasks, sourceSet);
@@ -145,16 +140,16 @@ public class DefaultJvmSoftwareComponent extends DefaultAdhocSoftwareComponent i
         addVariantsFromConfiguration(runtimeElements, new JavaConfigurationVariantMapping("runtime", false));
     }
 
-    private SourceSet createMainSourceSet(SourceSetContainer sourceSets) {
-        if (sourceSets.findByName(SourceSet.MAIN_SOURCE_SET_NAME) != null) {
-            throw new GradleException("Cannot create multiple instances of " + this.getClass().getSimpleName() + ".");
+    private SourceSet createSourceSet(String name, SourceSetContainer sourceSets) {
+        if (sourceSets.findByName(name) != null) {
+            throw new GradleException("Cannot create multiple instances of " + this.getClass().getSimpleName() + " with source set name '" + name +"'.");
         }
 
-        return sourceSets.create(SourceSet.MAIN_SOURCE_SET_NAME);
+        return sourceSets.create(name);
     }
 
     private static TaskProvider<Jar> registerJarTask(TaskContainer tasks, SourceSet sourceSet) {
-        return tasks.register(JvmConstants.JAR_TASK_NAME, Jar.class, jar -> {
+        return tasks.register(sourceSet.getJarTaskName(), Jar.class, jar -> {
             jar.setDescription("Assembles a jar archive containing the main classes.");
             jar.setGroup(BasePlugin.BUILD_GROUP);
             jar.from(sourceSet.getOutput());
@@ -218,7 +213,14 @@ public class DefaultJvmSoftwareComponent extends DefaultAdhocSoftwareComponent i
     }
 
     private Configuration createSourceElements(ConfigurationContainer configurations, ProviderFactory providerFactory, ObjectFactory objectFactory, SourceSet sourceSet) {
-        Configuration variant = configurations.create(SOURCE_ELEMENTS_VARIANT_NAME);
+
+        // TODO: Why are we using this non-standard name? For the `java` component, this
+        // equates to `mainSourceElements` instead of `sourceElements` as one would expect.
+        // Can we change this name without breaking compatibility? Is the variant name part
+        // of the component's API?
+        String variantName = sourceSet.getName() + SOURCE_ELEMENTS_VARIANT_NAME_SUFFIX;
+
+        Configuration variant = configurations.create(variantName);
         variant.setDescription("List of source directories contained in the Main SourceSet.");
         variant.setVisible(false);
         variant.setCanBeResolved(false);
@@ -259,11 +261,11 @@ public class DefaultJvmSoftwareComponent extends DefaultAdhocSoftwareComponent i
 
     @Override
     public void enableJavadocJarVariant() {
-        if (project.getConfigurations().findByName(JAVADOC_ELEMENTS_CONFIGURATION_NAME) != null) {
+        if (project.getConfigurations().findByName(sourceSet.getJavadocElementsConfigurationName()) != null) {
             return;
         }
         Configuration javadocVariant = JvmPluginsHelper.createDocumentationVariantWithArtifact(
-            JAVADOC_ELEMENTS_CONFIGURATION_NAME,
+            sourceSet.getJavadocElementsConfigurationName(),
             null,
             JAVADOC,
             ImmutableList.of(),
@@ -276,11 +278,11 @@ public class DefaultJvmSoftwareComponent extends DefaultAdhocSoftwareComponent i
 
     @Override
     public void enableSourcesJarVariant() {
-        if (project.getConfigurations().findByName(SOURCES_ELEMENTS_CONFIGURATION_NAME) != null) {
+        if (project.getConfigurations().findByName(sourceSet.getSourcesElementsConfigurationName()) != null) {
             return;
         }
         Configuration sourcesVariant = JvmPluginsHelper.createDocumentationVariantWithArtifact(
-            SOURCES_ELEMENTS_CONFIGURATION_NAME,
+            sourceSet.getSourcesElementsConfigurationName(),
             null,
             SOURCES,
             ImmutableList.of(),

--- a/subprojects/plugins/src/test/groovy/org/gradle/jvm/component/internal/DefaultJvmSoftwareComponentTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/jvm/component/internal/DefaultJvmSoftwareComponentTest.groovy
@@ -56,7 +56,7 @@ class DefaultJvmSoftwareComponentTest extends AbstractProjectBuilderSpec {
         project.tasks.findByName(JvmConstants.PROCESS_RESOURCES_TASK_NAME) == null
 
         when:
-        def component = project.objects.newInstance(DefaultJvmSoftwareComponent, "name", "main", ext)
+        def component = project.objects.newInstance(DefaultJvmSoftwareComponent, "name", "main")
 
         then:
         component.sourceSet == ext.sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME)
@@ -100,7 +100,7 @@ class DefaultJvmSoftwareComponentTest extends AbstractProjectBuilderSpec {
         project.tasks.findByName('processFeatureResources') == null
 
         when:
-        def component = project.objects.newInstance(DefaultJvmSoftwareComponent, "name", "feature", ext)
+        def component = project.objects.newInstance(DefaultJvmSoftwareComponent, "name", "feature")
 
         then:
         component.sourceSet == ext.sourceSets.getByName('feature')
@@ -126,9 +126,9 @@ class DefaultJvmSoftwareComponentTest extends AbstractProjectBuilderSpec {
         def ext = project.getExtensions().getByType(JavaPluginExtension.class)
 
         when:
-        project.objects.newInstance(DefaultJvmSoftwareComponent, "name", "main", ext)
-        project.objects.newInstance(DefaultJvmSoftwareComponent, "name", "feature1", ext)
-        project.objects.newInstance(DefaultJvmSoftwareComponent, "name", "feature2", ext)
+        project.objects.newInstance(DefaultJvmSoftwareComponent, "name", "main")
+        project.objects.newInstance(DefaultJvmSoftwareComponent, "name", "feature1")
+        project.objects.newInstance(DefaultJvmSoftwareComponent, "name", "feature2")
 
         then:
         ext.sourceSets.getByName('main')
@@ -142,12 +142,12 @@ class DefaultJvmSoftwareComponentTest extends AbstractProjectBuilderSpec {
         def ext = project.getExtensions().getByType(JavaPluginExtension.class)
 
         when:
-        project.objects.newInstance(DefaultJvmSoftwareComponent, "name1", "feature", ext)
-        project.objects.newInstance(DefaultJvmSoftwareComponent, "name2", "feature", ext)
+        project.objects.newInstance(DefaultJvmSoftwareComponent, "name1", "feature")
+        project.objects.newInstance(DefaultJvmSoftwareComponent, "name2", "feature")
 
         then:
         def e = thrown(ObjectInstantiationException)
-        e.cause.message == "Cannot create multiple instances of DefaultJvmSoftwareComponent_Decorated with source set name 'feature'."
+        e.cause.message == "Cannot create multiple instances of DefaultJvmSoftwareComponent with source set name 'feature'."
     }
 
     def "can configure javadoc jar variant"() {
@@ -162,7 +162,7 @@ class DefaultJvmSoftwareComponentTest extends AbstractProjectBuilderSpec {
         project.tasks.findByName("javadoc") == null
 
         when:
-        def component = project.objects.newInstance(DefaultJvmSoftwareComponent, "name", "main", ext)
+        def component = project.objects.newInstance(DefaultJvmSoftwareComponent, "name", "main")
         component.enableJavadocJarVariant()
 
         then:
@@ -191,7 +191,7 @@ class DefaultJvmSoftwareComponentTest extends AbstractProjectBuilderSpec {
         project.tasks.findByName("sources") == null
 
         when:
-        def component = project.objects.newInstance(DefaultJvmSoftwareComponent, "name", "main", ext)
+        def component = project.objects.newInstance(DefaultJvmSoftwareComponent, "name", "main")
         component.enableSourcesJarVariant()
 
         then:
@@ -212,7 +212,7 @@ class DefaultJvmSoftwareComponentTest extends AbstractProjectBuilderSpec {
         when:
         project.plugins.apply(JavaBasePlugin)
         def ext = project.getExtensions().getByType(JavaPluginExtension.class)
-        def component = project.objects.newInstance(DefaultJvmSoftwareComponent, "name", "main", ext)
+        def component = project.objects.newInstance(DefaultJvmSoftwareComponent, "name", "main")
 
         then:
         component.usages*.name == ["apiElements", "runtimeElements"]

--- a/subprojects/plugins/src/test/groovy/org/gradle/jvm/component/internal/DefaultJvmSoftwareComponentTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/jvm/component/internal/DefaultJvmSoftwareComponentTest.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.attributes.Usage
 import org.gradle.api.internal.tasks.JvmConstants
 import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.reflect.ObjectInstantiationException
 import org.gradle.api.tasks.SourceSet
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 
@@ -31,7 +32,7 @@ import org.gradle.test.fixtures.AbstractProjectBuilderSpec
  */
 class DefaultJvmSoftwareComponentTest extends AbstractProjectBuilderSpec {
 
-    def "configures the project"() {
+    def "configures the project when using the main source set"() {
         when:
         project.plugins.apply(JavaBasePlugin)
         def ext = project.getExtensions().getByType(JavaPluginExtension.class)
@@ -41,8 +42,8 @@ class DefaultJvmSoftwareComponentTest extends AbstractProjectBuilderSpec {
         then:
         ext.sourceSets.findByName(SourceSet.MAIN_SOURCE_SET_NAME) == null
         project.configurations.findByName(JvmConstants.RUNTIME_CLASSPATH_CONFIGURATION_NAME) == null
-        project.configurations.findByName(JvmConstants.RUNTIME_ELEMENTS_CONFIGURATION_NAME) == null
         project.configurations.findByName(JvmConstants.COMPILE_CLASSPATH_CONFIGURATION_NAME) == null
+        project.configurations.findByName(JvmConstants.RUNTIME_ELEMENTS_CONFIGURATION_NAME) == null
         project.configurations.findByName(JvmConstants.API_ELEMENTS_CONFIGURATION_NAME) == null
         project.configurations.findByName('mainSourceElements') == null
         project.configurations.findByName(JvmConstants.IMPLEMENTATION_CONFIGURATION_NAME) == null
@@ -55,7 +56,7 @@ class DefaultJvmSoftwareComponentTest extends AbstractProjectBuilderSpec {
         project.tasks.findByName(JvmConstants.PROCESS_RESOURCES_TASK_NAME) == null
 
         when:
-        def component = project.objects.newInstance(DefaultJvmSoftwareComponent, "name", ext)
+        def component = project.objects.newInstance(DefaultJvmSoftwareComponent, "name", "main", ext)
 
         then:
         component.sourceSet == ext.sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME)
@@ -75,6 +76,80 @@ class DefaultJvmSoftwareComponentTest extends AbstractProjectBuilderSpec {
         project.tasks.getByName(JvmConstants.PROCESS_RESOURCES_TASK_NAME)
     }
 
+    def "configures the project when using the non-main source set"() {
+        when:
+        project.plugins.apply(JavaBasePlugin)
+        def ext = project.getExtensions().getByType(JavaPluginExtension.class)
+
+        // Verify the JavaBasePlugin does not create the below tested objects so we can
+        // ensure the DefaultJvmSoftwareComponent is actually creating these domain objects.
+        then:
+        ext.sourceSets.findByName("feature") == null
+        project.configurations.findByName('featureRuntimeClasspath') == null
+        project.configurations.findByName('featureCompileClasspath') == null
+        project.configurations.findByName('featureRuntimeElements') == null
+        project.configurations.findByName('featureApiElements') == null
+        project.configurations.findByName('featureSourceElements') == null
+        project.configurations.findByName('featureImplementation') == null
+        project.configurations.findByName('featureRuntimeOnly') == null
+        project.configurations.findByName('featureCompileOnly') == null
+        project.configurations.findByName('featureAnnotationProcessor') == null
+        project.tasks.findByName('compileFeatureJava') == null
+        project.tasks.findByName('featureJar') == null
+        project.tasks.findByName('featureJavadoc') == null
+        project.tasks.findByName('processFeatureResources') == null
+
+        when:
+        def component = project.objects.newInstance(DefaultJvmSoftwareComponent, "name", "feature", ext)
+
+        then:
+        component.sourceSet == ext.sourceSets.getByName('feature')
+        component.mainOutput == component.getSourceSet().getOutput()
+        component.runtimeClasspathConfiguration == project.configurations.getByName('featureRuntimeClasspath')
+        component.compileClasspathConfiguration == project.configurations.getByName('featureCompileClasspath')
+        component.runtimeElementsConfiguration == project.configurations.getByName('featureRuntimeElements')
+        component.apiElementsConfiguration == project.configurations.getByName('featureApiElements')
+        project.configurations.getByName('featureSourceElements')
+        component.implementationConfiguration == project.configurations.getByName('featureImplementation')
+        component.runtimeOnlyConfiguration == project.configurations.getByName('featureRuntimeOnly')
+        component.compileOnlyConfiguration == project.configurations.getByName('featureCompileOnly')
+        project.configurations.getByName('featureAnnotationProcessor')
+        component.mainCompileJavaTask.get() == project.tasks.getByName('compileFeatureJava')
+        component.mainJarTask.get() == project.tasks.getByName('featureJar')
+        project.tasks.getByName('featureJavadoc')
+        project.tasks.getByName('processFeatureResources')
+    }
+
+    def "can create multiple component instances"() {
+        given:
+        project.plugins.apply(JavaBasePlugin)
+        def ext = project.getExtensions().getByType(JavaPluginExtension.class)
+
+        when:
+        project.objects.newInstance(DefaultJvmSoftwareComponent, "name", "main", ext)
+        project.objects.newInstance(DefaultJvmSoftwareComponent, "name", "feature1", ext)
+        project.objects.newInstance(DefaultJvmSoftwareComponent, "name", "feature2", ext)
+
+        then:
+        ext.sourceSets.getByName('main')
+        ext.sourceSets.getByName('feature1')
+        ext.sourceSets.getByName('feature2')
+    }
+
+    def "cannot create multiple component instances with the same source set name"() {
+        given:
+        project.plugins.apply(JavaBasePlugin)
+        def ext = project.getExtensions().getByType(JavaPluginExtension.class)
+
+        when:
+        project.objects.newInstance(DefaultJvmSoftwareComponent, "name1", "feature", ext)
+        project.objects.newInstance(DefaultJvmSoftwareComponent, "name2", "feature", ext)
+
+        then:
+        def e = thrown(ObjectInstantiationException)
+        e.cause.message == "Cannot create multiple instances of DefaultJvmSoftwareComponent_Decorated with source set name 'feature'."
+    }
+
     def "can configure javadoc jar variant"() {
         when:
         project.plugins.apply(JavaBasePlugin)
@@ -87,7 +162,7 @@ class DefaultJvmSoftwareComponentTest extends AbstractProjectBuilderSpec {
         project.tasks.findByName("javadoc") == null
 
         when:
-        def component = project.objects.newInstance(DefaultJvmSoftwareComponent, "name", ext)
+        def component = project.objects.newInstance(DefaultJvmSoftwareComponent, "name", "main", ext)
         component.enableJavadocJarVariant()
 
         then:
@@ -116,7 +191,7 @@ class DefaultJvmSoftwareComponentTest extends AbstractProjectBuilderSpec {
         project.tasks.findByName("sources") == null
 
         when:
-        def component = project.objects.newInstance(DefaultJvmSoftwareComponent, "name", ext)
+        def component = project.objects.newInstance(DefaultJvmSoftwareComponent, "name", "main", ext)
         component.enableSourcesJarVariant()
 
         then:
@@ -133,11 +208,11 @@ class DefaultJvmSoftwareComponentTest extends AbstractProjectBuilderSpec {
         component.usages.find { it.name == JvmConstants.SOURCES_ELEMENTS_CONFIGURATION_NAME}
     }
 
-    def "has expected variants "() {
+    def "has expected variants"() {
         when:
         project.plugins.apply(JavaBasePlugin)
         def ext = project.getExtensions().getByType(JavaPluginExtension.class)
-        def component = project.objects.newInstance(DefaultJvmSoftwareComponent, "name", ext)
+        def component = project.objects.newInstance(DefaultJvmSoftwareComponent, "name", "main", ext)
 
         then:
         component.usages*.name == ["apiElements", "runtimeElements"]


### PR DESCRIPTION
Updates DefaultSoftwareComponentContainer to be an extensible polymorphic container.
This will allow our internal plugins and external plugins to register component implementations
so that the component container may instantiate component instances on behalf of the user.

In addition, this PR updates the DefaultJvmSoftwareComponent to be multi-instance aware so that
once the type is made public, users will be able to use the now-extensible software component
container to create arbitrary instances of the default JVM software component

- [x] Add kotlin DSL tests