### PR TITLE
Detect more cases when Scala target is already configured in parameters

### DIFF
--- a/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/internal/ScalaCompileOptionsConfigurer.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/internal/ScalaCompileOptionsConfigurer.java
@@ -36,13 +36,20 @@ import java.util.Set;
 public class ScalaCompileOptionsConfigurer {
 
     private static final int FALLBACK_JVM_TARGET = 8;
+
+    /**
+     * Support for these flags in different minor releases of Scala varies,
+     * but we need to detect as many variants as possible to avoid overriding the target or release.
+     */
     private static final List<String> TARGET_DEFINING_PARAMETERS = Arrays.asList(
         // Scala 2
-        "-target:", "--target:",
+        "-target", "--target",
         // Scala 2 and 3
-        "-release:", "--release:",
+        "-release", "--release",
         // Scala 3
-        "-Xtarget:", "-java-output-version:", "-Xunchecked-java-output-version:"
+        "-java-output-version", "--java-output-version",
+        "-Xunchecked-java-output-version", "--Xunchecked-java-output-version",
+        "-Xtarget", "--Xtarget"
     );
 
     private static final VersionNumber PLAIN_TARGET_FORMAT_SINCE_VERSION = VersionNumber.parse("2.13.1");
@@ -76,7 +83,8 @@ public class ScalaCompileOptionsConfigurer {
     }
 
     private static boolean hasTargetDefiningParameter(List<String> additionalParameters) {
-        return additionalParameters.stream().anyMatch(s -> TARGET_DEFINING_PARAMETERS.stream().anyMatch(s::startsWith));
+        return additionalParameters.stream()
+            .anyMatch(s -> TARGET_DEFINING_PARAMETERS.stream().anyMatch(param -> param.equals(s) || s.startsWith(param + ":")));
     }
 
     /**

--- a/subprojects/scala/src/test/groovy/org/gradle/scala/compile/internal/ScalaCompileOptionsConfigurerTest.groovy
+++ b/subprojects/scala/src/test/groovy/org/gradle/scala/compile/internal/ScalaCompileOptionsConfigurerTest.groovy
@@ -120,21 +120,38 @@ class ScalaCompileOptionsConfigurerTest extends Specification {
         ]
     }
 
-    def 'does not configure target jvm if scala compiler already has a target via #targetFlag flag'() {
+    def 'does not configure target jvm if scala compiler already has a configured target via #targetFlagName flag'() {
         given:
         ScalaCompileOptions scalaCompileOptions = TestUtil.newInstance(ScalaCompileOptions)
-        scalaCompileOptions.additionalParameters = [targetFlag]
+        scalaCompileOptions.additionalParameters = targetFlagParts.toList()
         Set<File> classpath = [new File("scala-library-2.13.1.jar")]
 
         when:
         ScalaCompileOptionsConfigurer.configure(scalaCompileOptions, createToolchain(17, false), classpath)
 
         then:
-        scalaCompileOptions.additionalParameters.find { it == targetFlag }
+        scalaCompileOptions.additionalParameters.find { it == targetFlagParts[0] }
         scalaCompileOptions.additionalParameters.find { it.contains("17") } == null
 
         where:
-        targetFlag << ['-target:8', '--target:8', '-release:8', '--release:8', '-Xtarget:8', '-java-output-version:8', '-Xunchecked-java-output-version:8']
+        targetFlagParts                          | _
+        ['-target:8']                            | _
+        ['--target:8']                           | _
+        ['-target', '8']                         | _
+        ['-release:8']                           | _
+        ['--release:8']                          | _
+        ['-release', '8']                        | _
+        ['--release', '8']                       | _
+        ['-java-output-version:8']               | _
+        ['-java-output-version', '8']            | _
+        ['-Xtarget:8']                           | _
+        ['-Xtarget', '8']                        | _
+        ['--Xtarget:8']                          | _
+        ['--Xtarget', '8']                       | _
+        ['-Xunchecked-java-output-version:8']    | _
+        ['-Xunchecked-java-output-version', '8'] | _
+
+        targetFlagName = targetFlagParts[0]
     }
 
     private JavaToolchain createToolchain(int javaVersion, boolean isFallback) {


### PR DESCRIPTION
Fixes #23962

When deciding whether to supply Java target from toolchain during Scala compilation configuration, we now detect more cases.

More specifically, new cases include specifying a parameter and its value as separate values:
```groovy
tasks.withType(ScalaCompile).configureEach { 
    it.scalaCompileOptions.additionalParameters.addAll(['-release', '8']) 
}
```

An additional target flag variant for Scala 3 (`--Xtarget`) is also detected.

Support for these flags in different minor releases of Scala varies, but we need to detect as many variants as possible to avoid overriding the target or release. The sources for Scala flags:
- [Scala 2.12.17](https://github.com/scala/scala/blob/v2.13.10/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala#L54-L75)
- [Scala 2.13.10](https://github.com/scala/scala/blob/v2.12.17/src/compiler/scala/tools/nsc/settings/StandardScalaSettings.scala#L59-L82)
- [Scala 3.2.2](https://github.com/lampepfl/dotty/blob/3.2.2/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala#L112)

