### PR TITLE
Increase metaspace for Gradle daemon

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx2500m -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2500m -XX:MaxMetaspaceSize=768m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 org.gradle.caching=true
 


### PR DESCRIPTION
We saw the Gradle daemon running out of metaspace on 8.1 versions. Let's increase metaspace to avoid this.
The problem is probably related to https://github.com/gradle/gradle/issues/23698.