### PR TITLE
Handle ValueSource exceptions during fingerprint checking

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintChecker.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintChecker.kt
@@ -25,6 +25,7 @@ import org.gradle.configurationcache.CheckedFingerprint
 import org.gradle.configurationcache.extensions.fileSystemEntryType
 import org.gradle.configurationcache.extensions.filterKeysByPrefix
 import org.gradle.configurationcache.extensions.uncheckedCast
+import org.gradle.configurationcache.logger
 import org.gradle.configurationcache.serialization.ReadContext
 import org.gradle.internal.file.FileType
 import org.gradle.internal.hash.HashCode
@@ -284,11 +285,19 @@ class ConfigurationCacheFingerprintChecker(private val host: Host) {
 
     private
     fun checkFingerprintValueIsUpToDate(obtainedValue: ObtainedValue): InvalidationReason? {
-        val valueSource = host.instantiateValueSourceOf(obtainedValue)
-        if (obtainedValue.value.get() != valueSource.obtain()) {
-            return buildLogicInputHasChanged(valueSource)
+        return obtainedValue.value.map { fingerprintedValue ->
+            val valueSource = host.instantiateValueSourceOf(obtainedValue)
+            if (fingerprintedValue != valueSource.obtain()) {
+                buildLogicInputHasChanged(valueSource)
+            } else {
+                null
+            }
+        }.getOrMapFailure { failure ->
+            // This can only happen if someone ignored configuration cache problems and still stored the entry.
+            // We're invalidating the cache to save the user a manual "rm -rf .gradle/configuration-cache", as there is no way out.
+            logger.info("The build logic input of type ${obtainedValue.valueSourceType} cannot be checked because it failed when storing the entry", failure)
+            buildLogicInputFailed(obtainedValue, failure)
         }
-        return null
     }
 
     private
@@ -312,6 +321,10 @@ class ConfigurationCacheFingerprintChecker(private val host: Host) {
         (valueSource as? Describable)?.let {
             it.displayName + " has changed"
         } ?: "a build logic input of type '${unpackType(valueSource).simpleName}' has changed"
+
+    private
+    fun buildLogicInputFailed(obtainedValue: ObtainedValue, failure: Throwable): InvalidationReason =
+        "a build logic input of type '${obtainedValue.valueSourceType.simpleName}' failed when storing the entry with $failure"
 
     private
     class ProjectInvalidationState {

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintController.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintController.kt
@@ -28,9 +28,13 @@ import org.gradle.configurationcache.InputTrackingState
 import org.gradle.configurationcache.extensions.directoryContentHash
 import org.gradle.configurationcache.extensions.uncheckedCast
 import org.gradle.configurationcache.initialization.ConfigurationCacheStartParameter
+import org.gradle.configurationcache.problems.ConfigurationCacheProblems
 import org.gradle.configurationcache.problems.ConfigurationCacheReport
+import org.gradle.configurationcache.problems.DocumentationSection
 import org.gradle.configurationcache.problems.ProblemFactory
 import org.gradle.configurationcache.problems.PropertyProblem
+import org.gradle.configurationcache.problems.StructuredMessage
+import org.gradle.configurationcache.problems.StructuredMessageBuilder
 import org.gradle.configurationcache.serialization.DefaultWriteContext
 import org.gradle.configurationcache.serialization.ReadContext
 import org.gradle.configurationcache.services.ConfigurationCacheEnvironmentChangeTracker
@@ -84,6 +88,7 @@ class ConfigurationCacheFingerprintController internal constructor(
     private val scriptFileResolverListeners: ScriptFileResolverListeners,
     private val remoteScriptUpToDateChecker: RemoteScriptUpToDateChecker,
     private val agentStatus: AgentStatus,
+    private val problems: ConfigurationCacheProblems
 ) : Stoppable {
 
     interface Host {
@@ -314,6 +319,9 @@ class ConfigurationCacheFingerprintController internal constructor(
 
         override fun reportInput(input: PropertyProblem) =
             report.onInput(input)
+
+        override fun reportProblem(exception: Throwable?, documentationSection: DocumentationSection?, message: StructuredMessageBuilder) =
+            problems.onProblem(problemFactory.problem(StructuredMessage.build(message), exception, documentationSection))
 
         override fun location(consumer: String?) =
             problemFactory.locationForCaller(consumer)

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintWriter.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintWriter.kt
@@ -59,6 +59,7 @@ import org.gradle.configurationcache.problems.DocumentationSection
 import org.gradle.configurationcache.problems.PropertyProblem
 import org.gradle.configurationcache.problems.PropertyTrace
 import org.gradle.configurationcache.problems.StructuredMessage
+import org.gradle.configurationcache.problems.StructuredMessageBuilder
 import org.gradle.configurationcache.serialization.DefaultWriteContext
 import org.gradle.configurationcache.services.ConfigurationCacheEnvironment
 import org.gradle.configurationcache.services.ConfigurationCacheEnvironmentChangeTracker
@@ -119,6 +120,7 @@ class ConfigurationCacheFingerprintWriter(
         fun hashCodeOf(file: File): HashCode
         fun hashCodeOfDirectoryContent(file: File): HashCode
         fun displayNameOf(file: File): String
+        fun reportProblem(exception: Throwable? = null, documentationSection: DocumentationSection? = null, message: StructuredMessageBuilder)
         fun reportInput(input: PropertyProblem)
         fun location(consumer: String?): PropertyTrace
     }
@@ -381,6 +383,18 @@ class ConfigurationCacheFingerprintWriter(
         obtainedValue: ValueSourceProviderFactory.ValueListener.ObtainedValue<T, P>,
         source: org.gradle.api.provider.ValueSource<T, P>
     ) {
+        obtainedValue.value.failure.ifPresent { exception ->
+            host.reportProblem(exception) {
+                text("failed to compute value with custom source ")
+                reference(obtainedValue.valueSourceType)
+                source.displayNameIfAvailable?.let {
+                    text(" ($it)")
+                }
+                text(" with ")
+                text(exception.toString())
+            }
+        }
+
         // TODO(https://github.com/gradle/gradle/issues/22494) ValueSources become part of the fingerprint even if they are only obtained
         //  inside other value sources. This is not really necessary for the correctness and causes excessive cache invalidation.
         when (val parameters = obtainedValue.valueSourceParameters) {
@@ -433,15 +447,19 @@ class ConfigurationCacheFingerprintWriter(
                 sink().write(ValueSource(obtainedValue.uncheckedCast()), trace)
                 reportUniqueValueSourceInput(
                     trace,
-                    displayName = when (source) {
-                        is Describable -> source.displayName
-                        else -> null
-                    },
+                    displayName = source.displayNameIfAvailable,
                     typeName = obtainedValue.valueSourceType.simpleName
                 )
             }
         }
     }
+
+    private
+    val org.gradle.api.provider.ValueSource<*, *>.displayNameIfAvailable: String?
+        get() = when (this) {
+            is Describable -> displayName
+            else -> null
+        }
 
     private
     fun isSystemPropertyLoaded(key: String): Boolean {

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/ProcessOutputProviderIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/ProcessOutputProviderIntegrationTest.groovy
@@ -89,10 +89,12 @@ class ProcessOutputProviderIntegrationTest extends AbstractIntegrationSpec {
                 ${cmdToExecConfig(*testScript.commandLine)}
             }
 
-            println("exit value = " + execProvider.result.get().exitValue)
-            println(execProvider.standardOutput.asText.get())
-
-            task empty() {}
+            task empty() {
+                doLast {
+                    println("exit value = " + execProvider.result.get().exitValue)
+                    println(execProvider.standardOutput.asText.get())
+                }
+            }
         """
 
         when:


### PR DESCRIPTION
This affects value sources obtained at configuration time, which become build inputs.
* `ValueSource.obtain()` throws while storing the cache entry. 
  Before: `provider.get()` callsite gets an exception, cache entry is stored.
  After: `provider.get()` callsite still gets an exception, cache problem is emitted. The entry is discarded, unless problems are turned into warnings.
* An obtained "failed" value is stored in the fingerprint
  Before: the stored exception is re-thrown, failing the build. Big surprise for anyone who caught the exception at configuration phase when storing the cache entry.
  After: this can only happen if the user turned problems into warnings when storing the cache. Build doesn't fail right away anymore, the cache entry is now invalidated, and the configuration phase re-runs.
* `ValueSource.obtain()` throws when computing new value during fingerprint check
  No changes in behavior in this case. The build fails, the exception propagates. The cache entry (that has a valid value stored) is left intact.

Fixes #23997 

