### PR TITLE
Change dev-prod owned files from global `*.gradle.kts` to specific ones

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -77,11 +77,12 @@ subprojects/docs/src/docs/userguide/reference/directory_layout.adoc             
 subprojects/docs/src/docs/userguide/troubleshooting/version_catalog_problems.adoc @gradle/bt-jvm
 
 # Dev-prod team
-.teamcity/                                  @gradle/bt-developer-productivity
-.github/                                    @gradle/bt-developer-productivity
-gradle/shared-with-buildSrc/                @gradle/bt-developer-productivity
-build-logic/                                @gradle/bt-developer-productivity
-build-logic-commons/                        @gradle/bt-developer-productivity
-build-logic-settings/                       @gradle/bt-developer-productivity
-subprojects/*/build.gradle*                 @gradle/bt-developer-productivity
-*.gradle.kts                                @gradle/bt-developer-productivity
+.teamcity/                   @gradle/bt-developer-productivity
+.github/                     @gradle/bt-developer-productivity
+gradle/shared-with-buildSrc/ @gradle/bt-developer-productivity
+build-logic/                 @gradle/bt-developer-productivity
+build-logic-commons/         @gradle/bt-developer-productivity
+build-logic-settings/        @gradle/bt-developer-productivity
+subprojects/*/build.gradle*  @gradle/bt-developer-productivity
+build.gradle*                @gradle/bt-developer-productivity
+setting.gradle*              @gradle/bt-developer-productivity

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -85,4 +85,4 @@ build-logic-commons/         @gradle/bt-developer-productivity
 build-logic-settings/        @gradle/bt-developer-productivity
 subprojects/*/build.gradle*  @gradle/bt-developer-productivity
 build.gradle*                @gradle/bt-developer-productivity
-setting.gradle*              @gradle/bt-developer-productivity
+settings.gradle*              @gradle/bt-developer-productivity


### PR DESCRIPTION
I think the previous version was too broad - I've received notifications from all over the repository, and we are needlessly added in a lot of places. 

As we have test resources with this name, my suggestion is to replace them with more specific ones - in this case, I think we only missed the root `[build | settings].gradle[.kts]` files.