### PR TITLE
Restore an edge case of non-javac toolchain tools being used as a Java compiler

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/jvm/JavaToolchainFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/jvm/JavaToolchainFixture.groovy
@@ -97,7 +97,7 @@ trait JavaToolchainFixture {
      * Returns the Java version from the compiled class bytecode.
      */
     JavaVersion classJavaVersion(File classFile) {
-        assert classFile.exists(), "Class file ${classFile} does not exist"
+        assert classFile.exists()
         return JavaVersion.forClass(classFile.bytes)
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/jvm/JavaToolchainFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/jvm/JavaToolchainFixture.groovy
@@ -97,7 +97,7 @@ trait JavaToolchainFixture {
      * Returns the Java version from the compiled class bytecode.
      */
     JavaVersion classJavaVersion(File classFile) {
-        assert classFile.exists()
+        assert classFile.exists(), "Class file ${classFile} does not exist"
         return JavaVersion.forClass(classFile.bytes)
     }
 }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileToolchainIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileToolchainIntegrationTest.groovy
@@ -470,10 +470,12 @@ class JavaCompileToolchainIntegrationTest extends AbstractIntegrationSpec implem
     }
 
     @Issue("https://github.com/gradle/gradle/issues/23990")
-    @Requires(TestPrecondition.JDK11_OR_LATER)
     def "can compile with a custom compiler executable"() {
-        def jdk = AvailableJavaHomes.getJdk(JavaVersion.current())
-        def otherJdk = AvailableJavaHomes.differentVersion
+        def otherJdk = AvailableJavaHomes.getJdk(JavaVersion.current())
+        def jdk = AvailableJavaHomes.getDifferentVersion {
+            def v = it.languageVersion.majorVersion.toInteger()
+            11 <= v && v <= 18 // Java versions supported by ECJ releases used in the test
+        }
 
         buildFile << """
             plugins {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/AbstractJavaCompileSpecFactory.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/AbstractJavaCompileSpecFactory.java
@@ -42,17 +42,7 @@ public abstract class AbstractJavaCompileSpecFactory<T extends JavaCompileSpec> 
         }
 
         if (compileOptions.isFork()) {
-            File customJavaHome = compileOptions.getForkOptions().getJavaHome();
-            if (customJavaHome != null) {
-                return getCommandLineSpec(Jvm.forHome(customJavaHome).getJavacExecutable());
-            }
-
-            String customExecutable = compileOptions.getForkOptions().getExecutable();
-            if (customExecutable != null) {
-                return getCommandLineSpec(JavaExecutableUtils.resolveExecutable(customExecutable));
-            }
-
-            return getForkingSpec(Jvm.current().getJavaHome());
+            return chooseSpecFromCompileOptions(Jvm.current().getJavaHome());
         }
 
         return getDefaultSpec();
@@ -65,13 +55,7 @@ public abstract class AbstractJavaCompileSpecFactory<T extends JavaCompileSpec> 
         }
 
         if (compileOptions.isFork()) {
-            // Presence of the fork options means that the user has explicitly requested a command-line compiler
-            if (compileOptions.getForkOptions().getJavaHome() != null || compileOptions.getForkOptions().getExecutable() != null) {
-                // We use the toolchain path because the fork options must agree with the selected toolchain
-                return getCommandLineSpec(Jvm.forHome(toolchainJavaHome).getJavacExecutable());
-            }
-
-            return getForkingSpec(toolchainJavaHome);
+            return chooseSpecFromCompileOptions(toolchainJavaHome);
         }
 
         if (!toolchain.isCurrentJvm()) {
@@ -79,6 +63,20 @@ public abstract class AbstractJavaCompileSpecFactory<T extends JavaCompileSpec> 
         }
 
         return getDefaultSpec();
+    }
+
+    private T chooseSpecFromCompileOptions(File fallbackJavaHome) {
+        File forkJavaHome = compileOptions.getForkOptions().getJavaHome();
+        if (forkJavaHome != null) {
+            return getCommandLineSpec(Jvm.forHome(forkJavaHome).getJavacExecutable());
+        }
+
+        String forkExecutable = compileOptions.getForkOptions().getExecutable();
+        if (forkExecutable != null) {
+            return getCommandLineSpec(JavaExecutableUtils.resolveExecutable(forkExecutable));
+        }
+
+        return getForkingSpec(fallbackJavaHome);
     }
 
     abstract protected T getCommandLineSpec(File executable);

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -75,8 +75,6 @@ import java.io.File;
 import java.util.List;
 import java.util.concurrent.Callable;
 
-import static com.google.common.base.Preconditions.checkState;
-
 /**
  * Compiles Java source files.
  *
@@ -261,23 +259,23 @@ public abstract class JavaCompile extends AbstractCompile implements HasCompileO
 
         ForkOptions forkOptions = getOptions().getForkOptions();
         File customJavaHome = forkOptions.getJavaHome();
-        checkState(
-            customJavaHome == null || customJavaHome.equals(toolchainJavaHome),
-            "Toolchain from `javaHome` property on `ForkOptions` does not match toolchain from `javaCompiler` property"
-        );
-
-        String customExecutablePath = forkOptions.getExecutable();
-        if (customExecutablePath == null) {
-            return;
+        if (customJavaHome != null) {
+            JavaExecutableUtils.validateMatchingFiles(
+                customJavaHome, "Toolchain from `javaHome` property on `ForkOptions`",
+                toolchainJavaHome, "toolchain from `javaCompiler` property"
+            );
         }
 
-        // We do not match the custom executable against the compiler executable from the toolchain (javac),
-        // because the custom executable can be set to the path of another tool in the toolchain such as a launcher (java).
-        File customExecutableJavaHome = JavaExecutableUtils.resolveJavaHomeOfExecutable(customExecutablePath);
-        checkState(
-            customExecutableJavaHome.equals(toolchainJavaHome),
-            "Toolchain from `executable` property on `ForkOptions` does not match toolchain from `javaCompiler` property"
-        );
+        String customExecutablePath = forkOptions.getExecutable();
+        if (customExecutablePath != null) {
+            // We do not match the custom executable against the compiler executable from the toolchain (javac),
+            // because the custom executable can be set to the path of another tool in the toolchain such as a launcher (java).
+            File customExecutableJavaHome = JavaExecutableUtils.resolveJavaHomeOfExecutable(customExecutablePath);
+            JavaExecutableUtils.validateMatchingFiles(
+                customExecutableJavaHome, "Toolchain from `executable` property on `ForkOptions`",
+                toolchainJavaHome, "toolchain from `javaCompiler` property"
+            );
+        }
     }
 
     private boolean isToolchainCompatibleWithJava8() {

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaExecutableUtils.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaExecutableUtils.java
@@ -61,17 +61,21 @@ public class JavaExecutableUtils {
         }
 
         File executableFile = resolveExecutable(executable);
-        if (executableFile.equals(referenceFile)) {
+        validateMatchingFiles(executableFile, executableDescription, referenceFile, referenceDescription);
+    }
+
+    public static void validateMatchingFiles(File customFile, String customDescription, File referenceFile, String referenceDescription) {
+        if (customFile.equals(referenceFile)) {
             return;
         }
 
-        File canonicalExecutableFile = canonicalFile(executableFile);
+        File canonicalCustomFile = canonicalFile(customFile);
         File canonicalReferenceFile = canonicalFile(referenceFile);
-        if (canonicalExecutableFile.equals(canonicalReferenceFile)) {
+        if (canonicalCustomFile.equals(canonicalReferenceFile)) {
             return;
         }
 
-        throw new IllegalStateException(executableDescription + " does not match " + referenceDescription + ".");
+        throw new IllegalStateException(customDescription + " does not match " + referenceDescription + ".");
     }
 
     private static File canonicalFile(File file) {

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaExecutableUtils.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaExecutableUtils.java
@@ -48,6 +48,12 @@ public class JavaExecutableUtils {
         return executableFile;
     }
 
+    public static File resolveJavaHomeOfExecutable(String executable) {
+        // Relying on the layout of the toolchain distribution: <JAVA HOME>/bin/<executable>
+        return resolveExecutable(executable).getParentFile().getParentFile();
+    }
+
+
     public static void validateExecutable(@Nullable String executable, String executableDescription, File referenceFile, String referenceDescription) {
         if (executable == null) {
             return;

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaExecutableUtils.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaExecutableUtils.java
@@ -39,13 +39,14 @@ public class JavaExecutableUtils {
                     .undocumented()
                     .nagUser();
         }
-        if (!executableFile.getAbsoluteFile().exists()) {
+        File executableAbsoluteFile = executableFile.getAbsoluteFile();
+        if (!executableAbsoluteFile.exists()) {
             throw new InvalidUserDataException("The configured executable does not exist (" + executableFile.getAbsolutePath() + ")");
         }
-        if (executableFile.getAbsoluteFile().isDirectory()) {
+        if (executableAbsoluteFile.isDirectory()) {
             throw new InvalidUserDataException("The configured executable is a directory (" + executableFile.getAbsolutePath() + ")");
         }
-        return executableFile;
+        return executableAbsoluteFile;
     }
 
     public static File resolveJavaHomeOfExecutable(String executable) {

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/SpecificInstallationToolchainSpec.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/SpecificInstallationToolchainSpec.java
@@ -74,10 +74,7 @@ public class SpecificInstallationToolchainSpec extends DefaultToolchainSpec {
     }
 
     public static SpecificInstallationToolchainSpec fromJavaExecutable(ObjectFactory objectFactory, String executable) {
-        File executableFile = JavaExecutableUtils.resolveExecutable(executable);
-        // Relying on the layout of the toolchain distribution: <JAVA HOME>/bin/<executable>
-        final File parentJavaHome = executableFile.getParentFile().getParentFile();
-        return new SpecificInstallationToolchainSpec(objectFactory, parentJavaHome);
+        return new SpecificInstallationToolchainSpec(objectFactory, JavaExecutableUtils.resolveJavaHomeOfExecutable(executable));
     }
 
     @Override


### PR DESCRIPTION
Gradle 8 introduced unconditional usage of Java toolchains for Java compilation. However, providing custom tool paths (custom Java home or a compiler executable path) was still supported.

In addition to that, Gradle 8 protect users from doubly-configuring the toolchain via the tool property and a Java home/executable. Validations were added to make sure that toolchain from a custom path agrees with the final resolved toolchain property. In particular, the path to the executable is checked to exactly match the path to `javac` within the toolchain. This, however, made it impossible to use custom Java compilers that rely on being started as a JVM via `java` launcher tool.

This PR relaxes the checks to only validate that a custom executable path leads to a tool within the same toolchain without checking which exact tool it is. In particular, a path to the `java` tool can be specified.

Fixes: https://github.com/gradle/gradle/issues/23990