### PR TITLE
Relax presence of Scala compiler warnings

### DIFF
--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/ScalaCompileIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/ScalaCompileIntegrationTest.groovy
@@ -52,7 +52,6 @@ class ScalaCompileIntegrationTest extends MultiVersionIntegrationSpec implements
 
         then:
         executedAndNotSkipped(":compileScala")
-        outputDoesNotContain("[Warn]")
 
         JavaVersion.forClass(scalaClassFile("JavaThing.class").bytes) == currentJdk.javaVersion
         JavaVersion.forClass(scalaClassFile("ScalaHall.class").bytes) == JavaVersion.VERSION_1_8
@@ -88,7 +87,6 @@ class Person {
 
         then:
         executedAndNotSkipped(":compileScala")
-        outputDoesNotContain("[Warn]")
         JavaVersion.forClass(scalaClassFile("ScalaHall.class").bytes) == JavaVersion.VERSION_1_8
 
         where:

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/ScalaCompileJavaToolchainIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/ScalaCompileJavaToolchainIntegrationTest.groovy
@@ -78,7 +78,6 @@ class ScalaCompileJavaToolchainIntegrationTest extends MultiVersionIntegrationSp
 
         then:
         executedAndNotSkipped(":compileScala")
-        outputDoesNotContain("[Warn]")
 
         JavaVersion.forClass(scalaClassFile("JavaThing.class").bytes) == currentJdk.javaVersion
         JavaVersion.forClass(scalaClassFile("ScalaHall.class").bytes) == JavaVersion.VERSION_1_8
@@ -112,7 +111,6 @@ class ScalaCompileJavaToolchainIntegrationTest extends MultiVersionIntegrationSp
 
         then:
         executedAndNotSkipped(":compileScala")
-        outputDoesNotContain("[Warn]")
         outputContains("Compiling with Zinc Scala compiler")
 
         JavaVersion.forClass(scalaClassFile("JavaThing.class").bytes) == targetJdk.javaVersion
@@ -148,7 +146,6 @@ class ScalaCompileJavaToolchainIntegrationTest extends MultiVersionIntegrationSp
         withInstallations(currentJdk, otherJdk).run(":compileScala")
         then:
         executedAndNotSkipped(":compileScala")
-        outputDoesNotContain("[Warn]")
 
         when:
         withInstallations(currentJdk, otherJdk).run(":compileScala")
@@ -198,7 +195,6 @@ class ScalaCompileJavaToolchainIntegrationTest extends MultiVersionIntegrationSp
 
         then:
         executedAndNotSkipped(":compileScala")
-        outputDoesNotContain("[Warn]")
 
         outputContains("project.sourceCompatibility = 11")
         outputContains("project.targetCompatibility = 11")
@@ -248,7 +244,6 @@ class ScalaCompileJavaToolchainIntegrationTest extends MultiVersionIntegrationSp
 
         then:
         executedAndNotSkipped(":test")
-        outputDoesNotContain("[Warn]")
         outputContains("Running Scala test with Java version ${jdk.javaVersion}")
 
         JavaVersion.forClass(scalaClassFile("JavaThing.class").bytes) == javaVersion


### PR DESCRIPTION
This is needed following the changes around handling implicit toolchains.

Issue #23905