### PR TITLE
Follow up on transformation build operations

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ToPlannedTaskConverter.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ToPlannedTaskConverter.java
@@ -101,4 +101,9 @@ public class ToPlannedTaskConverter implements ToPlannedNodeConverter {
             .map(this::getNodeIdentity)
             .collect(Collectors.toList());
     }
+
+    @Override
+    public String toString() {
+        return "ToPlannedTaskConverter(" + getSupportedNodeType().getSimpleName() + ")";
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ToPlannedTaskConverter.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ToPlannedTaskConverter.java
@@ -44,6 +44,11 @@ public class ToPlannedTaskConverter implements ToPlannedNodeConverter {
         org.gradle.api.internal.project.taskfactory.TaskIdentity<?> delegate = taskNode.getTask().getTaskIdentity();
         return new TaskIdentity() {
             @Override
+            public NodeType getNodeType() {
+                return NodeType.TASK;
+            }
+
+            @Override
             public String getBuildPath() {
                 return delegate.getBuildPath();
             }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -109,7 +109,6 @@ import org.gradle.execution.plan.OrdinalGroupFactory;
 import org.gradle.execution.plan.TaskDependencyResolver;
 import org.gradle.execution.plan.TaskNodeDependencyResolver;
 import org.gradle.execution.plan.TaskNodeFactory;
-import org.gradle.execution.plan.ToPlannedNodeConverter;
 import org.gradle.execution.plan.WorkNodeDependencyResolver;
 import org.gradle.execution.selection.BuildTaskSelector;
 import org.gradle.groovy.scripts.DefaultScriptCompilerFactory;
@@ -560,13 +559,13 @@ public class BuildScopeServices extends DefaultServiceRegistry {
             buildOperationExecutor);
     }
 
-    protected BuildWorkPreparer createWorkPreparer(BuildOperationExecutor buildOperationExecutor, ExecutionPlanFactory executionPlanFactory, List<ToPlannedNodeConverter> converters) {
+    protected BuildWorkPreparer createWorkPreparer(BuildOperationExecutor buildOperationExecutor, ExecutionPlanFactory executionPlanFactory, ToPlannedNodeConverterRegistry converterRegistry) {
         return new BuildOperationFiringBuildWorkPreparer(
             buildOperationExecutor,
             new DefaultBuildWorkPreparer(
                 executionPlanFactory
             ),
-            converters
+            converterRegistry
         );
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleUserHomeScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleUserHomeScopeServices.java
@@ -115,6 +115,10 @@ public class GradleUserHomeScopeServices extends WorkerSharedUserHomeScopeServic
         }
     }
 
+    ToPlannedNodeConverterRegistry createToPlannedNodeConverterRegistry(List<ToPlannedNodeConverter> converters) {
+        return new ToPlannedNodeConverterRegistry(converters);
+    }
+
     ToPlannedNodeConverter createToPlannedTransformConverter() {
         return new ToPlannedTaskConverter();
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ToPlannedNodeConverterRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ToPlannedNodeConverterRegistry.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.service.scopes;
+
+import com.google.common.collect.ImmutableList;
+import org.gradle.execution.plan.Node;
+import org.gradle.execution.plan.ToPlannedNodeConverter;
+
+import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A Gradle user home level registry of {@link ToPlannedNodeConverter} instances.
+ * <p>
+ * All the available converters are expected to support disjoined set of {@link Node node types}.
+ */
+public class ToPlannedNodeConverterRegistry {
+
+    private final List<ToPlannedNodeConverter> converters;
+
+    private final Map<Class<?>, ToPlannedNodeConverter> convertersByNodeType = new HashMap<>();
+    private final Set<Class<?>> unsupportedNodeTypes = new HashSet<>();
+
+    public ToPlannedNodeConverterRegistry(List<ToPlannedNodeConverter> converters) {
+        validateConverters(converters);
+        this.converters = ImmutableList.copyOf(converters);
+
+        for (ToPlannedNodeConverter converter : this.converters) {
+            convertersByNodeType.put(converter.getSupportedNodeType(), converter);
+        }
+    }
+
+    /**
+     * Returns a converter for the given node, or null if there is no converter for the node.
+     */
+    @Nullable
+    public ToPlannedNodeConverter getConverter(Node node) {
+        Class<? extends Node> nodeType = node.getClass();
+        ToPlannedNodeConverter converter = convertersByNodeType.get(nodeType);
+        if (converter != null) {
+            return converter;
+        }
+
+        if (unsupportedNodeTypes.contains(nodeType)) {
+            return null;
+        }
+
+        for (ToPlannedNodeConverter converterCandidate : converters) {
+            Class<? extends Node> supportedNodeType = converterCandidate.getSupportedNodeType();
+            if (supportedNodeType.isAssignableFrom(nodeType)) {
+                converter = converterCandidate;
+                break;
+            }
+        }
+
+        if (converter != null) {
+            convertersByNodeType.put(nodeType, converter);
+        } else {
+            unsupportedNodeTypes.add(nodeType);
+        }
+
+        return converter;
+    }
+
+    private static void validateConverters(List<ToPlannedNodeConverter> converters) {
+        int converterCount = converters.size();
+        for (int i = 0; i < converterCount; i++) {
+            ToPlannedNodeConverter converter1 = converters.get(i);
+            for (int j = i + 1; j < converterCount; j++) {
+                ToPlannedNodeConverter converter2 = converters.get(j);
+                checkOverlappingConverters(converter1, converter2);
+            }
+        }
+    }
+
+    private static void checkOverlappingConverters(ToPlannedNodeConverter converter1, ToPlannedNodeConverter converter2) {
+        Class<? extends Node> supportedNodeType1 = converter1.getSupportedNodeType();
+        Class<? extends Node> supportedNodeType2 = converter2.getSupportedNodeType();
+        if (supportedNodeType1.isAssignableFrom(supportedNodeType2) || supportedNodeType2.isAssignableFrom(supportedNodeType1)) {
+            throw new IllegalStateException("Converter " + converter1 + " overlaps by supported node type with converter " + converter2);
+        }
+    }
+
+}

--- a/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/ToPlannedNodeConverterRegistryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/ToPlannedNodeConverterRegistryTest.groovy
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.service.scopes
+
+import org.gradle.execution.plan.Node
+import org.gradle.execution.plan.TaskDependencyResolver
+import org.gradle.execution.plan.TaskNode
+import org.gradle.execution.plan.ToPlannedNodeConverter
+import org.gradle.execution.plan.ToPlannedTaskConverter
+import spock.lang.Specification
+
+class ToPlannedNodeConverterRegistryTest extends Specification {
+
+    def "can be empty"() {
+        def registry = new ToPlannedNodeConverterRegistry([])
+        expect:
+        registry.getConverter(Stub(Node)) == null
+    }
+
+    def "finds converter matching type"() {
+        def testConverter = Stub(ToPlannedNodeConverter) {
+            getSupportedNodeType() >> TestNode
+        }
+        def registry = new ToPlannedNodeConverterRegistry([testConverter])
+
+        when:
+        def foundConverter = registry.getConverter(new TestNode())
+        then:
+        foundConverter.is(testConverter)
+    }
+
+    def "finds converter for node of sub type"() {
+        def testConverter = Stub(ToPlannedNodeConverter) {
+            getSupportedNodeType() >> Node
+        }
+        def registry = new ToPlannedNodeConverterRegistry([testConverter])
+
+        when:
+        def foundConverter = registry.getConverter(new TestNode())
+        then:
+        foundConverter.is(testConverter)
+    }
+
+    def "does not find converter for node of parent type"() {
+        def testConverter = Stub(ToPlannedNodeConverter) {
+            getSupportedNodeType() >> TestNode
+        }
+        def registry = new ToPlannedNodeConverterRegistry([testConverter])
+
+        when:
+        def foundConverter = registry.getConverter(Stub(Node))
+        then:
+        foundConverter == null
+    }
+
+    def "finds converter matching type among multiple"() {
+        def testConverter = Stub(ToPlannedNodeConverter) {
+            getSupportedNodeType() >> TestNode
+        }
+        def taskConverter = new ToPlannedTaskConverter()
+        def registry = new ToPlannedNodeConverterRegistry([taskConverter, testConverter])
+
+        when:
+        def foundConverter = registry.getConverter(new TestNode())
+        then:
+        foundConverter.is(testConverter)
+
+        when:
+        foundConverter = registry.getConverter(Stub(TaskNode))
+        then:
+        foundConverter.is(taskConverter)
+    }
+
+    def "validates converters support disjoint set of types"() {
+        def testConverter1 = Stub(ToPlannedNodeConverter) {
+            getSupportedNodeType() >> TestNode
+            toString() >> "testConverter1"
+        }
+        def testConverter2 = Stub(ToPlannedNodeConverter) {
+            getSupportedNodeType() >> TestNode
+            toString() >> "testConverter2"
+        }
+
+        when:
+        new ToPlannedNodeConverterRegistry([testConverter1, testConverter2])
+        then:
+        def e = thrown(IllegalStateException)
+        e.message == "Converter testConverter1 overlaps by supported node type with converter testConverter2"
+    }
+
+    static class TestNode extends Node {
+        @Override
+        Throwable getNodeFailure() {
+            return null
+        }
+
+        @Override
+        void resolveDependencies(TaskDependencyResolver dependencyResolver) {}
+
+        @Override
+        String toString() {
+            "TestNode"
+        }
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/ToPlannedNodeConverterRegistryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/ToPlannedNodeConverterRegistryTest.groovy
@@ -41,6 +41,12 @@ class ToPlannedNodeConverterRegistryTest extends Specification {
         def foundConverter = registry.getConverter(new TestNode())
         then:
         foundConverter.is(testConverter)
+
+        // verify caching works
+        when:
+        foundConverter = registry.getConverter(new TestNode())
+        then:
+        foundConverter.is(testConverter)
     }
 
     def "finds converter for node of sub type"() {
@@ -63,6 +69,12 @@ class ToPlannedNodeConverterRegistryTest extends Specification {
 
         when:
         def foundConverter = registry.getConverter(Stub(Node))
+        then:
+        foundConverter == null
+
+        // Verify caching works
+        when:
+        foundConverter = registry.getConverter(Stub(Node))
         then:
         foundConverter == null
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformBuildOperationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformBuildOperationIntegrationTest.groovy
@@ -153,8 +153,6 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
             }
             transformType == "MakeGreen"
             sourceAttributes == [color: "blue", artifactType: "jar"]
-            fromAttributes == [color: "blue"]
-            toAttributes == [color: "green"]
         }
     }
 
@@ -230,8 +228,6 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
             }
             transformType == "MakeColor"
             sourceAttributes == [color: "blue", artifactType: "jar"]
-            fromAttributes == [color: "blue"]
-            toAttributes == [color: "red"]
         }
 
         def executeTransformationOp2 = executeTransformationOps[1]
@@ -250,8 +246,6 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
             }
             transformType == "MakeColor"
             sourceAttributes == [color: "red", artifactType: "jar"]
-            fromAttributes == [color: "red"]
-            toAttributes == [color: "green"]
         }
     }
 
