### PR TITLE
Wrapper task should test distributionUrl set with --gradle-distribution-url or --gradle-version

### DIFF
--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/internal/WrapperPluginAutoApplyActionIntegTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/internal/WrapperPluginAutoApplyActionIntegTest.groovy
@@ -68,7 +68,7 @@ class WrapperPluginAutoApplyActionIntegTest extends AbstractIntegrationSpec {
                 gradleVersion = '12.34'
             }
     """
-        run 'wrapper'
+        run 'wrapper', '--offline'
         then:
         wrapper.generated("12.34")
     }

--- a/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
+++ b/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
@@ -515,6 +515,12 @@ public abstract class Wrapper extends DefaultTask {
         return networkTimeout;
     }
 
+    /**
+     * Sets the offline modus of the wrapper task.
+     *
+     * @since 8.2
+     */
+    @Incubating
     public void setIsOffline(boolean isOffline) {
         this.isOffline = isOffline;
     }

--- a/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
+++ b/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
@@ -112,8 +112,8 @@ public abstract class Wrapper extends DefaultTask {
     private PathBase archiveBase = PathBase.GRADLE_USER_HOME;
     private final Property<Integer> networkTimeout = getProject().getObjects().property(Integer.class);
     private final DistributionLocator locator = new DistributionLocator();
+    private final boolean isOffline;
     private boolean distributionUrlConfigured = false;
-    private boolean isOffline;
 
     public Wrapper() {
         scriptFile = "gradlew";

--- a/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
+++ b/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
@@ -167,7 +167,7 @@ public abstract class Wrapper extends DefaultTask {
         }
     }
 
-    private static final String DISTRIBUTION_URL_EXCEPTION_MESSAGE = "Test of distribution url failed. Please check the values set with --gradle-distribution-url and --gradle-version.";
+    private static final String DISTRIBUTION_URL_EXCEPTION_MESSAGE = "Test of distribution url %s failed. Please check the values set with --gradle-distribution-url and --gradle-version.";
 
     private void testDistributionUrl() {
         if (distributionUrlConfigured) {
@@ -175,13 +175,13 @@ public abstract class Wrapper extends DefaultTask {
             URI uri = URI.create(url);
             if (uri.getScheme().equals("file")) {
                 if (!Files.exists(Paths.get(uri).toAbsolutePath())) {
-                    throw new UncheckedIOException(DISTRIBUTION_URL_EXCEPTION_MESSAGE);
+                    throw new UncheckedIOException(String.format(DISTRIBUTION_URL_EXCEPTION_MESSAGE, url));
                 }
             } else if (uri.getScheme().startsWith("http") && !isOffline) {
                 try {
                     new Download(new Logger(true), "gradlew", Download.UNKNOWN_VERSION).sendHeadRequest(uri);
                 } catch (Exception e) {
-                    throw new UncheckedIOException(DISTRIBUTION_URL_EXCEPTION_MESSAGE, e);
+                    throw new UncheckedIOException(String.format(DISTRIBUTION_URL_EXCEPTION_MESSAGE, url), e);
                 }
             }
         }

--- a/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
+++ b/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
@@ -110,6 +110,7 @@ public abstract class Wrapper extends DefaultTask {
     private final Property<Integer> networkTimeout = getProject().getObjects().property(Integer.class);
     private final DistributionLocator locator = new DistributionLocator();
     private boolean distributionUrlConfiguredOnCommandLine = false;
+    private boolean isOffline = false;
 
     public Wrapper() {
         scriptFile = "gradlew";
@@ -163,7 +164,7 @@ public abstract class Wrapper extends DefaultTask {
     }
 
     private void testDistributionUrl() {
-        if (distributionUrlConfiguredOnCommandLine) {
+        if (distributionUrlConfiguredOnCommandLine && !isOffline) {
             try {
                 new Download(new Logger(true), "gradlew", Download.UNKNOWN_VERSION).sendHeadRequest(getDistributionUrl());
             } catch (Exception e) {
@@ -512,5 +513,9 @@ public abstract class Wrapper extends DefaultTask {
     @Option(option = "network-timeout", description = "Timeout in ms to use when the wrapper is performing network operations")
     public Property<Integer> getNetworkTimeout() {
         return networkTimeout;
+    }
+
+    public void setIsOffline(boolean isOffline) {
+        this.isOffline = isOffline;
     }
 }

--- a/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
+++ b/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
@@ -109,7 +109,7 @@ public abstract class Wrapper extends DefaultTask {
     private PathBase archiveBase = PathBase.GRADLE_USER_HOME;
     private final Property<Integer> networkTimeout = getProject().getObjects().property(Integer.class);
     private final DistributionLocator locator = new DistributionLocator();
-    private boolean distributionUrlConfiguredOnCommandLine = false;
+    private boolean distributionUrlConfigured = false;
     private boolean isOffline = false;
 
     public Wrapper() {
@@ -164,7 +164,7 @@ public abstract class Wrapper extends DefaultTask {
     }
 
     private void testDistributionUrl() {
-        if (distributionUrlConfiguredOnCommandLine && !isOffline) {
+        if (distributionUrlConfigured && !isOffline) {
             try {
                 new Download(new Logger(true), "gradlew", Download.UNKNOWN_VERSION).sendHeadRequest(getDistributionUrl());
             } catch (Exception e) {
@@ -338,11 +338,13 @@ public abstract class Wrapper extends DefaultTask {
      * The version of the gradle distribution required by the wrapper.
      * This is usually the same version of Gradle you use for building your project.
      * The following labels are allowed to specify a version: {@code latest}, {@code release-candidate}, {@code nightly}, and {@code release-nightly}
+     *
+     * <p>The resulting distribution url is validated with a HEAD request before it is written to the gradle-wrapper.properties file.
      */
     @Option(option = "gradle-version", description = "The version of the Gradle distribution required by the wrapper. " +
         "The following labels are allowed: latest, release-candidate, nightly, and release-nightly.")
     public void setGradleVersion(String gradleVersion) {
-        distributionUrlConfiguredOnCommandLine = true;
+        distributionUrlConfigured = true;
         this.gradleVersionResolver.setGradleVersionString(gradleVersion);
     }
 
@@ -409,10 +411,12 @@ public abstract class Wrapper extends DefaultTask {
      * project, you might submit the distribution to your version control system. That way no download is necessary at
      * all. This might be in particular interesting, if you provide a custom gradle snapshot to the wrapper, because you
      * don't need to provide a download server then.
+     *
+     * <p>The distribution url is validated with a HEAD request before it is written to the gradle-wrapper.properties file.
      */
     @Option(option = "gradle-distribution-url", description = "The URL to download the Gradle distribution from.")
     public void setDistributionUrl(String url) {
-        distributionUrlConfiguredOnCommandLine = true;
+        distributionUrlConfigured = true;
         this.distributionUrl = url;
     }
 
@@ -516,7 +520,7 @@ public abstract class Wrapper extends DefaultTask {
     }
 
     /**
-     * Sets the offline modus of the wrapper task.
+     * Sets the offline mode of the wrapper task.
      *
      * @since 8.2
      */

--- a/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
+++ b/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
@@ -117,6 +117,7 @@ public abstract class Wrapper extends DefaultTask {
         jarFile = "gradle/wrapper/gradle-wrapper.jar";
         distributionPath = DEFAULT_DISTRIBUTION_PARENT_NAME;
         archivePath = DEFAULT_DISTRIBUTION_PARENT_NAME;
+        isOffline = getProject().getGradle().getStartParameter().isOffline();
     }
 
     @Inject
@@ -517,15 +518,5 @@ public abstract class Wrapper extends DefaultTask {
     @Option(option = "network-timeout", description = "Timeout in ms to use when the wrapper is performing network operations")
     public Property<Integer> getNetworkTimeout() {
         return networkTimeout;
-    }
-
-    /**
-     * Sets the offline mode of the wrapper task.
-     *
-     * @since 8.2
-     */
-    @Incubating
-    public void setIsOffline(boolean isOffline) {
-        this.isOffline = isOffline;
     }
 }

--- a/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
+++ b/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
@@ -174,14 +174,14 @@ public abstract class Wrapper extends DefaultTask {
             String url = getDistributionUrl();
             URI uri = URI.create(url);
             if (uri.getScheme().equals("file")) {
-                if (!Files.exists(Paths.get(uri.getPath()).toAbsolutePath())) {
-                    throw new UncheckedIOException(DISTRIBUTION_URL_EXCEPTION_MESSAGE + " " + uri);
+                if (!Files.exists(Paths.get(uri).toAbsolutePath())) {
+                    throw new UncheckedIOException(DISTRIBUTION_URL_EXCEPTION_MESSAGE);
                 }
             } else if (uri.getScheme().startsWith("http") && !isOffline) {
                 try {
-                    new Download(new Logger(true), "gradlew", Download.UNKNOWN_VERSION).sendHeadRequest(url);
+                    new Download(new Logger(true), "gradlew", Download.UNKNOWN_VERSION).sendHeadRequest(uri);
                 } catch (Exception e) {
-                    throw new UncheckedIOException(DISTRIBUTION_URL_EXCEPTION_MESSAGE + " " + uri, e);
+                    throw new UncheckedIOException(DISTRIBUTION_URL_EXCEPTION_MESSAGE, e);
                 }
             }
         }

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/WrapperPlugin.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/WrapperPlugin.java
@@ -35,8 +35,6 @@ import static org.gradle.api.tasks.wrapper.internal.DefaultWrapperVersionsResour
  */
 public abstract class WrapperPlugin implements Plugin<Project> {
 
-    private static final String SERVICES_GRADLE_ORG_VERSIONS_OVERRIDE_URL_PROPERTY = "org.gradle.internal.services.version.url.override";
-
     @Override
     public void apply(Project project) {
         if (project.getParent() == null) {
@@ -57,8 +55,7 @@ public abstract class WrapperPlugin implements Plugin<Project> {
     }
 
     private static String getVersionUrl() {
-        String baseUrl = System.getProperty(SERVICES_GRADLE_ORG_VERSIONS_OVERRIDE_URL_PROPERTY,
-            DistributionLocator.SERVICES_GRADLE_BASE_URL);
+        String baseUrl = DistributionLocator.getBaseUrl();
         return baseUrl + "/versions";
     }
 

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/WrapperPlugin.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/WrapperPlugin.java
@@ -51,6 +51,7 @@ public abstract class WrapperPlugin implements Plugin<Project> {
                 wrapper.setGroup("Build Setup");
                 wrapper.setDescription("Generates Gradle wrapper files.");
                 wrapper.getNetworkTimeout().convention(10000);
+                wrapper.setIsOffline(project.getGradle().getStartParameter().isOffline());
                 wrapper.setWrapperVersionsResources(new DefaultWrapperVersionsResources(latest, releaseCandidate, nightly, releaseNightly));
             });
         }

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/WrapperPlugin.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/WrapperPlugin.java
@@ -51,7 +51,6 @@ public abstract class WrapperPlugin implements Plugin<Project> {
                 wrapper.setGroup("Build Setup");
                 wrapper.setDescription("Generates Gradle wrapper files.");
                 wrapper.getNetworkTimeout().convention(10000);
-                wrapper.setIsOffline(project.getGradle().getStartParameter().isOffline());
                 wrapper.setWrapperVersionsResources(new DefaultWrapperVersionsResources(latest, releaseCandidate, nightly, releaseNightly));
             });
         }

--- a/subprojects/build-init/src/test/groovy/org/gradle/api/tasks/wrapper/WrapperTest.groovy
+++ b/subprojects/build-init/src/test/groovy/org/gradle/api/tasks/wrapper/WrapperTest.groovy
@@ -21,7 +21,6 @@ import org.gradle.api.tasks.TaskPropertyTestUtils
 import org.gradle.api.tasks.wrapper.internal.DefaultWrapperVersionsResources
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.GradleVersion
-import org.gradle.util.internal.DistributionLocator
 import org.gradle.util.internal.GUtil
 import org.gradle.util.internal.WrapUtil
 import org.gradle.wrapper.GradleWrapperMain
@@ -107,7 +106,7 @@ class WrapperTest extends AbstractTaskTest {
         wrapper.setGradleVersion(version)
 
         then:
-        "$DistributionLocator.RELEASE_REPOSITORY$snapshot/gradle-$out-bin.zip" == wrapper.getDistributionUrl()
+        "https://services.gradle.org/distributions$snapshot/gradle-$out-bin.zip" == wrapper.getDistributionUrl()
 
         where:
         version                     | out                         | snapshot

--- a/subprojects/core/src/main/java/org/gradle/util/internal/DistributionLocator.java
+++ b/subprojects/core/src/main/java/org/gradle/util/internal/DistributionLocator.java
@@ -23,10 +23,14 @@ import java.net.URISyntaxException;
 
 public class DistributionLocator {
 
-    public static final String SERVICES_GRADLE_BASE_URL = "https://services.gradle.org";
+    private static final String SERVICES_GRADLE_BASE_URL_PROPERTY = "org.gradle.internal.services.base.url";
+    private static final String SERVICES_GRADLE_BASE_URL = "https://services.gradle.org";
+    private static final String RELEASE_REPOSITORY = "/distributions";
+    private static final String SNAPSHOT_REPOSITORY = "/distributions-snapshots";
 
-    public static final String RELEASE_REPOSITORY = SERVICES_GRADLE_BASE_URL + "/distributions";
-    private static final String SNAPSHOT_REPOSITORY = SERVICES_GRADLE_BASE_URL + "/distributions-snapshots";
+    public static String getBaseUrl() {
+        return System.getProperty(SERVICES_GRADLE_BASE_URL_PROPERTY, SERVICES_GRADLE_BASE_URL);
+    }
 
     public URI getDistributionFor(GradleVersion version) {
         return getDistributionFor(version, "bin");
@@ -38,9 +42,9 @@ public class DistributionLocator {
 
     private String getDistributionRepository(GradleVersion version) {
         if (version.isSnapshot()) {
-            return SNAPSHOT_REPOSITORY;
+            return getBaseUrl() + SNAPSHOT_REPOSITORY;
         } else {
-            return RELEASE_REPOSITORY;
+            return getBaseUrl() + RELEASE_REPOSITORY;
         }
     }
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -52,7 +52,7 @@ vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv -->
 
 ### Wrapper task validates distribution url
 
-The wrapper task now validates the configured distribution url before writing it to the gradle-wrapper.properties file.
+The wrapper task now validates the configured distribution url before writing it to the `gradle-wrapper.properties` file.
 This surfaces invalid urls early and can prevent IO exceptions at execution time.
 
 More details can be found in the dedicated section of the [Gradle Wrapper](gradle_wrapper.html#[adding_the_gradle_wrapper](sec:adding_wrapper)) user manual chapter.

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -53,8 +53,6 @@ vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv -->
 ### Wrapper task validates distribution url
 
 The wrapper task now validates the configured distribution url before writing it to the gradle-wrapper.properties file.
-If the url scheme is `http` or `https`, a HEAD request is sent.
-If the scheme is `file`, the existence of the file is checked.
 This surfaces invalid urls early and can prevent IO exceptions at execution time.
 
 More details can be found in the dedicated section of the [Gradle Wrapper](gradle_wrapper.html#[adding_the_gradle_wrapper](sec:adding_wrapper)) user manual chapter.

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -50,6 +50,12 @@ Example:
 ADD RELEASE FEATURES BELOW
 vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv -->
 
+### Wrapper task validates distribution url
+
+The wrapper task now validates the configured distribution url with a HEAD request before writing it to the gradle-wrapper.properties file. 
+This surfaces invalid urls early and can prevent IO exceptions at execution time.
+
+More details can be found in the dedicated section of the [Gradle Wrapper](gradle_wrapper.html#[adding_the_gradle_wrapper](sec:adding_wrapper)) user manual chapter.
 
 
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -52,7 +52,9 @@ vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv -->
 
 ### Wrapper task validates distribution url
 
-The wrapper task now validates the configured distribution url with a HEAD request before writing it to the gradle-wrapper.properties file. 
+The wrapper task now validates the configured distribution url before writing it to the gradle-wrapper.properties file.
+If the url scheme is `http` or `https`, a HEAD request is sent.
+If the scheme is `file`, the existence of the file is checked.
 This surfaces invalid urls early and can prevent IO exceptions at execution time.
 
 More details can be found in the dedicated section of the [Gradle Wrapper](gradle_wrapper.html#[adding_the_gradle_wrapper](sec:adding_wrapper)) user manual chapter.

--- a/subprojects/docs/src/docs/userguide/reference/gradle_wrapper.adoc
+++ b/subprojects/docs/src/docs/userguide/reference/gradle_wrapper.adoc
@@ -103,7 +103,7 @@ The SHA256 hash sum used for <<#sec:verification,verifying the downloaded Gradle
 `--network-timeout`::
 The network timeout to use when downloading the gradle distribution, in ms. The default value is `10000`.
 
-If the distribution url is configured with `--gradle-version` or `--gradle-distribution-url`, the url is validated by sending a HEAD request in the case of the `http` scheme or by checking the existence of the file in the case of the `file` scheme.
+If the distribution url is configured with `--gradle-version` or `--gradle-distribution-url`, the url is validated by sending a HEAD request in the case of the `https` scheme or by checking the existence of the file in the case of the `file` scheme.
 
 Let’s assume the following use case to illustrate the use of the command line options. You would like to generate the Wrapper with version {gradleVersion} and use the `-all` distribution to enable your IDE to enable code-completion and being able to navigate to the Gradle source code. Those requirements are captured by the following command line execution:
 

--- a/subprojects/docs/src/docs/userguide/reference/gradle_wrapper.adoc
+++ b/subprojects/docs/src/docs/userguide/reference/gradle_wrapper.adoc
@@ -103,6 +103,8 @@ The SHA256 hash sum used for <<#sec:verification,verifying the downloaded Gradle
 `--network-timeout`::
 The network timeout to use when downloading the gradle distribution, in ms. The default value is `10000`.
 
+If the distribution url is configured with `--gradle-version` or `--gradle-distribution-url`, the url is validated by sending a HEAD request in the case of the `http` scheme or by checking the existence of the file in the case of the `file` scheme.
+
 Let’s assume the following use case to illustrate the use of the command line options. You would like to generate the Wrapper with version {gradleVersion} and use the `-all` distribution to enable your IDE to enable code-completion and being able to navigate to the Gradle source code. Those requirements are captured by the following command line execution:
 
 .Providing options to Wrapper task

--- a/subprojects/docs/src/docs/userguide/reference/gradle_wrapper.adoc
+++ b/subprojects/docs/src/docs/userguide/reference/gradle_wrapper.adoc
@@ -77,7 +77,7 @@ All of those aspects are configurable at the time of generating the Wrapper file
 
 `--gradle-version`::
 The Gradle version used for downloading and executing the Wrapper.
-The resulting distribution url is validated with a HEAD request.
+The resulting distribution url is validated before it is written to the properties file.
 +
 The following labels are allowed:
 +
@@ -95,7 +95,7 @@ The default value is `bin`.
 The full URL pointing to Gradle distribution ZIP file.
 Using this option makes `--gradle-version` and `--distribution-type` obsolete as the URL already contains this information.
 This option is extremely valuable if you want to host the Gradle distribution inside your company’s network.
-The url is validated with a HEAD request.
+The url is validated before it is written to the properties file.
 
 `--gradle-distribution-sha256-sum`::
 The SHA256 hash sum used for <<#sec:verification,verifying the downloaded Gradle distribution>>.

--- a/subprojects/docs/src/docs/userguide/reference/gradle_wrapper.adoc
+++ b/subprojects/docs/src/docs/userguide/reference/gradle_wrapper.adoc
@@ -76,7 +76,8 @@ distributionUrl=https\://services.gradle.org/distributions/gradle-{gradleVersion
 All of those aspects are configurable at the time of generating the Wrapper files with the help of the following command line options.
 
 `--gradle-version`::
-The Gradle version used for downloading and executing the Wrapper.
+The Gradle version used for downloading and executing the Wrapper. The resulting distribution url
+is validated with a HEAD request.
 +
 The following labels are allowed:
 +
@@ -93,7 +94,8 @@ The default value is `bin`.
 `--gradle-distribution-url`::
 The full URL pointing to Gradle distribution ZIP file.
 Using this option makes `--gradle-version` and `--distribution-type` obsolete as the URL already contains this information.
-This option is extremely valuable if you want to host the Gradle distribution inside your company’s network.
+This option is extremely valuable if you want to host the Gradle distribution inside your company’s network. The url is
+validated with a HEAD request.
 
 `--gradle-distribution-sha256-sum`::
 The SHA256 hash sum used for <<#sec:verification,verifying the downloaded Gradle distribution>>.

--- a/subprojects/docs/src/docs/userguide/reference/gradle_wrapper.adoc
+++ b/subprojects/docs/src/docs/userguide/reference/gradle_wrapper.adoc
@@ -76,8 +76,8 @@ distributionUrl=https\://services.gradle.org/distributions/gradle-{gradleVersion
 All of those aspects are configurable at the time of generating the Wrapper files with the help of the following command line options.
 
 `--gradle-version`::
-The Gradle version used for downloading and executing the Wrapper. The resulting distribution url
-is validated with a HEAD request.
+The Gradle version used for downloading and executing the Wrapper.
+The resulting distribution url is validated with a HEAD request.
 +
 The following labels are allowed:
 +
@@ -94,8 +94,8 @@ The default value is `bin`.
 `--gradle-distribution-url`::
 The full URL pointing to Gradle distribution ZIP file.
 Using this option makes `--gradle-version` and `--distribution-type` obsolete as the URL already contains this information.
-This option is extremely valuable if you want to host the Gradle distribution inside your company’s network. The url is
-validated with a HEAD request.
+This option is extremely valuable if you want to host the Gradle distribution inside your company’s network.
+The url is validated with a HEAD request.
 
 `--gradle-distribution-sha256-sum`::
 The SHA256 hash sum used for <<#sec:verification,verifying the downloaded Gradle distribution>>.

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiIntegrationTest.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiIntegrationTest.groovy
@@ -137,7 +137,8 @@ class ToolingApiIntegrationTest extends AbstractIntegrationSpec {
                 assert gradle.gradleVersion == '${otherVersion.version.version}'
             }
         }"""
