### PR TITLE
Dynamically performance test AGP lastest stable/RC versions with SantaTracker

### DIFF
--- a/build-logic/build-update-utils/src/main/kotlin/gradlebuild.update-versions.gradle.kts
+++ b/build-logic/build-update-utils/src/main/kotlin/gradlebuild.update-versions.gradle.kts
@@ -3,6 +3,7 @@ import com.google.gson.Gson
 import gradlebuild.basics.releasedVersionsFile
 import gradlebuild.buildutils.model.ReleasedVersion
 import gradlebuild.buildutils.tasks.UpdateAgpVersions
+import gradlebuild.buildutils.tasks.UpdateKotlinVersions
 import gradlebuild.buildutils.tasks.UpdateReleasedVersions
 import java.net.URL
 
@@ -33,6 +34,12 @@ tasks.register<UpdateAgpVersions>("updateAgpVersions") {
     minimumSupportedMinor = "7.3"
     fetchNightly = false
     propertiesFile = layout.projectDirectory.file("gradle/dependency-management/agp-versions.properties")
+}
+
+tasks.register<UpdateKotlinVersions>("updateKotlinVersions") {
+    comment = " Generated - Update by running `./gradlew updateKotlinVersions`"
+    minimumSupported = "1.6.10"
+    propertiesFile = layout.projectDirectory.file("gradle/dependency-management/kotlin-versions.properties")
 }
 
 data class VersionBuildTimeInfo(val version: String, val buildTime: String)

--- a/build-logic/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/UpdateKotlinVersions.kt
+++ b/build-logic/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/UpdateKotlinVersions.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gradlebuild.buildutils.tasks
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+import java.util.Properties
+import javax.xml.parsers.DocumentBuilderFactory
+
+
+/**
+ * Fetch the latest Kotlin versions and write a properties file.
+ * Never up-to-date, non-cacheable.
+ */
+@DisableCachingByDefault(because = "Not worth caching")
+abstract class UpdateKotlinVersions : DefaultTask() {
+
+    @get:Internal
+    abstract val comment: Property<String>
+
+    @get:Internal
+    abstract val minimumSupported: Property<String>
+
+    @get:Internal
+    abstract val propertiesFile: RegularFileProperty
+
+    @TaskAction
+    fun action() {
+
+        val dbf = DocumentBuilderFactory.newInstance()
+        val properties = Properties().apply {
+
+            val latests = dbf.fetchFirstAndLatestsOfEachMinor(
+                minimumSupported.get(),
+                "https://repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/maven-metadata.xml"
+            )
+            setProperty("latests", latests.joinToString(","))
+        }
+        properties.store(
+            propertiesFile.get().asFile,
+            comment.get()
+        )
+    }
+
+    private
+    fun DocumentBuilderFactory.fetchFirstAndLatestsOfEachMinor(minimumSupported: String, mavenMetadataUrl: String): List<String> {
+        val versionsByMinor = fetchVersionsFromMavenMetadata(mavenMetadataUrl)
+            .groupBy { it.take(3) }
+            .toSortedMap()
+        val latests = buildList {
+            versionsByMinor.entries.forEachIndexed { idx, entry ->
+                add(entry.value.lastOrNull { !it.contains("-") })
+                if (idx < versionsByMinor.size - 1) {
+                    add(entry.value.first())
+                } else {
+                    add(entry.value.firstOrNull { !it.contains("-") })
+                    add(entry.value.first())
+                }
+            }
+            add(minimumSupported)
+        }.filterNotNull().distinct().sorted()
+        return latests.subList(latests.indexOf(minimumSupported), latests.size)
+    }
+}

--- a/gradle/dependency-management/kotlin-versions.properties
+++ b/gradle/dependency-management/kotlin-versions.properties
@@ -1,0 +1,2 @@
+# Generated - Update by running `./gradlew updateKotlinVersions`
+latests=1.6.10,1.6.21,1.7.0,1.7.22,1.8.0,1.8.10,1.8.20-Beta

--- a/subprojects/internal-integ-testing/build.gradle.kts
+++ b/subprojects/internal-integ-testing/build.gradle.kts
@@ -117,9 +117,10 @@ val prepareVersionsInfo = tasks.register<PrepareVersionsInfo>("prepareVersionsIn
     mostRecentSnapshot = moduleIdentity.releasedVersions.map { it.mostRecentSnapshot.version }
 }
 
