### PR TITLE
Mention that output directories and output file parent directories are automatically created

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/OutputDirectory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/OutputDirectory.java
@@ -23,6 +23,8 @@ import java.lang.annotation.*;
  * <p>This annotation should be attached to the getter method in Java or the property in Groovy.
  * Annotations on setters or just the field in Java are ignored.</p>
  *
+ * <p>The directory will be created before the task is executed if it does not exist already.</p>
+ *
  * <p>This will cause the task to be considered out-of-date when the directory path or task
  * output to that directory has been modified since the task was last run.</p>
  */

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/OutputFile.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/OutputFile.java
@@ -23,6 +23,9 @@ import java.lang.annotation.*;
  * <p>This annotation should be attached to the getter method in Java or the property in Groovy.
  * Annotations on setters or just the field in Java are ignored.</p>
  *
+ * <p>The parent directory will be created before the task is executed if it does not exist
+ * already.</p>
+ *
  * <p>This will cause the task to be considered out-of-date when the file path or contents
  * are different to when the task was last run.</p>
  */


### PR DESCRIPTION
This is explained in the docs ([here](https://docs.gradle.org/current/userguide/working_with_files.html#sec:creating_directories_example)) but mentioning it in the JavaDoc shouldn't hurt 