### PR TITLE
Emit deprecation warning when configuration usage is changed

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleUsageIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleUsageIntegrationTest.groovy
@@ -530,6 +530,12 @@ class ConfigurationRoleUsageIntegrationTest extends AbstractIntegrationSpec impl
         configuration << ['api', 'implementation', 'compileOnly', 'runtimeOnly', 'archives']
     }
 
+    /**
+     * This test ensures that the Kotlin plugin will not emit deprecation warnings when it prevents these configurations created by the
+     * Java plugin from being consumed.
+     *
+     * @see <a href="https://github.com/JetBrains/kotlin/blob/4be359ba02fba4c5539ba50392126b5367fa9169/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/jvm/KotlinJvmTarget.kt#L101">KotlinJvmTarget.kt</a>
+     */
     def "setting consumable = false is permitted without warning for special cases to support Kotlin plugin (can change #configuration usage without warning = #allowed)"() {
         given: "a buildscript which attempts to change a configuration's usage"
         buildFile << """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleUsageIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleUsageIntegrationTest.groovy
@@ -584,8 +584,8 @@ class ConfigurationRoleUsageIntegrationTest extends AbstractIntegrationSpec impl
         expectConsumableChanging(":$configuration", true)
         succeeds 'help'
 
-        where: "a non-exhaustive list of configurations is tested"
-        configuration << ['api', 'implementation']
+        where:
+        configuration << ['api', 'implementation', 'runtimeOnly', 'compileOnly', 'compileOnlyApi', 'runtimeClasspath', 'compileClasspath']
     }
 
     def "changing usage for custom configuration in the legacy role is allowed"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleUsageIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleUsageIntegrationTest.groovy
@@ -590,7 +590,7 @@ class ConfigurationRoleUsageIntegrationTest extends AbstractIntegrationSpec impl
         succeeds 'help'
     }
 
-    def "changing usage on detached configurations warns"() {
+    def "changing usage on detached configurations does not warn"() {
         given:
         buildFile << """
             def detached = project.configurations.detachedConfiguration()
@@ -599,7 +599,6 @@ class ConfigurationRoleUsageIntegrationTest extends AbstractIntegrationSpec impl
         """
 
         expect:
-        expectResolvableChanging(':detachedConfiguration1', false)
         run "help"
     }
     // endregion Warnings

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleUsageIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleUsageIntegrationTest.groovy
@@ -19,8 +19,9 @@ package org.gradle.integtests.resolve.api
 
 import org.gradle.api.internal.artifacts.configurations.ConfigurationRoles
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.ConfigurationUsageChangingFixture
 
-class ConfigurationRoleUsageIntegrationTest extends AbstractIntegrationSpec {
+class ConfigurationRoleUsageIntegrationTest extends AbstractIntegrationSpec implements ConfigurationUsageChangingFixture {
     // region Roleless (Implicit LEGACY Role) Configurations
     def "default usage for roleless configuration is to allow anything"() {
         given:
@@ -165,9 +166,9 @@ class ConfigurationRoleUsageIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
-        executer.expectDocumentedDeprecationWarning("Allowed usage is changing for configuration ':buildSrc:implementation', consumable was false and is now true. Ideally, usage should be fixed upon creation. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Usage should be fixed upon creation. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#configurations_allowed_usage")
-        executer.expectDocumentedDeprecationWarning("Allowed usage is changing for configuration ':buildSrc:implementation', resolvable was false and is now true. Ideally, usage should be fixed upon creation. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Usage should be fixed upon creation. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#configurations_allowed_usage")
-        executer.expectDocumentedDeprecationWarning("Allowed usage is changing for configuration ':buildSrc:implementation', declarable against was true and is now false. Ideally, usage should be fixed upon creation. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Usage should be fixed upon creation. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#configurations_allowed_usage")
+        expectConsumableChanging(':buildSrc:implementation', true)
+        expectResolvableChanging(':buildSrc:implementation', true)
+        expectDeclarableAgainstChanging(':buildSrc:implementation', false)
         succeeds 'myTask'
     }
 
@@ -207,12 +208,12 @@ class ConfigurationRoleUsageIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
-        executer.expectDocumentedDeprecationWarning("Allowed usage is changing for configuration ':projectA:implementation', consumable was false and is now true. Ideally, usage should be fixed upon creation. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Usage should be fixed upon creation. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#configurations_allowed_usage")
-        executer.expectDocumentedDeprecationWarning("Allowed usage is changing for configuration ':projectA:implementation', resolvable was false and is now true. Ideally, usage should be fixed upon creation. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Usage should be fixed upon creation. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#configurations_allowed_usage")
-        executer.expectDocumentedDeprecationWarning("Allowed usage is changing for configuration ':projectA:implementation', declarable against was true and is now false. Ideally, usage should be fixed upon creation. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Usage should be fixed upon creation. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#configurations_allowed_usage")
-        executer.expectDocumentedDeprecationWarning("Allowed usage is changing for configuration ':projectB:implementation', consumable was false and is now true. Ideally, usage should be fixed upon creation. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Usage should be fixed upon creation. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#configurations_allowed_usage")
-        executer.expectDocumentedDeprecationWarning("Allowed usage is changing for configuration ':projectB:implementation', resolvable was false and is now true. Ideally, usage should be fixed upon creation. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Usage should be fixed upon creation. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#configurations_allowed_usage")
-        executer.expectDocumentedDeprecationWarning("Allowed usage is changing for configuration ':projectB:implementation', declarable against was true and is now false. Ideally, usage should be fixed upon creation. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Usage should be fixed upon creation. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#configurations_allowed_usage")
+        expectConsumableChanging(':projectA:implementation', true)
+        expectResolvableChanging(':projectA:implementation', true)
+        expectDeclarableAgainstChanging(':projectA:implementation', false)
+        expectConsumableChanging(':projectB:implementation', true)
+        expectResolvableChanging(':projectB:implementation', true)
+        expectDeclarableAgainstChanging(':projectB:implementation', false)
         succeeds 'help'
     }
     // endregion Roleless (Implicit LEGACY Role) Configurations
@@ -523,7 +524,7 @@ class ConfigurationRoleUsageIntegrationTest extends AbstractIntegrationSpec {
 
         expect: "the build succeeds and a deprecation warning is logged if the configuration is not allowed to change"
         if (!allowed) {
-            executer.expectDocumentedDeprecationWarning("Allowed usage is changing for configuration ':$configuration', resolvable was false and is now true. Ideally, usage should be fixed upon creation. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Usage should be fixed upon creation. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#configurations_allowed_usage")
+            expectResolvableChanging(":$configuration", true)
         }
         succeeds 'help'
 
@@ -598,7 +599,7 @@ class ConfigurationRoleUsageIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
-        executer.expectDocumentedDeprecationWarning("Allowed usage is changing for configuration ':detachedConfiguration1', resolvable was true and is now false. Ideally, usage should be fixed upon creation. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Usage should be fixed upon creation. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#configurations_allowed_usage")
+        expectResolvableChanging(':detachedConfiguration1', false)
         run "help"
     }
     // endregion Warnings

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/AbstractConfigurationAttributesResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/AbstractConfigurationAttributesResolveIntegrationTest.groovy
@@ -621,6 +621,7 @@ All of them match the consumer attributes:
         """
 
         when:
+        executer.expectDocumentedDeprecationWarning("Allowed usage is changing for configuration ':b:default', consumable was true and is now false. Ideally, usage should be fixed upon creation. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Usage should be fixed upon creation. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#configurations_allowed_usage")
         fails ':a:checkDebug'
 
         then:
@@ -712,6 +713,7 @@ All of them match the consumer attributes:
         """
 
         when:
+        executer.expectDocumentedDeprecationWarning("Allowed usage is changing for configuration ':b:default', consumable was true and is now false. Ideally, usage should be fixed upon creation. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Usage should be fixed upon creation. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#configurations_allowed_usage")
         fails ':a:checkDebug'
 
         then:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/AbstractConfigurationAttributesResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/AbstractConfigurationAttributesResolveIntegrationTest.groovy
@@ -622,7 +622,7 @@ All of them match the consumer attributes:
         """
 
         when:
-        expectChangingUsage(':b:default')
+        expectConsumableChanging(':b:default', false)
         fails ':a:checkDebug'
 
         then:
@@ -714,7 +714,7 @@ All of them match the consumer attributes:
         """
 
         when:
-        expectChangingUsage(':b:default')
+        expectConsumableChanging(':b:default', false)
         fails ':a:checkDebug'
 
         then:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/AbstractConfigurationAttributesResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/AbstractConfigurationAttributesResolveIntegrationTest.groovy
@@ -18,11 +18,12 @@
 package org.gradle.integtests.resolve.attributes
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.ConfigurationUsageChangingFixture
 import org.gradle.integtests.fixtures.extensions.FluidDependenciesResolveTest
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 
 @FluidDependenciesResolveTest
-abstract class AbstractConfigurationAttributesResolveIntegrationTest extends AbstractIntegrationSpec {
+abstract class AbstractConfigurationAttributesResolveIntegrationTest extends AbstractIntegrationSpec implements ConfigurationUsageChangingFixture {
 
     abstract String getTypeDefs()
 
@@ -621,7 +622,7 @@ All of them match the consumer attributes:
         """
 
         when:
-        executer.expectDocumentedDeprecationWarning("Allowed usage is changing for configuration ':b:default', consumable was true and is now false. Ideally, usage should be fixed upon creation. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Usage should be fixed upon creation. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#configurations_allowed_usage")
+        expectChangingUsage(':b:default')
         fails ':a:checkDebug'
 
         then:
@@ -713,7 +714,7 @@ All of them match the consumer attributes:
         """
 
         when:
-        executer.expectDocumentedDeprecationWarning("Allowed usage is changing for configuration ':b:default', consumable was true and is now false. Ideally, usage should be fixed upon creation. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Usage should be fixed upon creation. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#configurations_allowed_usage")
+        expectChangingUsage(':b:default')
         fails ':a:checkDebug'
 
         then:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/StringConfigurationAttributesResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/StringConfigurationAttributesResolveIntegrationTest.groovy
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 package org.gradle.integtests.resolve.attributes
+
 /**
  * Variant of the configuration attributes resolution integration test which makes use of the string attributes notation.
  */

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -1816,7 +1816,7 @@ since users cannot create non-legacy configurations and there is no current publ
      * </ol>
      * <p>
      * This method is temporary, so the duplication of the configuration names defined in
-     * {@link JavaPlatformPlugin}, which are not available to be referenced directly from here, is unfortunate, but not a showstopper.
+     * {@link JvmConstants}, which are not available to be referenced directly from here, is unfortunate, but not a showstopper.
      *
      * @param usage the name usage that is being changed
      * @param current the current value of the usage after the change

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -1791,7 +1791,9 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     private void maybeWarnOnChangingUsage(String usage, boolean current) {
         if (!isSpecialCaseOfChangingUsage(usage, current)) {
             String msgTemplate = "Allowed usage is changing for %s, %s. Ideally, usage should be fixed upon creation.";
-            DeprecationLogger.deprecateBehaviour(String.format(msgTemplate, getDisplayName(), describeChangingUsage(usage, current)))
+            String changingUsage = usage + " was " + !current + " and is now " + current;
+            
+            DeprecationLogger.deprecateBehaviour(String.format(msgTemplate, getDisplayName(), changingUsage))
                     .withAdvice("Usage should be fixed upon creation.")
                     .willBeRemovedInGradle9()
                     .withUpgradeGuideSection(8, "configurations_allowed_usage")
@@ -1829,10 +1831,6 @@ since users cannot create non-legacy configurations and there is no current publ
         boolean isPermittedConfigurationChangeForKotlin = name.equals("apiElements") || name.equals("runtimeElements") && usage.equals("consumable") && !current;
 
         return isInitializing || isDetachedConfiguration || isLegacyRole || isPermittedConfigurationChangeForKotlin;
-    }
-
-    private String describeChangingUsage(String usage, boolean current) {
-        return usage + " was " + !current + " and is now " + current;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -1823,8 +1823,8 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     @SuppressWarnings({"JavadocReference", "deprecation"})
     private boolean isSpecialCaseOfChangingUsage(String usage, boolean current) {
         boolean isInitializing = roleAtCreation == null;
-        boolean isLegacyRole = roleAtCreation == ConfigurationRoles.LEGACY;
         boolean isDetachedConfiguration = this.configurationsProvider instanceof DetachedConfigurationsProvider;
+        boolean isLegacyRole = roleAtCreation == ConfigurationRoles.LEGACY;
         boolean isPermittedConfigurationChangeForKotlin = name.equals("apiElements") || name.equals("runtimeElements") && usage.equals("consumable") && !current;
 
         return isInitializing || isDetachedConfiguration || isLegacyRole || isPermittedConfigurationChangeForKotlin;

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ConfigurationUsageChangingFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ConfigurationUsageChangingFixture.groovy
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures
+
+import groovy.transform.SelfType
+
+/**
+ * Allows adding methods to the test class that are useful for testing configuration usage changes.
+ */
+@SelfType(AbstractIntegrationSpec)
+trait ConfigurationUsageChangingFixture {
+    void expectConsumableChanging(String configurationPath, boolean current) {
+        expectChangingUsage(configurationPath, "consumable", current)
+    }
+
+    void expectResolvableChanging(String configurationPath, boolean current) {
+        expectChangingUsage(configurationPath, "resolvable", current)
+    }
+
+    void expectDeclarableAgainstChanging(String configurationPath, boolean current) {
+        expectChangingUsage(configurationPath, "declarable against", current)
+    }
+
+    void expectChangingUsage(String configurationPath, String usage, boolean current) {
+        executer.expectDocumentedDeprecationWarning("Allowed usage is changing for configuration '$configurationPath', $usage was ${!current} and is now $current. Ideally, usage should be fixed upon creation. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Usage should be fixed upon creation. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#configurations_allowed_usage")
+    }
+}

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.tasks
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AvailableJavaHomes
+import org.gradle.integtests.fixtures.ConfigurationUsageChangingFixture
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.jvm.JavaToolchainBuildOperationsFixture
 import org.gradle.integtests.fixtures.jvm.JavaToolchainFixture
@@ -30,7 +31,7 @@ import org.gradle.util.internal.TextUtil
 import org.gradle.util.internal.VersionNumber
 import spock.lang.Issue
 
-class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpec implements JavaToolchainFixture, JavaToolchainBuildOperationsFixture {
+class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpec implements JavaToolchainFixture, JavaToolchainBuildOperationsFixture, ConfigurationUsageChangingFixture {
 
     static kgpLatestVersions = new KotlinGradlePluginVersions().latests.toList()
 

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.api.tasks
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AvailableJavaHomes
-import org.gradle.integtests.fixtures.ConfigurationUsageChangingFixture
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.jvm.JavaToolchainBuildOperationsFixture
 import org.gradle.integtests.fixtures.jvm.JavaToolchainFixture
@@ -31,7 +30,7 @@ import org.gradle.util.internal.TextUtil
 import org.gradle.util.internal.VersionNumber
 import spock.lang.Issue
 
-class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpec implements JavaToolchainFixture, JavaToolchainBuildOperationsFixture, ConfigurationUsageChangingFixture {
+class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpec implements JavaToolchainFixture, JavaToolchainBuildOperationsFixture {
 
     static kgpLatestVersions = new KotlinGradlePluginVersions().latests.toList()
 


### PR DESCRIPTION
There are exceptions to this (documented in `DefaultConfiguration#isSpecialCaseOfChangingUsage()` method and tested).  Tests are updated with new expectations and expanded to include additional scenarios.
