### PR TITLE
Initialize build cache controller only once

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/caching/internal/BuildCacheServices.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/BuildCacheServices.java
@@ -58,6 +58,8 @@ import org.gradle.internal.service.scopes.AbstractPluginServiceRegistry;
 import org.gradle.internal.vfs.FileSystemAccess;
 import org.gradle.util.GradleVersion;
 import org.gradle.util.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.List;
@@ -66,6 +68,7 @@ import java.util.List;
  * Build scoped services for build cache usage.
  */
 public final class BuildCacheServices extends AbstractPluginServiceRegistry {
+    private static final Logger LOGGER = LoggerFactory.getLogger(BuildCacheServices.class);
 
     @Override
     public void registerBuildTreeServices(ServiceRegistration registration) {
@@ -151,9 +154,11 @@ public final class BuildCacheServices extends AbstractPluginServiceRegistry {
                 StringInterner stringInterner
             ) {
                 if (isRoot(gradle) || isGradleBuildTaskRoot(rootControllerRef)) {
+                    LOGGER.warn("[MASTER] Creating build cache controller");
                     return doCreateBuildCacheController(serviceRegistry, buildCacheConfiguration, buildOperationExecutor, instantiatorFactory, gradle, temporaryFileProvider, fileSystemAccess, packer, originMetadataFactory, stringInterner);
                 } else {
                     // must be an included build or buildSrc
+                    LOGGER.warn("[MASTER] Reusing root build cache controller in non-root build");
                     return rootControllerRef.getForNonRootBuild();
                 }
             }


### PR DESCRIPTION
We have some code that seemingly ensures that composite builds use a singleton `BuildCacheController` bound to the root build. See comment here:

https://github.com/gradle/gradle/blob/142cb66aae5e7a6b45d6c6b9fafc1b5e51dc8956/subprojects/core/src/main/java/org/gradle/initialization/RootBuildCacheControllerSettingsProcessor.java#L27-L36

We are supposed to reuse it from here:

https://github.com/gradle/gradle/blob/90bda21f9f6f6420e9dab041cd48a6cf0e4f12b3/subprojects/core/src/main/java/org/gradle/caching/internal/BuildCacheServices.java#L153-L158

However, it seems that we end up creating many controllers instead, supposedly because the `RootBuildCacheControllerSettingsProcessor` is triggered later than the code to create the controllers themselves.