### PR TITLE
Fix upgrade guides

### DIFF
--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
@@ -37,11 +37,6 @@ Some plugins will break with this new version of Gradle, for example because the
 [[changes_7.0]]
 == Upgrading from 6.9
 
-Nothing to do.
-
-[[changes_6.9]]
-== Upgrading from 6.9
-
 === Changes in the IDE integration
 
 ==== Changes in the IDEA model

--- a/subprojects/docs/src/main/resources/header.html
+++ b/subprojects/docs/src/main/resources/header.html
@@ -99,7 +99,7 @@
             <li><a href="../release-notes.html">Release Notes</a></li>
             <li><a class="nav-dropdown" data-toggle="collapse" href="#upgrading-gradle" aria-expanded="false" aria-controls="upgrading-gradle">Upgrading Gradle</a>
                 <ul id="upgrading-gradle">
-                    <li><a href="../userguide/upgrading_version_7.html">version 7.X to latest</a></li>
+                    <li><a href="../userguide/upgrading_version_7.html">version 7.X to 8.0</a></li>
                     <li><a href="../userguide/upgrading_version_6.html">version 6.X to 7.0</a></li>
                     <li><a href="../userguide/upgrading_version_5.html">version 5.X to 6.0</a></li>
                     <li><a href="../userguide/upgrading_version_4.html">version 4.X to 5.0</a></li>


### PR DESCRIPTION
* Indicate 8.0 instead of latest for 7.x to 8 upgrade guide
* Fix merge mistake in 6.x to 7 upgrade guide