### PR TITLE
Fix issue with test exception that cannot be deserialized

### DIFF
--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestFailureSerializationException.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestFailureSerializationException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.testing;
+
+import org.gradle.api.GradleException;
+
+import javax.annotation.Nullable;
+
+/**
+ *  Thrown when there is an error while serializing/deserializing a test result.
+ */
+public class TestFailureSerializationException extends GradleException {
+    public TestFailureSerializationException(String message, @Nullable Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitIntegrationTest.groovy
@@ -534,7 +534,7 @@ class JUnitIntegrationTest extends JUnitMultiVersionIntegrationSpec {
         then:
         with(new DefaultTestExecutionResult(testDirectory).testClass("PoisonTest")) {
             assertTestPassed("passingTest")
-            assertTestFailed("testWithUnserializableException", containsString("java.lang.IllegalStateException: An exception of type PoisonTest\$UnserializableException was thrown by the test, but there was a failure while transmitting the exception back to the build process"))
+            assertTestFailed("testWithUnserializableException", containsString("TestFailureSerializationException: An exception of type PoisonTest\$UnserializableException was thrown by the test, but Gradle was unable to recreate the exception in the build process"))
             assertTestFailed("normalFailingTest", containsString("AssertionError"))
         }
     }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitIntegrationTest.groovy
@@ -488,4 +488,54 @@ class JUnitIntegrationTest extends JUnitMultiVersionIntegrationSpec {
                 .assertTestFailed("initializationError", containsString('ClassFormatError'))
         }
     }
+
+    @Issue("https://github.com/gradle/gradle/issues/23602")
+    def "handles unserializable exception thrown from test"() {
+        given:
+        buildFile << """
+            apply plugin: 'java'
+            ${mavenCentralRepository()}
+            dependencies { testImplementation 'junit:junit:4.13' }
+        """
+
+        file('src/test/java/PoisonTest.java') << """
+            import org.junit.Test;
+
+            public class PoisonTest {
+                @Test public void passingTest() { }
+
+                @Test public void testWithUnserializableException() {
+                    if (true) {
+                        throw new UnserializableException();
+                    }
+                }
+
+                @Test public void normalFailingTest() {
+                    assert false;
+                }
+
+                private static class WriteReplacer implements java.io.Serializable {
+                    private Object readResolve() {
+                        return new RuntimeException();
+                    }
+                }
+
+                private static class UnserializableException extends RuntimeException {
+                    private Object writeReplace() {
+                        return new WriteReplacer();
+                    }
+                }
+            }
+        """
+
+        when:
+        fails("test")
+
+        then:
+        with(new DefaultTestExecutionResult(testDirectory).testClass("PoisonTest")) {
+            assertTestPassed("passingTest")
+            assertTestFailed("testWithUnserializableException", containsString("java.lang.IllegalStateException: An exception of type PoisonTest\$UnserializableException was thrown by the test, but there was a failure while transmitting the exception back to the build process"))
+            assertTestFailed("normalFailingTest", containsString("AssertionError"))
+        }
+    }
 }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformIntegrationTest.groovy
@@ -433,7 +433,7 @@ public class StaticInnerTest {
         then:
         with(new DefaultTestExecutionResult(testDirectory).testClass("PoisonTest")) {
             assertTestPassed("passingTest")
-            assertTestFailed("testWithUnserializableException", containsString("java.lang.IllegalStateException: An exception of type PoisonTest\$UnserializableException was thrown by the test, but there was a failure while transmitting the exception back to the build process"))
+            assertTestFailed("testWithUnserializableException", containsString("TestFailureSerializationException: An exception of type PoisonTest\$UnserializableException was thrown by the test, but Gradle was unable to recreate the exception in the build process"))
             assertTestFailed("normalFailingTest", containsString("AssertionFailedError"))
         }
     }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGIntegrationTest.groovy
