### PR TITLE
Do not add the agent switch in tests unless agent is disabled

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -1074,8 +1074,8 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
         }
 
         boolean hasAgentArgument = args.stream().anyMatch(s -> s.contains(DaemonBuildOptions.ApplyInstrumentationAgentOption.GRADLE_PROPERTY));
-        if (!hasAgentArgument && isAgentInstrumentationEnabled()) {
-            allArgs.add("-D" + DaemonBuildOptions.ApplyInstrumentationAgentOption.GRADLE_PROPERTY + "=true");
+        if (!hasAgentArgument && !isAgentInstrumentationEnabled()) {
+            allArgs.add("-D" + DaemonBuildOptions.ApplyInstrumentationAgentOption.GRADLE_PROPERTY + "=false");
         }
 
         allArgs.addAll(args);


### PR DESCRIPTION
The instrumentation agent is enabled by default, there is no need to add the switch explicitly unless it has to be disabled.
