### PR TITLE
Publish enterprise-operations

### DIFF
--- a/subprojects/enterprise-operations/build.gradle.kts
+++ b/subprojects/enterprise-operations/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("gradlebuild.distribution.api-java")
+    id("gradlebuild.publish-public-libraries")
 }
 
 description = "Build operations consumed by the Gradle Enterprise plugin"

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/api/internal/tasks/RealizeTaskBuildOperationType.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/api/internal/tasks/RealizeTaskBuildOperationType.java
@@ -31,7 +31,7 @@ public final class RealizeTaskBuildOperationType implements BuildOperationType<R
         String getTaskPath();
 
         /**
-         * @see org.gradle.api.internal.project.taskfactory.TaskIdentity#uniqueId
+         * See {@code org.gradle.api.internal.project.taskfactory.TaskIdentity#uniqueId}.
          */
         long getTaskId();
 

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/api/internal/tasks/RegisterTaskBuildOperationType.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/api/internal/tasks/RegisterTaskBuildOperationType.java
@@ -31,7 +31,7 @@ public final class RegisterTaskBuildOperationType implements BuildOperationType<
         String getTaskPath();
 
         /**
-         * @see org.gradle.api.internal.project.taskfactory.TaskIdentity#uniqueId
+         * See {@code org.gradle.api.internal.project.taskfactory.TaskIdentity#uniqueId}.
          */
         long getTaskId();
 

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationType.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationType.java
@@ -161,16 +161,18 @@ public final class SnapshotTaskInputsBuildOperationType implements BuildOperatio
             /**
              * The “primary” attribute of the current property.
              *
-             * Used by Gradle Enterprise plugin < 3.8, retained for backwards compatibility.
+             * Used by Gradle Enterprise plugin &lt; 3.8, retained for backwards compatibility.
              *
              * Returns the name value of one of:
              *
+             * <ul>
              * <li>org.gradle.internal.fingerprint.FingerprintingStrategy#CLASSPATH_IDENTIFIER</li>
              * <li>org.gradle.internal.fingerprint.FingerprintingStrategy#COMPILE_CLASSPATH_IDENTIFIER</li>
              * <li>org.gradle.internal.fingerprint.impl.AbsolutePathFingerprintingStrategy#IDENTIFIER</li>
              * <li>org.gradle.internal.fingerprint.impl.RelativePathFingerprintingStrategy#IDENTIFIER</li>
              * <li>org.gradle.internal.fingerprint.impl.NameOnlyFingerprintingStrategy#IDENTIFIER</li>
              * <li>org.gradle.internal.fingerprint.impl.IgnoredPathFingerprintingStrategy#IDENTIFIER</li>
+             * </ul>
              *
              * @deprecated since 7.3, superseded by {@link #getPropertyAttributes()}
              */

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteTaskBuildOperationType.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteTaskBuildOperationType.java
@@ -44,7 +44,7 @@ public final class ExecuteTaskBuildOperationType implements BuildOperationType<E
         String getTaskPath();
 
         /**
-         * @see org.gradle.api.internal.project.taskfactory.TaskIdentity#uniqueId
+         * See {@code org.gradle.api.internal.project.taskfactory.TaskIdentity#uniqueId}.
          */
         long getTaskId();
 
@@ -57,7 +57,7 @@ public final class ExecuteTaskBuildOperationType implements BuildOperationType<E
         /**
          * The message describing why the task was skipped.
          *
-         * Expected to be {@link org.gradle.api.tasks.TaskState#getSkipMessage()}.
+         * Expected to be {@code org.gradle.api.tasks.TaskState#getSkipMessage()}.
          */
         @Nullable
         String getSkipMessage();
@@ -65,7 +65,7 @@ public final class ExecuteTaskBuildOperationType implements BuildOperationType<E
         /**
          * The detailed reason why the task was skipped, if provided by the project configuration.
          *
-         * Expected to be {@link org.gradle.api.tasks.TaskState#getSkipReasonMessage()}.
+         * Expected to be {@code org.gradle.api.tasks.TaskState#getSkipReasonMessage()}.
          *
          * @since 7.6
          */
@@ -74,7 +74,7 @@ public final class ExecuteTaskBuildOperationType implements BuildOperationType<E
 
         /**
          * Whether the task had any actions.
-         * See {@link org.gradle.api.internal.tasks.TaskStateInternal#isActionable()}.
+         * See {@code org.gradle.api.internal.tasks.TaskStateInternal#isActionable()}.
          */
         boolean isActionable();
 
