### PR TITLE
Let :kotlin-dsl-plugins not use `Convention` when accessing extensions

### DIFF
--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinDslJvmDefaultIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinDslJvmDefaultIntegrationTest.kt
@@ -99,7 +99,7 @@ class KotlinDslJvmDefaultIntegrationTest : AbstractPluginIntegrationTest() {
     @Test
     fun `kotlin-dsl java and groovy consumers can use kotlin interface default methods directly`() {
 
-        withSettings(
+        file("settings.gradle.kts").appendText(
             """
             include("kotlin-dsl-producer")
             include("java-consumer")

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
@@ -858,6 +858,7 @@ class PrecompiledScriptPluginIntegrationTest : AbstractPluginIntegrationTest() {
         val pluginJarV1 = withPluginJar("my-plugin-1.0.jar", "1.0")
         val pluginJarV2 = withPluginJar("my-plugin-2.0.jar", "2.0")
 
+        withDefaultSettingsIn("buildSrc")
         withBuildScriptIn("buildSrc", """
             plugins {
                 `kotlin-dsl`
@@ -902,7 +903,7 @@ class PrecompiledScriptPluginIntegrationTest : AbstractPluginIntegrationTest() {
     @Issue("https://github.com/gradle/gradle/issues/23564")
     fun `respects offline start parameter on synthetic builds for accessors generation`() {
 
-        withSettings("""include("producer", "consumer")""")
+        file("settings.gradle.kts").appendText("""include("producer", "consumer")""")
 
         withKotlinDslPluginIn("producer")
         withFile("producer/src/main/kotlin/offline.gradle.kts", """

--- a/subprojects/kotlin-dsl-plugins/build.gradle.kts
+++ b/subprojects/kotlin-dsl-plugins/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 description = "Kotlin DSL Gradle Plugins deployed to the Plugin Portal"
 
 group = "org.gradle.kotlin"
-version = "4.0.8"
+version = "4.0.10"
 
 base.archivesName = "plugins"
 

--- a/subprojects/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/base/KotlinDslBasePlugin.kt
+++ b/subprojects/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/base/KotlinDslBasePlugin.kt
@@ -18,13 +18,11 @@ package org.gradle.kotlin.dsl.plugins.base
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-
+import org.gradle.kotlin.dsl.*
 import org.gradle.kotlin.dsl.plugins.dsl.KotlinDslCompilerPlugins
 import org.gradle.kotlin.dsl.plugins.dsl.KotlinDslPluginOptions
 import org.gradle.kotlin.dsl.plugins.embedded.EmbeddedKotlinPlugin
 import org.gradle.kotlin.dsl.plugins.embedded.kotlinArtifactConfigurationNames
-
-import org.gradle.kotlin.dsl.*
 
 
 /**

--- a/subprojects/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPlugin.kt
+++ b/subprojects/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPlugin.kt
@@ -17,15 +17,11 @@ package org.gradle.kotlin.dsl.plugins.dsl
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-
 import org.gradle.kotlin.dsl.*
-
 import org.gradle.kotlin.dsl.plugins.appliedKotlinDslPluginsVersion
 import org.gradle.kotlin.dsl.plugins.base.KotlinDslBasePlugin
 import org.gradle.kotlin.dsl.plugins.precompiled.PrecompiledScriptPlugins
-
 import org.gradle.kotlin.dsl.support.expectedKotlinDslPluginsVersion
-
 import org.gradle.plugin.devel.plugins.JavaGradlePluginPlugin
 
 

--- a/subprojects/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginOptions.kt
+++ b/subprojects/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginOptions.kt
@@ -20,7 +20,6 @@ import org.gradle.api.Project
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.internal.deprecation.DeprecationLogger
-
 import org.gradle.kotlin.dsl.*
 
 
@@ -62,4 +61,4 @@ fun nagUserAboutJvmTarget() {
 
 internal
 fun Project.kotlinDslPluginOptions(action: KotlinDslPluginOptions.() -> Unit) =
-    configure(action)
+    extensions.getByType<KotlinDslPluginOptions>().apply(action)

--- a/subprojects/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPlugins.kt
+++ b/subprojects/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPlugins.kt
@@ -24,14 +24,11 @@ import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.internal.Factory
 import org.gradle.internal.deprecation.DeprecationLogger
-
 import org.gradle.kotlin.dsl.*
 import org.gradle.kotlin.dsl.plugins.dsl.KotlinDslPluginOptions
 import org.gradle.kotlin.dsl.provider.PrecompiledScriptPluginsSupport
 import org.gradle.kotlin.dsl.provider.gradleKotlinDslJarsOf
 import org.gradle.kotlin.dsl.support.serviceOf
-
-import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 
 
 /**
@@ -58,7 +55,7 @@ abstract class PrecompiledScriptPlugins : Plugin<Project> {
         override val jvmTarget: Provider<JavaVersion> =
             DeprecationLogger.whileDisabled(Factory {
                 @Suppress("DEPRECATION")
-                project.the<KotlinDslPluginOptions>().jvmTarget.map { JavaVersion.toVersion(it) }
+                project.kotlinDslPluginOptions.jvmTarget.map { JavaVersion.toVersion(it) }
             })!!
 
         override val kotlinSourceDirectorySet: SourceDirectorySet
@@ -68,10 +65,15 @@ abstract class PrecompiledScriptPlugins : Plugin<Project> {
 
 
 private
-val Project.sourceSets
-    get() = project.the<SourceSetContainer>()
+val Project.kotlinDslPluginOptions: KotlinDslPluginOptions
+    get() = extensions.getByType()
+
+
+private
+val Project.sourceSets: SourceSetContainer
+    get() = extensions.getByType()
 
 
 private
 val SourceSet.kotlin: SourceDirectorySet
-    get() = @Suppress("deprecation") withConvention(KotlinSourceSet::class) { kotlin }
+    get() = extensions.getByName("kotlin") as SourceDirectorySet

--- a/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/DefaultPrecompiledScriptPluginsSupport.kt
+++ b/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/DefaultPrecompiledScriptPluginsSupport.kt
@@ -443,17 +443,14 @@ fun SourceDirectorySet.collectScriptPluginFiles(): Set<File> =
         .files
 
 
-/**
- * Uses the Groovy builder to access the `kotlin` source set because KGP types are not available here.
- */
 private
 val SourceSet.kotlin: SourceDirectorySet
-    get() = withGroovyBuilder { getProperty("kotlin") } as SourceDirectorySet
+    get() = extensions.getByName<SourceDirectorySet>("kotlin")
 
 
 private
-val Project.gradlePlugin
-    get() = the<GradlePluginDevelopmentExtension>()
+val Project.gradlePlugin: GradlePluginDevelopmentExtension
+    get() = extensions.getByType()
 
 
 private
@@ -482,7 +479,7 @@ fun Project.validateScriptPlugin(scriptPlugin: PrecompiledScriptPlugin) {
 private
 fun Project.declareScriptPlugins(scriptPlugins: List<PrecompiledScriptPlugin>) {
 
-    configure<GradlePluginDevelopmentExtension> {
+    gradlePlugin.apply {
         for (scriptPlugin in scriptPlugins) {
             plugins.create(scriptPlugin.id) {
                 it.id = scriptPlugin.id
@@ -527,15 +524,15 @@ fun Project.buildDir(path: String) = layout.buildDirectory.dir(path)
 
 
 private
-val Project.sourceSets
-    get() = project.the<SourceSetContainer>()
+val Project.sourceSets: SourceSetContainer
+    get() = extensions.getByType()
 
 
 private
-val Project.javaToolchainService
-    get() = serviceOf<JavaToolchainService>()
+val Project.javaToolchainService: JavaToolchainService
+    get() = serviceOf()
 
 
 private
-val Project.java
-    get() = the<JavaPluginExtension>()
+val Project.java: JavaPluginExtension
+    get() = extensions.getByType()


### PR DESCRIPTION
This PR changes `:kotlin-dsl-plugins` implementation to not use any Kotlin DSL extension functions that would access conventions when accessing extensions.

This was extracted from a PR that grown too big for a reasonable review:
* https://github.com/gradle/gradle/pull/23707