### PR TITLE
Grouped output assertions for transformations

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/TransformationLoggingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/TransformationLoggingIntegrationTest.groovy
@@ -166,6 +166,14 @@ class TransformationLoggingIntegrationTest extends AbstractConsoleGroupedTaskFun
         then:
         result.groupedOutput.transformationCount == 2
 
+        result.groupedOutput.transform("GreenMultiplier", "lib1.jar (project :lib)")
+            .assertOutputContains("Creating multiplier")
+            .assertOutputContains("Transforming lib1.jar to lib1.jar.green")
+
+        result.groupedOutput.transform("GreenMultiplier", "lib2.jar (project :lib)")
+            .assertOutputContains("Creating multiplier")
+            .assertOutputContains("Transforming lib2.jar to lib2.jar.green")
+
         where:
         type << TESTED_CONSOLE_TYPES
     }
@@ -236,7 +244,7 @@ class TransformationLoggingIntegrationTest extends AbstractConsoleGroupedTaskFun
         succeeds(":util:resolveBlue", "-DshowOutput")
         then:
         result.groupedOutput.transformationCount == 4
-        def initialSubjects = ((1..2).collect { "lib${it}.jar (project :lib)".toString() }) as Set
+        def initialSubjects = ["lib1.jar (project :lib)", "lib2.jar (project :lib)"] as Set
         result.groupedOutput.subjectsFor('GreenMultiplier') == initialSubjects
         result.groupedOutput.subjectsFor('BlueMultiplier') == initialSubjects
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/GroupedTaskOutputFixture.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/GroupedTaskOutputFixture.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures.logging;
+
+public class GroupedTaskOutputFixture extends GroupedWorkOutputFixture {
+    private final String taskName;
+
+    private String taskOutcome;
+
+    public GroupedTaskOutputFixture(String taskName) {
+        this.taskName = taskName;
+    }
+
+    public void setOutcome(String taskOutcome) {
+        if (this.taskOutcome != null) {
+            throw new AssertionError(taskName + " task's outcome is set twice!");
+        }
+        this.taskOutcome = taskOutcome;
+    }
+
+    public String getOutcome() {
+        return taskOutcome;
+    }
+
+    public String getName() {
+        return taskName;
+    }
+
+    @Override
+    public String toString() {
+        return "Output for task: " + taskName + (null != taskOutcome ? " (" + taskOutcome + ")" : "");
+    }
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/GroupedTransformationOutputFixture.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/GroupedTransformationOutputFixture.java
@@ -16,28 +16,15 @@
 
 package org.gradle.integtests.fixtures.logging;
 
-import org.gradle.api.specs.Spec;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.gradle.util.internal.CollectionUtils.filter;
-import static org.gradle.util.internal.CollectionUtils.join;
-
-public class GroupedTransformationFixture {
+public class GroupedTransformationOutputFixture extends GroupedWorkOutputFixture {
     private final String initialSubjectType;
     private final String subject;
     private final String transformer;
-    private final List<String> outputs = new ArrayList<String>(1);
 
-    public GroupedTransformationFixture(String initialSubjectType, String subject, String transformer) {
+    public GroupedTransformationOutputFixture(String initialSubjectType, String subject, String transformer) {
         this.initialSubjectType = initialSubjectType;
         this.subject = subject;
         this.transformer = transformer;
-    }
-
-    public void addOutput(String transformationOutput) {
-        outputs.add(transformationOutput);
     }
 
     public String getInitialSubjectType() {
@@ -52,22 +39,12 @@ public class GroupedTransformationFixture {
         return transformer;
     }
 
-    public String getOutput() {
-        List<String> nonEmptyOutputs = filter(outputs, new Spec<String>() {
-            @Override
-            public boolean isSatisfiedBy(String string) {
-                return !string.equals("");
-            }
-        });
-        return join("\n", nonEmptyOutputs);
-    }
-
     @Override
     public String toString() {
         return "GroupedTransformationFixture{" +
-                "initialSubjectType='" + initialSubjectType + '\'' +
-                ", subject='" + subject + '\'' +
-                ", transformer='" + transformer + '\'' +
-                '}';
+            "initialSubjectType='" + initialSubjectType + '\'' +
+            ", subject='" + subject + '\'' +
+            ", transformer='" + transformer + '\'' +
+            '}';
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/GroupedWorkOutputFixture.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/GroupedWorkOutputFixture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package org.gradle.integtests.fixtures.logging;
 
-import org.gradle.api.specs.Spec;
 import org.gradle.integtests.fixtures.logging.comparison.ExhaustiveLinesSearcher;
 
 import java.util.ArrayList;
@@ -26,49 +25,36 @@ import java.util.List;
 import static org.gradle.util.internal.CollectionUtils.filter;
 import static org.gradle.util.internal.CollectionUtils.join;
 
-public class GroupedTaskFixture {
-    private final String taskName;
+/**
+ * Collects the output entries produced by a work item such as a task or a transformation,
+ * and allows assertions to be made about the output.
+ *
+ * @see GroupedOutputFixture
+ */
+public abstract class GroupedWorkOutputFixture {
 
-    private String taskOutcome;
+    private final List<String> outputs = new ArrayList<>(1);
 
-    private final List<String> outputs = new ArrayList<String>(1);
-
-    public GroupedTaskFixture(String taskName) {
-        this.taskName = taskName;
-    }
-
-    protected void addOutput(String output) {
+    /**
+     * Adds an output entry to the group.
+     */
+    public void addOutput(String output) {
         outputs.add(output);
     }
 
-    public void setOutcome(String taskOutcome) {
-        if (this.taskOutcome != null) {
-            throw new AssertionError(taskName + " task's outcome is set twice!");
-        }
-        this.taskOutcome = taskOutcome;
-    }
-
-    public String getOutcome(){
-        return taskOutcome;
-    }
-
-    public String getName() {
-        return taskName;
-    }
-
+    /**
+     * Returns concatenated non-empty output entries.
+     */
     public String getOutput() {
-        List<String> nonEmptyOutputs = filter(outputs, new Spec<String>() {
-            @Override
-            public boolean isSatisfiedBy(String string) {
-                return !string.equals("");
-            }
-        });
+        List<String> nonEmptyOutputs = filter(outputs, string -> !string.equals(""));
         return join("\n", nonEmptyOutputs);
     }
 
-    @Override
-    public String toString() {
-        return "Output for task: " + taskName + (null != taskOutcome ? " (" + taskOutcome + ")" : "");
+    /**
+     * Returns all output entries.
+     */
+    public List<String> getOutputs() {
+        return outputs;
     }
 
     /**
@@ -77,7 +63,7 @@ public class GroupedTaskFixture {
      * @param expectedText the expected lines of expectedText
      * @return this fixture
      */
-    public GroupedTaskFixture assertOutputContains(String expectedText) {
+    public GroupedWorkOutputFixture assertOutputContains(String expectedText) {
         return assertOutputContains(ComparisonFailureFormat.LINEWISE, expectedText);
     }
 
@@ -90,7 +76,7 @@ public class GroupedTaskFixture {
      * @param expectedText the expected lines of expectedText
      * @return this fixture
      */
-    public GroupedTaskFixture assertOutputContains(ComparisonFailureFormat assertionFailureFormat, String expectedText) {
+    public GroupedWorkOutputFixture assertOutputContains(ComparisonFailureFormat assertionFailureFormat, String expectedText) {
         switch (assertionFailureFormat) {
             case LINEWISE:
                 return assertOutputContainsUsingSearcher(expectedText, ExhaustiveLinesSearcher.useLcsDiff());
@@ -111,7 +97,7 @@ public class GroupedTaskFixture {
      * @param searcher      the searcher to use to find the expected sequence of lines in the actual output
      * @return this fixture
      */
-    private GroupedTaskFixture assertOutputContainsUsingSearcher(String expectedText, ExhaustiveLinesSearcher searcher) {
+    private GroupedWorkOutputFixture assertOutputContainsUsingSearcher(String expectedText, ExhaustiveLinesSearcher searcher) {
         List<String> actualLines = Arrays.asList(getOutput().split("\\R"));
         List<String> expectedLines = Arrays.asList(expectedText.split("\\R"));
         searcher.assertLinesContainedIn(expectedLines, actualLines);
@@ -132,4 +118,5 @@ public class GroupedTaskFixture {
          */
         UNIFIED
     }
+
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/comparison/ExhaustiveLinesSearcher.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/comparison/ExhaustiveLinesSearcher.java
@@ -28,7 +28,8 @@ import java.util.Optional;
 import java.util.Set;
 
 public class ExhaustiveLinesSearcher {
-    private boolean useUnifiedDiff;
+    private final boolean useUnifiedDiff;
+
     private ExhaustiveLinesSearcher(boolean useUnifiedDiff) {
         this.useUnifiedDiff = useUnifiedDiff;
     }
@@ -63,17 +64,16 @@ public class ExhaustiveLinesSearcher {
         }
 
         if (!findFirstCompleteMatch(expectedLines, actualLines).isPresent()) {
-            exhaustiveSearch(expectedLines, actualLines);
+            exhaustiveSearch(expectedLines, actualLines, useUnifiedDiff);
         }
     }
 
     /**
      * Quickly attempts to find a complete match of the expected lines in the actual lines.
-     * @param expectedLines
-     * @param actualLines
+     *
      * @return the index of the first matching line, or {@link Optional#empty()} if no match was found
      */
-    private Optional<Integer> findFirstCompleteMatch(List<String> expectedLines, List<String> actualLines) {
+    private static Optional<Integer> findFirstCompleteMatch(List<String> expectedLines, List<String> actualLines) {
         for (int actualIdx = 0; actualIdx < actualLines.size(); actualIdx++) {
             if (isMatchingIndex(expectedLines, actualLines, actualIdx)) {
                 return Optional.of(actualIdx);
@@ -84,13 +84,11 @@ public class ExhaustiveLinesSearcher {
 
     /**
      * Checks whether the given actual line matches the expected line at the given actual index.
-     * @param expectedLines
-     * @param actualLines
-     * @param actualMatchStartIdx
+     *
      * @return {@code true} if the actual index is a valid potential match position for the given number of expected lines,
-     *  and the actual lines matches the corresponding expected lines beginning at that index
+     * and the actual lines matches the corresponding expected lines beginning at that index
      */
-    private boolean isMatchingIndex(List<String> expectedLines, List<String> actualLines, int actualMatchStartIdx) {
+    private static boolean isMatchingIndex(List<String> expectedLines, List<String> actualLines, int actualMatchStartIdx) {
         for (int expectedIdx = 0; expectedIdx < expectedLines.size(); expectedIdx++) {
             int actualIdx = actualMatchStartIdx + expectedIdx;
             if (actualIdx >= actualLines.size() || !Objects.equals(expectedLines.get(expectedIdx), actualLines.get(actualIdx))) {
@@ -102,11 +100,10 @@ public class ExhaustiveLinesSearcher {
 
     /**
      * Finds all the lines in the actual line that match any line in the expected list.
-     * @param expectedLines
-     * @param actualLines
+     *
      * @return a map of expected line index to a list of all actual line indices that match the expected line
      */
-    private Map<Integer, List<Integer>> findMatchingLines(List<String> expectedLines, List<String> actualLines) {
+    private static Map<Integer, List<Integer>> findMatchingLines(List<String> expectedLines, List<String> actualLines) {
         Map<Integer, List<Integer>> result = new HashMap<>(expectedLines.size());
         for (int expectedIdx = 0; expectedIdx < expectedLines.size(); expectedIdx++) {
             String expectedLine = expectedLines.get(expectedIdx);
@@ -120,7 +117,7 @@ public class ExhaustiveLinesSearcher {
         return result;
     }
 
-    private void exhaustiveSearch(List<String> expectedLines, List<String> actualLines) {
+    private static void exhaustiveSearch(List<String> expectedLines, List<String> actualLines, boolean useUnifiedDiff) {
         Map<Integer, List<Integer>> matchingLines = findMatchingLines(expectedLines, actualLines);
         Set<PotentialMatch> potentialMatches = convertMatchingLines(expectedLines, actualLines, matchingLines);
         if (matchingLines.isEmpty()) {
@@ -131,12 +128,12 @@ public class ExhaustiveLinesSearcher {
         }
     }
 
-    private void filterLessLikelyMatches(Set<PotentialMatch> potentialMatches) {
+    private static void filterLessLikelyMatches(Set<PotentialMatch> potentialMatches) {
         final long highestNumMatches = potentialMatches.stream().map(PotentialMatch::getNumMatches).max(Long::compareTo).orElse(0L);
         potentialMatches.removeIf(pm -> pm.getNumMatches() < highestNumMatches);
     }
 
-    private Set<PotentialMatch> convertMatchingLines(List<String> expectedLines, List<String> actualLines, Map<Integer, List<Integer>> matchingLines) {
+    private static Set<PotentialMatch> convertMatchingLines(List<String> expectedLines, List<String> actualLines, Map<Integer, List<Integer>> matchingLines) {
         Set<PotentialMatch> potentialMatches = new HashSet<>(matchingLines.size());
         for (Map.Entry<Integer, List<Integer>> entry : matchingLines.entrySet()) {
             int expectedIdx = entry.getKey();

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixtureTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixtureTest.groovy
@@ -16,8 +16,8 @@
 
 package org.gradle.integtests.fixtures.logging
 
-import org.gradle.integtests.fixtures.logging.GroupedTaskFixture.ComparisonFailureFormat
 import org.gradle.integtests.fixtures.executer.LogContent
+import org.gradle.integtests.fixtures.logging.GroupedWorkOutputFixture.ComparisonFailureFormat
 import org.gradle.integtests.fixtures.logging.comparison.LineSearchFailures
 import org.gradle.integtests.fixtures.logging.comparison.LineSearchFailures.PotentialMatchesExistComparisonFailure
 import spock.lang.Specification


### PR DESCRIPTION
Similarly to tasks, support output assertions for grouped output of transformations (artifact transforms)

```
        result.groupedOutput.transform("GreenMultiplier", "lib1.jar (project :lib)")
            .assertOutputContains("Creating multiplier")
            .assertOutputContains("Transforming lib1.jar to lib1.jar.green")
```