### PR TITLE
Use buffered stream for keyring file read

### DIFF
--- a/subprojects/security/src/main/java/org/gradle/security/internal/SecuritySupport.java
+++ b/subprojects/security/src/main/java/org/gradle/security/internal/SecuritySupport.java
@@ -121,7 +121,7 @@ public class SecuritySupport {
     }
 
     private static InputStream createInputStreamFor(File keyringFile) throws IOException {
-        InputStream stream = new FileInputStream(keyringFile);
+        InputStream stream = new BufferedInputStream(new FileInputStream(keyringFile));
         if (keyringFile.getName().endsWith(KEYS_FILE_EXT)) {
             return new ArmoredInputStream(stream);
         }


### PR DESCRIPTION

Without this change, we get thousands of I/O read calls as the used library calls
InputStream#read() one byte at a time

Track trace:
java.io.FileInputStream.read(FileInputStream.java)
org.bouncycastle.bcpg.ArmoredInputStream.readIgnoreSpace()
org.bouncycastle.bcpg.ArmoredInputStream.read()
java.io.InputStream.read(InputStream.java:293)
java.io.BufferedInputStream.fill(BufferedInputStream.java:244)
java.io.BufferedInputStream.read(BufferedInputStream.java:263)
org.bouncycastle.bcpg.BCPGInputStream.nextPacketTag()
org.bouncycastle.openpgp.PGPKeyRing.readOptionalTrustPacket()
org.bouncycastle.openpgp.PGPKeyRing.readSignaturesAndTrust()
org.bouncycastle.openpgp.PGPPublicKeyRing.readSubkey()
org.bouncycastle.openpgp.PGPPublicKeyRing.<init>()
org.bouncycastle.openpgp.PGPObjectFactory.nextObject()
org.bouncycastle.openpgp.PGPObjectFactory$1.getObject()
org.bouncycastle.openpgp.PGPObjectFactory$1.hasNext()
org.gradle.security.internal.SecuritySupport.loadKeyRingFile(SecuritySupport.java:111)
