### PR TITLE
Request max heap memory when starting worker process

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/worker/DefaultWorkerProcessBuilderIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/worker/DefaultWorkerProcessBuilderIntegrationTest.groovy
@@ -19,7 +19,7 @@ package org.gradle.process.internal.worker
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 
-class DefaultWorkerProcessBuilderTest extends AbstractIntegrationSpec {
+class DefaultWorkerProcessBuilderIntegrationTest extends AbstractIntegrationSpec {
 
     def "test classpath does not contain nonexistent entries"() {
         given:

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/DefaultWorkerProcessBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/DefaultWorkerProcessBuilder.java
@@ -240,7 +240,7 @@ public class DefaultWorkerProcessBuilder implements WorkerProcessBuilder {
 
         workerProcess.setExecHandle(execHandle);
 
-        return new MemoryRequestingWorkerProcess(workerProcess, memoryManager, MemoryAmount.parseNotation(javaCommand.getMinHeapSize()));
+        return new MemoryRequestingWorkerProcess(workerProcess, memoryManager, MemoryAmount.parseNotation(javaCommand.getMaxHeapSize()));
     }
 
     private static class MemoryRequestingWorkerProcess implements WorkerProcess {


### PR DESCRIPTION
Previously, we requested min heap memory when starting a worker process.  In the event that this was much different than max heap, then once the process grew to full size, we'd rely on reactive physical memory monitoring to shut down worker daemons which might not be aggressive enough.  Using max heap causes the memory management to be more aggressive and free up the maximum memory before starting the process.

Fixes #22977 