### PR TITLE
Replace TestNG with JUnit in MavenConversionIntegrationTest

### DIFF
--- a/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/javadocJar/some-thing/pom.xml
+++ b/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/javadocJar/some-thing/pom.xml
@@ -30,9 +30,9 @@
             <version>2.6</version>
         </dependency>
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-            <version>6.7</version>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/javadocJar/some-thing/src/test/java/FooTest.java
+++ b/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/javadocJar/some-thing/src/test/java/FooTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import org.testng.annotations.Test;
+import org.junit.Test;
 
 public class FooTest {
   @Test public void test() { }

--- a/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/singleModule/some-thing/pom.xml
+++ b/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/singleModule/some-thing/pom.xml
@@ -8,18 +8,18 @@
   <packaging>jar</packaging>
 
 		<dependencies>
-			<dependency>
+            <dependency>
                 <groupId>commons-lang</groupId>
                 <artifactId>commons-lang</artifactId>
                 <version>2.6</version>
-			</dependency>
-			<dependency>
-				<groupId>org.testng</groupId>
-				<artifactId>testng</artifactId>
-				<version>6.7</version>
-				<scope>test</scope>
-			</dependency>
-		</dependencies>
+            </dependency>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.13.1</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
     <build>
         <plugins>
             <plugin>

--- a/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/singleModule/some-thing/src/test/java/FooTest.java
+++ b/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/singleModule/some-thing/src/test/java/FooTest.java
@@ -1,4 +1,4 @@
-import org.testng.annotations.Test;
+import org.junit.Test;
 
 public class FooTest {
   @Test public void test() {

--- a/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/sourcesJar/some-thing/pom.xml
+++ b/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/sourcesJar/some-thing/pom.xml
@@ -30,9 +30,9 @@
             <version>2.6</version>
         </dependency>
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-            <version>6.7</version>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/sourcesJar/some-thing/src/test/java/FooTest.java
+++ b/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/sourcesJar/some-thing/src/test/java/FooTest.java
@@ -1,4 +1,4 @@
-import org.testng.annotations.Test;
+import org.junit.Test;
 
 public class FooTest {
   @Test public void test() { }


### PR DESCRIPTION
Fixes #23818.
Note that JUnit4 is used because JUnit5 requires Java 8, but these tests require Java 7 compatibility.
