### PR TITLE
Remove redundant `atConfigurationTime()` checks

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/initialization/ConfigurationCacheProblemsListener.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/initialization/ConfigurationCacheProblemsListener.kt
@@ -59,16 +59,10 @@ class DefaultConfigurationCacheProblemsListener internal constructor(
 ) : ConfigurationCacheProblemsListener {
 
     override fun onProjectAccess(invocationDescription: String, task: TaskInternal) {
-        if (atConfigurationTime()) {
-            return
-        }
         onTaskExecutionAccessProblem(invocationDescription, task)
     }
 
     override fun onTaskDependenciesAccess(invocationDescription: String, task: TaskInternal) {
-        if (atConfigurationTime()) {
-            return
-        }
         onTaskExecutionAccessProblem(invocationDescription, task)
     }
 


### PR DESCRIPTION
From `ConfigurationCacheProblemsListener` as that responsibility has been moved to `TaskExecutionAccessChecker`.