-        executer.withTasks('wrapper', '--offline').run()
+        otherVersion.binDistribution.makeReadable()
+        executer.withTasks('wrapper').run()
 
         when:
         toolingApi.withConnector { connector ->
@@ -158,7 +159,8 @@ class ToolingApiIntegrationTest extends AbstractIntegrationSpec {
         }
         """
         projectDir.file('child').createDir()
-        executer.withTasks('wrapper', '--offline').run()
+        otherVersion.binDistribution.makeReadable()
+        executer.withTasks('wrapper').run()
 
         when:
         toolingApi.withConnector { connector ->

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiIntegrationTest.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiIntegrationTest.groovy
@@ -137,7 +137,7 @@ class ToolingApiIntegrationTest extends AbstractIntegrationSpec {
                 assert gradle.gradleVersion == '${otherVersion.version.version}'
             }
         }"""
-        executer.withTasks('wrapper').run()
+        executer.withTasks('wrapper', '--offline').run()
 
         when:
         toolingApi.withConnector { connector ->
@@ -158,7 +158,7 @@ class ToolingApiIntegrationTest extends AbstractIntegrationSpec {
         }
         """
         projectDir.file('child').createDir()
-        executer.withTasks('wrapper').run()
+        executer.withTasks('wrapper', '--offline').run()
 
         when:
         toolingApi.withConnector { connector ->

--- a/subprojects/wrapper-shared/src/main/java/org/gradle/wrapper/Download.java
+++ b/subprojects/wrapper-shared/src/main/java/org/gradle/wrapper/Download.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.reflect.Method;
 import java.net.Authenticator;
+import java.net.HttpURLConnection;
 import java.net.PasswordAuthentication;
 import java.net.SocketTimeoutException;
 import java.net.URI;
@@ -81,6 +82,26 @@ public class Download implements IDownload {
         if (systemProperties.get("http.proxyUser") != null || systemProperties.get("https.proxyUser") != null) {
             // Only an authenticator for proxies needs to be set. Basic authentication is supported by directly setting the request header field.
             Authenticator.setDefault(new ProxyAuthenticator());
+        }
+    }
+
+    public void sendHeadRequest(String distributionUrl) throws Exception {
+        URI address = URI.create(distributionUrl);
+        URL safeUrl = safeUri(address).toURL();
+        int responseCode = -1;
+        try {
+            HttpURLConnection conn = (HttpURLConnection)safeUrl.openConnection();
+            conn.setRequestMethod("HEAD");
+            addBasicAuthentication(address, conn);
+            conn.setRequestProperty("User-Agent", calculateUserAgent());
+            conn.setConnectTimeout(networkTimeout);
+            conn.connect();
+            responseCode = conn.getResponseCode();
+            if (responseCode != 200) {
+                throw new RuntimeException("HEAD request to " + safeUrl + " failed: response code (" + responseCode + ")");
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("HEAD request to " + safeUrl + " failed: response code (" + responseCode + "), timeout (" + networkTimeout + "ms)", e);
         }
     }
 

--- a/subprojects/wrapper-shared/src/main/java/org/gradle/wrapper/Download.java
+++ b/subprojects/wrapper-shared/src/main/java/org/gradle/wrapper/Download.java
@@ -85,14 +85,13 @@ public class Download implements IDownload {
         }
     }
 
-    public void sendHeadRequest(String distributionUrl) throws Exception {
-        URI address = URI.create(distributionUrl);
-        URL safeUrl = safeUri(address).toURL();
+    public void sendHeadRequest(URI uri) throws Exception {
+        URL safeUrl = safeUri(uri).toURL();
         int responseCode = -1;
         try {
             HttpURLConnection conn = (HttpURLConnection)safeUrl.openConnection();
             conn.setRequestMethod("HEAD");
-            addBasicAuthentication(address, conn);
+            addBasicAuthentication(uri, conn);
             conn.setRequestProperty("User-Agent", calculateUserAgent());
             conn.setConnectTimeout(networkTimeout);
             conn.connect();

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/AbstractWrapperIntegrationSpec.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/AbstractWrapperIntegrationSpec.groovy
@@ -37,6 +37,14 @@ class AbstractWrapperIntegrationSpec extends AbstractIntegrationSpec {
         executer.withArguments("wrapper", "--gradle-distribution-url", distributionUri.toString()).run()
     }
 
+    void prepareWrapper(URI distributionUri = distribution.binDistribution.toURI(), String trustStore, String trustStorePassword) {
+        def executer = new InProcessGradleExecuter(distribution, temporaryFolder)
+        executer.withArguments("wrapper", "--gradle-distribution-url", distributionUri.toString(),
+            "-Djavax.net.ssl.trustStore=$trustStore",
+            "-Djavax.net.ssl.trustStorePassword=$trustStorePassword")
+            .run()
+    }
+
     GradleExecuter getWrapperExecuter() {
         executer.requireOwnGradleUserHomeDir()
         executer.requireIsolatedDaemons()

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperBadArchiveTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperBadArchiveTest.groovy
@@ -42,6 +42,7 @@ class WrapperBadArchiveTest extends AbstractWrapperIntegrationSpec {
 
     def "wrapper gets bad archive on 1 attempt"() {
         given:
+        server.expect(server.head(GRADLE_BIN_ZIP))
         server.expect(server.get(GRADLE_BIN_ZIP).sendFile(badArchive))
         server.expect(server.get(GRADLE_BIN_HASH).missing())
         server.expect(server.get(GRADLE_BIN_ZIP).sendFile(distribution.binDistribution))
@@ -62,6 +63,7 @@ class WrapperBadArchiveTest extends AbstractWrapperIntegrationSpec {
 
     def "wrapper gets bad archive on 2 attempts"() {
         given:
+        server.expect(server.head(GRADLE_BIN_ZIP))
         server.expect(server.get(GRADLE_BIN_ZIP).sendFile(badArchive))
         server.expect(server.get(GRADLE_BIN_HASH).missing())
         server.expect(server.get(GRADLE_BIN_ZIP).sendFile(badArchive))
@@ -83,6 +85,7 @@ class WrapperBadArchiveTest extends AbstractWrapperIntegrationSpec {
 
     def "wrapper gets bad archive on 3 attempts"() {
         given:
+        server.expect(server.head(GRADLE_BIN_ZIP))
         server.expect(server.get(GRADLE_BIN_ZIP).sendFile(badArchive))
         server.expect(server.get(GRADLE_BIN_HASH).missing())
         server.expect(server.get(GRADLE_BIN_ZIP).sendFile(badArchive))
@@ -102,6 +105,7 @@ class WrapperBadArchiveTest extends AbstractWrapperIntegrationSpec {
 
     def "wrapper gets bad archive on 1 attempt and good hash"() {
         given:
+        server.expect(server.head(GRADLE_BIN_ZIP))
         server.expect(server.get(GRADLE_BIN_ZIP).sendFile(badArchive))
         server.expect(server.get(GRADLE_BIN_HASH).send(getDistributionHash(distribution)))
         server.expect(server.get(GRADLE_BIN_ZIP).sendFile(distribution.binDistribution))

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperChecksumVerificationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperChecksumVerificationTest.groovy
@@ -41,6 +41,7 @@ class WrapperChecksumVerificationTest extends AbstractWrapperIntegrationSpec {
     BlockingHttpServer server = new BlockingHttpServer()
 
     def setup() {
+        server.expect(server.head("/gradle-bin.zip"))
         server.expect(server.get("/gradle-bin.zip").sendFile(distribution.binDistribution))
         server.start()
     }

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperChecksumVerificationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperChecksumVerificationTest.groovy
@@ -40,14 +40,17 @@ class WrapperChecksumVerificationTest extends AbstractWrapperIntegrationSpec {
     @Rule
     BlockingHttpServer server = new BlockingHttpServer()
 
-    def setup() {
-        server.expect(server.head("/gradle-bin.zip"))
+    def configureServer(boolean expectHead) {
+        if (expectHead) {
+            server.expect(server.head("/gradle-bin.zip"))
+        }
         server.expect(server.get("/gradle-bin.zip").sendFile(distribution.binDistribution))
         server.start()
     }
 
     def "wrapper execution fails when using bad checksum"() {
         given:
+        configureServer(true)
         prepareWrapper(new URI(gradleBin))
 
         and:
@@ -84,6 +87,7 @@ Expected checksum: 'bad'
 
     def "wrapper successfully verifies good checksum"() {
         given:
+        configureServer(true)
         prepareWrapper(new URI(gradleBin))
 
         and:
@@ -97,6 +101,7 @@ Expected checksum: 'bad'
 
     def "wrapper requires checksum configuration if a checksum is present in gradle-wrapper.properties"() {
         given:
+        configureServer(true)
         prepareWrapper(new URI(gradleBin))
 
         and:
@@ -116,6 +121,7 @@ Expected checksum: 'bad'
 
     def "wrapper uses new checksum if it was provided as an option"() {
         given:
+        configureServer(true)
         prepareWrapper(new URI(gradleBin))
 
         and:
@@ -137,6 +143,7 @@ Expected checksum: 'bad'
 
     def "wrapper preserves new checksum if it was provided in properties"() {
         given:
+        configureServer(false)
         def releasedDistribution = IntegrationTestBuildContext.INSTANCE.distribution("7.5")
         prepareWrapper(releasedDistribution.binDistribution.toURI())
 

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperConcurrentDownloadTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperConcurrentDownloadTest.groovy
@@ -26,6 +26,7 @@ class WrapperConcurrentDownloadTest extends AbstractWrapperIntegrationSpec {
     @Rule BlockingHttpServer server = new BlockingHttpServer()
 
     def setup() {
+        server.expect(server.head("/gradle-bin.zip"))
         server.expect(server.get("/gradle-bin.zip").sendFile(distribution.binDistribution))
         server.start()
     }

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
@@ -180,7 +180,7 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         Throwable throwable = thrown(UnexpectedBuildFailure.class)
-        assert throwable.message.contains("Test of distribution url failed. Please check the values set with --gradle-distribution-url and --gradle-version.")
+        assert throwable.message.contains("Test of distribution url ${url} failed. Please check the values set with --gradle-distribution-url and --gradle-version.")
         file("gradle/wrapper/gradle-wrapper.properties").assertDoesNotExist()
     }
 
@@ -212,7 +212,7 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         Throwable throwable = thrown(UnexpectedBuildFailure.class)
-        assert throwable.message.contains("Test of distribution url failed. Please check the values set with --gradle-distribution-url and --gradle-version.")
+        assert throwable.message.contains("Test of distribution url ${url} failed. Please check the values set with --gradle-distribution-url and --gradle-version.")
         file("gradle/wrapper/gradle-wrapper.properties").assertDoesNotExist()
     }
 

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
@@ -24,6 +24,7 @@ import org.gradle.test.fixtures.ConcurrentTestUtil
 import org.gradle.test.fixtures.server.http.HttpServer
 import org.gradle.util.internal.TextUtil
 import org.junit.Rule
+import spock.util.Exceptions
 
 import java.util.jar.Attributes
 import java.util.jar.Manifest
@@ -177,7 +178,8 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         Throwable throwable = thrown()
-        def exception = throwable.cause.cause.cause
+        List<Throwable> causeChain = Exceptions.getCauseChain(throwable);
+        def exception = causeChain.get(causeChain.size()-2)
         assert exception.class == UncheckedIOException.class
         assert exception.message == "Test of distribution url failed. Please check the values set with --gradle-distribution-url and --gradle-version."
 

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
@@ -70,8 +70,8 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
 
     def "generated wrapper files are reproducible"() {
         when:
-        executer.inDirectory(file("first")).withTasks("wrapper", "--offline").run()
-        executer.inDirectory(file("second")).withTasks("wrapper", "--offline").run()
+        executer.inDirectory(file("first")).withTasks("wrapper").run()
+        executer.inDirectory(file("second")).withTasks("wrapper").run()
 
         then: "the checksum should be constant (unless there are code changes)"
         Hashing.sha256().hashFile(file("first/gradle/wrapper/gradle-wrapper.jar")) == HashCode.fromString("db163900b4008d4556d12cd8dd312dfb5b1efdb63050db5cfec4561eb4eff495")
@@ -203,16 +203,11 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def "wrapper task with distribution url from command-line respects --offline"() {
+        httpServer.start()
+        def path = "/distributions/8.0-RC-5"
+        def url = "${httpServer.uri}" + path
         when:
-        run("wrapper", "--gradle-distribution-url", "https://not-a-valid-url/distributions/8.0-RC-5", "--offline")
-
-        then:
-        succeeds()
-    }
-
-    def "wrapper task with gradle version from command-line respects --offline mode"() {
-        when:
-        run "wrapper", "--gradle-version", "8.0-RC-5", "--offline"
+        run("wrapper", "--gradle-distribution-url", "${url}", "--offline")
 
         then:
         succeeds()

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
@@ -76,7 +76,7 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
         executer.inDirectory(file("second")).withTasks("wrapper").run()
 
         then: "the checksum should be constant (unless there are code changes)"
-        Hashing.sha256().hashFile(file("first/gradle/wrapper/gradle-wrapper.jar")) == HashCode.fromString("db163900b4008d4556d12cd8dd312dfb5b1efdb63050db5cfec4561eb4eff495")
+        Hashing.sha256().hashFile(file("first/gradle/wrapper/gradle-wrapper.jar")) == HashCode.fromString("d6e9cf246766412ce1f6ba205230ec404d0eaa6be2ce297f305ba718e951a266")
 
         and:
         file("first/gradle/wrapper/gradle-wrapper.jar").md5Hash == file("second/gradle/wrapper/gradle-wrapper.jar").md5Hash

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperHttpIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperHttpIntegrationTest.groovy
@@ -68,8 +68,8 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
     def "downloads wrapper from http server and caches"() {
         given:
         server.expect(server.head("/$TEST_DISTRIBUTION_URL"))
-        server.expect(server.get("/$TEST_DISTRIBUTION_URL").sendFile(distribution.binDistribution))
         prepareWrapper(getDefaultBaseUrl())
+        server.expect(server.get("/$TEST_DISTRIBUTION_URL").sendFile(distribution.binDistribution))
 
         when:
         def result = wrapperExecuter.withTasks('hello').run()
@@ -88,8 +88,8 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
     def "recovers from failed download"() {
         given:
         server.expect(server.head("/$TEST_DISTRIBUTION_URL"))
-        server.expect(server.get("/$TEST_DISTRIBUTION_URL").broken())
         prepareWrapper(getDefaultBaseUrl())
+        server.expect(server.get("/$TEST_DISTRIBUTION_URL").broken())
 
         when:
         wrapperExecuter.withStackTraceChecksDisabled()
@@ -112,8 +112,8 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
     def "fails with reasonable message when download times out"() {
         given:
         server.expect(server.head("/$TEST_DISTRIBUTION_URL"))
-        server.expectAndBlock(server.get("/$TEST_DISTRIBUTION_URL"))
         prepareWrapper(getDefaultBaseUrl())
+        server.expectAndBlock(server.get("/$TEST_DISTRIBUTION_URL"))
 
         when:
         wrapperExecuter.withStackTraceChecksDisabled()
@@ -128,8 +128,8 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
     def "does not leak credentials when download times out"() {
         given:
         server.expect(server.head("/$TEST_DISTRIBUTION_URL"))
-        server.expectAndBlock(server.get("/$TEST_DISTRIBUTION_URL"))
         prepareWrapper("http://username:password@localhost:${server.port}")
+        server.expectAndBlock(server.get("/$TEST_DISTRIBUTION_URL"))
 
         when:
         wrapperExecuter.withStackTraceChecksDisabled()
@@ -145,8 +145,8 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
     def "reads timeout from wrapper properties"() {
         given:
         server.expect(server.head("/$TEST_DISTRIBUTION_URL"))
-        server.expectAndBlock(server.get("/$TEST_DISTRIBUTION_URL"))
         prepareWrapper(getDefaultBaseUrl())
+        server.expectAndBlock(server.get("/$TEST_DISTRIBUTION_URL"))
 
         and:
         file('gradle/wrapper/gradle-wrapper.properties') << "networkTimeout=5000"
@@ -165,8 +165,8 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
 
         and:
         server.expect(server.head("/$TEST_DISTRIBUTION_URL"))
-        server.expect(server.get("/$TEST_DISTRIBUTION_URL").sendFile(distribution.binDistribution))
         prepareWrapper(server.uri.toString())
+        server.expect(server.get("/$TEST_DISTRIBUTION_URL").sendFile(distribution.binDistribution))
 
         file("gradle.properties") << """
     systemProp.http.proxyHost=localhost
@@ -189,8 +189,8 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
 
         and:
         server.expect(server.head("/$TEST_DISTRIBUTION_URL"))
-        server.expect(server.get("/$TEST_DISTRIBUTION_URL").sendFile(distribution.binDistribution))
         prepareWrapper(server.uri.toString())
+        server.expect(server.get("/$TEST_DISTRIBUTION_URL").sendFile(distribution.binDistribution))
 
         file("gradle.properties") << """
     systemProp.http.proxyHost=localhost
@@ -213,8 +213,8 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
         given:
         server.withBasicAuthentication("jdoe", "changeit")
         server.expect(server.head("/$TEST_DISTRIBUTION_URL"))
-        server.expect(server.get("/$TEST_DISTRIBUTION_URL").sendFile(distribution.binDistribution))
         prepareWrapper(getDefaultAuthenticatedBaseUrl())
+        server.expect(server.get("/$TEST_DISTRIBUTION_URL").sendFile(distribution.binDistribution))
 
         when:
         result = wrapperExecuter.withTasks('hello').run()
@@ -239,8 +239,8 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
         and:
         server.withBasicAuthentication("jdoe", "changeit")
         server.expect(server.head("/$TEST_DISTRIBUTION_URL"))
-        server.expect(server.get("/$TEST_DISTRIBUTION_URL").sendFile(distribution.binDistribution))
         prepareWrapper(getDefaultBaseUrl())
+        server.expect(server.get("/$TEST_DISTRIBUTION_URL").sendFile(distribution.binDistribution))
 
         when:
         result = wrapperExecuter.withTasks('hello').run()
@@ -253,8 +253,8 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
         given:
         server.withBasicAuthentication("jdoe", "changeit")
         server.expect(server.head("/$TEST_DISTRIBUTION_URL"))
-        server.expect(server.get("/$TEST_DISTRIBUTION_URL").sendFile(distribution.binDistribution))
         prepareWrapper(getDefaultAuthenticatedBaseUrl())
+        server.expect(server.get("/$TEST_DISTRIBUTION_URL").sendFile(distribution.binDistribution))
 
         when:
         result = wrapperExecuter.withTasks('hello').run()
@@ -267,8 +267,8 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
         given:
         server.withBasicAuthentication("jdoe", "changeit")
         server.expect(server.head("/$TEST_DISTRIBUTION_URL"))
-        server.expect(server.get("/$TEST_DISTRIBUTION_URL").sendFile(distribution.binDistribution))
         prepareWrapper(getDefaultAuthenticatedBaseUrl())
+        server.expect(server.get("/$TEST_DISTRIBUTION_URL").sendFile(distribution.binDistribution))
 
         when:
         def result = wrapperExecuter.withTasks('hello').run()
@@ -280,8 +280,8 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
     def "does not leak basic authentication credentials in exception messages"() {
         given:
         server.expect(server.head("/$TEST_DISTRIBUTION_URL"))
-        server.expect(server.get("/$TEST_DISTRIBUTION_URL").broken())
         prepareWrapper(getDefaultAuthenticatedBaseUrl())
+        server.expect(server.get("/$TEST_DISTRIBUTION_URL").broken())
 
         when:
         wrapperExecuter.withTasks('hello').run()
@@ -307,8 +307,8 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
         and:
         server.withBasicAuthentication("jdoe", "changeit")
         server.expect(server.head("/$TEST_DISTRIBUTION_URL"))
-        server.expect(server.get("/$TEST_DISTRIBUTION_URL").sendFile(distribution.binDistribution))
         prepareWrapper(getDefaultAuthenticatedBaseUrl())
+        server.expect(server.get("/$TEST_DISTRIBUTION_URL").sendFile(distribution.binDistribution))
 
         when:
         result = wrapperExecuter.withTasks('hello').run()

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperHttpsIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperHttpsIntegrationTest.groovy
@@ -77,6 +77,7 @@ class WrapperHttpsIntegrationTest extends AbstractWrapperIntegrationSpec {
     def "does not warn about using basic authentication over secure connection"() {
         given:
         prepareWrapper(getAuthenticatedBaseUrl())
+        server.expect(server.head("/$TEST_DISTRIBUTION_URL"))
         server.expect(server.get("/$TEST_DISTRIBUTION_URL")
             .expectUserAgent(matchesNameAndVersion("gradlew", Download.UNKNOWN_VERSION))
             .sendFile(distribution.binDistribution))
@@ -99,6 +100,7 @@ class WrapperHttpsIntegrationTest extends AbstractWrapperIntegrationSpec {
     systemProp.https.proxyPort=${proxyServer.port}
     systemProp.http.nonProxyHosts=
 """
+        server.expect(server.head("/$TEST_DISTRIBUTION_URL"))
         server.expect(server.get("/$TEST_DISTRIBUTION_URL").sendFile(distribution.binDistribution))
 
         when:
@@ -118,6 +120,7 @@ class WrapperHttpsIntegrationTest extends AbstractWrapperIntegrationSpec {
 
         and:
         prepareWrapper(getAuthenticatedBaseUrl())
+        server.expect(server.head("/$TEST_DISTRIBUTION_URL"))
         server.expect(server.get("/$TEST_DISTRIBUTION_URL").sendFile(distribution.binDistribution))
 
         // Note that the HTTPS protocol handler uses the same nonProxyHosts property as the HTTP protocol.
@@ -148,6 +151,7 @@ class WrapperHttpsIntegrationTest extends AbstractWrapperIntegrationSpec {
         given:
         def baseUrl = getAuthenticatedBaseUrl()
         prepareWrapper(baseUrl)
+        server.expect(server.head("/$TEST_DISTRIBUTION_URL"))
         server.expect(server.get("/$TEST_DISTRIBUTION_URL")
             .sendFile(distribution.binDistribution))
         server.expect(server.get("/versions/current").send("""{ "version" : "7.6" }"""))
@@ -163,8 +167,8 @@ class WrapperHttpsIntegrationTest extends AbstractWrapperIntegrationSpec {
         given:
         def baseUrl = getAuthenticatedBaseUrl()
         prepareWrapper(baseUrl)
+        server.expect(server.head("/$TEST_DISTRIBUTION_URL"))
         server.expect(server.get("/$TEST_DISTRIBUTION_URL").sendFile(distribution.binDistribution))
-
 
         def version = "7.6"
         when:

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperHttpsIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperHttpsIntegrationTest.groovy
@@ -71,13 +71,13 @@ class WrapperHttpsIntegrationTest extends AbstractWrapperIntegrationSpec {
     }
 
     private prepareWrapper(String baseUrl) {
-        prepareWrapper(new URI("${baseUrl}/$TEST_DISTRIBUTION_URL"))
+        prepareWrapper(new URI("${baseUrl}/$TEST_DISTRIBUTION_URL"), keyStore.keyStore.path, keyStore.keyStorePassword)
     }
 
     def "does not warn about using basic authentication over secure connection"() {
         given:
-        prepareWrapper(getAuthenticatedBaseUrl())
         server.expect(server.head("/$TEST_DISTRIBUTION_URL"))
+        prepareWrapper(getAuthenticatedBaseUrl())
         server.expect(server.get("/$TEST_DISTRIBUTION_URL")
             .expectUserAgent(matchesNameAndVersion("gradlew", Download.UNKNOWN_VERSION))
             .sendFile(distribution.binDistribution))
@@ -92,7 +92,6 @@ class WrapperHttpsIntegrationTest extends AbstractWrapperIntegrationSpec {
     def "downloads wrapper via proxy"() {
         given:
         proxyServer.start()
-        prepareWrapper(getAuthenticatedBaseUrl())
 
         // Note that the HTTPS protocol handler uses the same nonProxyHosts property as the HTTP protocol.
         file("gradle.properties") << """
@@ -101,6 +100,7 @@ class WrapperHttpsIntegrationTest extends AbstractWrapperIntegrationSpec {
     systemProp.http.nonProxyHosts=
 """
         server.expect(server.head("/$TEST_DISTRIBUTION_URL"))
+        prepareWrapper(getAuthenticatedBaseUrl())
         server.expect(server.get("/$TEST_DISTRIBUTION_URL").sendFile(distribution.binDistribution))
 
         when:
@@ -110,7 +110,7 @@ class WrapperHttpsIntegrationTest extends AbstractWrapperIntegrationSpec {
         assertThat(result.output, containsString('hello'))
 
         and:
-        proxyServer.requestCount == 1
+        proxyServer.requestCount == 2
     }
 
     @Issue('https://github.com/gradle/gradle/issues/5052')
@@ -119,8 +119,8 @@ class WrapperHttpsIntegrationTest extends AbstractWrapperIntegrationSpec {
         proxyServer.start('my_user', 'my_password')
 
         and:
-        prepareWrapper(getAuthenticatedBaseUrl())
         server.expect(server.head("/$TEST_DISTRIBUTION_URL"))
+        prepareWrapper(getAuthenticatedBaseUrl())
         server.expect(server.get("/$TEST_DISTRIBUTION_URL").sendFile(distribution.binDistribution))
 
         // Note that the HTTPS protocol handler uses the same nonProxyHosts property as the HTTP protocol.
@@ -143,48 +143,55 @@ class WrapperHttpsIntegrationTest extends AbstractWrapperIntegrationSpec {
         proxyServer.requestCount == 1
     }
 
-    private String getAuthenticatedBaseUrl() {
-        "https://$DEFAULT_USER:$DEFAULT_PASSWORD@localhost:${server.port}"
-    }
-
     def "validate properties file content for latest"() {
         given:
+        server.expect(server.head("/$TEST_DISTRIBUTION_URL"))
         def baseUrl = getAuthenticatedBaseUrl()
         prepareWrapper(baseUrl)
-        server.expect(server.head("/$TEST_DISTRIBUTION_URL"))
         server.expect(server.get("/$TEST_DISTRIBUTION_URL")
             .sendFile(distribution.binDistribution))
         server.expect(server.get("/versions/current").send("""{ "version" : "7.6" }"""))
+        server.expect(server.head("/distributions/gradle-7.6-bin.zip"))
 
         when:
         result = runWithVersion(baseUrl, "latest")
 
         then:
-        validateDistributionUrl("7.6")
+        validateDistributionUrl("7.6", getEscapedAuthenticatedBaseUrl())
     }
 
     def "validate properties file content for any version"() {
         given:
+        server.expect(server.head("/$TEST_DISTRIBUTION_URL"))
         def baseUrl = getAuthenticatedBaseUrl()
         prepareWrapper(baseUrl)
-        server.expect(server.head("/$TEST_DISTRIBUTION_URL"))
         server.expect(server.get("/$TEST_DISTRIBUTION_URL").sendFile(distribution.binDistribution))
 
         def version = "7.6"
+        server.expect(server.head("/distributions/gradle-$version-bin.zip"))
+
         when:
         runWithVersion(baseUrl, version)
 
         then:
-        validateDistributionUrl(version)
+        validateDistributionUrl(version, getEscapedAuthenticatedBaseUrl())
     }
 
-    private boolean validateDistributionUrl(String version) {
+    private String getAuthenticatedBaseUrl() {
+        "https://$DEFAULT_USER:$DEFAULT_PASSWORD@localhost:${server.port}"
+    }
+
+    private String getEscapedAuthenticatedBaseUrl() {
+        "https\\://$DEFAULT_USER\\:$DEFAULT_PASSWORD@localhost\\:${server.port}"
+    }
+
+    private boolean validateDistributionUrl(String version, String escapedBaseUrl) {
         file("gradle/wrapper/gradle-wrapper.properties")
-            .text.contains("distributionUrl=https\\://services.gradle.org/distributions/gradle-$version-bin.zip")
+            .text.contains("distributionUrl=$escapedBaseUrl/distributions/gradle-$version-bin.zip")
     }
 
     private ExecutionResult runWithVersion(String baseUrl, String version) {
-        result = wrapperExecuter.withCommandLineGradleOpts("-Dorg.gradle.internal.services.version.url.override=$baseUrl",
+        result = wrapperExecuter.withCommandLineGradleOpts("-Dorg.gradle.internal.services.base.url=$baseUrl",
             "-Djavax.net.ssl.trustStore=$keyStore.keyStore.path",
             "-Djavax.net.ssl.trustStorePassword=$keyStore.keyStorePassword")
             .withArguments("wrapper", "--gradle-version", version)

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperSupportedBuildJvmIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperSupportedBuildJvmIntegrationTest.groovy
@@ -30,7 +30,7 @@ class WrapperSupportedBuildJvmIntegrationTest extends AbstractWrapperIntegration
         wrapperExecuter.withJavaHome(jdk.javaHome)
 
         expect:
-        def failure = wrapperExecuter.withTasks("help").runWithFailure()
+        def failure = wrapperExecuter.withTasks("help", "--offline").runWithFailure()
         failure.assertHasErrorOutput("Gradle ${GradleVersion.current().version} requires Java 1.8 or later to run. You are currently using Java ${jdk.javaVersion}.")
 
         where:
@@ -43,7 +43,7 @@ class WrapperSupportedBuildJvmIntegrationTest extends AbstractWrapperIntegration
         file("gradle.properties").writeProperties("org.gradle.java.home": jdk.javaHome.canonicalPath)
 
         expect:
-        def failure = wrapperExecuter.withTasks("help").runWithFailure()
+        def failure = wrapperExecuter.withTasks("help", "--offline").runWithFailure()
         failure.assertHasErrorOutput("Gradle ${GradleVersion.current().version} requires Java 8 or later to run. Your build is currently configured to use Java ${jdk.javaVersion.majorVersion}.")
 
         where:

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperSupportedBuildJvmIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperSupportedBuildJvmIntegrationTest.groovy
@@ -30,7 +30,7 @@ class WrapperSupportedBuildJvmIntegrationTest extends AbstractWrapperIntegration
         wrapperExecuter.withJavaHome(jdk.javaHome)
 
         expect:
-        def failure = wrapperExecuter.withTasks("help", "--offline").runWithFailure()
+        def failure = wrapperExecuter.withTasks("help").runWithFailure()
         failure.assertHasErrorOutput("Gradle ${GradleVersion.current().version} requires Java 1.8 or later to run. You are currently using Java ${jdk.javaVersion}.")
 
         where:
@@ -43,7 +43,7 @@ class WrapperSupportedBuildJvmIntegrationTest extends AbstractWrapperIntegration
         file("gradle.properties").writeProperties("org.gradle.java.home": jdk.javaHome.canonicalPath)
 
         expect:
-        def failure = wrapperExecuter.withTasks("help", "--offline").runWithFailure()
+        def failure = wrapperExecuter.withTasks("help").runWithFailure()
         failure.assertHasErrorOutput("Gradle ${GradleVersion.current().version} requires Java 8 or later to run. Your build is currently configured to use Java ${jdk.javaVersion.majorVersion}.")
 
         where:


### PR DESCRIPTION
### Context
The wrapper task should validate a url set by the user by sending a HEAD request before it is written to the `gradle-wrapper.properties` file. This helps the user to catch an invalid url early and can prevent an IO exception at execution time.

If needed, `--offline` can be passed to disable any networking.

Fixes #23865

