### PR TITLE
Document that SourceSetOutput.classesDirs are a ConfigurableFileCollection

### DIFF
--- a/subprojects/platform-jvm/src/main/java/org/gradle/api/tasks/SourceSetOutput.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/api/tasks/SourceSetOutput.java
@@ -87,7 +87,7 @@ public interface SourceSetOutput extends FileCollection {
     /**
      * Returns the directories containing compiled classes.
      *
-     * @return The classes directories. Never returns null.
+     * @return The classes directories. This value may safely be cast to a {@link org.gradle.api.file.ConfigurableFileCollection}.
      * @since 4.0
      */
     FileCollection getClassesDirs();

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaBasePluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaBasePluginIntegrationTest.groovy
@@ -118,4 +118,24 @@ class JavaBasePluginIntegrationTest extends AbstractIntegrationSpec {
         executer.expectDeprecationWarning("consistentResolution(Action) was called without the presence of the java component. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Apply a JVM component plugin such as: java-library, application, groovy, or scala Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#java_extension_without_java_component")
         succeeds("help")
     }
+
+    def "source set output classes dirs are instances of ConfigurableFileCollection"() {
+        given:
+        buildFile << """
+            plugins {
+                id("java-base")
+            }
+
+            sourceSets {
+                sources
+            }
+
+            task verify {
+                assert sourceSets.sources.output.classesDirs instanceof ConfigurableFileCollection
+            }
+        """
+
+        expect:
+        succeeds "verify"
+    }
 }


### PR DESCRIPTION
Fixes: https://github.com/gradle/gradle/issues/22629

For binary compatiblilty reasons, we cannot update this method to return a ConfigurableFileCollection. Instead, we add a note in the javadoc that users may cast the return value from the classesDirs to a ConfigurableFileCollection.

Eventually, as the provider API migration effort progresses, we will be able to upgrade this method to properly return a ConfigurableFileCollection. Further work will need to be done to ensure that providers mapped from task providers that are registered to this ConfigurableFileCollection do not realize the task early. This is a problem with registering compile task outputs with the clean task, and is out of scope for this issue. This work is tracked by: https://github.com/gradle/gradle/issues/23932


