### PR TITLE
Finalize transform build operations naming

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/LocalFileDependencyBackedArtifactSetCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/LocalFileDependencyBackedArtifactSetCodec.kt
@@ -29,7 +29,6 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.artifacts.ArtifactTransformRegistration
 import org.gradle.api.internal.artifacts.VariantTransformRegistry
-import org.gradle.api.internal.artifacts.configurations.ConfigurationIdentity
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.LocalFileDependencyBackedArtifactSet
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet
@@ -71,6 +70,7 @@ import org.gradle.internal.component.local.model.LocalFileDependencyMetadata
 import org.gradle.internal.component.model.VariantResolveMetadata
 import org.gradle.internal.model.CalculatedValueContainerFactory
 import org.gradle.internal.reflect.Instantiator
+import org.gradle.operations.dependencies.configurations.ConfigurationIdentity
 
 
 class LocalFileDependencyBackedArtifactSetCodec(

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/transform/Transforms.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/transform/Transforms.kt
@@ -17,7 +17,6 @@
 package org.gradle.configurationcache.serialization.codecs.transform
 
 import org.gradle.api.file.FileCollection
-import org.gradle.api.internal.artifacts.configurations.ConfigurationIdentity
 import org.gradle.api.internal.artifacts.transform.ArtifactTransformDependencies
 import org.gradle.api.internal.artifacts.transform.BoundTransformationStep
 import org.gradle.api.internal.artifacts.transform.DefaultArtifactTransformDependencies
@@ -31,6 +30,7 @@ import org.gradle.configurationcache.serialization.ReadContext
 import org.gradle.configurationcache.serialization.WriteContext
 import org.gradle.configurationcache.serialization.readNonNull
 import org.gradle.internal.Try
+import org.gradle.operations.dependencies.configurations.ConfigurationIdentity
 
 
 sealed class TransformStepSpec(val transformation: TransformationStep) {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformBuildOperationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformBuildOperationIntegrationTest.groovy
@@ -17,13 +17,13 @@
 package org.gradle.integtests.resolve.transform
 
 import groovy.transform.EqualsAndHashCode
-import org.gradle.api.internal.artifacts.transform.ExecutePlannedTransformStepBuildOperationType
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.internal.operations.trace.BuildOperationRecord
 import org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType
 import org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType.PlannedNode
 import org.gradle.internal.taskgraph.NodeIdentity
+import org.gradle.operations.dependencies.transforms.ExecutePlannedTransformStepBuildOperationType
 
 import java.util.function.Predicate
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformBuildOperationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformBuildOperationIntegrationTest.groovy
@@ -48,8 +48,8 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
     }
 
     static class PlannedTransformStepIdentityWithoutId {
-        String buildPath
-        String projectPath
+        String consumerBuildPath
+        String consumerProjectPath
         Map<String, String> componentId
         Map<String, String> targetAttributes
         List<Map<String, String>> capabilities
@@ -130,8 +130,8 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         List<PlannedNode> plannedNodes = getPlannedNodes(1)
 
         def expectedTransformId = new PlannedTransformStepIdentityWithoutId([
-            buildPath: ":",
-            projectPath: ":consumer",
+            consumerBuildPath: ":",
+            consumerProjectPath: ":consumer",
             componentId: [buildPath: ":", projectPath: ":producer"],
             targetAttributes: [color: "green", artifactType: "jar"],
             capabilities: [[group: "colored", name: "producer", version: "unspecified"]],
@@ -192,8 +192,8 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         def plannedNodes = getPlannedNodes(2)
 
         def expectedTransformId1 = new PlannedTransformStepIdentityWithoutId([
-            buildPath: ":",
-            projectPath: ":consumer",
+            consumerBuildPath: ":",
+            consumerProjectPath: ":consumer",
             componentId: [buildPath: ":", projectPath: ":producer"],
             targetAttributes: [color: "red", artifactType: "jar"],
             capabilities: [[group: "colored", name: "producer", version: "unspecified"]],
@@ -202,8 +202,8 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         ])
 
         def expectedTransformId2 = new PlannedTransformStepIdentityWithoutId([
-            buildPath: ":",
-            projectPath: ":consumer",
+            consumerBuildPath: ":",
+            consumerProjectPath: ":consumer",
             componentId: [buildPath: ":", projectPath: ":producer"],
             targetAttributes: [color: "green", artifactType: "jar"],
             capabilities: [[group: "colored", name: "producer", version: "unspecified"]],
@@ -273,8 +273,8 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         def plannedNodes = getPlannedNodes(2)
 
         def expectedTransformId1 = new PlannedTransformStepIdentityWithoutId([
-            buildPath: ":",
-            projectPath: ":consumer",
+            consumerBuildPath: ":",
+            consumerProjectPath: ":consumer",
             componentId: [buildPath: ":", projectPath: ":producer"],
             targetAttributes: [color: "red", artifactType: "jar"],
             capabilities: [[group: "colored", name: "producer", version: "unspecified"]],
@@ -283,8 +283,8 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         ])
 
         def expectedTransformId2 = new PlannedTransformStepIdentityWithoutId([
-            buildPath: ":",
-            projectPath: ":consumer",
+            consumerBuildPath: ":",
+            consumerProjectPath: ":consumer",
             componentId: [buildPath: ":", projectPath: ":producer"],
             targetAttributes: [color: "green", artifactType: "jar"],
             capabilities: [[group: "colored", name: "producer", version: "unspecified"]],
@@ -363,8 +363,8 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         def plannedNodes = getPlannedNodes(1)
 
         def expectedTransformId1 = new PlannedTransformStepIdentityWithoutId([
-            buildPath: ":",
-            projectPath: ":consumer",
+            consumerBuildPath: ":",
+            consumerProjectPath: ":consumer",
             componentId: [buildPath: ":", projectPath: ":producer"],
             targetAttributes: [color: "green", artifactType: "jar"],
             capabilities: [[group: "colored", name: "producer", version: "unspecified"]],
@@ -425,8 +425,8 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         def plannedNodes = getPlannedNodes(2)
 
         def expectedTransformId1 = new PlannedTransformStepIdentityWithoutId([
-            buildPath: ":",
-            projectPath: ":consumer",
+            consumerBuildPath: ":",
+            consumerProjectPath: ":consumer",
             componentId: [buildPath: ":", projectPath: ":producer"],
             targetAttributes: [color: "red", artifactType: "jar"],
             capabilities: [[group: "colored", name: "producer", version: "unspecified"]],
@@ -435,8 +435,8 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         ])
 
         def expectedTransformId2 = new PlannedTransformStepIdentityWithoutId([
-            buildPath: ":",
-            projectPath: ":consumer",
+            consumerBuildPath: ":",
+            consumerProjectPath: ":consumer",
             componentId: [buildPath: ":", projectPath: ":producer"],
             targetAttributes: [color: "green", artifactType: "jar"],
             capabilities: [[group: "colored", name: "producer", version: "unspecified"]],
@@ -547,8 +547,8 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         def plannedNodes = getPlannedNodes(2)
 
         def expectedTransformId1 = new PlannedTransformStepIdentityWithoutId([
-            buildPath: ":",
-            projectPath: ":consumer",
+            consumerBuildPath: ":",
+            consumerProjectPath: ":consumer",
             componentId: [buildPath: ":", projectPath: ":producer"],
             targetAttributes: [color: "red", artifactType: "jar"],
             capabilities: [[group: "colored", name: "producer", version: "unspecified"]],
@@ -557,8 +557,8 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         ])
 
         def expectedTransformId2 = new PlannedTransformStepIdentityWithoutId([
-            buildPath: ":",
-            projectPath: ":consumer",
+            consumerBuildPath: ":",
+            consumerProjectPath: ":consumer",
             componentId: [buildPath: ":", projectPath: ":producer"],
             targetAttributes: [color: "green", artifactType: "jar"],
             capabilities: [[group: "colored", name: "producer", version: "unspecified"]],
@@ -675,8 +675,8 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         def plannedNodes = getPlannedNodes(2)
 
         def expectedTransformId1 = new PlannedTransformStepIdentityWithoutId([
-            buildPath: ":",
-            projectPath: ":consumer",
+            consumerBuildPath: ":",
+            consumerProjectPath: ":consumer",
             componentId: [buildPath: ":", projectPath: ":producer"],
             targetAttributes: [color: "green", artifactType: "jar"],
             capabilities: [[group: "colored", name: "producer", version: "unspecified"]],
@@ -685,8 +685,8 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         ])
 
         def expectedTransformId2 = new PlannedTransformStepIdentityWithoutId([
-            buildPath: ":",
-            projectPath: ":consumer",
+            consumerBuildPath: ":",
+            consumerProjectPath: ":consumer",
             componentId: [buildPath: ":", projectPath: ":producer"],
             targetAttributes: [color: "green", artifactType: "jar"],
             capabilities: [[group: "colored", name: "producer", version: "unspecified"]],
@@ -769,8 +769,8 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         def plannedNodes = getPlannedNodes(1)
 
         def expectedTransformId1 = new PlannedTransformStepIdentityWithoutId([
-            buildPath: ":",
-            projectPath: ":consumer",
+            consumerBuildPath: ":",
+            consumerProjectPath: ":consumer",
             componentId: [buildPath: ":", projectPath: ":producer"],
             targetAttributes: [color: "green", artifactType: "jar"],
             capabilities: [[group: "colored", name: "producer", version: "unspecified"]],
@@ -870,8 +870,8 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
 
     boolean matchTransformationIdentity(actual, PlannedTransformStepIdentityWithoutId expected) {
         actual.nodeType.toString() == TRANSFORM_STEP &&
-            actual.buildPath == expected.buildPath &&
-            actual.projectPath == expected.projectPath &&
+            actual.consumerBuildPath == expected.consumerBuildPath &&
+            actual.consumerProjectPath == expected.consumerProjectPath &&
             actual.componentId == expected.componentId &&
             actual.targetAttributes == expected.targetAttributes &&
             actual.capabilities == expected.capabilities &&
@@ -882,8 +882,8 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
     void verifyTransformationIdentity(actual, PlannedTransformStepIdentityWithoutId expected) {
         verifyAll(actual) {
             nodeType.toString() == TRANSFORM_STEP
-            buildPath == expected.buildPath
-            projectPath == expected.projectPath
+            consumerBuildPath == expected.consumerBuildPath
+            consumerProjectPath == expected.consumerProjectPath
             componentId == expected.componentId
             targetAttributes == expected.targetAttributes
             capabilities == expected.capabilities

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformBuildOperationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformBuildOperationIntegrationTest.groovy
@@ -856,7 +856,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
             case TASK:
                 return new TypedNodeId(nodeType: TASK, nodeIdInType: nodeIdentity.taskId.toString())
             case TRANSFORM_STEP:
-                return new TypedNodeId(nodeType: TRANSFORM_STEP, nodeIdInType: nodeIdentity.transformationNodeId)
+                return new TypedNodeId(nodeType: TRANSFORM_STEP, nodeIdInType: nodeIdentity.transformStepNodeId)
             default:
                 throw new IllegalArgumentException("Unknown node type: ${nodeIdentity.nodeType}")
         }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformBuildOperationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformBuildOperationIntegrationTest.groovy
@@ -152,7 +152,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
 
         with(executeTransformationOps[0].details) {
             verifyTransformationIdentity(plannedTransformStepIdentity, expectedTransformId)
-            transformType == "MakeGreen"
+            transformActionClass == "MakeGreen"
             sourceAttributes == [color: "blue", artifactType: "jar"]
 
             transformerName == "MakeGreen"
@@ -224,7 +224,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         def executeTransformationOps = getExecuteTransformOperations(2)
         with(executeTransformationOps[0].details) {
             verifyTransformationIdentity(plannedTransformStepIdentity, expectedTransformId1)
-            transformType == "MakeColor"
+            transformActionClass == "MakeColor"
             sourceAttributes == [color: "blue", artifactType: "jar"]
 
             transformerName == "MakeColor"
@@ -233,7 +233,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
 
         with(executeTransformationOps[1].details) {
             verifyTransformationIdentity(plannedTransformStepIdentity, expectedTransformId2)
-            transformType == "MakeColor"
+            transformActionClass == "MakeColor"
             sourceAttributes == [color: "red", artifactType: "jar"]
 
             transformerName == "MakeColor"
@@ -306,7 +306,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
 
         with(executeTransformationOps[0].details) {
             verifyTransformationIdentity(plannedTransformStepIdentity, expectedTransformId1)
-            transformType == "MakeRed"
+            transformActionClass == "MakeRed"
             sourceAttributes == [color: "blue", artifactType: "jar"]
 
             transformerName == "MakeRed"
@@ -315,7 +315,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
 
         with(executeTransformationOps[1].details) {
             verifyTransformationIdentity(plannedTransformStepIdentity, expectedTransformId2)
-            transformType == "MakeGreen"
+            transformActionClass == "MakeGreen"
             sourceAttributes == [color: "blue", artifactType: "jar"]
 
             transformerName == "MakeGreen"
@@ -383,7 +383,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
 
         with(buildOperations.only(ExecutePlannedTransformStepBuildOperationType).details) {
             verifyTransformationIdentity(plannedTransformStepIdentity, expectedTransformId1)
-            transformType == "MakeGreen"
+            transformActionClass == "MakeGreen"
             sourceAttributes == [color: "blue", artifactType: "jar"]
 
             transformerName == "MakeGreen"
@@ -457,7 +457,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         def executeTransformationOps = getExecuteTransformOperations(2)
         with(executeTransformationOps[0].details) {
             verifyTransformationIdentity(plannedTransformStepIdentity, expectedTransformId1)
-            transformType == "MakeRed"
+            transformActionClass == "MakeRed"
             sourceAttributes == [color: "blue", artifactType: "jar"]
 
             transformerName == "MakeRed"
@@ -466,7 +466,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
 
         with(executeTransformationOps[1].details) {
             verifyTransformationIdentity(plannedTransformStepIdentity, expectedTransformId2)
-            transformType == "MakeGreen"
+            transformActionClass == "MakeGreen"
             sourceAttributes == [color: "red", artifactType: "jar"]
 
             transformerName == "MakeGreen"
@@ -579,7 +579,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         def executeTransformationOps = getExecuteTransformOperations(2)
         with(executeTransformationOps[0].details) {
             verifyTransformationIdentity(plannedTransformStepIdentity, expectedTransformId1)
-            transformType == "MakeColor"
+            transformActionClass == "MakeColor"
             sourceAttributes == [color: "blue", artifactType: "jar"]
 
             transformerName == "MakeColor"
@@ -588,7 +588,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
 
         with(executeTransformationOps[1].details) {
             verifyTransformationIdentity(plannedTransformStepIdentity, expectedTransformId2)
-            transformType == "MakeColor"
+            transformActionClass == "MakeColor"
             sourceAttributes == [color: "red", artifactType: "jar"]
 
             transformerName == "MakeColor"
@@ -707,13 +707,13 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         def executeTransformationOps = getExecuteTransformOperations(2)
         // Order of scheduling/execution is not guaranteed between the transforms
         checkExecuteTransformOperation(executeTransformationOps, expectedTransformId1, [
-            transformType: "MakeGreen",
+            transformActionClass: "MakeGreen",
             sourceAttributes: [color: "blue", artifactType: "jar"],
             transformerName: "MakeGreen",
             subjectName: "producer.out1.jar (project :producer)",
         ])
         checkExecuteTransformOperation(executeTransformationOps, expectedTransformId2, [
-            transformType: "MakeGreen",
+            transformActionClass: "MakeGreen",
             sourceAttributes: [color: "blue", artifactType: "jar"],
             transformerName: "MakeGreen",
             subjectName: "producer.out2.jar (project :producer)",
@@ -792,7 +792,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
 
         with(executeTransformationOp.details) {
             verifyTransformationIdentity(plannedTransformStepIdentity, expectedTransformId1)
-            transformType == "MakeGreen"
+            transformActionClass == "MakeGreen"
             sourceAttributes == [color: "blue", artifactType: "jar"]
 
             transformerName == "MakeGreen"
@@ -914,7 +914,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         def operation = matchedOperations[0]
 
         verifyAll(operation.details) {
-            transformType == expectedDetails.transformType
+            transformActionClass == expectedDetails.transformActionClass
             sourceAttributes == expectedDetails.sourceAttributes
 
             transformerName == expectedDetails.transformerName

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.integtests.resolve.transform
 
-import org.gradle.api.internal.artifacts.transform.ExecuteScheduledTransformationStepBuildOperationType
+import org.gradle.api.internal.artifacts.transform.ExecutePlannedTransformStepBuildOperationType
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
@@ -2639,14 +2639,14 @@ Found the following transforms:
         outputContains("After transformer FileSizer on lib.jar (project :lib)")
 
         and:
-        def executeTransformationOp = buildOperations.only(ExecuteScheduledTransformationStepBuildOperationType)
+        def executeTransformationOp = buildOperations.only(ExecutePlannedTransformStepBuildOperationType)
         executeTransformationOp.failure == null
         executeTransformationOp.displayName == "Transform lib.jar (project :lib) with FileSizer"
         with(executeTransformationOp.details) {
             transformerName == "FileSizer"
             subjectName == "lib.jar (project :lib)"
-            with(transformationIdentity) {
-                nodeType == "ARTIFACT_TRANSFORM"
+            with(plannedTransformStepIdentity) {
+                nodeType == "TRANSFORM_STEP"
                 buildPath == ":"
                 projectPath == ":app"
                 componentId == [buildPath: ":", projectPath: ":lib"]
@@ -2712,14 +2712,14 @@ Found the following transforms:
         outputContains("After transformer BrokenTransform on lib.jar (project :lib)")
 
         and:
-        def executeTransformationOp = buildOperations.only(ExecuteScheduledTransformationStepBuildOperationType)
+        def executeTransformationOp = buildOperations.only(ExecutePlannedTransformStepBuildOperationType)
         executeTransformationOp.failure != null
         executeTransformationOp.displayName == "Transform lib.jar (project :lib) with BrokenTransform"
         with(executeTransformationOp.details) {
             transformerName == "BrokenTransform"
             subjectName == "lib.jar (project :lib)"
-            with(transformationIdentity) {
-                nodeType == "ARTIFACT_TRANSFORM"
+            with(plannedTransformStepIdentity) {
+                nodeType == "TRANSFORM_STEP"
                 buildPath == ":"
                 projectPath == ":app"
                 componentId == [buildPath: ":", projectPath: ":lib"]

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -2647,8 +2647,8 @@ Found the following transforms:
             subjectName == "lib.jar (project :lib)"
             with(plannedTransformStepIdentity) {
                 nodeType == "TRANSFORM_STEP"
-                buildPath == ":"
-                projectPath == ":app"
+                consumerBuildPath == ":"
+                consumerProjectPath == ":app"
                 componentId == [buildPath: ":", projectPath: ":lib"]
                 targetAttributes == [artifactType: "size", usage: "api"]
                 capabilities == [[group: "root", name: "lib", version: "unspecified"]]
@@ -2720,8 +2720,8 @@ Found the following transforms:
             subjectName == "lib.jar (project :lib)"
             with(plannedTransformStepIdentity) {
                 nodeType == "TRANSFORM_STEP"
-                buildPath == ":"
-                projectPath == ":app"
+                consumerBuildPath == ":"
+                consumerProjectPath == ":app"
                 componentId == [buildPath: ":", projectPath: ":lib"]
                 targetAttributes == [artifactType: "size", usage: "api"]
                 capabilities == [[group: "root", name: "lib", version: "unspecified"]]

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -16,12 +16,12 @@
 
 package org.gradle.integtests.resolve.transform
 
-import org.gradle.api.internal.artifacts.transform.ExecutePlannedTransformStepBuildOperationType
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import org.gradle.internal.file.FileType
+import org.gradle.operations.dependencies.transforms.ExecutePlannedTransformStepBuildOperationType
 import org.gradle.test.fixtures.maven.MavenFileRepository
 import org.hamcrest.Matcher
 import spock.lang.Issue

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -2655,7 +2655,7 @@ Found the following transforms:
                 artifactName == "lib.jar"
                 dependenciesConfigurationIdentity == null
             }
-            transformType == "FileSizer"
+            transformActionClass == "FileSizer"
             sourceAttributes == [artifactType: "jar", usage: "api"]
         }
     }
@@ -2728,7 +2728,7 @@ Found the following transforms:
                 artifactName == "lib.jar"
                 dependenciesConfigurationIdentity == null
             }
-            transformType == "BrokenTransform"
+            transformActionClass == "BrokenTransform"
             sourceAttributes == [artifactType: "jar", usage: "api"]
         }
     }
@@ -2822,6 +2822,6 @@ Found the following transforms:
                     println "capabilities: " + artifacts.collect { it.variant.capabilities }
                 }
             }
-"""
+        """
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGradleUserHomeScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGradleUserHomeScopeServices.java
@@ -22,7 +22,7 @@ import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.artifacts.ivyservice.ArtifactCachesProvider;
 import org.gradle.api.internal.artifacts.ivyservice.DefaultArtifactCaches;
 import org.gradle.api.internal.artifacts.transform.ImmutableTransformationWorkspaceServices;
-import org.gradle.api.internal.artifacts.transform.ToPlannedTransformConverter;
+import org.gradle.api.internal.artifacts.transform.ToPlannedTransformStepConverter;
 import org.gradle.api.internal.cache.CacheConfigurationsInternal;
 import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.api.internal.changedetection.state.DefaultExecutionHistoryCacheAccess;
@@ -43,8 +43,8 @@ import org.gradle.internal.hash.ClassLoaderHierarchyHasher;
 
 public class DependencyManagementGradleUserHomeScopeServices {
 
-    ToPlannedNodeConverter createToPlannedTransformConverter() {
-        return new ToPlannedTransformConverter();
+    ToPlannedNodeConverter createToPlannedTransformStepConverter() {
+        return new ToPlannedTransformStepConverter();
     }
 
     DefaultArtifactCaches.WritableArtifactCacheLockingParameters createWritableArtifactCacheLockingParameters(FileAccessTimeJournal fileAccessTimeJournal, UsedGradleVersions usedGradleVersions) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -136,6 +136,7 @@ import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resolve.ModuleVersionNotFoundException;
 import org.gradle.internal.typeconversion.NotationParser;
 import org.gradle.internal.work.WorkerThreadRegistry;
+import org.gradle.operations.dependencies.configurations.ConfigurationIdentity;
 import org.gradle.util.Path;
 import org.gradle.util.internal.CollectionUtils;
 import org.gradle.util.internal.ConfigureUtil;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultExtraExecutionGraphDependenciesResolverFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultExtraExecutionGraphDependenciesResolverFactory.java
@@ -19,9 +19,9 @@ package org.gradle.api.internal.artifacts.transform;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolutionResult;
 import org.gradle.api.internal.DomainObjectContext;
-import org.gradle.api.internal.artifacts.configurations.ConfigurationIdentity;
 import org.gradle.api.internal.artifacts.configurations.ResolutionResultProvider;
 import org.gradle.internal.model.CalculatedValueContainerFactory;
+import org.gradle.operations.dependencies.configurations.ConfigurationIdentity;
 
 public class DefaultExtraExecutionGraphDependenciesResolverFactory implements ExtraExecutionGraphDependenciesResolverFactory {
     public static final TransformUpstreamDependenciesResolver NO_DEPENDENCIES_RESOLVER = transformationStep -> DefaultTransformUpstreamDependenciesResolver.NO_DEPENDENCIES;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultPlannedTransformStep.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultPlannedTransformStep.java
@@ -24,22 +24,22 @@ import java.util.List;
 /**
  * A {@link CalculateTaskGraphBuildOperationType.PlannedNode} for a {@link TransformationNode}.
  */
-public class DefaultPlannedTransform implements CalculateTaskGraphBuildOperationType.PlannedNode {
+public class DefaultPlannedTransformStep implements CalculateTaskGraphBuildOperationType.PlannedNode {
 
-    private final TransformationIdentity transformationIdentity;
+    private final PlannedTransformStepIdentity identity;
     private final List<? extends NodeIdentity> dependencies;
 
-    public DefaultPlannedTransform(
-        TransformationIdentity transformationIdentity,
+    public DefaultPlannedTransformStep(
+        PlannedTransformStepIdentity identity,
         List<? extends NodeIdentity> dependencies
     ) {
-        this.transformationIdentity = transformationIdentity;
+        this.identity = identity;
         this.dependencies = dependencies;
     }
 
     @Override
-    public TransformationIdentity getNodeIdentity() {
-        return transformationIdentity;
+    public PlannedTransformStepIdentity getNodeIdentity() {
+        return identity;
     }
 
     @Override
@@ -49,6 +49,6 @@ public class DefaultPlannedTransform implements CalculateTaskGraphBuildOperation
 
     @Override
     public String toString() {
-        return transformationIdentity.toString();
+        return identity.toString();
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultPlannedTransformStep.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultPlannedTransformStep.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.transform;
 
 import org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType;
 import org.gradle.internal.taskgraph.NodeIdentity;
+import org.gradle.operations.dependencies.transforms.PlannedTransformStepIdentity;
 
 import java.util.List;
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformUpstreamDependenciesResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformUpstreamDependenciesResolver.java
@@ -25,7 +25,6 @@ import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.artifacts.result.ResolvedDependencyResult;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.DomainObjectContext;
-import org.gradle.api.internal.artifacts.configurations.ConfigurationIdentity;
 import org.gradle.api.internal.artifacts.configurations.ResolutionResultProvider;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.file.FileCollectionInternal;
@@ -42,6 +41,7 @@ import org.gradle.internal.Try;
 import org.gradle.internal.model.CalculatedValueContainer;
 import org.gradle.internal.model.CalculatedValueContainerFactory;
 import org.gradle.internal.model.ValueCalculator;
+import org.gradle.operations.dependencies.configurations.ConfigurationIdentity;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ExecutePlannedTransformStepBuildOperationDetails.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ExecutePlannedTransformStepBuildOperationDetails.java
@@ -21,13 +21,13 @@ import org.gradle.internal.operations.trace.CustomOperationTraceSerialization;
 
 import java.util.Map;
 
-public class ExecuteScheduledTransformationStepBuildOperationDetails implements ExecuteScheduledTransformationStepBuildOperationType.Details, CustomOperationTraceSerialization {
+public class ExecutePlannedTransformStepBuildOperationDetails implements ExecutePlannedTransformStepBuildOperationType.Details, CustomOperationTraceSerialization {
 
     private final TransformationNode transformationNode;
     private final String transformerName;
     private final String subjectName;
 
-    public ExecuteScheduledTransformationStepBuildOperationDetails(TransformationNode transformationNode, String transformerName, String subjectName) {
+    public ExecutePlannedTransformStepBuildOperationDetails(TransformationNode transformationNode, String transformerName, String subjectName) {
         this.transformationNode = transformationNode;
         this.transformerName = transformerName;
         this.subjectName = subjectName;
@@ -38,7 +38,7 @@ public class ExecuteScheduledTransformationStepBuildOperationDetails implements 
     }
 
     @Override
-    public TransformationIdentity getTransformationIdentity() {
+    public PlannedTransformStepIdentity getPlannedTransformStepIdentity() {
         return transformationNode.getNodeIdentity();
     }
 
@@ -65,7 +65,7 @@ public class ExecuteScheduledTransformationStepBuildOperationDetails implements 
     @Override
     public Object getCustomOperationTraceSerializableModel() {
         ImmutableMap.Builder<String, Object> builder = new ImmutableMap.Builder<>();
-        builder.put("transformationIdentity", getTransformationIdentity());
+        builder.put("plannedTransformStepIdentity", getPlannedTransformStepIdentity());
         builder.put("sourceAttributes", getSourceAttributes());
         builder.put("transformType", getTransformType());
         builder.put("transformerName", transformerName);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ExecutePlannedTransformStepBuildOperationDetails.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ExecutePlannedTransformStepBuildOperationDetails.java
@@ -48,7 +48,7 @@ public class ExecutePlannedTransformStepBuildOperationDetails implements Execute
     }
 
     @Override
-    public Class<?> getTransformType() {
+    public Class<?> getTransformActionClass() {
         return transformationNode.getTransformationStep().getTransformer().getImplementationClass();
     }
 
@@ -67,7 +67,7 @@ public class ExecutePlannedTransformStepBuildOperationDetails implements Execute
         ImmutableMap.Builder<String, Object> builder = new ImmutableMap.Builder<>();
         builder.put("plannedTransformStepIdentity", getPlannedTransformStepIdentity());
         builder.put("sourceAttributes", getSourceAttributes());
-        builder.put("transformType", getTransformType());
+        builder.put("transformActionClass", getTransformActionClass());
         builder.put("transformerName", transformerName);
         builder.put("subjectName", subjectName);
         return builder.build();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ExecutePlannedTransformStepBuildOperationDetails.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ExecutePlannedTransformStepBuildOperationDetails.java
@@ -18,6 +18,8 @@ package org.gradle.api.internal.artifacts.transform;
 
 import com.google.common.collect.ImmutableMap;
 import org.gradle.internal.operations.trace.CustomOperationTraceSerialization;
+import org.gradle.operations.dependencies.transforms.ExecutePlannedTransformStepBuildOperationType;
+import org.gradle.operations.dependencies.transforms.PlannedTransformStepIdentity;
 
 import java.util.Map;
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ToPlannedTransformStepConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ToPlannedTransformStepConverter.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.transform;
 import org.gradle.execution.plan.Node;
 import org.gradle.execution.plan.ToPlannedNodeConverter;
 import org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType;
+import org.gradle.operations.dependencies.transforms.PlannedTransformStepIdentity;
 
 /**
  * A converter from {@link TransformationNode} to {@link CalculateTaskGraphBuildOperationType.PlannedNode}.

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ToPlannedTransformStepConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ToPlannedTransformStepConverter.java
@@ -18,13 +18,12 @@ package org.gradle.api.internal.artifacts.transform;
 
 import org.gradle.execution.plan.Node;
 import org.gradle.execution.plan.ToPlannedNodeConverter;
-import org.gradle.execution.plan.ToPlannedTaskConverter;
 import org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType;
 
 /**
- * A {@link ToPlannedTaskConverter} for {@link TransformationNode}s.
+ * A converter from {@link TransformationNode} to {@link CalculateTaskGraphBuildOperationType.PlannedNode}.
  */
-public class ToPlannedTransformConverter implements ToPlannedNodeConverter {
+public class ToPlannedTransformStepConverter implements ToPlannedNodeConverter {
 
     @Override
     public Class<? extends Node> getSupportedNodeType() {
@@ -32,7 +31,7 @@ public class ToPlannedTransformConverter implements ToPlannedNodeConverter {
     }
 
     @Override
-    public TransformationIdentity getNodeIdentity(Node node) {
+    public PlannedTransformStepIdentity getNodeIdentity(Node node) {
         TransformationNode transformationNode = (TransformationNode) node;
         return transformationNode.getNodeIdentity();
     }
@@ -45,7 +44,7 @@ public class ToPlannedTransformConverter implements ToPlannedNodeConverter {
     @Override
     public CalculateTaskGraphBuildOperationType.PlannedNode convert(Node node, DependencyLookup dependencyLookup) {
         TransformationNode transformationNode = (TransformationNode) node;
-        return new DefaultPlannedTransform(
+        return new DefaultPlannedTransformStep(
             transformationNode.getNodeIdentity(),
             dependencyLookup.findNodeDependencies(transformationNode)
         );
@@ -53,6 +52,6 @@ public class ToPlannedTransformConverter implements ToPlannedNodeConverter {
 
     @Override
     public String toString() {
-        return "ToPlannedTransformConverter(" + getSupportedNodeType().getSimpleName() + ")";
+        return "ToPlannedTransformStepConverter(" + getSupportedNodeType().getSimpleName() + ")";
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformUpstreamDependencies.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformUpstreamDependencies.java
@@ -17,9 +17,9 @@
 package org.gradle.api.internal.artifacts.transform;
 
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.internal.artifacts.configurations.ConfigurationIdentity;
 import org.gradle.api.internal.tasks.TaskDependencyContainer;
 import org.gradle.internal.Try;
+import org.gradle.operations.dependencies.configurations.ConfigurationIdentity;
 
 import javax.annotation.Nullable;
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNode.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNode.java
@@ -21,12 +21,8 @@ import org.gradle.api.artifacts.ResolveException;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
-import org.gradle.api.internal.artifacts.component.ComponentIdentifier;
-import org.gradle.api.internal.artifacts.component.OpaqueComponentIdentifier;
-import org.gradle.api.internal.artifacts.configurations.ConfigurationIdentity;
 import org.gradle.api.internal.artifacts.ivyservice.DefaultLenientConfiguration;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
-import org.gradle.api.internal.capabilities.Capability;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.tasks.NodeExecutionContext;
 import org.gradle.api.internal.tasks.TaskDependencyContainer;
@@ -46,6 +42,12 @@ import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.CallableBuildOperation;
 import org.gradle.internal.scan.UsedByScanPlugin;
+import org.gradle.operations.dependencies.configurations.ConfigurationIdentity;
+import org.gradle.operations.dependencies.transforms.ExecutePlannedTransformStepBuildOperationType;
+import org.gradle.operations.dependencies.transforms.PlannedTransformStepIdentity;
+import org.gradle.operations.dependencies.variants.Capability;
+import org.gradle.operations.dependencies.variants.ComponentIdentifier;
+import org.gradle.operations.dependencies.variants.OpaqueComponentIdentifier;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -215,7 +217,7 @@ public abstract class TransformationNode extends CreationOrderedNode implements 
     private static ComponentIdentifier getComponentIdentifier(org.gradle.api.artifacts.component.ComponentIdentifier componentId) {
         if (componentId instanceof ProjectComponentIdentifier) {
             ProjectComponentIdentifier projectComponentIdentifier = (ProjectComponentIdentifier) componentId;
-            return new org.gradle.api.internal.artifacts.component.ProjectComponentIdentifier() {
+            return new org.gradle.operations.dependencies.variants.ProjectComponentIdentifier() {
                 @Override
                 public String getBuildPath() {
                     return projectComponentIdentifier.getBuild().getName();
@@ -233,7 +235,7 @@ public abstract class TransformationNode extends CreationOrderedNode implements 
             };
         } else if (componentId instanceof ModuleComponentIdentifier) {
             ModuleComponentIdentifier moduleComponentIdentifier = (ModuleComponentIdentifier) componentId;
-            return new org.gradle.api.internal.artifacts.component.ModuleComponentIdentifier() {
+            return new org.gradle.operations.dependencies.variants.ModuleComponentIdentifier() {
                 @Override
                 public String getGroup() {
                     return moduleComponentIdentifier.getGroup();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNode.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNode.java
@@ -66,7 +66,7 @@ public abstract class TransformationNode extends CreationOrderedNode implements 
     protected final TransformUpstreamDependencies upstreamDependencies;
     private final long transformationNodeId;
 
-    private TransformationIdentity cachedIdentity;
+    private PlannedTransformStepIdentity cachedIdentity;
 
     public static ChainedTransformationNode chained(
         ComponentVariantIdentifier targetComponentVariant,
@@ -119,14 +119,14 @@ public abstract class TransformationNode extends CreationOrderedNode implements 
         return sourceAttributes;
     }
 
-    public TransformationIdentity getNodeIdentity() {
+    public PlannedTransformStepIdentity getNodeIdentity() {
         if (cachedIdentity == null) {
             cachedIdentity = createIdentity();
         }
         return cachedIdentity;
     }
 
-    private TransformationIdentity createIdentity() {
+    private PlannedTransformStepIdentity createIdentity() {
         String consumerBuildPath = transformationStep.getOwningProject().getBuildPath().toString();
         String consumerProjectPath = transformationStep.getOwningProject().getIdentityPath().toString();
         ComponentIdentifier componentId = getComponentIdentifier(targetComponentVariant.getComponentId());
@@ -135,10 +135,10 @@ public abstract class TransformationNode extends CreationOrderedNode implements 
             .map(TransformationNode::convertCapability)
             .collect(Collectors.toList());
 
-        return new TransformationIdentity() {
+        return new PlannedTransformStepIdentity() {
             @Override
             public NodeType getNodeType() {
-                return NodeType.ARTIFACT_TRANSFORM;
+                return NodeType.TRANSFORM_STEP;
             }
 
             @Override
@@ -483,7 +483,7 @@ public abstract class TransformationNode extends CreationOrderedNode implements 
             return BuildOperationDescriptor.displayName("Transform " + basicName)
                 .progressDisplayName(TRANSFORMING_PROGRESS_PREFIX + basicName)
                 .metadata(BuildOperationCategory.TRANSFORM)
-                .details(new ExecuteScheduledTransformationStepBuildOperationDetails(TransformationNode.this, transformerName, subjectName));
+                .details(new ExecutePlannedTransformStepBuildOperationDetails(TransformationNode.this, transformerName, subjectName));
         }
 
         protected abstract String describeSubject();
@@ -497,7 +497,7 @@ public abstract class TransformationNode extends CreationOrderedNode implements 
         protected abstract TransformationSubject transform();
     }
 
-    private static final ExecuteScheduledTransformationStepBuildOperationType.Result RESULT = new ExecuteScheduledTransformationStepBuildOperationType.Result() {
+    private static final ExecutePlannedTransformStepBuildOperationType.Result RESULT = new ExecutePlannedTransformStepBuildOperationType.Result() {
     };
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNode.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNode.java
@@ -142,12 +142,12 @@ public abstract class TransformationNode extends CreationOrderedNode implements 
             }
 
             @Override
-            public String getBuildPath() {
+            public String getConsumerBuildPath() {
                 return consumerBuildPath;
             }
 
             @Override
-            public String getProjectPath() {
+            public String getConsumerProjectPath() {
                 return consumerProjectPath;
             }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNode.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNode.java
@@ -177,7 +177,7 @@ public abstract class TransformationNode extends CreationOrderedNode implements 
             }
 
             @Override
-            public long getTransformationNodeId() {
+            public long getTransformStepNodeId() {
                 return transformationNodeId;
             }
 

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/api/internal/artifacts/transform/ExecutePlannedTransformStepBuildOperationType.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/api/internal/artifacts/transform/ExecutePlannedTransformStepBuildOperationType.java
@@ -27,14 +27,14 @@ import java.util.Map;
  * Encompasses the execution of a transformation node.
  * A transformation node runs only one transformation step, though possibly on multiple files.
  */
-public class ExecuteScheduledTransformationStepBuildOperationType implements BuildOperationType<ExecuteScheduledTransformationStepBuildOperationType.Details, ExecuteScheduledTransformationStepBuildOperationType.Result> {
+public class ExecutePlannedTransformStepBuildOperationType implements BuildOperationType<ExecutePlannedTransformStepBuildOperationType.Details, ExecutePlannedTransformStepBuildOperationType.Result> {
 
     public interface Details {
 
         /**
          * The identity of the transformation executed in this operation.
          */
-        TransformationIdentity getTransformationIdentity();
+        PlannedTransformStepIdentity getPlannedTransformStepIdentity();
 
         /**
          * Full set of attributes of the artifact before the transformation.

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/api/internal/artifacts/transform/ExecutePlannedTransformStepBuildOperationType.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/api/internal/artifacts/transform/ExecutePlannedTransformStepBuildOperationType.java
@@ -26,6 +26,8 @@ import java.util.Map;
  * <p>
  * Encompasses the execution of a transformation node.
  * A transformation node runs only one transformation step, though possibly on multiple files.
+ *
+ * @since 8.1
  */
 public class ExecutePlannedTransformStepBuildOperationType implements BuildOperationType<ExecutePlannedTransformStepBuildOperationType.Details, ExecutePlannedTransformStepBuildOperationType.Result> {
 
@@ -42,9 +44,9 @@ public class ExecutePlannedTransformStepBuildOperationType implements BuildOpera
         Map<String, String> getSourceAttributes();
 
         /**
-         * Type of the transformer implementation used during transform registration.
+         * Class of the transformer action implementation provided as part of transform registration.
          */
-        Class<?> getTransformType();
+        Class<?> getTransformActionClass();
 
         /**
          * Returns the display name of the transformer.

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/api/internal/artifacts/transform/PlannedTransformStepIdentity.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/api/internal/artifacts/transform/PlannedTransformStepIdentity.java
@@ -30,7 +30,7 @@ import java.util.Map;
  *
  * @since 8.1
  */
-public interface TransformationIdentity extends NodeIdentity {
+public interface PlannedTransformStepIdentity extends NodeIdentity {
 
     /**
      * Path of an included build of the consumer project.

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/api/internal/artifacts/transform/PlannedTransformStepIdentity.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/api/internal/artifacts/transform/PlannedTransformStepIdentity.java
@@ -35,12 +35,12 @@ public interface PlannedTransformStepIdentity extends NodeIdentity {
     /**
      * Path of an included build of the consumer project.
      */
-    String getBuildPath();
+    String getConsumerBuildPath();
 
     /**
      * Consumer project path within the build.
      */
-    String getProjectPath();
+    String getConsumerProjectPath();
 
     /**
      * The component identifier of the transformed artifact.

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/api/internal/artifacts/transform/PlannedTransformStepIdentity.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/api/internal/artifacts/transform/PlannedTransformStepIdentity.java
@@ -80,6 +80,6 @@ public interface PlannedTransformStepIdentity extends NodeIdentity {
     /**
      * An opaque identifier distinguishes between different transformation nodes in case other identity properties are the same.
      */
-    long getTransformationNodeId();
+    long getTransformStepNodeId();
 
 }

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/internal/taskgraph/CalculateTaskGraphBuildOperationType.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/internal/taskgraph/CalculateTaskGraphBuildOperationType.java
@@ -120,7 +120,6 @@ public final class CalculateTaskGraphBuildOperationType implements BuildOperatio
          */
         List<PlannedTask> getTaskPlan();
 
-
         /**
          * Returns all identifiable nodes of requested types in the execution graph in no particular order.
          * <p>

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/internal/taskgraph/NodeIdentity.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/internal/taskgraph/NodeIdentity.java
@@ -20,6 +20,8 @@ package org.gradle.internal.taskgraph;
  * The identity of a node in the execution graph.
  * <p>
  * Needs to be unique across all the execution graphs of the current build.
+ *
+ * @since 8.1
  */
 public interface NodeIdentity {
 

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/internal/taskgraph/NodeIdentity.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/internal/taskgraph/NodeIdentity.java
@@ -25,7 +25,7 @@ public interface NodeIdentity {
 
     enum NodeType {
         TASK,
-        ARTIFACT_TRANSFORM
+        TRANSFORM_STEP
     }
 
     NodeType getNodeType();

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/operations/dependencies/configurations/ConfigurationIdentity.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/operations/dependencies/configurations/ConfigurationIdentity.java
@@ -14,12 +14,22 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.artifacts.component;
+package org.gradle.operations.dependencies.configurations;
+
+import javax.annotation.Nullable;
 
 /**
- * A marker interface for identifiers for a component instance.
- * <p>
- * There are various sub-interfaces that expose specific details about the identifier.
+ * Identifies a configuration.
+ *
+ * @since 8.1
  */
-public interface ComponentIdentifier {
+public interface ConfigurationIdentity {
+
+    String getBuildPath();
+
+    @Nullable
+    String getProjectPath();
+
+    String getName();
+
 }

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/operations/dependencies/transforms/ExecutePlannedTransformStepBuildOperationType.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/operations/dependencies/transforms/ExecutePlannedTransformStepBuildOperationType.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.artifacts.transform;
+package org.gradle.operations.dependencies.transforms;
 
 import org.gradle.internal.operations.BuildOperationType;
 import org.gradle.internal.scan.NotUsedByScanPlugin;

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/operations/dependencies/transforms/PlannedTransformStepIdentity.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/operations/dependencies/transforms/PlannedTransformStepIdentity.java
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.artifacts.transform;
+package org.gradle.operations.dependencies.transforms;
 
-import org.gradle.api.internal.artifacts.component.ComponentIdentifier;
-import org.gradle.api.internal.artifacts.configurations.ConfigurationIdentity;
-import org.gradle.api.internal.capabilities.Capability;
 import org.gradle.internal.taskgraph.NodeIdentity;
+import org.gradle.operations.dependencies.configurations.ConfigurationIdentity;
+import org.gradle.operations.dependencies.variants.Capability;
+import org.gradle.operations.dependencies.variants.ComponentIdentifier;
 
 import javax.annotation.Nullable;
 import java.util.List;

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/operations/dependencies/variants/Capability.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/operations/dependencies/variants/Capability.java
@@ -14,20 +14,21 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.artifacts.configurations;
+package org.gradle.operations.dependencies.variants;
 
 import javax.annotation.Nullable;
 
 /**
- * Identifies a configuration.
+ * A capability provided by a component.
+ *
+ * @since 8.1
  */
-public interface ConfigurationIdentity {
+public interface Capability {
 
-    String getBuildPath();
-
-    @Nullable
-    String getProjectPath();
+    String getGroup();
 
     String getName();
 
+    @Nullable
+    String getVersion();
 }

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/operations/dependencies/variants/ComponentIdentifier.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/operations/dependencies/variants/ComponentIdentifier.java
@@ -14,21 +14,14 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.capabilities;
-
-import javax.annotation.Nullable;
+package org.gradle.operations.dependencies.variants;
 
 /**
- * A capability provided by a component.
+ * A marker interface for identifiers for a component instance.
+ * <p>
+ * There are various sub-interfaces that expose specific details about the identifier.
  *
  * @since 8.1
  */
-public interface Capability {
-
-    String getGroup();
-
-    String getName();
-
-    @Nullable
-    String getVersion();
+public interface ComponentIdentifier {
 }

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/operations/dependencies/variants/ModuleComponentIdentifier.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/operations/dependencies/variants/ModuleComponentIdentifier.java
@@ -14,15 +14,19 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.artifacts.component;
+package org.gradle.operations.dependencies.variants;
 
 /**
- * An opaque immutable identifier for a component instance.
- */
-public interface OpaqueComponentIdentifier extends ComponentIdentifier {
+ * An identifier for a component instance which is available as a module version.
+ *
+ * @since 8.1
+ **/
+public interface ModuleComponentIdentifier extends ComponentIdentifier {
 
-    String getDisplayName();
+    String getGroup();
 
-    String getClassName();
+    String getModule();
+
+    String getVersion();
 
 }

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/operations/dependencies/variants/OpaqueComponentIdentifier.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/operations/dependencies/variants/OpaqueComponentIdentifier.java
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.artifacts.component;
+package org.gradle.operations.dependencies.variants;
 
 /**
- * An identifier for a component instance which is available as a module version.
- **/
-public interface ModuleComponentIdentifier extends ComponentIdentifier {
+ * An opaque immutable identifier for a component instance.
+ *
+ * @since 8.1
+ */
+public interface OpaqueComponentIdentifier extends ComponentIdentifier {
 
-    String getGroup();
+    String getDisplayName();
 
-    String getModule();
-
-    String getVersion();
+    String getClassName();
 
 }

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/operations/dependencies/variants/ProjectComponentIdentifier.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/operations/dependencies/variants/ProjectComponentIdentifier.java
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.artifacts.component;
+package org.gradle.operations.dependencies.variants;
 
 /**
  * An identifier for a component instance that is built as part of the current build.
+ *
+ * @since 8.1
  */
 public interface ProjectComponentIdentifier extends ComponentIdentifier {
 

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TransformOperationMapper.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TransformOperationMapper.java
@@ -16,7 +16,7 @@
 
 package org.gradle.tooling.internal.provider.runner;
 
-import org.gradle.api.internal.artifacts.transform.ExecuteScheduledTransformationStepBuildOperationDetails;
+import org.gradle.api.internal.artifacts.transform.ExecutePlannedTransformStepBuildOperationDetails;
 import org.gradle.api.internal.artifacts.transform.TransformationNode;
 import org.gradle.execution.plan.Node;
 import org.gradle.internal.build.event.BuildEventSubscriptions;
@@ -44,7 +44,7 @@ import static org.gradle.tooling.internal.provider.runner.ClientForwardingBuildO
  *
  * @since 5.1
  */
-class TransformOperationMapper implements BuildOperationMapper<ExecuteScheduledTransformationStepBuildOperationDetails, DefaultTransformDescriptor>, OperationDependencyLookup {
+class TransformOperationMapper implements BuildOperationMapper<ExecutePlannedTransformStepBuildOperationDetails, DefaultTransformDescriptor>, OperationDependencyLookup {
     private final Map<TransformationNode, DefaultTransformDescriptor> descriptors = new ConcurrentHashMap<>();
     private final OperationDependenciesResolver operationDependenciesResolver;
 
@@ -58,8 +58,8 @@ class TransformOperationMapper implements BuildOperationMapper<ExecuteScheduledT
     }
 
     @Override
-    public Class<ExecuteScheduledTransformationStepBuildOperationDetails> getDetailsType() {
-        return ExecuteScheduledTransformationStepBuildOperationDetails.class;
+    public Class<ExecutePlannedTransformStepBuildOperationDetails> getDetailsType() {
+        return ExecutePlannedTransformStepBuildOperationDetails.class;
     }
 
     @Override
@@ -71,7 +71,7 @@ class TransformOperationMapper implements BuildOperationMapper<ExecuteScheduledT
     }
 
     @Override
-    public DefaultTransformDescriptor createDescriptor(ExecuteScheduledTransformationStepBuildOperationDetails details, BuildOperationDescriptor buildOperation, @Nullable OperationIdentifier parent) {
+    public DefaultTransformDescriptor createDescriptor(ExecutePlannedTransformStepBuildOperationDetails details, BuildOperationDescriptor buildOperation, @Nullable OperationIdentifier parent) {
         OperationIdentifier id = buildOperation.getId();
         String displayName = buildOperation.getDisplayName();
         String transformerName = details.getTransformerName();
@@ -83,12 +83,12 @@ class TransformOperationMapper implements BuildOperationMapper<ExecuteScheduledT
     }
 
     @Override
-    public InternalOperationStartedProgressEvent createStartedEvent(DefaultTransformDescriptor descriptor, ExecuteScheduledTransformationStepBuildOperationDetails executeScheduledTransformationStepBuildOperationDetails, OperationStartEvent startEvent) {
+    public InternalOperationStartedProgressEvent createStartedEvent(DefaultTransformDescriptor descriptor, ExecutePlannedTransformStepBuildOperationDetails details, OperationStartEvent startEvent) {
         return new DefaultOperationStartedProgressEvent(startEvent.getStartTime(), descriptor);
     }
 
     @Override
-    public InternalOperationFinishedProgressEvent createFinishedEvent(DefaultTransformDescriptor descriptor, ExecuteScheduledTransformationStepBuildOperationDetails executeScheduledTransformationStepBuildOperationDetails, OperationFinishEvent finishEvent) {
+    public InternalOperationFinishedProgressEvent createFinishedEvent(DefaultTransformDescriptor descriptor, ExecutePlannedTransformStepBuildOperationDetails details, OperationFinishEvent finishEvent) {
         return new DefaultOperationFinishedProgressEvent(finishEvent.getEndTime(), descriptor, toOperationResult(finishEvent));
     }
 }


### PR DESCRIPTION
Follow up for
- https://github.com/gradle/gradle/pull/23592

New build operations introduced as part of Gradle 8.1 are working primarily with the concept of "transform step". The actual classes that represent various aspects of it use this name, but also align in the naming with other similar classes.

- `PlannedTransformStepIdentity`
- `ExecutePlannedTransformStepBuildOperationType`
- `ToPlannedTransformStepConverter`
