### PR TITLE
Rebaseline perf tests once more to accept instrumentation regressions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ systemProp.gradle.internal.testdistribution.writeTraceFile=true
 systemProp.gradle.internal.testdistribution.queryResponseTimeout=PT20S
 
 # Default performance baseline
-defaultPerformanceBaselines=8.1-commit-ef851f664df
+defaultPerformanceBaselines=8.1-commit-98943ba9b6d


### PR DESCRIPTION
After enabling agent by default, the extra work loading instrumented classes became noticeable in some cold daemon scenarios. It is about 1-2%, but it is necessary to allow Gradle instrument all kinds of buildscript dependencies.
