### PR TITLE
Define GitHub action to get notifications about IDE-related issues

### DIFF
--- a/.github/workflows/slack-notifier.yml
+++ b/.github/workflows/slack-notifier.yml
@@ -1,0 +1,31 @@
+name: IDE Experience team notifier
+run-name: Notify the IDE Experience team about relevant issues
+on:
+  issues:
+    types:
+      - labeled
+
+jobs:
+  send-slack-notification:
+    if: ${{ github.event.label.name == 'in:ide' || github.event.label.name == 'in:eclipse-plugin' || github.event.label.name == 'in:idea-plugin' || github.event.label.name == 'in:tooling-api' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Slack notification about issues with specific labels
+        id: slack
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          payload: |
+            {
+              "text": "<https://github.com/gradle/gradle/${{ github.event.issue.number }}|[gradle/gradle#${{ github.event.issue.number }}]> `${{ github.event.issue.title }}` has label `${{ github.event.label.name }}`",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "<https://github.com/gradle/gradle/${{ github.event.issue.number }}|[gradle/gradle#${{ github.event.issue.number }}]> `${{ github.event.issue.title }}` has label `${{ github.event.label.name }}`"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.IDE_EXPERIENCE_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/slack-notifier.yml
+++ b/.github/workflows/slack-notifier.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   send-slack-notification:
     if: ${{ github.event.label.name == 'in:ide' || github.event.label.name == 'in:eclipse-plugin' || github.event.label.name == 'in:idea-plugin' || github.event.label.name == 'in:tooling-api' }}
-    runs-on: ubuntu-latest
     steps:
       - name: Send Slack notification about issues with specific labels
         id: slack


### PR DESCRIPTION
The GitHub Slack plugin does not support listening to multiple labels. We work around this limitation by setting up a github action that sends similar messages.

The PR can be merged after we have the Slack webhook URL deployed as secret on the gradle/gradle repository.