### PR TITLE
Share LocalComponentGraphResolveState across builds in tree

### DIFF
--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildServices.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildServices.java
@@ -24,6 +24,7 @@ import org.gradle.api.internal.composite.CompositeBuildContext;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.composite.internal.plugins.CompositeBuildPluginResolverContributor;
 import org.gradle.internal.buildtree.GlobalDependencySubstitutionRegistry;
+import org.gradle.internal.model.CalculatedValueContainerFactory;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.scopes.AbstractPluginServiceRegistry;
@@ -75,8 +76,8 @@ public class CompositeBuildServices extends AbstractPluginServiceRegistry {
             return new DefaultBuildableCompositeBuildContext();
         }
 
-        public DefaultLocalComponentInAnotherBuildProvider createLocalComponentProvider() {
-            return new DefaultLocalComponentInAnotherBuildProvider(new IncludedBuildDependencyMetadataBuilder());
+        public DefaultLocalComponentInAnotherBuildProvider createLocalComponentProvider(CalculatedValueContainerFactory calculatedValueContainerFactory) {
+            return new DefaultLocalComponentInAnotherBuildProvider(new IncludedBuildDependencyMetadataBuilder(), calculatedValueContainerFactory);
         }
     }
 }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultLocalComponentInAnotherBuildProvider.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultLocalComponentInAnotherBuildProvider.java
@@ -16,35 +16,74 @@
 
 package org.gradle.composite.internal;
 
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.LocalComponentInAnotherBuildProvider;
+import org.gradle.api.internal.project.HoldsProjectState;
 import org.gradle.api.internal.project.ProjectState;
+import org.gradle.api.internal.tasks.NodeExecutionContext;
+import org.gradle.internal.Describables;
 import org.gradle.internal.build.CompositeBuildParticipantBuildState;
 import org.gradle.internal.build.IncludedBuildState;
 import org.gradle.internal.component.local.model.DefaultLocalComponentGraphResolveState;
 import org.gradle.internal.component.local.model.LocalComponentGraphResolveState;
 import org.gradle.internal.component.local.model.LocalComponentMetadata;
+import org.gradle.internal.model.CalculatedValueContainer;
+import org.gradle.internal.model.CalculatedValueContainerFactory;
+import org.gradle.internal.model.ValueCalculator;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Provides the metadata for a local component consumed from a build that is not the producing build.
  *
  * <p>Currently, the metadata for a component is different based on whether it is consumed from the producing build or from another build. This difference should go away, but in the meantime this class provides the mapping.
  */
-public class DefaultLocalComponentInAnotherBuildProvider implements LocalComponentInAnotherBuildProvider {
+public class DefaultLocalComponentInAnotherBuildProvider implements LocalComponentInAnotherBuildProvider, HoldsProjectState {
     private final IncludedBuildDependencyMetadataBuilder dependencyMetadataBuilder;
+    private final CalculatedValueContainerFactory calculatedValueContainerFactory;
+    private final Map<ProjectComponentIdentifier, CalculatedValueContainer<LocalComponentGraphResolveState, ?>> projects = new ConcurrentHashMap<>();
 
-    public DefaultLocalComponentInAnotherBuildProvider(IncludedBuildDependencyMetadataBuilder dependencyMetadataBuilder) {
+    public DefaultLocalComponentInAnotherBuildProvider(
+        IncludedBuildDependencyMetadataBuilder dependencyMetadataBuilder,
+        CalculatedValueContainerFactory calculatedValueContainerFactory
+    ) {
         this.dependencyMetadataBuilder = dependencyMetadataBuilder;
+        this.calculatedValueContainerFactory = calculatedValueContainerFactory;
     }
 
     public LocalComponentGraphResolveState getComponent(ProjectState projectState) {
-        // TODO - this should work for any build, rather than just an included build
-        CompositeBuildParticipantBuildState buildState = (CompositeBuildParticipantBuildState) projectState.getOwner();
-        if (buildState instanceof IncludedBuildState) {
-            // make sure the build is configured now (not do this for the root build, as we are already configuring it right now)
-            buildState.ensureProjectsConfigured();
+        ProjectComponentIdentifier projectIdentifier = projectState.getComponentIdentifier();
+        CalculatedValueContainer<LocalComponentGraphResolveState, ?> valueContainer = projects.computeIfAbsent(projectIdentifier, projectComponentIdentifier ->
+            calculatedValueContainerFactory.create(Describables.of("metadata of", projectIdentifier), new MetadataSupplier(projectState)));
+        // Calculate the value after adding the entry to the map, so that the value container can take care of thread synchronization
+        valueContainer.finalizeIfNotAlready();
+        return valueContainer.get();
+    }
+
+    @Override
+    public void discardAll() {
+        projects.clear();
+    }
+
+    private class MetadataSupplier implements ValueCalculator<LocalComponentGraphResolveState> {
+        private final ProjectState projectState;
+
+        public MetadataSupplier(ProjectState projectState) {
+            this.projectState = projectState;
         }
-        // Metadata builder uses mutable project state, so synchronize access to the project state
-        LocalComponentMetadata metadata = projectState.fromMutableState(p -> dependencyMetadataBuilder.build(buildState, projectState.getComponentIdentifier()));
-        return new DefaultLocalComponentGraphResolveState(metadata);
+
+        @Override
+        public LocalComponentGraphResolveState calculateValue(NodeExecutionContext context) {
+            // TODO - this should work for any build, rather than just an included build
+            CompositeBuildParticipantBuildState buildState = (CompositeBuildParticipantBuildState) projectState.getOwner();
+            if (buildState instanceof IncludedBuildState) {
+                // make sure the build is configured now (not do this for the root build, as we are already configuring it right now)
+                buildState.ensureProjectsConfigured();
+            }
+            // Metadata builder uses mutable project state, so synchronize access to the project state
+            LocalComponentMetadata metadata = projectState.fromMutableState(p -> dependencyMetadataBuilder.build(buildState, projectState.getComponentIdentifier()));
+            return new DefaultLocalComponentGraphResolveState(metadata);
+        }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/LocalComponentGraphResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/LocalComponentGraphResolveState.java
@@ -25,9 +25,6 @@ import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * <p>Instances of this type are cached and reused for multiple graph resolutions, possibly in parallel. This means that the implementation must be thread-safe.
- *
- * <p>Currently, instances of this type are cached once per project per build in the tree (ie a copy is created for each build in the tree where the project is referenced as a dependency.
- * This is because some of the composite build infrastructure assumes a specialized copy per build. This should be changed to remove the need for multiple copies.</p>
  */
 @ThreadSafe
 public interface LocalComponentGraphResolveState extends ComponentGraphResolveState {


### PR DESCRIPTION
### Context

Switching a large single build of ~1200 subprojects to a ~170 included builds, we get a huge overhead (several GB) by having many instances of the `LocalComponentGraphResolveState` cache in `DefaultLocalComponentRegistry`. This PR suggests to cache these across the whole _build tree_ where possible.

### Implementation
The local `LocalComponentGraphResolveState`s for any component (project) that is in "another build" is the same everywhere in the build tree. It does not matter from which build in the tree the component is seen. Therefore, we can cache these resolve states on the BuildTree scope to be reused across all dependency resolutions of all builds. 

The PR adds a test that checks that `component.id.build.currentBuild` in resolution results is still correct despite the added caching.


### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
