### PR TITLE
Re-enable caching for checkBinaryCompatibility

### DIFF
--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/BinaryCompatibilityHelper.groovy
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/BinaryCompatibilityHelper.groovy
@@ -44,8 +44,6 @@ class BinaryCompatibilityHelper {
         Directory projectRootDir
     ) {
         japicmpTask.tap {
-            doNotTrackState("classloading issues with rules")
-
             addExcludeFilter(AnonymousClassesFilter)
             addExcludeFilter(KotlinInternalFilter)
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildSanityCheckConfigurationCacheSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildSanityCheckConfigurationCacheSmokeTest.groovy
@@ -65,8 +65,7 @@ class GradleBuildSanityCheckConfigurationCacheSmokeTest extends AbstractGradleBu
         result.task(":configuration-cache:codeQuality").outcome == TaskOutcome.UP_TO_DATE
         result.task(":docs:checkstyleApi").outcome == TaskOutcome.FROM_CACHE
         result.task(":internal-build-reports:allIncubationReportsZip").outcome == TaskOutcome.SUCCESS
-        // For now, this task is not CC compatible:
-        result.task(":architecture-test:checkBinaryCompatibility").outcome == TaskOutcome.SUCCESS
+        result.task(":architecture-test:checkBinaryCompatibility").outcome == TaskOutcome.FROM_CACHE
         result.task(":docs:javadocAll").outcome == TaskOutcome.FROM_CACHE
         result.task(":architecture-test:test").outcome == TaskOutcome.FROM_CACHE
         result.task(":tooling-api:toolingApiShadedJar").outcome == TaskOutcome.SUCCESS


### PR DESCRIPTION
With Gradle 8, we don't try to deserialize the inputs anymore. The `doNotTrackState()` call has been introduced in #21831.

See #17324.