@@ -114,7 +114,7 @@ public final class ExecuteTaskBuildOperationType implements BuildOperationType<E
          * The categorisation of the why the task was not cacheable.
          * Null if the task was cacheable.
          * Not null if {@link #getCachingDisabledReasonMessage()}l is not null.
-         * Values are expected to correlate to {@link org.gradle.api.internal.tasks.TaskOutputCachingDisabledReasonCategory}.
+         * Values are expected to correlate to {@code org.gradle.api.internal.tasks.TaskOutputCachingDisabledReasonCategory}.
          */
         @Nullable
         String getCachingDisabledReasonCategory();
@@ -131,7 +131,7 @@ public final class ExecuteTaskBuildOperationType implements BuildOperationType<E
         /**
          * Returns if this task was executed incrementally.
          *
-         * @see org.gradle.work.InputChanges#isIncremental()
+         * See {@code org.gradle.work.InputChanges#isIncremental()}.
          */
         @NotUsedByScanPlugin("used to report incrementality to TAPI progress listeners")
         boolean isIncremental();

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/api/internal/tasks/execution/ResolveTaskMutationsBuildOperationType.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/api/internal/tasks/execution/ResolveTaskMutationsBuildOperationType.java
@@ -36,7 +36,7 @@ public final class ResolveTaskMutationsBuildOperationType implements BuildOperat
         String getTaskPath();
 
         /**
-         * @see org.gradle.api.internal.project.taskfactory.TaskIdentity#uniqueId
+         * See {@code org.gradle.api.internal.project.taskfactory.TaskIdentity#uniqueId}.
          */
         long getTaskId();
     }

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/caching/internal/FinalizeBuildCacheConfigurationBuildOperationType.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/caching/internal/FinalizeBuildCacheConfigurationBuildOperationType.java
@@ -68,14 +68,14 @@ public final class FinalizeBuildCacheConfigurationBuildOperationType implements 
             /**
              * The class name of the DSL configuration type.
              *
-             * e.g. {@link org.gradle.caching.local.DirectoryBuildCache}
+             * E.g. {@code org.gradle.caching.local.DirectoryBuildCache}.
              */
             String getClassName();
 
             /**
              * The human friendly description of the type (e.g. "HTTP", "directory")
              *
-             * @see org.gradle.caching.BuildCacheServiceFactory.Describer#type(String)
+             * See {@code org.gradle.caching.BuildCacheServiceFactory.Describer#type(String)}.
              */
             String getType();
 
@@ -89,7 +89,7 @@ public final class FinalizeBuildCacheConfigurationBuildOperationType implements 
              * No null values or keys.
              * Ordered by key lexicographically.
              *
