### PR TITLE
Add reproduction instructions for docsTest

### DIFF
--- a/subprojects/docs/src/docsTest/java/org/gradle/docs/samples/IntegrationTestSamplesRunnerTest.java
+++ b/subprojects/docs/src/docsTest/java/org/gradle/docs/samples/IntegrationTestSamplesRunnerTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.docs.samples;
+
+import org.gradle.exemplar.model.Command;
+import org.gradle.exemplar.model.Sample;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunListener;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.JUnit4;
+import org.junit.runners.model.InitializationError;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(JUnit4.class)
+public class IntegrationTestSamplesRunnerTest {
+    @Test
+    public void canAddReproductionInstructionsUponFailure() throws InitializationError {
+        IntegrationTestSamplesRunner runner = new IntegrationTestSamplesRunner(Sample.class);
+        RunNotifier notifier = new RunNotifier();
+        List<Failure> capturedFailures = new ArrayList<>();
+        Sample errorThrowingSample = new Sample("test-sample", new File(""), emptyList()) {
+            @Override
+            public List<Command> getCommands() {
+                throw new RuntimeException("I am a test failure!");
+            }
+        };
+
+        notifier.addListener(new RunListener() {
+            @Override
+            public void testFailure(Failure failure) throws Exception {
+                capturedFailures.add(failure);
+            }
+        });
+
+        runner.runChild(errorThrowingSample, notifier);
+        assertEquals(1, capturedFailures.size());
+        assertTrue(capturedFailures.get(0).getException().getMessage().contains("To reproduce this failure, run:\n  ./gradlew docs:docsTest --tests '*test-sample*' "));
+    }
+}


### PR DESCRIPTION
Previously, developers were usually confused by docsTest failures because it was using a very uncommon runner.
This PR adds "reproduction instructions" upon such failures to help people easily reproduce them.

This is how it looks like when a docs test fails:

```
org.gradle.api.GradleException: Sample test run failed.
To understand how docsTest works, See:
  https://github.com/gradle/gradle/blob/master/subprojects/docs/README.md#testing-samples-and-snippets
To reproduce this failure, run:
  ./gradlew docs:docsTest --tests '*snippet-best-practices-conditional-logic-do_groovy_conditionalLogicDo.sample*' -PenableConfigurationCacheForDocsTests=true
	at org.gradle.docs.samples.IntegrationTestSamplesRunner$1.fireTestFailure(IntegrationTestSamplesRunner.java:66)
	at org.gradle.exemplar.test.runner.SamplesRunner.runChild(SamplesRunner.java:178)
	at org.gradle.docs.samples.IntegrationTestSamplesRunner.runChild(IntegrationTestSamplesRunner.java:56)
	at org.gradle.docs.samples.IntegrationTestSamplesRunner.runChild(IntegrationTestSamplesRunner.java:32)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
	at org.junit.vintage.engine.execution.RunnerExecutor.execute(RunnerExecutor.java:42)
	at org.junit.vintage.engine.VintageTestEngine.executeAllChildren(VintageTestEngine.java:80)
	at org.junit.vintage.engine.VintageTestEngine.execute(VintageTestEngine.java:72)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:107)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:88)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:54)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:67)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:52)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:114)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:86)
	at org.junit.platform.launcher.core.DefaultLauncherSession$DelegatingLauncher.execute(DefaultLauncherSession.java:86)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.processAllTestClasses(JUnitPlatformTestClassProcessor.java:110)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.access$000(JUnitPlatformTestClassProcessor.java:90)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor.stop(JUnitPlatformTestClassProcessor.java:85)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.stop(SuiteTestClassProcessor.java:62)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	at com.sun.proxy.$Proxy2.stop(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker$3.run(TestWorker.java:193)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:129)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:100)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:60)
	at org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:113)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:65)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)
Caused by: org.gradle.integtests.fixtures.executer.UnexpectedBuildFailure: Gradle execution failed in /var/folders/r9/yqcy1f4918l5cfd9vsqc2s0h0000gn/T/junit7764447783895875263/snippet-best-practices-conditional-logic-do_groovy_conditionalLogicDo.sample with: /Users/zhb/Projects/gradle/subprojects/distributions-full/build/bin distribution/bin/gradle [--daemon, --gradle-user-home, /Users/zhb/Projects/gradle/intTestHomeDir/distributions-full, --warning-mode=fail, -Porg.gradle.java.installations.auto-download=false, --quiet, -Porg.gradle.java.installations.paths=/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home,/Library/Java/JavaVirtualMachines/adoptopenjdk-11.jdk/Contents/Home,/Library/Java/JavaVirtualMachines/adoptopenjdk-16.jdk/Contents/Home,/Library/Java/JavaVirtualMachines/temurin-11.jdk/Contents/Home,/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home,/Library/Java/JavaVirtualMachines/temurin-18.jdk/Contents/Home,/Library/Java/JavaVirtualMachines/temurin-19.jdk/Contents/Home,/Library/Java/JavaVirtualMachines/jdk-17.jdk/Contents/Home,/Library/Java/JavaVirtualMachines/jdk1.8.0_301.jdk/Contents/Home,/Library/Java/JavaVirtualMachines/jdk1.8.0_291.jdk/Contents/Home,/Library/Java/JavaVirtualMachines/jdk-15.0.2.jdk/Contents/Home,/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home, -PreleaseEngineer=true, release, --init-script, /var/folders/r9/yqcy1f4918l5cfd9vsqc2s0h0000gn/T/mirrors12002724393917290641.gradle, -Dorg.gradle.internal.plugins.portal.url.override=https://plugins.gradle.org/m2, --configuration-cache, -Dorg.gradle.unsafe.configuration-cache.quiet=true, -Dorg.gradle.unsafe.configuration-cache.max-problems=0, -Dorg.gradle.configuration-cache.internal.load-after-store=false]
Process ExecResult:
{exitValue=1, failure=null}
-----
Output:

-----
Error:

FAILURE: Build failed with an exception.

... original failure stack traces
```