### PR TITLE
Document de-incubated Settings API

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -364,6 +364,9 @@ The `War.getWebAppDirectory()` method is now considered stable.
 
 ### Promoted features in the `Settings` API
 
+The `includeBuild` methods in `Settings.pluginManagement` are now stable.
+They are the recommended way of including builds that contribute build logic.
+
 The methods `Settings.dependencyResolutionManagement(Action)` and `Settings.getDependencyResolutionManagement()` are now considered stable.
 
 All the methods in `DependencyResolutionManagement` are now stable, except the ones for central repository declaration.

--- a/subprojects/docs/src/docs/userguide/authoring-builds/software-product/composite_builds.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/software-product/composite_builds.adoc
@@ -91,9 +91,11 @@ include::sample[dir="snippets/developingPlugins/testingPlugins/kotlin/include-pl
 include::sample[dir="snippets/developingPlugins/testingPlugins/groovy/include-plugin-build",files="settings.gradle[tags=include-build]"]
 ====
 
-NOTE: Including plugin builds via the plugin management block is an incubating feature.
-You may also use the stable `includeBuild` mechanism outside `pluginManagement` to include plugin builds.
-However, this does not support all use cases and including plugin builds like that will be deprecated once the new mechanism is stable.
+[NOTE]
+====
+You may also use the `includeBuild` mechanism outside `pluginManagement` to include plugin builds.
+However, this does not support all use cases and including plugin builds like that might be deprecated in a future Gradle version.
+====
 
 [[included_builds]]
 === Restrictions on included builds


### PR DESCRIPTION
* settings.pluginManagement.includeBuild is no longer incubating
* Clarify limits of using settings.includeBuild for build logic

Fixes #24129