### PR TITLE
Let tests use extensions instead of conventions

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/codenarc/CodeNarcPluginIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/codenarc/CodeNarcPluginIntegrationTest.groovy
@@ -47,7 +47,7 @@ class CodeNarcPluginIntegrationTest extends WellBehavedPluginTest {
                 assert task instanceof CodeNarc
                 task.with {
                     assert description == "Run CodeNarc analysis for ${sourceSet.name} classes"
-                    assert source as List == sourceSet.allGroovy  as List
+                    assert source as List == sourceSet.groovy as List
                     assert codenarcClasspath == project.configurations.codenarc
                     assert config.inputFiles.singleFile == project.file("config/codenarc/codenarc.xml")
                     assert configFile == project.file("config/codenarc/codenarc.xml")
@@ -111,7 +111,7 @@ class CodeNarcPluginIntegrationTest extends WellBehavedPluginTest {
                 assert task instanceof CodeNarc
                 task.with {
                     assert description == "Run CodeNarc analysis for ${sourceSet.name} classes"
-                    assert source as List == sourceSet.allGroovy as List
+                    assert source as List == sourceSet.groovy as List
                     assert codenarcClasspath == project.configurations.codenarc
                     assert config.inputFiles.singleFile == project.file("codenarc-config")
                     assert configFile == project.file("codenarc-config")

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/AbstractPmdPluginVersionIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/AbstractPmdPluginVersionIntegrationTest.groovy
@@ -38,19 +38,19 @@ class AbstractPmdPluginVersionIntegrationTest extends MultiVersionIntegrationSpe
      */
     String requiredSourceCompatibility() {
         if (versionNumber < VersionNumber.parse('6.0.0') && TestPrecondition.JDK9_OR_LATER.isFulfilled()) {
-            "sourceCompatibility = 1.8"
+            "java.sourceCompatibility = 1.8"
         } else if (versionNumber < VersionNumber.parse('6.4.0') && TestPrecondition.JDK10_OR_LATER.isFulfilled()) {
-            "sourceCompatibility = 9"
+            "java.sourceCompatibility = 9"
         } else if (versionNumber < VersionNumber.parse('6.6.0') && TestPrecondition.JDK11_OR_LATER.isFulfilled()) {
-            "sourceCompatibility = 10"
+            "java.sourceCompatibility = 10"
         } else if (versionNumber < VersionNumber.parse('6.13.0') && TestPrecondition.JDK12_OR_LATER.isFulfilled()) {
-            "sourceCompatibility = 11"
+            "java.sourceCompatibility = 11"
         } else if (versionNumber < VersionNumber.parse('6.18.0') && TestPrecondition.JDK13_OR_LATER.isFulfilled()) {
-            "sourceCompatibility = 12"
+            "java.sourceCompatibility = 12"
         } else if (versionNumber < VersionNumber.parse('6.22.0') && TestPrecondition.JDK14_OR_LATER.isFulfilled()) {
-            "sourceCompatibility = 13"
+            "java.sourceCompatibility = 13"
         } else if (versionNumber < VersionNumber.parse('6.48.0') && TestPrecondition.JDK19_OR_LATER.isFulfilled()) {
-            "sourceCompatibility = 18"
+            "java.sourceCompatibility = 18"
         } else {
             "" // do not set a source compatibility for the DEFAULT_PMD_VERSION running on latest Java, this way we will catch if it breaks with a new Java version
         }

--- a/subprojects/core/src/integTest/groovy/org/gradle/JansiEndUserIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/JansiEndUserIntegrationTest.groovy
@@ -139,7 +139,7 @@ class JansiEndUserIntegrationTest extends AbstractIntegrationSpec {
 
     static String annotationProcessorDependency(File repoDir, String processorDependency) {
         """
-            sourceCompatibility = '1.7'
+            java.sourceCompatibility = '1.7'
 
             repositories {
                 maven {
@@ -200,7 +200,7 @@ class JansiEndUserIntegrationTest extends AbstractIntegrationSpec {
 
                 group = '$group'
                 version = '$version'
-                sourceCompatibility = '1.7'
+                java.sourceCompatibility = '1.7'
 
                 dependencies {
                     implementation 'org.fusesource.jansi:jansi:$JANSI_VERSION'

--- a/subprojects/docs/src/snippets/java/customDirs/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/java/customDirs/groovy/build.gradle
@@ -2,9 +2,12 @@ plugins {
     id 'java'
 }
 
-sourceCompatibility = '1.8'
-targetCompatibility = '1.8'
 version = '1.2.1'
+
+java {
+    sourceCompatibility = '1.8'
+    targetCompatibility = '1.8'
+}
 
 repositories {
     mavenCentral()
@@ -49,16 +52,16 @@ sourceSets {
 
 // tag::custom-report-dirs[]
 reporting.baseDir = "my-reports"
-testResultsDirName = "$buildDir/my-test-results"
+java.testResultsDir = layout.buildDirectory.dir("my-test-results")
 
 tasks.register('showDirs') {
     def rootDir = project.rootDir
-    def reportsDir = project.reportsDir
-    def testResultsDir = project.testResultsDir
+    def reportsDir = project.reporting.baseDirectory
+    def testResultsDir = project.java.testResultsDir
 
     doLast {
-        logger.quiet(rootDir.toPath().relativize(reportsDir.toPath()).toString())
-        logger.quiet(rootDir.toPath().relativize(testResultsDir.toPath()).toString())
+        logger.quiet(rootDir.toPath().relativize(reportsDir.get().asFile.toPath()).toString())
+        logger.quiet(rootDir.toPath().relativize(testResultsDir.get().asFile.toPath()).toString())
     }
 }
 // end::custom-report-dirs[]

--- a/subprojects/docs/src/snippets/java/customDirs/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java/customDirs/kotlin/build.gradle.kts
@@ -52,7 +52,7 @@ sourceSets {
 
 // tag::custom-report-dirs[]
 reporting.baseDir = file("my-reports")
-project.setProperty("testResultsDirName", "$buildDir/my-test-results")
+java.testResultsDir.set(layout.buildDirectory.dir("my-test-results"))
 
 tasks.register("showDirs") {
     val rootDir = project.rootDir

--- a/subprojects/docs/src/snippets/kotlinDsl/noAccessors/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/kotlinDsl/noAccessors/kotlin/build.gradle.kts
@@ -30,7 +30,7 @@ configure<SourceSetContainer> {
 }
 // end::project-container-extension[]
 
-configure<JavaPluginConvention> {
+configure<JavaPluginExtension> {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
 }

--- a/subprojects/docs/src/snippets/mavenMigration/basic/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/mavenMigration/basic/groovy/build.gradle
@@ -3,9 +3,12 @@ plugins {
     id 'checkstyle'
 }
 
-sourceCompatibility = '1.8'
-targetCompatibility = '1.8'
 version = '1.2.1'
+
+java {
+    sourceCompatibility = '1.8'
+    targetCompatibility = '1.8'
+}
 
 ext {
     currentBuildNumber = '1234'

--- a/subprojects/docs/src/snippets/scala/customizedLayout/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/scala/customizedLayout/kotlin/build.gradle.kts
@@ -17,17 +17,13 @@ dependencies {
 // tag::custom-source-locations[]
 sourceSets {
     main {
-        withConvention(ScalaSourceSet::class) {
-            scala {
-                setSrcDirs(listOf("src/scala"))
-            }
+        scala {
+            setSrcDirs(listOf("src/scala"))
         }
     }
     test {
-        withConvention(ScalaSourceSet::class) {
-            scala {
-                setSrcDirs(listOf("test/scala"))
-            }
+        scala {
+            setSrcDirs(listOf("test/scala"))
         }
     }
 }

--- a/subprojects/docs/src/snippets/testing/junit-xml-results/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/testing/junit-xml-results/groovy/build.gradle
@@ -19,7 +19,7 @@ test {
 // end::configure-location-task[]
 
 // tag::configure-location-convention[]
-testResultsDirName = "$buildDir/junit-xml"
+java.testResultsDir = layout.buildDirectory.dir("junit-xml")
 // end::configure-location-convention[]
 
 // tag::configure-content[]

--- a/subprojects/docs/src/snippets/testing/junit-xml-results/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/testing/junit-xml-results/kotlin/build.gradle.kts
@@ -19,7 +19,7 @@ tasks.test {
 // end::configure-location-task[]
 
 // tag::configure-location-convention[]
-project.setProperty("testResultsDirName", "$buildDir/junit-xml")
+java.testResultsDir.set(layout.buildDirectory.dir("junit-xml"))
 // end::configure-location-convention[]
 
 // tag::configure-content[]

--- a/subprojects/docs/src/snippets/tutorial/manifest/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/tutorial/manifest/groovy/build.gradle
@@ -13,12 +13,12 @@ jar {
 // end::add-to-manifest[]
 
 // tag::custom-manifest[]
-ext.sharedManifest = manifest {
+def sharedManifest = java.manifest {
     attributes("Implementation-Title": "Gradle",
                "Implementation-Version": version)
 }
 tasks.register('fooJar', Jar) {
-    manifest = project.manifest {
+    manifest = java.manifest {
         from sharedManifest
     }
 }

--- a/subprojects/docs/src/snippets/tutorial/manifest/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/tutorial/manifest/kotlin/build.gradle.kts
@@ -15,7 +15,7 @@ tasks.jar {
 // end::add-to-manifest[]
 
 // tag::custom-manifest[]
-val sharedManifest = the<JavaPluginConvention>().manifest {
+val sharedManifest = java.manifest {
     attributes (
         "Implementation-Title" to "Gradle",
         "Implementation-Version" to version
@@ -23,7 +23,7 @@ val sharedManifest = the<JavaPluginConvention>().manifest {
 }
 
 tasks.register<Jar>("fooJar") {
-    manifest = project.the<JavaPluginConvention>().manifest {
+    manifest = java.manifest {
         from(sharedManifest)
     }
 }

--- a/subprojects/ear/src/integTest/groovy/org/gradle/plugins/ear/EarPluginIntegrationTest.groovy
+++ b/subprojects/ear/src/integTest/groovy/org/gradle/plugins/ear/EarPluginIntegrationTest.groovy
@@ -179,7 +179,7 @@ apply plugin: 'ear'
 ear {
     ${descriptorConfig}
     deploymentDescriptor {
-        applicationName = 'descriptor modification will not have any affect when application.xml already exists in source'
+        applicationName = 'descriptor modification will not have any effect when application.xml already exists in source'
     }
 }
 """
@@ -194,9 +194,9 @@ ear {
         ear.assertFileContent("META-INF/application.xml", applicationXml)
 
         where:
-        location    | descriptorConfig   | appDirectory
-        "specified" | "appDirName 'app'" | "app"
-        "default"   | ""                 | "src/main/application"
+        location    | descriptorConfig             | appDirectory
+        "specified" | "appDirectory = file('app')" | "app"
+        "default"   | ""                           | "src/main/application"
     }
 
     @ToBeFixedForConfigurationCache(because = "Entry META-INF/application.xml is a duplicate")

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r210/ToolingApiEclipseModelCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r210/ToolingApiEclipseModelCrossVersionSpec.groovy
@@ -62,7 +62,7 @@ class ToolingApiEclipseModelCrossVersionSpec extends ToolingApiSpecification {
         given:
         buildFile << """
             apply plugin: 'java'
-            sourceCompatibility = 1.6
+            java.sourceCompatibility = 1.6
         """
 
         when:
@@ -77,7 +77,7 @@ class ToolingApiEclipseModelCrossVersionSpec extends ToolingApiSpecification {
         buildFile << """
             project(':subproject-a') {
                 apply plugin: 'java'
-                sourceCompatibility = 1.1
+                java.sourceCompatibility = 1.1
             }
             project(':subproject-b') {
                 apply plugin: 'java'
@@ -91,7 +91,7 @@ class ToolingApiEclipseModelCrossVersionSpec extends ToolingApiSpecification {
             project(':subproject-c') {
                 apply plugin: 'java'
                 apply plugin: 'eclipse'
-                sourceCompatibility = 1.6
+                java.sourceCompatibility = 1.6
                 eclipse {
                     jdt {
                         sourceCompatibility = 1.3

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r211/ToolingApiIdeaModelCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r211/ToolingApiIdeaModelCrossVersionSpec.groovy
@@ -134,12 +134,12 @@ class ToolingApiIdeaModelCrossVersionSpec extends ToolingApiSpecification {
 
             project(':child2') {
                 apply plugin: 'java'
-                sourceCompatibility = '1.2'
+                java.sourceCompatibility = '1.2'
             }
 
             project(':child3') {
                 apply plugin: 'java'
-                sourceCompatibility = '1.5'
+                java.sourceCompatibility = '1.5'
             }
 
         """
@@ -173,12 +173,12 @@ class ToolingApiIdeaModelCrossVersionSpec extends ToolingApiSpecification {
 
             project(':child2') {
                 apply plugin: 'java'
-                sourceCompatibility = '1.2'
+                java.sourceCompatibility = '1.2'
             }
 
             project(':child3') {
                 apply plugin: 'java'
-                sourceCompatibility = '1.5'
+                java.sourceCompatibility = '1.5'
             }
 
         """

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r212/ToolingApiIdeaModelCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r212/ToolingApiIdeaModelCrossVersionSpec.groovy
@@ -44,12 +44,12 @@ class ToolingApiIdeaModelCrossVersionSpec extends ToolingApiSpecification {
 
             project(':child2') {
                 apply plugin: 'java'
-                sourceCompatibility = '1.2'
+                java.sourceCompatibility = '1.2'
             }
 
             project(':child3') {
                 apply plugin: 'java'
-                sourceCompatibility = '1.5'
+                java.sourceCompatibility = '1.5'
             }
 
         """

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest.groovy
@@ -389,8 +389,8 @@ apply plugin: 'eclipse'
         runEclipseTask '''
 apply plugin: 'java'
 apply plugin: 'eclipse'
-    sourceCompatibility = 1.4
-    targetCompatibility = 1.3
+java.sourceCompatibility = 1.4
+java.targetCompatibility = 1.3
 '''
         def jdt = parseJdtFile()
         assert jdt.contains('source=1.4')
@@ -403,8 +403,8 @@ apply plugin: 'eclipse'
         runEclipseTask '''
 apply plugin: 'java'
 apply plugin: 'eclipse'
-sourceCompatibility = 1.4
-targetCompatibility = 1.5
+java.sourceCompatibility = 1.4
+java.targetCompatibility = 1.5
 eclipse {
     jdt {
         sourceCompatibility = 1.3

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseJavaProjectIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseJavaProjectIntegrationTest.groovy
@@ -25,7 +25,7 @@ class EclipseJavaProjectIntegrationTest extends AbstractEclipseIntegrationSpec {
         buildFile << """
             apply plugin: 'java'
             apply plugin: 'eclipse'
-            targetCompatibility = $version
+            java.targetCompatibility = $version
         """
 
         when:
@@ -55,7 +55,7 @@ class EclipseJavaProjectIntegrationTest extends AbstractEclipseIntegrationSpec {
         buildFile << """
             apply plugin: 'java'
             apply plugin: 'eclipse'
-            sourceCompatibility = $version
+            java.sourceCompatibility = $version
         """
 
         when:
@@ -86,7 +86,7 @@ class EclipseJavaProjectIntegrationTest extends AbstractEclipseIntegrationSpec {
         buildFile << """
             apply plugin: 'java'
             apply plugin: 'eclipse'
-            targetCompatibility = $version
+            java.targetCompatibility = $version
         """
 
         when:

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpEarProjectIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpEarProjectIntegrationTest.groovy
@@ -93,7 +93,9 @@ class EclipseWtpEarProjectIntegrationTest extends AbstractEclipseIntegrationSpec
                deploy 'org.example:lib2-impl:2.0'
            }
 
-           libDirName = 'APP-INF/lib'
+           ear {
+               libDirName = 'APP-INF/lib'
+           }
         """
 
         when:

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpJavaProjectIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpJavaProjectIntegrationTest.groovy
@@ -32,7 +32,7 @@ class EclipseWtpJavaProjectIntegrationTest extends AbstractEclipseIntegrationSpe
 
            ${mavenCentralRepository()}
 
-           sourceCompatibility = 1.6
+           java.sourceCompatibility = 1.6
 
            dependencies {
                implementation 'com.google.guava:guava:18.0'

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpModelIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpModelIntegrationTest.groovy
@@ -399,7 +399,7 @@ project(':contrib') {
 
           sourceSets.main.java.srcDirs 'yyySource', 'xxxSource'
 
-          appDirName = 'nonexistentAppDir'
+          ear.appDirectory = file 'nonexistentAppDir'
 
           eclipse.wtp.component {
             resource sourcePath: 'xxxResource', deployPath: 'deploy-xxx'
@@ -430,7 +430,7 @@ project(':contrib') {
           apply plugin: 'ear'
           apply plugin: 'eclipse-wtp'
 
-          appDirName = 'coolAppDir'
+          ear.appDirectory = file 'coolAppDir'
 """
         //then
         def component = getComponentFile().text

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpWebAndJavaProjectIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpWebAndJavaProjectIntegrationTest.groovy
@@ -36,7 +36,7 @@ class EclipseWtpWebAndJavaProjectIntegrationTest extends AbstractEclipseIntegrat
            project(':web') {
                apply plugin: 'war'
 
-               sourceCompatibility = 1.6
+               java.sourceCompatibility = 1.6
 
                dependencies {
                    providedCompile 'javax.servlet:javax.servlet-api:3.1.0'
@@ -48,7 +48,7 @@ class EclipseWtpWebAndJavaProjectIntegrationTest extends AbstractEclipseIntegrat
             project(':java') {
                 apply plugin: 'java'
 
-                sourceCompatibility = 1.6
+                java.sourceCompatibility = 1.6
 
                 dependencies {
                     implementation 'com.google.guava:guava:18.0'

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpWebProjectIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpWebProjectIntegrationTest.groovy
@@ -32,7 +32,7 @@ class EclipseWtpWebProjectIntegrationTest extends AbstractEclipseIntegrationSpec
         """apply plugin: 'war'
            apply plugin: 'eclipse-wtp'
 
-           sourceCompatibility = 1.6
+           java.sourceCompatibility = 1.6
 
            ${mavenCentralRepository()}
 

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaJavaLanguageSettingsIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaJavaLanguageSettingsIntegrationTest.groovy
@@ -42,7 +42,7 @@ allprojects {
     apply plugin:'idea'
     apply plugin:'java'
 
-    sourceCompatibility = "1.7"
+    java.sourceCompatibility = "1.7"
 }
 """
         when:
@@ -64,19 +64,19 @@ allprojects {
     apply plugin:'idea'
     apply plugin:'java'
 
-    sourceCompatibility = 1.6
+    java.sourceCompatibility = 1.6
 }
 
 project(':child1') {
-    sourceCompatibility = 1.7
+    java.sourceCompatibility = 1.7
 }
 
 project(':child2') {
-    sourceCompatibility = 1.5
+    java.sourceCompatibility = 1.5
 }
 
 project(':child3') {
-    sourceCompatibility = 1.8
+    java.sourceCompatibility = 1.8
 }
 """
         when:
@@ -98,8 +98,8 @@ allprojects {
     apply plugin:'idea'
     apply plugin:'java'
 
-    sourceCompatibility = 1.4
-    targetCompatibility = 1.4
+    java.sourceCompatibility = 1.4
+    java.targetCompatibility = 1.4
 }
 
 idea {
@@ -110,18 +110,18 @@ idea {
 }
 
 project(':child1') {
-    sourceCompatibility = 1.6
-    targetCompatibility = 1.6
+    java.sourceCompatibility = 1.6
+    java.targetCompatibility = 1.6
 }
 
 project(':child2') {
-    sourceCompatibility = 1.5
-    targetCompatibility = 1.5
+    java.sourceCompatibility = 1.5
+    java.targetCompatibility = 1.5
 }
 
 project(':child3') {
-    sourceCompatibility = 1.7
-    targetCompatibility = 1.8
+    java.sourceCompatibility = 1.7
+    java.targetCompatibility = 1.8
 }
 """
         when:
@@ -158,8 +158,8 @@ project(':child3') {
             apply plugin:'idea'
             apply plugin:'java'
 
-            sourceCompatibility = 1.4
-            targetCompatibility = 1.4
+            java.sourceCompatibility = 1.4
+            java.targetCompatibility = 1.4
         }
         """
         and:
@@ -177,7 +177,7 @@ allprojects {
 }
 subprojects {
     apply plugin:'java'
-    sourceCompatibility = 1.7
+    java.sourceCompatibility = 1.7
 }
 """
 
@@ -197,7 +197,7 @@ subprojects {
 subprojects {
     apply plugin:'java'
     apply plugin: 'idea'
-    sourceCompatibility = 1.7
+    java.sourceCompatibility = 1.7
 }
 """
 
@@ -225,7 +225,7 @@ include 'subprojectC'
 allprojects {
     apply plugin: 'java'
     apply plugin: 'idea'
-    targetCompatibility = '1.6'
+    java.targetCompatibility = '1.6'
 }
 
 idea {
@@ -258,7 +258,7 @@ include 'subprojectC'
 allprojects {
     apply plugin: 'java'
     apply plugin: 'idea'
-    targetCompatibility = '1.7'
+    java.targetCompatibility = '1.7'
 }
 
 idea {
@@ -291,11 +291,11 @@ allprojects {
 }
 
 project(':') {
-    targetCompatibility = 1.8
+    java.targetCompatibility = 1.8
 }
 
 project(':subprojectA') {
-    targetCompatibility = 1.7
+    java.targetCompatibility = 1.7
 }
 """
 
@@ -322,11 +322,11 @@ allprojects {
 }
 
 project(':') {
-    sourceCompatibility = 1.8
+    java.sourceCompatibility = 1.8
 }
 
 project(':child1') {
-    sourceCompatibility = 1.7
+    java.sourceCompatibility = 1.7
 }
 """
 
@@ -348,7 +348,7 @@ include 'child1'
         buildFile << """
 allprojects {
     apply plugin: 'java'
-    sourceCompatibility = 1.7
+    java.sourceCompatibility = 1.7
 }
 
 project(':child1') {
@@ -378,19 +378,19 @@ include 'subprojectD'
 configure(project(':subprojectA')) {
     apply plugin: 'java'
     apply plugin: 'idea'
-    targetCompatibility = '1.6'
+    java.targetCompatibility = '1.6'
 }
 
 configure(project(':subprojectB')) {
     apply plugin: 'java'
     apply plugin: 'idea'
-    targetCompatibility = '1.7'
+    java.targetCompatibility = '1.7'
 }
 
 configure(project(':subprojectC')) {
     apply plugin: 'java'
     apply plugin: 'idea'
-    targetCompatibility = '1.8'
+    java.targetCompatibility = '1.8'
 }
 
 configure(project(':subprojectD')) {
@@ -420,8 +420,8 @@ idea {
     void "language levels specified in properties files are ignored"() {
         given:
         file('gradle.properties') << """
-sourceCompatibility=1.3
-targetCompatibility=1.3
+java.sourceCompatibility=1.3
+java.targetCompatibility=1.3
 """
 
         buildFile << """

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/build.gradle
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/build.gradle
@@ -20,7 +20,7 @@ allprojects {
     group = 'org.gradle'
 
     plugins.withType(JavaBasePlugin) {
-        sourceCompatibility = 1.5
+        java.sourceCompatibility = 1.5
     }
 }
 

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/common/build.gradle
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/common/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'java'
 
-sourceCompatibility = 1.6
+java.sourceCompatibility = 1.6
 
 configurations {
     provided

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/webAppJava6/build.gradle
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/webAppJava6/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'war'
 
-sourceCompatibility = 6
+java.sourceCompatibility = 6
 
 dependencies {
     implementation project(":common")

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/idea/IdeaIntegrationTest/canCreateAndDeleteMetaData/build.gradle
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/idea/IdeaIntegrationTest/canCreateAndDeleteMetaData/build.gradle
@@ -26,7 +26,7 @@ subprojects {
 
     group = 'org.gradle'
     version = '1.0'
-    sourceCompatibility = '1.6'
+    java.sourceCompatibility = '1.6'
 }
 
 cleanIdea.doLast {

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/idea/IdeaIntegrationTest/worksWithNonStandardLayout/root/build.gradle
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/idea/IdeaIntegrationTest/worksWithNonStandardLayout/root/build.gradle
@@ -2,7 +2,7 @@ allprojects {
     apply plugin: 'java'
     apply plugin: 'idea'
 
-    sourceCompatibility = 1.5
+    java.sourceCompatibility = 1.5
 }
 
 idea.project.jdkName = '1.7'

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpPluginTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpPluginTest.groovy
@@ -60,7 +60,7 @@ class EclipseWtpPluginTest extends AbstractProjectBuilderSpec {
     def applyToJavaProject_shouldHaveWebProjectAndClasspathTask() {
         when:
         project.apply(plugin: 'java')
-        project.sourceCompatibility = 1.6
+        project.java.sourceCompatibility = 1.6
         wtpPlugin.apply(project)
 
         then:
@@ -79,7 +79,7 @@ class EclipseWtpPluginTest extends AbstractProjectBuilderSpec {
         when:
         wtpPlugin.apply(project)
         project.apply(plugin: 'java')
-        project.sourceCompatibility = 1.7
+        project.java.sourceCompatibility = 1.7
 
         then:
         [project.tasks.cleanEclipseWtpComponent, project.tasks.cleanEclipseWtpFacet].each {
@@ -97,7 +97,7 @@ class EclipseWtpPluginTest extends AbstractProjectBuilderSpec {
         when:
         project.apply(plugin: 'java')
         wtpPlugin.apply(project)
-        project.sourceCompatibility = 1.3
+        project.java.sourceCompatibility = 1.3
 
         project.eclipse.wtp {
             facet {
@@ -116,7 +116,7 @@ class EclipseWtpPluginTest extends AbstractProjectBuilderSpec {
     def applyToWarProject_shouldHaveWebProjectAndClasspathTask() {
         when:
         project.apply(plugin: 'war')
-        project.sourceCompatibility = 1.5
+        project.java.sourceCompatibility = 1.5
         project.apply(plugin: 'eclipse-wtp')
 
         then:
@@ -137,7 +137,7 @@ class EclipseWtpPluginTest extends AbstractProjectBuilderSpec {
         when:
         project.apply(plugin: 'eclipse-wtp')
         project.apply(plugin: 'war')
-        project.sourceCompatibility = 1.8
+        project.java.sourceCompatibility = 1.8
 
         then:
         [project.cleanEclipseWtpComponent, project.cleanEclipseWtpFacet].each {
@@ -157,7 +157,7 @@ class EclipseWtpPluginTest extends AbstractProjectBuilderSpec {
         when:
         project.apply(plugin: 'war')
         project.apply(plugin: 'eclipse-wtp')
-        project.sourceCompatibility = 1.4
+        project.java.sourceCompatibility = 1.4
 
         project.eclipse.wtp {
             facet {
@@ -283,7 +283,7 @@ class EclipseWtpPluginTest extends AbstractProjectBuilderSpec {
         when:
         project.apply(plugin: 'war')
         project.apply(plugin: 'eclipse-wtp')
-        project.sourceCompatibility = 1.4
+        project.java.sourceCompatibility = 1.4
 
         project.eclipse.wtp {
             facet {
@@ -304,7 +304,7 @@ class EclipseWtpPluginTest extends AbstractProjectBuilderSpec {
         when:
         project.apply(plugin: 'java')
         project.apply(plugin: 'eclipse-wtp')
-        project.sourceCompatibility = 1.8
+        project.java.sourceCompatibility = 1.8
 
         project.eclipse.wtp {
             facet {
@@ -325,7 +325,7 @@ class EclipseWtpPluginTest extends AbstractProjectBuilderSpec {
         when:
         project.apply(plugin: 'java')
         wtpPlugin.apply(project)
-        project.sourceCompatibility = 1.7
+        project.java.sourceCompatibility = 1.7
 
         project.eclipse.wtp {
             component {

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/IdeaPluginTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/IdeaPluginTest.groovy
@@ -124,7 +124,7 @@ class IdeaPluginTest extends AbstractProjectBuilderSpec {
         project.apply(plugin: 'java')
 
         then:
-        project.idea.project.languageLevel.level == new IdeaLanguageLevel(project.sourceCompatibility).level
+        project.idea.project.languageLevel.level == new IdeaLanguageLevel(project.java.sourceCompatibility).level
 
         project.idea.module.scopes == [
                 PROVIDED: [plus: [project.configurations.compileClasspath], minus: []],
@@ -198,9 +198,9 @@ class IdeaPluginTest extends AbstractProjectBuilderSpec {
 
 
         and:
-        project.sourceCompatibility = JavaVersion.VERSION_1_5
-        childProject.sourceCompatibility = JavaVersion.VERSION_1_6
-        anotherChildProject.sourceCompatibility = JavaVersion.VERSION_1_7
+        project.java.sourceCompatibility = JavaVersion.VERSION_1_5
+        childProject.java.sourceCompatibility = JavaVersion.VERSION_1_6
+        anotherChildProject.java.sourceCompatibility = JavaVersion.VERSION_1_7
 
         then:
         project.idea.project.languageLevel.level == new IdeaLanguageLevel(JavaVersion.VERSION_1_7).level

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/model/IdeaModuleTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/model/IdeaModuleTest.groovy
@@ -44,8 +44,8 @@ class IdeaModuleTest extends AbstractProjectBuilderSpec {
         project.getPlugins().apply(IdeaPlugin)
         project.getPlugins().apply(JavaPlugin)
         moduleProject.getPlugins().apply(JavaPlugin)
-        moduleProject.sourceCompatibility = 1.5
-        project.sourceCompatibility = 1.5
+        moduleProject.java.sourceCompatibility = 1.5
+        project.java.sourceCompatibility = 1.5
 
         def iml = Mock(IdeaModuleIml)
         def module = TestUtil.newInstance(IdeaModule, moduleProject, iml)

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/eclipse/EclipseModelBuilderTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/eclipse/EclipseModelBuilderTest.groovy
@@ -136,21 +136,21 @@ class EclipseModelBuilderTest extends AbstractProjectBuilderSpec {
         eclipseModel.javaSourceSettings."$languageLevelProperty" == JavaVersion.current()
 
         where:
-        type     | compatibilityProperty | languageLevelProperty   | projectType | pluginType
-        "source" | "sourceCompatibility" | "sourceLanguageLevel"   | "java"      | JavaBasePlugin
-        "target" | "targetCompatibility" | "targetBytecodeVersion" | "java"      | JavaBasePlugin
-        "source" | "sourceCompatibility" | "sourceLanguageLevel"   | "scala"     | ScalaBasePlugin
-        "target" | "targetCompatibility" | "targetBytecodeVersion" | "scala"     | ScalaBasePlugin
-        "source" | "sourceCompatibility" | "sourceLanguageLevel"   | "groovy"    | GroovyBasePlugin
-        "target" | "targetCompatibility" | "targetBytecodeVersion" | "groovy"    | GroovyBasePlugin
+        type     | compatibilityProperty      | languageLevelProperty   | projectType | pluginType
+        "source" | "java.sourceCompatibility" | "sourceLanguageLevel"   | "java"      | JavaBasePlugin
+        "target" | "java.targetCompatibility" | "targetBytecodeVersion" | "java"      | JavaBasePlugin
+        "source" | "java.sourceCompatibility" | "sourceLanguageLevel"   | "scala"     | ScalaBasePlugin
+        "target" | "java.targetCompatibility" | "targetBytecodeVersion" | "scala"     | ScalaBasePlugin
+        "source" | "java.sourceCompatibility" | "sourceLanguageLevel"   | "groovy"    | GroovyBasePlugin
+        "target" | "java.targetCompatibility" | "targetBytecodeVersion" | "groovy"    | GroovyBasePlugin
     }
 
     def "default language levels are set for JVM projects if compatibility is set to null"() {
         given:
         def modelBuilder = createEclipseModelBuilder()
         project.plugins.apply(pluginType)
-        project.sourceCompatibility = null
-        project.targetCompatibility = null
+        project.java.sourceCompatibility = null
+        project.java.targetCompatibility = null
 
         when:
         def eclipseModel = modelBuilder.buildAll("org.gradle.tooling.model.eclipse.EclipseProject", project)
@@ -163,11 +163,11 @@ class EclipseModelBuilderTest extends AbstractProjectBuilderSpec {
         pluginType << [JavaPlugin, GroovyPlugin, ScalaPlugin]
     }
 
-    def "custom #type language level derived Java plugin convention"() {
+    def "custom #type language level derived Java plugin extension"() {
         given:
         def modelBuilder = createEclipseModelBuilder()
         project.plugins.apply(JavaPlugin)
-        project."$compatibilityProperty" = "1.2"
+        project.java."$compatibilityProperty" = "1.2"
 
         when:
         def eclipseModel = modelBuilder.buildAll("org.gradle.tooling.model.eclipse.EclipseProject", project)
@@ -181,12 +181,12 @@ class EclipseModelBuilderTest extends AbstractProjectBuilderSpec {
         "target" | "targetCompatibility" | "targetBytecodeVersion"
     }
 
-    def "#type language level derived from eclipse jdt overrules java plugin convention configuration"() {
+    def "#type language level derived from eclipse jdt overrules java plugin extension configuration"() {
         given:
         def modelBuilder = createEclipseModelBuilder()
         project.plugins.apply(JavaPlugin)
         project.plugins.apply(EclipsePlugin)
-        project."$compatibilityProperty" = "1.2"
+        project.java."$compatibilityProperty" = "1.2"
         project.eclipse.jdt."$compatibilityProperty" = "1.3"
 
         when:
@@ -209,7 +209,7 @@ class EclipseModelBuilderTest extends AbstractProjectBuilderSpec {
         child1.eclipse.jdt."$compatibilityProperty" = "1.2"
         child2.plugins.apply(JavaPlugin)
         child2.plugins.apply(EclipsePlugin)
-        child2."$compatibilityProperty" = "1.3"
+        child2.java."$compatibilityProperty" = "1.3"
         child2.eclipse.jdt."$compatibilityProperty" = "1.1"
 
         when:

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/idea/IdeaModelBuilderTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/idea/IdeaModelBuilderTest.groovy
@@ -91,8 +91,8 @@ class IdeaModelBuilderTest extends AbstractProjectBuilderSpec {
         given:
         project.plugins.apply(JavaPlugin)
         child1.plugins.apply(JavaPlugin)
-        project.sourceCompatibility = '19'
-        child1.sourceCompatibility = sourceCompatibility
+        project.java.sourceCompatibility = '19'
+        child1.java.sourceCompatibility = sourceCompatibility
 
         when:
         def ideaProject = buildIdeaProjectModel()
@@ -108,8 +108,8 @@ class IdeaModelBuilderTest extends AbstractProjectBuilderSpec {
         given:
         project.plugins.apply(JavaPlugin)
         child1.plugins.apply(JavaPlugin)
-        project.sourceCompatibility = '1.2'
-        child1.sourceCompatibility = '1.3'
+        project.java.sourceCompatibility = '1.2'
+        child1.java.sourceCompatibility = '1.3'
         when:
         def ideaProject = buildIdeaProjectModel()
 
@@ -124,9 +124,9 @@ class IdeaModelBuilderTest extends AbstractProjectBuilderSpec {
         child1.plugins.apply(JavaPlugin)
         child2.plugins.apply(JavaPlugin)
         project.idea.project.languageLevel = '1.2'
-        project.sourceCompatibility = '1.3'
-        child1.sourceCompatibility = '1.4'
-        child2.sourceCompatibility = '1.5'
+        project.java.sourceCompatibility = '1.3'
+        child1.java.sourceCompatibility = '1.4'
+        child2.java.sourceCompatibility = '1.5'
 
         when:
         def ideaProject = buildIdeaProjectModel()
@@ -172,9 +172,9 @@ class IdeaModelBuilderTest extends AbstractProjectBuilderSpec {
     def "can handle multi project builds with different source language levels"() {
         given:
         [project, child1, child2].each { it.plugins.apply(JavaPlugin) }
-        project.sourceCompatibility = '1.3'
-        child1.sourceCompatibility = '1.2'
-        child2.sourceCompatibility = '1.3'
+        project.java.sourceCompatibility = '1.3'
+        child1.java.sourceCompatibility = '1.2'
+        child2.java.sourceCompatibility = '1.3'
 
         when:
         def ideaProject = buildIdeaProjectModel()
@@ -189,9 +189,9 @@ class IdeaModelBuilderTest extends AbstractProjectBuilderSpec {
     def "can handle multi project builds where only some projects are java projects"() {
         given:
         project.plugins.apply(JavaPlugin)
-        project.sourceCompatibility = '1.4'
+        project.java.sourceCompatibility = '1.4'
         child1.plugins.apply(JavaPlugin)
-        child1.sourceCompatibility = '1.3'
+        child1.java.sourceCompatibility = '1.3'
 
         when:
         def ideaProject = buildIdeaProjectModel()

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ApplicationIntegrationSpec.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ApplicationIntegrationSpec.groovy
@@ -78,7 +78,7 @@ class Main {
 
     def canUseDefaultJvmArgsToPassMultipleOptionsToJvmWhenRunningScript() {
         file("build.gradle") << '''
-applicationDefaultJvmArgs = ['-DtestValue=value', '-DtestValue2=some value', '-DtestValue3=some value']
+application.applicationDefaultJvmArgs = ['-DtestValue=value', '-DtestValue2=some value', '-DtestValue3=some value']
 '''
         file('src/main/java/org/gradle/test/Main.java') << '''
 package org.gradle.test;
@@ -113,7 +113,7 @@ class Main {
 
     def canUseBothDefaultJvmArgsAndEnvironmentVariableToPassOptionsToJvmWhenRunningScript() {
         file("build.gradle") << '''
-applicationDefaultJvmArgs = ['-Dvar1=value1', '-Dvar2=some value2']
+application.applicationDefaultJvmArgs = ['-Dvar1=value1', '-Dvar2=some value2']
 '''
         file('src/main/java/org/gradle/test/Main.java') << '''
 package org.gradle.test;
@@ -153,7 +153,7 @@ class Main {
         def testValue2 = OperatingSystem.current().windows ? 'some value$PATH' : 'some value\\\\$PATH'
         def testValue3 = 'some value%PATH%'
         file("build.gradle") << '''
-            applicationDefaultJvmArgs = [
+            application.applicationDefaultJvmArgs = [
                 '-DtestValue=value',
                 '-DtestValue2=some value$PATH',
                 '-DtestValue3=some value%PATH%',
@@ -191,7 +191,7 @@ class Main {
 
     def "can customize application name"() {
         file('build.gradle') << '''
-applicationName = 'mega-app'
+application.applicationName = 'mega-app'
 '''
         file('src/main/java/org/gradle/test/Main.java') << '''
 package org.gradle.test;
@@ -345,7 +345,7 @@ class Main {
 
         and:
         buildFile << """
-            applicationDistribution.from("src/somewhere-else") {
+            application.applicationDistribution.from("src/somewhere-else") {
                 include "**/r2.*"
             }
         """
@@ -375,7 +375,7 @@ class Main {
                 }
             }
 
-            applicationDistribution.from(createDocs) {
+            application.applicationDistribution.from(createDocs) {
                 into "docs"
                 rename 'readme(.*)', 'READ-ME\$1'
             }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileCompatibilityIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileCompatibilityIntegrationTest.groovy
@@ -187,8 +187,8 @@ class JavaCompileCompatibilityIntegrationTest extends AbstractIntegrationSpec im
                 def projectSourceCompat = project.java.sourceCompatibility
                 def projectTargetCompat = project.java.targetCompatibility
                 doLast {
-                    logger.lifecycle("project.sourceCompatibility = '\${projectSourceCompat}'")
-                    logger.lifecycle("project.targetCompatibility = '\${projectTargetCompat}'")
+                    logger.lifecycle("project.java.sourceCompatibility = '\${projectSourceCompat}'")
+                    logger.lifecycle("project.java.targetCompatibility = '\${projectTargetCompat}'")
                     logger.lifecycle("task.sourceCompatibility = '\$sourceCompatibility'")
                     logger.lifecycle("task.targetCompatibility = '\$targetCompatibility'")
                 }
@@ -199,8 +199,8 @@ class JavaCompileCompatibilityIntegrationTest extends AbstractIntegrationSpec im
         withInstallations(jdk11).run(":compileJava")
 
         then:
-        outputContains("project.sourceCompatibility = '11'")
-        outputContains("project.targetCompatibility = '11'")
+        outputContains("project.java.sourceCompatibility = '11'")
+        outputContains("project.java.targetCompatibility = '11'")
         outputContains("task.sourceCompatibility = '$sourceOut'")
         outputContains("task.targetCompatibility = '$targetOut'")
         classJavaVersion(javaClassFile("Foo.class")) == JavaVersion.toVersion(targetOut)
@@ -230,8 +230,8 @@ class JavaCompileCompatibilityIntegrationTest extends AbstractIntegrationSpec im
                 def projectSourceCompat = project.java.sourceCompatibility
                 def projectTargetCompat = project.java.targetCompatibility
                 doLast {
-                    logger.lifecycle("project.sourceCompatibility = '\${projectSourceCompat}'")
-                    logger.lifecycle("project.targetCompatibility = '\${projectTargetCompat}'")
+                    logger.lifecycle("project.java.sourceCompatibility = '\${projectSourceCompat}'")
+                    logger.lifecycle("project.java.targetCompatibility = '\${projectTargetCompat}'")
                     logger.lifecycle("task.sourceCompatibility = '\$sourceCompatibility'")
                     logger.lifecycle("task.targetCompatibility = '\$targetCompatibility'")
                 }
@@ -242,8 +242,8 @@ class JavaCompileCompatibilityIntegrationTest extends AbstractIntegrationSpec im
         withInstallations(jdk).run(":compileJava")
 
         then:
-        outputContains("project.sourceCompatibility = '$prevJavaVersion'")
-        outputContains("project.targetCompatibility = '$prevJavaVersion'")
+        outputContains("project.java.sourceCompatibility = '$prevJavaVersion'")
+        outputContains("project.java.targetCompatibility = '$prevJavaVersion'")
         outputContains("task.sourceCompatibility = '$prevJavaVersion'")
         outputContains("task.targetCompatibility = '$prevJavaVersion'")
         classJavaVersion(javaClassFile("Foo.class")) == JavaVersion.toVersion(prevJavaVersion)

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileJavaVersionIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileJavaVersionIntegrationTest.groovy
@@ -43,8 +43,8 @@ class JavaCompileJavaVersionIntegrationTest extends AbstractIntegrationSpec {
         buildFile << """
             apply plugin: "java"
 
-            sourceCompatibility = "1.6"
-            targetCompatibility = "1.6"
+            java.sourceCompatibility = "1.6"
+            java.targetCompatibility = "1.6"
         """
 
         and:
@@ -113,8 +113,8 @@ class JavaCompileJavaVersionIntegrationTest extends AbstractIntegrationSpec {
         """
             apply plugin: "java"
 
-            sourceCompatibility = "1.6"
-            targetCompatibility = "1.6"
+            java.sourceCompatibility = "1.6"
+            java.targetCompatibility = "1.6"
 
             compileJava {
                 options.with {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginIntegrationTest.groovy
@@ -66,8 +66,10 @@ class ApplicationPluginIntegrationTest extends WellBehavedPluginTest {
     def "can generate starts script generation with custom user configuration"() {
         given:
         buildFile << """
-applicationName = 'myApp'
-applicationDefaultJvmArgs = ["-Dgreeting.language=en", "-DappId=\${project.name - ':'}"]
+application {
+    applicationName = 'myApp'
+    applicationDefaultJvmArgs = ["-Dgreeting.language=en", "-DappId=\${project.name - ':'}"]
+}
 """
 
         when:
@@ -266,7 +268,7 @@ dependencies {
     def "executables can be placed at the root of the distribution"() {
         given:
         buildFile << """
-executableDir = ''
+application.executableDir = ''
 """
         when:
         run "installDist"
@@ -284,7 +286,7 @@ executableDir = ''
     def "executables can be placed in a custom directory"() {
         given:
         buildFile << """
-executableDir = 'foo/bar'
+application.executableDir = 'foo/bar'
 """
         when:
         run "installDist"
@@ -468,7 +470,7 @@ dependencies {
     def "run task honors applicationDefaultJvmArgs"() {
         given:
         buildFile """
-            applicationDefaultJvmArgs = ['-DFOO=42']
+            application.applicationDefaultJvmArgs = ['-DFOO=42']
         """
         when:
         succeeds 'run'
@@ -480,7 +482,7 @@ dependencies {
     def "can use APP_HOME in DEFAULT_JVM_OPTS with custom start script"() {
         given:
         buildFile << """
-applicationDefaultJvmArgs = ["-DappHomeSystemProp=REPLACE_THIS_WITH_APP_HOME"]
+application.applicationDefaultJvmArgs = ["-DappHomeSystemProp=REPLACE_THIS_WITH_APP_HOME"]
 
 startScripts {
     doLast {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginUnixShellsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginUnixShellsIntegrationTest.groovy
@@ -249,7 +249,7 @@ application {
 
     private void extendBuildFileWithAppHomeProperty() {
         buildFile << """
-applicationDefaultJvmArgs = ["-DappHomeSystemProp=REPLACE_THIS_WITH_APP_HOME"]
+application.applicationDefaultJvmArgs = ["-DappHomeSystemProp=REPLACE_THIS_WITH_APP_HOME"]
 
 startScripts {
     doLast {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecMainClassIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecMainClassIntegrationTest.groovy
@@ -73,10 +73,10 @@ class JavaExecMainClassIntegrationTest extends AbstractIntegrationSpec {
             def resolveMainClassName = tasks.register('resolveMainClassName', ResolveMainClassName) {
                 classpath.from(compileJava)
                 mainClassFromBootExtension.set(
-                    project.convention.findByType(BootExtension.class)?.mainClassName
+                    project.extensions.findByType(BootExtension.class)?.mainClassName
                 )
                 mainClassFromJavaApplication.set(
-                    project.convention.findByType(JavaApplication.class)?.mainClass
+                    project.extensions.findByType(JavaApplication.class)?.mainClass
                 )
                 mainClassFile = layout.buildDirectory.file('mainClass.txt')
             }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/GroovyCompileToolchainIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/GroovyCompileToolchainIntegrationTest.groovy
@@ -169,8 +169,8 @@ class GroovyCompileToolchainIntegrationTest extends MultiVersionIntegrationSpec 
                 def projectSourceCompat = project.java.sourceCompatibility
                 def projectTargetCompat = project.java.targetCompatibility
                 doLast {
-                    logger.lifecycle("project.sourceCompatibility = \$projectSourceCompat")
-                    logger.lifecycle("project.targetCompatibility = \$projectTargetCompat")
+                    logger.lifecycle("project.java.sourceCompatibility = \$projectSourceCompat")
+                    logger.lifecycle("project.java.targetCompatibility = \$projectTargetCompat")
                     logger.lifecycle("task.sourceCompatibility = \$sourceCompatibility")
                     logger.lifecycle("task.targetCompatibility = \$targetCompatibility")
                 }
@@ -183,8 +183,8 @@ class GroovyCompileToolchainIntegrationTest extends MultiVersionIntegrationSpec 
         then:
         executedAndNotSkipped(":compileGroovy")
 
-        outputContains("project.sourceCompatibility = 11")
-        outputContains("project.targetCompatibility = 11")
+        outputContains("project.java.sourceCompatibility = 11")
+        outputContains("project.java.targetCompatibility = 11")
         outputContains("task.sourceCompatibility = $sourceOut")
         outputContains("task.targetCompatibility = $targetOut")
         JavaVersion.forClass(groovyClassFile("JavaThing.class").bytes) == JavaVersion.toVersion(targetOut)

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/ParallelTestTaskIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/ParallelTestTaskIntegrationTest.groovy
@@ -53,8 +53,8 @@ import ${CountDownLatch.canonicalName}
 def latch = new CountDownLatch(${subprojects.size()})
 subprojects {
     apply plugin: 'java'
-    sourceCompatibility = ${version}
-    targetCompatibility = ${version}
+    java.sourceCompatibility = ${version}
+    java.targetCompatibility = ${version}
 
     ${mavenCentralRepository()}
     dependencies { testImplementation 'junit:junit:4.13' }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/UnsupportedJavaVersionCrossCompilationIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/UnsupportedJavaVersionCrossCompilationIntegrationTest.groovy
@@ -42,8 +42,8 @@ class UnsupportedJavaVersionCrossCompilationIntegrationTest extends MultiVersion
 
         buildFile << """
 apply plugin: 'java'
-sourceCompatibility = ${version}
-targetCompatibility = ${version}
+java.sourceCompatibility = ${version}
+java.targetCompatibility = ${version}
 ${mavenCentralRepository()}
 tasks.withType(JavaCompile) {
     options.with {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/AbstractIncrementalCompileIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/AbstractIncrementalCompileIntegrationTest.groovy
@@ -34,7 +34,7 @@ abstract class AbstractIncrementalCompileIntegrationTest extends AbstractIntegra
         file("src/main/${language.name}/Test.${language.name}") << 'public class Test{}'
         buildFile << """
             apply plugin: '${language.name}'
-            sourceCompatibility = 1.7
+            java.sourceCompatibility = 1.7
             ${language.compileTaskName}.options.debug = true
             ${language.compileTaskName}.options.incremental = true
             ${language.projectGroovyDependencies()}
@@ -47,7 +47,7 @@ abstract class AbstractIncrementalCompileIntegrationTest extends AbstractIntegra
         executedAndNotSkipped ":${language.compileTaskName}"
 
         when:
-        buildFile << 'sourceCompatibility = 1.8\n'
+        buildFile << 'java.sourceCompatibility = 1.8\n'
         succeeds ":${language.compileTaskName}"
 
         then:

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/ApplicationPluginConvention.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/ApplicationPluginConvention.java
@@ -79,8 +79,10 @@ public abstract class ApplicationPluginConvention {
      *     id 'application'
      * }
      *
-     * applicationDistribution.from("some/dir") {
-     *   include "*.txt"
+     * application {
+     *     applicationDistribution.from("some/dir") {
+     *       include "*.txt"
+     *     }
      * }
      * </pre>
      * <p>

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaApplication.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaApplication.java
@@ -91,8 +91,10 @@ public interface JavaApplication {
      *     id 'application'
      * }
      *
-     * applicationDistribution.from("some/dir") {
-     *   include "*.txt"
+     * application {
+     *     applicationDistribution.from("some/dir") {
+     *       include "*.txt"
+     *     }
      * }
      * </pre>
      * <p>

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
@@ -76,17 +76,17 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
 
         then:
         def ext = project.extensions.java
-        project.sourceCompatibility == JavaVersion.current()
-        project.targetCompatibility == JavaVersion.current()
+        project.java.sourceCompatibility == JavaVersion.current()
+        project.java.targetCompatibility == JavaVersion.current()
         ext.sourceCompatibility == JavaVersion.current()
         ext.targetCompatibility == JavaVersion.current()
 
         when:
-        project.sourceCompatibility = JavaVersion.VERSION_1_6
+        project.java.sourceCompatibility = JavaVersion.VERSION_1_6
 
         then:
-        project.sourceCompatibility == JavaVersion.VERSION_1_6
-        project.targetCompatibility == JavaVersion.VERSION_1_6
+        project.java.sourceCompatibility == JavaVersion.VERSION_1_6
+        project.java.targetCompatibility == JavaVersion.VERSION_1_6
         ext.sourceCompatibility == JavaVersion.VERSION_1_6
         ext.targetCompatibility == JavaVersion.VERSION_1_6
 
@@ -94,17 +94,17 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         ext.sourceCompatibility = JavaVersion.VERSION_1_8
 
         then:
-        project.sourceCompatibility == JavaVersion.VERSION_1_8
-        project.targetCompatibility == JavaVersion.VERSION_1_8
+        project.java.sourceCompatibility == JavaVersion.VERSION_1_8
+        project.java.targetCompatibility == JavaVersion.VERSION_1_8
         ext.sourceCompatibility == JavaVersion.VERSION_1_8
         ext.targetCompatibility == JavaVersion.VERSION_1_8
 
         when:
-        project.targetCompatibility = JavaVersion.VERSION_1_7
+        project.java.targetCompatibility = JavaVersion.VERSION_1_7
 
         then:
-        project.sourceCompatibility == JavaVersion.VERSION_1_8
-        project.targetCompatibility == JavaVersion.VERSION_1_7
+        project.java.sourceCompatibility == JavaVersion.VERSION_1_8
+        project.java.targetCompatibility == JavaVersion.VERSION_1_7
         ext.sourceCompatibility == JavaVersion.VERSION_1_8
         ext.targetCompatibility == JavaVersion.VERSION_1_7
 
@@ -112,8 +112,8 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         ext.targetCompatibility = JavaVersion.VERSION_1_6
 
         then:
-        project.sourceCompatibility == JavaVersion.VERSION_1_8
-        project.targetCompatibility == JavaVersion.VERSION_1_6
+        project.java.sourceCompatibility == JavaVersion.VERSION_1_8
+        project.java.targetCompatibility == JavaVersion.VERSION_1_6
         ext.sourceCompatibility == JavaVersion.VERSION_1_8
         ext.targetCompatibility == JavaVersion.VERSION_1_6
     }
@@ -361,7 +361,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
 
         then:
         def compile = project.task('customCompile', type: JavaCompile)
-        compile.sourceCompatibility == project.sourceCompatibility.toString()
+        compile.sourceCompatibility == project.java.sourceCompatibility.toString()
 
         def test = project.task('customTest', type: Test.class)
         test.workingDir == project.projectDir

--- a/subprojects/scala/src/integTest/groovy/org/gradle/integtests/ScalaAnnotationProcessingIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/integtests/ScalaAnnotationProcessingIntegrationTest.groovy
@@ -181,7 +181,7 @@ class ScalaAnnotationProcessingIntegrationTest extends AbstractIntegrationSpec {
 
     static String annotationProcessorDependency(File repoDir, String processorDependency) {
         """
-            sourceCompatibility = '1.7'
+            java.sourceCompatibility = '1.7'
 
             repositories {
                 maven {
@@ -266,7 +266,7 @@ class ScalaAnnotationProcessingIntegrationTest extends AbstractIntegrationSpec {
 
                 group = '$group'
                 version = '$version'
-                sourceCompatibility = '1.7'
+                java.sourceCompatibility = '1.7'
 
                 publishing {
                    publications {

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/ScalaCompilationFixture.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/ScalaCompilationFixture.groovy
@@ -107,8 +107,8 @@ class ScalaCompilationFixture {
                 }
             }
 
-            sourceCompatibility = '${sourceCompatibility}'
-            targetCompatibility = '${sourceCompatibility}'
+            java.sourceCompatibility = '${sourceCompatibility}'
+            java.targetCompatibility = '${sourceCompatibility}'
         """.stripIndent()
     }
 

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/ScalaCompileJavaToolchainIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/ScalaCompileJavaToolchainIntegrationTest.groovy
@@ -182,8 +182,8 @@ class ScalaCompileJavaToolchainIntegrationTest extends MultiVersionIntegrationSp
                 def projectSourceCompat = project.java.sourceCompatibility
                 def projectTargetCompat = project.java.targetCompatibility
                 doLast {
-                    logger.lifecycle("project.sourceCompatibility = \$projectSourceCompat")
-                    logger.lifecycle("project.targetCompatibility = \$projectTargetCompat")
+                    logger.lifecycle("project.java.sourceCompatibility = \$projectSourceCompat")
+                    logger.lifecycle("project.java.targetCompatibility = \$projectTargetCompat")
                     logger.lifecycle("task.sourceCompatibility = \$sourceCompatibility")
                     logger.lifecycle("task.targetCompatibility = \$targetCompatibility")
                 }
@@ -196,8 +196,8 @@ class ScalaCompileJavaToolchainIntegrationTest extends MultiVersionIntegrationSp
         then:
         executedAndNotSkipped(":compileScala")
 
-        outputContains("project.sourceCompatibility = 11")
-        outputContains("project.targetCompatibility = 11")
+        outputContains("project.java.sourceCompatibility = 11")
+        outputContains("project.java.targetCompatibility = 11")
         outputContains("task.sourceCompatibility = $sourceOut")
         outputContains("task.targetCompatibility = $targetOut")
         JavaVersion.forClass(scalaClassFile("JavaThing.class").bytes) == JavaVersion.toVersion(targetOut)

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/UpToDateScalaCompileIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/UpToDateScalaCompileIntegrationTest.groovy
@@ -103,8 +103,8 @@ class UpToDateScalaCompileIntegrationTest extends AbstractIntegrationSpec implem
                 zincVersion = "${zincVersion}"
             }
 
-            sourceCompatibility = '1.7'
-            targetCompatibility = '1.7'
+            java.sourceCompatibility = '1.7'
+            java.targetCompatibility = '1.7'
         """.stripIndent()
     }
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/SpringBootPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/SpringBootPluginSmokeTest.groovy
@@ -35,7 +35,9 @@ class SpringBootPluginSmokeTest extends AbstractPluginValidatingSmokeTest implem
 
             ${mavenCentralRepository()}
 
-            project.setProperty('applicationDefaultJvmArgs', ['-DFOO=42'])
+            application {
+                applicationDefaultJvmArgs = ['-DFOO=42']
+            }
 
             dependencies {
                 implementation 'org.springframework.boot:spring-boot-starter'

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskIntegrationTest.groovy
@@ -544,8 +544,8 @@ class TestTaskIntegrationTest extends JUnitMultiVersionIntegrationSpec {
                 testImplementation 'junit:junit:4.13'
             }
 
-            sourceCompatibility = 1.9
-            targetCompatibility = 1.9
+            java.sourceCompatibility = 1.9
+            java.targetCompatibility = 1.9
         """
     }
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskJdkRelocationIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskJdkRelocationIntegrationTest.groovy
@@ -68,8 +68,8 @@ class TestTaskJdkRelocationIntegrationTest extends AbstractTaskRelocationIntegra
                 testImplementation "junit:junit:4.13"
             }
 
-            sourceCompatibility = "1.7"
-            targetCompatibility = "1.7"
+            java.sourceCompatibility = "1.7"
+            java.targetCompatibility = "1.7"
 
             test {
                 executable "${TextUtil.escapeString(originalJavaExecutable)}"

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r25/TestProgressCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r25/TestProgressCrossVersionSpec.groovy
@@ -482,7 +482,7 @@ class TestProgressCrossVersionSpec extends ToolingApiSpecification implements Wi
     def goodCode() {
         buildFile << """
             apply plugin: 'java'
-            sourceCompatibility = 1.7
+            java.sourceCompatibility = 1.7
             ${mavenCentralRepository()}
             dependencies { ${testImplementationConfiguration} 'junit:junit:4.13' }
             compileTestJava.options.fork = true  // forked as 'Gradle Test Executor 1'


### PR DESCRIPTION
This PR changes tests to use extensions instead of conventions where available.

This was extracted from a PR that grown too big for a reasonable review:
* https://github.com/gradle/gradle/pull/23707

This is the first step.