@@ -327,8 +321,6 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
             }
             transformType == "MakeRed"
             sourceAttributes == [color: "blue", artifactType: "jar"]
-            fromAttributes == [color: "blue"]
-            toAttributes == [color: "red"]
         }
 
         def executeTransformationOp2 = executeTransformationOps[1]
@@ -347,8 +339,6 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
             }
             transformType == "MakeGreen"
             sourceAttributes == [color: "blue", artifactType: "jar"]
-            fromAttributes == [color: "blue"]
-            toAttributes == [color: "green"]
         }
     }
 
@@ -426,8 +416,6 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
             }
             transformType == "MakeGreen"
             sourceAttributes == [color: "blue", artifactType: "jar"]
-            fromAttributes == [color: "blue"]
-            toAttributes == [color: "green"]
         }
     }
 
@@ -505,8 +493,6 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
             }
             transformType == "MakeRed"
             sourceAttributes == [color: "blue", artifactType: "jar"]
-            fromAttributes == [color: "blue"]
-            toAttributes == [color: "red"]
         }
 
         def executeTransformationOp2 = executeTransformationOps[1]
@@ -525,8 +511,6 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
             }
             transformType == "MakeGreen"
             sourceAttributes == [color: "red", artifactType: "jar"]
-            fromAttributes == [color: "red"]
-            toAttributes == [color: "green"]
         }
     }
 
@@ -643,8 +627,6 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
             }
             transformType == "MakeColor"
             sourceAttributes == [color: "blue", artifactType: "jar"]
-            fromAttributes == [color: "blue"]
-            toAttributes == [color: "red"]
         }
 
         def executeTransformationOp2 = executeTransformationOps[1]
@@ -663,8 +645,6 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
             }
             transformType == "MakeColor"
             sourceAttributes == [color: "red", artifactType: "jar"]
-            fromAttributes == [color: "red"]
-            toAttributes == [color: "green"]
         }
     }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformBuildOperationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformBuildOperationIntegrationTest.groovy
@@ -151,7 +151,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         List<BuildOperationRecord> executeTransformationOps = getExecuteTransformOperations(1)
 
         with(executeTransformationOps[0].details) {
-            matchTransformationIdentity(transformationIdentity, expectedTransformId)
+            verifyTransformationIdentity(transformationIdentity, expectedTransformId)
             transformType == "MakeGreen"
             sourceAttributes == [color: "blue", artifactType: "jar"]
 
@@ -223,7 +223,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
 
         def executeTransformationOps = getExecuteTransformOperations(2)
         with(executeTransformationOps[0].details) {
-            matchTransformationIdentity(transformationIdentity, expectedTransformId1)
+            verifyTransformationIdentity(transformationIdentity, expectedTransformId1)
             transformType == "MakeColor"
             sourceAttributes == [color: "blue", artifactType: "jar"]
 
@@ -232,7 +232,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         }
 
         with(executeTransformationOps[1].details) {
-            matchTransformationIdentity(transformationIdentity, expectedTransformId2)
+            verifyTransformationIdentity(transformationIdentity, expectedTransformId2)
             transformType == "MakeColor"
             sourceAttributes == [color: "red", artifactType: "jar"]
 
@@ -305,7 +305,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         def executeTransformationOps = getExecuteTransformOperations(2)
 
         with(executeTransformationOps[0].details) {
-            matchTransformationIdentity(transformationIdentity, expectedTransformId1)
+            verifyTransformationIdentity(transformationIdentity, expectedTransformId1)
             transformType == "MakeRed"
             sourceAttributes == [color: "blue", artifactType: "jar"]
 
@@ -314,7 +314,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         }
 
         with(executeTransformationOps[1].details) {
-            matchTransformationIdentity(transformationIdentity, expectedTransformId2)
+            verifyTransformationIdentity(transformationIdentity, expectedTransformId2)
             transformType == "MakeGreen"
             sourceAttributes == [color: "blue", artifactType: "jar"]
 
@@ -382,7 +382,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         )
 
         with(buildOperations.only(ExecuteScheduledTransformationStepBuildOperationType).details) {
-            matchTransformationIdentity(transformationIdentity, expectedTransformId1)
+            verifyTransformationIdentity(transformationIdentity, expectedTransformId1)
             transformType == "MakeGreen"
             sourceAttributes == [color: "blue", artifactType: "jar"]
 
@@ -456,7 +456,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
 
         def executeTransformationOps = getExecuteTransformOperations(2)
         with(executeTransformationOps[0].details) {
-            matchTransformationIdentity(transformationIdentity, expectedTransformId1)
+            verifyTransformationIdentity(transformationIdentity, expectedTransformId1)
             transformType == "MakeRed"
             sourceAttributes == [color: "blue", artifactType: "jar"]
 
@@ -465,7 +465,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         }
 
         with(executeTransformationOps[1].details) {
-            matchTransformationIdentity(transformationIdentity, expectedTransformId2)
+            verifyTransformationIdentity(transformationIdentity, expectedTransformId2)
             transformType == "MakeGreen"
             sourceAttributes == [color: "red", artifactType: "jar"]
 
@@ -578,7 +578,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
 
         def executeTransformationOps = getExecuteTransformOperations(2)
         with(executeTransformationOps[0].details) {
-            matchTransformationIdentity(transformationIdentity, expectedTransformId1)
+            verifyTransformationIdentity(transformationIdentity, expectedTransformId1)
             transformType == "MakeColor"
             sourceAttributes == [color: "blue", artifactType: "jar"]
 
@@ -587,7 +587,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         }
 
         with(executeTransformationOps[1].details) {
-            matchTransformationIdentity(transformationIdentity, expectedTransformId2)
+            verifyTransformationIdentity(transformationIdentity, expectedTransformId2)
             transformType == "MakeColor"
             sourceAttributes == [color: "red", artifactType: "jar"]
 
@@ -791,7 +791,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         executeTransformationOp.failure.startsWith("org.gradle.api.internal.artifacts.transform.TransformException: Execution failed for MakeGreen:")
 
         with(executeTransformationOp.details) {
-            matchTransformationIdentity(transformationIdentity, expectedTransformId1)
+            verifyTransformationIdentity(transformationIdentity, expectedTransformId1)
             transformType == "MakeGreen"
             sourceAttributes == [color: "blue", artifactType: "jar"]
 
@@ -879,6 +879,19 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
             actual.dependenciesConfigurationIdentity == expected.dependenciesConfigurationIdentity
     }
 
+    void verifyTransformationIdentity(actual, TransformationIdentityWithoutId expected) {
+        verifyAll(actual) {
+            nodeType.toString() == ARTIFACT_TRANSFORM
+            buildPath == expected.buildPath
+            projectPath == expected.projectPath
+            componentId == expected.componentId
+            targetAttributes == expected.targetAttributes
+            capabilities == expected.capabilities
+            artifactName == expected.artifactName
+            dependenciesConfigurationIdentity == expected.dependenciesConfigurationIdentity
+        }
+    }
+
     def getPlannedNodes(int transformNodeCount) {
         def plannedNodes = buildOperations.only(CalculateTaskGraphBuildOperationType).result.executionPlan as List<PlannedNode>
         assert plannedNodes.every { KNOWN_NODE_TYPES.contains(it.nodeIdentity.nodeType) }
@@ -898,12 +911,12 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         assert matchedOperations.size() == 1
         def operation = matchedOperations[0]
 
-        with(operation.details) {
-            assert transformType == expectedDetails.transformType
-            assert sourceAttributes == expectedDetails.sourceAttributes
+        verifyAll(operation.details) {
+            transformType == expectedDetails.transformType
+            sourceAttributes == expectedDetails.sourceAttributes
 
-            assert transformerName == expectedDetails.transformerName
-            assert subjectName == expectedDetails.subjectName
+            transformerName == expectedDetails.transformerName
+            subjectName == expectedDetails.subjectName
         }
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformBuildOperationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformBuildOperationIntegrationTest.groovy
@@ -20,6 +20,7 @@ import groovy.transform.EqualsAndHashCode
 import org.gradle.api.internal.artifacts.transform.ExecuteScheduledTransformationStepBuildOperationType
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationsFixture
+import org.gradle.internal.operations.trace.BuildOperationRecord
 import org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType
 import org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType.PlannedNode
 import org.gradle.internal.taskgraph.NodeIdentity
@@ -44,6 +45,16 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         def matchNode(plannedNode) {
             plannedNode.nodeIdentity.nodeType.toString() == nodeType && identityPredicate.test(plannedNode.nodeIdentity)
         }
+    }
+
+    static class TransformationIdentityWithoutId {
+        String buildPath
+        String projectPath
+        Map<String, String> componentId
+        Map<String, String> targetAttributes
+        List<Map<String, String>> capabilities
+        String artifactName
+        Map<String, String> dependenciesConfigurationIdentity
     }
 
     static final Set<String> KNOWN_NODE_TYPES = NodeIdentity.NodeType.values()*.name() as Set<String>
@@ -116,45 +127,39 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         result.groupedOutput.task(":consumer:resolve")
             .assertOutputContains("result = [producer.jar.green, test-4.2.jar]")
 
-        def plannedNodes = buildOperations.only(CalculateTaskGraphBuildOperationType).result.executionPlan as List<PlannedNode>
-        plannedNodes.every { KNOWN_NODE_TYPES.contains(it.nodeIdentity.nodeType) }
-        plannedNodes.count { it.nodeIdentity.nodeType.toString() == ARTIFACT_TRANSFORM } == 1
+        List<PlannedNode> plannedNodes = getPlannedNodes(1)
+
+        def expectedTransformId = new TransformationIdentityWithoutId([
+            buildPath: ":",
+            projectPath: ":consumer",
+            componentId: [buildPath: ":", projectPath: ":producer"],
+            targetAttributes: [color: "green", artifactType: "jar"],
+            capabilities: [[group: "colored", name: "producer", version: "unspecified"]],
+            artifactName: "producer.jar",
+            dependenciesConfigurationIdentity: null,
+        ])
 
         checkExecutionPlanMatchingDependencies(
             plannedNodes,
             [
-                taskMatcher(
-                    "node1", ":producer:producer",
-                    []
-                ),
-                transformMatcher(
-                    "node2", ":consumer", [buildPath: ":", projectPath: ":producer"], [artifactType: "jar", color: "green"],
-                    ["node1"]
-                ),
-                taskMatcher(
-                    "node3", ":consumer:resolve",
-                    ["node2"]
-                ),
+                taskMatcher("node1", ":producer:producer", []),
+                transformMatcher("node2", expectedTransformId, ["node1"]),
+                taskMatcher("node3", ":consumer:resolve", ["node2"]),
             ]
         )
 
-        with(buildOperations.only(ExecuteScheduledTransformationStepBuildOperationType).details) {
-            transformerName == "MakeGreen"
-            subjectName == "producer.jar (project :producer)"
-            with(transformationIdentity) {
-                nodeType == "ARTIFACT_TRANSFORM"
-                buildPath == ":"
-                projectPath == ":consumer"
-                componentId == [buildPath: ":", projectPath: ":producer"]
-                targetAttributes == [color: "green", artifactType: "jar"]
-                capabilities == [[group: "colored", name: "producer", version: "unspecified"]]
-                artifactName == "producer.jar"
-                dependenciesConfigurationIdentity == null
-            }
+        List<BuildOperationRecord> executeTransformationOps = getExecuteTransformOperations(1)
+
+        with(executeTransformationOps[0].details) {
+            matchTransformationIdentity(transformationIdentity, expectedTransformId)
             transformType == "MakeGreen"
             sourceAttributes == [color: "blue", artifactType: "jar"]
+
+            transformerName == "MakeGreen"
+            subjectName == "producer.jar (project :producer)"
         }
     }
+
 
     def "chained transform operations are captured"() {
         settingsFile << """
@@ -185,67 +190,55 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         result.groupedOutput.task(":consumer:resolve")
             .assertOutputContains("result = [producer.jar.red.green, test-4.2.jar]")
 
-        def plannedNodes = buildOperations.only(CalculateTaskGraphBuildOperationType).result.executionPlan as List<PlannedNode>
-        plannedNodes.every { KNOWN_NODE_TYPES.contains(it.nodeIdentity.nodeType) }
-        plannedNodes.count { it.nodeIdentity.nodeType.toString() == ARTIFACT_TRANSFORM } == 2
+        def plannedNodes = getPlannedNodes(2)
+
+        def expectedTransformId1 = new TransformationIdentityWithoutId([
+            buildPath: ":",
+            projectPath: ":consumer",
+            componentId: [buildPath: ":", projectPath: ":producer"],
+            targetAttributes: [color: "red", artifactType: "jar"],
+            capabilities: [[group: "colored", name: "producer", version: "unspecified"]],
+            artifactName: "producer.jar",
+            dependenciesConfigurationIdentity: null,
+        ])
+
+        def expectedTransformId2 = new TransformationIdentityWithoutId([
+            buildPath: ":",
+            projectPath: ":consumer",
+            componentId: [buildPath: ":", projectPath: ":producer"],
+            targetAttributes: [color: "green", artifactType: "jar"],
+            capabilities: [[group: "colored", name: "producer", version: "unspecified"]],
+            artifactName: "producer.jar",
+            dependenciesConfigurationIdentity: null,
+        ])
 
         checkExecutionPlanMatchingDependencies(
             plannedNodes,
             [
-                taskMatcher(
-                    "node1", ":producer:producer",
-                    []
-                ),
-                transformMatcher(
-                    "node2", ":consumer", [buildPath: ":", projectPath: ":producer"], [artifactType: "jar", color: "red"],
-                    ["node1"]
-                ),
-                transformMatcher(
-                    "node3", ":consumer", [buildPath: ":", projectPath: ":producer"], [artifactType: "jar", color: "green"],
-                    ["node2"]
-                ),
-                taskMatcher(
-                    "node4", ":consumer:resolve",
-                    ["node3"]
-                ),
+                taskMatcher("node1", ":producer:producer", []),
+                transformMatcher("node2", expectedTransformId1, ["node1"]),
+                transformMatcher("node3", expectedTransformId2, ["node2"]),
+                taskMatcher("node4", ":consumer:resolve", ["node3"]),
             ]
         )
 
-        def executeTransformationOps = buildOperations.all(ExecuteScheduledTransformationStepBuildOperationType)
-        def executeTransformationOp1 = executeTransformationOps[0]
-        with(executeTransformationOp1.details) {
-            transformerName == "MakeColor"
-            subjectName == "producer.jar (project :producer)"
-            with(transformationIdentity) {
-                nodeType == "ARTIFACT_TRANSFORM"
-                buildPath == ":"
-                projectPath == ":consumer"
-                componentId == [buildPath: ":", projectPath: ":producer"]
-                targetAttributes == [color: "red", artifactType: "jar"]
-                capabilities == [[group: "colored", name: "producer", version: "unspecified"]]
-                artifactName == "producer.jar"
-                dependenciesConfigurationIdentity == null
-            }
+        def executeTransformationOps = getExecuteTransformOperations(2)
+        with(executeTransformationOps[0].details) {
+            matchTransformationIdentity(transformationIdentity, expectedTransformId1)
             transformType == "MakeColor"
             sourceAttributes == [color: "blue", artifactType: "jar"]
-        }
 
-        def executeTransformationOp2 = executeTransformationOps[1]
-        with(executeTransformationOp2.details) {
             transformerName == "MakeColor"
             subjectName == "producer.jar (project :producer)"
-            with(transformationIdentity) {
-                nodeType == "ARTIFACT_TRANSFORM"
-                buildPath == ":"
-                projectPath == ":consumer"
-                componentId == [buildPath: ":", projectPath: ":producer"]
-                targetAttributes == [color: "green", artifactType: "jar"]
-                capabilities == [[group: "colored", name: "producer", version: "unspecified"]]
-                artifactName == "producer.jar"
-                dependenciesConfigurationIdentity == null
-            }
+        }
+
+        with(executeTransformationOps[1].details) {
+            matchTransformationIdentity(transformationIdentity, expectedTransformId2)
             transformType == "MakeColor"
             sourceAttributes == [color: "red", artifactType: "jar"]
+
+            transformerName == "MakeColor"
+            subjectName == "producer.jar (project :producer)"
         }
     }
 
@@ -278,67 +271,56 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         result.groupedOutput.task(":consumer:resolve")
             .assertOutputContains("result = [producer.jar.green, test-4.2.jar]")
 
-        def plannedNodes = buildOperations.only(CalculateTaskGraphBuildOperationType).result.executionPlan as List<PlannedNode>
-        plannedNodes.every { KNOWN_NODE_TYPES.contains(it.nodeIdentity.nodeType) }
-        plannedNodes.count { it.nodeIdentity.nodeType.toString() == ARTIFACT_TRANSFORM } == 2
+        def plannedNodes = getPlannedNodes(2)
+
+        def expectedTransformId1 = new TransformationIdentityWithoutId([
+            buildPath: ":",
+            projectPath: ":consumer",
+            componentId: [buildPath: ":", projectPath: ":producer"],
+            targetAttributes: [color: "red", artifactType: "jar"],
+            capabilities: [[group: "colored", name: "producer", version: "unspecified"]],
+            artifactName: "producer.jar",
+            dependenciesConfigurationIdentity: null,
+        ])
+
+        def expectedTransformId2 = new TransformationIdentityWithoutId([
+            buildPath: ":",
+            projectPath: ":consumer",
+            componentId: [buildPath: ":", projectPath: ":producer"],
+            targetAttributes: [color: "green", artifactType: "jar"],
+            capabilities: [[group: "colored", name: "producer", version: "unspecified"]],
+            artifactName: "producer.jar",
+            dependenciesConfigurationIdentity: null,
+        ])
 
         checkExecutionPlanMatchingDependencies(
             plannedNodes,
             [
-                taskMatcher(
-                    "node1", ":producer:producer",
-                    []
-                ),
-                transformMatcher(
-                    "node2", ":consumer", [buildPath: ":", projectPath: ":producer"], [artifactType: "jar", color: "red"],
-                    ["node1"]
-                ),
-                transformMatcher(
-                    "node3", ":consumer", [buildPath: ":", projectPath: ":producer"], [artifactType: "jar", color: "green"],
-                    ["node1", "node2"]
-                ),
-                taskMatcher(
-                    "node4", ":consumer:resolve",
-                    ["node3"]
-                ),
+                taskMatcher("node1", ":producer:producer", []),
+                transformMatcher("node2", expectedTransformId1, ["node1"]),
+                transformMatcher("node3", expectedTransformId2, ["node1", "node2"]),
+                taskMatcher("node4", ":consumer:resolve", ["node3"]),
             ]
         )
 
-        def executeTransformationOps = buildOperations.all(ExecuteScheduledTransformationStepBuildOperationType)
-        def executeTransformationOp1 = executeTransformationOps[0]
-        with(executeTransformationOp1.details) {
-            transformerName == "MakeRed"
-            subjectName == "producer.jar (project :producer)"
-            with(transformationIdentity) {
-                nodeType == "ARTIFACT_TRANSFORM"
-                buildPath == ":"
-                projectPath == ":consumer"
-                componentId == [buildPath: ":", projectPath: ":producer"]
-                targetAttributes == [color: "red", artifactType: "jar"]
-                capabilities == [[group: "colored", name: "producer", version: "unspecified"]]
-                artifactName == "producer.jar"
-                dependenciesConfigurationIdentity == null
-            }
+        def executeTransformationOps = getExecuteTransformOperations(2)
+
+        with(executeTransformationOps[0].details) {
+            matchTransformationIdentity(transformationIdentity, expectedTransformId1)
             transformType == "MakeRed"
             sourceAttributes == [color: "blue", artifactType: "jar"]
+
+            transformerName == "MakeRed"
+            subjectName == "producer.jar (project :producer)"
         }
 
-        def executeTransformationOp2 = executeTransformationOps[1]
-        with(executeTransformationOp2.details) {
-            transformerName == "MakeGreen"
-            subjectName == "producer.jar (project :producer)"
-            with(transformationIdentity) {
-                nodeType == "ARTIFACT_TRANSFORM"
-                buildPath == ":"
-                projectPath == ":consumer"
-                componentId == [buildPath: ":", projectPath: ":producer"]
-                targetAttributes == [color: "green", artifactType: "jar"]
-                capabilities == [[group: "colored", name: "producer", version: "unspecified"]]
-                artifactName == "producer.jar"
-                dependenciesConfigurationIdentity == null
-            }
+        with(executeTransformationOps[1].details) {
+            matchTransformationIdentity(transformationIdentity, expectedTransformId2)
             transformType == "MakeGreen"
             sourceAttributes == [color: "blue", artifactType: "jar"]
+
+            transformerName == "MakeGreen"
+            subjectName == "producer.jar (project :producer)"
         }
     }
 
@@ -379,43 +361,34 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         result.groupedOutput.task(":consumer:resolve")
             .assertOutputContains("result = [producer.jar.green, test-4.2.jar]")
 
-        def plannedNodes = buildOperations.only(CalculateTaskGraphBuildOperationType).result.executionPlan as List<PlannedNode>
-        plannedNodes.every { KNOWN_NODE_TYPES.contains(it.nodeIdentity.nodeType) }
-        plannedNodes.count { it.nodeIdentity.nodeType.toString() == ARTIFACT_TRANSFORM } == 1
+        def plannedNodes = getPlannedNodes(1)
+
+        def expectedTransformId1 = new TransformationIdentityWithoutId([
+            buildPath: ":",
+            projectPath: ":consumer",
+            componentId: [buildPath: ":", projectPath: ":producer"],
+            targetAttributes: [color: "green", artifactType: "jar"],
+            capabilities: [[group: "colored", name: "producer", version: "unspecified"]],
+            artifactName: "producer.jar",
+            dependenciesConfigurationIdentity: [buildPath: ":", projectPath: ":consumer", name: "resolver"],
+        ])
 
         checkExecutionPlanMatchingDependencies(
             plannedNodes,
             [
-                taskMatcher(
-                    "node1", ":producer:producer",
-                    []
-                ),
-                transformMatcher(
-                    "node2", ":consumer", [buildPath: ":", projectPath: ":producer"], [artifactType: "jar", color: "green"],
-                    ["node1"]
-                ),
-                taskMatcher(
-                    "node3", ":consumer:resolve",
-                    ["node2"]
-                ),
+                taskMatcher("node1", ":producer:producer", []),
+                transformMatcher("node2", expectedTransformId1, ["node1"]),
+                taskMatcher("node3", ":consumer:resolve", ["node2"]),
             ]
         )
 
         with(buildOperations.only(ExecuteScheduledTransformationStepBuildOperationType).details) {
-            transformerName == "MakeGreen"
-            subjectName == "producer.jar (project :producer)"
-            with(transformationIdentity) {
-                nodeType == "ARTIFACT_TRANSFORM"
-                buildPath == ":"
-                projectPath == ":consumer"
-                componentId == [buildPath: ":", projectPath: ":producer"]
-                targetAttributes == [color: "green", artifactType: "jar"]
-                capabilities == [[group: "colored", name: "producer", version: "unspecified"]]
-                artifactName == "producer.jar"
-                dependenciesConfigurationIdentity == [buildPath: ":", projectPath: ":consumer", name: "resolver"]
-            }
+            matchTransformationIdentity(transformationIdentity, expectedTransformId1)
             transformType == "MakeGreen"
             sourceAttributes == [color: "blue", artifactType: "jar"]
+
+            transformerName == "MakeGreen"
+            subjectName == "producer.jar (project :producer)"
         }
     }
 
@@ -450,67 +423,55 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         result.groupedOutput.task(":consumer:resolve")
             .assertOutputContains("result = [producer.jar.red.green, test-4.2.jar]")
 
-        def plannedNodes = buildOperations.only(CalculateTaskGraphBuildOperationType).result.executionPlan as List<PlannedNode>
-        plannedNodes.every { KNOWN_NODE_TYPES.contains(it.nodeIdentity.nodeType) }
-        plannedNodes.count { it.nodeIdentity.nodeType.toString() == ARTIFACT_TRANSFORM } == 2
+        def plannedNodes = getPlannedNodes(2)
+
+        def expectedTransformId1 = new TransformationIdentityWithoutId([
+            buildPath: ":",
+            projectPath: ":consumer",
+            componentId: [buildPath: ":", projectPath: ":producer"],
+            targetAttributes: [color: "red", artifactType: "jar"],
+            capabilities: [[group: "colored", name: "producer", version: "unspecified"]],
+            artifactName: "producer.jar",
+            dependenciesConfigurationIdentity: null,
+        ])
+
+        def expectedTransformId2 = new TransformationIdentityWithoutId([
+            buildPath: ":",
+            projectPath: ":consumer",
+            componentId: [buildPath: ":", projectPath: ":producer"],
+            targetAttributes: [color: "green", artifactType: "jar"],
+            capabilities: [[group: "colored", name: "producer", version: "unspecified"]],
+            artifactName: "producer.jar",
+            dependenciesConfigurationIdentity: [buildPath: ":", projectPath: ":consumer", name: "resolver"],
+        ])
 
         checkExecutionPlanMatchingDependencies(
             plannedNodes,
             [
-                taskMatcher(
-                    "node1", ":producer:producer",
-                    []
-                ),
-                transformMatcher(
-                    "node2", ":consumer", [buildPath: ":", projectPath: ":producer"], [artifactType: "jar", color: "red"],
-                    ["node1"]
-                ),
-                transformMatcher(
-                    "node3", ":consumer", [buildPath: ":", projectPath: ":producer"], [artifactType: "jar", color: "green"],
-                    ["node2"]
-                ),
-                taskMatcher(
-                    "node4", ":consumer:resolve",
-                    ["node3"]
-                ),
+                taskMatcher("node1", ":producer:producer", []),
+                transformMatcher("node2", expectedTransformId1, ["node1"]),
+                transformMatcher("node3", expectedTransformId2, ["node2"]),
+                taskMatcher("node4", ":consumer:resolve", ["node3"]),
             ]
         )
 
-        def executeTransformationOps = buildOperations.all(ExecuteScheduledTransformationStepBuildOperationType)
-        def executeTransformationOp1 = executeTransformationOps[0]
-        with(executeTransformationOp1.details) {
-            transformerName == "MakeRed"
-            subjectName == "producer.jar (project :producer)"
-            with(transformationIdentity) {
-                nodeType == "ARTIFACT_TRANSFORM"
-                buildPath == ":"
-                projectPath == ":consumer"
-                componentId == [buildPath: ":", projectPath: ":producer"]
-                targetAttributes == [color: "red", artifactType: "jar"]
-                capabilities == [[group: "colored", name: "producer", version: "unspecified"]]
-                artifactName == "producer.jar"
-                dependenciesConfigurationIdentity == null
-            }
+        def executeTransformationOps = getExecuteTransformOperations(2)
+        with(executeTransformationOps[0].details) {
+            matchTransformationIdentity(transformationIdentity, expectedTransformId1)
             transformType == "MakeRed"
             sourceAttributes == [color: "blue", artifactType: "jar"]
+
+            transformerName == "MakeRed"
+            subjectName == "producer.jar (project :producer)"
         }
 
-        def executeTransformationOp2 = executeTransformationOps[1]
-        with(executeTransformationOp2.details) {
-            transformerName == "MakeGreen"
-            subjectName == "producer.jar (project :producer)"
-            with(transformationIdentity) {
-                nodeType == "ARTIFACT_TRANSFORM"
-                buildPath == ":"
-                projectPath == ":consumer"
-                componentId == [buildPath: ":", projectPath: ":producer"]
-                targetAttributes == [color: "green", artifactType: "jar"]
-                capabilities == [[group: "colored", name: "producer", version: "unspecified"]]
-                artifactName == "producer.jar"
-                dependenciesConfigurationIdentity == [buildPath: ":", projectPath: ":consumer", name: "resolver"]
-            }
+        with(executeTransformationOps[1].details) {
+            matchTransformationIdentity(transformationIdentity, expectedTransformId2)
             transformType == "MakeGreen"
             sourceAttributes == [color: "red", artifactType: "jar"]
+
+            transformerName == "MakeGreen"
+            subjectName == "producer.jar (project :producer)"
         }
     }
 
@@ -584,67 +545,55 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         result.groupedOutput.task(":consumer:resolve")
             .assertOutputContains("result = [producer.jar.red-1.green-1, producer.jar.red-2.green-1, test-4.2.jar]")
 
-        def plannedNodes = buildOperations.only(CalculateTaskGraphBuildOperationType).result.executionPlan as List<PlannedNode>
-        plannedNodes.every { KNOWN_NODE_TYPES.contains(it.nodeIdentity.nodeType) }
-        plannedNodes.count { it.nodeIdentity.nodeType.toString() == ARTIFACT_TRANSFORM } == 2
+        def plannedNodes = getPlannedNodes(2)
+
+        def expectedTransformId1 = new TransformationIdentityWithoutId([
+            buildPath: ":",
+            projectPath: ":consumer",
+            componentId: [buildPath: ":", projectPath: ":producer"],
+            targetAttributes: [color: "red", artifactType: "jar"],
+            capabilities: [[group: "colored", name: "producer", version: "unspecified"]],
+            artifactName: "producer.jar",
+            dependenciesConfigurationIdentity: null,
+        ])
+
+        def expectedTransformId2 = new TransformationIdentityWithoutId([
+            buildPath: ":",
+            projectPath: ":consumer",
+            componentId: [buildPath: ":", projectPath: ":producer"],
+            targetAttributes: [color: "green", artifactType: "jar"],
+            capabilities: [[group: "colored", name: "producer", version: "unspecified"]],
+            artifactName: "producer.jar",
+            dependenciesConfigurationIdentity: null,
+        ])
 
         checkExecutionPlanMatchingDependencies(
             plannedNodes,
             [
-                taskMatcher(
-                    "node1", ":producer:producer",
-                    []
-                ),
-                transformMatcher(
-                    "node2", ":consumer", [buildPath: ":", projectPath: ":producer"], [artifactType: "jar", color: "red"],
-                    ["node1"]
-                ),
-                transformMatcher(
-                    "node3", ":consumer", [buildPath: ":", projectPath: ":producer"], [artifactType: "jar", color: "green"],
-                    ["node2"]
-                ),
-                taskMatcher(
-                    "node4", ":consumer:resolve",
-                    ["node3"]
-                ),
+                taskMatcher("node1", ":producer:producer", []),
+                transformMatcher("node2", expectedTransformId1, ["node1"]),
+                transformMatcher("node3", expectedTransformId2, ["node2"]),
+                taskMatcher("node4", ":consumer:resolve", ["node3"]),
             ]
         )
 
-        def executeTransformationOps = buildOperations.all(ExecuteScheduledTransformationStepBuildOperationType)
-        def executeTransformationOp1 = executeTransformationOps[0]
-        with(executeTransformationOp1.details) {
-            transformerName == "MakeColor"
-            subjectName == "producer.jar (project :producer)"
-            with(transformationIdentity) {
-                nodeType == "ARTIFACT_TRANSFORM"
-                buildPath == ":"
-                projectPath == ":consumer"
-                componentId == [buildPath: ":", projectPath: ":producer"]
-                targetAttributes == [color: "red", artifactType: "jar"]
-                capabilities == [[group: "colored", name: "producer", version: "unspecified"]]
-                artifactName == "producer.jar"
-                dependenciesConfigurationIdentity == null
-            }
+        def executeTransformationOps = getExecuteTransformOperations(2)
+        with(executeTransformationOps[0].details) {
+            matchTransformationIdentity(transformationIdentity, expectedTransformId1)
             transformType == "MakeColor"
             sourceAttributes == [color: "blue", artifactType: "jar"]
-        }
 
-        def executeTransformationOp2 = executeTransformationOps[1]
-        with(executeTransformationOp2.details) {
             transformerName == "MakeColor"
             subjectName == "producer.jar (project :producer)"
-            with(transformationIdentity) {
-                nodeType == "ARTIFACT_TRANSFORM"
-                buildPath == ":"
-                projectPath == ":consumer"
-                componentId == [buildPath: ":", projectPath: ":producer"]
-                targetAttributes == [color: "green", artifactType: "jar"]
-                capabilities == [[group: "colored", name: "producer", version: "unspecified"]]
-                artifactName == "producer.jar"
-                dependenciesConfigurationIdentity == null
-            }
+        }
+
+        with(executeTransformationOps[1].details) {
+            matchTransformationIdentity(transformationIdentity, expectedTransformId2)
             transformType == "MakeColor"
             sourceAttributes == [color: "red", artifactType: "jar"]
+
+            transformerName == "MakeColor"
+            subjectName == "producer.jar (project :producer)"
         }
     }
 
@@ -688,19 +637,13 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
 
     def transformMatcher(
         String nodeId,
-        String consumerIdentityPath,
-        Map<String, String> componentId,
-        Map<String, String> attributes,
+        TransformationIdentityWithoutId transformationIdentity,
         List<String> dependencyNodeIds
     ) {
         new NodeMatcher(
             nodeId: nodeId,
             nodeType: ARTIFACT_TRANSFORM,
-            identityPredicate: {
-                joinPaths(it.buildPath, it.projectPath) == consumerIdentityPath &&
-                    it.componentId == componentId &&
-                    it.targetAttributes == attributes
-            },
+            identityPredicate: { matchTransformationIdentity(it, transformationIdentity) },
             dependencyNodeIds: dependencyNodeIds
         )
     }
@@ -720,5 +663,30 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         paths.inject("") { acc, path ->
             acc + (acc.endsWith(":") && path.startsWith(":") ? path.substring(1) : path)
         }
+    }
+
+    boolean matchTransformationIdentity(actual, TransformationIdentityWithoutId expected) {
+        actual.nodeType.toString() == ARTIFACT_TRANSFORM &&
+            actual.buildPath == expected.buildPath &&
+            actual.projectPath == expected.projectPath &&
+            actual.componentId == expected.componentId &&
+            actual.targetAttributes == expected.targetAttributes &&
+            actual.capabilities == expected.capabilities &&
+            actual.artifactName == expected.artifactName &&
+            actual.dependenciesConfigurationIdentity == expected.dependenciesConfigurationIdentity
+    }
+
+    def getPlannedNodes(int transformNodeCount) {
+        def plannedNodes = buildOperations.only(CalculateTaskGraphBuildOperationType).result.executionPlan as List<PlannedNode>
+        assert plannedNodes.every { KNOWN_NODE_TYPES.contains(it.nodeIdentity.nodeType) }
+        assert plannedNodes.count { it.nodeIdentity.nodeType.toString() == ARTIFACT_TRANSFORM } == transformNodeCount
+        return plannedNodes
+    }
+
+    def getExecuteTransformOperations(int expectOperationsCount) {
+        def operations = buildOperations.all(ExecuteScheduledTransformationStepBuildOperationType)
+        assert operations.every { it.failure == null }
+        assert operations.size() == expectOperationsCount
+        return operations
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -2639,11 +2639,24 @@ Found the following transforms:
         outputContains("After transformer FileSizer on lib.jar (project :lib)")
 
         and:
-        with(buildOperations.only(ExecuteScheduledTransformationStepBuildOperationType)) {
-            it.failure == null
-            displayName == "Transform lib.jar (project :lib) with FileSizer"
-            details.transformerName == "FileSizer"
-            details.subjectName == "lib.jar (project :lib)"
+        def executeTransformationOp = buildOperations.only(ExecuteScheduledTransformationStepBuildOperationType)
+        executeTransformationOp.failure == null
+        executeTransformationOp.displayName == "Transform lib.jar (project :lib) with FileSizer"
+        with(executeTransformationOp.details) {
+            transformerName == "FileSizer"
+            subjectName == "lib.jar (project :lib)"
+            with(transformationIdentity) {
+                nodeType == "ARTIFACT_TRANSFORM"
+                buildPath == ":"
+                projectPath == ":app"
+                componentId == [buildPath: ":", projectPath: ":lib"]
+                targetAttributes == [artifactType: "size", usage: "api"]
+                capabilities == [[group: "root", name: "lib", version: "unspecified"]]
+                artifactName == "lib.jar"
+                dependenciesConfigurationIdentity == null
+            }
+            transformType == "FileSizer"
+            sourceAttributes == [artifactType: "jar", usage: "api"]
         }
     }
 
@@ -2699,10 +2712,24 @@ Found the following transforms:
         outputContains("After transformer BrokenTransform on lib.jar (project :lib)")
 
         and:
-        with(buildOperations.only(ExecuteScheduledTransformationStepBuildOperationType)) {
-            displayName == "Transform lib.jar (project :lib) with BrokenTransform"
-            details.transformerName == "BrokenTransform"
-            details.subjectName == "lib.jar (project :lib)"
+        def executeTransformationOp = buildOperations.only(ExecuteScheduledTransformationStepBuildOperationType)
+        executeTransformationOp.failure != null
+        executeTransformationOp.displayName == "Transform lib.jar (project :lib) with BrokenTransform"
+        with(executeTransformationOp.details) {
+            transformerName == "BrokenTransform"
+            subjectName == "lib.jar (project :lib)"
+            with(transformationIdentity) {
+                nodeType == "ARTIFACT_TRANSFORM"
+                buildPath == ":"
+                projectPath == ":app"
+                componentId == [buildPath: ":", projectPath: ":lib"]
+                targetAttributes == [artifactType: "size", usage: "api"]
+                capabilities == [[group: "root", name: "lib", version: "unspecified"]]
+                artifactName == "lib.jar"
+                dependenciesConfigurationIdentity == null
+            }
+            transformType == "BrokenTransform"
+            sourceAttributes == [artifactType: "jar", usage: "api"]
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ExecuteScheduledTransformationStepBuildOperationDetails.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ExecuteScheduledTransformationStepBuildOperationDetails.java
@@ -48,16 +48,6 @@ public class ExecuteScheduledTransformationStepBuildOperationDetails implements 
     }
 
     @Override
-    public Map<String, String> getFromAttributes() {
-        return AttributesToMapConverter.convertToMap(transformationNode.getTransformationStep().getFromAttributes());
-    }
-
-    @Override
-    public Map<String, String> getToAttributes() {
-        return AttributesToMapConverter.convertToMap(transformationNode.getTransformationStep().getToAttributes());
-    }
-
-    @Override
     public Class<?> getTransformType() {
         return transformationNode.getTransformationStep().getTransformer().getImplementationClass();
     }
@@ -77,8 +67,6 @@ public class ExecuteScheduledTransformationStepBuildOperationDetails implements 
         ImmutableMap.Builder<String, Object> builder = new ImmutableMap.Builder<>();
         builder.put("transformationIdentity", getTransformationIdentity());
         builder.put("sourceAttributes", getSourceAttributes());
-        builder.put("fromAttributes", getFromAttributes());
-        builder.put("toAttributes", getToAttributes());
         builder.put("transformType", getTransformType());
         builder.put("transformerName", transformerName);
         builder.put("subjectName", subjectName);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ToPlannedTransformConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ToPlannedTransformConverter.java
@@ -50,4 +50,9 @@ public class ToPlannedTransformConverter implements ToPlannedNodeConverter {
             dependencyLookup.findNodeDependencies(transformationNode)
         );
     }
+
+    @Override
+    public String toString() {
+        return "ToPlannedTransformConverter(" + getSupportedNodeType().getSimpleName() + ")";
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNode.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNode.java
@@ -137,6 +137,11 @@ public abstract class TransformationNode extends CreationOrderedNode implements 
 
         return new TransformationIdentity() {
             @Override
+            public NodeType getNodeType() {
+                return NodeType.ARTIFACT_TRANSFORM;
+            }
+
+            @Override
             public String getBuildPath() {
                 return consumerBuildPath;
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationStep.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationStep.java
@@ -137,10 +137,6 @@ public class TransformationStep implements Transformation, TaskDependencyContain
         return transformer.getFromAttributes();
     }
 
-    public ImmutableAttributes getToAttributes() {
-        return transformer.getToAttributes();
-    }
-
     @Override
     public String toString() {
         return transformer.getDisplayName();

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/api/internal/artifacts/transform/ExecuteScheduledTransformationStepBuildOperationType.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/api/internal/artifacts/transform/ExecuteScheduledTransformationStepBuildOperationType.java
@@ -31,10 +31,19 @@ public class ExecuteScheduledTransformationStepBuildOperationType implements Bui
 
     public interface Details {
 
+        /**
+         * The identity of the transformation executed in this operation.
+         */
         TransformationIdentity getTransformationIdentity();
 
+        /**
+         * Full set of attributes of the artifact before the transformation.
+         */
         Map<String, String> getSourceAttributes();
 
+        /**
+         * Type of the transformer implementation used during transform registration.
+         */
         Class<?> getTransformType();
 
         /**

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/api/internal/artifacts/transform/ExecuteScheduledTransformationStepBuildOperationType.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/api/internal/artifacts/transform/ExecuteScheduledTransformationStepBuildOperationType.java
@@ -35,10 +35,6 @@ public class ExecuteScheduledTransformationStepBuildOperationType implements Bui
 
         Map<String, String> getSourceAttributes();
 
-        Map<String, String> getFromAttributes();
-
-        Map<String, String> getToAttributes();
-
         Class<?> getTransformType();
 
         /**

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationIdentity.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationIdentity.java
@@ -32,11 +32,6 @@ import java.util.Map;
  */
 public interface TransformationIdentity extends NodeIdentity {
 
-    @Override
-    default NodeType getNodeType() {
-        return NodeType.ARTIFACT_TRANSFORM;
-    }
-
     /**
      * Path of an included build of the consumer project.
      */

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationIdentity.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationIdentity.java
@@ -55,7 +55,8 @@ public interface TransformationIdentity extends NodeIdentity {
     /**
      * Target attributes of the transformed artifact.
      * <p>
-     * The attributes include the source attributes of the artifact before the transformation and
+     * The attributes include all source attributes of the artifact before the transformation,
+     * values for some of which have been changed by the transformation.
      */
     Map<String, String> getTargetAttributes();
 

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/internal/taskgraph/CalculateTaskGraphBuildOperationType.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/internal/taskgraph/CalculateTaskGraphBuildOperationType.java
@@ -56,11 +56,6 @@ public final class CalculateTaskGraphBuildOperationType implements BuildOperatio
      */
     public interface TaskIdentity extends NodeIdentity {
 
-        @Override
-        default NodeType getNodeType() {
-            return NodeType.TASK;
-        }
-
         String getBuildPath();
 
         String getTaskPath();

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/internal/taskgraph/NodeIdentity.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/internal/taskgraph/NodeIdentity.java
@@ -21,7 +21,6 @@ package org.gradle.internal.taskgraph;
  * <p>
  * Needs to be unique across all the execution graphs of the current build.
  */
-// TODO: should identities implement equality? If not, this should be noted in the contract
 public interface NodeIdentity {
 
     enum NodeType {


### PR DESCRIPTION
Follow up for
- https://github.com/gradle/gradle/pull/23592

Changes summary:
- Remove `fromAttributes` and `toAttributes` from the execute-transformation operation, as they are not going to be used by the scan plugin at the moment
- Add more integration tests for transformation build operations and adjust existing tests to check new fields of the operation records
- Extract `ToPlannedNodeConverterRegistry` into a Gradle User Home service