-val copyAgpVersionsInfo by tasks.registering(Copy::class) {
+val copyTestedVersionsInfo by tasks.registering(Copy::class) {
     from(rootProject.layout.projectDirectory.file("gradle/dependency-management/agp-versions.properties"))
-    into(layout.buildDirectory.dir("generated-resources/agp-versions"))
+    from(rootProject.layout.projectDirectory.file("gradle/dependency-management/kotlin-versions.properties"))
+    into(layout.buildDirectory.dir("generated-resources/tested-versions"))
 }
 
 val generateLanguageAnnotations by tasks.registering(GenerateLanguageAnnotations::class) {
@@ -131,7 +132,7 @@ val generateLanguageAnnotations by tasks.registering(GenerateLanguageAnnotations
 sourceSets.main {
     groovy.srcDir(generateLanguageAnnotations.flatMap { it.destDir })
     output.dir(prepareVersionsInfo.map { it.destFile.get().asFile.parentFile })
-    output.dir(copyAgpVersionsInfo)
+    output.dir(copyTestedVersionsInfo)
 }
 
 @CacheableTask

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/versions/AndroidGradlePluginVersions.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/versions/AndroidGradlePluginVersions.groovy
@@ -57,6 +57,7 @@ class AndroidGradlePluginVersions {
         }
     """
 
+    private static final VersionNumber AGP_8_0 = VersionNumber.parse('7.0.0')
     private static final VersionNumber AGP_7_0 = VersionNumber.parse('7.0.0')
     private static final VersionNumber AGP_7_3 = VersionNumber.parse('7.3.0')
     private static final VersionNumber KOTLIN_1_6_20 = VersionNumber.parse('1.6.20')
@@ -85,6 +86,32 @@ class AndroidGradlePluginVersions {
 
     List<String> getLatests() {
         return getVersionList("latests")
+    }
+
+    String getLatest() {
+        return latests.last()
+    }
+
+    List<String> getLatestsStable() {
+        return latests
+            .collect { VersionNumber.parse(it) }
+            .findAll { it.baseVersion == it }
+            .collect { it.toString() }
+    }
+
+    String getLatestStable() {
+        return latestsStable.last()
+    }
+
+    List<String> getLatestsStableOrRC() {
+        return latests.findAll {
+            def lowerCaseVersion = it.toLowerCase(Locale.US)
+            !lowerCaseVersion.contains('-alpha') && !(lowerCaseVersion.contains('-beta'))
+        }
+    }
+
+    String getLatestStableOrRC() {
+        return latestsStableOrRC.last()
     }
 
     List<String> getNightlies() {
@@ -148,7 +175,10 @@ class AndroidGradlePluginVersions {
         if (agpVersion.baseVersion < AGP_7_0) {
             return JavaVersion.VERSION_1_8
         }
-        return JavaVersion.VERSION_11
+        if (agpVersion.baseVersion < AGP_8_0) {
+            JavaVersion.VERSION_11
+        }
+        return JavaVersion.VERSION_17
     }
 
     private static JavaVersion getMaximumJavaVersionFor(VersionNumber agpVersion) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/versions/AndroidGradlePluginVersions.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/versions/AndroidGradlePluginVersions.groovy
@@ -20,6 +20,8 @@ import org.gradle.api.JavaVersion
 import org.gradle.internal.Factory
 import org.gradle.util.internal.VersionNumber
 
+import javax.annotation.Nullable
+
 import static org.junit.Assume.assumeTrue
 
 
@@ -119,6 +121,14 @@ class AndroidGradlePluginVersions {
         return properties
     }
 
+    @Nullable
+    String getMinimumGradleBaseVersionFor(String agpVersion) {
+        if (VersionNumber.parse(agpVersion) >= AGP_7_3) {
+            return '7.4'
+        }
+        return null
+    }
+
     static void assumeCurrentJavaVersionIsSupportedBy(String agpVersion) {
         VersionNumber agpVersionNumber = VersionNumber.parse(agpVersion)
         JavaVersion current = JavaVersion.current()
@@ -130,7 +140,11 @@ class AndroidGradlePluginVersions {
         }
     }
 
-    private static JavaVersion getMinimumJavaVersionFor(VersionNumber agpVersion) {
+    static JavaVersion getMinimumJavaVersionFor(String agpVersion) {
+        return getMinimumJavaVersionFor(VersionNumber.parse(agpVersion))
+    }
+
+    static JavaVersion getMinimumJavaVersionFor(VersionNumber agpVersion) {
         if (agpVersion.baseVersion < AGP_7_0) {
             return JavaVersion.VERSION_1_8
         }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/versions/AndroidGradlePluginVersions.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/versions/AndroidGradlePluginVersions.groovy
@@ -176,7 +176,7 @@ class AndroidGradlePluginVersions {
             return JavaVersion.VERSION_1_8
         }
         if (agpVersion.baseVersion < AGP_8_0) {
-            JavaVersion.VERSION_11
+            return JavaVersion.VERSION_11
         }
         return JavaVersion.VERSION_17
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/versions/AndroidGradlePluginVersions.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/versions/AndroidGradlePluginVersions.groovy
@@ -57,7 +57,7 @@ class AndroidGradlePluginVersions {
         }
     """
 
-    private static final VersionNumber AGP_8_0 = VersionNumber.parse('7.0.0')
+    private static final VersionNumber AGP_8_0 = VersionNumber.parse('8.0.0')
     private static final VersionNumber AGP_7_0 = VersionNumber.parse('7.0.0')
     private static final VersionNumber AGP_7_3 = VersionNumber.parse('7.3.0')
     private static final VersionNumber KOTLIN_1_6_20 = VersionNumber.parse('1.6.20')

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/versions/KotlinGradlePluginVersions.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/versions/KotlinGradlePluginVersions.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.integtests.fixtures.versions
 
+import org.gradle.util.internal.VersionNumber
+
 /**
  * Kotlin Gradle Plugin Versions.
  */
@@ -31,4 +33,51 @@ class KotlinGradlePluginVersions {
     List<String> getLatests() {
         return LATEST_VERSIONS
     }
+
+    String getLatest() {
+        return latests.last()
+    }
+
+    List<String> getLatestsStable() {
+        return latests
+            .collect { VersionNumber.parse(it) }
+            .findAll { it.baseVersion == it }
+            .collect { it.toString() }
+    }
+
+    String getLatestStable() {
+        return latestsStable.last()
+    }
+
+    List<String> getLatestsStableOrRC() {
+        return latests.findAll {
+            def lowerCaseVersion = it.toLowerCase(Locale.US)
+            !lowerCaseVersion.contains('-m') && !(lowerCaseVersion.contains('-beta'))
+        }
+    }
+
+    String getLatestStableOrRC() {
+        return latestsStableOrRC.last()
+    }
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/versions/KotlinGradlePluginVersions.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/versions/KotlinGradlePluginVersions.groovy
@@ -26,7 +26,7 @@ class KotlinGradlePluginVersions {
     // https://search.maven.org/search?q=g:org.jetbrains.kotlin%20AND%20a:kotlin-project&core=gav
     private static final List<String> LATEST_VERSIONS = [
         '1.6.10', '1.6.21',
-        '1.7.0', '1.7.10', "1.7.22",
+        '1.7.0', "1.7.22",
         "1.8.10", "1.8.20-Beta",
     ]
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/versions/KotlinGradlePluginVersions.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/versions/KotlinGradlePluginVersions.groovy
@@ -16,22 +16,38 @@
 
 package org.gradle.integtests.fixtures.versions
 
+import org.gradle.internal.Factory
 import org.gradle.util.internal.VersionNumber
 
 /**
  * Kotlin Gradle Plugin Versions.
+ *
+ * See UpdateKotlinVersions.
  */
 class KotlinGradlePluginVersions {
 
-    // https://search.maven.org/search?q=g:org.jetbrains.kotlin%20AND%20a:kotlin-project&core=gav
-    private static final List<String> LATEST_VERSIONS = [
-        '1.6.10', '1.6.21',
-        '1.7.0', "1.7.22",
-        "1.8.10", "1.8.20-Beta",
-    ]
+    private final Factory<Properties> propertiesFactory
+    private Properties properties
+
+    KotlinGradlePluginVersions() {
+        this(new ClasspathVersionSource("kotlin-versions.properties", KotlinGradlePluginVersions.classLoader))
+    }
+
+    private KotlinGradlePluginVersions(Factory<Properties> propertiesFactory) {
+        this.propertiesFactory = propertiesFactory
+    }
+
+    private Properties loadedProperties() {
+        if (properties == null) {
+            properties = propertiesFactory.create()
+        }
+        return properties
+    }
+
 
     List<String> getLatests() {
-        return LATEST_VERSIONS
+        def versionList = loadedProperties().getProperty("latests")
+        return (versionList == null || versionList.empty) ? [] : versionList.split(",")
     }
 
     String getLatest() {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/versions/KotlinGradlePluginVersions.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/versions/KotlinGradlePluginVersions.groovy
@@ -60,24 +60,3 @@ class KotlinGradlePluginVersions {
         return latestsStableOrRC.last()
     }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AndroidTestProject.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AndroidTestProject.groovy
@@ -74,6 +74,10 @@ class AndroidTestProject implements TestProject {
         runner.args.add("-DkotlinVersion=${KGP_VERSIONS.latest}")
     }
 
+    static void useAgpLatestOfMinorVersion(CrossVersionPerformanceTestRunner runner, String lowerBound) {
+        configureForAgpVersion(runner, AGP_VERSIONS.getLatestOfMinor(lowerBound))
+    }
+
     static void useAgpLatestStableOrRcVersion(CrossVersionPerformanceTestRunner runner) {
         configureForAgpVersion(runner, AGP_VERSIONS.latestStableOrRC)
     }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AndroidTestProject.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AndroidTestProject.groovy
@@ -29,8 +29,6 @@ class AndroidTestProject implements TestProject {
 
     private static final AndroidGradlePluginVersions AGP_VERSIONS = new AndroidGradlePluginVersions()
     private static final KotlinGradlePluginVersions KGP_VERSIONS = new KotlinGradlePluginVersions()
-    private static final String AGP_STABLE_TARGET_VERSION = "7.3"
-    private static final String AGP_LATEST_TARGET_VERSION = "7.3"
     public static final LARGE_ANDROID_BUILD = new AndroidTestProject(
         templateName: 'largeAndroidBuild'
     )
@@ -77,16 +75,15 @@ class AndroidTestProject implements TestProject {
     }
 
     static void useAgpLatestStableVersion(CrossVersionPerformanceTestRunner runner) {
-        configureForLatestAgpVersionOfMinor(runner, AGP_STABLE_TARGET_VERSION)
+        configureForAgpVersion(runner, AGP_VERSIONS.latestStable)
     }
 
     static void useAgpLatestVersion(CrossVersionPerformanceTestRunner runner) {
-        configureForLatestAgpVersionOfMinor(runner, AGP_LATEST_TARGET_VERSION)
+        configureForAgpVersion(runner, AGP_VERSIONS.latest)
     }
 
-    private static void configureForLatestAgpVersionOfMinor(CrossVersionPerformanceTestRunner runner, String lowerBound) {
+    private static void configureForAgpVersion(CrossVersionPerformanceTestRunner runner, String agpVersion) {
 
-        def agpVersion = AGP_VERSIONS.getLatestOfMinor(lowerBound)
         runner.args.add("-DagpVersion=${agpVersion}")
 
         def buildJavaHome = AvailableJavaHomes.getJdk(AGP_VERSIONS.getMinimumJavaVersionFor(agpVersion)).javaHome

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AndroidTestProject.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AndroidTestProject.groovy
@@ -66,16 +66,16 @@ class AndroidTestProject implements TestProject {
     void configure(GradleBuildExperimentSpec.GradleBuilder builder) {
     }
 
-    static void useKotlinLatestStableVersion(CrossVersionPerformanceTestRunner runner) {
-        runner.args.add("-DkotlinVersion=${KGP_VERSIONS.latestStable}")
+    static void useKotlinLatestStableOrRcVersion(CrossVersionPerformanceTestRunner runner) {
+        runner.args.add("-DkotlinVersion=${KGP_VERSIONS.latestStableOrRC}")
     }
 
     static void useKotlinLatestVersion(CrossVersionPerformanceTestRunner runner) {
         runner.args.add("-DkotlinVersion=${KGP_VERSIONS.latest}")
     }
 
-    static void useAgpLatestStableVersion(CrossVersionPerformanceTestRunner runner) {
-        configureForAgpVersion(runner, AGP_VERSIONS.latestStable)
+    static void useAgpLatestStableOrRcVersion(CrossVersionPerformanceTestRunner runner) {
+        configureForAgpVersion(runner, AGP_VERSIONS.latestStableOrRC)
     }
 
     static void useAgpLatestVersion(CrossVersionPerformanceTestRunner runner) {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AndroidTestProject.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AndroidTestProject.groovy
@@ -71,7 +71,7 @@ class AndroidTestProject implements TestProject {
     }
 
     static void useLatestKotlinVersion(CrossVersionPerformanceTestRunner runner) {
-        runner.args.add("-DkotlinVersion=${KGP_VERSIONS.getLatests().last()}")
+        runner.args.add("-DkotlinVersion=${KGP_VERSIONS.latest}")
     }
 
     static void useStableAgpVersion(CrossVersionPerformanceTestRunner runner) {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AndroidTestProject.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AndroidTestProject.groovy
@@ -86,16 +86,8 @@ class AndroidTestProject implements TestProject {
         configureForLatestAgpVersionOfMinor(runner, AGP_LATEST_TARGET_VERSION)
     }
 
-    static void useLatestAgpVersion(GradleBuildExperimentSpec.GradleBuilder builder) {
-        configureForLatestAgpVersionOfMinor(builder, AGP_LATEST_TARGET_VERSION)
-    }
-
     static void configureForLatestAgpVersionOfMinor(CrossVersionPerformanceTestRunner runner, String lowerBound) {
         runner.args.add("-DagpVersion=${AGP_VERSIONS.getLatestOfMinor(lowerBound)}")
-    }
-
-    static void configureForLatestAgpVersionOfMinor(GradleBuildExperimentSpec.GradleBuilder builder, String lowerBound) {
-        builder.invocation.args("-DagpVersion=${AGP_VERSIONS.getLatestOfMinor(lowerBound)}")
     }
 
     @Override

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
@@ -32,7 +32,7 @@ import spock.lang.Issue
 
 class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpec implements JavaToolchainFixture, JavaToolchainBuildOperationsFixture {
 
-    static kgpLatestVersions = new KotlinGradlePluginVersions().latests.toList()
+    static kgpLatestVersions = new KotlinGradlePluginVersions().latests
 
     def setup() {
         captureBuildOperations()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/AndroidIncrementalExecutionPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/AndroidIncrementalExecutionPerformanceTest.groovy
@@ -42,8 +42,8 @@ class AndroidIncrementalExecutionPerformanceTest extends AbstractIncrementalExec
 
     def setup() {
         testProject = AndroidTestProject.findProjectFor(runner.testProject) as IncrementalAndroidTestProject
-        AndroidTestProject.useAgpLatestVersion(runner)
-        AndroidTestProject.useKotlinLatestVersion(runner)
+        AndroidTestProject.useAgpLatestStableVersion(runner)
+        AndroidTestProject.useKotlinLatestStableVersion(runner)
         runner.args.add('-Dorg.gradle.parallel=true')
         runner.args.addAll(["--no-build-cache", "--no-scan"])
         runner.args.add("-D${StartParameterBuildOptions.ConfigurationCacheProblemsOption.PROPERTY_NAME}=warn")

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/AndroidIncrementalExecutionPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/AndroidIncrementalExecutionPerformanceTest.groovy
@@ -42,15 +42,12 @@ class AndroidIncrementalExecutionPerformanceTest extends AbstractIncrementalExec
 
     def setup() {
         testProject = AndroidTestProject.findProjectFor(runner.testProject) as IncrementalAndroidTestProject
-        AndroidTestProject.useLatestAgpVersion(runner)
+        AndroidTestProject.useAgpLatestVersion(runner)
+        AndroidTestProject.useKotlinLatestVersion(runner)
         runner.args.add('-Dorg.gradle.parallel=true')
         runner.args.addAll(["--no-build-cache", "--no-scan"])
         runner.args.add("-D${StartParameterBuildOptions.ConfigurationCacheProblemsOption.PROPERTY_NAME}=warn")
-        AndroidTestProject.useLatestKotlinVersion(runner)
-        // AGP 7.3 requires Gradle 7.4
-        runner.minimumBaseVersion = "7.4"
         applyEnterprisePlugin()
-        configureProjectJavaHomeToJdk11()
     }
 
     def "abi change#configurationCaching"() {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/AndroidIncrementalExecutionPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/AndroidIncrementalExecutionPerformanceTest.groovy
@@ -42,8 +42,8 @@ class AndroidIncrementalExecutionPerformanceTest extends AbstractIncrementalExec
 
     def setup() {
         testProject = AndroidTestProject.findProjectFor(runner.testProject) as IncrementalAndroidTestProject
-        AndroidTestProject.useAgpLatestStableVersion(runner)
-        AndroidTestProject.useKotlinLatestStableVersion(runner)
+        AndroidTestProject.useAgpLatestStableOrRcVersion(runner)
+        AndroidTestProject.useKotlinLatestStableOrRcVersion(runner)
         runner.args.add('-Dorg.gradle.parallel=true')
         runner.args.addAll(["--no-build-cache", "--no-scan"])
         runner.args.add("-D${StartParameterBuildOptions.ConfigurationCacheProblemsOption.PROPERTY_NAME}=warn")

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/AndroidPerformanceTestFixture.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/AndroidPerformanceTestFixture.groovy
@@ -17,12 +17,8 @@
 package org.gradle.performance.regression.android
 
 import groovy.transform.SelfType
-import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.performance.AbstractCrossVersionPerformanceTest
 import org.gradle.performance.fixture.AndroidTestProject
-import org.gradle.profiler.BuildMutator
-import org.gradle.profiler.InvocationSettings
-import org.gradle.profiler.ScenarioContext
 
 @SelfType(AbstractCrossVersionPerformanceTest)
 trait AndroidPerformanceTestFixture {
@@ -32,26 +28,5 @@ trait AndroidPerformanceTestFixture {
         // which fails when the test project is non-incremental.
         runner.assumeShouldRun()
         AndroidTestProject.projectFor(runner.testProject)
-    }
-
-    void configureProjectJavaHomeToJdk11() {
-        def buildJavaHome = AvailableJavaHomes.jdk11.javaHome
-        runner.addBuildMutator { invocation -> new JavaHomeMutator(invocation, buildJavaHome) }
-    }
-
-    static class JavaHomeMutator implements BuildMutator {
-        private final File buildJavaHome
-        private final InvocationSettings invocation
-
-        JavaHomeMutator(InvocationSettings invocation, File buildJavaHome) {
-            this.invocation = invocation
-            this.buildJavaHome = buildJavaHome
-        }
-
-        @Override
-        void beforeScenario(ScenarioContext context) {
-            def gradleProps = new File(invocation.projectDir, "gradle.properties")
-            gradleProps << "\norg.gradle.java.home=${buildJavaHome.absolutePath.replace("\\", "/")}\n"
-        }
     }
 }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
@@ -34,8 +34,8 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionPerformanc
 
     def setup() {
         runner.args = [AndroidGradlePluginVersions.OVERRIDE_VERSION_CHECK]
-        AndroidTestProject.useAgpLatestStableVersion(runner)
-        AndroidTestProject.useKotlinLatestStableVersion(runner)
+        AndroidTestProject.useAgpLatestStableOrRcVersion(runner)
+        AndroidTestProject.useKotlinLatestStableOrRcVersion(runner)
     }
 
     @RunFor([

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
@@ -34,11 +34,8 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionPerformanc
 
     def setup() {
         runner.args = [AndroidGradlePluginVersions.OVERRIDE_VERSION_CHECK]
-        AndroidTestProject.useStableAgpVersion(runner)
-        AndroidTestProject.useStableKotlinVersion(runner)
-        // AGP 7.3 requires Gradle 7.4
-        runner.minimumBaseVersion = "7.4"
-        configureProjectJavaHomeToJdk11()
+        AndroidTestProject.useAgpLatestStableVersion(runner)
+        AndroidTestProject.useKotlinLatestStableVersion(runner)
     }
 
     @RunFor([

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidStudioPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidStudioPerformanceTest.groovy
@@ -39,7 +39,7 @@ class RealLifeAndroidStudioPerformanceTest extends AbstractCrossVersionPerforman
         runner.args = [AndroidGradlePluginVersions.OVERRIDE_VERSION_CHECK]
         def testProject = AndroidTestProject.projectFor(runner.testProject)
         testProject.configure(runner)
-        AndroidTestProject.useAgpLatestStableOrRcVersion(runner)
+        AndroidTestProject.useAgpLatestOfMinorVersion(runner, "7.3") // TODO get new AndroidStudio versions on CI agents
         AndroidTestProject.useKotlinLatestStableOrRcVersion(runner)
         runner.warmUpRuns = 20
         runner.runs = 20

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidStudioPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidStudioPerformanceTest.groovy
@@ -39,14 +39,11 @@ class RealLifeAndroidStudioPerformanceTest extends AbstractCrossVersionPerforman
         runner.args = [AndroidGradlePluginVersions.OVERRIDE_VERSION_CHECK]
         def testProject = AndroidTestProject.projectFor(runner.testProject)
         testProject.configure(runner)
-        AndroidTestProject.useStableAgpVersion(runner)
-        AndroidTestProject.useStableKotlinVersion(runner)
+        AndroidTestProject.useAgpLatestStableVersion(runner)
+        AndroidTestProject.useKotlinLatestStableVersion(runner)
         runner.warmUpRuns = 20
         runner.runs = 20
-        // AGP 7.3 requires Gradle 7.4
-        runner.minimumBaseVersion = "7.4"
         runner.setupAndroidStudioSync()
-        configureProjectJavaHomeToJdk11()
 
         when:
         def result = runner.run()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidStudioPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidStudioPerformanceTest.groovy
@@ -39,8 +39,8 @@ class RealLifeAndroidStudioPerformanceTest extends AbstractCrossVersionPerforman
         runner.args = [AndroidGradlePluginVersions.OVERRIDE_VERSION_CHECK]
         def testProject = AndroidTestProject.projectFor(runner.testProject)
         testProject.configure(runner)
-        AndroidTestProject.useAgpLatestStableVersion(runner)
-        AndroidTestProject.useKotlinLatestStableVersion(runner)
+        AndroidTestProject.useAgpLatestStableOrRcVersion(runner)
+        AndroidTestProject.useKotlinLatestStableOrRcVersion(runner)
         runner.warmUpRuns = 20
         runner.runs = 20
         runner.setupAndroidStudioSync()

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractAndroidSantaTrackerSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractAndroidSantaTrackerSmokeTest.groovy
@@ -34,7 +34,7 @@ class AbstractAndroidSantaTrackerSmokeTest extends AbstractSmokeTest {
     TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
     TestFile homeDir
 
-    String kotlinVersion = TestedVersions.kotlin.latestStable()
+    String kotlinVersion = KOTLIN_VERSIONS.latestStable
 
     def setup() {
         homeDir = temporaryFolder.createDir("test-kit-home")

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -207,10 +207,6 @@ abstract class AbstractSmokeTest extends Specification {
             }
         }
 
-        String latestStartsWith(String prefix) {
-            return versions.reverse().find { it.startsWith(prefix) }
-        }
-
         private Versions(String... given) {
             versions = Arrays.asList(given)
         }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -97,7 +97,7 @@ abstract class AbstractSmokeTest extends Specification {
         // https://developer.android.com/studio/releases/build-tools
         static androidTools = "30.0.2"
         // https://developer.android.com/studio/releases/gradle-plugin
-        static androidGradle = Versions.of(*AGP_VERSIONS.getLatestsFromMinorPlusNightly("4.0"))
+        static androidGradle = Versions.of(*AGP_VERSIONS.latests)
 
         // https://search.maven.org/search?q=g:org.jetbrains.kotlin%20AND%20a:kotlin-project&core=gav
         static kotlin = Versions.of(*KOTLIN_VERSIONS.latestsStableOrRC)

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -194,19 +194,6 @@ abstract class AbstractSmokeTest extends Specification {
 
         final List<String> versions
 
-        String latest() {
-            versions.last()
-        }
-
-        String latestStable() {
-            versions.reverse().find { version ->
-                !version.containsIgnoreCase("rc") &&
-                !version.containsIgnoreCase("beta") &&
-                !version.containsIgnoreCase("alpha") &&
-                !version.containsIgnoreCase("milestone")
-            }
-        }
-
         private Versions(String... given) {
             versions = Arrays.asList(given)
         }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -100,10 +100,7 @@ abstract class AbstractSmokeTest extends Specification {
         static androidGradle = Versions.of(*AGP_VERSIONS.getLatestsFromMinorPlusNightly("4.0"))
 
         // https://search.maven.org/search?q=g:org.jetbrains.kotlin%20AND%20a:kotlin-project&core=gav
-        static kotlin = Versions.of(*KOTLIN_VERSIONS.latests.findAll {
-            def lowerCaseVersion = it.toLowerCase(Locale.US)
-            !lowerCaseVersion.contains('-m') && !(lowerCaseVersion.contains('-beta'))
-        })
+        static kotlin = Versions.of(*KOTLIN_VERSIONS.latestsStableOrRC)
 
         // https://plugins.gradle.org/plugin/org.gretty
         static gretty = [

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -100,7 +100,7 @@ abstract class AbstractSmokeTest extends Specification {
         static androidGradle = Versions.of(*AGP_VERSIONS.latests)
 
         // https://search.maven.org/search?q=g:org.jetbrains.kotlin%20AND%20a:kotlin-project&core=gav
-        static kotlin = Versions.of(*KOTLIN_VERSIONS.latestsStableOrRC)
+        static kotlin = Versions.of(*KOTLIN_VERSIONS.latests)
 
         // https://plugins.gradle.org/plugin/org.gretty
         static gretty = [

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -345,9 +345,6 @@ abstract class AbstractSmokeTest extends Specification {
             def init = AGP_VERSIONS.createAgpNightlyRepositoryInitScript()
             extraArgs += ["-I", init.canonicalPath]
         }
-        if (agpVersion.startsWith("7.2") && JavaVersion.current().java9Compatible) {
-            runner = runner.withJvmArguments('--add-opens', 'java.logging/java.util.logging=ALL-UNNAMED')
-        }
         return runner.withArguments([runner.arguments, extraArgs].flatten())
     }
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidCommunityPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidCommunityPluginsSmokeTest.groovy
@@ -153,7 +153,7 @@ class AndroidCommunityPluginsSmokeTest extends AbstractPluginValidatingSmokeTest
         if (testedPluginId == DAGGER_HILT_ANDROID_PLUGIN_ID) {
             return [
                 'com.android.application': ANDROID_PLUGIN_VERSION_FOR_TESTS,
-                'org.jetbrains.kotlin.android': TestedVersions.kotlin.latestStable()
+                'org.jetbrains.kotlin.android': KOTLIN_VERSIONS.latestStable
             ]
         }
         return ['com.android.application': ANDROID_PLUGIN_VERSION_FOR_TESTS]

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidCommunityPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidCommunityPluginsSmokeTest.groovy
@@ -21,7 +21,7 @@ import org.gradle.internal.reflect.validation.ValidationMessageChecker
 
 class AndroidCommunityPluginsSmokeTest extends AbstractPluginValidatingSmokeTest implements ValidationMessageChecker {
 
-    private static final String ANDROID_PLUGIN_VERSION_FOR_TESTS = TestedVersions.androidGradle.latestStartsWith("7.3")
+    private static final String ANDROID_PLUGIN_VERSION_FOR_TESTS = AGP_VERSIONS.latestStable
 
     private static final String DAGGER_HILT_ANDROID_PLUGIN_ID = 'dagger.hilt.android.plugin'
     private static final String TRIPLET_PLAY_PLUGIN_ID = 'com.github.triplet.play'

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
@@ -218,12 +218,11 @@ class KotlinPluginSmokeTest extends AbstractPluginValidatingSmokeTest implements
         """
 
         when:
-        def versionNumber = VersionNumber.parse(kotlinVersion)
-        def result = runner(false, versionNumber, ':tasks')
-            .expectDeprecationWarning("The TestReport.reportOn(Object...) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Please use the testResults method instead. See https://docs.gradle.org/${GradleVersion.current().version}/dsl/org.gradle.api.tasks.testing.TestReport.html#org.gradle.api.tasks.testing.TestReport:testResults for more details.", '')
-            .expectDeprecationWarning("The TestReport.destinationDir property has been deprecated. This is scheduled to be removed in Gradle 9.0. Please use the destinationDirectory property instead. See https://docs.gradle.org/${GradleVersion.current().version}/dsl/org.gradle.api.tasks.testing.TestReport.html#org.gradle.api.tasks.testing.TestReport:destinationDir for more details.", '')
+        def result = runner(false, VersionNumber.parse(kotlinVersion), ':tasks')
             .deprecations(KotlinDeprecations) {
                 expectOrgGradleUtilWrapUtilDeprecation(kotlinVersion)
+                expectTestReportReportOnDeprecation(kotlinVersion)
+                expectTestReportDestinationDirOnDeprecation(kotlinVersion)
             }
             .build()
 
@@ -431,6 +430,30 @@ class KotlinPluginSmokeTest extends AbstractPluginValidatingSmokeTest implements
                     "This is scheduled to be removed in Gradle 9.0. " +
                     "Consult the upgrading guide for further information: " +
                     "https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_7.html#org_gradle_util_reports_deprecations",
+                ""
+            )
+        }
+
+        void expectTestReportReportOnDeprecation(String version) {
+            VersionNumber versionNumber = VersionNumber.parse(version)
+            runner.expectDeprecationWarningIf(
+                versionNumber.baseVersion < VersionNumber.parse("1.8.20"),
+                "The TestReport.reportOn(Object...) method has been deprecated. " +
+                    "This is scheduled to be removed in Gradle 9.0. " +
+                    "Please use the testResults method instead. " +
+                    "See https://docs.gradle.org/${GradleVersion.current().version}/dsl/org.gradle.api.tasks.testing.TestReport.html#org.gradle.api.tasks.testing.TestReport:testResults for more details.",
+                ""
+            )
+        }
+
+        void expectTestReportDestinationDirOnDeprecation(String version) {
+            VersionNumber versionNumber = VersionNumber.parse(version)
+            runner.expectDeprecationWarningIf(
+                versionNumber.baseVersion < VersionNumber.parse("1.8.20"),
+                "The TestReport.destinationDir property has been deprecated. " +
+                    "This is scheduled to be removed in Gradle 9.0. " +
+                    "Please use the destinationDirectory property instead. " +
+                    "See https://docs.gradle.org/${GradleVersion.current().version}/dsl/org.gradle.api.tasks.testing.TestReport.html#org.gradle.api.tasks.testing.TestReport:destinationDir for more details.",
                 ""
             )
         }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
@@ -314,7 +314,7 @@ class KotlinPluginSmokeTest extends AbstractPluginValidatingSmokeTest implements
 
     @Override
     Map<String, String> getExtraPluginsRequiredForValidation(String testedPluginId, String version) {
-        def androidVersion = TestedVersions.androidGradle.latestStable()
+        def androidVersion = AGP_VERSIONS.latestStable
         if (testedPluginId in ['org.jetbrains.kotlin.kapt', 'org.jetbrains.kotlin.plugin.scripting']) {
             return ['org.jetbrains.kotlin.jvm': version]
         }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyGradleModuleMetadataSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyGradleModuleMetadataSmokeTest.groovy
@@ -49,7 +49,7 @@ class ThirdPartyGradleModuleMetadataSmokeTest extends AbstractSmokeTest {
         given:
         BuildResult result
         useSample("gmm-example")
-        def kotlinVersion = TestedVersions.kotlin.latestStartsWith("1.7.10")
+        def kotlinVersion = "1.7.10"
         def androidPluginVersion = AGP_VERSIONS.getLatestOfMinor("7.3")
         def arch = OperatingSystem.current().macOsX ? 'MacosX64' : 'LinuxX64'
 


### PR DESCRIPTION
Instead of harcoded outdated AGP 7.3.

This PR also enable smoke testing of preview versions of KGP, this was disabled long ago...
It also simplifies how smoke tested KGP and AGP versions are selected.
It also moves knowledge of KGP and AGP requirements for Java or Gradle versions in central places.
It also moves tested KGP versions declaration to a properties file with a helper task to update it, the same way it was already done for AGP.
It also removes dead test code remaining from testing old KGP or AGP versions.

----

Android Studio tests still use hardcoded outdated AGP 7.3 because CI agents have an old Android Studio version installed
```
Gradle sync has failed with error message: 'The project is using an incompatible version (AGP 7.4.2) of the Android Gradle plugin. Latest supported version is AGP 7.4.0-beta02
```
https://ge.gradle.org/s/orelbeoprrcwy/tests/:performance:santaTrackerAndroidBuildPerformanceTest/org.gradle.performance.regression.android.RealLifeAndroidStudioPerformanceTest/run%20Android%20Studio%20sync?top-execution=1

* See https://github.com/gradle/gradle-private/issues/3755

----

All the android performance tests except SantaTracker use hardcoded AGP 7.3 and Kotlin 1.6 in their source.
This PR doesn't change that.

* See https://github.com/gradle/gradle/issues/24160