### PR TITLE
Trusted GPG-key should only accept 160-bit fingerprints

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/StartParameterResolutionOverride.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/StartParameterResolutionOverride.java
@@ -16,7 +16,6 @@
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
 import org.gradle.StartParameter;
-import org.gradle.api.GradleException;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.artifacts.verification.DependencyVerificationMode;
@@ -28,6 +27,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.Depe
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.writer.WriteDependencyVerificationFile;
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.ExternalResourceCachePolicy;
 import org.gradle.api.internal.artifacts.repositories.resolver.MetadataFetchingCost;
+import org.gradle.api.internal.artifacts.verification.exceptions.DependencyVerificationException;
 import org.gradle.api.internal.artifacts.verification.signatures.SignatureVerificationServiceFactory;
 import org.gradle.api.internal.component.ArtifactType;
 import org.gradle.api.internal.properties.GradleProperties;
@@ -237,7 +237,7 @@ public class StartParameterResolutionOverride {
 
         @Override
         public ModuleComponentRepository overrideDependencyVerification(ModuleComponentRepository original, String resolveContextName, ResolutionStrategyInternal resolutionStrategy) {
-            throw new GradleException("Dependency verification cannot be performed", error);
+            throw new DependencyVerificationException("Dependency verification cannot be performed", error);
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/ChecksumAndSignatureVerificationOverride.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/ChecksumAndSignatureVerificationOverride.java
@@ -31,6 +31,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.DependencyVerifyi
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ModuleComponentRepository;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.report.DependencyVerificationReportWriter;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.report.VerificationReport;
+import org.gradle.api.internal.artifacts.verification.exceptions.DependencyVerificationException;
 import org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationsXmlReader;
 import org.gradle.api.internal.artifacts.verification.signatures.SignatureVerificationService;
 import org.gradle.api.internal.artifacts.verification.signatures.SignatureVerificationServiceFactory;
@@ -94,8 +95,8 @@ public class ChecksumAndSignatureVerificationOverride implements DependencyVerif
             this.reportWriter = new DependencyVerificationReportWriter(gradleUserHome.toPath(), documentationRegistry, verificationsFile, verifier.getSuggestedWriteFlags(), reportsDirectory, gradlePropertiesFactory);
         } catch (FileNotFoundException e) {
             throw UncheckedException.throwAsUncheckedException(e);
-        } catch (InvalidUserDataException e) {
-            throw new InvalidUserDataException("Unable to read dependency verification metadata from " + verificationsFile, e.getCause());
+        } catch (DependencyVerificationException e) {
+            throw new DependencyVerificationException("Unable to read dependency verification metadata from " + verificationsFile, e.getCause());
         }
         this.signatureVerificationService = signatureVerificationServiceFactory.create(keyRingsFile, keyServers());
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/exceptions/ComponentVerificationException.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/exceptions/ComponentVerificationException.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.verification.exceptions;
+
+import org.gradle.api.GradleException;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.internal.logging.text.TreeFormatter;
+
+import java.util.function.Consumer;
+
+public class ComponentVerificationException extends GradleException {
+
+    private final ModuleComponentIdentifier component;
+    private final Consumer<TreeFormatter> causeErrorFormatter;
+
+    /**
+     * Creates a new exception when a component cannot be verified - because of some reason.
+     *
+     * @param component the component which failed the verification
+     */
+    public ComponentVerificationException(String message, ModuleComponentIdentifier component) {
+        super(message);
+        this.component = component;
+        this.causeErrorFormatter = null;
+    }
+
+    /**
+     * Creates a new exception when a component cannot be verified - because of some reason.
+     *
+     * @param component the component which failed the verification
+     * @param causeErrorFormatter a consumer, which will be called with a {@link TreeFormatter}, and can put extra details what happened
+     */
+    public ComponentVerificationException(ModuleComponentIdentifier component, Consumer<TreeFormatter> causeErrorFormatter) {
+        this.component = component;
+        this.causeErrorFormatter = causeErrorFormatter;
+    }
+
+    @Override
+    public String getMessage() {
+        final TreeFormatter treeFormatter = new TreeFormatter();
+        // Add our header first
+        treeFormatter.node(
+            String.format(
+                "An error happened meanwhile verifying '%s:%s:%s':",
+                component.getGroup(), component.getModule(), component.getVersion()
+            )
+        );
+
+        if (this.causeErrorFormatter != null) {
+            treeFormatter.startChildren();
+            // Let the underlying exception explain the situation
+            causeErrorFormatter.accept(treeFormatter);
+            treeFormatter.endChildren();
+
+        }
+        return treeFormatter.toString();
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/exceptions/DependencyVerificationException.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/exceptions/DependencyVerificationException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.verification.exceptions;
+
+import org.gradle.api.GradleException;
+import org.gradle.internal.exceptions.Contextual;
+
+@Contextual
+public class DependencyVerificationException extends GradleException {
+
+    public DependencyVerificationException(String message) {
+        super(message);
+    }
+
+    public DependencyVerificationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/exceptions/InvalidGpgKeyIdsException.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/exceptions/InvalidGpgKeyIdsException.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.verification.exceptions;
+
+import org.gradle.api.GradleException;
+import org.gradle.api.internal.DocumentationRegistry;
+import org.gradle.internal.logging.text.TreeFormatter;
+
+import java.util.List;
+
+/**
+ * Exception class used when a GPG IDs were not correct.
+ *
+ * <p>
+ * An example is using short/long IDs instead of fingerprints when trusting keys
+ */
+public class InvalidGpgKeyIdsException extends GradleException {
+    private final List<String> wrongKeys;
+
+    /**
+     * Creates a new exception with a list of incorrect keys.
+     *
+     * @param wrongKeys the list of incorrect IDs, which will be nicely formatted as part of the exception messages so the user can find them
+     */
+    public InvalidGpgKeyIdsException(List<String> wrongKeys) {
+        this.wrongKeys = wrongKeys;
+    }
+
+    /**
+     * Formats a nice error message by using a {@link TreeFormatter}.
+     *
+     * <p>
+     * Idea for this method is that you can pass a higher-level {@link TreeFormatter} into here, and get a coherent, nice error message printed out - so the user will see a nice chain of causes.
+     */
+    public void formatMessage(TreeFormatter formatter) {
+        final DocumentationRegistry documentationRegistry = new DocumentationRegistry();
+        final String documentLink = documentationRegistry.getDocumentationFor("dependency_verification", "sec:understanding-signature-verification");
+
+        formatter.node(
+            String.format("The following trusted GPG IDs are not in a minimum 160-bit fingerprint format (see: %s):", documentLink)
+        );
+        formatter.startChildren();
+        wrongKeys
+            .stream()
+            .map(key -> String.format("'%s'", key))
+            .forEach(formatter::node);
+        formatter.endChildren();
+    }
+
+    @Override
+    public String getMessage() {
+        final TreeFormatter treeFormatter = new TreeFormatter();
+        formatMessage(treeFormatter);
+        return treeFormatter.toString();
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/serializer/DependencyVerificationsXmlReader.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/serializer/DependencyVerificationsXmlReader.java
@@ -21,6 +21,7 @@ import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
+import org.gradle.api.internal.artifacts.verification.exceptions.DependencyVerificationException;
 import org.gradle.api.internal.artifacts.verification.model.ChecksumKind;
 import org.gradle.api.internal.artifacts.verification.model.IgnoredKey;
 import org.gradle.api.internal.artifacts.verification.verifier.DependencyVerifier;
@@ -81,7 +82,7 @@ public class DependencyVerificationsXmlReader {
             xmlReader.setContentHandler(handler);
             xmlReader.parse(new InputSource(in));
         } catch (Exception e) {
-            throw new InvalidUserDataException("Unable to read dependency verification metadata", e);
+            throw new DependencyVerificationException("Unable to read dependency verification metadata", e);
         } finally {
             try {
                 in.close();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/verifier/DependencyVerificationConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/verifier/DependencyVerificationConfiguration.java
@@ -17,11 +17,14 @@ package org.gradle.api.internal.artifacts.verification.verifier;
 
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.internal.artifacts.verification.exceptions.InvalidGpgKeyIdsException;
 import org.gradle.api.internal.artifacts.verification.model.IgnoredKey;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
 
 import javax.annotation.Nullable;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -168,7 +171,19 @@ public class DependencyVerificationConfiguration {
 
         TrustedKey(String keyId, @Nullable String group, @Nullable String name, @Nullable String version, @Nullable String fileName, boolean regex) {
             super(group, name, version, fileName, regex);
-            this.keyId = keyId;
+
+            // The key is 160 bits long, encoded in base32 (case-insensitive characters).
+            //
+            // Base32 gives us 4 bits per character, so the whole fingerprint will be:
+            // (160 bits) / (4 bits / character) = 40 characters
+            //
+            // By getting ASCII bytes (aka. strictly 1 byte per character, no variable-length magic)
+            // we can safely check if the fingerprint is of the correct length.
+            if (keyId.getBytes(StandardCharsets.US_ASCII).length < 40) {
+                throw new InvalidGpgKeyIdsException(Collections.singletonList(keyId));
+            } else {
+                this.keyId = keyId;
+            }
         }
 
         public String getKeyId() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/verifier/DependencyVerifierBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/verifier/DependencyVerifierBuilder.java
@@ -21,9 +21,11 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.internal.artifacts.verification.exceptions.ComponentVerificationException;
+import org.gradle.api.internal.artifacts.verification.exceptions.DependencyVerificationException;
+import org.gradle.api.internal.artifacts.verification.exceptions.InvalidGpgKeyIdsException;
 import org.gradle.api.internal.artifacts.verification.model.ArtifactVerificationMetadata;
 import org.gradle.api.internal.artifacts.verification.model.Checksum;
 import org.gradle.api.internal.artifacts.verification.model.ChecksumKind;
@@ -35,6 +37,7 @@ import org.gradle.internal.component.external.model.ModuleComponentArtifactIdent
 
 import javax.annotation.Nullable;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -108,7 +111,7 @@ public class DependencyVerifierBuilder {
     private void validateUserInput(@Nullable String group, @Nullable String name, @Nullable String version, @Nullable String fileName) {
         // because this can be called from parsing XML, we need to perform additional verification
         if (group == null && name == null && version == null && fileName == null) {
-            throw new InvalidUserDataException("A trusted artifact must have at least one of group, name, version or file name not null");
+            throw new DependencyVerificationException("A trusted artifact must have at least one of group, name, version or file name not null");
         }
     }
 
@@ -129,11 +132,11 @@ public class DependencyVerifierBuilder {
         keyServers.add(uri);
     }
 
-    private static class ComponentVerificationsBuilder {
+    protected static class ComponentVerificationsBuilder {
         private final ModuleComponentIdentifier component;
         private final Map<String, ArtifactVerificationBuilder> byArtifact = Maps.newHashMap();
 
-        private ComponentVerificationsBuilder(ModuleComponentIdentifier component) {
+        protected ComponentVerificationsBuilder(ModuleComponentIdentifier component) {
             this.component = component;
         }
 
@@ -149,7 +152,7 @@ public class DependencyVerifierBuilder {
             byArtifact.computeIfAbsent(artifact.getFileName(), id -> new ArtifactVerificationBuilder()).addIgnoredKey(key);
         }
 
-        private static ArtifactVerificationMetadata toArtifactVerification(Map.Entry<String, ArtifactVerificationBuilder> entry) {
+        private static ArtifactVerificationMetadata toArtifactVerification(Map.Entry<String, ArtifactVerificationBuilder> entry) throws InvalidGpgKeyIdsException {
             String key = entry.getKey();
             ArtifactVerificationBuilder value = entry.getValue();
             return new ImmutableArtifactVerificationMetadata(
@@ -160,17 +163,21 @@ public class DependencyVerifierBuilder {
         }
 
         ComponentVerificationMetadata build() {
-            return new ImmutableComponentVerificationMetadata(component,
-                byArtifact.entrySet()
-                    .stream()
-                    .map(ComponentVerificationsBuilder::toArtifactVerification)
-                    .sorted(Comparator.comparing(ArtifactVerificationMetadata::getArtifactName))
-                    .collect(Collectors.toList())
-            );
+            try {
+                return new ImmutableComponentVerificationMetadata(component,
+                    byArtifact.entrySet()
+                        .stream()
+                        .map(ComponentVerificationsBuilder::toArtifactVerification)
+                        .sorted(Comparator.comparing(ArtifactVerificationMetadata::getArtifactName))
+                        .collect(Collectors.toList())
+                );
+            } catch (InvalidGpgKeyIdsException ex) {
+                throw new ComponentVerificationException(component, ex::formatMessage);
+            }
         }
     }
 
-    private static class ArtifactVerificationBuilder {
+    protected static class ArtifactVerificationBuilder {
         private final Map<ChecksumKind, ChecksumBuilder> builder = Maps.newEnumMap(ChecksumKind.class);
         private final Set<String> pgpKeys = Sets.newLinkedHashSet();
         private final Set<IgnoredKey> ignoredPgpKeys = Sets.newLinkedHashSet();
@@ -199,8 +206,37 @@ public class DependencyVerifierBuilder {
             ignoredPgpKeys.add(key);
         }
 
-        public Set<String> buildTrustedPgpKeys() {
-            return pgpKeys;
+        /**
+         * Builds the list of trusted GPG keys.
+         * <p>
+         * This method will verify if all the trusted keys are in 160-bit fingerprint format.
+         * We do not accept either short or long formats, as they can be vulnerable to collision attacks.
+         *
+         * <p>
+         * Note: the fingerprints' formatting is not verified (i.e. if it's true base32 or not) at this stage.
+         * It will happen when these fingerprints will be converted to {@link org.gradle.security.internal.Fingerprint}.
+         *
+         * @return a set of trusted GPG keys
+         * @throws InvalidGpgKeyIdsException if keys not fitting the requirements were found
+         */
+        public Set<String> buildTrustedPgpKeys() throws InvalidGpgKeyIdsException {
+            final List<String> wrongPgpKeys = pgpKeys
+                .stream()
+                // The key is 160 bits long, encoded in base32 (case-insensitive characters).
+                //
+                // Base32 gives us 4 bits per character, so the whole fingerprint will be:
+                // (160 bits) / (4 bits / character) = 40 characters
+                //
+                // By getting ASCII bytes (aka. strictly 1 byte per character, no variable-length magic)
+                // we can safely check if the fingerprint is of the correct length.
+                .filter(key -> key.getBytes(StandardCharsets.US_ASCII).length < 40)
+                .collect(Collectors.toList());
+
+            if (wrongPgpKeys.isEmpty()) {
+                return pgpKeys;
+            } else {
+                throw new InvalidGpgKeyIdsException(wrongPgpKeys);
+            }
         }
 
         public Set<IgnoredKey> buildIgnoredPgpKeys() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/PgpKeyGrouperTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/PgpKeyGrouperTest.groovy
@@ -23,14 +23,15 @@ import org.gradle.api.internal.artifacts.verification.verifier.DependencyVerifie
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.external.model.ModuleComponentFileArtifactIdentifier
 import spock.lang.Specification
-import spock.lang.Unroll
 
 class PgpKeyGrouperTest extends Specification {
     private DependencyVerifierBuilder builder = new DependencyVerifierBuilder()
     private DependencyVerifier verifier
     private PgpKeyGrouper pgpKeyGrouper
 
-    @Unroll
+    private static final String KEY_1 = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+    private static final String KEY_2 = 'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'
+
     def "common prefix for groups #groups == #expected"() {
         expect:
         PgpKeyGrouper.tryComputeCommonPrefixes(groups) == expected
@@ -66,39 +67,39 @@ class PgpKeyGrouperTest extends Specification {
 
     def "groups entries which have the same module component id"() {
         grouper {
-            entry("org", "foo", "1.0", "foo-1.0.jar").addVerifiedKey("key1")
-            entry("org", "foo", "1.0", "foo-1.0.pom").addVerifiedKey("key1")
+            entry("org", "foo", "1.0", "foo-1.0.jar").addVerifiedKey(KEY_1)
+            entry("org", "foo", "1.0", "foo-1.0.pom").addVerifiedKey(KEY_1)
         }
 
         when:
         executeGrouping()
 
         then:
-        verifier.configuration.trustedKeys*.keyId == ["key1"]
+        verifier.configuration.trustedKeys*.keyId == [KEY_1]
         verifier.verificationMetadata.empty
     }
 
     def "groups entries which have the same module id"() {
         grouper {
-            entry("org", "foo", "1.0", "foo-1.0.jar").addVerifiedKey("key1")
-            entry("org", "foo", "1.0", "foo-1.0.pom").addVerifiedKey("key1")
-            entry("org", "foo", "1.1", "foo-1.1.jar").addVerifiedKey("key1")
-            entry("org", "foo", "1.1", "foo-1.1.pom").addVerifiedKey("key1")
+            entry("org", "foo", "1.0", "foo-1.0.jar").addVerifiedKey(KEY_1)
+            entry("org", "foo", "1.0", "foo-1.0.pom").addVerifiedKey(KEY_1)
+            entry("org", "foo", "1.1", "foo-1.1.jar").addVerifiedKey(KEY_1)
+            entry("org", "foo", "1.1", "foo-1.1.pom").addVerifiedKey(KEY_1)
         }
 
         when:
         executeGrouping()
 
         then:
-        verifier.configuration.trustedKeys*.keyId == ["key1"]
+        verifier.configuration.trustedKeys*.keyId == [KEY_1]
     }
 
     def "doesn't group entries which have the same module id but different keys"() {
         grouper {
-            entry("org", "foo", "1.0", "foo-1.0.jar").addVerifiedKey("key1")
-            entry("org", "foo", "1.0", "foo-1.0.pom").addVerifiedKey("key1")
-            entry("org", "foo", "1.1", "foo-1.1.jar").addVerifiedKey("key2")
-            entry("org", "foo", "1.1", "foo-1.1.pom").addVerifiedKey("key2")
+            entry("org", "foo", "1.0", "foo-1.0.jar").addVerifiedKey(KEY_1)
+            entry("org", "foo", "1.0", "foo-1.0.pom").addVerifiedKey(KEY_1)
+            entry("org", "foo", "1.1", "foo-1.1.jar").addVerifiedKey(KEY_2)
+            entry("org", "foo", "1.1", "foo-1.1.pom").addVerifiedKey(KEY_2)
         }
 
         when:
@@ -106,17 +107,17 @@ class PgpKeyGrouperTest extends Specification {
 
         then:
         def keys = verifier.configuration.trustedKeys
-        keys*.keyId == ["key1", "key2"]
+        keys*.keyId == [KEY_1, KEY_2]
         keys[0].version == '1.0'
         keys[1].version == '1.1'
     }
 
     def "groups entries which have the same group id"() {
         grouper {
-            entry("org", "foo", "1.0", "foo-1.0.jar").addVerifiedKey("key1")
-            entry("org", "foo", "1.0", "foo-1.0.pom").addVerifiedKey("key1")
-            entry("org", "bar", "1.1", "bar-1.1.jar").addVerifiedKey("key1")
-            entry("org", "bar", "1.1", "bar-1.1.pom").addVerifiedKey("key1")
+            entry("org", "foo", "1.0", "foo-1.0.jar").addVerifiedKey(KEY_1)
+            entry("org", "foo", "1.0", "foo-1.0.pom").addVerifiedKey(KEY_1)
+            entry("org", "bar", "1.1", "bar-1.1.jar").addVerifiedKey(KEY_1)
+            entry("org", "bar", "1.1", "bar-1.1.pom").addVerifiedKey(KEY_1)
         }
 
         when:
@@ -124,7 +125,7 @@ class PgpKeyGrouperTest extends Specification {
 
         then:
         def keys = verifier.configuration.trustedKeys
-        keys*.keyId == ["key1"]
+        keys*.keyId == [KEY_1]
         keys[0].group == 'org'
         keys[0].name == null
         keys[0].version == null
@@ -133,10 +134,10 @@ class PgpKeyGrouperTest extends Specification {
 
     def "groups entries which have a common group prefix"() {
         grouper {
-            entry("org.group.a", "foo", "1.0", "foo-1.0.jar").addVerifiedKey("key1")
-            entry("org.group.a", "foo", "1.0", "foo-1.0.pom").addVerifiedKey("key1")
-            entry("org.group.b", "bar", "1.1", "bar-1.1.jar").addVerifiedKey("key1")
-            entry("org.group.b", "bar", "1.1", "bar-1.1.pom").addVerifiedKey("key1")
+            entry("org.group.a", "foo", "1.0", "foo-1.0.jar").addVerifiedKey(KEY_1)
+            entry("org.group.a", "foo", "1.0", "foo-1.0.pom").addVerifiedKey(KEY_1)
+            entry("org.group.b", "bar", "1.1", "bar-1.1.jar").addVerifiedKey(KEY_1)
+            entry("org.group.b", "bar", "1.1", "bar-1.1.pom").addVerifiedKey(KEY_1)
         }
 
         when:
@@ -144,7 +145,7 @@ class PgpKeyGrouperTest extends Specification {
 
         then:
         def keys = verifier.configuration.trustedKeys
-        keys*.keyId == ["key1"]
+        keys*.keyId == [KEY_1]
         keys[0].group == '^org[.]group($|([.].*))'
         keys[0].name == null
         keys[0].version == null

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/verification/serializer/DependencyVerificationsXmlReaderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/verification/serializer/DependencyVerificationsXmlReaderTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.artifacts.verification.serializer
 
-import org.gradle.api.InvalidUserDataException
+import org.gradle.api.internal.artifacts.verification.exceptions.DependencyVerificationException
 import org.gradle.api.internal.artifacts.verification.model.ChecksumKind
 import org.gradle.api.internal.artifacts.verification.model.IgnoredKey
 import org.gradle.api.internal.artifacts.verification.verifier.DependencyVerifier
@@ -31,7 +31,7 @@ class DependencyVerificationsXmlReaderTest extends Specification {
         parse("invalid")
 
         then:
-        InvalidUserDataException e = thrown()
+        DependencyVerificationException e = thrown()
         e.message == "Unable to read dependency verification metadata"
     }
 
@@ -55,7 +55,7 @@ class DependencyVerificationsXmlReaderTest extends Specification {
 </verification-metadata>"""
 
         then:
-        InvalidUserDataException e = thrown()
+        DependencyVerificationException e = thrown()
         e.message == "Unable to read dependency verification metadata"
         e.cause.message == "Invalid dependency verification metadata file: <component> must be found under the <components> tag"
     }
@@ -167,7 +167,7 @@ class DependencyVerificationsXmlReaderTest extends Specification {
 </verification-metadata>
 """
         then:
-        InvalidUserDataException ex = thrown()
+        DependencyVerificationException ex = thrown()
         ex.message == "Unable to read dependency verification metadata"
         ex.cause.message == "A trusted artifact must have at least one of group, name, version or file name not null"
     }
@@ -197,13 +197,13 @@ class DependencyVerificationsXmlReaderTest extends Specification {
       <verify-metadata>true</verify-metadata>
       <verify-signatures>false</verify-signatures>
       <trusted-keys>
-         <trusted-key id="012345" group="g2" name="m1" file="file.jar" regex="true"/>
-         <trusted-key id="456DEF">
+         <trusted-key id="A000000000000000000000000000000000000000" group="g2" name="m1" file="file.jar" regex="true"/>
+         <trusted-key id="B000000000000000000000000000000000000000">
             <trusting name="m3" version="1.4" file="file.zip"/>
             <trusting name="m4" file="other-file.zip" regex="true"/>
          </trusted-key>
-         <trusted-key id="ABC123" group="g3" name="m2" version="1.0" regex="true"/>
-         <trusted-key id="ABCDEF" group="g1"/>
+         <trusted-key id="C000000000000000000000000000000000000000" group="g3" name="m2" version="1.0" regex="true"/>
+         <trusted-key id="D000000000000000000000000000000000000000" group="g1"/>
       </trusted-keys>
    </configuration>
    <components/>
@@ -214,35 +214,35 @@ class DependencyVerificationsXmlReaderTest extends Specification {
         def trustedKeys = verifier.configuration.trustedKeys
         trustedKeys.size() == 5
 
-        trustedKeys[0].keyId == "012345"
+        trustedKeys[0].keyId == "A000000000000000000000000000000000000000"
         trustedKeys[0].group == "g2"
         trustedKeys[0].name == "m1"
         trustedKeys[0].version == null
         trustedKeys[0].fileName == "file.jar"
         trustedKeys[0].regex == true
 
-        trustedKeys[1].keyId == "456DEF"
+        trustedKeys[1].keyId == "B000000000000000000000000000000000000000"
         trustedKeys[1].group == null
         trustedKeys[1].name == "m3"
         trustedKeys[1].version == "1.4"
         trustedKeys[1].fileName == "file.zip"
         trustedKeys[1].regex == false
 
-        trustedKeys[2].keyId == "456DEF"
+        trustedKeys[2].keyId == "B000000000000000000000000000000000000000"
         trustedKeys[2].group == null
         trustedKeys[2].name == "m4"
         trustedKeys[2].version == null
         trustedKeys[2].fileName == "other-file.zip"
         trustedKeys[2].regex == true
 
-        trustedKeys[3].keyId == "ABC123"
+        trustedKeys[3].keyId == "C000000000000000000000000000000000000000"
         trustedKeys[3].group == "g3"
         trustedKeys[3].name == "m2"
         trustedKeys[3].version == "1.0"
         trustedKeys[3].fileName == null
         trustedKeys[3].regex == true
 
-        trustedKeys[4].keyId == "ABCDEF"
+        trustedKeys[4].keyId == "D000000000000000000000000000000000000000"
         trustedKeys[4].group == "g1"
         trustedKeys[4].name == null
         trustedKeys[4].version == null

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/verification/serializer/DependencyVerificationsXmlWriterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/verification/serializer/DependencyVerificationsXmlWriterTest.groovy
@@ -143,11 +143,11 @@ class DependencyVerificationsXmlWriterTest extends Specification {
 
     def "can declare trusted keys"() {
         when:
-        builder.addTrustedKey("ABCDEF", "g1", null, null, null, false)
-        builder.addTrustedKey("012345", "g2", "m1", null, "file.jar", true)
-        builder.addTrustedKey("ABC123", "g3", "m2", "1.0", null, true)
-        builder.addTrustedKey("456DEF", null, "m3", "1.4", "file.zip", false)
-        builder.addTrustedKey("456DEF", null, "m4", null, "other-file.zip", true)
+        builder.addTrustedKey("A000000000000000000000000000000000000000", "g1", null, null, null, false)
+        builder.addTrustedKey("B000000000000000000000000000000000000000", "g2", "m1", null, "file.jar", true)
+        builder.addTrustedKey("C000000000000000000000000000000000000000", "g3", "m2", "1.0", null, true)
+        builder.addTrustedKey("D000000000000000000000000000000000000000", null, "m3", "1.4", "file.zip", false)
+        builder.addTrustedKey("D000000000000000000000000000000000000000", null, "m4", null, "other-file.zip", true)
         serialize()
 
         then:
@@ -157,13 +157,13 @@ class DependencyVerificationsXmlWriterTest extends Specification {
       <verify-metadata>true</verify-metadata>
       <verify-signatures>false</verify-signatures>
       <trusted-keys>
-         <trusted-key id="012345" group="g2" name="m1" file="file.jar" regex="true"/>
-         <trusted-key id="456DEF">
+         <trusted-key id="A000000000000000000000000000000000000000" group="g1"/>
+         <trusted-key id="B000000000000000000000000000000000000000" group="g2" name="m1" file="file.jar" regex="true"/>
+         <trusted-key id="C000000000000000000000000000000000000000" group="g3" name="m2" version="1.0" regex="true"/>
+         <trusted-key id="D000000000000000000000000000000000000000">
             <trusting name="m3" version="1.4" file="file.zip"/>
             <trusting name="m4" file="other-file.zip" regex="true"/>
          </trusted-key>
-         <trusted-key id="ABC123" group="g3" name="m2" version="1.0" regex="true"/>
-         <trusted-key id="ABCDEF" group="g1"/>
       </trusted-keys>
    </configuration>
    <components/>

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/verification/verifier/DependencyVerifierBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/verification/verifier/DependencyVerifierBuilderTest.groovy
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.verification.verifier
+
+
+import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
+import org.gradle.api.internal.artifacts.verification.exceptions.ComponentVerificationException
+import org.gradle.api.internal.artifacts.verification.exceptions.InvalidGpgKeyIdsException
+import org.gradle.internal.component.external.model.DefaultModuleComponentArtifactIdentifier
+import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
+import spock.lang.Specification
+
+class DependencyVerifierBuilderTest extends Specification {
+
+    def "ComponentVerificationsBuilder should fail if trusted GPG key is not a fingerprint but a #name"() {
+        given:
+        def moduleComponentIdentifier = DefaultModuleComponentIdentifier.newId(
+            DefaultModuleVersionIdentifier.newId("test.group", "test-module", "0.0.0")
+        )
+        def componentArtifactIdentified = new DefaultModuleComponentArtifactIdentifier(
+            moduleComponentIdentifier, "artifact", "jar", ".jar"
+        )
+
+        def dependencyVerifier = new DependencyVerifierBuilder.ComponentVerificationsBuilder(moduleComponentIdentifier);
+        keyIds.forEach {
+            dependencyVerifier.addTrustedKey(componentArtifactIdentified, it)
+        }
+
+        when:
+        dependencyVerifier.build()
+
+        then:
+        def ex = thrown(ComponentVerificationException)
+        println(ex.getMessage())
+
+        where:
+        name                  | keyIds
+        "short id"            | ["AAAAAAA"]
+        "long id"             | ["AAAAAAAAAAAAAA"]
+        "mixed short/long id" | ["AAAAAAAA", "AAAAAAAAAAAAAA"]
+    }
+
+    def "ArtifactVerificationBuilder should fail if trusted GPG key is not a fingerprint but a #name"() {
+        given:
+        def verificationBuilder = new DependencyVerifierBuilder.ArtifactVerificationBuilder()
+        keyIds.forEach { verificationBuilder.addTrustedKey(it) }
+
+        when:
+        verificationBuilder.buildTrustedPgpKeys();
+
+        then:
+        def ex = thrown(InvalidGpgKeyIdsException)
+        println(ex.getMessage())
+
+        where:
+        name                  | keyIds
+        "short id"            | ["AAAAAAA"]
+        "long id"             | ["AAAAAAAAAAAAAA"]
+        "mixed short/long id" | ["AAAAAAAA", "AAAAAAAAAAAAAA"]
+    }
+
+    def "ArtifactVerificationBuilder should succeed if trusted GPG key is a fingerprint"() {
+        given:
+        def verificationBuilder = new DependencyVerifierBuilder.ArtifactVerificationBuilder()
+        verificationBuilder.addTrustedKey("d7bf96a169f77b28c934ab1614f53f0824875d73")
+
+        when:
+        verificationBuilder.buildTrustedPgpKeys();
+
+        then:
+        noExceptionThrown()
+    }
+
+}

--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/dependency_verification.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/dependency_verification.adoc
@@ -111,7 +111,6 @@ Therefore, it's recommended to always use the same parameters once you started b
 
 The dependency verification file can be generated with the following CLI instructions:
 
-
 ----
 gradle --write-verification-metadata sha256 help
 ----
@@ -160,7 +159,6 @@ By default, bootstrapping is incremental, which means that if you run it multipl
 There are situations where you would just want to _see_ what the generated verification metadata file would look like without actually changing the existing one or overwriting it.
 
 For this purpose, you can just add `--dry-run`:
-
 
 ----
 gradle --write-verification-metadata sha256 help --dry-run
@@ -258,7 +256,6 @@ Changing the `origin` gives users a sense of how trustworthy your build it.
 Interestingly, using `pdfbox` will require _much more_ than those 2 artifacts, because it will also bring in transitive dependencies.
 If the dependency verification file only included the checksums for the main artifacts you used, the build would fail with an error like this one:
 
-
 ----
 Execution failed for task ':compileJava'.
 > Dependency verification failed for configuration ':compileClasspath':
@@ -287,7 +284,8 @@ For example, the following configuration would check both the `md5` and `sha256`
 
 There are multiple reasons why you'd like to do so:
 
-1. an official site doesn't publish _secure_ checksums (SHA-256, SHA-512) but publishes multiple insecure ones (MD5, SHA1). While it's easy to fake a MD5 checksum and hard but possible to fake a SHA1 checksum, it's harder to fake both of them for the same artifact.
+1. an official site doesn't publish _secure_ checksums (SHA-256, SHA-512) but publishes multiple insecure ones (MD5, SHA1).
+While it's easy to fake a MD5 checksum and hard but possible to fake a SHA1 checksum, it's harder to fake both of them for the same artifact.
 2. you might want to add generated checksums to the list above
 3. when _updating_ dependency verification file with more secure checksums, you don't want to accidentally erase checksums
 
@@ -370,10 +368,14 @@ In practice, it means you need to list the keys that you trust for each artifact
 </component>
 ----
 
-[TIP]
+[WARNING]
 ====
-Gradle supports both full fingerprint ids or long (64-bit) key ids in `pgp`, `trusted-key` and `ignore-key` elements.
-For maximum security, you should use full fingerprints as it's possible to have collisions for long key ids.
+For the `pgp` and `trusted-key` elements, Gradle _requires_ full fingerprint IDs (e.g. `b801e2f8ef035068ec1139cc29579f18fa8fd93b` instead of a long ID `29579f18fa8fd93b`) .
+This minimizes the chance of a https://en.wikipedia.org/wiki/Collision_attack[collision attack].
+
+At the time, https://www.rfc-editor.org/rfc/rfc4880#section-12.2[V4 key fingerprints] are of 160-bit (40 characters) length. We accept longer keys to be future-proof in case a longer key fingerprint is introduced.
+
+In `ignore-key` elements, either fingerprints or long (64-bit) IDs can be used. A shorter ID can only result in a bigger range of exclusion, therefore, it's safe to use.
 ====
 
 This effectively means that you trust `com.github.javaparser:javaparser-core:3.6.11` if it's signed with the key `8756c4f765c9ac3cb6b85d62379ce192d401ab61`.
@@ -407,14 +409,14 @@ If this is the case, you can move the trusted key from the artifact level to the
       <verify-metadata>true</verify-metadata>
       <verify-signatures>true</verify-signatures>
       <trusted-keys>
-         <trusted-key id="379ce192d401ab61" group="com.github.javaparser"/>
+         <trusted-key id="8756c4f765c9ac3cb6b85d62379ce192d401ab61" group="com.github.javaparser"/>
       </trusted-keys>
    </configuration>
    <components/>
 </verification-metadata>
 ----
 
-The configuration above means that for any artifact belonging to the group `com.github.javaparser`, we trust it if it's signed with the `379ce192d401ab61`.
+The configuration above means that for any artifact belonging to the group `com.github.javaparser`, we trust it if it's signed with the `8756c4f765c9ac3cb6b85d62379ce192d401ab61` fingerprint.
 
 The `trusted-key` element works similarly to the <<sec:trusting-artifacts,trusted-artifact>> element:
 
@@ -497,14 +499,14 @@ You can generate this file using GPG, for example issuing the following commands
 
 [source,bash]
 ----
-$ gpg --no-default-keyring --keyring gradle/verification-keyring.gpg --recv-keys 379ce192d401ab61
+$ gpg --no-default-keyring --keyring gradle/verification-keyring.gpg --recv-keys 8756c4f765c9ac3cb6b85d62379ce192d401ab61
 
 gpg: keybox 'gradle/verification-keyring.gpg' created
 gpg: key 379CE192D401AB61: public key "Bintray (by JFrog) <****>" imported
 gpg: Total number processed: 1
 gpg:               imported: 1
 
-$ gpg --no-default-keyring --keyring gradle/verification-keyring.gpg --recv-keys 6a0975f8b1127b83
+$ gpg --no-default-keyring --keyring gradle/verification-keyring.gpg --recv-keys 6f538074ccebf35f28af9b066a0975f8b1127b83
 
 gpg: key 0729A0AFF8999A87: public key "Kotlin Release <****>" imported
 gpg: Total number processed: 1
@@ -575,14 +577,14 @@ This is the case for example if you use <<sec:checksum-verification,checksum ver
 
 Gradle will tell you what metadata is missing:
 
-
 ----
 Execution failed for task ':compileJava'.
 > Dependency verification failed for configuration ':compileClasspath':
     - On artifact commons-logging-1.2.jar (commons-logging:commons-logging:1.2) in repository 'MavenRepo': checksum is missing from verification metadata.
 ----
 
-- the missing module group is `commons-logging`, it's artifact name is `commons-logging` and its version is `1.2`. The corresponding artifact is `commons-logging-1.2.jar` so you need to add the following entry to the verification file:
+- the missing module group is `commons-logging`, it's artifact name is `commons-logging` and its version is `1.2`.
+The corresponding artifact is `commons-logging-1.2.jar` so you need to add the following entry to the verification file:
 
 [source,xml]
 ----
@@ -599,7 +601,6 @@ Alternatively, you can ask Gradle to generate the missing information by using t
 
 A more problematic issue is when the actual checksum verification fails:
 
-
 ----
 Execution failed for task ':compileJava'.
 > Dependency verification failed for configuration ':compileClasspath':
@@ -612,7 +613,8 @@ Such a failure indicates that a **dependency may have been compromised**.
 At this stage, you **must** perform manual verification and check what happens.
 Several things can happen:
 
-* a dependency was tampered in the local dependency cache of Gradle. This is usually harmless: erase the file from the cache and Gradle would redownload the dependency.
+* a dependency was tampered in the local dependency cache of Gradle.
+This is usually harmless: erase the file from the cache and Gradle would redownload the dependency.
 * a dependency is available in multiple sources with slightly different binaries (additional whitespace, ...)
 ** please inform the maintainers of the library that they have such an issue
 ** you can use <<#sec:trusting-several-checksums,`also-trust`>> to accept the additional checksums
@@ -625,7 +627,6 @@ Note that a variation of a compromised library is often _name squatting_, when a
 ==== Untrusted signatures
 
 If you have signature verification enabled, Gradle will perform verification of the signatures but will not trust them automatically:
-
 
 ----
 > Dependency verification failed for configuration ':compileClasspath':
@@ -711,7 +712,7 @@ $ curl https://my-company-mirror.com/repo/com/google/j2objc/j2objc-annotations/1
 Then we can use the key information provided in the error message to import the key locally:
 
 ----
-$ gpg --recv-keys 29579f18fa8fd93b
+$ gpg --recv-keys B801E2F8EF035068EC1139CC29579F18FA8FD93B
 ----
 
 And perform verification:
@@ -798,13 +799,11 @@ The verification errors will be displayed during the build without causing a bui
 
 All those modes can be activated on the CLI using the `--dependency-verification` flag, for example:
 
-
 ----
 ./gradlew --dependency-verification lenient build
 ----
 
 Alternatively, you can set the `org.gradle.dependency.verification` system property, either on the CLI:
-
 
 ----
 ./gradlew -Dorg.gradle.dependency.verification=lenient build
@@ -927,7 +926,6 @@ We need to move the existing file because both the bootstrapping mode and the dr
 Gradle caches missing keys for 24 hours, meaning it will not attempt to re-download the missing keys for 24 hours after failing.
 
 If you want to retry immediately, you can run with the `--refresh-keys` CLI flag:
-
 
 ----
 ./gradlew build --refresh-keys


### PR DESCRIPTION
Backport from #23667 to 6.9.4

Fixes #23945