### PR TITLE
Reduce the padding of footer for mobile devices

### DIFF
--- a/subprojects/docs/src/docs/css/manual.css
+++ b/subprojects/docs/src/docs/css/manual.css
@@ -1834,7 +1834,14 @@ div.screenshot {
     padding: 30px 12px;
     max-width: 62.5rem;
     margin: 0 auto;
-    padding-left: 5rem
+    padding-left: 5rem;
+}
+
+@media not screen and (min-width: 64rem) {
+    .site-footer__navigation {
+        /* same to nav.docs-navigation for mobiles */
+        padding: 20px 20px 20px 26px;
+    }
 }
 
 .site-footer__links {


### PR DESCRIPTION
### Context

This PR reduces the padding of footer for mobile devices so the content doesn't overflow.

#### Before

<img width="337" alt="image" src="https://user-images.githubusercontent.com/28441561/219965516-5129ea44-0152-40fe-a88e-c0cc81928e55.png">

#### After

<img width="285" alt="image" src="https://user-images.githubusercontent.com/28441561/219965491-7aecd338-daac-4f34-b2d6-dd6faf48bbc8.png">


### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