@@ -312,6 +312,50 @@ class TestNGIntegrationTest extends MultiVersionIntegrationSpec {
             .testClass('TestNG7878').assertTestCount(4, 0, 0)
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/23602")
+    def "handles unserializable exception thrown from test"() {
+        given:
+        file('src/test/java/PoisonTest.java') << """
+            import org.testng.annotations.Test;
+
+            public class PoisonTest {
+                @Test public void passingTest() { }
+
+                @Test public void testWithUnserializableException() {
+                    if (true) {
+                        throw new UnserializableException();
+                    }
+                }
+
+                @Test public void normalFailingTest() {
+                    assert false;
+                }
+
+                private static class WriteReplacer implements java.io.Serializable {
+                    private Object readResolve() {
+                        return new RuntimeException();
+                    }
+                }
+
+                private static class UnserializableException extends RuntimeException {
+                    private Object writeReplace() {
+                        return new WriteReplacer();
+                    }
+                }
+            }
+        """
+
+        when:
+        fails("test")
+
+        then:
+        with(new DefaultTestExecutionResult(testDirectory).testClass("PoisonTest")) {
+            assertTestPassed("passingTest")
+            assertTestFailed("testWithUnserializableException", containsString("java.lang.IllegalStateException: An exception of type PoisonTest\$UnserializableException was thrown by the test, but there was a failure while transmitting the exception back to the build process"))
+            assertTestFailed("normalFailingTest", containsString("AssertionError"))
+        }
+    }
+
     private static String testListener() {
         return '''
             def listener = new TestListenerImpl()

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGIntegrationTest.groovy
@@ -351,7 +351,7 @@ class TestNGIntegrationTest extends MultiVersionIntegrationSpec {
         then:
         with(new DefaultTestExecutionResult(testDirectory).testClass("PoisonTest")) {
             assertTestPassed("passingTest")
-            assertTestFailed("testWithUnserializableException", containsString("java.lang.IllegalStateException: An exception of type PoisonTest\$UnserializableException was thrown by the test, but there was a failure while transmitting the exception back to the build process"))
+            assertTestFailed("testWithUnserializableException", containsString("TestFailureSerializationException: An exception of type PoisonTest\$UnserializableException was thrown by the test, but Gradle was unable to recreate the exception in the build process"))
             assertTestFailed("normalFailingTest", containsString("AssertionError"))
         }
     }

--- a/subprojects/testing-jvm/src/testFixtures/groovy/org/gradle/testing/fixture/JUnitPlatformTestFixture.groovy
+++ b/subprojects/testing-jvm/src/testFixtures/groovy/org/gradle/testing/fixture/JUnitPlatformTestFixture.groovy
@@ -83,6 +83,7 @@ trait JUnitPlatformTestFixture {
         final TestFile projectDir
 
         Set<TestMethod> methods = [] as LinkedHashSet
+        String additionalContent = ""
         boolean disabled
 
         TestClass(String name, TestFile projectDir) {
@@ -108,6 +109,11 @@ trait JUnitPlatformTestFixture {
             return this
         }
 
+        TestClass withAdditionalContent(String content) {
+            additionalContent = content
+            return this
+        }
+
         TestClass writeContents() {
             def classFile = projectDir.createFile("src/test/java/${name}.java")
             classFile.parentFile.mkdirs()
@@ -121,6 +127,7 @@ trait JUnitPlatformTestFixture {
                 ${disabled ? "@Disabled"  : ""}
                 public class ${name} {
                     ${methodContents}
+                    ${additionalContent}
                 }
             """.stripIndent()
             return this

--- a/subprojects/testing-jvm/src/testFixtures/groovy/org/gradle/testing/fixture/JUnitPlatformTestFixture.groovy
+++ b/subprojects/testing-jvm/src/testFixtures/groovy/org/gradle/testing/fixture/JUnitPlatformTestFixture.groovy
@@ -83,7 +83,6 @@ trait JUnitPlatformTestFixture {
         final TestFile projectDir
 
         Set<TestMethod> methods = [] as LinkedHashSet
-        String additionalContent = ""
         boolean disabled
 
         TestClass(String name, TestFile projectDir) {
@@ -109,11 +108,6 @@ trait JUnitPlatformTestFixture {
             return this
         }
 
-        TestClass withAdditionalContent(String content) {
-            additionalContent = content
-            return this
-        }
-
         TestClass writeContents() {
             def classFile = projectDir.createFile("src/test/java/${name}.java")
             classFile.parentFile.mkdirs()
@@ -127,7 +121,6 @@ trait JUnitPlatformTestFixture {
                 ${disabled ? "@Disabled"  : ""}
                 public class ${name} {
                     ${methodContents}
-                    ${additionalContent}
                 }
             """.stripIndent()
             return this


### PR DESCRIPTION
Previously, a failure while deserializing an exception thrown by a test would cause the result processor proxy to blow up and fail and the test would be in an unknown state.  This changes it so that we capture failures that occur during deserialization of the exception and we replace the test exception with an exception that notifies the user that there was an exception with a given type, but we are unable to provide the full exception because it failed to deserialize when transmitting back to the build process.  In specific cases, we might be able to do something about the issue with deserialization, but in the general case, I think this is the best we can do.  We'll now at least report the test as failed and provide some minimal information to the user so that they know what exception was thrown and why we couldn't provide more.

Fixes #23602

