### PR TITLE
Mention remote cache in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ If you run into any trouble, please reach out to us on the issue you are working
 
 In order to make changes to Gradle, you'll need:
 
-* A [Java Development Kit](http://jdk.java.net/) (JDK) **version 11**.
+* A [Java Development Kit](http://jdk.java.net/) (JDK) **version 11**. Fixed version is required to use [remote cache](#remote-build-cache). 
 * A text editor or IDE. We use and recommend [IntelliJ IDEA CE](http://www.jetbrains.com/idea/).  IntelliJ Ultimate will also work. You'll need IntelliJ 2021.2.2 or newer.
 * [git](https://git-scm.com/) and a [GitHub account](https://github.com/join).
 
@@ -162,6 +162,14 @@ Tasks known to have problems are listed in the build logic. You can find this li
 If you discover a task that doesn't work with the configuration but it not in this list, please add it.
 
 For more information on the configuration cache, see the [user manual](https://docs.gradle.org/current/userguide/configuration_cache.html).
+
+### Remote build cache
+
+Gradle, Inc runs a set of remote build cache nodes to speed up local builds when developing Gradle. By default, the build is [configured](https://github.com/gradle/gradle-org-conventions-plugin#what-it-does) to use the build cache node in the EU region.
+
+The build cache has anonymous read access, so you don't need to authenticate in order to use it. You can use a different build cache node by specifying `-DcacheNode=us` for a build cache node in the US or `-DcacheNode=au` for a build cache node in Australia.
+
+If you are not getting cache hits from the build cache, you may be using the wrong version of Java. A fixed version (Java 11) is required to get remote cache hits.
 
 ### Building a distribution from source
 


### PR DESCRIPTION
### Context
It may be unclear for a new contributor why a fixed version of Java 11 is required. Tried to clarify this a bit.