### PR TITLE
Respect build log level in tooling api builds

### DIFF
--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/protocol/DaemonMessageSerializer.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/protocol/DaemonMessageSerializer.java
@@ -281,12 +281,10 @@ public class DaemonMessageSerializer {
     private static class BuildActionParametersSerializer implements Serializer<BuildActionParameters> {
         private final Serializer<LogLevel> logLevelSerializer;
         private final Serializer<List<File>> classPathSerializer;
-
         BuildActionParametersSerializer() {
             logLevelSerializer = new BaseSerializerFactory().getSerializerFor(LogLevel.class);
             classPathSerializer = new ListSerializer<>(FILE_SERIALIZER);
         }
-
         @Override
         public void write(Encoder encoder, BuildActionParameters parameters) throws Exception {
             FILE_SERIALIZER.write(encoder, parameters.getCurrentDir());
@@ -296,7 +294,6 @@ public class DaemonMessageSerializer {
             encoder.writeBoolean(parameters.isUseDaemon()); // Can probably skip this
             classPathSerializer.write(encoder, parameters.getInjectedPluginClasspath().getAsFiles());
         }
-
         @Override
         public BuildActionParameters read(Decoder decoder) throws Exception {
             File currentDir = FILE_SERIALIZER.read(decoder);

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/exec/LogToClient.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/exec/LogToClient.java
@@ -84,13 +84,11 @@ public class LogToClient extends BuildCommandOnly {
                         dispatcher.submit(event);
                     }
                 }
-
                 private boolean isProgressEvent(OutputEvent event) {
                     return event instanceof ProgressStartEvent || event instanceof ProgressEvent || event instanceof ProgressCompleteEvent;
                 }
-
                 private boolean isMatchingBuildLogLevel(OutputEvent event) {
-                    return event.getLogLevel() != null && event.getLogLevel().compareTo(buildLogLevel) >= 0;
+                    return buildLogLevel != null && event.getLogLevel() != null && event.getLogLevel().compareTo(buildLogLevel) >= 0;
                 }
             };
             LOGGER.debug(DaemonMessages.ABOUT_TO_START_RELAYING_LOGS);

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/DaemonBuildActionExecuter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/DaemonBuildActionExecuter.java
@@ -40,7 +40,7 @@ public class DaemonBuildActionExecuter implements BuildActionExecuter<Connection
         ClassPath classPath = DefaultClassPath.of(operationParameters.getInjectedPluginClasspath());
 
         DaemonParameters daemonParameters = parameters.getDaemonParameters();
-        BuildActionParameters actionParameters = new DefaultBuildActionParameters(parameters.getTapiSystemProperties(), daemonParameters.getEnvironmentVariables(), SystemProperties.getInstance().getCurrentDir(), operationParameters.getBuildLogLevel(), daemonParameters.isEnabled(), classPath);
+        BuildActionParameters actionParameters = new DefaultBuildActionParameters(parameters.getTapiSystemProperties(), daemonParameters.getEnvironmentVariables(), SystemProperties.getInstance().getCurrentDir(), action.getStartParameter().getLogLevel(), daemonParameters.isEnabled(), classPath);
         return executer.execute(action, actionParameters, buildRequestContext);
     }
 }

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/LoggingBridgingBuildActionExecuter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/LoggingBridgingBuildActionExecuter.java
@@ -46,11 +46,7 @@ public class LoggingBridgingBuildActionExecuter implements BuildActionExecuter<C
     @Override
     public BuildActionResult execute(BuildAction action, ConnectionOperationParameters parameters, BuildRequestContext buildRequestContext) {
         ProviderOperationParameters actionParameters = parameters.getOperationParameters();
-        if (Boolean.TRUE.equals(actionParameters.isColorOutput()) && actionParameters.getStandardOutput() != null) {
-            loggingManager.attachConsole(actionParameters.getStandardOutput(), notNull(actionParameters.getStandardError()), ConsoleOutput.Rich);
-        } else if (actionParameters.getStandardOutput() != null || actionParameters.getStandardError() != null) {
-            loggingManager.attachConsole(notNull(actionParameters.getStandardOutput()), notNull(actionParameters.getStandardError()), ConsoleOutput.Plain);
-        }
+        attachConsole(actionParameters);
         ProgressListenerVersion1 progressListener = actionParameters.getProgressListener();
         OutputEventListenerAdapter listener = new OutputEventListenerAdapter(progressListener);
         loggingManager.addOutputEventListener(listener);
@@ -60,6 +56,16 @@ public class LoggingBridgingBuildActionExecuter implements BuildActionExecuter<C
             return executer.execute(action, parameters, buildRequestContext);
         } finally {
             loggingManager.stop();
+        }
+    }
+
+    private void attachConsole(ProviderOperationParameters actionParameters) {
+        OutputStream stdOut = actionParameters.getStandardOutput();
+        OutputStream stdErr = actionParameters.getStandardError();
+        if (Boolean.TRUE.equals(actionParameters.isColorOutput()) && stdOut != null) {
+            loggingManager.attachConsole(stdOut, notNull(stdErr), ConsoleOutput.Rich);
+        } else if (stdOut != null || stdErr != null) {
+            loggingManager.attachConsole(notNull(stdOut), notNull(stdErr), ConsoleOutput.Plain);
         }
     }
 

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/connection/BuildLogLevelMixIn.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/connection/BuildLogLevelMixIn.java
@@ -21,7 +21,6 @@ import org.gradle.api.logging.configuration.LoggingConfiguration;
 import org.gradle.cli.CommandLineConverter;
 import org.gradle.cli.CommandLineParser;
 import org.gradle.cli.ParsedCommandLine;
