### PR TITLE
Add internal API to disable storing in the cache

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedTaskIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedTaskIntegrationTest.groovy
@@ -56,7 +56,13 @@ class CachedTaskIntegrationTest extends AbstractIntegrationSpec implements Direc
         buildFile << defineCacheableTask()
         buildFile << """
             apply plugin: 'base'
-            cacheable.outputs.storeInCacheWhen { project.hasProperty('storeInCache') }
+
+            def storeInCache = project.hasProperty('storeInCache')
+            cacheable.doLast {
+                if (!storeInCache) {
+                    outputs.doNotStoreInCache()
+                }
+            }
         """
 
         when:

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedTaskIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedTaskIntegrationTest.groovy
@@ -52,6 +52,17 @@ class CachedTaskIntegrationTest extends AbstractIntegrationSpec implements Direc
         metadata.contains("userName=")
     }
 
+    def "storing in the cache can be disabled"() {
+        buildFile << defineCacheableTask()
+        buildFile << "cacheable.outputs.storeInCacheWhen { false }"
+
+        when:
+        withBuildCache().run("cacheable")
+
+        then:
+        listCacheFiles().size() == 0
+    }
+
     def "task is cacheable after previous failure"() {
         buildFile << """
             task foo {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/TaskOutputsEnterpriseInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/TaskOutputsEnterpriseInternal.java
@@ -17,18 +17,15 @@
 package org.gradle.api.internal;
 
 import org.gradle.api.NonNullApi;
-import org.gradle.api.Task;
-import org.gradle.api.specs.AndSpec;
-import org.gradle.api.specs.Spec;
 
 @NonNullApi
 public interface TaskOutputsEnterpriseInternal extends TaskOutputsInternal {
 
-    AndSpec<? super TaskInternal> getStoreInCacheSpec();
+    boolean getStoreInCache();
 
     /**
-     * Called after the task finishes executing. If the spec returns false, the outputs will not be stored in the cache.
+     * Avoid storing the task's outputs in the build cache.
      */
-    void storeInCacheWhen(Spec<? super Task> spec);
+    void doNotStoreInCache();
 
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/TaskOutputsEnterpriseInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/TaskOutputsEnterpriseInternal.java
@@ -16,15 +16,29 @@
 
 package org.gradle.api.internal;
 
+import org.gradle.api.DefaultTask;
 import org.gradle.api.NonNullApi;
 
+/**
+ * Gradle Enterprise specific extensions of {@link TaskOutputsInternal}.
+ * <p>
+ * This class exists to hide these additional methods from the public API since {@link DefaultTask#getOutputs()}
+ * returns {@link TaskOutputsInternal} rather than {@link org.gradle.api.tasks.TaskOutputs}.
+ *
+ * @since 8.2
+ */
 @NonNullApi
 public interface TaskOutputsEnterpriseInternal extends TaskOutputsInternal {
 
+    /**
+     * Whether the task's outputs should be stored in the build cache.
+     */
     boolean getStoreInCache();
 
     /**
      * Avoid storing the task's outputs in the build cache.
+     * <p>
+     * This does not prevent the task from being up-to-date.
      */
     void doNotStoreInCache();
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/TaskOutputsEnterpriseInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/TaskOutputsEnterpriseInternal.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2010 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal;
+
+import org.gradle.api.NonNullApi;
+import org.gradle.api.Task;
+import org.gradle.api.specs.AndSpec;
+import org.gradle.api.specs.Spec;
+
+@NonNullApi
+public interface TaskOutputsEnterpriseInternal extends TaskOutputsInternal {
+
+    AndSpec<? super TaskInternal> getStoreInCacheSpec();
+
+    /**
+     * Called after the task finishes executing. If the spec returns false, the outputs will not be stored in the cache.
+     */
+    void storeInCacheWhen(Spec<? super Task> spec);
+
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/TaskOutputsInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/TaskOutputsInternal.java
@@ -17,9 +17,11 @@
 package org.gradle.api.internal;
 
 import org.gradle.api.NonNullApi;
+import org.gradle.api.Task;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.tasks.execution.SelfDescribingSpec;
 import org.gradle.api.specs.AndSpec;
+import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.TaskOutputs;
 import org.gradle.internal.properties.PropertyVisitor;
 
@@ -36,6 +38,13 @@ public interface TaskOutputsInternal extends TaskOutputs {
     void visitRegisteredProperties(PropertyVisitor visitor);
 
     AndSpec<? super TaskInternal> getUpToDateSpec();
+
+    AndSpec<? super TaskInternal> getStoreInCacheSpec();
+
+    /**
+     * Called after the task finishes executing. If the spec returns false, the outputs will not be stored in the cache.
+     */
+    void storeInCacheWhen(Spec<? super Task> spec);
 
     void setPreviousOutputFiles(FileCollection previousOutputFiles);
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/TaskOutputsInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/TaskOutputsInternal.java
@@ -17,11 +17,9 @@
 package org.gradle.api.internal;
 
 import org.gradle.api.NonNullApi;
-import org.gradle.api.Task;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.tasks.execution.SelfDescribingSpec;
 import org.gradle.api.specs.AndSpec;
-import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.TaskOutputs;
 import org.gradle.internal.properties.PropertyVisitor;
 
@@ -38,13 +36,6 @@ public interface TaskOutputsInternal extends TaskOutputs {
     void visitRegisteredProperties(PropertyVisitor visitor);
 
     AndSpec<? super TaskInternal> getUpToDateSpec();
-
-    AndSpec<? super TaskInternal> getStoreInCacheSpec();
-
-    /**
-     * Called after the task finishes executing. If the spec returns false, the outputs will not be stored in the cache.
-     */
-    void storeInCacheWhen(Spec<? super Task> spec);
 
     void setPreviousOutputFiles(FileCollection previousOutputFiles);
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskOutputs.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskOutputs.java
@@ -24,7 +24,7 @@ import org.gradle.api.Task;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.FilePropertyContainer;
 import org.gradle.api.internal.TaskInternal;
-import org.gradle.api.internal.TaskOutputsInternal;
+import org.gradle.api.internal.TaskOutputsEnterpriseInternal;
 import org.gradle.api.internal.file.CompositeFileCollection;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileCollectionInternal;
@@ -50,7 +50,7 @@ import java.util.concurrent.Callable;
 import java.util.function.Consumer;
 
 @NonNullApi
-public class DefaultTaskOutputs implements TaskOutputsInternal {
+public class DefaultTaskOutputs implements TaskOutputsEnterpriseInternal {
     private final FileCollection allOutputFiles;
     private final PropertyWalker propertyWalker;
     private final FileCollectionFactory fileCollectionFactory;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskOutputs.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskOutputs.java
@@ -55,7 +55,7 @@ public class DefaultTaskOutputs implements TaskOutputsEnterpriseInternal {
     private final PropertyWalker propertyWalker;
     private final FileCollectionFactory fileCollectionFactory;
     private AndSpec<TaskInternal> upToDateSpec = AndSpec.empty();
-    private AndSpec<TaskInternal> storeInCache = AndSpec.empty();
+    private boolean storeInCache = true;
     private final List<SelfDescribingSpec<TaskInternal>> cacheIfSpecs = new LinkedList<>();
     private final List<SelfDescribingSpec<TaskInternal>> doNotCacheIfSpecs = new LinkedList<>();
     private FileCollection previousOutputFiles;
@@ -98,15 +98,14 @@ public class DefaultTaskOutputs implements TaskOutputsEnterpriseInternal {
     }
 
     @Override
-    public AndSpec<TaskInternal> getStoreInCacheSpec() {
+    public boolean getStoreInCache() {
         return storeInCache;
     }
 
     @Override
-    public void storeInCacheWhen(Spec<? super Task> spec) {
-        taskMutator.mutate("TaskOutputs.storeInCacheWhen(Spec)", () -> {
-            storeInCache = storeInCache.and(spec);
-        });
+    public void doNotStoreInCache() {
+        // Not wrapped in TaskMutator to allow calls during task execution
+        storeInCache = false;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskOutputs.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskOutputs.java
@@ -55,6 +55,7 @@ public class DefaultTaskOutputs implements TaskOutputsInternal {
     private final PropertyWalker propertyWalker;
     private final FileCollectionFactory fileCollectionFactory;
     private AndSpec<TaskInternal> upToDateSpec = AndSpec.empty();
+    private AndSpec<TaskInternal> storeInCache = AndSpec.empty();
     private final List<SelfDescribingSpec<TaskInternal>> cacheIfSpecs = new LinkedList<>();
     private final List<SelfDescribingSpec<TaskInternal>> doNotCacheIfSpecs = new LinkedList<>();
     private FileCollection previousOutputFiles;
@@ -93,6 +94,18 @@ public class DefaultTaskOutputs implements TaskOutputsInternal {
     public void upToDateWhen(final Spec<? super Task> spec) {
         taskMutator.mutate("TaskOutputs.upToDateWhen(Spec)", () -> {
             upToDateSpec = upToDateSpec.and(spec);
+        });
+    }
+
+    @Override
+    public AndSpec<TaskInternal> getStoreInCacheSpec() {
+        return storeInCache;
+    }
+
+    @Override
+    public void storeInCacheWhen(Spec<? super Task> spec) {
+        taskMutator.mutate("TaskOutputs.storeOutputsInCacheWhen(Spec)", () -> {
+            storeInCache = storeInCache.and(spec);
         });
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskOutputs.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskOutputs.java
@@ -104,7 +104,7 @@ public class DefaultTaskOutputs implements TaskOutputsInternal {
 
     @Override
     public void storeInCacheWhen(Spec<? super Task> spec) {
-        taskMutator.mutate("TaskOutputs.storeOutputsInCacheWhen(Spec)", () -> {
+        taskMutator.mutate("TaskOutputs.storeInCacheWhen(Spec)", () -> {
             storeInCache = storeInCache.and(spec);
         });
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecution.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecution.java
@@ -21,7 +21,7 @@ import com.google.common.collect.Lists;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.GeneratedSubclasses;
 import org.gradle.api.internal.TaskInternal;
-import org.gradle.api.internal.TaskOutputsInternal;
+import org.gradle.api.internal.TaskOutputsEnterpriseInternal;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.file.collections.LazilyInitializedFileCollection;
@@ -160,7 +160,7 @@ public class TaskExecution implements UnitOfWork {
         FileCollection previousFiles = executionRequest.getPreviouslyProducedOutputs()
             .<FileCollection>map(previousOutputs -> new PreviousOutputFileCollection(task, taskDependencyFactory, fileCollectionFactory, previousOutputs))
             .orElseGet(FileCollectionFactory::empty);
-        TaskOutputsInternal outputs = task.getOutputs();
+        TaskOutputsEnterpriseInternal outputs = (TaskOutputsEnterpriseInternal) task.getOutputs();
         outputs.setPreviousOutputFiles(previousFiles);
         try {
             WorkResult didWork = executeWithPreviousOutputFiles(executionRequest.getInputChanges().orElse(null));

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecution.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecution.java
@@ -164,7 +164,7 @@ public class TaskExecution implements UnitOfWork {
         outputs.setPreviousOutputFiles(previousFiles);
         try {
             WorkResult didWork = executeWithPreviousOutputFiles(executionRequest.getInputChanges().orElse(null));
-            boolean storeInCache = outputs.getStoreInCacheSpec().isSatisfiedBy(task);
+            boolean storeInCache = outputs.getStoreInCache();
             return new WorkOutput() {
                 @Override
                 public WorkResult getDidWork() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecution.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecution.java
@@ -164,6 +164,7 @@ public class TaskExecution implements UnitOfWork {
         outputs.setPreviousOutputFiles(previousFiles);
         try {
             WorkResult didWork = executeWithPreviousOutputFiles(executionRequest.getInputChanges().orElse(null));
+            boolean storeInCache = outputs.getStoreInCacheSpec().isSatisfiedBy(task);
             return new WorkOutput() {
                 @Override
                 public WorkResult getDidWork() {
@@ -173,6 +174,11 @@ public class TaskExecution implements UnitOfWork {
                 @Override
                 public Object getOutput() {
                     return null;
+                }
+
+                @Override
+                public boolean canStoreInCache() {
+                    return storeInCache;
                 }
             };
         } finally {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
@@ -30,6 +30,7 @@ import org.gradle.api.internal.tasks.TaskExecutionContext
 import org.gradle.api.internal.tasks.TaskExecutionOutcome
 import org.gradle.api.internal.tasks.TaskStateInternal
 import org.gradle.api.internal.tasks.properties.TaskProperties
+import org.gradle.api.specs.AndSpec
 import org.gradle.api.tasks.StopActionException
 import org.gradle.api.tasks.StopExecutionException
 import org.gradle.api.tasks.TaskExecutionException
@@ -209,6 +210,7 @@ class ExecuteActionsTaskExecuterTest extends Specification {
         task.getState() >> state
         task.getOutputs() >> taskOutputs
         task.getPath() >> "task"
+        _ * taskOutputs.getStoreInCacheSpec() >> AndSpec.empty()
         taskOutputs.setPreviousOutputFiles(_ as FileCollection)
         project.getBuildScriptSource() >> scriptSource
         task.getStandardOutputCapture() >> standardOutputCapture

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
@@ -30,7 +30,6 @@ import org.gradle.api.internal.tasks.TaskExecutionContext
 import org.gradle.api.internal.tasks.TaskExecutionOutcome
 import org.gradle.api.internal.tasks.TaskStateInternal
 import org.gradle.api.internal.tasks.properties.TaskProperties
-import org.gradle.api.specs.AndSpec
 import org.gradle.api.tasks.StopActionException
 import org.gradle.api.tasks.StopExecutionException
 import org.gradle.api.tasks.TaskExecutionException
@@ -210,7 +209,6 @@ class ExecuteActionsTaskExecuterTest extends Specification {
         task.getState() >> state
         task.getOutputs() >> taskOutputs
         task.getPath() >> "task"
-        _ * taskOutputs.getStoreInCacheSpec() >> AndSpec.empty()
         taskOutputs.setPreviousOutputFiles(_ as FileCollection)
         project.getBuildScriptSource() >> scriptSource
         task.getStandardOutputCapture() >> standardOutputCapture

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
@@ -21,7 +21,7 @@ import org.gradle.api.execution.TaskActionListener
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.DocumentationRegistry
 import org.gradle.api.internal.TaskInternal
-import org.gradle.api.internal.TaskOutputsInternal
+import org.gradle.api.internal.TaskOutputsEnterpriseInternal
 import org.gradle.api.internal.changedetection.TaskExecutionMode
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.project.ProjectInternal
@@ -104,7 +104,7 @@ import static org.gradle.internal.work.AsyncWorkTracker.ProjectLockRetention.REL
 class ExecuteActionsTaskExecuterTest extends Specification {
     private final DocumentationRegistry documentationRegistry = new DocumentationRegistry()
     def task = Mock(TaskInternal)
-    def taskOutputs = Mock(TaskOutputsInternal)
+    def taskOutputs = Mock(TaskOutputsEnterpriseInternal)
     def action1 = Mock(InputChangesAwareTaskAction) {
         getActionImplementation(_ as ClassLoaderHierarchyHasher) >> ImplementationSnapshot.of("Action1", TestHashCodes.hashCodeFrom(1234))
     }

--- a/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/test/TestTaskPropertiesServiceIntegrationTest.groovy
+++ b/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/test/TestTaskPropertiesServiceIntegrationTest.groovy
@@ -99,9 +99,9 @@ class TestTaskPropertiesServiceIntegrationTest extends AbstractIntegrationSpec {
                 environment('KEY', 'VALUE')
             }
         """
-        file('src/test/java/org/example/TestClass.java') << """
+        file('src/test/java/org/example/SomeClass.java') << """
             package org.example;
-            public class TestClass {}
+            public class SomeClass {}
         """
 
         when:
@@ -143,8 +143,8 @@ class TestTaskPropertiesServiceIntegrationTest extends AbstractIntegrationSpec {
             with(candidateClassFiles, List) {
                 size() == 1
                 with(first(), Map) {
-                    file == file("build/classes/java/test/org/example/TestClass.class").absolutePath
-                    relativePath == "org/example/TestClass.class"
+                    file == file("build/classes/java/test/org/example/SomeClass.class").absolutePath
+                    relativePath == "org/example/SomeClass.class"
                 }
             }
             with(inputFileProperties, List) {

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/test/TestTaskPropertiesService.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/test/TestTaskPropertiesService.java
@@ -18,10 +18,24 @@ package org.gradle.internal.enterprise.test;
 
 import org.gradle.api.tasks.testing.Test;
 
+/**
+ * Provides access to the configuration of {@link Test} tasks and allows
+ * disabling storing their outputs in the build cache.
+ */
 public interface TestTaskPropertiesService {
 
+    /**
+     * Collect the configuration of the given task.
+     */
     TestTaskProperties collectProperties(Test task);
 
+    /**
+     * Avoid storing the task's outputs in the build cache.
+     * <p>
+     * This allows disabling storing a task's outputs in the build cache if it only executed a subset of tests
+     * while still allowing the task to be loaded from the build cache if a prior execution with the same
+     * cache key executed all tests.
+     */
     void doNotStoreInCache(Test task);
 
 }

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/test/TestTaskPropertiesService.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/test/TestTaskPropertiesService.java
@@ -22,4 +22,6 @@ public interface TestTaskPropertiesService {
 
     TestTaskProperties collectProperties(Test task);
 
+    void doNotStoreInCache(Test task);
+
 }

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/test/TestTaskPropertiesService.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/test/TestTaskPropertiesService.java
@@ -17,11 +17,14 @@
 package org.gradle.internal.enterprise.test;
 
 import org.gradle.api.tasks.testing.Test;
+import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 /**
  * Provides access to the configuration of {@link Test} tasks and allows
  * disabling storing their outputs in the build cache.
  */
+@ServiceScope(Scopes.Project.class)
 public interface TestTaskPropertiesService {
 
     /**

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/test/impl/DefaultTestTaskPropertiesService.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/test/impl/DefaultTestTaskPropertiesService.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableSet;
 import org.gradle.api.file.EmptyFileVisitor;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileVisitDetails;
+import org.gradle.api.internal.TaskOutputsEnterpriseInternal;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.tasks.TaskPropertyUtils;
 import org.gradle.api.internal.tasks.testing.filter.DefaultTestFilter;
@@ -121,6 +122,11 @@ public class DefaultTestTaskPropertiesService implements TestTaskPropertiesServi
             inputFileProperties.build(),
             outputFileProperties.build()
         );
+    }
+
+    @Override
+    public void doNotStoreInCache(Test task) {
+        ((TaskOutputsEnterpriseInternal) task.getOutputs()).doNotStoreInCache();
     }
 
     private ImmutableList<CandidateClassFile> collectCandidateClassFiles(Test task) {

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/ExecutionEngine.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/ExecutionEngine.java
@@ -97,6 +97,10 @@ public interface ExecutionEngine {
         // TODO Parametrize UnitOfWork with this generated result
         @Nullable
         Object getOutput();
+
+        default boolean canStoreOutputsInCache() {
+            return true;
+        }
     }
 
     /**

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/ExecutionEngine.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/ExecutionEngine.java
@@ -98,6 +98,9 @@ public interface ExecutionEngine {
         @Nullable
         Object getOutput();
 
+        /**
+         * Whether the outputs of this execution should be stored in the build cache.
+         */
         default boolean canStoreOutputsInCache() {
             return true;
         }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/UnitOfWork.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/UnitOfWork.java
@@ -104,7 +104,7 @@ public interface UnitOfWork extends Describable {
         Object getOutput();
 
         /**
-         * Whether the outputs can be reused by other builds.
+         * Whether this output should be stored in the build cache.
          */
         default boolean canStoreInCache() {
             return true;

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/UnitOfWork.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/UnitOfWork.java
@@ -102,6 +102,13 @@ public interface UnitOfWork extends Describable {
          */
         @Nullable
         Object getOutput();
+
+        /**
+         * Whether the outputs can be reused by other builds.
+         */
+        default boolean canStoreInCache() {
+            return true;
+        }
     }
 
     enum WorkResult {

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/BuildCacheStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/BuildCacheStep.java
@@ -138,17 +138,24 @@ public class BuildCacheStep implements Step<IncrementalChangesContext, AfterExec
         }
         AfterExecutionResult result = executeWithoutCache(cacheableWork.work, context);
         result.getExecution().ifSuccessfulOrElse(
-            executionResult -> {
-                if (executionResult.canStoreOutputsInCache()) {
-                    result.getAfterExecutionState()
-                        .ifPresent(afterExecutionState -> store(cacheableWork, cacheKey, afterExecutionState.getOutputFilesProducedByWork(), afterExecutionState.getOriginMetadata().getExecutionTime()));
-                } else {
-                    LOGGER.debug("Not storing result of {} in cache because reuse of its outputs was disabled", cacheableWork.getDisplayName());
-                }
-            },
+            executionResult -> storeInCacheUnlessDisabled(cacheableWork, cacheKey, result, executionResult),
             failure -> LOGGER.debug("Not storing result of {} in cache because the execution failed", cacheableWork.getDisplayName())
         );
         return result;
+    }
+
+    /**
+     * Stores the results of the given work in the build cache, unless storing was disabled for this execution or work was untracked.
+     * <p>
+     * The former is currently used only for tasks and can be triggered via {@code org.gradle.api.internal.TaskOutputsEnterpriseInternal}.
+     */
+    private void storeInCacheUnlessDisabled(CacheableWork cacheableWork, BuildCacheKey cacheKey, AfterExecutionResult result, Execution executionResult) {
+        if (executionResult.canStoreOutputsInCache()) {
+            result.getAfterExecutionState()
+                .ifPresent(afterExecutionState -> store(cacheableWork, cacheKey, afterExecutionState.getOutputFilesProducedByWork(), afterExecutionState.getOriginMetadata().getExecutionTime()));
+        } else {
+            LOGGER.debug("Not storing result of {} in cache because storing was disabled for this execution", cacheableWork.getDisplayName());
+        }
     }
 
     private void store(CacheableWork work, BuildCacheKey cacheKey, ImmutableSortedMap<String, FileSystemSnapshot> outputFilesProducedByWork, Duration executionTime) {

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ExecuteStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ExecuteStep.java
@@ -160,5 +160,10 @@ public class ExecuteStep<C extends ChangingOutputsContext> implements Step<C, Re
         public Object getOutput() {
             return workOutput.getOutput();
         }
+
+        @Override
+        public boolean canStoreOutputsInCache() {
+            return workOutput.canStoreInCache();
+        }
     }
 }

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/BuildCacheStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/BuildCacheStepTest.groovy
@@ -91,6 +91,9 @@ class BuildCacheStepTest extends StepSpec<IncrementalChangesContext> implements 
     }
 
     def "executes work and stores in cache on cache miss"() {
+        given:
+        def execution = Mock(Execution)
+
         when:
         def result = step.execute(work, context)
 
@@ -105,7 +108,8 @@ class BuildCacheStepTest extends StepSpec<IncrementalChangesContext> implements 
 
         then:
         1 * delegate.execute(work, context) >> delegateResult
-        1 * delegateResult.execution >> Try.successful(Mock(Execution))
+        1 * delegateResult.execution >> Try.successful(execution)
+        1 * execution.canStoreOutputsInCache() >> true
 
         then:
         interaction { outputStored {} }
@@ -141,6 +145,9 @@ class BuildCacheStepTest extends StepSpec<IncrementalChangesContext> implements 
     }
 
     def "does not store untracked result in cache"() {
+        given:
+        def execution = Mock(Execution)
+
         when:
         def result = step.execute(work, context)
 
@@ -155,8 +162,9 @@ class BuildCacheStepTest extends StepSpec<IncrementalChangesContext> implements 
 
         then:
         1 * delegate.execute(work, context) >> delegateResult
-        1 * delegateResult.execution >> Try.successful(Mock(Execution))
+        1 * delegateResult.execution >> Try.successful(execution)
         1 * delegateResult.afterExecutionState >> Optional.empty()
+        1 * execution.canStoreOutputsInCache() >> true
 
         then:
         0 * buildCacheController.store(_)
@@ -186,6 +194,9 @@ class BuildCacheStepTest extends StepSpec<IncrementalChangesContext> implements 
     }
 
     def "does not load but stores when loading is disabled"() {
+        given:
+        def execution = Mock(Execution)
+
         when:
         def result = step.execute(work, context)
 
@@ -199,7 +210,8 @@ class BuildCacheStepTest extends StepSpec<IncrementalChangesContext> implements 
 
         then:
         1 * delegate.execute(work, context) >> delegateResult
-        1 * delegateResult.execution >> Try.successful(Mock(Execution))
+        1 * delegateResult.execution >> Try.successful(execution)
+        1 * execution.canStoreOutputsInCache() >> true
 
         then:
         interaction { outputStored {} }
@@ -207,6 +219,8 @@ class BuildCacheStepTest extends StepSpec<IncrementalChangesContext> implements 
     }
 
     def "fails when cache backend throws exception while storing cached result"() {
+        given:
+        def execution = Mock(Execution)
         def failure = new RuntimeException("store failure")
 
         when:
@@ -224,7 +238,8 @@ class BuildCacheStepTest extends StepSpec<IncrementalChangesContext> implements 
 
         then:
         1 * delegate.execute(work, context) >> delegateResult
-        1 * delegateResult.execution >> Try.successful(Mock(Execution))
+        1 * delegateResult.execution >> Try.successful(execution)
+        1 * execution.canStoreOutputsInCache() >> true
 
         then:
         interaction { outputStored { throw failure } }

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/BuildCacheStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/BuildCacheStepTest.groovy
@@ -258,6 +258,24 @@ class BuildCacheStepTest extends StepSpec<IncrementalChangesContext> implements 
         0 * _
     }
 
+    def "executes and doesn't store when storing is disabled"() {
+        given:
+        def execution = Mock(Execution)
+
+        when:
+        def result = step.execute(work, context)
+
+        then:
+        result == delegateResult
+
+        interaction { withValidCacheKey() }
+
+        1 * delegate.execute(work, context) >> delegateResult
+        1 * delegateResult.execution >> Try.successful(execution)
+        1 * execution.canStoreOutputsInCache() >> false
+        0 * _
+    }
+
     private void withValidCacheKey() {
         _ * context.cachingState >> CachingState.enabled(cacheKey, beforeExecutionState)
     }


### PR DESCRIPTION
This would be used by the predictive test selection plugin in Gradle Enterprise to disable storing in the cache when only a subset of tests was selected. This prevents other builds pulling this subset when they really wanted to run all tests.

Left it as internal, since we have no other use case for this right now.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
