### PR TITLE
Move sourceAttributes to PlannedTransformStepIdentity

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformBuildOperationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformBuildOperationIntegrationTest.groovy
@@ -51,6 +51,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         String consumerBuildPath
         String consumerProjectPath
         Map<String, String> componentId
+        Map<String, String> sourceAttributes
         Map<String, String> targetAttributes
         List<Map<String, String>> capabilities
         String artifactName
@@ -133,6 +134,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
             consumerBuildPath: ":",
             consumerProjectPath: ":consumer",
             componentId: [buildPath: ":", projectPath: ":producer"],
+            sourceAttributes: [color: "blue", artifactType: "jar"],
             targetAttributes: [color: "green", artifactType: "jar"],
             capabilities: [[group: "colored", name: "producer", version: "unspecified"]],
             artifactName: "producer.jar",
@@ -153,7 +155,6 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         with(executeTransformationOps[0].details) {
             verifyTransformationIdentity(plannedTransformStepIdentity, expectedTransformId)
             transformActionClass == "MakeGreen"
-            sourceAttributes == [color: "blue", artifactType: "jar"]
 
             transformerName == "MakeGreen"
             subjectName == "producer.jar (project :producer)"
@@ -195,6 +196,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
             consumerBuildPath: ":",
             consumerProjectPath: ":consumer",
             componentId: [buildPath: ":", projectPath: ":producer"],
+            sourceAttributes: [color: "blue", artifactType: "jar"],
             targetAttributes: [color: "red", artifactType: "jar"],
             capabilities: [[group: "colored", name: "producer", version: "unspecified"]],
             artifactName: "producer.jar",
@@ -205,6 +207,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
             consumerBuildPath: ":",
             consumerProjectPath: ":consumer",
             componentId: [buildPath: ":", projectPath: ":producer"],
+            sourceAttributes: [color: "red", artifactType: "jar"],
             targetAttributes: [color: "green", artifactType: "jar"],
             capabilities: [[group: "colored", name: "producer", version: "unspecified"]],
             artifactName: "producer.jar",
@@ -225,7 +228,6 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         with(executeTransformationOps[0].details) {
             verifyTransformationIdentity(plannedTransformStepIdentity, expectedTransformId1)
             transformActionClass == "MakeColor"
-            sourceAttributes == [color: "blue", artifactType: "jar"]
 
             transformerName == "MakeColor"
             subjectName == "producer.jar (project :producer)"
@@ -234,7 +236,6 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         with(executeTransformationOps[1].details) {
             verifyTransformationIdentity(plannedTransformStepIdentity, expectedTransformId2)
             transformActionClass == "MakeColor"
-            sourceAttributes == [color: "red", artifactType: "jar"]
 
             transformerName == "MakeColor"
             subjectName == "producer.jar (project :producer)"
@@ -276,6 +277,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
             consumerBuildPath: ":",
             consumerProjectPath: ":consumer",
             componentId: [buildPath: ":", projectPath: ":producer"],
+            sourceAttributes: [color: "blue", artifactType: "jar"],
             targetAttributes: [color: "red", artifactType: "jar"],
             capabilities: [[group: "colored", name: "producer", version: "unspecified"]],
             artifactName: "producer.jar",
@@ -286,6 +288,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
             consumerBuildPath: ":",
             consumerProjectPath: ":consumer",
             componentId: [buildPath: ":", projectPath: ":producer"],
+            sourceAttributes: [color: "blue", artifactType: "jar"],
             targetAttributes: [color: "green", artifactType: "jar"],
             capabilities: [[group: "colored", name: "producer", version: "unspecified"]],
             artifactName: "producer.jar",
@@ -307,7 +310,6 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         with(executeTransformationOps[0].details) {
             verifyTransformationIdentity(plannedTransformStepIdentity, expectedTransformId1)
             transformActionClass == "MakeRed"
-            sourceAttributes == [color: "blue", artifactType: "jar"]
 
             transformerName == "MakeRed"
             subjectName == "producer.jar (project :producer)"
@@ -316,7 +318,6 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         with(executeTransformationOps[1].details) {
             verifyTransformationIdentity(plannedTransformStepIdentity, expectedTransformId2)
             transformActionClass == "MakeGreen"
-            sourceAttributes == [color: "blue", artifactType: "jar"]
 
             transformerName == "MakeGreen"
             subjectName == "producer.jar (project :producer)"
@@ -366,6 +367,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
             consumerBuildPath: ":",
             consumerProjectPath: ":consumer",
             componentId: [buildPath: ":", projectPath: ":producer"],
+            sourceAttributes: [color: "blue", artifactType: "jar"],
             targetAttributes: [color: "green", artifactType: "jar"],
             capabilities: [[group: "colored", name: "producer", version: "unspecified"]],
             artifactName: "producer.jar",
@@ -384,7 +386,6 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         with(buildOperations.only(ExecutePlannedTransformStepBuildOperationType).details) {
             verifyTransformationIdentity(plannedTransformStepIdentity, expectedTransformId1)
             transformActionClass == "MakeGreen"
-            sourceAttributes == [color: "blue", artifactType: "jar"]
 
             transformerName == "MakeGreen"
             subjectName == "producer.jar (project :producer)"
@@ -428,6 +429,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
             consumerBuildPath: ":",
             consumerProjectPath: ":consumer",
             componentId: [buildPath: ":", projectPath: ":producer"],
+            sourceAttributes: [color: "blue", artifactType: "jar"],
             targetAttributes: [color: "red", artifactType: "jar"],
             capabilities: [[group: "colored", name: "producer", version: "unspecified"]],
             artifactName: "producer.jar",
@@ -438,6 +440,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
             consumerBuildPath: ":",
             consumerProjectPath: ":consumer",
             componentId: [buildPath: ":", projectPath: ":producer"],
+            sourceAttributes: [color: "red", artifactType: "jar"],
             targetAttributes: [color: "green", artifactType: "jar"],
             capabilities: [[group: "colored", name: "producer", version: "unspecified"]],
             artifactName: "producer.jar",
@@ -458,7 +461,6 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         with(executeTransformationOps[0].details) {
             verifyTransformationIdentity(plannedTransformStepIdentity, expectedTransformId1)
             transformActionClass == "MakeRed"
-            sourceAttributes == [color: "blue", artifactType: "jar"]
 
             transformerName == "MakeRed"
             subjectName == "producer.jar (project :producer)"
@@ -467,7 +469,6 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         with(executeTransformationOps[1].details) {
             verifyTransformationIdentity(plannedTransformStepIdentity, expectedTransformId2)
             transformActionClass == "MakeGreen"
-            sourceAttributes == [color: "red", artifactType: "jar"]
 
             transformerName == "MakeGreen"
             subjectName == "producer.jar (project :producer)"
@@ -550,6 +551,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
             consumerBuildPath: ":",
             consumerProjectPath: ":consumer",
             componentId: [buildPath: ":", projectPath: ":producer"],
+            sourceAttributes: [color: "blue", artifactType: "jar"],
             targetAttributes: [color: "red", artifactType: "jar"],
             capabilities: [[group: "colored", name: "producer", version: "unspecified"]],
             artifactName: "producer.jar",
@@ -560,6 +562,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
             consumerBuildPath: ":",
             consumerProjectPath: ":consumer",
             componentId: [buildPath: ":", projectPath: ":producer"],
+            sourceAttributes: [color: "red", artifactType: "jar"],
             targetAttributes: [color: "green", artifactType: "jar"],
             capabilities: [[group: "colored", name: "producer", version: "unspecified"]],
             artifactName: "producer.jar",
@@ -580,7 +583,6 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         with(executeTransformationOps[0].details) {
             verifyTransformationIdentity(plannedTransformStepIdentity, expectedTransformId1)
             transformActionClass == "MakeColor"
-            sourceAttributes == [color: "blue", artifactType: "jar"]
 
             transformerName == "MakeColor"
             subjectName == "producer.jar (project :producer)"
@@ -589,7 +591,6 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         with(executeTransformationOps[1].details) {
             verifyTransformationIdentity(plannedTransformStepIdentity, expectedTransformId2)
             transformActionClass == "MakeColor"
-            sourceAttributes == [color: "red", artifactType: "jar"]
 
             transformerName == "MakeColor"
             subjectName == "producer.jar (project :producer)"
@@ -678,6 +679,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
             consumerBuildPath: ":",
             consumerProjectPath: ":consumer",
             componentId: [buildPath: ":", projectPath: ":producer"],
+            sourceAttributes: [color: "blue", artifactType: "jar"],
             targetAttributes: [color: "green", artifactType: "jar"],
             capabilities: [[group: "colored", name: "producer", version: "unspecified"]],
             artifactName: "producer.out1.jar",
@@ -688,6 +690,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
             consumerBuildPath: ":",
             consumerProjectPath: ":consumer",
             componentId: [buildPath: ":", projectPath: ":producer"],
+            sourceAttributes: [color: "blue", artifactType: "jar"],
             targetAttributes: [color: "green", artifactType: "jar"],
             capabilities: [[group: "colored", name: "producer", version: "unspecified"]],
             artifactName: "producer.out2.jar",
@@ -708,13 +711,11 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         // Order of scheduling/execution is not guaranteed between the transforms
         checkExecuteTransformOperation(executeTransformationOps, expectedTransformId1, [
             transformActionClass: "MakeGreen",
-            sourceAttributes: [color: "blue", artifactType: "jar"],
             transformerName: "MakeGreen",
             subjectName: "producer.out1.jar (project :producer)",
         ])
         checkExecuteTransformOperation(executeTransformationOps, expectedTransformId2, [
             transformActionClass: "MakeGreen",
-            sourceAttributes: [color: "blue", artifactType: "jar"],
             transformerName: "MakeGreen",
             subjectName: "producer.out2.jar (project :producer)",
         ])
@@ -772,6 +773,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
             consumerBuildPath: ":",
             consumerProjectPath: ":consumer",
             componentId: [buildPath: ":", projectPath: ":producer"],
+            sourceAttributes: [color: "blue", artifactType: "jar"],
             targetAttributes: [color: "green", artifactType: "jar"],
             capabilities: [[group: "colored", name: "producer", version: "unspecified"]],
             artifactName: "producer.jar",
@@ -793,7 +795,6 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         with(executeTransformationOp.details) {
             verifyTransformationIdentity(plannedTransformStepIdentity, expectedTransformId1)
             transformActionClass == "MakeGreen"
-            sourceAttributes == [color: "blue", artifactType: "jar"]
 
             transformerName == "MakeGreen"
             subjectName == "producer.jar (project :producer)"
@@ -873,6 +874,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
             actual.consumerBuildPath == expected.consumerBuildPath &&
             actual.consumerProjectPath == expected.consumerProjectPath &&
             actual.componentId == expected.componentId &&
+            actual.sourceAttributes == expected.sourceAttributes &&
             actual.targetAttributes == expected.targetAttributes &&
             actual.capabilities == expected.capabilities &&
             actual.artifactName == expected.artifactName &&
@@ -885,6 +887,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
             consumerBuildPath == expected.consumerBuildPath
             consumerProjectPath == expected.consumerProjectPath
             componentId == expected.componentId
+            sourceAttributes == expected.sourceAttributes
             targetAttributes == expected.targetAttributes
             capabilities == expected.capabilities
             artifactName == expected.artifactName
@@ -915,7 +918,6 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
 
         verifyAll(operation.details) {
             transformActionClass == expectedDetails.transformActionClass
-            sourceAttributes == expectedDetails.sourceAttributes
 
             transformerName == expectedDetails.transformerName
             subjectName == expectedDetails.subjectName

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -2650,13 +2650,13 @@ Found the following transforms:
                 consumerBuildPath == ":"
                 consumerProjectPath == ":app"
                 componentId == [buildPath: ":", projectPath: ":lib"]
+                sourceAttributes == [artifactType: "jar", usage: "api"]
                 targetAttributes == [artifactType: "size", usage: "api"]
                 capabilities == [[group: "root", name: "lib", version: "unspecified"]]
                 artifactName == "lib.jar"
                 dependenciesConfigurationIdentity == null
             }
             transformActionClass == "FileSizer"
-            sourceAttributes == [artifactType: "jar", usage: "api"]
         }
     }
 
@@ -2723,13 +2723,13 @@ Found the following transforms:
                 consumerBuildPath == ":"
                 consumerProjectPath == ":app"
                 componentId == [buildPath: ":", projectPath: ":lib"]
+                sourceAttributes == [artifactType: "jar", usage: "api"]
                 targetAttributes == [artifactType: "size", usage: "api"]
                 capabilities == [[group: "root", name: "lib", version: "unspecified"]]
                 artifactName == "lib.jar"
                 dependenciesConfigurationIdentity == null
             }
             transformActionClass == "BrokenTransform"
-            sourceAttributes == [artifactType: "jar", usage: "api"]
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ExecutePlannedTransformStepBuildOperationDetails.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ExecutePlannedTransformStepBuildOperationDetails.java
@@ -21,8 +21,6 @@ import org.gradle.internal.operations.trace.CustomOperationTraceSerialization;
 import org.gradle.operations.dependencies.transforms.ExecutePlannedTransformStepBuildOperationType;
 import org.gradle.operations.dependencies.transforms.PlannedTransformStepIdentity;
 
-import java.util.Map;
-
 public class ExecutePlannedTransformStepBuildOperationDetails implements ExecutePlannedTransformStepBuildOperationType.Details, CustomOperationTraceSerialization {
 
     private final TransformationNode transformationNode;
@@ -45,11 +43,6 @@ public class ExecutePlannedTransformStepBuildOperationDetails implements Execute
     }
 
     @Override
-    public Map<String, String> getSourceAttributes() {
-        return AttributesToMapConverter.convertToMap(transformationNode.getSourceAttributes());
-    }
-
-    @Override
     public Class<?> getTransformActionClass() {
         return transformationNode.getTransformationStep().getTransformer().getImplementationClass();
     }
@@ -68,7 +61,6 @@ public class ExecutePlannedTransformStepBuildOperationDetails implements Execute
     public Object getCustomOperationTraceSerializableModel() {
         ImmutableMap.Builder<String, Object> builder = new ImmutableMap.Builder<>();
         builder.put("plannedTransformStepIdentity", getPlannedTransformStepIdentity());
-        builder.put("sourceAttributes", getSourceAttributes());
         builder.put("transformActionClass", getTransformActionClass());
         builder.put("transformerName", transformerName);
         builder.put("subjectName", subjectName);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNode.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNode.java
@@ -132,6 +132,7 @@ public abstract class TransformationNode extends CreationOrderedNode implements 
         String consumerBuildPath = transformationStep.getOwningProject().getBuildPath().toString();
         String consumerProjectPath = transformationStep.getOwningProject().getIdentityPath().toString();
         ComponentIdentifier componentId = getComponentIdentifier(targetComponentVariant.getComponentId());
+        Map<String, String> sourceAttributes = AttributesToMapConverter.convertToMap(this.sourceAttributes);
         Map<String, String> targetAttributes = AttributesToMapConverter.convertToMap(targetComponentVariant.getAttributes());
         List<Capability> capabilities = targetComponentVariant.getCapabilities().stream()
             .map(TransformationNode::convertCapability)
@@ -156,6 +157,11 @@ public abstract class TransformationNode extends CreationOrderedNode implements 
             @Override
             public ComponentIdentifier getComponentId() {
                 return componentId;
+            }
+
+            @Override
+            public Map<String, String> getSourceAttributes() {
+                return sourceAttributes;
             }
 
             @Override

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/operations/dependencies/transforms/ExecutePlannedTransformStepBuildOperationType.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/operations/dependencies/transforms/ExecutePlannedTransformStepBuildOperationType.java
@@ -19,8 +19,6 @@ package org.gradle.operations.dependencies.transforms;
 import org.gradle.internal.operations.BuildOperationType;
 import org.gradle.internal.scan.NotUsedByScanPlugin;
 
-import java.util.Map;
-
 /**
  * A {@link BuildOperationType} for executing a scheduled transformation step.
  * <p>
@@ -37,11 +35,6 @@ public class ExecutePlannedTransformStepBuildOperationType implements BuildOpera
          * The identity of the transformation executed in this operation.
          */
         PlannedTransformStepIdentity getPlannedTransformStepIdentity();
-
-        /**
-         * Full set of attributes of the artifact before the transformation.
-         */
-        Map<String, String> getSourceAttributes();
 
         /**
          * Class of the transformer action implementation provided as part of transform registration.

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/operations/dependencies/transforms/PlannedTransformStepIdentity.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/operations/dependencies/transforms/PlannedTransformStepIdentity.java
@@ -48,6 +48,11 @@ public interface PlannedTransformStepIdentity extends NodeIdentity {
     ComponentIdentifier getComponentId();
 
     /**
+     * Full set of attributes of the artifact before the transformation.
+     */
+    Map<String, String> getSourceAttributes();
+
+    /**
      * Target attributes of the transformed artifact.
      * <p>
      * The attributes include all source attributes of the artifact before the transformation,


### PR DESCRIPTION
So both attributes are on the identity and we can always infer the name of the transform.
