### PR TITLE
Fix spurious `:compilePluginsBlock` warnings for non-existing classpath entries

### DIFF
--- a/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/CompilePrecompiledScriptPluginPlugins.kt
+++ b/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/CompilePrecompiledScriptPluginPlugins.kt
@@ -101,7 +101,7 @@ abstract class CompilePrecompiledScriptPluginPlugins @Inject constructor(
                         PrecompiledPluginsBlock::class,
                         implicitImportsForPrecompiledScriptPlugins(implicitImports)
                     ),
-                    classPathFiles,
+                    classPathFiles.filter { it.exists() },
                     logger,
                     { it } // TODO: translate paths
                 )


### PR DESCRIPTION
This is a follow up to
* https://github.com/gradle/gradle/pull/23720

It fixes warnings such as:

```
> Task :build-logic:publishing:compilePluginsBlocks
w: Classpath entry points to a non-existent location: /Users/rafael/sources/master-gradle/build-logic/module-identity/build/classes/java/main
w: Classpath entry points to a non-existent location: /Users/rafael/sources/master-gradle/build-logic-commons/gradle-plugin/build/classes/java/main

> Task :build-logic:jvm:compilePluginsBlocks
w: Classpath entry points to a non-existent location: /Users/rafael/sources/master-gradle/build-logic/basics/build/classes/java/main
w: Classpath entry points to a non-existent location: /Users/rafael/sources/master-gradle/build-logic/dependency-modules/build/classes/java/main
w: Classpath entry points to a non-existent location: /Users/rafael/sources/master-gradle/build-logic/module-identity/build/classes/java/main
w: Classpath entry points to a non-existent location: /Users/rafael/sources/master-gradle/build-logic-commons/gradle-plugin/build/classes/java/main 
```
