### PR TITLE
Remove fallback behavior from attribute matcher

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultAttributesSchema.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultAttributesSchema.java
@@ -24,7 +24,7 @@ import org.gradle.internal.Cast;
 import org.gradle.internal.component.model.AttributeMatcher;
 import org.gradle.internal.component.model.AttributeSelectionSchema;
 import org.gradle.internal.component.model.AttributeSelectionUtils;
-import org.gradle.internal.component.model.ComponentAttributeMatcher;
+import org.gradle.internal.component.model.DefaultAttributeMatcher;
 import org.gradle.internal.component.model.DefaultCompatibilityCheckResult;
 import org.gradle.internal.component.model.DefaultMultipleCandidateResult;
 import org.gradle.internal.instantiation.InstantiatorFactory;
@@ -100,7 +100,7 @@ public class DefaultAttributesSchema implements AttributesSchemaInternal {
     @Override
     public AttributeMatcher withProducer(AttributesSchemaInternal producerSchema) {
         return matcherCache.computeIfAbsent(producerSchema, key ->
-            new ComponentAttributeMatcher(new DefaultAttributeSelectionSchema(this, producerSchema)));
+            new DefaultAttributeMatcher(new DefaultAttributeSelectionSchema(this, producerSchema)));
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/AttributeConfigurationSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/AttributeConfigurationSelector.java
@@ -62,16 +62,7 @@ public abstract class AttributeConfigurationSelector {
 
         // Fallback to the default configuration if there are no variants or if variant aware resolution is not supported.
         if (!variantAware || variantsForGraphTraversal.get().isEmpty()) {
-            ConfigurationGraphResolveMetadata fallbackConfiguration = targetComponent.getConfiguration(Dependency.DEFAULT_CONFIGURATION);
-            if (fallbackConfiguration != null &&
-                fallbackConfiguration.isCanBeConsumed() &&
-                attributeMatcher.isMatching(fallbackConfiguration.getAttributes(), consumerAttributes)
-            ) {
-                return singleVariant(variantAware, ImmutableList.of(fallbackConfiguration));
-            }
-
-            AttributeDescriber describer = DescriberSelector.selectDescriber(consumerAttributes, consumerSchema);
-            throw new NoMatchingConfigurationSelectionException(describer, consumerAttributes, attributeMatcher, targetComponent, variantAware);
+            return selectDefaultConfiguration(consumerAttributes, consumerSchema, targetComponent, attributeMatcher, variantAware);
         }
 
         List<? extends VariantGraphResolveMetadata> allConsumableVariants = variantsForGraphTraversal.get();
@@ -125,6 +116,22 @@ public abstract class AttributeConfigurationSelector {
             AttributeDescriber describer = DescriberSelector.selectDescriber(consumerAttributes, consumerSchema);
             throw new NoMatchingConfigurationSelectionException(describer, consumerAttributes, attributeMatcher, targetComponent, true);
         }
+    }
+
+    private static VariantSelectionResult selectDefaultConfiguration(
+        ImmutableAttributes consumerAttributes, AttributesSchemaInternal consumerSchema,
+        ComponentGraphResolveMetadata targetComponent, AttributeMatcher attributeMatcher, boolean variantAware
+    ) {
+        ConfigurationGraphResolveMetadata fallbackConfiguration = targetComponent.getConfiguration(Dependency.DEFAULT_CONFIGURATION);
+        if (fallbackConfiguration != null &&
+            fallbackConfiguration.isCanBeConsumed() &&
+            attributeMatcher.isMatching(fallbackConfiguration.getAttributes(), consumerAttributes)
+        ) {
+            return singleVariant(variantAware, ImmutableList.of(fallbackConfiguration));
+        }
+
+        AttributeDescriber describer = DescriberSelector.selectDescriber(consumerAttributes, consumerSchema);
+        throw new NoMatchingConfigurationSelectionException(describer, consumerAttributes, attributeMatcher, targetComponent, variantAware);
     }
 
     @Nullable

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/AttributeConfigurationSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/AttributeConfigurationSelector.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.gradle.api.artifacts.ArtifactIdentifier;
 import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.HasAttributes;
@@ -32,14 +33,15 @@ import org.gradle.api.internal.attributes.AttributeDescriber;
 import org.gradle.api.internal.attributes.AttributeValue;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.api.internal.capabilities.CapabilitiesMetadataInternal;
+import org.gradle.api.internal.capabilities.ShadowedCapability;
 import org.gradle.internal.Cast;
 import org.gradle.internal.component.AmbiguousConfigurationSelectionException;
 import org.gradle.internal.component.NoMatchingCapabilitiesException;
 import org.gradle.internal.component.NoMatchingConfigurationSelectionException;
-import org.gradle.api.internal.capabilities.CapabilitiesMetadataInternal;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
-import org.gradle.api.internal.capabilities.ShadowedCapability;
 
+import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -53,37 +55,47 @@ public abstract class AttributeConfigurationSelector {
 
     private static VariantSelectionResult selectVariantsUsingAttributeMatching(ImmutableAttributes consumerAttributes, Collection<? extends Capability> explicitRequestedCapabilities, ComponentGraphResolveState targetComponentState, AttributesSchemaInternal consumerSchema, List<IvyArtifactName> requestedArtifacts, AttributeMatchingExplanationBuilder explanationBuilder) {
         ComponentGraphResolveMetadata targetComponent = targetComponentState.getMetadata();
+        AttributeMatcher attributeMatcher = consumerSchema.withProducer(targetComponent.getAttributesSchema());
+
         Optional<List<? extends VariantGraphResolveMetadata>> variantsForGraphTraversal = targetComponent.getVariantsForGraphTraversal();
-        List<? extends VariantGraphResolveMetadata> consumableVariants = variantsForGraphTraversal.or(ImmutableList.of());
-        AttributesSchemaInternal producerAttributeSchema = targetComponent.getAttributesSchema();
-        AttributeMatcher attributeMatcher = consumerSchema.withProducer(producerAttributeSchema);
-        ConfigurationGraphResolveMetadata fallbackConfiguration = targetComponent.getConfiguration(Dependency.DEFAULT_CONFIGURATION);
-        if (fallbackConfiguration != null && !fallbackConfiguration.isCanBeConsumed()) {
-            fallbackConfiguration = null;
-        }
-        ModuleVersionIdentifier versionId = targetComponent.getModuleVersionId();
-        if (!consumableVariants.isEmpty()) {
-            ImmutableList<VariantGraphResolveMetadata> variantsProvidingRequestedCapabilities = filterVariantsByRequestedCapabilities(targetComponent, explicitRequestedCapabilities, consumableVariants, versionId.getGroup(), versionId.getName(), true);
-            if (variantsProvidingRequestedCapabilities.isEmpty()) {
-                throw new NoMatchingCapabilitiesException(targetComponent, explicitRequestedCapabilities, consumableVariants);
+        boolean variantAware = variantsForGraphTraversal.isPresent();
+
+        // Fallback to the default configuration if there are no variants or if variant aware resolution is not supported.
+        if (!variantAware || variantsForGraphTraversal.get().isEmpty()) {
+            ConfigurationGraphResolveMetadata fallbackConfiguration = targetComponent.getConfiguration(Dependency.DEFAULT_CONFIGURATION);
+            if (fallbackConfiguration != null &&
+                fallbackConfiguration.isCanBeConsumed() &&
+                attributeMatcher.isMatching(fallbackConfiguration.getAttributes(), consumerAttributes)
+            ) {
+                return singleVariant(variantAware, ImmutableList.of(fallbackConfiguration));
             }
-            consumableVariants = variantsProvidingRequestedCapabilities;
+
+            AttributeDescriber describer = DescriberSelector.selectDescriber(consumerAttributes, consumerSchema);
+            throw new NoMatchingConfigurationSelectionException(describer, consumerAttributes, attributeMatcher, targetComponent, variantAware);
         }
-        List<VariantGraphResolveMetadata> matches = attributeMatcher.matches(consumableVariants, consumerAttributes, fallbackConfiguration, explanationBuilder);
+
+        List<? extends VariantGraphResolveMetadata> allConsumableVariants = variantsForGraphTraversal.get();
+        ImmutableList<VariantGraphResolveMetadata> variantsProvidingRequestedCapabilities = filterVariantsByRequestedCapabilities(targetComponent, explicitRequestedCapabilities, allConsumableVariants, true);
+        if (variantsProvidingRequestedCapabilities.isEmpty()) {
+            throw new NoMatchingCapabilitiesException(targetComponent, explicitRequestedCapabilities, allConsumableVariants);
+        }
+
+        List<VariantGraphResolveMetadata> matches = attributeMatcher.matches(variantsProvidingRequestedCapabilities, consumerAttributes, explanationBuilder);
         if (matches.size() > 1) {
             // there's an ambiguity, but we may have several variants matching the requested capabilities.
             // Here we're going to check if in the candidates, there's a single one _strictly_ matching the requested capabilities.
-            List<VariantGraphResolveMetadata> strictlyMatchingCapabilities = filterVariantsByRequestedCapabilities(targetComponent, explicitRequestedCapabilities, matches, versionId.getGroup(), versionId.getName(), false);
+            List<VariantGraphResolveMetadata> strictlyMatchingCapabilities = filterVariantsByRequestedCapabilities(targetComponent, explicitRequestedCapabilities, matches, false);
             if (strictlyMatchingCapabilities.size() == 1) {
-                return singleVariant(variantsForGraphTraversal, strictlyMatchingCapabilities);
+                return singleVariant(true, strictlyMatchingCapabilities);
             } else if (strictlyMatchingCapabilities.size() > 1) {
                 // there are still more than one candidate, but this time we know only a subset strictly matches the required attributes
                 // so we perform another round of selection on the remaining candidates
-                strictlyMatchingCapabilities = attributeMatcher.matches(strictlyMatchingCapabilities, consumerAttributes, fallbackConfiguration, explanationBuilder);
+                strictlyMatchingCapabilities = attributeMatcher.matches(strictlyMatchingCapabilities, consumerAttributes, explanationBuilder);
                 if (strictlyMatchingCapabilities.size() == 1) {
-                    return singleVariant(variantsForGraphTraversal, strictlyMatchingCapabilities);
+                    return singleVariant(true, strictlyMatchingCapabilities);
                 }
             }
+
             if (requestedArtifacts.size() == 1) {
                 // Here, we know that the user requested a specific classifier. There may be multiple
                 // candidate variants left, but maybe only one of them provides the classified artifact
@@ -92,28 +104,30 @@ public abstract class AttributeConfigurationSelector {
                 if (classifier != null) {
                     List<VariantGraphResolveMetadata> sameClassifier = findVariantsProvidingExactlySameClassifier(matches, classifier, targetComponentState);
                     if (sameClassifier != null && sameClassifier.size() == 1) {
-                        return singleVariant(variantsForGraphTraversal, sameClassifier);
+                        return singleVariant(true, sameClassifier);
                     }
                 }
             }
         }
+
         if (matches.size() == 1) {
-            return singleVariant(variantsForGraphTraversal, matches);
+            return singleVariant(true, matches);
         } else if (!matches.isEmpty()) {
             AttributeDescriber describer = DescriberSelector.selectDescriber(consumerAttributes, consumerSchema);
             if (explanationBuilder instanceof TraceDiscardedConfigurations) {
                 Set<VariantGraphResolveMetadata> discarded = Cast.uncheckedCast(((TraceDiscardedConfigurations) explanationBuilder).discarded);
-                throw new AmbiguousConfigurationSelectionException(describer, consumerAttributes, attributeMatcher, matches, targetComponent, variantsForGraphTraversal.isPresent(), discarded);
+                throw new AmbiguousConfigurationSelectionException(describer, consumerAttributes, attributeMatcher, matches, targetComponent, true, discarded);
             } else {
                 // Perform a second resolution with tracing
                 return selectVariantsUsingAttributeMatching(consumerAttributes, explicitRequestedCapabilities, targetComponentState, consumerSchema, requestedArtifacts, new TraceDiscardedConfigurations());
             }
         } else {
             AttributeDescriber describer = DescriberSelector.selectDescriber(consumerAttributes, consumerSchema);
-            throw new NoMatchingConfigurationSelectionException(describer, consumerAttributes, attributeMatcher, targetComponent, variantsForGraphTraversal.isPresent());
+            throw new NoMatchingConfigurationSelectionException(describer, consumerAttributes, attributeMatcher, targetComponent, true);
         }
     }
 
+    @Nullable
     private static List<VariantGraphResolveMetadata> findVariantsProvidingExactlySameClassifier(List<VariantGraphResolveMetadata> matches, String classifier, ComponentGraphResolveState targetComponent) {
         List<VariantGraphResolveMetadata> sameClassifier = null;
         // let's see if we can find a single variant which has exactly the requested artifacts
@@ -137,16 +151,18 @@ public abstract class AttributeConfigurationSelector {
         return sameClassifier;
     }
 
-    private static VariantSelectionResult singleVariant(Optional<List<? extends VariantGraphResolveMetadata>> variantsForGraphTraversal, List<VariantGraphResolveMetadata> matches) {
-        return new VariantSelectionResult(ImmutableList.of(matches.get(0)), variantsForGraphTraversal.isPresent());
+    private static VariantSelectionResult singleVariant(boolean variantAware, List<VariantGraphResolveMetadata> matches) {
+        assert matches.size() == 1;
+        return new VariantSelectionResult(ImmutableList.of(matches.get(0)), variantAware);
     }
 
-    private static ImmutableList<VariantGraphResolveMetadata> filterVariantsByRequestedCapabilities(ComponentGraphResolveMetadata targetComponent, Collection<? extends Capability> explicitRequestedCapabilities, Collection<? extends VariantGraphResolveMetadata> consumableVariants, String group, String name, boolean lenient) {
+    private static ImmutableList<VariantGraphResolveMetadata> filterVariantsByRequestedCapabilities(ComponentGraphResolveMetadata targetComponent, Collection<? extends Capability> explicitRequestedCapabilities, Collection<? extends VariantGraphResolveMetadata> consumableVariants, boolean lenient) {
         if (consumableVariants.isEmpty()) {
             return ImmutableList.of();
         }
         ImmutableList.Builder<VariantGraphResolveMetadata> builder = ImmutableList.builderWithExpectedSize(consumableVariants.size());
         boolean explicitlyRequested = !explicitRequestedCapabilities.isEmpty();
+        ModuleIdentifier moduleId = targetComponent.getModuleVersionId().getModule();
         for (VariantGraphResolveMetadata variant : consumableVariants) {
             CapabilitiesMetadata capabilitiesMetadata = variant.getCapabilities();
             List<? extends Capability> capabilities = capabilitiesMetadata.getCapabilities();
@@ -157,7 +173,7 @@ public abstract class AttributeConfigurationSelector {
                 result = providesAllCapabilities(targetComponent, explicitRequestedCapabilities, capabilities);
             } else {
                 // we need to make sure the variants we consider provide the implicit capability
-                result = containsImplicitCapability(capabilitiesMetadata, capabilities, group, name);
+                result = containsImplicitCapability(capabilitiesMetadata, capabilities, moduleId.getGroup(), moduleId.getName());
             }
             if (result.matches) {
                 if (lenient || result == MatchResult.EXACT_MATCH) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/AttributeMatcher.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/AttributeMatcher.java
@@ -37,6 +37,9 @@ public interface AttributeMatcher {
 
     <T> boolean isMatching(Attribute<T> attribute, T candidate, T requested);
 
+    /**
+     * Selects all matches from {@code candidates} that are compatible with the {@code requested} criteria attributes.
+     */
     <T extends HasAttributes> List<T> matches(Collection<? extends T> candidates, AttributeContainerInternal requested, AttributeMatchingExplanationBuilder builder);
 
     List<MatchingDescription<?>> describeMatching(AttributeContainerInternal candidate, AttributeContainerInternal requested);

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/AttributeMatcher.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/AttributeMatcher.java
@@ -22,7 +22,6 @@ import org.gradle.api.attributes.HasAttributes;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.AttributeValue;
 
-import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
 
@@ -39,11 +38,6 @@ public interface AttributeMatcher {
     <T> boolean isMatching(Attribute<T> attribute, T candidate, T requested);
 
     <T extends HasAttributes> List<T> matches(Collection<? extends T> candidates, AttributeContainerInternal requested, AttributeMatchingExplanationBuilder builder);
-
-    /**
-     * Selects the candidates from the given set that are compatible with the requested criteria.
-     */
-    <T extends HasAttributes, E extends T> List<T> matches(Collection<E> candidates, AttributeContainerInternal requested, @Nullable T fallback, AttributeMatchingExplanationBuilder builder);
 
     List<MatchingDescription<?>> describeMatching(AttributeContainerInternal candidate, AttributeContainerInternal requested);
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/AttributeMatchingExplanationBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/AttributeMatchingExplanationBuilder.java
@@ -31,10 +31,7 @@ public interface AttributeMatchingExplanationBuilder {
 
     boolean canSkipExplanation();
 
-    default <T extends HasAttributes> void selectedFallbackConfiguration(AttributeContainerInternal requested, T fallback) {
-    }
-
-    default <T extends HasAttributes> void noCandidates(AttributeContainerInternal requested, T fallback) {
+    default <T extends HasAttributes> void noCandidates(AttributeContainerInternal requested) {
 
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LoggingAttributeMatchingExplanationBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LoggingAttributeMatchingExplanationBuilder.java
@@ -41,13 +41,8 @@ public class LoggingAttributeMatchingExplanationBuilder implements AttributeMatc
     }
 
     @Override
-    public <T extends HasAttributes> void selectedFallbackConfiguration(AttributeContainerInternal requested, T fallback) {
-        LOGGER.debug("No candidates for {}, selected matching fallback {}", requested, fallback);
-    }
-
-    @Override
-    public <T extends HasAttributes> void noCandidates(AttributeContainerInternal requested, T fallback) {
-        LOGGER.debug("No candidates for {} and fallback {} does not match. Select nothing.", requested, fallback);
+    public <T extends HasAttributes> void noCandidates(AttributeContainerInternal requested) {
+        LOGGER.debug("No candidates for {}. Select nothing.", requested);
     }
 
     @Override

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/GradlePluginVariantsSupportTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/GradlePluginVariantsSupportTest.groovy
@@ -45,7 +45,7 @@ class GradlePluginVariantsSupportTest extends Specification {
         def producer = versionAttribute('7.0')
 
         then:
-        accepts == (schema.matcher().matches([producer], consumer, null, ep) == [producer])
+        accepts == (schema.matcher().matches([producer], consumer, ep) == [producer])
         accepts == schema.matcher().isMatching(producer, consumer)
 
         where:
@@ -74,7 +74,7 @@ class GradlePluginVariantsSupportTest extends Specification {
         ]
 
         then:
-        schema.matcher().matches(producer, consumer, null, ep) == [versionAttribute('7.0')]
+        schema.matcher().matches(producer, consumer, ep) == [versionAttribute('7.0')]
 
     }
 
@@ -92,7 +92,7 @@ class GradlePluginVariantsSupportTest extends Specification {
         ]
 
         then:
-        schema.matcher().matches(producer, consumer, null, ep) == [versionAttribute('7.1')]
+        schema.matcher().matches(producer, consumer, ep) == [versionAttribute('7.1')]
     }
 
     def "fails to select one candidate if there is no clear preference"() {
@@ -107,7 +107,7 @@ class GradlePluginVariantsSupportTest extends Specification {
         ]
 
         then:
-        schema.matcher().matches(producer, consumer, null, ep) == [versionAttribute('7.1'), versionAttribute('7.1')]
+        schema.matcher().matches(producer, consumer, ep) == [versionAttribute('7.1'), versionAttribute('7.1')]
     }
 
     private AttributeContainerInternal versionAttribute(String version) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/AttributePrecedenceSchemaAttributeMatcherTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/AttributePrecedenceSchemaAttributeMatcherTest.groovy
@@ -98,13 +98,13 @@ class AttributePrecedenceSchemaAttributeMatcherTest extends Specification {
         def candidate6 = candidate("compatible", "compatible", "compatible")
         def requested = requested("requested", "requested","requested")
         expect:
-        schema.matcher().matches([candidate1], requested, null, explanationBuilder) == [candidate1]
-        schema.matcher().matches([candidate1, candidate2, candidate3, candidate4, candidate5, candidate6], requested, null, explanationBuilder) == [candidate1]
-        schema.matcher().matches([candidate2, candidate3, candidate4, candidate5, candidate6], requested, null, explanationBuilder) == [candidate2]
-        schema.matcher().matches([candidate3, candidate4, candidate5, candidate6], requested, null, explanationBuilder) == [candidate3]
-        schema.matcher().matches([candidate4, candidate5, candidate6], requested, null, explanationBuilder) == [candidate4]
-        schema.matcher().matches([candidate5, candidate6], requested, null, explanationBuilder) == [candidate5]
-        schema.matcher().matches([candidate6], requested, null, explanationBuilder) == [candidate6]
+        schema.matcher().matches([candidate1], requested, explanationBuilder) == [candidate1]
+        schema.matcher().matches([candidate1, candidate2, candidate3, candidate4, candidate5, candidate6], requested, explanationBuilder) == [candidate1]
+        schema.matcher().matches([candidate2, candidate3, candidate4, candidate5, candidate6], requested, explanationBuilder) == [candidate2]
+        schema.matcher().matches([candidate3, candidate4, candidate5, candidate6], requested, explanationBuilder) == [candidate3]
+        schema.matcher().matches([candidate4, candidate5, candidate6], requested, explanationBuilder) == [candidate4]
+        schema.matcher().matches([candidate5, candidate6], requested, explanationBuilder) == [candidate5]
+        schema.matcher().matches([candidate6], requested, explanationBuilder) == [candidate6]
     }
 
     def "disambiguates extra attributes in precedence order"() {
@@ -115,9 +115,9 @@ class AttributePrecedenceSchemaAttributeMatcherTest extends Specification {
         def requested = AttributeTestUtil.attributes("unknown": "unknown")
 
         expect:
-        schema.matcher().matches([candidate1, candidate2, candidate3, candidate4], requested, null, explanationBuilder) == [candidate1]
-        schema.matcher().matches([candidate2, candidate3, candidate4], requested, null, explanationBuilder) == [candidate2]
-        schema.matcher().matches([candidate3, candidate4], requested, null, explanationBuilder) == [candidate3]
+        schema.matcher().matches([candidate1, candidate2, candidate3, candidate4], requested, explanationBuilder) == [candidate1]
+        schema.matcher().matches([candidate2, candidate3, candidate4], requested, explanationBuilder) == [candidate2]
+        schema.matcher().matches([candidate3, candidate4], requested, explanationBuilder) == [candidate3]
     }
 
     private static AttributeContainerInternal requested(String highestValue, String middleValue, String lowestValue) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/DefaultAttributeMatcherTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/DefaultAttributeMatcherTest.groovy
@@ -33,7 +33,7 @@ import java.util.stream.IntStream
 import static org.gradle.util.AttributeTestUtil.attributes
 import static org.gradle.util.TestUtil.objectFactory
 
-class ComponentAttributeMatcherTest extends Specification {
+class DefaultAttributeMatcherTest extends Specification {
 
     def schema = new TestSchema()
     def factory = AttributeTestUtil.attributesFactory()
@@ -41,7 +41,7 @@ class ComponentAttributeMatcherTest extends Specification {
 
     def "selects candidate with same set of attributes and whose values match"() {
         given:
-        def matcher = new ComponentAttributeMatcher(schema)
+        def matcher = new DefaultAttributeMatcher(schema)
 
         def usage = Attribute.of('usage', String)
         schema.attribute(usage)
@@ -51,8 +51,8 @@ class ComponentAttributeMatcherTest extends Specification {
         def requested = attributes(usage: "match")
 
         expect:
-        matcher.matches([candidate1, candidate2], requested, null, explanationBuilder) == [candidate1]
-        matcher.matches([candidate2], requested, null, explanationBuilder) == []
+        matcher.matches([candidate1, candidate2], requested, explanationBuilder) == [candidate1]
+        matcher.matches([candidate2], requested, explanationBuilder) == []
 
         matcher.isMatching(candidate1, requested)
         !matcher.isMatching(candidate2, requested)
@@ -60,7 +60,7 @@ class ComponentAttributeMatcherTest extends Specification {
 
     def "selects candidate with subset of attributes and whose values match"() {
         given:
-        def matcher = new ComponentAttributeMatcher(schema)
+        def matcher = new DefaultAttributeMatcher(schema)
 
         def usage = Attribute.of('usage', String)
         schema.attribute(usage)
@@ -75,8 +75,8 @@ class ComponentAttributeMatcherTest extends Specification {
         def requested = attributes(usage: "match", other: "match")
 
         expect:
-        matcher.matches([candidate1, candidate2, candidate3, candidate4], requested, null, explanationBuilder) == [candidate1]
-        matcher.matches([candidate2, candidate3, candidate4], requested, null, explanationBuilder) == [candidate4]
+        matcher.matches([candidate1, candidate2, candidate3, candidate4], requested, explanationBuilder) == [candidate1]
+        matcher.matches([candidate2, candidate3, candidate4], requested, explanationBuilder) == [candidate4]
 
         matcher.isMatching(candidate1, requested)
         !matcher.isMatching(candidate2, requested)
@@ -86,7 +86,7 @@ class ComponentAttributeMatcherTest extends Specification {
 
     def "selects candidate with additional attributes and whose values match"() {
         given:
-        def matcher = new ComponentAttributeMatcher(schema)
+        def matcher = new DefaultAttributeMatcher(schema)
 
         def usage = Attribute.of('usage', String)
         schema.attribute(usage)
@@ -98,8 +98,8 @@ class ComponentAttributeMatcherTest extends Specification {
         def requested = attributes(usage: "match")
 
         expect:
-        matcher.matches([candidate1, candidate2], requested, null, explanationBuilder) == [candidate1]
-        matcher.matches([candidate2], requested, null, explanationBuilder) == []
+        matcher.matches([candidate1, candidate2], requested, explanationBuilder) == [candidate1]
+        matcher.matches([candidate2], requested, explanationBuilder) == []
 
         matcher.isMatching(candidate1, requested)
         !matcher.isMatching(candidate2, requested)
@@ -107,7 +107,7 @@ class ComponentAttributeMatcherTest extends Specification {
 
     def "selects multiple candidates with compatible values"() {
         given:
-        def matcher = new ComponentAttributeMatcher(schema)
+        def matcher = new DefaultAttributeMatcher(schema)
 
         def usage = Attribute.of('usage', String)
         schema.attribute(usage)
@@ -123,12 +123,12 @@ class ComponentAttributeMatcherTest extends Specification {
         def requested = attributes(usage: "match", other: "match")
 
         expect:
-        matcher.matches([candidate1, candidate2, candidate3, candidate4, candidate5], requested, null, explanationBuilder) == [candidate1, candidate3, candidate4, candidate5]
+        matcher.matches([candidate1, candidate2, candidate3, candidate4, candidate5], requested, explanationBuilder) == [candidate1, candidate3, candidate4, candidate5]
     }
 
     def "applies disambiguation rules and selects intersection of best matches for each attribute"() {
         given:
-        def matcher = new ComponentAttributeMatcher(schema)
+        def matcher = new DefaultAttributeMatcher(schema)
 
         def usage = Attribute.of('usage', String)
         schema.attribute(usage)
@@ -150,15 +150,15 @@ class ComponentAttributeMatcherTest extends Specification {
         def requested = attributes(usage: "requested", other: "requested")
 
         expect:
-        matcher.matches([candidate1, candidate2, candidate3, candidate4, candidate5], requested, null, explanationBuilder) == [candidate5]
-        matcher.matches([candidate1, candidate2, candidate3, candidate4], requested, null, explanationBuilder) == [candidate1, candidate3, candidate4]
-        matcher.matches([candidate1, candidate2, candidate4], requested, null, explanationBuilder) == [candidate1]
-        matcher.matches([candidate2, candidate4], requested, null, explanationBuilder) == [candidate4]
+        matcher.matches([candidate1, candidate2, candidate3, candidate4, candidate5], requested, explanationBuilder) == [candidate5]
+        matcher.matches([candidate1, candidate2, candidate3, candidate4], requested, explanationBuilder) == [candidate1, candidate3, candidate4]
+        matcher.matches([candidate1, candidate2, candidate4], requested, explanationBuilder) == [candidate1]
+        matcher.matches([candidate2, candidate4], requested, explanationBuilder) == [candidate4]
     }
 
     def "rule can disambiguate based on requested value"() {
         given:
-        def matcher = new ComponentAttributeMatcher(schema)
+        def matcher = new DefaultAttributeMatcher(schema)
 
         def usage = Attribute.of('usage', String)
         def rule = new AttributeDisambiguationRule<String>() {
@@ -185,13 +185,13 @@ class ComponentAttributeMatcherTest extends Specification {
 
 
         expect:
-        matcher.matches([candidate1, candidate2, candidate3, candidate4], requested1, null, explanationBuilder) == [candidate3]
-        matcher.matches([candidate1, candidate2, candidate3, candidate4], requested2, null, explanationBuilder) == [candidate1]
+        matcher.matches([candidate1, candidate2, candidate3, candidate4], requested1, explanationBuilder) == [candidate3]
+        matcher.matches([candidate1, candidate2, candidate3, candidate4], requested2, explanationBuilder) == [candidate1]
     }
 
     def "disambiguation rule is presented with all non-null candidate values"() {
         given:
-        def matcher = new ComponentAttributeMatcher(schema)
+        def matcher = new DefaultAttributeMatcher(schema)
         def usage = Attribute.of("usage", String)
         def rule = new AttributeDisambiguationRule<String>() {
             @Override
@@ -213,12 +213,12 @@ class ComponentAttributeMatcherTest extends Specification {
         def requested = attributes(usage: "requested")
 
         expect:
-        matcher.matches([candidate1, candidate2, candidate3], requested, null, explanationBuilder) == [candidate1]
+        matcher.matches([candidate1, candidate2, candidate3], requested, explanationBuilder) == [candidate1]
     }
 
     def "prefers match with superset of matching attributes"() {
         given:
-        def matcher = new ComponentAttributeMatcher(schema)
+        def matcher = new DefaultAttributeMatcher(schema)
 
         def usage = Attribute.of('usage', String)
         schema.attribute(usage)
@@ -234,15 +234,15 @@ class ComponentAttributeMatcherTest extends Specification {
         def requested = attributes(usage: "match", other: "match")
 
         expect:
-        matcher.matches([candidate1, candidate2, candidate3, candidate4, candidate5, candidate6], requested, null, explanationBuilder) == [candidate5]
-        matcher.matches([candidate1, candidate2, candidate3, candidate4, candidate6], requested, null, explanationBuilder) == [candidate1, candidate3, candidate4, candidate6]
-        matcher.matches([candidate1, candidate2, candidate4, candidate6], requested, null, explanationBuilder) == [candidate1, candidate4, candidate6]
-        matcher.matches([candidate2, candidate3, candidate4], requested, null, explanationBuilder) == [candidate3]
+        matcher.matches([candidate1, candidate2, candidate3, candidate4, candidate5, candidate6], requested, explanationBuilder) == [candidate5]
+        matcher.matches([candidate1, candidate2, candidate3, candidate4, candidate6], requested, explanationBuilder) == [candidate1, candidate3, candidate4, candidate6]
+        matcher.matches([candidate1, candidate2, candidate4, candidate6], requested, explanationBuilder) == [candidate1, candidate4, candidate6]
+        matcher.matches([candidate2, candidate3, candidate4], requested, explanationBuilder) == [candidate3]
     }
 
     def "disambiguates multiple matches using extra attributes from producer"() {
         given:
-        def matcher = new ComponentAttributeMatcher(schema)
+        def matcher = new DefaultAttributeMatcher(schema)
         def usage = Attribute.of("usage", String)
         def other = Attribute.of("other", String)
         schema.attribute(usage)
@@ -254,13 +254,13 @@ class ComponentAttributeMatcherTest extends Specification {
         def requested = attributes(usage: "match")
 
         expect:
-        def matches = matcher.matches([candidate1, candidate2], requested, null, explanationBuilder)
+        def matches = matcher.matches([candidate1, candidate2], requested, explanationBuilder)
         matches == [candidate2]
     }
 
     def "ignores extra attributes if match is found after disambiguation requested attributes"() {
         given:
-        def matcher = new ComponentAttributeMatcher(schema)
+        def matcher = new DefaultAttributeMatcher(schema)
 
         def usage = Attribute.of("usage", String)
         schema.attribute(usage)
@@ -277,13 +277,13 @@ class ComponentAttributeMatcherTest extends Specification {
         def requested = attributes(usage: "foo")
 
         expect:
-        def matches = matcher.matches([candidate1, candidate2], requested, null, explanationBuilder)
+        def matches = matcher.matches([candidate1, candidate2], requested, explanationBuilder)
         matches == [candidate2]
     }
 
     def "empty consumer attributes match any producer attributes"() {
         given:
-        def matcher = new ComponentAttributeMatcher(schema)
+        def matcher = new DefaultAttributeMatcher(schema)
 
         def usage = Attribute.of("usage", String)
         schema.attribute(usage)
@@ -293,72 +293,30 @@ class ComponentAttributeMatcherTest extends Specification {
         def requested = attributes()
 
         expect:
-        matcher.matches([candidate1, candidate2], requested, null, explanationBuilder) == [candidate1, candidate2]
+        matcher.matches([candidate1, candidate2], requested, explanationBuilder) == [candidate1, candidate2]
 
-        matcher.matches([candidate1], requested, null, explanationBuilder) == [candidate1]
+        matcher.matches([candidate1], requested, explanationBuilder) == [candidate1]
         matcher.isMatching(candidate1, requested)
 
-        matcher.matches([candidate2], requested, null, explanationBuilder) == [candidate2]
+        matcher.matches([candidate2], requested, explanationBuilder) == [candidate2]
         matcher.isMatching(candidate2, requested)
     }
 
     def "non-empty consumer attributes match empty producer attributes"() {
         given:
-        def matcher = new ComponentAttributeMatcher(schema)
+        def matcher = new DefaultAttributeMatcher(schema)
 
         def candidate = attributes()
         def requested = attributes(usage: "dont care", other: "dont care")
 
         expect:
-        matcher.matches([candidate], requested, null, explanationBuilder) == [candidate]
+        matcher.matches([candidate], requested, explanationBuilder) == [candidate]
         matcher.isMatching(candidate, requested)
-    }
-
-    def "selects fallback when it matches requested and there are no candidates"() {
-        given:
-        def matcher = new ComponentAttributeMatcher(schema)
-
-        def usage = Attribute.of("usage", String)
-        def other = Attribute.of("other", String)
-        def another = Attribute.of("another", String)
-        schema.attribute(usage)
-        schema.attribute(other)
-        schema.attribute(another)
-
-        def candidate1 = attributes(usage: "no match")
-        def candidate2 = attributes(other: "no match")
-        def fallback1 = attributes()
-        def fallback2 = attributes(usage: "match")
-        def fallback3 = attributes(another: "dont care")
-        def fallback4 = attributes(usage: "other")
-        def requested = attributes(usage: "match", other: "match")
-
-        expect:
-        // No candidates, fallback matches
-        matcher.matches([], requested, fallback1, explanationBuilder) == [fallback1]
-        matcher.matches([], requested, fallback2, explanationBuilder) == [fallback2]
-        matcher.matches([], requested, fallback3, explanationBuilder) == [fallback3]
-
-        // Fallback does not match
-        matcher.matches([], requested, fallback4, explanationBuilder) == []
-
-        // Candidates, fallback matches
-        matcher.matches([candidate1, candidate2], requested, fallback1, explanationBuilder) == []
-        matcher.matches([candidate1, candidate2], requested, fallback2, explanationBuilder) == []
-        matcher.matches([candidate1, candidate2], requested, fallback3, explanationBuilder) == []
-
-        // No fallback
-        matcher.matches([candidate1, candidate2], requested, null, explanationBuilder) == []
-        matcher.matches([], requested, null, explanationBuilder) == []
-
-        // Fallback also a candidate
-        matcher.matches([candidate1, fallback4], requested, fallback4, explanationBuilder) == []
-        matcher.matches([candidate1, candidate2, fallback1], requested, fallback1, explanationBuilder) == [fallback1]
     }
 
     def "can match when consumer uses more general type for attribute"() {
         given:
-        def matcher = new ComponentAttributeMatcher(schema)
+        def matcher = new DefaultAttributeMatcher(schema)
 
         def consumer = Attribute.of("a", Number)
         def producer = Attribute.of("a", Integer)
@@ -369,12 +327,12 @@ class ComponentAttributeMatcherTest extends Specification {
         def requested = attributes().attribute(consumer, 1)
 
         expect:
-        matcher.matches([candidate1, candidate2], requested, null, explanationBuilder) == [candidate1]
+        matcher.matches([candidate1, candidate2], requested, explanationBuilder) == [candidate1]
     }
 
     def "can match when producer uses desugared attribute of type Named"() {
         given:
-        def matcher = new ComponentAttributeMatcher(schema)
+        def matcher = new DefaultAttributeMatcher(schema)
 
         def consumer = Attribute.of("a", NamedTestAttribute)
         def producer = Attribute.of("a", String)
@@ -385,12 +343,12 @@ class ComponentAttributeMatcherTest extends Specification {
         def requested = attributes().attribute(consumer, objectFactory().named(NamedTestAttribute, "name1"))
 
         expect:
-        matcher.matches([candidate1, candidate2], requested, null, explanationBuilder) == [candidate1]
+        matcher.matches([candidate1, candidate2], requested, explanationBuilder) == [candidate1]
     }
 
     def "can match when consumer uses desugared attribute of type Named"() {
         given:
-        def matcher = new ComponentAttributeMatcher(schema)
+        def matcher = new DefaultAttributeMatcher(schema)
 
         def consumer = Attribute.of("a", String)
         def producer = Attribute.of("a", NamedTestAttribute)
@@ -401,12 +359,12 @@ class ComponentAttributeMatcherTest extends Specification {
         def requested = attributes().attribute(consumer, "name1")
 
         expect:
-        matcher.matches([candidate1, candidate2], requested, null, explanationBuilder) == [candidate1]
+        matcher.matches([candidate1, candidate2], requested, explanationBuilder) == [candidate1]
     }
 
     def "can match when producer uses desugared attribute of type Enum"() {
         given:
-        def matcher = new ComponentAttributeMatcher(schema)
+        def matcher = new DefaultAttributeMatcher(schema)
 
         def consumer = Attribute.of("a", EnumTestAttribute)
         def producer = Attribute.of("a", String)
@@ -417,12 +375,12 @@ class ComponentAttributeMatcherTest extends Specification {
         def requested = attributes().attribute(consumer, EnumTestAttribute.NAME1)
 
         expect:
-        matcher.matches([candidate1, candidate2], requested, null, explanationBuilder) == [candidate1]
+        matcher.matches([candidate1, candidate2], requested, explanationBuilder) == [candidate1]
     }
 
     def "can match when consumer uses desugared attribute of type Enum"() {
         given:
-        def matcher = new ComponentAttributeMatcher(schema)
+        def matcher = new DefaultAttributeMatcher(schema)
 
         def consumer = Attribute.of("a", String)
         def producer = Attribute.of("a", EnumTestAttribute)
@@ -433,12 +391,12 @@ class ComponentAttributeMatcherTest extends Specification {
         def requested = attributes().attribute(consumer, "NAME1")
 
         expect:
-        matcher.matches([candidate1, candidate2], requested, null, explanationBuilder) == [candidate1]
+        matcher.matches([candidate1, candidate2], requested, explanationBuilder) == [candidate1]
     }
 
     def "cannot match when producer uses desugared attribute of unsupported type"() {
         given:
-        def matcher = new ComponentAttributeMatcher(schema)
+        def matcher = new DefaultAttributeMatcher(schema)
 
         def consumer = Attribute.of("a", NotSerializableInGradleMetadataAttribute)
         def producer = Attribute.of("a", String)
@@ -449,16 +407,16 @@ class ComponentAttributeMatcherTest extends Specification {
         def requested = attributes().attribute(consumer, new NotSerializableInGradleMetadataAttribute("name1"))
 
         when:
-        matcher.matches([candidate1, candidate2], requested, null, explanationBuilder)
+        matcher.matches([candidate1, candidate2], requested, explanationBuilder)
 
         then:
         def e = thrown(IllegalArgumentException)
-        e.message == "Unexpected type for attribute 'a' provided. Expected a value of type org.gradle.internal.component.model.ComponentAttributeMatcherTest${'$'}NotSerializableInGradleMetadataAttribute but found a value of type java.lang.String."
+        e.message == "Unexpected type for attribute 'a' provided. Expected a value of type org.gradle.internal.component.model.DefaultAttributeMatcherTest\$NotSerializableInGradleMetadataAttribute but found a value of type java.lang.String."
     }
 
     def "cannot match when consumer uses desugared attribute of unsupported type"() {
         given:
-        def matcher = new ComponentAttributeMatcher(schema)
+        def matcher = new DefaultAttributeMatcher(schema)
 
         def consumer = Attribute.of("a", String)
         def producer = Attribute.of("a", NotSerializableInGradleMetadataAttribute)
@@ -469,16 +427,16 @@ class ComponentAttributeMatcherTest extends Specification {
         def requested = attributes().attribute(consumer, "name1")
 
         when:
-        matcher.matches([candidate1, candidate2], requested, null, explanationBuilder)
+        matcher.matches([candidate1, candidate2], requested, explanationBuilder)
 
         then:
         def e = thrown(IllegalArgumentException)
-        e.message == "Unexpected type for attribute 'a' provided. Expected a value of type java.lang.String but found a value of type org.gradle.internal.component.model.ComponentAttributeMatcherTest${'$'}NotSerializableInGradleMetadataAttribute."
+        e.message == "Unexpected type for attribute 'a' provided. Expected a value of type java.lang.String but found a value of type org.gradle.internal.component.model.DefaultAttributeMatcherTest\$NotSerializableInGradleMetadataAttribute."
     }
 
     def "matching fails when attribute has incompatible types in consumer and producer"() {
         given:
-        def matcher = new ComponentAttributeMatcher(schema)
+        def matcher = new DefaultAttributeMatcher(schema)
 
         def consumer = Attribute.of("a", String)
         def producer = Attribute.of("a", Number)
@@ -488,7 +446,7 @@ class ComponentAttributeMatcherTest extends Specification {
         def requested = attributes().attribute(consumer, "1")
 
         when:
-        matcher.matches([candidate], requested, null, explanationBuilder)
+        matcher.matches([candidate], requested, explanationBuilder)
 
         then:
         def e = thrown(IllegalArgumentException)
@@ -497,7 +455,7 @@ class ComponentAttributeMatcherTest extends Specification {
 
     def "prefers a strict match with requested values"() {
         given:
-        def matcher = new ComponentAttributeMatcher(schema)
+        def matcher = new DefaultAttributeMatcher(schema)
 
         def usage = Attribute.of("usage", String)
         def other = Attribute.of("other", String)
@@ -509,13 +467,13 @@ class ComponentAttributeMatcherTest extends Specification {
         def requested = attributes(usage: 'match')
 
         expect:
-        def matches = matcher.matches([candidate1, candidate2], requested, null, explanationBuilder)
+        def matches = matcher.matches([candidate1, candidate2], requested, explanationBuilder)
         matches == [candidate1]
     }
 
     def "prefers a shorter match with compatible requested values and more than one extra attribute (type: #type)"() {
         given:
-        def matcher = new ComponentAttributeMatcher(schema)
+        def matcher = new DefaultAttributeMatcher(schema)
 
         def usage = Attribute.of("usage", String)
         def bundling = Attribute.of("bundling", type)
@@ -537,7 +495,7 @@ class ComponentAttributeMatcherTest extends Specification {
         def requested = attributes(usage: 'java-api')
 
         when:
-        def result = matcher.matches([candidate1, candidate2, candidate3, candidate4], requested, null, explanationBuilder)
+        def result = matcher.matches([candidate1, candidate2, candidate3, candidate4], requested, explanationBuilder)
         then:
         result == [candidate1]
 
@@ -547,7 +505,7 @@ class ComponentAttributeMatcherTest extends Specification {
         candidate3 = attributes(usage: 'java-api-extra', bundling: value2, status: 'integration')
         candidate4 = attributes(usage: 'java-runtime-extra', bundling: value1, status: 'integration')
 
-        result = matcher.matches([candidate1, candidate2, candidate3, candidate4], requested, null, explanationBuilder)
+        result = matcher.matches([candidate1, candidate2, candidate3, candidate4], requested, explanationBuilder)
 
         then:
         result == [candidate1]
@@ -558,7 +516,7 @@ class ComponentAttributeMatcherTest extends Specification {
         candidate3 = attributes(bundling: value1, status: 'integration', usage: 'java-api-extra')
         candidate4 = attributes(status: 'integration', usage: 'java-runtime-extra', bundling: value2)
 
-        result = matcher.matches([candidate1, candidate2, candidate3, candidate4], requested, null, explanationBuilder)
+        result = matcher.matches([candidate1, candidate2, candidate3, candidate4], requested, explanationBuilder)
 
         then:
         result == [candidate1]

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/JavaEcosystemAttributeMatcherTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/JavaEcosystemAttributeMatcherTest.groovy
@@ -320,7 +320,7 @@ class JavaEcosystemAttributeMatcherTest extends Specification {
     def matchConfigurations(List<List<AttributeContainerInternal>> candidates, AttributeContainerInternal requested) {
         // The first element in each configuration array is the implicit variant.
         def implicitVariants = candidates.collect { it.first() }
-        def configurationMatches = schema.matcher().matches(implicitVariants, requested, null, explanationBuilder)
+        def configurationMatches = schema.matcher().matches(implicitVariants, requested, explanationBuilder)
 
         // This test is checking only for successful (single) matches. If we matched multiple configurations
         // in the first round, something is wrong here. Fail before attempting the second round of variant matching.
@@ -328,7 +328,7 @@ class JavaEcosystemAttributeMatcherTest extends Specification {
 
         // Get all the variants for the configuration which was selected and apply variant matching on them.
         def configurationVariants = candidates.get(implicitVariants.indexOf(configurationMatches.get(0)))
-        def variantMatches = schema.matcher().matches(configurationVariants, requested, null, explanationBuilder)
+        def variantMatches = schema.matcher().matches(configurationVariants, requested, explanationBuilder)
 
         // Once again, the purpose of this test is for successful results. Something is wrong if we have
         // multiple matched variants.


### PR DESCRIPTION
Attribute matching only requires fallback behavior for 'default configuration fallback'. In order to simplify the attribute matching API and make the default-configuration fallback case more straightfoward, we extract the fallback behavior of attribute matching and implement it one-off for configuration selection.
