### PR TITLE
Mention deprecation of relative paths to Java executables in upgrade guide

### DIFF
--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
@@ -105,7 +105,7 @@ Starting in Gradle 9.0, this method will be removed without replacement.
 
 By default, when applying the link:java_plugin.html[`java`] plugin, the `testClassesDirs`
 and `classpath` of all `Test` tasks have the same convention. Unless otherwise changed,
-the default behavior is to execute the tests from the default `test` link:jvm_test_suite_plugin.html[`TestSuite`] 
+the default behavior is to execute the tests from the default `test` link:jvm_test_suite_plugin.html[`TestSuite`]
 by configuring the task with the `classpath` and `testClassesDirs` from the `test` suite.
 This behavior will be removed in Gradle 9.0.
 
@@ -367,6 +367,11 @@ beforeSettings {
 ----
 =====
 ====
+
+[no_relative_paths_for_java_executables]
+==== Deprecated using relative paths to specify Java executables
+Using relative file paths to point to Java executables is now deprecated and will become an error in Gradle 9.
+This is done to reduce confusion about what such relative paths should resolve against.
 
 === Changes in the IDE integration
 

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
@@ -49,10 +49,11 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
         file("src/main/java/Foo.java") << "public class Foo {}"
 
         when:
-        executer.expectDeprecationWarning("Configuring a Java executable via a relative path. " +
-                "This behavior has been deprecated. This will fail with an error in Gradle 9.0. " +
-                "Resolving relative file paths might yield unexpected results, there is no single clear location it would make sense to resolve against. " +
-                "Configure an absolute path to a Java executable instead.")
+        executer.expectDocumentedDeprecationWarning("Configuring a Java executable via a relative path. " +
+            "This behavior has been deprecated. This will fail with an error in Gradle 9.0. " +
+            "Resolving relative file paths might yield unexpected results, there is no single clear location it would make sense to resolve against. " +
+            "Configure an absolute path to a Java executable instead. " +
+            "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#no_relative_paths_for_java_executables")
         run("compileJava")
 
         then:

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/javadoc/JavadocIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/javadoc/JavadocIntegrationTest.groovy
@@ -140,10 +140,11 @@ Joe!""")
         writeSourceFile()
 
         when:
-        executer.expectDeprecationWarning("Configuring a Java executable via a relative path. " +
+        executer.expectDocumentedDeprecationWarning("Configuring a Java executable via a relative path. " +
                 "This behavior has been deprecated. This will fail with an error in Gradle 9.0. " +
                 "Resolving relative file paths might yield unexpected results, there is no single clear location it would make sense to resolve against. " +
-                "Configure an absolute path to a Java executable instead.")
+                "Configure an absolute path to a Java executable instead. " +
+                "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#no_relative_paths_for_java_executables")
         run("javadoc")
 
         then:

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaExecutableUtils.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaExecutableUtils.java
@@ -36,7 +36,7 @@ public class JavaExecutableUtils {
                     .withContext("Resolving relative file paths might yield unexpected results, there is no single clear location it would make sense to resolve against.")
                     .withAdvice("Configure an absolute path to a Java executable instead.")
                     .willBecomeAnErrorInGradle9()
-                    .undocumented()
+                    .withUpgradeGuideSection(8, "no_relative_paths_for_java_executables")
                     .nagUser();
         }
         File executableAbsoluteFile = executableFile.getAbsoluteFile();

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecIntegrationTest.groovy
@@ -79,10 +79,11 @@ class JavaExecIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when:
-        executer.expectDeprecationWarning("Configuring a Java executable via a relative path. " +
-                "This behavior has been deprecated. This will fail with an error in Gradle 9.0. " +
-                "Resolving relative file paths might yield unexpected results, there is no single clear location it would make sense to resolve against. " +
-                "Configure an absolute path to a Java executable instead.")
+        executer.expectDocumentedDeprecationWarning("Configuring a Java executable via a relative path. " +
+            "This behavior has been deprecated. This will fail with an error in Gradle 9.0. " +
+            "Resolving relative file paths might yield unexpected results, there is no single clear location it would make sense to resolve against. " +
+            "Configure an absolute path to a Java executable instead. " +
+            "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#no_relative_paths_for_java_executables")
         run "run"
 
         then:

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestingIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestingIntegrationTest.groovy
@@ -438,10 +438,11 @@ class TestingIntegrationTest extends JUnitMultiVersionIntegrationSpec implements
             }
         """
         when:
-        executer.expectDeprecationWarning("Configuring a Java executable via a relative path. " +
-                "This behavior has been deprecated. This will fail with an error in Gradle 9.0. " +
-                "Resolving relative file paths might yield unexpected results, there is no single clear location it would make sense to resolve against. " +
-                "Configure an absolute path to a Java executable instead.")
+        executer.expectDocumentedDeprecationWarning("Configuring a Java executable via a relative path. " +
+            "This behavior has been deprecated. This will fail with an error in Gradle 9.0. " +
+            "Resolving relative file paths might yield unexpected results, there is no single clear location it would make sense to resolve against. " +
+            "Configure an absolute path to a Java executable instead. " +
+            "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#no_relative_paths_for_java_executables")
 
         then:
         succeeds("test")


### PR DESCRIPTION
Continues #23423 