-             * @see org.gradle.caching.BuildCacheServiceFactory.Describer#config(String, String)
+             * See {@code org.gradle.caching.BuildCacheServiceFactory.Describer#config(String, String)}.
              */
             Map<String, String> getConfig();
 

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/initialization/LoadProjectsBuildOperationType.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/initialization/LoadProjectsBuildOperationType.java
@@ -40,14 +40,14 @@ public final class LoadProjectsBuildOperationType implements BuildOperationType<
          * The path of the build configuration that contains these projects.
          * This will be ':' for top-level builds. Nested builds will have a sub-path.
          *
-         * @see org.gradle.api.internal.GradleInternal#getIdentityPath()
+         * See {@code org.gradle.api.internal.GradleInternal#getIdentityPath()}.
          */
         String getBuildPath();
 
         /**
          * A description of the root Project for this build.
          *
-         * @see org.gradle.api.initialization.Settings#getRootProject()
+         * See {@code org.gradle.api.initialization.Settings#getRootProject()}.
          */
         Project getRootProject();
 
@@ -56,14 +56,14 @@ public final class LoadProjectsBuildOperationType implements BuildOperationType<
             /**
              * The name of the project.
              *
-             * @see org.gradle.api.Project#getName()
+             * See {@code org.gradle.api.Project#getName()}.
              */
             String getName();
 
             /**
              * The path of the project.
              *
-             * @see org.gradle.api.Project#getPath()
+             * See {@code org.gradle.api.Project#getPath()}.
              */
             String getPath();
 
@@ -72,21 +72,21 @@ public final class LoadProjectsBuildOperationType implements BuildOperationType<
              * For top-level builds this will be the same as {@link #getPath()}.
              * For nested builds the project path will be prefixed with a build path.
              *
-             * @see org.gradle.api.internal.project.ProjectInternal#getIdentityPath()
+             * See {@code org.gradle.api.internal.project.ProjectInternal#getIdentityPath()}.
              */
             String getIdentityPath();
 
             /**
              * The absolute file path of the project directory.
              *
-             * @see org.gradle.api.Project#getProjectDir()
+             * See {@code org.gradle.api.Project#getProjectDir()}.
              */
             String getProjectDir();
 
             /**
              * The absolute file path of the projects build file.
              *
-             * @see org.gradle.api.Project#getBuildFile()
+             * See {@code org.gradle.api.Project#getBuildFile()}.
              */
             String getBuildFile();
 
@@ -95,7 +95,7 @@ public final class LoadProjectsBuildOperationType implements BuildOperationType<
              * No null values.
              * Ordered by project name lexicographically.
              *
-             * @see org.gradle.api.Project#getChildProjects()
+             * See {@code org.gradle.api.Project#getChildProjects()}.
              */
 
             Set<? extends Project> getChildren();

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/internal/taskgraph/CalculateTaskGraphBuildOperationType.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/internal/taskgraph/CalculateTaskGraphBuildOperationType.java
@@ -66,7 +66,7 @@ public final class CalculateTaskGraphBuildOperationType implements BuildOperatio
         String getTaskPath();
 
         /**
-         * @see org.gradle.api.internal.project.taskfactory.TaskIdentity#uniqueId
+         * See {@code org.gradle.api.internal.project.taskfactory.TaskIdentity#uniqueId}.
          */
         long getTaskId();
 

--- a/subprojects/enterprise-workers/build.gradle.kts
+++ b/subprojects/enterprise-workers/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("gradlebuild.distribution.api-java")
+    id("gradlebuild.publish-public-libraries")
 }
 
 description = "Gradle Enterprise plugin dependencies that also need to be exposed to workers"

--- a/subprojects/enterprise-workers/src/main/java/org/gradle/internal/featurelifecycle/DeprecatedUsageProgressDetails.java
+++ b/subprojects/enterprise-workers/src/main/java/org/gradle/internal/featurelifecycle/DeprecatedUsageProgressDetails.java
@@ -27,29 +27,29 @@ import java.util.List;
 public interface DeprecatedUsageProgressDetails {
 
     /**
-     * See {@link org.gradle.internal.deprecation.DeprecatedFeatureUsage#getSummary()}
+     * See {@code org.gradle.internal.deprecation.DeprecatedFeatureUsage#getSummary()}
      */
     String getSummary();
 
     /**
-     * See {@link org.gradle.internal.deprecation.DeprecatedFeatureUsage#getRemovalDetails()}
+     * See {@code org.gradle.internal.deprecation.DeprecatedFeatureUsage#getRemovalDetails()}
      */
     String getRemovalDetails();
 
     /**
-     * See {@link org.gradle.internal.deprecation.DeprecatedFeatureUsage#getAdvice()}
+     * See {@code org.gradle.internal.deprecation.DeprecatedFeatureUsage#getAdvice()}
      */
     @Nullable
     String getAdvice();
 
     /**
-     * See {@link org.gradle.internal.deprecation.DeprecatedFeatureUsage#getContextualAdvice()}
+     * See {@code org.gradle.internal.deprecation.DeprecatedFeatureUsage#getContextualAdvice()}
      */
     @Nullable
     String getContextualAdvice();
 
     /**
-     * See {@link org.gradle.internal.deprecation.DeprecatedFeatureUsage#getDocumentationUrl()}
+     * See {@code org.gradle.internal.deprecation.DeprecatedFeatureUsage#getDocumentationUrl()}
      *
      * @since 6.2
      */
@@ -57,14 +57,14 @@ public interface DeprecatedUsageProgressDetails {
     String getDocumentationUrl();
 
     /**
-     * See {@link org.gradle.internal.deprecation.DeprecatedFeatureUsage#getType()}.
+     * See {@code org.gradle.internal.deprecation.DeprecatedFeatureUsage#getType()}.
      *
-     * Value is always of {@link DeprecatedFeatureUsage.Type#name()}.
+     * Value is always of {@code org.gradle.internal.deprecation.DeprecatedFeatureUsage.Type#name()}.
      */
     String getType();
 
     /**
-     * See {@link org.gradle.internal.deprecation.DeprecatedFeatureUsage#getStack()}
+     * See {@code org.gradle.internal.deprecation.DeprecatedFeatureUsage#getStack()}
      */
     List<StackTraceElement> getStackTrace();
 

--- a/subprojects/enterprise-workers/src/main/java/org/gradle/internal/operations/logging/StyledTextBuildOperationProgressDetails.java
+++ b/subprojects/enterprise-workers/src/main/java/org/gradle/internal/operations/logging/StyledTextBuildOperationProgressDetails.java
@@ -19,7 +19,7 @@ package org.gradle.internal.operations.logging;
 import java.util.List;
 
 /**
- * Build operation observer's view of {@link org.gradle.internal.logging.events.StyledTextOutputEvent}.
+ * Build operation observer's view of {@code org.gradle.internal.logging.events.StyledTextOutputEvent}.
  *
  * See LoggingBuildOperationProgressBroadcaster.
  *
@@ -36,7 +36,7 @@ public interface StyledTextBuildOperationProgressDetails {
     interface Span {
 
         /**
-         * Always a value name of {@link org.gradle.internal.logging.text.StyledTextOutput.Style}.
+         * Always a value name of {@code org.gradle.internal.logging.text.StyledTextOutput.Style}.
          */
         String getStyleName();
 


### PR DESCRIPTION
to our internal repository to simplify the development of Build Scans.