### PR TITLE
Clear root metadata when adding or removing configurations

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/AddingConfigurationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/AddingConfigurationIntegrationTest.groovy
@@ -84,4 +84,31 @@ class AddingConfigurationIntegrationTest extends AbstractIntegrationSpec {
         expect:
         succeeds "addConfigs"
     }
+
+    def "can remove and add configurations between resolutions"() {
+        given:
+        mavenRepo.module("org", "foo", "1.0").publish()
+
+        buildFile << """
+            repositories {
+                maven { url '$mavenRepo.uri' }
+            }
+
+            task resolve {
+                doLast {
+                    def conf = configurations.create("conf")
+                    conf.dependencies.add(project.dependencies.create("org:foo:1.0"))
+                    conf.files
+                    configurations.remove(conf)
+
+                    def conf2 = configurations.create("conf2")
+                    conf2.dependencies.add(project.dependencies.create("org:foo:1.0"))
+                    conf2.files
+                }
+            }
+        """
+
+        expect:
+        succeeds("resolve")
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
@@ -81,6 +81,8 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
         };
         this.rootComponentMetadataBuilder = rootComponentMetadataBuilderFactory.create(this);
         this.defaultConfigurationFactory = defaultConfigurationFactory;
+        this.whenObjectAdded(x -> rootComponentMetadataBuilder.discardAll());
+        this.whenObjectRemoved(x -> rootComponentMetadataBuilder.discardAll());
     }
 
     @Override


### PR DESCRIPTION
This ensures when a configuration is removed and added between resolutions, we can clear and subsequently re-calculate updated metadata

Fixes https://github.com/gradle/gradle/issues/23985