-import org.gradle.internal.logging.DefaultLoggingConfiguration;
 import org.gradle.internal.logging.LoggingConfigurationBuildOptions;
 
 import java.util.Collections;
@@ -46,7 +45,6 @@ public class BuildLogLevelMixIn {
             return LogLevel.DEBUG;
         }
 
-        LoggingConfiguration loggingConfiguration = converter.convert(parsedCommandLine, new DefaultLoggingConfiguration());
-        return loggingConfiguration.getLogLevel();
+        return null;
     }
 }

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/connection/BuildLogLevelMixIn.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/connection/BuildLogLevelMixIn.java
@@ -21,12 +21,18 @@ import org.gradle.api.logging.configuration.LoggingConfiguration;
 import org.gradle.cli.CommandLineConverter;
 import org.gradle.cli.CommandLineParser;
 import org.gradle.cli.ParsedCommandLine;
+import org.gradle.cli.SystemPropertiesCommandLineConverter;
 import org.gradle.internal.logging.LoggingConfigurationBuildOptions;
+import org.gradle.internal.logging.LoggingConfigurationBuildOptions.LogLevelOption;
 
+import javax.annotation.Nonnull;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
-import static java.util.stream.Collectors.toList;
+import static java.util.Optional.empty;
 
 public class BuildLogLevelMixIn {
     private final LogLevel logLevel;
@@ -42,20 +48,47 @@ public class BuildLogLevelMixIn {
     private LogLevel calcBuildLogLevel(ProviderOperationParameters parameters) {
         LoggingConfigurationBuildOptions loggingBuildOptions = new LoggingConfigurationBuildOptions();
         CommandLineConverter<LoggingConfiguration> converter = loggingBuildOptions.commandLineConverter();
+
+        SystemPropertiesCommandLineConverter propertiesCommandLineConverter = new SystemPropertiesCommandLineConverter();
         CommandLineParser parser = new CommandLineParser().allowUnknownOptions().allowMixedSubcommandsAndOptions();
+
         converter.configure(parser);
+        propertiesCommandLineConverter.configure(parser);
+
         List<String> arguments = parameters.getArguments();
         ParsedCommandLine parsedCommandLine = parser.parse(arguments == null ? Collections.<String>emptyList() : arguments);
-        //configure verbosely only if arguments do not specify any log level.
 
+        //configure verbosely only if arguments do not specify any log level.
+        return getLogLevelFromCommandLineOptions(loggingBuildOptions, parsedCommandLine)
+            .orElseGet(() ->
+                getLogLevelFromCommandLineProperties(parameters, propertiesCommandLineConverter, parsedCommandLine).orElseGet(() -> {
+                    if (parameters.getVerboseLogging()) {
+                        return LogLevel.DEBUG;
+                    }
+                    return null;
+                })
+            );
+    }
+
+    @Nonnull
+    private static Optional<LogLevel> getLogLevelFromCommandLineOptions(LoggingConfigurationBuildOptions loggingBuildOptions, ParsedCommandLine parsedCommandLine) {
         return loggingBuildOptions.getLongLogLevelOptions().stream()
             .filter(parsedCommandLine::hasOption)
-            .map(LoggingConfigurationBuildOptions.LogLevelOption::parseLogLevel)
-            .collect(toList()).stream().findFirst().orElseGet(() -> {
-                if (parameters.getVerboseLogging()) {
-                    return LogLevel.DEBUG;
-                }
-                return null;
-            });
+            .map(LogLevelOption::parseLogLevel)
+            .findFirst();
+    }
+
+    private static Optional<LogLevel> getLogLevelFromCommandLineProperties(ProviderOperationParameters parameters, SystemPropertiesCommandLineConverter propertiesCommandLineConverter, ParsedCommandLine parsedCommandLine) {
+        Map<String, String> properties = propertiesCommandLineConverter.convert(parsedCommandLine, new HashMap<>());
+        String logLevelCommandLineProperty = properties.get(LogLevelOption.GRADLE_PROPERTY);
+        if (logLevelCommandLineProperty != null) {
+            try {
+                return Optional.of(LogLevelOption.parseLogLevel(logLevelCommandLineProperty));
+            } catch (IllegalArgumentException e) {
+                // fall through
+            }
+        }
+        return empty();
+
     }
 }

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/connection/BuildLogLevelMixInTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/connection/BuildLogLevelMixInTest.groovy
@@ -16,55 +16,36 @@
 
 package org.gradle.tooling.internal.provider.connection
 
+
 import org.gradle.api.logging.LogLevel
 import spock.lang.Specification
 
 class BuildLogLevelMixInTest extends Specification {
 
     final parameters = Mock(ProviderOperationParameters)
-    final mixin = new BuildLogLevelMixIn(parameters)
 
-    def "knows build log level for mixed set of arguments"() {
-        when:
-        parameters.getArguments() >> args
-        parameters.getVerboseLogging() >> false
-
-        then:
-        mixin.getBuildLogLevel() == logLevel
-
-        where:
-        args                     | logLevel
-        ['-i']                   | LogLevel.INFO
-        ['-q']                   | LogLevel.QUIET
-        ['-w']                   | LogLevel.WARN
-        ['foo', '--info', 'bar'] | LogLevel.INFO
-        ['-i', 'foo', 'bar']     | LogLevel.INFO
-        ['foo', 'bar', '-i']     | LogLevel.INFO
-    }
-
-    def "verbose flag is only used when no log level arguments"() {
+    def "knows build log level for mixed set of arguments (or not arguments)"() {
         when:
         parameters.getArguments() >> args
         parameters.getVerboseLogging() >> verbose
+        def mixin = new BuildLogLevelMixIn(parameters)
 
         then:
         mixin.getBuildLogLevel() == logLevel
 
         where:
-        args                    | verbose | logLevel
-        ['-q']                  | false   | LogLevel.QUIET
-        ['-q']                  | true    | LogLevel.QUIET
-        ['noLogLevelArguments'] | true    | LogLevel.DEBUG
-        null                    | false   | LogLevel.LIFECYCLE
-        null                    | true    | LogLevel.DEBUG
-    }
+        args                       | verbose | logLevel
+        ['-i']                     | false   | LogLevel.INFO
+        ['no log level arguments'] | false   | null
+        null                       | false   | null
+        ['-q']                     | false   | LogLevel.QUIET
+        ['-w']                     | false   | LogLevel.WARN
+        ['foo', '--info', 'bar']   | false   | LogLevel.INFO
+        ['-i', 'foo', 'bar']       | false   | LogLevel.INFO
+        ['foo', 'bar', '-i']       | false   | LogLevel.INFO
+        ['-q']                     | true    | LogLevel.QUIET
+        ['no log level arguments'] | true    | LogLevel.DEBUG
+        null                       | true    | LogLevel.DEBUG
 
-    def "default log level is lifecycle"() {
-        when:
-        parameters.getArguments() >> ['no log level arguments']
-        parameters.getVerboseLogging() >> false
-
-        then:
-        mixin.getBuildLogLevel() == LogLevel.LIFECYCLE
     }
 }

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/connection/BuildLogLevelMixInTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/connection/BuildLogLevelMixInTest.groovy
@@ -34,18 +34,19 @@ class BuildLogLevelMixInTest extends Specification {
         mixin.getBuildLogLevel() == logLevel
 
         where:
-        args                       | verbose | logLevel
-        ['-i']                     | false   | LogLevel.INFO
-        ['no log level arguments'] | false   | null
-        null                       | false   | null
-        ['-q']                     | false   | LogLevel.QUIET
-        ['-w']                     | false   | LogLevel.WARN
-        ['foo', '--info', 'bar']   | false   | LogLevel.INFO
-        ['-i', 'foo', 'bar']       | false   | LogLevel.INFO
-        ['foo', 'bar', '-i']       | false   | LogLevel.INFO
-        ['-q']                     | true    | LogLevel.QUIET
-        ['no log level arguments'] | true    | LogLevel.DEBUG
-        null                       | true    | LogLevel.DEBUG
+        args                                | verbose | logLevel
+        ['-i']                              | false   | LogLevel.INFO
+        ['no log level arguments']          | false   | null
+        null                                | false   | null
+        ['-q']                              | false   | LogLevel.QUIET
+        ['-w']                              | false   | LogLevel.WARN
+        ['foo', '--info', 'bar']            | false   | LogLevel.INFO
+        ['-i', 'foo', 'bar']                | false   | LogLevel.INFO
+        ['foo', 'bar', '-i']                | false   | LogLevel.INFO
+        ['-Dorg.gradle.logging.level=info'] | false   | LogLevel.INFO
+        ['-q']                              | true    | LogLevel.QUIET
+        ['no log level arguments']          | true    | LogLevel.DEBUG
+        null                                | true    | LogLevel.DEBUG
 
     }
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingConfigurationBuildOptions.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingConfigurationBuildOptions.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.logging;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.logging.configuration.ConsoleOutput;
 import org.gradle.api.logging.configuration.LoggingConfiguration;
@@ -31,26 +32,18 @@ import org.gradle.internal.buildoption.Origin;
 import org.gradle.internal.buildoption.StringBuildOption;
 import org.gradle.util.internal.TextUtil;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
 public class LoggingConfigurationBuildOptions extends BuildOptionSet<LoggingConfiguration> {
 
-    private static List<BuildOption<LoggingConfiguration>> options;
-
-    static {
-        List<BuildOption<LoggingConfiguration>> options = new ArrayList<BuildOption<LoggingConfiguration>>();
-        options.add(new LogLevelOption());
-        options.add(new StacktraceOption());
-        options.add(new ConsoleOption());
-        options.add(new WarningsOption());
-        LoggingConfigurationBuildOptions.options = Collections.unmodifiableList(options);
-    }
+    private static List<BuildOption<LoggingConfiguration>> options = ImmutableList.<BuildOption<LoggingConfiguration>>of(
+        new LogLevelOption(),
+        new StacktraceOption(),
+        new ConsoleOption(),
+        new WarningsOption());
 
     public static List<BuildOption<LoggingConfiguration>> get() {
         return options;
@@ -61,15 +54,11 @@ public class LoggingConfigurationBuildOptions extends BuildOptionSet<LoggingConf
         return options;
     }
 
-    public Collection<String> getLogLevelOptions() {
-        return Arrays.asList(
-            LogLevelOption.DEBUG_SHORT_OPTION,
+    public Collection<String> getLongLogLevelOptions() {
+        return ImmutableList.of(
             LogLevelOption.DEBUG_LONG_OPTION,
-            LogLevelOption.WARN_SHORT_OPTION,
             LogLevelOption.WARN_LONG_OPTION,
-            LogLevelOption.INFO_SHORT_OPTION,
             LogLevelOption.INFO_LONG_OPTION,
-            LogLevelOption.QUIET_SHORT_OPTION,
             LogLevelOption.QUIET_LONG_OPTION);
     }
 
@@ -127,17 +116,17 @@ public class LoggingConfigurationBuildOptions extends BuildOptionSet<LoggingConf
             }
         }
 
-        private LogLevel parseLogLevel(String value) {
-            LogLevel logLevel = null;
+        public static LogLevel parseLogLevel(String value) {
             try {
-                logLevel = LogLevel.valueOf(value.toUpperCase(Locale.ENGLISH));
+                LogLevel logLevel = LogLevel.valueOf(value.toUpperCase(Locale.ENGLISH));
                 if (logLevel == LogLevel.ERROR) {
                     throw new IllegalArgumentException("Log level cannot be set to 'ERROR'.");
                 }
+                return logLevel;
             } catch (IllegalArgumentException e) {
                 Origin.forGradleProperty(GRADLE_PROPERTY).handleInvalidValue(value, "must be one of quiet, warn, lifecycle, info, or debug)");
             }
-            return logLevel;
+            return null;
         }
     }
 

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r81/LogLevelConfigCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r81/LogLevelConfigCrossVersionSpec.groovy
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r81
+
+import org.gradle.api.logging.LogLevel
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+
+import static org.gradle.integtests.tooling.fixture.ToolingApiTestCommon.LOG_LEVEL_TEST_SCRIPT
+import static org.gradle.integtests.tooling.fixture.ToolingApiTestCommon.runLogScript
+import static org.gradle.integtests.tooling.fixture.ToolingApiTestCommon.validateLogs
+
+class LogLevelConfigCrossVersionSpec
+    extends ToolingApiSpecification {
+
+    def setupLoggingTest() {
+        propertiesFile << "org.gradle.logging.level=quiet"
+        buildFile << LOG_LEVEL_TEST_SCRIPT
+    }
+
+    @ToolingApiVersion('>=8.1')
+    @TargetGradleVersion('>=3.0 <=8.0')
+    def "tooling api uses log level set in arguments over gradle properties TAPI >= 8.1"() {
+        given:
+        setupLoggingTest()
+        when:
+        def stdOut = runLogScript(toolingApi, arguments)
+
+        then:
+        validateLogs(stdOut, expectedLevel)
+
+        where:
+        expectedLevel  | arguments
+        LogLevel.LIFECYCLE | []
+        LogLevel.INFO  | ["--info"]
+        LogLevel.LIFECYCLE  | ["-Dorg.gradle.logging.level=info"]
+    }
+
+    @ToolingApiVersion("<8.1")
+    @TargetGradleVersion('>=8.1')
+    def "tooling api uses log level set in arguments over gradle properties TAPI < 8.1"() {
+        given:
+        setupLoggingTest()
+        when:
+        def stdOut = runLogScript(toolingApi, arguments)
+
+        then:
+        validateLogs(stdOut, expectedLevel)
+
+        where:
+        expectedLevel  | arguments
+        LogLevel.QUIET | []
+        LogLevel.INFO  | ["--info"]
+        LogLevel.INFO  | ["-Dorg.gradle.logging.level=info"]
+    }
+
+}

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r81/LogLevelConfigCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r81/LogLevelConfigCrossVersionSpec.groovy
@@ -25,10 +25,9 @@ import static org.gradle.integtests.tooling.fixture.ToolingApiTestCommon.LOG_LEV
 import static org.gradle.integtests.tooling.fixture.ToolingApiTestCommon.runLogScript
 import static org.gradle.integtests.tooling.fixture.ToolingApiTestCommon.validateLogs
 
-class LogLevelConfigCrossVersionSpec
-    extends ToolingApiSpecification {
+class LogLevelConfigCrossVersionSpec extends ToolingApiSpecification {
 
-    def setupLoggingTest() {
+    def setup() {
         propertiesFile << "org.gradle.logging.level=quiet"
         buildFile << LOG_LEVEL_TEST_SCRIPT
     }
@@ -36,8 +35,6 @@ class LogLevelConfigCrossVersionSpec
     @ToolingApiVersion('>=8.1')
     @TargetGradleVersion('>=3.0 <=8.0')
     def "tooling api uses log level set in arguments over gradle properties TAPI >= 8.1"() {
-        given:
-        setupLoggingTest()
         when:
         def stdOut = runLogScript(toolingApi, arguments)
 
@@ -54,8 +51,6 @@ class LogLevelConfigCrossVersionSpec
     @ToolingApiVersion(">=7.0 <8.1")
     @TargetGradleVersion('>=8.1')
     def "tooling api uses log level set in arguments over gradle properties TAPI < 8.1"() {
-        given:
-        setupLoggingTest()
         when:
         def stdOut = runLogScript(toolingApi, arguments)
 
@@ -68,5 +63,4 @@ class LogLevelConfigCrossVersionSpec
         LogLevel.INFO  | ["--info"]
         LogLevel.INFO  | ["-Dorg.gradle.logging.level=info"]
     }
-
 }

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r81/LogLevelConfigCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r81/LogLevelConfigCrossVersionSpec.groovy
@@ -51,7 +51,7 @@ class LogLevelConfigCrossVersionSpec
         LogLevel.LIFECYCLE  | ["-Dorg.gradle.logging.level=info"]
     }
 
-    @ToolingApiVersion("<8.1")
+    @ToolingApiVersion(">=7.0 <8.1")
     @TargetGradleVersion('>=8.1')
     def "tooling api uses log level set in arguments over gradle properties TAPI < 8.1"() {
         given:

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiIntegrationTest.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiIntegrationTest.groovy
@@ -120,19 +120,23 @@ System.out.println("\\nCurrent log level property value (org.gradle.logging.leve
 
         then:
         def output = stdOut.toString()
-
         LogLevel.values().findAll { it < expectedLevel }.collect {
-            /[\s\S]*Hello $it[\s\S]*/
+            getOutputPattern(it)
         }.every { !output.matches(it)}
 
         LogLevel.values().findAll { it >= expectedLevel}.collect{
-            /[\s\S]*Hello $it[\s\S]*/
+            getOutputPattern(it)
         }.every { output.matches(it)}
 
         where:
         expectedLevel  | arguments
         LogLevel.QUIET | []
         LogLevel.INFO  | ["--info"]
+        LogLevel.INFO  | ["-Dorg.gradle.logging.level=info"]
+    }
+
+    private getOutputPattern(LogLevel it) {
+        /[\s\S]*Hello $it[\s\S]*/
     }
 
 

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiIntegrationTest.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiIntegrationTest.groovy
@@ -48,7 +48,7 @@ class ToolingApiIntegrationTest extends AbstractIntegrationSpec {
     final GradleDistribution otherVersion = new ReleasedVersionDistributions().mostRecentRelease
 
     TestFile projectDir
-//
+
     def setup() {
         projectDir = temporaryFolder.testDirectory
         // When adding support for a new JDK version, the previous release might not work with it yet.
@@ -64,7 +64,7 @@ class ToolingApiIntegrationTest extends AbstractIntegrationSpec {
 
 
     def "tooling api uses to the current version of gradle when none has been specified"() {
-        projectDir.file('build.gradle') << "assert gradle.gradleVersion == '${GradleVersion.current().version}'"
+        buildFile << "assert gradle.gradleVersion == '${GradleVersion.current().version}'"
 
         when:
         GradleProject model = toolingApi.withConnection { connection -> connection.getModel(GradleProject.class) }
@@ -74,7 +74,7 @@ class ToolingApiIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def "tooling api output reports 'CONFIGURE SUCCESSFUL' for model requests"() {
-        projectDir.file('build.gradle') << "assert gradle.gradleVersion == '${GradleVersion.current().version}'"
+        buildFile << "assert gradle.gradleVersion == '${GradleVersion.current().version}'"
 
         when:
         def stdOut = new ByteArrayOutputStream()
@@ -126,7 +126,7 @@ class ToolingApiIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def "tooling api uses the wrapper properties to determine which version to use"() {
-        projectDir.file('build.gradle').text = """
+        buildFile << """
         wrapper {
             distributionUrl = '${otherVersion.binDistribution.toURI()}'
         }
@@ -148,8 +148,8 @@ class ToolingApiIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def "tooling api searches up from the project directory to find the wrapper properties"() {
-        projectDir.file('settings.gradle') << "include 'child'"
-        projectDir.file('build.gradle') << """
+        settingsFile << "include 'child'"
+        buildFile << """
         wrapper { distributionUrl = '${otherVersion.binDistribution.toURI()}' }
         allprojects {
             task check { doLast { assert gradle.gradleVersion == '${otherVersion.version.version}' } }
@@ -171,7 +171,7 @@ class ToolingApiIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def "can specify a gradle installation to use"() {
-        projectDir.file('build.gradle').text = "assert gradle.gradleVersion == '${otherVersion.version.version}'"
+        buildFile << "assert gradle.gradleVersion == '${otherVersion.version.version}'"
 
         when:
         toolingApi.withConnector { connector ->
@@ -184,7 +184,7 @@ class ToolingApiIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def "can specify a gradle distribution to use"() {
-        projectDir.file('build.gradle').text = "assert gradle.gradleVersion == '${otherVersion.version.version}'"
+        buildFile << "assert gradle.gradleVersion == '${otherVersion.version.version}'"
 
         when:
         toolingApi.withConnector { connector ->
@@ -197,7 +197,7 @@ class ToolingApiIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def "can specify a gradle version to use"() {
-        projectDir.file('build.gradle').text = "assert gradle.gradleVersion == '${otherVersion.version.version}'"
+        buildFile << "assert gradle.gradleVersion == '${otherVersion.version.version}'"
 
         when:
         toolingApi.withConnector { GradleConnector connector ->
@@ -212,7 +212,6 @@ class ToolingApiIntegrationTest extends AbstractIntegrationSpec {
     @Issue("GRADLE-2419")
     def "tooling API does not hold JVM open"() {
         given:
-        def buildFile = projectDir.file("build.gradle")
         def startTimeoutMs = 90000
         def stateChangeTimeoutMs = 15000
         def stopTimeoutMs = 10000

--- a/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApi.groovy
+++ b/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApi.groovy
@@ -186,6 +186,8 @@ class ToolingApi implements TestRule {
             connector.useInstallation(dist.gradleHomeDir.absoluteFile)
         }
         connector.embedded(embedded)
+
+//        this.
         if (GradleVersion.version(dist.getVersion().version) < GradleVersion.version("6.0")) {
             connector.searchUpwards(false)
         } else {

--- a/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
+++ b/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
@@ -126,8 +126,16 @@ abstract class ToolingApiSpecification extends Specification {
         file("build.gradle")
     }
 
+    TestFile getPropertiesFile() {
+        file("gradle.properties")
+    }
+
     TestFile getBuildFileKts() {
         file("build.gradle.kts")
+    }
+
+    TestFile getBuildKotlinFile() {
+        getBuildFileKts()
     }
 
     TestFile getSettingsFile() {

--- a/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiTestCommon.groovy
+++ b/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiTestCommon.groovy
@@ -17,46 +17,24 @@
 package org.gradle.integtests.tooling.fixture
 
 import org.gradle.api.logging.LogLevel
-import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.executer.GradleDistribution
-import org.gradle.integtests.fixtures.versions.ReleasedVersionDistributions
-import org.gradle.test.fixtures.file.TestFile
 import org.gradle.tooling.ProjectConnection
 
-class ToolingApiTestCommon extends AbstractIntegrationSpec {
+class ToolingApiTestCommon {
 
     public static final String LOG_LEVEL_TEST_SCRIPT = LogLevel.values()
         .collect { """logger.${it.name().toLowerCase()}("Hello $it\\n")""" }
-        .join("\n") + """
-if(project.hasProperty("org.gradle.logging.level")){
-    System.out.println("\\nCurrent log level property value (org.gradle.logging.level): "  + project.property("org.gradle.logging.level"))
-}
-else {
-    System.out.println("\\\\nNo property org.gradle.logging.level set")
-}
-
-task emptyTask(){}
+        .join("\n") +
+        """
+        if(project.hasProperty("org.gradle.logging.level")){
+            System.out.println("\\nCurrent log level property value (org.gradle.logging.level): "  + project.property("org.gradle.logging.level"))
+        }
+        else {
+            System.out.println("\\\\nNo property org.gradle.logging.level set")
+        }
 """
-    final ToolingApi toolingApi = new ToolingApi(distribution, temporaryFolder)
-    final GradleDistribution otherVersion = new ReleasedVersionDistributions().mostRecentRelease
 
-    TestFile projectDir
-//
-    def setup() {
-        projectDir = temporaryFolder.testDirectory
-        // When adding support for a new JDK version, the previous release might not work with it yet.
-//        Assume.assumeTrue(otherVersion.worksWith(Jvm.current()))
-
-        settingsFile.touch()
-    }
-
-    void setupLoggingTest() {
-        propertiesFile << "org.gradle.logging.level=quiet"
-        buildFile << LOG_LEVEL_TEST_SCRIPT
-    }
-
-    static getOutputPattern(LogLevel it) {
-        /[\s\S]*Hello $it[\s\S]*/
+    static getOutputPattern(LogLevel logLevel) {
+        /[\s\S]*Hello $logLevel[\s\S]*/
     }
 
     static validateLogs(Object stdOut, LogLevel expectedLevel) {
@@ -78,7 +56,6 @@ task emptyTask(){}
                 .withArguments(arguments)
                 .setStandardOutput(stdOut)
                 .setStandardError(stdOut)
-                .forTasks("emptyTask")
                 .run()
         }
         stdOut

--- a/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiTestCommon.groovy
+++ b/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiTestCommon.groovy
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.fixture
+
+import org.gradle.api.logging.LogLevel
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.executer.GradleDistribution
+import org.gradle.integtests.fixtures.versions.ReleasedVersionDistributions
+import org.gradle.test.fixtures.file.TestFile
+import org.gradle.tooling.ProjectConnection
+
+class ToolingApiTestCommon extends AbstractIntegrationSpec {
+
+    public static final String LOG_LEVEL_TEST_SCRIPT = LogLevel.values()
+        .collect { """logger.${it.name().toLowerCase()}("Hello $it\\n")""" }
+        .join("\n") + """
+if(project.hasProperty("org.gradle.logging.level")){
+    System.out.println("\\nCurrent log level property value (org.gradle.logging.level): "  + project.property("org.gradle.logging.level"))
+}
+else {
+    System.out.println("\\\\nNo property org.gradle.logging.level set")
+}
+
+task emptyTask(){}
+"""
+    final ToolingApi toolingApi = new ToolingApi(distribution, temporaryFolder)
+    final GradleDistribution otherVersion = new ReleasedVersionDistributions().mostRecentRelease
+
+    TestFile projectDir
+//
+    def setup() {
+        projectDir = temporaryFolder.testDirectory
+        // When adding support for a new JDK version, the previous release might not work with it yet.
+//        Assume.assumeTrue(otherVersion.worksWith(Jvm.current()))
+
+        settingsFile.touch()
+    }
+
+    void setupLoggingTest() {
+        propertiesFile << "org.gradle.logging.level=quiet"
+        buildFile << LOG_LEVEL_TEST_SCRIPT
+    }
+
+    static getOutputPattern(LogLevel it) {
+        /[\s\S]*Hello $it[\s\S]*/
+    }
+
+    static validateLogs(Object stdOut, LogLevel expectedLevel) {
+        def output = stdOut.toString()
+        LogLevel.values().findAll { it < expectedLevel }.collect {
+            getOutputPattern(it)
+        }.every { !output.matches(it) }
+            &&
+            LogLevel.values().findAll { it >= expectedLevel }.collect {
+                getOutputPattern(it)
+            }.every { output.matches(it) }
+
+    }
+
+    static runLogScript(ToolingApi tapi, List<String> arguments) {
+        def stdOut = new ByteArrayOutputStream()
+        tapi.withConnection { ProjectConnection connection ->
+            connection.newBuild()
+                .withArguments(arguments)
+                .setStandardOutput(stdOut)
+                .setStandardError(stdOut)
+                .forTasks("emptyTask")
+                .run()
+        }
+        stdOut
+    }
+}


### PR DESCRIPTION
if non was set via the command line or the `verboseLogging` flag, it would fall back to the default log level. But we don't want any influence if it not explicitly overridden with the `verboseLogging`

- #19340