### PR TITLE
Avoid convention mapping in Java application plugin

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ kotlin.js.ir.output.granularity=whole-program
 systemProp.org.gradle.internal.ide.scan=true
 
 # If you're experimenting with changes and don't want to update the verification file right away, please change the mode to "lenient" (not "off")
-org.gradle.dependency.verification=off
+org.gradle.dependency.verification=strict
 
 # TD releated properties
 gradle.internal.testdistribution.writeTraceFile=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ kotlin.js.ir.output.granularity=whole-program
 systemProp.org.gradle.internal.ide.scan=true
 
 # If you're experimenting with changes and don't want to update the verification file right away, please change the mode to "lenient" (not "off")
-org.gradle.dependency.verification=strict
+org.gradle.dependency.verification=off
 
 # TD releated properties
 gradle.internal.testdistribution.writeTraceFile=true

--- a/subprojects/core-api/src/main/java/org/gradle/process/JavaExecSpec.java
+++ b/subprojects/core-api/src/main/java/org/gradle/process/JavaExecSpec.java
@@ -23,6 +23,7 @@ import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
 import org.gradle.internal.deprecation.DeprecationLogger;
@@ -38,11 +39,13 @@ public interface JavaExecSpec extends JavaForkOptions, BaseExecSpec {
     /**
      * Extra JVM arguments to be to use to launch the JVM for the process.
      *
+     * Must be used to set a convention for JVM arguments.
+     *
      * @since 8.1
      */
     @Incubating
     @Optional
-    @Input
+    @Internal
     ListProperty<String> getJvmArguments();
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/process/JavaExecSpec.java
+++ b/subprojects/core-api/src/main/java/org/gradle/process/JavaExecSpec.java
@@ -15,9 +15,11 @@
  */
 package org.gradle.process;
 
+import org.gradle.api.Incubating;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.jvm.ModularitySpec;
 import org.gradle.api.model.ReplacedBy;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
@@ -32,6 +34,16 @@ import java.util.List;
  * Specifies the options for executing a Java application.
  */
 public interface JavaExecSpec extends JavaForkOptions, BaseExecSpec {
+
+    /**
+     * Extra JVM arguments to be to use to launch the JVM for the process.
+     *
+     * @since 8.1
+     */
+    @Incubating
+    @Optional
+    @Input
+    ListProperty<String> getJvmArguments();
 
     /**
      * The name of the main module to be executed if the application should run as a Java module.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/model/InstantiatorBackedObjectFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/model/InstantiatorBackedObjectFactory.java
@@ -27,6 +27,7 @@ import org.gradle.api.file.ConfigurableFileTree;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.file.SourceDirectorySet;
+import org.gradle.api.internal.provider.DefaultListProperty;
 import org.gradle.api.internal.provider.DefaultProperty;
 import org.gradle.api.internal.provider.PropertyHost;
 import org.gradle.api.model.ObjectFactory;
@@ -101,7 +102,7 @@ public class InstantiatorBackedObjectFactory implements ObjectFactory {
 
     @Override
     public <T> ListProperty<T> listProperty(Class<T> elementType) {
-        return broken();
+        return new DefaultListProperty<>(PropertyHost.NO_OP, elementType);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaExecSpec.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaExecSpec.java
@@ -21,6 +21,7 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.jvm.ModularitySpec;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.internal.jvm.DefaultModularitySpec;
@@ -45,6 +46,7 @@ public class DefaultJavaExecSpec extends DefaultJavaForkOptions implements JavaE
     private final Property<String> mainClass;
     private final Property<String> mainModule;
     private final ModularitySpec modularity;
+    private final ListProperty<String> jvmArguments;
 
     private final FileCollectionFactory fileCollectionFactory;
     private ConfigurableFileCollection classpath;
@@ -56,6 +58,7 @@ public class DefaultJavaExecSpec extends DefaultJavaForkOptions implements JavaE
         FileCollectionFactory fileCollectionFactory
     ) {
         super(resolver, fileCollectionFactory, objectFactory.newInstance(DefaultJavaDebugOptions.class));
+        this.jvmArguments = objectFactory.listProperty(String.class);
         this.mainClass = objectFactory.property(String.class);
         this.mainModule = objectFactory.property(String.class);
         this.modularity = objectFactory.newInstance(DefaultModularitySpec.class);
@@ -177,6 +180,11 @@ public class DefaultJavaExecSpec extends DefaultJavaForkOptions implements JavaE
     public JavaExecSpec setErrorOutput(OutputStream errorOutput) {
         streamsSpec.setErrorOutput(errorOutput);
         return this;
+    }
+
+    @Override
+    public ListProperty<String> getJvmArguments() {
+        return jvmArguments;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/process/internal/JavaExecHandleBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/JavaExecHandleBuilder.java
@@ -25,6 +25,7 @@ import org.gradle.api.jvm.ModularitySpec;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.initialization.BuildCancellationToken;
 import org.gradle.internal.jvm.DefaultModularitySpec;
@@ -63,6 +64,7 @@ public class JavaExecHandleBuilder extends AbstractExecHandleBuilder implements 
     private final JavaModuleDetector javaModuleDetector;
     private final Property<String> mainModule;
     private final Property<String> mainClass;
+    private final ListProperty<String> jvmArguments;
     private ConfigurableFileCollection classpath;
     private final JavaForkOptions javaOptions;
     private final ProcessArgumentsSpec applicationArgsSpec = new ProcessArgumentsSpec(this);
@@ -85,6 +87,7 @@ public class JavaExecHandleBuilder extends AbstractExecHandleBuilder implements 
         this.classpath = fileCollectionFactory.configurableFiles("classpath");
         this.mainModule = objectFactory.property(String.class);
         this.mainClass = objectFactory.property(String.class);
+        this.jvmArguments = objectFactory.listProperty(String.class);
         this.javaOptions = javaOptions;
         this.modularity = new DefaultModularitySpec(objectFactory);
         executable(javaOptions.getExecutable());
@@ -183,6 +186,11 @@ public class JavaExecHandleBuilder extends AbstractExecHandleBuilder implements 
     public JavaExecHandleBuilder jvmArgs(Object... arguments) {
         javaOptions.jvmArgs(arguments);
         return this;
+    }
+
+    @Override
+    public ListProperty<String> getJvmArguments() {
+        return jvmArguments;
     }
 
     @Override

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.JavaExec.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.JavaExec.xml
@@ -17,6 +17,10 @@
                 <td><literal>[]</literal></td>
             </tr>
             <tr>
+                <td>jvmArguments</td>
+                <td><literal>null</literal></td>
+            </tr>
+            <tr>
                 <td>jvmArgumentProviders</td>
                 <td><literal>[]</literal></td>
             </tr>

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ApplicationIntegrationSpec.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ApplicationIntegrationSpec.groovy
@@ -192,7 +192,6 @@ class Main {
     }
 
     @Issue("https://github.com/gradle/gradle/issues/21505")
-    @ToBeFixedForConfigurationCache(because = "applicationDefaultJvmArgs")
     def canUseDefaultJvmArgsInRunTask() {
         file("build.gradle") << '''
         applicationDefaultJvmArgs = ['-Dvar1=value1', '-Dvar2=value2']

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ApplicationIntegrationSpec.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ApplicationIntegrationSpec.groovy
@@ -22,7 +22,6 @@ import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.test.fixtures.file.TestFile
 import spock.lang.IgnoreIf
-import spock.lang.Issue
 
 import static org.hamcrest.CoreMatchers.startsWith
 
@@ -188,30 +187,6 @@ class Main {
         then:
         def result = builder.run()
         result.assertNormalExitValue()
-    }
-
-    @Issue("https://github.com/gradle/gradle/issues/21505")
-    def canUseDefaultJvmArgsInRunTask() {
-        file("build.gradle") << '''
-        applicationDefaultJvmArgs = ['-Dvar1=value1', '-Dvar2=value2']
-        '''
-        file('src/main/java/org/gradle/test/Main.java') << '''
-        package org.gradle.test;
-
-        class Main {
-            public static void main(String[] args) {
-                if (!"value1".equals(System.getProperty("var1"))) {
-                    throw new RuntimeException("Expected system property not specified (var1)");
-                }
-                if (!"value2".equals(System.getProperty("var2"))) {
-                    throw new RuntimeException("Expected system property not specified (var2)");
-                }
-            }
-        }
-        '''
-
-        expect:
-        run 'run'
     }
 
     def "can customize application name"() {

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ApplicationIntegrationSpec.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ApplicationIntegrationSpec.groovy
@@ -17,7 +17,6 @@ package org.gradle.integtests
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ScriptExecuter
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.archives.TestReproducibleArchives
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.internal.os.OperatingSystem

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/JavaExec.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/JavaExec.java
@@ -18,7 +18,6 @@ package org.gradle.api.tasks;
 
 import org.apache.tools.ant.types.Commandline;
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.ConventionTask;
@@ -160,8 +159,8 @@ public abstract class JavaExec extends ConventionTask implements JavaExecSpec {
         File toolchainExecutable = getJavaLauncher().get().getExecutablePath().getAsFile();
         String customExecutable = getExecutable();
         JavaExecutableUtils.validateExecutable(
-                customExecutable, "Toolchain from `executable` property",
-                toolchainExecutable, "toolchain from `javaLauncher` property");
+            customExecutable, "Toolchain from `executable` property",
+            toolchainExecutable, "toolchain from `javaLauncher` property");
     }
 
     /**
@@ -744,13 +743,9 @@ public abstract class JavaExec extends ConventionTask implements JavaExecSpec {
     }
 
     /**
-     * Returns the list of configured extra JVM arguments.
-     *
-     * @return A property of extra JVM arguments.
-     * @since 8.1
+     * {@inheritDoc}
      */
-    @Input
-    @Incubating
+    @Override
     public ListProperty<String> getJvmArguments() {
         return jvmArguments;
     }

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/JavaExec.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/JavaExec.java
@@ -149,7 +149,11 @@ public abstract class JavaExec extends ConventionTask implements JavaExecSpec {
     public void exec() {
         validateExecutableMatchesToolchain();
 
-        javaExecSpec.setJvmArgs(jvmArguments.get());
+        List<String> jvmArgs = jvmArguments.getOrNull();
+        if (jvmArgs != null) {
+            javaExecSpec.setJvmArgs(jvmArgs);
+        }
+
         JavaExecAction javaExecAction = getExecActionFactory().newJavaExecAction();
         javaExecSpec.copyTo(javaExecAction);
         String effectiveExecutable = getJavaLauncher().get().getExecutablePath().toString();
@@ -222,10 +226,8 @@ public abstract class JavaExec extends ConventionTask implements JavaExecSpec {
      */
     @Override
     public JavaExec jvmArgs(Iterable<?> arguments) {
-        jvmArguments.empty();
         for (Object arg : arguments) {
             jvmArguments.add(arg.toString());
-
         }
         return this;
     }
@@ -235,10 +237,8 @@ public abstract class JavaExec extends ConventionTask implements JavaExecSpec {
      */
     @Override
     public JavaExec jvmArgs(Object... arguments) {
-        jvmArguments.empty();
         for (Object arg : arguments) {
             jvmArguments.add(arg.toString());
-
         }
         return this;
     }

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/JavaExec.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/JavaExec.java
@@ -127,9 +127,11 @@ public abstract class JavaExec extends ConventionTask implements JavaExecSpec {
         mainClass = objectFactory.property(String.class);
         modularity = objectFactory.newInstance(DefaultModularitySpec.class);
         execResult = objectFactory.property(ExecResult.class);
-        jvmArguments = objectFactory.listProperty(String.class);
-
         javaExecSpec = objectFactory.newInstance(DefaultJavaExecSpec.class);
+        Provider<Iterable<String>> jvmArgumentsConvention = getProviderFactory()
+            .provider(() -> getConventionMapping().getConventionValue(null, "jvmArgs", false));
+        jvmArguments = objectFactory.listProperty(String.class).convention(jvmArgumentsConvention);
+
         javaExecSpec.getMainClass().convention(mainClass);
         javaExecSpec.getMainModule().convention(mainModule);
         javaExecSpec.getModularity().getInferModulePath().convention(modularity.getInferModulePath());
@@ -146,6 +148,7 @@ public abstract class JavaExec extends ConventionTask implements JavaExecSpec {
     @TaskAction
     public void exec() {
         validateExecutableMatchesToolchain();
+
         javaExecSpec.setJvmArgs(jvmArguments.get());
         JavaExecAction javaExecAction = getExecActionFactory().newJavaExecAction();
         javaExecSpec.copyTo(javaExecAction);

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/JavaExec.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/JavaExec.java
@@ -18,11 +18,13 @@ package org.gradle.api.tasks;
 
 import org.apache.tools.ant.types.Commandline;
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.ConventionTask;
 import org.gradle.api.jvm.ModularitySpec;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
@@ -111,12 +113,14 @@ import java.util.Map;
  */
 @DisableCachingByDefault(because = "Gradle would require more information to cache this task")
 public abstract class JavaExec extends ConventionTask implements JavaExecSpec {
+
     private final DefaultJavaExecSpec javaExecSpec;
     private final Property<String> mainModule;
     private final Property<String> mainClass;
     private final ModularitySpec modularity;
     private final Property<ExecResult> execResult;
     private final Property<JavaLauncher> javaLauncher;
+    private final ListProperty<String> jvmArguments;
 
     public JavaExec() {
         ObjectFactory objectFactory = getObjectFactory();
@@ -124,6 +128,7 @@ public abstract class JavaExec extends ConventionTask implements JavaExecSpec {
         mainClass = objectFactory.property(String.class);
         modularity = objectFactory.newInstance(DefaultModularitySpec.class);
         execResult = objectFactory.property(ExecResult.class);
+        jvmArguments = objectFactory.listProperty(String.class);
 
         javaExecSpec = objectFactory.newInstance(DefaultJavaExecSpec.class);
         javaExecSpec.getMainClass().convention(mainClass);
@@ -142,7 +147,7 @@ public abstract class JavaExec extends ConventionTask implements JavaExecSpec {
     @TaskAction
     public void exec() {
         validateExecutableMatchesToolchain();
-        setJvmArgs(getJvmArgs()); // convention mapping for 'jvmArgs'
+        javaExecSpec.setJvmArgs(jvmArguments.get());
         JavaExecAction javaExecAction = getExecActionFactory().newJavaExecAction();
         javaExecSpec.copyTo(javaExecAction);
         String effectiveExecutable = getJavaLauncher().get().getExecutablePath().toString();
@@ -188,7 +193,7 @@ public abstract class JavaExec extends ConventionTask implements JavaExecSpec {
      */
     @Override
     public List<String> getJvmArgs() {
-        return javaExecSpec.getJvmArgs();
+        return jvmArguments.getOrNull();
     }
 
     /**
@@ -196,7 +201,7 @@ public abstract class JavaExec extends ConventionTask implements JavaExecSpec {
      */
     @Override
     public void setJvmArgs(List<String> arguments) {
-        javaExecSpec.setJvmArgs(arguments);
+        jvmArguments.set(arguments);
     }
 
     /**
@@ -204,7 +209,10 @@ public abstract class JavaExec extends ConventionTask implements JavaExecSpec {
      */
     @Override
     public void setJvmArgs(Iterable<?> arguments) {
-        javaExecSpec.setJvmArgs(arguments);
+        jvmArguments.empty();
+        for (Object arg : arguments) {
+            jvmArguments.add(arg.toString());
+        }
     }
 
     /**
@@ -212,7 +220,11 @@ public abstract class JavaExec extends ConventionTask implements JavaExecSpec {
      */
     @Override
     public JavaExec jvmArgs(Iterable<?> arguments) {
-        javaExecSpec.jvmArgs(arguments);
+        jvmArguments.empty();
+        for (Object arg : arguments) {
+            jvmArguments.add(arg.toString());
+
+        }
         return this;
     }
 
@@ -221,7 +233,11 @@ public abstract class JavaExec extends ConventionTask implements JavaExecSpec {
      */
     @Override
     public JavaExec jvmArgs(Object... arguments) {
-        javaExecSpec.jvmArgs(arguments);
+        jvmArguments.empty();
+        for (Object arg : arguments) {
+            jvmArguments.add(arg.toString());
+
+        }
         return this;
     }
 
@@ -725,6 +741,18 @@ public abstract class JavaExec extends ConventionTask implements JavaExecSpec {
     @Override
     public List<CommandLineArgumentProvider> getJvmArgumentProviders() {
         return javaExecSpec.getJvmArgumentProviders();
+    }
+
+    /**
+     * Returns the list of configured extra JVM arguments.
+     *
+     * @return A property of extra JVM arguments.
+     * @since 8.1
+     */
+    @Input
+    @Incubating
+    public ListProperty<String> getJvmArguments() {
+        return jvmArguments;
     }
 
     /**

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/JavaExec.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/JavaExec.java
@@ -216,9 +216,7 @@ public abstract class JavaExec extends ConventionTask implements JavaExecSpec {
     @Override
     public void setJvmArgs(Iterable<?> arguments) {
         jvmArguments.empty();
-        for (Object arg : arguments) {
-            jvmArguments.add(arg.toString());
-        }
+        jvmArgs(arguments);
     }
 
     /**

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/process/DelegatingJavaExecSpec.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/process/DelegatingJavaExecSpec.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.provider.sources.process;
 import org.gradle.api.Action;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.jvm.ModularitySpec;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.process.CommandLineArgumentProvider;
 import org.gradle.process.JavaDebugOptions;
@@ -244,6 +245,11 @@ interface DelegatingJavaExecSpec extends DelegatingBaseExecSpec, JavaExecSpec {
     @Override
     default void setAllJvmArgs(Iterable<?> arguments) {
         getDelegate().setAllJvmArgs(arguments);
+    }
+
+    @Override
+    default ListProperty<String> getJvmArguments() {
+        return getDelegate().getJvmArguments();
     }
 
     @Override

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginIntegrationTest.groovy
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.plugins
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.WellBehavedPluginTest
 import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
@@ -465,7 +464,6 @@ dependencies {
         (lines.find { it.startsWith 'set CLASSPATH=' } - 'set CLASSPATH=').split(';').collect([] as Set) { it - '%APP_HOME%\\lib\\' }
     }
 
-    @ToBeFixedForConfigurationCache
     @Issue("https://github.com/gradle/gradle/issues/21505")
     def "run task honors applicationDefaultJvmArgs"() {
         given:

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/ApplicationPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/ApplicationPlugin.java
@@ -156,7 +156,7 @@ public abstract class ApplicationPlugin implements Plugin<Project> {
             run.setClasspath(runtimeClasspath);
             run.getMainModule().set(pluginExtension.getMainModule());
             run.getMainClass().set(pluginExtension.getMainClass());
-            run.getJvmArguments().convention(pluginExtension.getApplicationDefaultJvmArgs());
+            run.getJvmArguments().convention(project.provider(pluginExtension::getApplicationDefaultJvmArgs));
 
             JavaPluginExtension javaPluginExtension = project.getExtensions().getByType(JavaPluginExtension.class);
             run.getModularity().getInferModulePath().convention(javaPluginExtension.getModularity().getInferModulePath());

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/ApplicationPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/ApplicationPlugin.java
@@ -156,7 +156,7 @@ public abstract class ApplicationPlugin implements Plugin<Project> {
             run.setClasspath(runtimeClasspath);
             run.getMainModule().set(pluginExtension.getMainModule());
             run.getMainClass().set(pluginExtension.getMainClass());
-            run.getConventionMapping().map("jvmArgs", pluginExtension::getApplicationDefaultJvmArgs);
+            run.getJvmArguments().convention(pluginExtension.getApplicationDefaultJvmArgs());
 
             JavaPluginExtension javaPluginExtension = project.getExtensions().getByType(JavaPluginExtension.class);
             run.getModularity().getInferModulePath().convention(javaPluginExtension.getModularity().getInferModulePath());

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/SpringBootPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/SpringBootPluginSmokeTest.groovy
@@ -57,7 +57,7 @@ class SpringBootPluginSmokeTest extends AbstractPluginValidatingSmokeTest implem
             public class Application {
                 public static void main(String[] args) {
                     SpringApplication.run(Application.class, args);
-                    System.out.println(System.getProperty("FOO"));
+                    System.out.println("FOO: " + System.getProperty("FOO"));
                 }
             }
         """.stripIndent()
@@ -87,7 +87,7 @@ class SpringBootPluginSmokeTest extends AbstractPluginValidatingSmokeTest implem
 
         then:
         runResult.task(':bootRun').outcome == SUCCESS
-        runResult.output.contains("42")
+        runResult.output.contains("FOO: 42")
     }
 
     @Override

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/SpringBootPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/SpringBootPluginSmokeTest.groovy
@@ -16,7 +16,9 @@
 
 package org.gradle.smoketests
 
+
 import org.gradle.internal.reflect.validation.ValidationMessageChecker
+import org.gradle.util.GradleVersion
 import spock.lang.Issue
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
@@ -34,11 +36,13 @@ class SpringBootPluginSmokeTest extends AbstractPluginValidatingSmokeTest implem
 
             ${mavenCentralRepository()}
 
+            project.setProperty('applicationDefaultJvmArgs', ['-DFOO=42'])
+
             dependencies {
                 implementation 'org.springframework.boot:spring-boot-starter'
                 testImplementation 'org.springframework.boot:spring-boot-starter-test'
             }
-            
+
             tasks.named('test') {
                 useJUnitPlatform()
             }
@@ -46,23 +50,24 @@ class SpringBootPluginSmokeTest extends AbstractPluginValidatingSmokeTest implem
 
         file('src/main/java/example/Application.java') << """
             package example;
-            
+
             import org.springframework.boot.SpringApplication;
             import org.springframework.boot.autoconfigure.SpringBootApplication;
-            
+
             @SpringBootApplication
             public class Application {
                 public static void main(String[] args) {
                     SpringApplication.run(Application.class, args);
+                    System.out.println(System.getProperty("FOO"));
                 }
             }
         """.stripIndent()
         file("src/test/java/example/ApplicationTest.java") << """
             package example;
-            
+
             import org.junit.jupiter.api.Test;
             import org.springframework.boot.test.context.SpringBootTest;
-            
+
             @SpringBootTest
             class ApplicationTest {
                 @Test
@@ -83,6 +88,7 @@ class SpringBootPluginSmokeTest extends AbstractPluginValidatingSmokeTest implem
 
         then:
         runResult.task(':bootRun').outcome == SUCCESS
+        runResult.output.contains("42")
     }
 
     @Override

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/SpringBootPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/SpringBootPluginSmokeTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.smoketests
 
 
 import org.gradle.internal.reflect.validation.ValidationMessageChecker
-import org.gradle.util.GradleVersion
 import spock.lang.Issue
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS


### PR DESCRIPTION
Application plugin using convention mapping to set `applicationDefaultJvmArgs`. 
`JavaExec` having a `jvmArgs` property with backing field as `javaExecSpec`. Because of names doesn't match, convention mapping is not able to set convention value to `jvmArgs`.

This PR introducing property `getJvmArguments()` backing by `ListProperty<String> jvmArguments` and getting rid off convention mapping in plugin in favor of `Provider.convention`.