### PR TITLE
Restore an edge case of non-javac toolchain tools being used as a Java compiler (Gradle 8.0.x)

### DIFF
--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/AbstractJavaCompileSpecFactory.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/AbstractJavaCompileSpecFactory.java
@@ -41,17 +41,7 @@ public abstract class AbstractJavaCompileSpecFactory<T extends JavaCompileSpec> 
         }
 
         if (compileOptions.isFork()) {
-            File customJavaHome = compileOptions.getForkOptions().getJavaHome();
-            if (customJavaHome != null) {
-                return getCommandLineSpec(Jvm.forHome(customJavaHome).getJavacExecutable());
-            }
-
-            String customExecutable = compileOptions.getForkOptions().getExecutable();
-            if (customExecutable != null) {
-                return getCommandLineSpec(new File(customExecutable));
-            }
-
-            return getForkingSpec(Jvm.current().getJavaHome());
+            return chooseSpecFromCompileOptions(Jvm.current().getJavaHome());
         }
 
         return getDefaultSpec();
@@ -64,13 +54,7 @@ public abstract class AbstractJavaCompileSpecFactory<T extends JavaCompileSpec> 
         }
 
         if (compileOptions.isFork()) {
-            // Presence of the fork options means that the user has explicitly requested a command-line compiler
-            if (compileOptions.getForkOptions().getJavaHome() != null || compileOptions.getForkOptions().getExecutable() != null) {
-                // We use the toolchain path because the fork options must agree with the selected toolchain
-                return getCommandLineSpec(Jvm.forHome(toolchainJavaHome).getJavacExecutable());
-            }
-
-            return getForkingSpec(toolchainJavaHome);
+            return chooseSpecFromCompileOptions(toolchainJavaHome);
         }
 
         if (!toolchain.isCurrentJvm()) {
@@ -78,6 +62,20 @@ public abstract class AbstractJavaCompileSpecFactory<T extends JavaCompileSpec> 
         }
 
         return getDefaultSpec();
+    }
+
+    private T chooseSpecFromCompileOptions(File fallbackJavaHome) {
+        File forkJavaHome = compileOptions.getForkOptions().getJavaHome();
+        if (forkJavaHome != null) {
+            return getCommandLineSpec(Jvm.forHome(forkJavaHome).getJavacExecutable());
+        }
+
+        String forkExecutable = compileOptions.getForkOptions().getExecutable();
+        if (forkExecutable != null) {
+            return getCommandLineSpec(new File(forkExecutable));
+        }
+
+        return getForkingSpec(fallbackJavaHome);
     }
 
     abstract protected T getCommandLineSpec(File executable);


### PR DESCRIPTION
Backporting of a fix from https://github.com/gradle/gradle/pull/24014