### PR TITLE
Box primitive types when checking arguments, also handle void methods in InterceptGroovyCallsGenerator

### DIFF
--- a/subprojects/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/groovy/InterceptGroovyCallsGenerator.java
+++ b/subprojects/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/groovy/InterceptGroovyCallsGenerator.java
@@ -207,6 +207,9 @@ public class InterceptGroovyCallsGenerator extends RequestGroupingInstrumentatio
                     CodeBlock interceptorArgs = CodeBlock.join(Arrays.asList(CodeBlock.of("result"), argsCode), ", ");
                     result.addStatement("$T.$L($L)", implementationOwner, request.getImplementationInfo().getName(), interceptorArgs);
                     result.addStatement("return result");
+                } else if (request.getInterceptedCallable().getReturnType() == Type.VOID_TYPE) {
+                    result.addStatement("$T.$L($L)", implementationOwner, request.getImplementationInfo().getName(), argsCode);
+                    result.addStatement("return null");
                 } else {
                     result.addStatement("return $T.$L($L)", implementationOwner, request.getImplementationInfo().getName(), argsCode);
                 }
@@ -222,7 +225,7 @@ public class InterceptGroovyCallsGenerator extends RequestGroupingInstrumentatio
                 TypeName entryChildType = TypeUtils.typeName(entry.type);
                 CodeBlock matchExpr = entry.kind == RECEIVER_AS_CLASS ?
                     CodeBlock.of("$L.equals($T.class)", argExpr, entryChildType) :
-                    CodeBlock.of("$L instanceof $T", argExpr, entryChildType);
+                    CodeBlock.of("$L instanceof $T", argExpr, entryChildType.box());
                 result.beginControlFlow("if ($L)", matchExpr);
                 boolean shouldPopParameter = false;
                 if (entry.kind != RECEIVER_AS_CLASS) {


### PR DESCRIPTION
For:
```
public static void intercept_setMaxErrors(@ParameterKind.Receiver Checkstyle self, int value)
```

That generates:
```
@Override
protected Object doIntercept(Invocation invocation, String consumer) throws Throwable {
    Object receiver = invocation.getReceiver();
    if (receiver instanceof Checkstyle) {
        Checkstyle receiverTyped = (Checkstyle) receiver;
        Object arg0 = invocation.getArgument(0);
        if (arg0 instanceof Integer) {
            int arg0Typed = (int) arg0;
            if (invocation.getArgsCount() == 1) {
                CheckstyleInterceptor.intercept_setMaxErrors(receiverTyped, arg0Typed);
                return null;
            }
        }
    }
    return invocation.callOriginal();
}
```

instead of:
```
@Override
protected Object doIntercept(Invocation invocation, String consumer) throws Throwable {
    Object receiver = invocation.getReceiver();
    if (receiver instanceof Checkstyle) {
        Checkstyle receiverTyped = (Checkstyle) receiver;
        Object arg0 = invocation.getArgument(0);
        if (arg0 instanceof int) { // <- compile error
            int arg0Typed = (int) arg0;
            if (invocation.getArgsCount() == 1) {
                return CheckstyleInterceptor.intercept_setMaxErrors(receiverTyped, arg0Typed); // <- compile error
            }
        }
    }
    return invocation.callOriginal();
}
```