### PR TITLE
Fix writing dependency verification file when configuration cache is enabled

### DIFF
--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java
@@ -277,7 +277,7 @@ public class DefaultIncludedBuildRegistry implements BuildStateRegistry, Stoppab
     @Override
     public void resetStateForAllBuilds() {
         for (BuildState build : buildsByIdentifier.values()) {
-            build.resetLifecycle();
+            build.resetModel();
         }
     }
 

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultNestedBuild.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultNestedBuild.java
@@ -135,20 +135,4 @@ class DefaultNestedBuild extends AbstractBuildState implements StandAloneNestedB
             return exceptionAnalyser.transform(failures);
         }
     }
-
-    private class FinishThisBuildOnlyFinishExecutor implements BuildTreeFinishExecutor {
-        private final ExceptionAnalyser exceptionAnalyser;
-
-        public FinishThisBuildOnlyFinishExecutor(ExceptionAnalyser exceptionAnalyser) {
-            this.exceptionAnalyser = exceptionAnalyser;
-        }
-
-        @Override
-        @Nullable
-        public RuntimeException finishBuildTree(List<Throwable> failures) {
-            RuntimeException reportable = exceptionAnalyser.transform(failures);
-            ExecutionResult<Void> finishResult = getBuildController().finishBuild(reportable);
-            return exceptionAnalyser.transform(ExecutionResult.maybeFailed(reportable).withFailures(finishResult).getFailures());
-        }
-    }
 }

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTaskGraphParallelTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTaskGraphParallelTest.groovy
@@ -340,7 +340,7 @@ class DefaultIncludedBuildTaskGraphParallelTest extends AbstractIncludedBuildTas
         }
 
         @Override
-        void resetLifecycle() {
+        void resetModel() {
         }
 
         @Override
@@ -409,6 +409,11 @@ class DefaultIncludedBuildTaskGraphParallelTest extends AbstractIncludedBuildTas
 
         @Override
         ExecutionResult<Void> beforeModelDiscarded(boolean failed) {
+            throw new UnsupportedOperationException()
+        }
+
+        @Override
+        ExecutionResult<Void> beforeModelReset() {
             throw new UnsupportedOperationException()
         }
 

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTaskGraphParallelTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTaskGraphParallelTest.groovy
@@ -408,6 +408,11 @@ class DefaultIncludedBuildTaskGraphParallelTest extends AbstractIncludedBuildTas
         }
 
         @Override
+        ExecutionResult<Void> beforeModelDiscarded(boolean failed) {
+            throw new UnsupportedOperationException()
+        }
+
+        @Override
         ExecutionResult<Void> finishBuild(@Nullable Throwable failure) {
             throw new UnsupportedOperationException()
         }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheAwareBuildTreeWorkController.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheAwareBuildTreeWorkController.kt
@@ -52,7 +52,12 @@ class ConfigurationCacheAwareBuildTreeWorkController(
         }
 
         cache.finalizeCacheEntry()
