### PR TITLE
Allow for easy customization of Kotlin options in `kotlin-dsl` projects

### DIFF
--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinDslPluginCustomKotlinOptionsIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinDslPluginCustomKotlinOptionsIntegrationTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.integration
+
+import org.junit.Test
+
+
+class KotlinDslPluginCustomKotlinOptionsIntegrationTest : AbstractPluginIntegrationTest() {
+
+    @Test
+    fun `can configure custom kotlin options on a kotlin-dsl project`() {
+
+        assumeNonEmbeddedGradleExecuter()
+
+        withDefaultSettingsIn("buildSrc")
+        val buildSrcBuildScript = withKotlinDslPluginIn("buildSrc")
+        withFile("buildSrc/src/main/kotlin/MyDataObject.kt", "data object MyDataObject")
+        withBuildScript("println(MyDataObject)")
+        buildAndFail("help").apply {
+            assertHasErrorOutput("""The feature "data objects" is only available since language version 1.9""")
+        }
+
+        buildSrcBuildScript.appendText("""
+            tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+                compilerOptions {
+                    apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_9)
+                    languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_9)
+                }
+            }
+        """)
+        build("help").apply {
+            assertOutputContains("MyDataObject")
+            assertOutputContains("Language version 1.9 is experimental, there are no backwards compatibility guarantees for new language and library features")
+        }
+    }
+}

--- a/subprojects/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslCompilerPlugins.kt
+++ b/subprojects/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslCompilerPlugins.kt
@@ -54,29 +54,27 @@ abstract class KotlinDslCompilerPlugins : Plugin<Project> {
             }
         }
 
-        afterEvaluate {
-            kotlinDslPluginOptions {
-                tasks.withType<KotlinCompile>().configureEach {
-                    it.compilerOptions {
-                        DeprecationLogger.whileDisabled {
-                            @Suppress("DEPRECATION")
-                            if (this@kotlinDslPluginOptions.jvmTarget.isPresent) {
-                                jvmTarget.set(JvmTarget.fromTarget(this@kotlinDslPluginOptions.jvmTarget.get()))
-                            }
+        kotlinDslPluginOptions {
+            tasks.withType<KotlinCompile>().configureEach { kotlinCompile ->
+                kotlinCompile.compilerOptions {
+                    DeprecationLogger.whileDisabled {
+                        @Suppress("DEPRECATION")
+                        if (this@kotlinDslPluginOptions.jvmTarget.isPresent) {
+                            jvmTarget.set(this@kotlinDslPluginOptions.jvmTarget.map { JvmTarget.fromTarget(it) })
                         }
-                        apiVersion.set(KotlinVersion.KOTLIN_1_8)
-                        languageVersion.set(KotlinVersion.KOTLIN_1_8)
-                        freeCompilerArgs.addAll(KotlinDslPluginSupport.kotlinCompilerArgs)
                     }
-                    it.setWarningRewriter(ExperimentalCompilerWarningSilencer(listOf(
-                        "-XXLanguage:+DisableCompatibilityModeForNewInference",
-                        "-XXLanguage:-TypeEnhancementImprovementsInStrictMode",
-                        "Assign Kotlin compiler plugin is an experimental feature",
-                        // Kotlin 1.8.0 has wrong warning message for assign plugin, remove once we update Kotlin to 1.8.20.
-                        // https://github.com/JetBrains/kotlin/commit/0eb34983cb38064684cfc76dacb8d4460fcc6573
-                        "Lombok Kotlin compiler plugin is an experimental feature",
-                    )))
+                    apiVersion.set(KotlinVersion.KOTLIN_1_8)
+                    languageVersion.set(KotlinVersion.KOTLIN_1_8)
+                    freeCompilerArgs.addAll(KotlinDslPluginSupport.kotlinCompilerArgs)
                 }
+                kotlinCompile.setWarningRewriter(ExperimentalCompilerWarningSilencer(listOf(
+                    "-XXLanguage:+DisableCompatibilityModeForNewInference",
+                    "-XXLanguage:-TypeEnhancementImprovementsInStrictMode",
+                    "Assign Kotlin compiler plugin is an experimental feature",
+                    // Kotlin 1.8.0 has wrong warning message for assign plugin, remove once we update Kotlin to 1.8.20.
+                    // https://github.com/JetBrains/kotlin/commit/0eb34983cb38064684cfc76dacb8d4460fcc6573
+                    "Lombok Kotlin compiler plugin is an experimental feature",
+                )))
             }
         }
     }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
@@ -399,6 +399,7 @@ val gradleKotlinDslLanguageVersionSettings = LanguageVersionSettingsImpl(
     apiVersion = ApiVersion.KOTLIN_1_8,
     analysisFlags = mapOf(
         AnalysisFlags.skipMetadataVersionCheck to true,
+        AnalysisFlags.skipPrereleaseCheck to true,
         JvmAnalysisFlags.jvmDefaultMode to JvmDefaultMode.ENABLE,
     ),
     specificFeatures = mapOf(


### PR DESCRIPTION
This PR removes usage of `afterEvaluate {}` from the `kotlin-dsl` plugin. This is possible now that it uses the Kotlin Gradle plugin >= 1.8.0 that provides lazy configuration properties.

This allows for easy configuration of the `KotlinCompile` tasks directly, thus Kotlin compiler options.

The standalone script compilation is also now configured to skip the pre-release check in order to allow referencing Kotlin code compiled with more recent Kotlin language versions on a best effort basis.

----

* Fixes https://github.com/gradle/gradle/issues/23955
