### PR TITLE
Add verbiage in upgrade guide about framework options no longer being overwritten

### DIFF
--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -93,6 +93,24 @@ test {
 }
 ```
 
+Additionally, setting the test framework multiple times to the _same_ framework now accumulates any options that might be set on the framework.
+Previously, each time the framework was set, it would cause the framework options to be overwritten.
+
+The following code now results in both the "foo" and "bar" tags to be included for the `test` task:
+```
+test {
+   useJUnitPlatform() {
+        includeTags("foo")
+   }
+}
+tasks.withType(Test).configureEach {
+   // previously, this would overwrite the included tags to only include "bar"
+   useJUnitPlatform() {
+        includeTags("bar")
+   }
+}
+```
+
 === Removed APIs
 
 ==== Legacy ArtifactTransform API


### PR DESCRIPTION
See #24149.  The fact that is vaguely mentioned in the upgrade guide, but it may not be clear that anything that relied on the overwriting behavior will no longer work.  This adds something to the upgrade guide to call out this new behavior specifically. 