### PR TITLE
Filter existing test framework implementation deps

### DIFF
--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformEnvironmentIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformEnvironmentIntegrationTest.groovy
@@ -93,6 +93,8 @@ class JUnitPlatformEnvironmentIntegrationTest extends AbstractIntegrationSpec {
 
         addClasspathTest("""
             Set<String> jarSet = new HashSet<>(Arrays.asList(
+                "gradle-worker.jar",
+                "test",
                 "junit-jupiter-params-${JUNIT_JUPITER_VERSION}.jar",
                 "junit-jupiter-engine-${JUNIT_JUPITER_VERSION}.jar",
                 "junit-jupiter-api-${JUNIT_JUPITER_VERSION}.jar",
@@ -131,6 +133,8 @@ class JUnitPlatformEnvironmentIntegrationTest extends AbstractIntegrationSpec {
 
         addClasspathTest("""
             assertTrue(new HashSet<>(jars).equals(new HashSet<>(Arrays.asList(
+                "gradle-worker.jar",
+                "test",
                 "junit-jupiter-params-${JUNIT_JUPITER_VERSION}.jar",
                 "junit-jupiter-engine-${JUNIT_JUPITER_VERSION}.jar",
                 "junit-jupiter-api-${JUNIT_JUPITER_VERSION}.jar",
@@ -177,6 +181,8 @@ class JUnitPlatformEnvironmentIntegrationTest extends AbstractIntegrationSpec {
 
         addClasspathTest("""
             assertTrue(new HashSet<>(jars).equals(new HashSet<>(Arrays.asList(
+                "gradle-worker.jar",
+                "test",
                 "renamed-junit-jupiter-api-${JUNIT_JUPITER_VERSION}.jar",
                 "renamed-junit-platform-launcher-${JUNIT_PLATFORM_VERSION}.jar",
                 "renamed-junit-jupiter-engine-${JUNIT_JUPITER_VERSION}.jar",
@@ -235,12 +241,8 @@ class JUnitPlatformEnvironmentIntegrationTest extends AbstractIntegrationSpec {
                     }
 
                     try {
-                        assertEquals(classpath.get(0), "gradle-worker.jar");
-                        assertEquals(classpath.get(1), "test");
-
                         // Any remaining jars should be verified by the individual test.
-                        List<String> jars = new ArrayList<>(classpath.subList(2, classpath.size()));
-
+                        List<String> jars = new ArrayList<>(classpath);
                         ${testCode}
                     } catch (AssertionError e) {
                         System.err.println(e.getMessage() + "\\nActual Jars:\\n- " + String.join("\\n- ", classpath));

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformEnvironmentIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformEnvironmentIntegrationTest.groovy
@@ -55,6 +55,7 @@ class JUnitPlatformEnvironmentIntegrationTest extends AbstractIntegrationSpec {
                 systemProperties.testSysProperty = 'value'
                 systemProperties.projectDir = projectDir
                 environment.TEST_ENV_VAR = 'value'
+                testLogging.showStandardStreams = true
             }
         """
     }
@@ -92,21 +93,21 @@ class JUnitPlatformEnvironmentIntegrationTest extends AbstractIntegrationSpec {
         """
 
         addClasspathTest("""
-            assert jars.get(0).endsWith("junit-jupiter-params-${JUNIT_JUPITER_VERSION}.jar");
-            assert jars.get(1).endsWith("junit-jupiter-engine-${JUNIT_JUPITER_VERSION}.jar");
-            assert jars.get(2).endsWith("junit-jupiter-api-${JUNIT_JUPITER_VERSION}.jar");
-            assert jars.get(3).endsWith("junit-platform-engine-${JUNIT_PLATFORM_VERSION}.jar");
-            assert jars.get(4).endsWith("junit-platform-commons-${JUNIT_PLATFORM_VERSION}.jar");
-            assert jars.get(5).endsWith("junit-jupiter-${JUNIT_JUPITER_VERSION}.jar");
-            assert jars.get(6).endsWith("opentest4j-${OPENTEST4J_VERSION}.jar");
+            assertEquals(jars.get(0), "junit-jupiter-params-${JUNIT_JUPITER_VERSION}.jar");
+            assertEquals(jars.get(1), "junit-jupiter-engine-${JUNIT_JUPITER_VERSION}.jar");
+            assertEquals(jars.get(2), "junit-jupiter-api-${JUNIT_JUPITER_VERSION}.jar");
+            assertEquals(jars.get(3), "junit-platform-engine-${JUNIT_PLATFORM_VERSION}.jar");
+            assertEquals(jars.get(4), "junit-platform-commons-${JUNIT_PLATFORM_VERSION}.jar");
+            assertEquals(jars.get(5), "junit-jupiter-${JUNIT_JUPITER_VERSION}.jar");
+            assertEquals(jars.get(6), "opentest4j-${OPENTEST4J_VERSION}.jar");
 
             // And then the distribution-loaded launcher
-            assert jars.get(7).endsWith("junit-platform-launcher-${JUnitCoverage.LATEST_PLATFORM_VERSION}.jar");
-            assert jars.size() == 8;
+            assertEquals(jars.get(7), "junit-platform-launcher-${JUnitCoverage.LATEST_PLATFORM_VERSION}.jar");
+            assertEquals(jars.size(), 8);
         """)
 
         expect:
-        succeeds "test"
+        succeeds "test", '--stacktrace'
     }
 
     def "does not load junit-platform-launcher from distribution when it is on the classpath already"() {
@@ -120,15 +121,15 @@ class JUnitPlatformEnvironmentIntegrationTest extends AbstractIntegrationSpec {
         """
 
         addClasspathTest("""
-            assert jars.get(0).endsWith("junit-jupiter-params-${JUNIT_JUPITER_VERSION}.jar");
-            assert jars.get(1).endsWith("junit-jupiter-engine-${JUNIT_JUPITER_VERSION}.jar");
-            assert jars.get(2).endsWith("junit-jupiter-api-${JUNIT_JUPITER_VERSION}.jar");
-            assert jars.get(3).endsWith("junit-platform-launcher-${JUNIT_PLATFORM_VERSION}.jar");
-            assert jars.get(4).endsWith("junit-platform-engine-${JUNIT_PLATFORM_VERSION}.jar");
-            assert jars.get(5).endsWith("junit-platform-commons-${JUNIT_PLATFORM_VERSION}.jar");
-            assert jars.get(6).endsWith("junit-jupiter-${JUNIT_JUPITER_VERSION}.jar");
-            assert jars.get(7).endsWith("opentest4j-${OPENTEST4J_VERSION}.jar");
-            assert jars.size() == 8;
+            assertEquals(jars.get(0), "junit-jupiter-params-${JUNIT_JUPITER_VERSION}.jar");
+            assertEquals(jars.get(1), "junit-jupiter-engine-${JUNIT_JUPITER_VERSION}.jar");
+            assertEquals(jars.get(2), "junit-jupiter-api-${JUNIT_JUPITER_VERSION}.jar");
+            assertEquals(jars.get(3), "junit-platform-launcher-${JUNIT_PLATFORM_VERSION}.jar");
+            assertEquals(jars.get(4), "junit-platform-engine-${JUNIT_PLATFORM_VERSION}.jar");
+            assertEquals(jars.get(5), "junit-platform-commons-${JUNIT_PLATFORM_VERSION}.jar");
+            assertEquals(jars.get(6), "junit-jupiter-${JUNIT_JUPITER_VERSION}.jar");
+            assertEquals(jars.get(7), "opentest4j-${OPENTEST4J_VERSION}.jar");
+            assertEquals(jars.size(), 8);
         """)
 
         expect:
@@ -164,15 +165,15 @@ class JUnitPlatformEnvironmentIntegrationTest extends AbstractIntegrationSpec {
         """
 
         addClasspathTest("""
-            assert jars.get(0).endsWith("renamed-junit-jupiter-api-${JUNIT_JUPITER_VERSION}.jar");
-            assert jars.get(1).endsWith("renamed-junit-platform-launcher-${JUNIT_PLATFORM_VERSION}.jar");
-            assert jars.get(2).endsWith("renamed-junit-jupiter-engine-${JUNIT_JUPITER_VERSION}.jar");
-            assert jars.get(3).endsWith("renamed-junit-platform-commons-${JUNIT_PLATFORM_VERSION}.jar");
-            assert jars.get(4).endsWith("renamed-junit-jupiter-${JUNIT_JUPITER_VERSION}.jar");
-            assert jars.get(5).endsWith("renamed-junit-platform-engine-${JUNIT_PLATFORM_VERSION}.jar");
-            assert jars.get(6).endsWith("opentest4j-${OPENTEST4J_VERSION}.jar");
-            assert jars.get(7).endsWith("renamed-junit-jupiter-params-${JUNIT_JUPITER_VERSION}.jar");
-            assert jars.size() == 8;
+            assertEquals(jars.get(0), "renamed-junit-jupiter-api-${JUNIT_JUPITER_VERSION}.jar");
+            assertEquals(jars.get(1), "renamed-junit-platform-launcher-${JUNIT_PLATFORM_VERSION}.jar");
+            assertEquals(jars.get(2), "renamed-junit-jupiter-engine-${JUNIT_JUPITER_VERSION}.jar");
+            assertEquals(jars.get(3), "renamed-junit-platform-commons-${JUNIT_PLATFORM_VERSION}.jar");
+            assertEquals(jars.get(4), "renamed-junit-jupiter-${JUNIT_JUPITER_VERSION}.jar");
+            assertEquals(jars.get(5), "renamed-junit-platform-engine-${JUNIT_PLATFORM_VERSION}.jar");
+            assertEquals(jars.get(6), "opentest4j-${OPENTEST4J_VERSION}.jar");
+            assertEquals(jars.get(7), "renamed-junit-jupiter-params-${JUNIT_JUPITER_VERSION}.jar");
+            assertEquals(jars.size(), 8);
         """)
 
         expect:
@@ -191,6 +192,8 @@ class JUnitPlatformEnvironmentIntegrationTest extends AbstractIntegrationSpec {
             import java.util.regex.Pattern;
             import java.util.stream.Collectors;
 
+            import static org.junit.jupiter.api.Assertions.assertEquals;
+
             public class ClasspathCheckingTest {
                 @org.junit.jupiter.api.Test
                 public void checkEnvironment() {
@@ -205,29 +208,26 @@ class JUnitPlatformEnvironmentIntegrationTest extends AbstractIntegrationSpec {
 
                     List<String> classpath;
                     if (isJava9) {
-                        classpath = Arrays.asList(System.getProperty("java.class.path").split(Pattern.quote(File.pathSeparator)));
+                        classpath = Arrays.stream(System.getProperty("java.class.path").split(Pattern.quote(File.pathSeparator)))
+                            .map(path -> new File(path).getName())
+                            .collect(Collectors.toList());
                     } else {
                         classpath = Arrays.stream(((URLClassLoader) ClassLoader.getSystemClassLoader()).getURLs())
-                            .map(URL::getPath)
+                            .map(url -> new File(url.getPath()).getName())
                             .collect(Collectors.toList());
                     }
 
                     try {
-                        // The worker jar is first on the classpath.
-                        String workerJar = classpath.get(0);
-                        assert workerJar.endsWith("gradle-worker.jar");
-
-                        // After, we expect the test runtime classpath.
-                        String testClasses = classpath.get(1);
-                        assert testClasses.endsWith("test") || testClasses.endsWith("test/");
+                        assertEquals(classpath.get(0), "gradle-worker.jar");
+                        assertEquals(classpath.get(1), "test");
 
                         // Any remaining jars should be verified by the individual test.
                         List<String> jars = classpath.subList(2, classpath.size());
 
                         ${testCode}
                     } catch (AssertionError e) {
-                        String output = "Expectation failed. Actual Jars:\\n" + String.join("\\n", classpath);
-                        throw new RuntimeException(output, e);
+                        System.err.println(e.getMessage() + "\\nActual Jars:\\n- " + String.join("\\n- ", classpath));
+                        throw e;
                     }
                 }
             }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformEnvironmentIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformEnvironmentIntegrationTest.groovy
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing.junitplatform
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.DefaultTestExecutionResult
+import org.gradle.testing.fixture.JUnitCoverage
+
+import static org.hamcrest.CoreMatchers.containsString
+
+/**
+ * Tests the state of the application classpath in the forked test process to ensure the correct
+ * test framework dependencies are exposed to the user's test code. Additionally tests environmental
+ * state like system properties, and environment variables.
+ *
+ * <p>This test intentionally does not extend {@link JUnitPlatformIntegrationSpec} in order to have
+ * complete control over the configuration of the test setup</p>
+ */
+class JUnitPlatformEnvironmentIntegrationTest extends AbstractIntegrationSpec {
+
+    // The versions tested against here are intentionally different than the version of junit-platform-launcher
+    // that Gradle will load from the distribution. This way, we can use the version on the application classpath
+    // to determine whether the launcher was loaded from the distribution or from the test runtime classpath.
+    // The version which Gradle loads from the distribution should be the same as `JUnitCoverage#LATEST_PLATFORM_VERSION`
+    private static final JUNIT_JUPITER_VERSION = '5.8.1'
+    private static final JUNIT_PLATFORM_VERSION = '1.8.1'
+    private static final OPENTEST4J_VERSION = '1.2.0'
+
+    def setup() {
+        buildFile << """
+            plugins {
+                id 'java-library'
+            }
+
+            ${mavenCentralRepository()}
+
+            test {
+                useJUnitPlatform()
+
+                systemProperties.isJava9 = "\${JavaVersion.current().isJava9Compatible()}"
+                systemProperties.testSysProperty = 'value'
+                systemProperties.projectDir = projectDir
+                environment.TEST_ENV_VAR = 'value'
+            }
+        """
+    }
+
+    def "should prompt user to add dependencies when they are not in test runtime classpath"() {
+        given:
+        buildFile << """
+            testing.suites.test.dependencies {
+                compileOnly 'org.junit.jupiter:junit-jupiter:${JUNIT_JUPITER_VERSION}'
+            }
+        """
+        file('src/test/java/org/example/ExampleTest.java') << """
+            package org.example;
+            public class ExampleTest {
+                @org.junit.jupiter.api.Test
+                public void ok() { }
+            }
+        """
+
+        when:
+        fails('test')
+
+        then:
+        new DefaultTestExecutionResult(testDirectory)
+            .testClassStartsWith('Gradle Test Executor')
+            .assertExecutionFailedWithCause(containsString('consider adding an engine implementation JAR to the classpath'))
+    }
+
+    def "automatically loads junit-platform-launcher from distribution"() {
+        given:
+        buildFile << """
+            testing.suites.test.dependencies {
+                implementation 'org.junit.jupiter:junit-jupiter:${JUNIT_JUPITER_VERSION}'
+            }
+        """
+
+        addClasspathTest("""
+            assert jars.get(0).endsWith("junit-jupiter-params-${JUNIT_JUPITER_VERSION}.jar");
+            assert jars.get(1).endsWith("junit-jupiter-engine-${JUNIT_JUPITER_VERSION}.jar");
+            assert jars.get(2).endsWith("junit-jupiter-api-${JUNIT_JUPITER_VERSION}.jar");
+            assert jars.get(3).endsWith("junit-platform-engine-${JUNIT_PLATFORM_VERSION}.jar");
+            assert jars.get(4).endsWith("junit-platform-commons-${JUNIT_PLATFORM_VERSION}.jar");
+            assert jars.get(5).endsWith("junit-jupiter-${JUNIT_JUPITER_VERSION}.jar");
+            assert jars.get(6).endsWith("opentest4j-${OPENTEST4J_VERSION}.jar");
+
+            // And then the distribution-loaded launcher
+            assert jars.get(7).endsWith("junit-platform-launcher-${JUnitCoverage.LATEST_PLATFORM_VERSION}.jar");
+            assert jars.size() == 8;
+        """)
+
+        expect:
+        succeeds "test"
+    }
+
+    def "does not load junit-platform-launcher from distribution when it is on the classpath already"() {
+        given:
+        buildFile << """
+            testing.suites.test.dependencies {
+                implementation 'org.junit.jupiter:junit-jupiter:${JUNIT_JUPITER_VERSION}'
+
+                runtimeOnly 'org.junit.platform:junit-platform-launcher'
+            }
+        """
+
+        addClasspathTest("""
+            assert jars.get(0).endsWith("junit-jupiter-params-${JUNIT_JUPITER_VERSION}.jar");
+            assert jars.get(1).endsWith("junit-jupiter-engine-${JUNIT_JUPITER_VERSION}.jar");
+            assert jars.get(2).endsWith("junit-jupiter-api-${JUNIT_JUPITER_VERSION}.jar");
+            assert jars.get(3).endsWith("junit-platform-launcher-${JUNIT_PLATFORM_VERSION}.jar");
+            assert jars.get(4).endsWith("junit-platform-engine-${JUNIT_PLATFORM_VERSION}.jar");
+            assert jars.get(5).endsWith("junit-platform-commons-${JUNIT_PLATFORM_VERSION}.jar");
+            assert jars.get(6).endsWith("junit-jupiter-${JUNIT_JUPITER_VERSION}.jar");
+            assert jars.get(7).endsWith("opentest4j-${OPENTEST4J_VERSION}.jar");
+            assert jars.size() == 8;
+        """)
+
+        expect:
+        succeeds "test"
+
+    }
+
+    def "does not load junit-platform-launcher even if it is on the classpath but has a nonstandard-named jar"() {
+        given:
+        buildFile << """
+            testing.suites.test.dependencies {
+                implementation 'org.junit.jupiter:junit-jupiter:${JUNIT_JUPITER_VERSION}'
+
+                runtimeOnly 'org.junit.platform:junit-platform-launcher'
+            }
+
+            task renameJUnitJars(type: Copy) {
+                from configurations.testRuntimeClasspath
+                into file('build/renamed-classpath')
+                rename { String fileName ->
+                    if (fileName.startsWith('junit')) {
+                        return fileName.replace('junit', 'renamed-junit')
+                    }
+                }
+            }
+
+            testing.suites.test.sources.runtimeClasspath =
+                testing.suites.test.sources.output.plus(
+                    renameJUnitJars.outputs.files.asFileTree.matching {
+                        include '**/*.jar'
+                    }
+                )
+        """
+
+        addClasspathTest("""
+            assert jars.get(0).endsWith("renamed-junit-jupiter-api-${JUNIT_JUPITER_VERSION}.jar");
+            assert jars.get(1).endsWith("renamed-junit-platform-launcher-${JUNIT_PLATFORM_VERSION}.jar");
+            assert jars.get(2).endsWith("renamed-junit-jupiter-engine-${JUNIT_JUPITER_VERSION}.jar");
+            assert jars.get(3).endsWith("renamed-junit-platform-commons-${JUNIT_PLATFORM_VERSION}.jar");
+            assert jars.get(4).endsWith("renamed-junit-jupiter-${JUNIT_JUPITER_VERSION}.jar");
+            assert jars.get(5).endsWith("renamed-junit-platform-engine-${JUNIT_PLATFORM_VERSION}.jar");
+            assert jars.get(6).endsWith("opentest4j-${OPENTEST4J_VERSION}.jar");
+            assert jars.get(7).endsWith("renamed-junit-jupiter-params-${JUNIT_JUPITER_VERSION}.jar");
+            assert jars.size() == 8;
+        """)
+
+        expect:
+        succeeds "test"
+    }
+
+    def addClasspathTest(String testCode) {
+        file("src/test/java/org/example/ClasspathCheckingTest.java") << """
+            package org.example;
+
+            import java.io.File;
+            import java.net.URL;
+            import java.net.URLClassLoader;
+            import java.util.Arrays;
+            import java.util.List;
+            import java.util.regex.Pattern;
+            import java.util.stream.Collectors;
+
+            public class ClasspathCheckingTest {
+                @org.junit.jupiter.api.Test
+                public void checkEnvironment() {
+                    assert System.getProperty("projectDir").equals(System.getProperty("user.dir"));
+                    assert "value".equals(System.getProperty("testSysProperty"));
+                    assert "value".equals(System.getenv("TEST_ENV_VAR"));
+
+                    assert ClassLoader.getSystemClassLoader() == getClass().getClassLoader();
+                    assert getClass().getClassLoader() == Thread.currentThread().getContextClassLoader();
+
+                    boolean isJava9 = Boolean.parseBoolean(System.getProperty("isJava9"));
+
+                    List<String> classpath;
+                    if (isJava9) {
+                        classpath = Arrays.asList(System.getProperty("java.class.path").split(Pattern.quote(File.pathSeparator)));
+                    } else {
+                        classpath = Arrays.stream(((URLClassLoader) ClassLoader.getSystemClassLoader()).getURLs())
+                            .map(URL::getPath)
+                            .collect(Collectors.toList());
+                    }
+
+                    try {
+                        // The worker jar is first on the classpath.
+                        String workerJar = classpath.get(0);
+                        assert workerJar.endsWith("gradle-worker.jar");
+
+                        // After, we expect the test runtime classpath.
+                        String testClasses = classpath.get(1);
+                        assert testClasses.endsWith("test") || testClasses.endsWith("test/");
+
+                        // Any remaining jars should be verified by the individual test.
+                        List<String> jars = classpath.subList(2, classpath.size());
+
+                        ${testCode}
+                    } catch (AssertionError e) {
+                        String output = "Expectation failed. Actual Jars:\\n" + String.join("\\n", classpath);
+                        throw new RuntimeException(output, e);
+                    }
+                }
+            }
+        """
+    }
+
+}

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformIntegrationTest.groovy
@@ -21,7 +21,6 @@ import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import spock.lang.Issue
 import spock.lang.Timeout
 
-import static org.gradle.testing.fixture.JUnitCoverage.LATEST_JUPITER_VERSION
 import static org.gradle.testing.fixture.JUnitCoverage.LATEST_PLATFORM_VERSION
 import static org.hamcrest.CoreMatchers.containsString
 
@@ -38,28 +37,6 @@ class JUnitPlatformIntegrationTest extends JUnitPlatformIntegrationSpec {
 
         expect:
         succeeds('test')
-    }
-
-    def 'should prompt user to add dependencies when they are not in test runtime classpath'() {
-        given:
-        buildFile.text = """
-            apply plugin: 'java'
-            ${mavenCentralRepository()}
-            dependencies {
-                testCompileOnly 'org.junit.jupiter:junit-jupiter:${LATEST_JUPITER_VERSION}'
-            }
-
-            test { useJUnitPlatform() }
-            """
-        createSimpleJupiterTest()
-
-        when:
-        fails('test')
-
-        then:
-        new DefaultTestExecutionResult(testDirectory)
-            .testClassStartsWith('Gradle Test Executor')
-            .assertExecutionFailedWithCause(containsString('consider adding an engine implementation JAR to the classpath'))
     }
 
     def 'can handle class level ignored tests'() {

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/TestFramework.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/TestFramework.java
@@ -68,7 +68,7 @@ public interface TestFramework extends Closeable {
     Action<WorkerProcessBuilder> getWorkerConfigurationAction();
 
     /**
-     * Returns a list of distribution module names that the test worker requires on the application classpath.
+     * Returns a list of distribution modules that the test worker requires on the application classpath.
      * These dependencies are loaded from the Gradle distribution.
      *
      * Application classes specified by {@link WorkerProcessBuilder#sharedPackages} are
@@ -77,12 +77,12 @@ public interface TestFramework extends Closeable {
      * @see #getUseDistributionDependencies()
      */
     @Internal
-    default List<String> getWorkerApplicationClasspathModuleNames() {
+    default List<TestFrameworkDistributionModule> getWorkerApplicationClasspathModules() {
         return Collections.emptyList();
     }
 
     /**
-     * Returns a list of distribution module names that the test worker requires on the application modulepath if it runs as a module.
+     * Returns a list of distribution modules that the test worker requires on the application modulepath if it runs as a module.
      * These dependencies are loaded from the Gradle distribution.
      *
      * Application classes specified by {@link WorkerProcessBuilder#sharedPackages} are
@@ -91,29 +91,29 @@ public interface TestFramework extends Closeable {
      * @see #getUseDistributionDependencies()
      */
     @Internal
-    default List<String> getWorkerApplicationModulepathModuleNames() {
+    default List<TestFrameworkDistributionModule> getWorkerApplicationModulepathModules() {
         return Collections.emptyList();
     }
 
     /**
-     * Returns a list of distribution module names that the test worker requires on implementation the classpath.
+     * Returns a list of distribution modules that the test worker requires on implementation the classpath.
      * These dependencies are loaded from the Gradle distribution.
      *
      * @see #getUseDistributionDependencies()
      */
     @Internal
-    default List<String> getWorkerImplementationClasspathModuleNames() {
+    default List<TestFrameworkDistributionModule> getWorkerImplementationClasspathModules() {
         return Collections.emptyList();
     }
 
     /**
-     * Returns a list of distribution module names that the test worker requires on the implementation modulepath if it runs as a module.
+     * Returns a list of distribution modules that the test worker requires on the implementation modulepath if it runs as a module.
      * These dependencies are loaded from the Gradle distribution.
      *
      * @see #getUseDistributionDependencies()
      */
     @Internal
-    default List<String> getWorkerImplementationModulepathModuleNames() {
+    default List<TestFrameworkDistributionModule> getWorkerImplementationModulepathModules() {
         return Collections.emptyList();
     }
 

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/TestFrameworkDistributionModule.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/TestFrameworkDistributionModule.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.testing;
+
+import java.util.regex.Pattern;
+
+/**
+ * Represents a module loaded from the gradle distribution, including metadata detailing the name of the JAR
+ * which implements the module and an example class name, which if loaded, signals the existence of the module.
+ *
+ * <p>The complexity here is necessary to determine if test framework dependencies are already present on the
+ * application classpath, and thus do not need to be loaded from the Gradle distribution. The behavior of loading
+ * test framework dependencies from the Gradle distribution is deprecated and will be removed in 9.0</p>
+ */
+public class TestFrameworkDistributionModule {
+
+    private final String moduleName;
+    private final Pattern jarFilePattern;
+    private final String exampleClassName;
+
+    public TestFrameworkDistributionModule(String moduleName, Pattern jarFilePattern, String exampleClassName) {
+        this.moduleName = moduleName;
+        this.jarFilePattern = jarFilePattern;
+        this.exampleClassName = exampleClassName;
+    }
+
+    public String getModuleName() {
+        return moduleName;
+    }
+
+    public Pattern getJarFilePattern() {
+        return jarFilePattern;
+    }
+
+    public String getExampleClassName() {
+        return exampleClassName;
+    }
+}

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/detection/ForkedTestClasspathFactory.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/detection/ForkedTestClasspathFactory.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.tasks.testing.detection;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -30,7 +31,6 @@ import org.gradle.internal.UncheckedException;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.classpath.DefaultClassPath;
 import org.gradle.util.internal.CollectionUtils;
-import org.jetbrains.annotations.VisibleForTesting;
 
 import java.io.Closeable;
 import java.io.File;

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/detection/ForkedTestClasspathFactory.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/detection/ForkedTestClasspathFactory.java
@@ -203,8 +203,8 @@ public class ForkedTestClasspathFactory {
      */
     private ImmutableList<File> pathWithAdditionalModules(Iterable<? extends File> testFiles, List<TestFrameworkDistributionModule> additionalModules) {
         return ImmutableList.<File>builder()
-            .addAll(testFiles)
             .addAll(loadDistributionFiles(additionalModules))
+            .addAll(testFiles)
             .build();
     }
 

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestFramework.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestFramework.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.tasks.testing.junit;
 
 import org.gradle.api.Action;
 import org.gradle.api.internal.tasks.testing.TestFramework;
+import org.gradle.api.internal.tasks.testing.TestFrameworkDistributionModule;
 import org.gradle.api.internal.tasks.testing.WorkerTestClassProcessorFactory;
 import org.gradle.api.internal.tasks.testing.detection.ClassFileExtractionManager;
 import org.gradle.api.internal.tasks.testing.filter.DefaultTestFilter;
@@ -32,9 +33,18 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Pattern;
 
 @UsedByScanPlugin("test-retry")
 public class JUnitTestFramework implements TestFramework {
+
+    private static final List<TestFrameworkDistributionModule> DISTRIBUTION_MODULES =
+        Collections.singletonList(new TestFrameworkDistributionModule(
+            "junit",
+            Pattern.compile("junit-4.*\\.jar"),
+            "org.junit.runner.Runner"
+        ));
+
     private JUnitOptions options;
     private JUnitDetector detector;
     private final DefaultTestFilter filter;
@@ -83,8 +93,8 @@ public class JUnitTestFramework implements TestFramework {
     }
 
     @Override
-    public List<String> getWorkerImplementationClasspathModuleNames() {
-        return Collections.singletonList("junit");
+    public List<TestFrameworkDistributionModule> getWorkerImplementationClasspathModules() {
+        return DISTRIBUTION_MODULES;
     }
 
     @Override

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestFramework.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestFramework.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import org.gradle.api.Action;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.internal.tasks.testing.TestFramework;
+import org.gradle.api.internal.tasks.testing.TestFrameworkDistributionModule;
 import org.gradle.api.internal.tasks.testing.WorkerTestClassProcessorFactory;
 import org.gradle.api.internal.tasks.testing.detection.TestFrameworkDetector;
 import org.gradle.api.internal.tasks.testing.filter.DefaultTestFilter;
@@ -31,9 +32,30 @@ import org.gradle.process.internal.worker.WorkerProcessBuilder;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.regex.Pattern;
 
 @UsedByScanPlugin("test-retry")
 public class JUnitPlatformTestFramework implements TestFramework {
+
+    private static final List<TestFrameworkDistributionModule> DISTRIBUTION_MODULES =
+        ImmutableList.of(
+            new TestFrameworkDistributionModule(
+                "junit-platform-engine",
+                Pattern.compile("junit-platform-engine-1.*\\.jar"),
+                "org.junit.platform.engine.DiscoverySelector"
+            ),
+            new TestFrameworkDistributionModule(
+                "junit-platform-launcher",
+                Pattern.compile("junit-platform-launcher-1.*\\.jar"),
+                "org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder"
+            ),
+            new TestFrameworkDistributionModule(
+                "junit-platform-commons",
+                Pattern.compile("junit-platform-commons-1.*\\.jar"),
+                "org.junit.platform.commons.util.ReflectionUtils"
+            )
+        );
+
     private final JUnitPlatformOptions options;
     private final DefaultTestFilter filter;
     private final boolean useImplementationDependencies;
@@ -78,8 +100,8 @@ public class JUnitPlatformTestFramework implements TestFramework {
     }
 
     @Override
-    public List<String> getWorkerApplicationModulepathModuleNames() {
-        return ImmutableList.of("junit-platform-engine", "junit-platform-launcher", "junit-platform-commons");
+    public List<TestFrameworkDistributionModule> getWorkerApplicationModulepathModules() {
+        return DISTRIBUTION_MODULES;
     }
 
     @Override

--- a/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/detection/ForkedTestClasspathFactoryTest.groovy
+++ b/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/detection/ForkedTestClasspathFactoryTest.groovy
@@ -42,7 +42,7 @@ class ForkedTestClasspathFactoryTest extends Specification {
 
     def runtimeClasses = Spy(TestClassDetector)
     def classDetectorFactory = Mock(ForkedTestClasspathFactory.ClassDetectorFactory) {
-        apply(_, _) >> { runtimeClasses }
+        create(_, _) >> { runtimeClasses }
     }
     ForkedTestClasspathFactory underTest = new ForkedTestClasspathFactory(moduleRegistry, classDetectorFactory)
 

--- a/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/detection/ForkedTestClasspathFactoryTest.groovy
+++ b/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/detection/ForkedTestClasspathFactoryTest.groovy
@@ -68,7 +68,7 @@ class ForkedTestClasspathFactoryTest extends Specification {
         def classpath = underTest.create([new File("cls.jar")], [new File("mod.jar")], framework, false)
 
         then:
-        classpath.applicationClasspath == [new File("cls.jar"), new File("app-cls-external.jar"), new File("app-mod-external.jar")]
+        classpath.applicationClasspath == [new File("app-cls-external.jar"), new File("app-mod-external.jar"), new File("cls.jar")]
         classpath.applicationModulepath == [new File("mod.jar")]
         classpath.implementationClasspath.size() == NUM_INTERNAL_JARS + NUM_EXTERNAL_JARS + 2
         classpath.implementationClasspath.findAll { it.toString().endsWith("-internal.jar") }.size() == NUM_INTERNAL_JARS
@@ -83,8 +83,8 @@ class ForkedTestClasspathFactoryTest extends Specification {
         def classpath = underTest.create([new File("cls.jar")], [new File("mod.jar")], framework, true)
 
         then:
-        classpath.applicationClasspath == [new File("cls.jar"), new File("app-cls-external.jar")]
-        classpath.applicationModulepath == [new File("mod.jar"), new File("app-mod-external.jar")]
+        classpath.applicationClasspath == [new File("app-cls-external.jar"), new File("cls.jar")]
+        classpath.applicationModulepath == [new File("app-mod-external.jar"), new File("mod.jar")]
         classpath.implementationClasspath.size() == NUM_INTERNAL_JARS + NUM_EXTERNAL_JARS + 1
         classpath.implementationClasspath.findAll { it.toString().endsWith("-internal.jar") }.size() == NUM_INTERNAL_JARS
         classpath.implementationClasspath.findAll { it.toString().endsWith("-external.jar") }.size() == NUM_EXTERNAL_JARS + 1
@@ -138,10 +138,10 @@ class ForkedTestClasspathFactoryTest extends Specification {
 
         then:
         if (loadsAll) {
-            assert classpath.applicationClasspath.takeRight(2) == ["a", "b"].collect { new File("$it-external.jar") }
-            assert classpath.applicationModulepath.takeRight(2) == ["c", "d"].collect { new File("$it-external.jar") }
+            assert classpath.applicationClasspath.take(2) == ["a", "b"].collect { new File("$it-external.jar") }
+            assert classpath.applicationModulepath.take(2) == ["c", "d"].collect { new File("$it-external.jar") }
             assert classpath.implementationClasspath.takeRight(2) == ["e", "f"].collect { new URL("file://$it-external.jar") }
-            assert classpath.implementationModulepath.takeRight(2) == ["g", "h"].collect { new URL("file://$it-external.jar") }
+            assert classpath.implementationModulepath == ["g", "h"].collect { new URL("file://$it-external.jar") }
         } else {
             assert classpath.applicationClasspath == cpFiles
             assert classpath.applicationModulepath == mpFiles
@@ -190,10 +190,10 @@ class ForkedTestClasspathFactoryTest extends Specification {
 
         then:
         if (loadsAll) {
-            assert classpath.applicationClasspath.takeRight(2) == ["a", "b"].collect { new File("$it-external.jar") }
-            assert classpath.applicationModulepath.takeRight(2) == ["c", "d"].collect { new File("$it-external.jar") }
+            assert classpath.applicationClasspath.take(2) == ["a", "b"].collect { new File("$it-external.jar") }
+            assert classpath.applicationModulepath.take(2) == ["c", "d"].collect { new File("$it-external.jar") }
             assert classpath.implementationClasspath.takeRight(2) == ["e", "f"].collect { new URL("file://$it-external.jar") }
-            assert classpath.implementationModulepath.takeRight(2) == ["g", "h"].collect { new URL("file://$it-external.jar") }
+            assert classpath.implementationModulepath == ["g", "h"].collect { new URL("file://$it-external.jar") }
         } else {
             assert classpath.applicationClasspath == cpFiles
             assert classpath.applicationModulepath == mpFiles


### PR DESCRIPTION
Use jar name matching and classpath probing to determine if required test framework dependencies are already present on the test runtime classpath. If so, don't load them from the distribution. 

We will enable a deprecation for this behavior in 8.2

Fixes #23995