-        buildRegistry.resetStateForAllBuilds()
+        buildRegistry.visitBuilds { build ->
+            build.beforeModelReset().rethrow()
+        }
+        buildRegistry.visitBuilds { build ->
+            build.resetModel()
+        }
 
         return workGraph.withNewWorkGraph { graph ->
             val finalizedGraph = cache.loadRequestedTasks(graph)

--- a/subprojects/core/src/main/java/org/gradle/internal/build/AbstractBuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/AbstractBuildState.java
@@ -71,10 +71,15 @@ public abstract class AbstractBuildState implements BuildState, Closeable {
     }
 
     @Override
-    public void resetLifecycle() {
+    public void resetModel() {
         projectStateRegistry.get().discardProjectsFor(this);
         workGraphController.get().resetState();
-        buildLifecycleController.get().resetLifecycle();
+        buildLifecycleController.get().resetModel();
+    }
+
+    @Override
+    public ExecutionResult<Void> beforeModelReset() {
+        return getBuildController().beforeModelReset();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/build/AbstractBuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/AbstractBuildState.java
@@ -18,7 +18,6 @@ package org.gradle.internal.build;
 
 import org.gradle.api.internal.BuildDefinition;
 import org.gradle.api.internal.GradleInternal;
-import org.gradle.api.internal.project.HoldsProjectState;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.initialization.IncludedBuildSpec;
 import org.gradle.internal.Describables;
@@ -76,9 +75,11 @@ public abstract class AbstractBuildState implements BuildState, Closeable {
         projectStateRegistry.get().discardProjectsFor(this);
         workGraphController.get().resetState();
         buildLifecycleController.get().resetLifecycle();
-        for (HoldsProjectState service : buildLifecycleController.get().getGradle().getServices().getAll(HoldsProjectState.class)) {
-            service.discardAll();
-        }
+    }
+
+    @Override
+    public ExecutionResult<Void> beforeModelDiscarded(boolean failed) {
+        return getBuildController().beforeModelDiscarded(failed);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildLifecycleController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildLifecycleController.java
@@ -124,10 +124,15 @@ public interface BuildLifecycleController {
     /**
      * Restarts the lifecycle of this build.
      */
-    void resetLifecycle();
+    void resetModel();
 
     /**
-     * Runs whatever work is required prior to discarding the model for this build. This can happen at the end of the build or prior to calling {@link #resetLifecycle()}.
+     * Runs whatever work is required prior to discarding the model for this build. This is called prior to calling {@link #resetModel()}.
+     */
+    ExecutionResult<Void> beforeModelReset();
+
+    /**
+     * Runs whatever work is required prior to discarding the model for this build. This is called at the end of the build, after {@link #finishBuild(Throwable)}.
      */
     ExecutionResult<Void> beforeModelDiscarded(boolean failed);
 

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildLifecycleController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildLifecycleController.java
@@ -126,6 +126,11 @@ public interface BuildLifecycleController {
      */
     void resetLifecycle();
 
+    /**
+     * Runs whatever work is required prior to discarding the model for this build. This can happen at the end of the build or prior to calling {@link #resetLifecycle()}.
+     */
+    ExecutionResult<Void> beforeModelDiscarded(boolean failed);
+
     interface WorkGraphBuilder {
         /**
          * Adds requested tasks, as defined in the {@link org.gradle.StartParameter}, and their dependencies to the work graph for this build.

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildModelLifecycleListener.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildModelLifecycleListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.initialization.internal;
+
+package org.gradle.internal.build;
 
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.internal.service.scopes.EventScope;
 import org.gradle.internal.service.scopes.Scopes;
 
 @EventScope(Scopes.Build.class)
-public interface InternalBuildFinishedListener {
+public interface BuildModelLifecycleListener {
     /**
-     * Called after all user buildFinished hooks have been executed, but before
-     * services are shutdown.
-     * @param gradle the Gradle instance being finalized
-     * @param failed
+     * Called immediately prior to discarding the build model.
      */
-    default void buildFinished(GradleInternal gradle, boolean failed) {
-
+    default void beforeModelDiscarded(GradleInternal model, boolean buildFailed) {
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildState.java
@@ -95,7 +95,7 @@ public interface BuildState {
     File getBuildRootDir();
 
     /**
-     * Returns the current state of the mutable model of this build. Try to use {@link #withState(Transformer)} instead.
+     * Returns the current state of the mutable model of this build. Try to avoid using the model directly.
      */
     GradleInternal getMutableModel();
 
@@ -113,4 +113,9 @@ public interface BuildState {
      * Restarts the lifecycle for this build, discarding all present model state.
      */
     void resetLifecycle();
+
+    /**
+     * Runs whatever work is required prior to discarding the model for this build. This can happen at the end of the build or prior to calling {@link #resetLifecycle()}.
+     */
+    ExecutionResult<Void> beforeModelDiscarded(boolean failed);
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildState.java
@@ -110,12 +110,17 @@ public interface BuildState {
     <T> T withToolingModels(Function<? super BuildToolingModelController, T> action);
 
     /**
-     * Restarts the lifecycle for this build, discarding all present model state.
+     * Runs whatever work is required prior to discarding the model for this build. Called prior to {@link #resetModel()}.
      */
-    void resetLifecycle();
+    ExecutionResult<Void> beforeModelReset();
 
     /**
-     * Runs whatever work is required prior to discarding the model for this build. This can happen at the end of the build or prior to calling {@link #resetLifecycle()}.
+     * Restarts the lifecycle of the model of this build, discarding all current model state.
+     */
+    void resetModel();
+
+    /**
+     * Runs whatever work is required prior to discarding the model for this build. Called at the end of the build.
      */
     ExecutionResult<Void> beforeModelDiscarded(boolean failed);
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/build/DefaultBuildLifecycleControllerFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/DefaultBuildLifecycleControllerFactory.java
@@ -21,7 +21,6 @@ import org.gradle.api.internal.BuildDefinition;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.execution.BuildWorkExecutor;
 import org.gradle.initialization.exception.ExceptionAnalyser;
-import org.gradle.initialization.internal.InternalBuildFinishedListener;
 import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.deprecation.DeprecationMessageBuilder;
 import org.gradle.internal.event.ListenerManager;
@@ -70,7 +69,7 @@ public class DefaultBuildLifecycleControllerFactory implements BuildLifecycleCon
             buildModelController,
             exceptionAnalyser,
             gradle.getBuildListenerBroadcaster(),
-            listenerManager.getBroadcaster(InternalBuildFinishedListener.class),
+            listenerManager.getBroadcaster(BuildModelLifecycleListener.class),
             gradle.getServices().get(BuildWorkPreparer.class),
             gradle.getServices().get(BuildWorkExecutor.class),
             buildToolingModelControllerFactory,

--- a/subprojects/core/src/main/java/org/gradle/internal/build/ExecutionResult.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/ExecutionResult.java
@@ -52,6 +52,11 @@ public abstract class ExecutionResult<T> {
     public abstract RuntimeException getFailure();
 
     /**
+     * Returns a single exception object that contains all failures in this result, or null if the operation was successful.
+     */
+    public abstract RuntimeException getFailureOrNull();
+
+    /**
      * Returns the value or rethrows the failures of this result.
      */
     public abstract T getValueOrRethrow();
@@ -82,6 +87,15 @@ public abstract class ExecutionResult<T> {
 
     public static ExecutionResult<Void> succeeded() {
         return SUCCESS;
+    }
+
+    public static ExecutionResult<Void> maybeFailing(Runnable action) {
+        try {
+            action.run();
+            return SUCCESS;
+        } catch (Throwable t) {
+            return failed(t);
+        }
     }
 
     public static <T> ExecutionResult<T> failed(Throwable failure) {
@@ -150,6 +164,11 @@ public abstract class ExecutionResult<T> {
         }
 
         @Override
+        public RuntimeException getFailureOrNull() {
+            return null;
+        }
+
+        @Override
         public RuntimeException getFailure() {
             throw new IllegalArgumentException("Cannot get the failure of a successful result.");
         }
@@ -181,6 +200,11 @@ public abstract class ExecutionResult<T> {
         @Override
         public List<Throwable> getFailures() {
             return failures;
+        }
+
+        @Override
+        public RuntimeException getFailureOrNull() {
+            return getFailure();
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/model/StateTransitionController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/model/StateTransitionController.java
@@ -23,6 +23,7 @@ import org.gradle.internal.work.Synchronizer;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
+import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -89,7 +90,7 @@ public class StateTransitionController<T extends StateTransitionController.State
     }
 
     /**
-     * Runs the given action.
+     * Runs the given action, verifying the current state is the expected state.
      * Fails if the current state is not the given state or a previous operation has failed.
      * Blocks until other operations are complete.
      */
@@ -136,10 +137,15 @@ public class StateTransitionController<T extends StateTransitionController.State
         });
     }
 
+    /**
+     * Resets the state to the given state.
+     * Fails if the current state is not the given state, ignores failures from previous operations.
+     * Blocks until other operations are complete.
+     */
     public void restart(T fromState, T toState, Runnable action) {
         synchronizer.withLock(() -> {
             CurrentState<T> current = state;
-            current.assertCanReset(fromState, toState);
+            current.assertCanTransition(fromState, toState, true);
             action.run();
             state = new InState<>(displayName, toState, null);
         });
@@ -211,21 +217,37 @@ public class StateTransitionController<T extends StateTransitionController.State
     /**
      * Transitions to a final state, taking any failures from previous transitions and transforming them.
      */
-    public ExecutionResult<Void> finish(T toState, Function<ExecutionResult<Void>, ExecutionResult<Void>> action) {
+    public ExecutionResult<Void> transition(T fromState, T toState, Function<ExecutionResult<Void>, ExecutionResult<Void>> action) {
         return synchronizer.withLock(() -> {
             CurrentState<T> current = state;
-            if (current.state == toState) {
-                // Don't rethrow the failure
-                return ExecutionResult.succeeded();
-            }
-            ExecutionResult<Void> result = current.asResult();
-            state = current.transitioningTo(toState);
-            try {
-                return action.apply(result);
-            } finally {
-                state = state.nextState(toState);
-            }
+            current.assertCanTransition(fromState, toState, true);
+            return doTransitionWithFailures(toState, action, current);
         });
+    }
+
+    public ExecutionResult<Void> transition(List<T> fromStates, T toState, Function<ExecutionResult<Void>, ExecutionResult<Void>> action) {
+        return synchronizer.withLock(() -> {
+            CurrentState<T> current = state;
+            current.assertCanTransition(fromStates, toState, true);
+            return doTransitionWithFailures(toState, action, current);
+        });
+    }
+
+    private ExecutionResult<Void> doTransitionWithFailures(T toState, Function<ExecutionResult<Void>, ExecutionResult<Void>> action, CurrentState<T> current) {
+        ExecutionResult<Void> currentResult = current.asResult();
+        state = current.transitioningTo(toState);
+        ExecutionResult<Void> result;
+        try {
+            result = action.apply(currentResult);
+        } catch (Throwable t) {
+            result = ExecutionResult.failed(t);
+        }
+        if (!result.getFailures().isEmpty()) {
+            state = state.failed(result);
+        } else {
+            state = state.nextState(toState);
+        }
+        return result;
     }
 
     private void doTransition(T fromState, T toState, Runnable action) {
@@ -266,11 +288,13 @@ public class StateTransitionController<T extends StateTransitionController.State
 
         public abstract void assertNotInState(T forbidden);
 
-        public abstract void assertCanTransition(T fromState, T toState);
-
-        public void assertCanReset(T fromState, T toState) {
-            assertCanTransition(fromState, toState);
+        public void assertCanTransition(T fromState, T toState) {
+            assertCanTransition(fromState, toState, false);
         }
+
+        public abstract void assertCanTransition(T fromState, T toState, boolean ignoreFailures);
+
+        public abstract void assertCanTransition(List<T> fromStates, T toState, boolean ignoreFailures);
 
         public abstract boolean inStateAndNotTransitioning(T toState);
 
@@ -328,9 +352,16 @@ public class StateTransitionController<T extends StateTransitionController.State
         }
 
         @Override
-        public void assertCanTransition(T fromState, T toState) {
+        public void assertCanTransition(T fromState, T toState, boolean ignoreFailures) {
             if (state != fromState) {
                 throw new IllegalStateException("Can only transition " + displayName.getCapitalizedDisplayName() + " to state " + toState + " from state " + fromState + " however it is currently in state " + state + ".");
+            }
+        }
+
+        @Override
+        public void assertCanTransition(List<T> fromStates, T toState, boolean ignoreFailures) {
+            if (!fromStates.contains(state)) {
+                throw new IllegalStateException("Can only transition " + displayName.getCapitalizedDisplayName() + " to state " + toState + " from states " + fromStates + " however it is currently in state " + state + ".");
             }
         }
 
@@ -403,7 +434,16 @@ public class StateTransitionController<T extends StateTransitionController.State
         }
 
         @Override
-        public void assertCanTransition(T fromState, T toState) {
+        public void assertCanTransition(T fromState, T toState, boolean ignoreFailures) {
+            failDueToTransition(toState);
+        }
+
+        @Override
+        public void assertCanTransition(List<T> fromStates, T toState, boolean ignoreFailures) {
+            failDueToTransition(toState);
+        }
+
+        private void failDueToTransition(T toState) {
             if (targetState == toState) {
                 throw new IllegalStateException("Cannot transition " + displayName.getDisplayName() + " to state " + toState + " as already transitioning to this state.");
             } else {
@@ -453,13 +493,17 @@ public class StateTransitionController<T extends StateTransitionController.State
         }
 
         @Override
-        public void assertCanTransition(T fromState, T toState) {
-            throwFailure();
+        public void assertCanTransition(List<T> fromStates, T toState, boolean ignoreFailures) {
+            if (!ignoreFailures) {
+                throwFailure();
+            }
         }
 
         @Override
-        public void assertCanReset(T fromState, T toState) {
-            // This is ok, failure will be discarded
+        public void assertCanTransition(T fromState, T toState, boolean ignoreFailures) {
+            if (!ignoreFailures) {
+                throwFailure();
+            }
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/model/StateTransitionController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/model/StateTransitionController.java
@@ -45,18 +45,6 @@ public class StateTransitionController<T extends StateTransitionController.State
     }
 
     /**
-     * Verifies that the current state is the given state. Ignores any transition in progress and failures of previous operations.
-     *
-     * <p>You should try to not use this method, as it does not provide any thread safety for the code that follows the call.</p>
-     */
-    public void assertInState(T expected) {
-        CurrentState<T> current = state;
-        if (current.state != expected) {
-            throw new IllegalStateException(displayName.getCapitalizedDisplayName() + " should be in state " + expected + " but is in " + current.state + ".");
-        }
-    }
-
-    /**
      * Verifies that the current state is not the given state. Ignores any transition in progress and failures of previous operations.
      *
      * <p>You should try to not use this method, as it does not provide any thread safety for the code that follows the call.</p>
@@ -65,17 +53,6 @@ public class StateTransitionController<T extends StateTransitionController.State
         if (state.state == forbidden) {
             throw new IllegalStateException(displayName.getCapitalizedDisplayName() + " should not be in state " + forbidden + ".");
         }
-    }
-
-    public void restart(T target, Runnable action) {
-        synchronizer.withLock(() -> {
-            action.run();
-            state = new InState<>(displayName, target, null);
-        });
-    }
-
-    public boolean isInStateOrLater(T expected) {
-        return state.hasSeenStateIgnoringTransitions(expected);
     }
 
     /**
@@ -156,6 +133,13 @@ public class StateTransitionController<T extends StateTransitionController.State
                 state = current.failed(ExecutionResult.failed(t));
                 throw state.rethrow();
             }
+        });
+    }
+
+    public void restart(T target, Runnable action) {
+        synchronizer.withLock(() -> {
+            action.run();
+            state = new InState<>(displayName, target, null);
         });
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/internal/build/ExecutionResultTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/build/ExecutionResultTest.groovy
@@ -28,6 +28,7 @@ class ExecutionResultTest extends Specification {
         expect:
         result.value == 12
         result.valueOrRethrow == 12
+        result.failureOrNull == null
         result.failures.empty
         result.rethrow()
 
@@ -50,6 +51,7 @@ class ExecutionResultTest extends Specification {
         expect:
         result.value == null
         result.valueOrRethrow == null
+        result.failureOrNull == null
         result.failures.empty
         result.rethrow()
     }
@@ -61,6 +63,7 @@ class ExecutionResultTest extends Specification {
         expect:
         result.failures == [failure]
         result.failure == failure
+        result.failureOrNull == failure
 
         when:
         result.valueOrRethrow
@@ -92,6 +95,8 @@ class ExecutionResultTest extends Specification {
         result.failures == [failure1, failure2]
         result.failure instanceof MultipleBuildFailures
         result.failure.causes == [failure1, failure2]
+        result.failureOrNull instanceof MultipleBuildFailures
+        result.failureOrNull.causes == [failure1, failure2]
 
         when:
         result.valueOrRethrow
@@ -120,6 +125,7 @@ class ExecutionResultTest extends Specification {
         expect:
         result.value == null
         result.valueOrRethrow == null
+        result.failureOrNull == null
         result.failures.empty
         result.rethrow()
     }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/model/StateTransitionControllerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/model/StateTransitionControllerTest.groovy
@@ -18,11 +18,13 @@ package org.gradle.internal.model
 
 import org.gradle.internal.Describables
 import org.gradle.internal.Factory
+import org.gradle.internal.build.ExecutionResult
 import org.gradle.internal.concurrent.DefaultParallelismConfiguration
 import org.gradle.internal.resources.DefaultResourceLockCoordinationService
 import org.gradle.internal.work.DefaultWorkerLeaseService
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
 
+import java.util.function.Function
 import java.util.function.Supplier
 
 class StateTransitionControllerTest extends ConcurrentSpec {
@@ -693,6 +695,117 @@ class StateTransitionControllerTest extends ConcurrentSpec {
         noExceptionThrown()
     }
 
+    def "can transition to new state and take previous failure as input when nothing has failed"() {
+        def action = Mock(Function)
+        def controller = controller(TestState.A)
+
+        when:
+        def result = asWorker {
+            controller.transition(TestState.A, TestState.B, action)
+        }
+
+        then:
+        1 * action.apply(_) >> { ExecutionResult r ->
+            assert r.failures.empty
+            ExecutionResult.succeeded()
+        }
+        0 * action._
+        result.failures.empty
+    }
+
+    def "can transition to new state and take previous failure as input"() {
+        def action = Mock(Function)
+        def controller = controller(TestState.A)
+
+        given:
+        asWorker {
+            makeBroken(controller)
+        }
+
+        when:
+        def result = asWorker {
+            controller.transition(TestState.A, TestState.B, action)
+        }
+
+        then:
+        1 * action.apply(_) >> { ExecutionResult r ->
+            assert r.failures.size() == 1
+            ExecutionResult.succeeded()
+        }
+        0 * action._
+        result.failures.empty
+    }
+
+    def "retains failure in action that takes previous failure as input"() {
+        def action = Mock(Function)
+        def failure = new RuntimeException()
+        def controller = controller(TestState.A)
+
+        when:
+        def result = asWorker {
+            controller.transition(TestState.A, TestState.B, action)
+        }
+
+        then:
+        1 * action.apply(_) >> { ExecutionResult r ->
+            throw failure
+        }
+        0 * action._
+        result.failures == [failure]
+
+        when:
+        asWorker {
+            controller.transition(TestState.B, TestState.A) {}
+        }
+
+        then:
+        def e = thrown(RuntimeException)
+        e == failure
+    }
+
+    def "transition that takes previous failure as input fails when in unexpected state"() {
+        def action = Mock(Function)
+        def controller = controller(TestState.A)
+
+        when:
+        asWorker {
+            controller.transition(TestState.B, TestState.C, action)
+        }
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message == 'Can only transition <state> to state C from state B however it is currently in state A.'
+    }
+
+    def "can reset state to initial state"() {
+        def action = Mock(Runnable)
+        def resetAction = Mock(Runnable)
+        def controller = controller(TestState.A)
+
+        given:
+        asWorker {
+            controller.transition(TestState.A, TestState.B) {}
+        }
+
+        when:
+        asWorker {
+            controller.restart(TestState.B, TestState.A, resetAction)
+        }
+
+        then:
+        1 * resetAction.run()
+        0 * _
+
+        when:
+        asWorker {
+            controller.transition(TestState.A, TestState.B, action)
+        }
+
+        then:
+        1 * action.run()
+        0 * _
+    }
+
     def "can reset state to initial state and discard collected failure"() {
         def action = Mock(Runnable)
         def resetAction = Mock(Runnable)
@@ -700,13 +813,7 @@ class StateTransitionControllerTest extends ConcurrentSpec {
 
         given:
         asWorker {
-            try {
-                controller.transition(TestState.A, TestState.B) {
-                    throw new RuntimeException("broken")
-                }
-            } catch (RuntimeException e) {
-                // ignore
-            }
+            makeBroken(controller)
         }
 
         when:
@@ -747,4 +854,13 @@ class StateTransitionControllerTest extends ConcurrentSpec {
         e.message == 'Can only transition <state> to state A from state B however it is currently in state C.'
     }
 
+    private makeBroken(StateTransitionController<TestState> controller) {
+        try {
+            controller.transition(TestState.A, TestState.B) {
+                throw new RuntimeException("broken")
+            }
+        } catch (RuntimeException e) {
+            // ignore
+        }
+    }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationWritingIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationWritingIntegTest.groovy
@@ -38,7 +38,6 @@ class DependencyVerificationWritingIntegTest extends AbstractDependencyVerificat
         then:
         assertMetadataExists()
         hasNoModules()
-
     }
 
     def "warns if trying to generate with an unknown checksum type (#checksums)"() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -108,8 +108,8 @@ import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.configuration.internal.UserCodeApplicationContext;
-import org.gradle.initialization.internal.InternalBuildFinishedListener;
 import org.gradle.internal.authentication.AuthenticationSchemeRegistry;
+import org.gradle.internal.build.BuildModelLifecycleListener;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.component.external.model.JavaEcosystemVariantDerivationStrategy;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
@@ -448,10 +448,10 @@ public class DefaultDependencyManagementServices implements DependencyManagement
 
             DefaultDependencyLockingProvider dependencyLockingProvider = new DefaultDependencyLockingProvider(fileResolver, startParameter, context, globalDependencyResolutionRules.getDependencySubstitutionRules(), propertyFactory, filePropertyFactory, listenerManager.getBroadcaster(FileResourceListener.class));
             if (startParameter.isWriteDependencyLocks()) {
-                listenerManager.addListener(new InternalBuildFinishedListener() {
+                listenerManager.addListener(new BuildModelLifecycleListener() {
                     @Override
-                    public void buildFinished(GradleInternal gradle, boolean failed) {
-                        if (!failed) {
+                    public void beforeModelDiscarded(GradleInternal model, boolean buildFailed) {
+                        if (!buildFailed) {
                             dependencyLockingProvider.buildFinished();
                         }
                     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -127,7 +127,7 @@ import org.gradle.cache.scopes.BuildScopedCacheBuilderFactory;
 import org.gradle.cache.scopes.GlobalScopedCacheBuilderFactory;
 import org.gradle.configuration.internal.UserCodeApplicationContext;
 import org.gradle.initialization.DependenciesAccessors;
-import org.gradle.initialization.internal.InternalBuildFinishedListener;
+import org.gradle.internal.build.BuildModelLifecycleListener;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.build.BuildStateRegistry;
 import org.gradle.internal.buildoption.FeatureFlags;
@@ -605,9 +605,9 @@ class DependencyManagementBuildScopeServices {
                                                                                       SuppliedComponentMetadataSerializer suppliedComponentMetadataSerializer,
                                                                                       ListenerManager listenerManager) {
         if (cacheDecoratorFactory instanceof CleaningInMemoryCacheDecoratorFactory) {
-            listenerManager.addListener(new InternalBuildFinishedListener() {
+            listenerManager.addListener(new BuildModelLifecycleListener() {
                 @Override
-                public void buildFinished(GradleInternal build, boolean failed) {
+                public void beforeModelDiscarded(GradleInternal model, boolean buildFailed) {
                     ((CleaningInMemoryCacheDecoratorFactory) cacheDecoratorFactory).clearCaches(ComponentMetadataRuleExecutor::isMetadataRuleExecutorCache);
                 }
             });
@@ -629,10 +629,10 @@ class DependencyManagementBuildScopeServices {
     }
 
     private void registerBuildFinishedHooks(ListenerManager listenerManager, DependencyVerificationOverride dependencyVerificationOverride) {
-        listenerManager.addListener(new InternalBuildFinishedListener() {
+        listenerManager.addListener(new BuildModelLifecycleListener() {
             @Override
-            public void buildFinished(GradleInternal build, boolean failed) {
-                dependencyVerificationOverride.buildFinished(build);
+            public void beforeModelDiscarded(GradleInternal model, boolean buildFailed) {
+                dependencyVerificationOverride.buildFinished(model);
             }
         });
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/StartParameterResolutionOverride.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/StartParameterResolutionOverride.java
@@ -20,6 +20,7 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.artifacts.verification.DependencyVerificationMode;
 import org.gradle.api.internal.DocumentationRegistry;
+import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal;
 import org.gradle.api.internal.artifacts.configurations.dynamicversion.CachePolicy;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.ChecksumAndSignatureVerificationOverride;
@@ -32,7 +33,6 @@ import org.gradle.api.internal.artifacts.verification.signatures.BuildTreeDefine
 import org.gradle.api.internal.artifacts.verification.signatures.SignatureVerificationServiceFactory;
 import org.gradle.api.internal.component.ArtifactType;
 import org.gradle.api.internal.properties.GradleProperties;
-import org.gradle.api.invocation.Gradle;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.resources.ResourceException;
@@ -268,8 +268,8 @@ public class StartParameterResolutionOverride {
         }
 
         @Override
-        public void buildFinished(Gradle gradle) {
-            delegate.buildFinished(gradle);
+        public void buildFinished(GradleInternal model) {
+            delegate.buildFinished(model);
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/DependencyVerificationOverride.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/DependencyVerificationOverride.java
@@ -16,9 +16,9 @@
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification;
 
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
+import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ModuleComponentRepository;
-import org.gradle.api.invocation.Gradle;
 
 import java.io.File;
 
@@ -38,8 +38,7 @@ public interface DependencyVerificationOverride {
 
     ModuleComponentRepository overrideDependencyVerification(ModuleComponentRepository original, String resolveContextName, ResolutionStrategyInternal resolutionStrategy);
 
-    default void buildFinished(Gradle gradle) {
-
+    default void buildFinished(GradleInternal model) {
     }
 
     /**

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFile.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFile.java
@@ -27,6 +27,7 @@ import org.gradle.api.UncheckedIOException;
 import org.gradle.api.artifacts.ArtifactView;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.DependencyVerifyingModuleComponentRepository;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ModuleComponentRepository;
@@ -176,7 +177,7 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
     }
 
     @Override
-    public void buildFinished(Gradle gradle) {
+    public void buildFinished(GradleInternal gradle) {
         ensureOutputDirCreated();
         maybeReadExistingFile();
         // when we generate the verification file, we intentionally ignore if the "use key servers" flag is false


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context

This PR introduces an explicit step that runs before the mutable project state is discarded, either at the end of the build or after storing the cache entry, and after all user code has finished using the project state.

Writing dependency resolution files, such as the dependency verification file, happens during this step. Previously, this would happen at the end of the build, at which point the state required to do dependency resolution has been discarded when configuration caching is enabled.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
