### PR TITLE
Rename `FlowProviders.{requestedTasks => buildWork}Result`

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheFlowScopeIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheFlowScopeIntegrationTest.groovy
@@ -166,7 +166,7 @@ class ConfigurationCacheFlowScopeIntegrationTest extends AbstractConfigurationCa
 
                 void apply($targetType target) {
                     flowScope.always(SetLavaLampColor) {
-                        parameters.color = flowProviders.requestedTasksResult.map {
+                        parameters.color = flowProviders.buildWorkResult.map {
                             it.failure.present ? 'red' : 'green'
                         }
                     }
@@ -296,7 +296,7 @@ class ConfigurationCacheFlowScopeIntegrationTest extends AbstractConfigurationCa
 
                 void apply($targetType target) {
                     flowScope.always(SetLavaLampColor) {
-                        parameters.color = flowProviders.requestedTasksResult.map {
+                        parameters.color = flowProviders.buildWorkResult.map {
                             it.failure.present ? 'red' : 'green'
                         }
                     }
@@ -378,7 +378,7 @@ class ConfigurationCacheFlowScopeIntegrationTest extends AbstractConfigurationCa
                     def lamp = target.gradle.sharedServices.registerIfAbsent('lamp', LavaLamp) {}
                     flowScope.always(SetLavaLampColor) {
                         ${namedAnnotation ? '' : 'parameters.lamp = lamp'}
-                        parameters.color = flowProviders.requestedTasksResult.map {
+                        parameters.color = flowProviders.buildWorkResult.map {
                             it.failure.present ? 'red' : 'green'
                         }
                     }
@@ -435,7 +435,7 @@ class ConfigurationCacheFlowScopeIntegrationTest extends AbstractConfigurationCa
 
         abstract class ResultSource implements ValueSource<String, Params> {
             interface Params extends ValueSourceParameters {
-                Property<RequestedTasksResult> getTasksResult();
+                Property<BuildWorkResult> getWorkResult();
             }
 
             @Override String obtain() {
@@ -450,7 +450,7 @@ class ConfigurationCacheFlowScopeIntegrationTest extends AbstractConfigurationCa
         def flowProviders = objects.newInstance(FlowProvidersGetter).flowProviders
 
         providers.of(ResultSource) {
-            parameters.tasksResult = flowProviders.requestedTasksResult
+            parameters.workResult = flowProviders.buildWorkResult
         }.get()
 
         """)

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/flow/BuildFlowScope.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/flow/BuildFlowScope.kt
@@ -114,7 +114,7 @@ open class BuildFlowScope @Inject constructor(
     }
 
     override fun buildFinished(result: BuildResult) {
-        setRequestedTasksResult(result.failure)
+        setBuildWorkResult(result.failure)
         schedulePendingActions()
     }
 
@@ -129,8 +129,8 @@ open class BuildFlowScope @Inject constructor(
     }
 
     private
-    fun setRequestedTasksResult(failure: Throwable?) {
-        flowProviders.requestedTasksResult.uncheckedCast<RequestedTasksResultProvider>().apply {
+    fun setBuildWorkResult(failure: Throwable?) {
+        flowProviders.buildWorkResult.uncheckedCast<BuildWorkResultProvider>().apply {
             set { Optional.ofNullable(failure) }
         }
     }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/flow/DefaultFlowProviders.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/flow/DefaultFlowProviders.kt
@@ -16,8 +16,8 @@
 
 package org.gradle.configurationcache.flow
 
+import org.gradle.api.flow.BuildWorkResult
 import org.gradle.api.flow.FlowProviders
-import org.gradle.api.flow.RequestedTasksResult
 import org.gradle.api.internal.provider.AbstractMinimalProvider
 import org.gradle.api.internal.provider.ValueSupplier
 import org.gradle.api.provider.Provider
@@ -29,36 +29,36 @@ import org.gradle.internal.service.scopes.ServiceScope
 class DefaultFlowProviders : FlowProviders {
 
     private
-    val requestedTasksResult by lazy {
-        RequestedTasksResultProvider()
+    val buildWorkResult by lazy {
+        BuildWorkResultProvider()
     }
 
-    override fun getRequestedTasksResult(): Provider<RequestedTasksResult> =
-        requestedTasksResult
+    override fun getBuildWorkResult(): Provider<BuildWorkResult> =
+        buildWorkResult
 }
 
 
 internal
-class RequestedTasksResultProvider : AbstractMinimalProvider<RequestedTasksResult>() {
+class BuildWorkResultProvider : AbstractMinimalProvider<BuildWorkResult>() {
 
     private
-    var result: RequestedTasksResult? = null
+    var result: BuildWorkResult? = null
 
-    fun set(result: RequestedTasksResult) {
+    fun set(result: BuildWorkResult) {
         require(this.result == null)
         this.result = result
     }
 
-    override fun getType(): Class<RequestedTasksResult> = RequestedTasksResult::class.java
+    override fun getType(): Class<BuildWorkResult> =
+        BuildWorkResult::class.java
 
-    override fun calculateOwnValue(consumer: ValueSupplier.ValueConsumer): ValueSupplier.Value<out RequestedTasksResult> {
+    override fun calculateOwnValue(consumer: ValueSupplier.ValueConsumer): ValueSupplier.Value<out BuildWorkResult> {
         require(result != null) {
-            "Cannot access flow provider value before it becomes available!"
+            "Cannot access the value of '${BuildWorkResult::class.simpleName}' before it becomes available!"
         }
         return ValueSupplier.Value.ofNullable(result)
     }
 
-    override fun calculateExecutionTimeValue(): ValueSupplier.ExecutionTimeValue<out RequestedTasksResult> {
-        return ValueSupplier.ExecutionTimeValue.changingValue(this)
-    }
+    override fun calculateExecutionTimeValue(): ValueSupplier.ExecutionTimeValue<out BuildWorkResult> =
+        ValueSupplier.ExecutionTimeValue.changingValue(this)
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/ProviderCodecs.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/ProviderCodecs.kt
@@ -41,7 +41,7 @@ import org.gradle.api.services.internal.BuildServiceProvider
 import org.gradle.api.services.internal.BuildServiceRegistryInternal
 import org.gradle.configurationcache.extensions.serviceOf
 import org.gradle.configurationcache.extensions.uncheckedCast
-import org.gradle.configurationcache.flow.RequestedTasksResultProvider
+import org.gradle.configurationcache.flow.BuildWorkResultProvider
 import org.gradle.configurationcache.serialization.Codec
 import org.gradle.configurationcache.serialization.ReadContext
 import org.gradle.configurationcache.serialization.WriteContext
@@ -62,7 +62,7 @@ internal
 class FixedValueReplacingProviderCodec(
     valueSourceProviderCodec: Codec<ValueSourceProvider<*, *>>,
     buildServiceProviderCodec: Codec<BuildServiceProvider<*, *>>,
-    flowProvidersCodec: Codec<RequestedTasksResultProvider>,
+    flowProvidersCodec: Codec<BuildWorkResultProvider>,
 ) {
     private
     val providerWithChangingValueCodec = Bindings.of {
@@ -133,13 +133,13 @@ class FixedValueReplacingProviderCodec(
 internal
 class FlowProvidersCodec(
     private val flowProviders: FlowProviders
-) : Codec<RequestedTasksResultProvider> {
+) : Codec<BuildWorkResultProvider> {
 
-    override suspend fun WriteContext.encode(value: RequestedTasksResultProvider) {
+    override suspend fun WriteContext.encode(value: BuildWorkResultProvider) {
     }
 
-    override suspend fun ReadContext.decode(): RequestedTasksResultProvider {
-        return flowProviders.requestedTasksResult.uncheckedCast()
+    override suspend fun ReadContext.decode(): BuildWorkResultProvider {
+        return flowProviders.buildWorkResult.uncheckedCast()
     }
 }
 

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/UnsupportedTypesCodecs.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/UnsupportedTypesCodecs.kt
@@ -55,7 +55,7 @@ import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskDependency
-import org.gradle.configurationcache.flow.RequestedTasksResultProvider
+import org.gradle.configurationcache.flow.BuildWorkResultProvider
 import org.gradle.configurationcache.problems.DocumentationSection
 import org.gradle.configurationcache.serialization.Codec
 import org.gradle.configurationcache.serialization.IsolateContext
@@ -166,12 +166,12 @@ object UnsupportedFingerprintBuildServiceProviderCodec : Codec<BuildServiceProvi
 
 
 internal
-object UnsupportedFingerprintFlowProviders : Codec<RequestedTasksResultProvider> {
-    override suspend fun WriteContext.encode(value: RequestedTasksResultProvider) {
+object UnsupportedFingerprintFlowProviders : Codec<BuildWorkResultProvider> {
+    override suspend fun WriteContext.encode(value: BuildWorkResultProvider) {
         logUnsupported("serialize")
     }
 
-    override suspend fun ReadContext.decode(): RequestedTasksResultProvider? {
+    override suspend fun ReadContext.decode(): BuildWorkResultProvider? {
         logUnsupported("deserialize")
         return null
     }
@@ -180,7 +180,7 @@ object UnsupportedFingerprintFlowProviders : Codec<RequestedTasksResultProvider>
     fun IsolateContext.logUnsupported(action: String) {
         logUnsupported(action) {
             text(" ")
-            reference(RequestedTasksResultProvider::class)
+            reference(BuildWorkResultProvider::class)
             text(" used at configuration time")
         }
     }

--- a/subprojects/core-api/src/main/java/org/gradle/api/flow/BuildWorkResult.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/flow/BuildWorkResult.java
@@ -25,11 +25,11 @@ import java.util.Optional;
  * Summary of the result of executing the
  * {@link StartParameter#getTaskRequests() requested tasks}.
  *
- * @see FlowProviders#getRequestedTasksResult()
+ * @see FlowProviders#getBuildWorkResult()
  * @since 8.1
  */
 @Incubating
-public interface RequestedTasksResult {
+public interface BuildWorkResult {
 
     /**
      * A summary of the failure(s) that occurred as Gradle tried to execute the requested tasks.

--- a/subprojects/core-api/src/main/java/org/gradle/api/flow/BuildWorkResult.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/flow/BuildWorkResult.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.flow;
 
-import org.gradle.StartParameter;
 import org.gradle.api.Incubating;
 
 import java.util.Optional;

--- a/subprojects/core-api/src/main/java/org/gradle/api/flow/BuildWorkResult.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/flow/BuildWorkResult.java
@@ -22,8 +22,7 @@ import org.gradle.api.Incubating;
 import java.util.Optional;
 
 /**
- * Summary of the result of executing the
- * {@link StartParameter#getTaskRequests() requested tasks}.
+ * Summary result of the execution of the work scheduled for the current build.
  *
  * @see FlowProviders#getBuildWorkResult()
  * @since 8.1
@@ -32,7 +31,8 @@ import java.util.Optional;
 public interface BuildWorkResult {
 
     /**
-     * A summary of the failure(s) that occurred as Gradle tried to execute the requested tasks.
+     * A summary of the configuration time and execution time failure(s) that occurred as Gradle tried to execute the
+     * scheduled work.
      *
      * @return {@link Optional#empty() empty} when no failures occur.
      */

--- a/subprojects/core-api/src/main/java/org/gradle/api/flow/FlowProviders.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/flow/FlowProviders.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.flow;
 
-import org.gradle.StartParameter;
 import org.gradle.api.Incubating;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.service.scopes.Scopes;
@@ -33,15 +32,14 @@ import org.gradle.internal.service.scopes.ServiceScope;
 public interface FlowProviders {
 
     /**
-     * Returns a {@link Provider provider} for the summary of the result of executing the
-     * {@link StartParameter#getTaskRequests() requested tasks}.
+     * Returns a {@link Provider provider} for the summary result of the execution of the work scheduled
+     * for the current build.
      * <p>
-     * The returned {@link Provider#get() provider's value} becomes available after all requested tasks
-     * have completed - successfully or otherwise - or after a configuration phase failure prevents the execution
-     * of the requested tasks.
+     * The returned {@link Provider#get() provider's value} becomes available after the scheduled work
+     * has completed - successfully or otherwise - or after a configuration phase failure prevents execution.
      * </p>
      * <p>
-     * <b>IMPORTANT:</b> trying to access the provider's value before the requested tasks have finished will
+     * <b>IMPORTANT:</b> trying to access the provider's value before the scheduled work has finished will
      * result in an error.
      * </p>
      *
@@ -65,7 +63,7 @@ public interface FlowProviders {
      *         final File soundsDir = new File(target.getSettingsDir(), "sounds");
      *         flowScope.always(FFPlay.class, spec -&gt;
      *             spec.getParameters().getMediaFile().fileProvider(
-     *                 flowProviders.getRequestedTasksResult().map(result -&gt;
+     *                 flowProviders.getBuildWorkResult().map(result -&gt;
      *                     new File(
      *                         soundsDir,
      *                         result.getFailure().isPresent() ? "sad-trombone.mp3" : "tada.mp3"
@@ -80,5 +78,5 @@ public interface FlowProviders {
      * @see FlowAction
      * @see FlowScope
      */
-    Provider<RequestedTasksResult> getRequestedTasksResult();
+    Provider<BuildWorkResult> getBuildWorkResult();
 }


### PR DESCRIPTION
In response to the
[feedback](https://docs.google.com/document/d/1nS1JTwdCMQN_0WaaFrSUxoQOj3zOqmKmXxC6k0OXUR0/edit?disco=AAAApl9FjEk) that `requestedTasks` seemed to imply that only task results and failures would flow through this provider (and not, say, configuration time failures).

The prefix `BuildWork` was chosen because we already use it in other type names with the same intended meaning.