### PR TITLE
Add nested composite build improvements to release notes

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -258,10 +258,10 @@ For more details, see the [user manual](userguide/dependency_verification.html#s
 
 #### Nested composite builds work in more cases
 
-It is common that builds have an included `build-logic` build for build logic.
-That caused problems when using such build as an included build.
+It is common to use an included `build-logic` build instead of `buildSrc`.
+Now it is possible to have a composite build including multiple projects that use `build-logic`.
 
-For example, take the following nested included build:
+For example, take the following setup:
 
 ```
 .
@@ -286,15 +286,14 @@ includeBuild("../included-build")
 includeBuild("build-logic")
 ```
 
-This build works in Gradle 8 since it uses the directory hierarchy to assign paths to nested included builds.
-You can run tasks in the different included builds by using e.g.:
+Before Gradle 8, this build failed due to a path conflict for `:build-logic`.
+It works now since the directory hierarchy is used to assign paths to nested included builds.
+You can run tasks in the different `build-logic` builds by using e.g.:
 
 ```
 ./gradlew :build-logic:test
 ./gradlew :included-build:build-logic:test
 ```
-
-Before Gradle 8, running such a build failed due to an included build path conflict.
 
 <a name="code-quality"></a>
 ### Code quality plugin improvements

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -256,6 +256,46 @@ You can now use the `export-keys` flag to export all already trusted keys:
 
 For more details, see the [user manual](userguide/dependency_verification.html#sec:local-keyring).
 
+#### Nested composite builds work in more cases
+
+It is common that builds have an included `build-logic` build for build logic.
+That caused problems when using such build as an included build.
+
+For example, take the following nested included build:
+
+```
+.
+├── rootBuild
+│   ├── settings.gradle.kts
+│   └── build-logic
+│       └── settings.gradle
+└── included-build
+    ├── settings.gradle.kts
+    └── build-logic
+        └── settings.gradle.kts
+```
+
+```groovy
+// rootBuild/settings.gradle
+includeBuild("build-logic")
+includeBuild("../included-build")
+```
+
+```groovy
+// included-build/settings.gradle
+includeBuild("build-logic")
+```
+
+This build works in Gradle 8 since it uses the directory hierarchy to assign paths to nested included builds.
+You can run tasks in the different included builds by using e.g.:
+
+```
+./gradlew :build-logic:test
+./gradlew :included-build:build-logic:test
+```
+
+Before Gradle 8, running such a build failed due to an included build path conflict.
+
 <a name="code-quality"></a>
 ### Code quality plugin improvements
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -258,7 +258,7 @@ For more details, see the [user manual](userguide/dependency_verification.html#s
 
 #### Nested composite builds work in more cases
 
-It is common to use an included `build-logic` build instead of `buildSrc`.
+It is common to use an included `build-logic` build instead of `buildSrc`, especially for [structuring larger projects](userguide/structuring_software_products.html#an_example)
 Now it is possible to have a composite build including multiple projects that use `build-logic`.
 
 For example, take the following setup:
@@ -294,6 +294,9 @@ You can run tasks in the different `build-logic` builds by using e.g.:
 ./gradlew :build-logic:test
 ./gradlew :included-build:build-logic:test
 ```
+
+For more details see the user manual on [composite builds](userguide/composite_builds.html) and [build logic](userguide/sharing_build_logic_between_subprojects.html#sec:convention_plugins).
+Visit the [upgrading guide](userguide/upgrading_version_7.html#changes_to_paths_of_included_builds) to learn about the changes to build paths for included builds.
 
 <a name="code-quality"></a>
 ### Code quality plugin improvements


### PR DESCRIPTION
Given that it helps using composite builds in more situations.

<img width="728" alt="image" src="https://user-images.githubusercontent.com/423186/221840638-5029615c-6456-41ff-bb00-68666a665321.png">


