### PR TITLE
Reduce OutputEventRenderer.onOutput() locking by refine lock granularity

### DIFF
--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/OutputEventRenderer.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/OutputEventRenderer.java
@@ -66,7 +66,7 @@ public class OutputEventRenderer implements OutputEventListener, LoggingRouter {
     private final AtomicReference<LogLevel> logLevel = new AtomicReference<LogLevel>(LogLevel.LIFECYCLE);
     private final Clock clock;
     private final ListenerBroadcast<OutputEventListener> formatters = new ListenerBroadcast<OutputEventListener>(OutputEventListener.class);
-    private final OutputEventTransformer transformer = new OutputEventTransformer(formatters.getSource());
+    private final OutputEventTransformer transformer = new OutputEventTransformer(formatters.getSource(), lock);
 
     private ColorMap colourMap;
     private OutputStream originalStdOut;
@@ -427,9 +427,7 @@ public class OutputEventRenderer implements OutputEventListener, LoggingRouter {
             }
             this.logLevel.set(newLogLevel);
         }
-        synchronized (lock) {
-            transformer.onOutput(event);
-        }
+        transformer.onOutput(event);
     }
 
     private boolean isProgressEvent(OutputEvent event) {


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Resolves: #23919 

<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
I try to reduce locking by refine lock granularity：
- Remove OutputEventRenderer.lock invoked by onOutput()
- Add synchronization logics to OutputEventTransformer class. 

Lock waiting counts reduced from 50,0000 to 3k, and it can save about 4s - 6s.