### PR TITLE
Copy command line argument providers lazily

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaForkOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaForkOptions.java
@@ -103,7 +103,7 @@ public class DefaultJavaForkOptions extends DefaultProcessForkOptions implements
     @Override
     public List<CommandLineArgumentProvider> getJvmArgumentProviders() {
         if (jvmArgumentProviders == null) {
-            jvmArgumentProviders = new ArrayList<CommandLineArgumentProvider>();
+            jvmArgumentProviders = new ArrayList<>();
         }
         return jvmArgumentProviders;
     }
@@ -210,9 +210,8 @@ public class DefaultJavaForkOptions extends DefaultProcessForkOptions implements
         super.copyTo(target);
         options.copyTo(target);
         if (jvmArgumentProviders != null) {
-            for (CommandLineArgumentProvider jvmArgumentProvider : jvmArgumentProviders) {
-                target.jvmArgs(jvmArgumentProvider.asArguments());
-            }
+            target.getJvmArgumentProviders().clear();
+            target.getJvmArgumentProviders().addAll(jvmArgumentProviders);
         }
         return this;
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultJavaForkOptionsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultJavaForkOptionsTest.groovy
@@ -363,6 +363,7 @@ class DefaultJavaForkOptionsTest extends Specification {
 
     def "can copy to target options"() {
         JavaForkOptions target = Mock(JavaForkOptions)
+        def targetJvmArgumentProviders = []
 
         given:
         options.executable('executable')
@@ -370,12 +371,14 @@ class DefaultJavaForkOptionsTest extends Specification {
         options.systemProperties(key: 12)
         options.minHeapSize = '64m'
         options.maxHeapSize = '1g'
-        options.jvmArgumentProviders << new CommandLineArgumentProvider() {
+
+        def commandLineArgumentProvider = new CommandLineArgumentProvider() {
             @Override
             Iterable<String> asArguments() {
                 return ['argFromProvider']
             }
         }
+        options.jvmArgumentProviders << commandLineArgumentProvider
 
         when:
         options.copyTo(target)
@@ -389,9 +392,9 @@ class DefaultJavaForkOptionsTest extends Specification {
         1 * target.bootstrapClasspath(_)
         1 * target.setEnableAssertions(false)
         1 * target.getDebugOptions() >> new DefaultJavaDebugOptions()
+        2 * target.jvmArgumentProviders >> targetJvmArgumentProviders
 
-        then:
-        1 * target.jvmArgs(['argFromProvider'])
+        targetJvmArgumentProviders == [commandLineArgumentProvider]
     }
 
     def "defaults are compatible"() {

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/TestTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/TestTest.groovy
@@ -228,7 +228,7 @@ class TestTest extends AbstractConventionTaskTest {
         test.copyTo(javaForkOptions)
 
         then:
-        javaForkOptions.getJvmArgs() == ['First', 'Second']
+        javaForkOptions.jvmArgumentProviders == test.jvmArgumentProviders
     }
 
     def "java version is determined with toolchain if set"() {


### PR DESCRIPTION
on in `JavaForkOptions.copyTo`. This is to avoid the realization of them at configuration time.