### PR TITLE
Fix binary compatibility for build cache NG

### DIFF
--- a/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
+++ b/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
@@ -9,22 +9,6 @@
             ]
         },
         {
-            "type": "org.gradle.caching.BuildCacheEntryWriter",
-            "member": "Method org.gradle.caching.BuildCacheEntryWriter.openStream()",
-            "acceptation": "Extended build cache service API",
-            "changes": [
-                "Method added to interface"
-            ]
-        },
-        {
-            "type": "org.gradle.caching.BuildCacheEntryWriter",
-            "member": "Method org.gradle.caching.BuildCacheEntryWriter.writeTo(java.io.OutputStream)",
-            "acceptation": "Extended build cache service API",
-            "changes": [
-                "Abstract method is now default method"
-            ]
-        },
-        {
             "type": "org.gradle.kotlin.dsl.KotlinAssignmentExtensionsKt",
             "member": "Method org.gradle.kotlin.dsl.KotlinAssignmentExtensionsKt.assign(org.gradle.api.file.FileSystemLocationProperty,java.io.File)",
             "acceptation": "Compatibility check has an issue with generic extension function",

--- a/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceTest.groovy
+++ b/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceTest.groovy
@@ -20,11 +20,11 @@ import org.apache.http.HttpHeaders
 import org.apache.http.HttpStatus
 import org.gradle.api.UncheckedIOException
 import org.gradle.api.internal.DocumentationRegistry
-import org.gradle.caching.BuildCacheEntryWriter
 import org.gradle.caching.BuildCacheException
 import org.gradle.caching.BuildCacheServiceFactory
 import org.gradle.caching.http.HttpBuildCache
 import org.gradle.caching.internal.DefaultBuildCacheKey
+import org.gradle.caching.internal.NextGenBuildCacheService
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.resource.transport.http.DefaultSslContextFactory
 import org.gradle.internal.resource.transport.http.HttpClientHelper
@@ -356,7 +356,7 @@ class HttpBuildCacheServiceTest extends Specification {
 
     }
 
-    static class Writer implements BuildCacheEntryWriter {
+    static class Writer implements NextGenBuildCacheService.NextGenWriter {
         private final byte[] content
         private int writeCount = 0
 

--- a/subprojects/build-cache-http/src/main/java/org/gradle/caching/http/internal/HttpBuildCacheService.java
+++ b/subprojects/build-cache-http/src/main/java/org/gradle/caching/http/internal/HttpBuildCacheService.java
@@ -29,10 +29,9 @@ import org.apache.http.entity.AbstractHttpEntity;
 import org.apache.http.protocol.HTTP;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.caching.BuildCacheEntryReader;
-import org.gradle.caching.BuildCacheEntryWriter;
 import org.gradle.caching.BuildCacheException;
 import org.gradle.caching.BuildCacheKey;
-import org.gradle.caching.BuildCacheService;
+import org.gradle.caching.internal.NextGenBuildCacheService;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.resource.transport.http.HttpClientHelper;
 import org.gradle.internal.resource.transport.http.HttpClientResponse;
@@ -49,7 +48,7 @@ import java.util.Set;
 /**
  * Build cache implementation that delegates to a service accessible via HTTP.
  */
-public class HttpBuildCacheService implements BuildCacheService {
+public class HttpBuildCacheService implements NextGenBuildCacheService {
     private static final Logger LOGGER = LoggerFactory.getLogger(HttpBuildCacheService.class);
     static final String BUILD_CACHE_CONTENT_TYPE = "application/vnd.gradle.build-cache-artifact.v1";
 
@@ -129,7 +128,7 @@ public class HttpBuildCacheService implements BuildCacheService {
     }
 
     @Override
-    public void store(BuildCacheKey key, final BuildCacheEntryWriter output) throws BuildCacheException {
+    public void store(BuildCacheKey key, NextGenWriter writer) throws BuildCacheException {
         final URI uri = root.resolve(key.getHashCode());
         HttpPut httpPut = new HttpPut(uri);
         if (useExpectContinue) {
@@ -146,7 +145,7 @@ public class HttpBuildCacheService implements BuildCacheService {
 
             @Override
             public long getContentLength() {
-                return output.getSize();
+                return writer.getSize();
             }
 
             @Override
@@ -156,7 +155,7 @@ public class HttpBuildCacheService implements BuildCacheService {
 
             @Override
             public void writeTo(OutputStream outstream) throws IOException {
-                output.writeTo(outstream);
+                writer.writeTo(outstream);
             }
 
             @Override

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/internal/NextGenBuildCacheService.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/internal/NextGenBuildCacheService.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.caching.internal;
+
+import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
+import org.gradle.api.Incubating;
+import org.gradle.caching.BuildCacheEntryWriter;
+import org.gradle.caching.BuildCacheException;
+import org.gradle.caching.BuildCacheKey;
+import org.gradle.caching.BuildCacheService;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * Build cache service with additional features for next-generation build cache implementation.
+ */
+@Incubating
+public interface NextGenBuildCacheService extends BuildCacheService  {
+    /**
+     * Returns whether the given entry exists in the cache.
+     *
+     * @param key the cache key.
+     * @return {code true} if the entry exists in the cache.
+     */
+    boolean contains(BuildCacheKey key);
+
+    @Override
+    default void store(BuildCacheKey key, BuildCacheEntryWriter legacyWriter) throws BuildCacheException {
+        NextGenWriter writer;
+        if (legacyWriter instanceof NextGenWriter) {
+            writer = (NextGenWriter) legacyWriter;
+        } else {
+            writer = new NextGenWriter() {
+                @Override
+                public InputStream openStream() throws IOException {
+                    UnsynchronizedByteArrayOutputStream data = new UnsynchronizedByteArrayOutputStream();
+                    writeTo(data);
+                    return data.toInputStream();
+                }
+
+                @Override
+                public void writeTo(OutputStream output) throws IOException {
+                    legacyWriter.writeTo(output);
+                }
+
+                @Override
+                public long getSize() {
+                    return legacyWriter.getSize();
+                }
+            };
+        }
+        store(key, writer);
+    }
+
+    void store(BuildCacheKey key, NextGenWriter writer) throws BuildCacheException;
+
+    /**
+     * A {@link BuildCacheEntryWriter} that can open an {@link InputStream} to the data instead of writing it to an {@link OutputStream}.
+     *
+     * In some backend implementations this results in better performance.
+     */
+    interface NextGenWriter extends BuildCacheEntryWriter {
+        InputStream openStream() throws IOException;
+    }
+}

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/internal/NoOpBuildCacheService.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/internal/NoOpBuildCacheService.java
@@ -24,7 +24,7 @@ import org.gradle.caching.BuildCacheService;
 
 import java.io.IOException;
 
-public class NoOpBuildCacheService implements BuildCacheService {
+public class NoOpBuildCacheService implements NextGenBuildCacheService {
     public static final BuildCacheService INSTANCE = new NoOpBuildCacheService();
 
     private NoOpBuildCacheService() {
@@ -41,7 +41,11 @@ public class NoOpBuildCacheService implements BuildCacheService {
     }
 
     @Override
-    public void store(BuildCacheKey key, BuildCacheEntryWriter writer) throws BuildCacheException {
+    public void store(BuildCacheKey key, BuildCacheEntryWriter legacyWriter) throws BuildCacheException {
+    }
+
+    @Override
+    public void store(BuildCacheKey key, NextGenWriter writer) throws BuildCacheException {
     }
 
     @Override

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/DefaultNextGenBuildCacheAccess.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/DefaultNextGenBuildCacheAccess.java
@@ -19,8 +19,8 @@ package org.gradle.caching.internal.controller;
 import com.google.common.io.Closer;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
-import org.gradle.caching.BuildCacheEntryWriter;
 import org.gradle.caching.BuildCacheKey;
+import org.gradle.caching.internal.NextGenBuildCacheService;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.concurrent.ManagedThreadPoolExecutor;
 import org.gradle.internal.file.BufferProvider;
@@ -162,7 +162,7 @@ public class DefaultNextGenBuildCacheAccess implements NextGenBuildCacheAccess {
                 // Mirror data in local cache
                 // TODO Do we need to support local push = false?
                 if (local.canStore()) {
-                    local.store(key, new BuildCacheEntryWriter() {
+                    local.store(key, new NextGenBuildCacheService.NextGenWriter() {
                         @Override
                         public InputStream openStream() {
                             return data.toInputStream();
@@ -211,10 +211,15 @@ public class DefaultNextGenBuildCacheAccess implements NextGenBuildCacheAccess {
             }
 
             LOGGER.warn("Storing {} in remote (size: {})", key, data.size());
-            remote.store(key, new BuildCacheEntryWriter() {
+            remote.store(key, new NextGenBuildCacheService.NextGenWriter() {
                 @Override
                 public InputStream openStream() {
                     return data.toInputStream();
+                }
+
+                @Override
+                public void writeTo(OutputStream output) throws IOException {
+                    data.writeTo(output);
                 }
 
                 @Override

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/GZipNextGenBuildCacheAccess.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/GZipNextGenBuildCacheAccess.java
@@ -18,8 +18,8 @@ package org.gradle.caching.internal.controller;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
-import org.gradle.caching.BuildCacheEntryWriter;
 import org.gradle.caching.BuildCacheKey;
+import org.gradle.caching.internal.NextGenBuildCacheService;
 import org.gradle.internal.file.BufferProvider;
 
 import java.io.IOException;
@@ -53,7 +53,7 @@ public class GZipNextGenBuildCacheAccess implements NextGenBuildCacheAccess {
     @Override
     public <T> void store(Map<BuildCacheKey, T> entries, StoreHandler<T> handler) {
         delegate.store(entries, payload -> {
-            BuildCacheEntryWriter delegateWriter = handler.handle(payload);
+            NextGenBuildCacheService.NextGenWriter delegateWriter = handler.handle(payload);
             // TODO Make this more performant for large files
             UnsynchronizedByteArrayOutputStream compressed = new UnsynchronizedByteArrayOutputStream((int) (delegateWriter.getSize() * 1.2));
             try (GZIPOutputStream zipOutput = new GZIPOutputStream(compressed)) {
@@ -64,7 +64,7 @@ public class GZipNextGenBuildCacheAccess implements NextGenBuildCacheAccess {
                 throw new UncheckedIOException(e);
             }
 
-            return new BuildCacheEntryWriter() {
+            return new NextGenBuildCacheService.NextGenWriter() {
                 @Override
                 public InputStream openStream() {
                     return compressed.toInputStream();

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/NextGenBuildCacheAccess.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/NextGenBuildCacheAccess.java
@@ -16,8 +16,8 @@
 
 package org.gradle.caching.internal.controller;
 
-import org.gradle.caching.BuildCacheEntryWriter;
 import org.gradle.caching.BuildCacheKey;
+import org.gradle.caching.internal.NextGenBuildCacheService;
 
 import java.io.Closeable;
 import java.io.InputStream;
@@ -33,6 +33,6 @@ public interface NextGenBuildCacheAccess extends Closeable {
     }
 
     interface StoreHandler<T> {
-        BuildCacheEntryWriter handle(T payload);
+        NextGenBuildCacheService.NextGenWriter handle(T payload);
     }
 }

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/NextGenBuildCacheController.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/NextGenBuildCacheController.java
@@ -34,10 +34,10 @@ import org.apache.commons.io.input.UnsynchronizedByteArrayInputStream;
 import org.apache.commons.io.output.NullOutputStream;
 import org.apache.commons.io.output.TeeOutputStream;
 import org.gradle.api.internal.cache.StringInterner;
-import org.gradle.caching.BuildCacheEntryWriter;
 import org.gradle.caching.BuildCacheKey;
 import org.gradle.caching.internal.CacheableEntity;
 import org.gradle.caching.internal.DefaultBuildCacheKey;
+import org.gradle.caching.internal.NextGenBuildCacheService;
 import org.gradle.caching.internal.controller.CacheManifest.ManifestEntry;
 import org.gradle.caching.internal.controller.service.BuildCacheLoadResult;
 import org.gradle.caching.internal.origin.OriginMetadata;
@@ -357,7 +357,7 @@ public class NextGenBuildCacheController implements BuildCacheController {
                     (a, b) -> a)
                 );
 
-            cacheAccess.store(manifestIndex, manifestEntry -> new BuildCacheEntryWriter() {
+            cacheAccess.store(manifestIndex, manifestEntry -> new NextGenBuildCacheService.NextGenWriter() {
                 @Override
                 public InputStream openStream() throws IOException {
                     // TODO Replace with "Files.newInputStream()" as it seems to be more efficient
@@ -384,7 +384,7 @@ public class NextGenBuildCacheController implements BuildCacheController {
             String manifestJson = gson.toJson(manifest);
             byte[] bytes = manifestJson.getBytes(StandardCharsets.UTF_8);
 
-            return new BuildCacheEntryWriter() {
+            return new NextGenBuildCacheService.NextGenWriter() {
                 @Override
                 public InputStream openStream() {
                     return new UnsynchronizedByteArrayInputStream(bytes);

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/NextGenBuildCacheHandler.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/NextGenBuildCacheHandler.java
@@ -17,9 +17,9 @@
 package org.gradle.caching.internal.controller;
 
 import org.gradle.caching.BuildCacheEntryReader;
-import org.gradle.caching.BuildCacheEntryWriter;
 import org.gradle.caching.BuildCacheException;
 import org.gradle.caching.BuildCacheKey;
+import org.gradle.caching.internal.NextGenBuildCacheService;
 
 import java.io.Closeable;
 
@@ -32,6 +32,6 @@ public interface NextGenBuildCacheHandler extends Closeable {
 
     boolean load(BuildCacheKey key, BuildCacheEntryReader reader) throws BuildCacheException;
 
-    void store(BuildCacheKey key, BuildCacheEntryWriter writer) throws BuildCacheException;
+    void store(BuildCacheKey key, NextGenBuildCacheService.NextGenWriter writer) throws BuildCacheException;
 
 }

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/service/StoreTarget.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/service/StoreTarget.java
@@ -21,9 +21,7 @@ import com.google.common.io.Files;
 import org.gradle.caching.BuildCacheEntryWriter;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 
 public class StoreTarget implements BuildCacheEntryWriter {
@@ -33,11 +31,6 @@ public class StoreTarget implements BuildCacheEntryWriter {
 
     public StoreTarget(File file) {
         this.file = file;
-    }
-
-    @Override
-    public InputStream openStream() throws IOException {
-        return new FileInputStream(file);
     }
 
     @Override

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/local/internal/DirectoryBuildCacheService.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/local/internal/DirectoryBuildCacheService.java
@@ -82,19 +82,6 @@ public class DirectoryBuildCacheService implements LocalBuildCacheService, Build
     }
 
     @Override
-    public boolean contains(BuildCacheKey key) {
-        // We need to lock other processes out here because garbage collection can be under way in another process
-        return persistentCache.withFileLock(() -> {
-            lock.readLock().lock();
-            try {
-                return fileStore.get(key.getHashCode()) != null;
-            } finally {
-                lock.readLock().unlock();
-            }
-        });
-    }
-
-    @Override
     public boolean load(final BuildCacheKey key, final BuildCacheEntryReader reader) throws BuildCacheException {
         LoadAction loadAction = new LoadAction(reader);
         loadLocally(key, loadAction);

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/local/internal/H2BuildCacheService.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/local/internal/H2BuildCacheService.java
@@ -19,10 +19,9 @@ package org.gradle.caching.local.internal;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import org.gradle.caching.BuildCacheEntryReader;
-import org.gradle.caching.BuildCacheEntryWriter;
 import org.gradle.caching.BuildCacheException;
 import org.gradle.caching.BuildCacheKey;
-import org.gradle.caching.BuildCacheService;
+import org.gradle.caching.internal.NextGenBuildCacheService;
 import org.h2.Driver;
 
 import java.io.IOException;
@@ -34,7 +33,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-public class H2BuildCacheService implements BuildCacheService {
+public class H2BuildCacheService implements NextGenBuildCacheService {
 
     private final HikariDataSource dataSource;
 
@@ -94,7 +93,7 @@ public class H2BuildCacheService implements BuildCacheService {
     }
 
     @Override
-    public void store(BuildCacheKey key, BuildCacheEntryWriter writer) throws BuildCacheException {
+    public void store(BuildCacheKey key, NextGenWriter writer) throws BuildCacheException {
         try (Connection conn = dataSource.getConnection()) {
             try (PreparedStatement stmt = conn.prepareStatement("insert ignore into filestore.catalog(entry_key, entry_size, entry_content) values (?, ?, ?)")) {
                 try (InputStream input = writer.openStream()) {

--- a/subprojects/build-cache/src/test/groovy/org/gradle/caching/local/internal/DirectoryBuildCacheServiceTest.groovy
+++ b/subprojects/build-cache/src/test/groovy/org/gradle/caching/local/internal/DirectoryBuildCacheServiceTest.groovy
@@ -52,11 +52,6 @@ class DirectoryBuildCacheServiceTest extends Specification {
         when:
         service.store(key, new BuildCacheEntryWriter() {
             @Override
-            InputStream openStream() throws IOException {
-                throw new UnsupportedOperationException()
-            }
-
-            @Override
             void writeTo(OutputStream output) throws IOException {
                 // Check that partial result file is created inside the cache directory
                 def cacheDirFiles = cacheDir.listFiles()
@@ -112,11 +107,6 @@ class DirectoryBuildCacheServiceTest extends Specification {
 
         when:
         service.store(key, new BuildCacheEntryWriter() {
-            @Override
-            InputStream openStream() throws IOException {
-                throw new UnsupportedOperationException()
-            }
-
             @Override
             void writeTo(OutputStream output) throws IOException {
                 output.write("foo".getBytes())

--- a/subprojects/core-api/src/main/java/org/gradle/caching/BuildCacheEntryWriter.java
+++ b/subprojects/core-api/src/main/java/org/gradle/caching/BuildCacheEntryWriter.java
@@ -16,11 +16,7 @@
 
 package org.gradle.caching;
 
-import com.google.common.io.ByteStreams;
-import org.gradle.api.Incubating;
-
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 
 /**
@@ -30,14 +26,6 @@ import java.io.OutputStream;
  */
 public interface BuildCacheEntryWriter {
     /**
-     * Opens a stream to read the contents to be written to cache.
-     *
-     * @throws IOException when an I/O error occurs while opening the stream.
-     */
-    @Incubating
-    InputStream openStream() throws IOException;
-
-    /**
      * Writes a build cache entry to the given stream.
      * <p>
      * The given output stream will be closed by this method.
@@ -45,13 +33,7 @@ public interface BuildCacheEntryWriter {
      * @param output output stream to write build cache entry to
      * @throws IOException when an I/O error occurs when writing the cache entry to the given output stream
      */
-    default void writeTo(OutputStream output) throws IOException {
-        try (InputStream input = openStream()) {
-            ByteStreams.copy(input, output);
-        } finally {
-            output.close();
-        }
-    }
+    void writeTo(OutputStream output) throws IOException;
 
     /**
      * Returns the size of the build cache entry to be written.

--- a/subprojects/core-api/src/main/java/org/gradle/caching/BuildCacheService.java
+++ b/subprojects/core-api/src/main/java/org/gradle/caching/BuildCacheService.java
@@ -16,8 +16,6 @@
 
 package org.gradle.caching;
 
-import org.gradle.api.Incubating;
-
 import java.io.Closeable;
 import java.io.IOException;
 
@@ -41,19 +39,6 @@ import java.io.IOException;
  * @since 3.5
  */
 public interface BuildCacheService extends Closeable {
-    /**
-     * Returns whether the given entry exists in the cache.
-     *
-     * @param key the cache key.
-     * @return {code true} if the entry exists in the cache.
-     *
-     * @since 8.1
-     */
-    @Incubating
-    default boolean contains(BuildCacheKey key) {
-        return load(key, __ -> {});
-    }
-
     /**
      * Load the cached entry corresponding to the given cache key. The {@code reader} will be called if an entry is found in the cache.
      *

--- a/subprojects/core-api/src/main/java/org/gradle/caching/MapBasedBuildCacheService.java
+++ b/subprojects/core-api/src/main/java/org/gradle/caching/MapBasedBuildCacheService.java
@@ -35,11 +35,6 @@ public class MapBasedBuildCacheService implements BuildCacheService {
     }
 
     @Override
-    public boolean contains(BuildCacheKey key) {
-        return delegate.containsKey(key.getHashCode());
-    }
-
-    @Override
     public boolean load(BuildCacheKey key, BuildCacheEntryReader reader) throws BuildCacheException {
         final byte[] bytes = delegate.get(key.getHashCode());
         if (bytes == null) {


### PR DESCRIPTION
This reverts the changes to BuildCacheService and BuildCacheEntryWriter, and moves the changes to internal types instead.