### PR TITLE
Skip failing cross version tests on unsupported Gradle versions

### DIFF
--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r42/BuildProgressTaskActionsCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r42/BuildProgressTaskActionsCrossVersionSpec.groovy
@@ -127,6 +127,7 @@ class BuildProgressTaskActionsCrossVersionSpec extends ToolingApiSpecification {
         task.descendant('Execute doLast {} action for :custom')
     }
 
+    @TargetGradleVersion(">=4.10.3")
     def "task actions defined in doFirst and doLast blocks of Kotlin build scripts have informative names"() {
         given:
         buildFileKts << """
@@ -163,6 +164,7 @@ class BuildProgressTaskActionsCrossVersionSpec extends ToolingApiSpecification {
         task.descendant('Execute One last thing... for :custom')
     }
 
+    @TargetGradleVersion(">=4.10.3")
     def "task actions defined in doFirst and doLast blocks of Kotlin build scripts can be named"() {
         given:
         buildFileKts << """


### PR DESCRIPTION
This is a follow up to
* https://github.com/gradle/gradle/pull/24070

See failures in https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_Stage_ReadyforRelease_CrossVersionTests_Trigger/62757267

Failures started with https://github.com/gradle/gradle/commit/ce961a3807656d6368971cd34cd2e482f429c9de and https://github.com/gradle/gradle/commit/8e476a33743056c55620f0d6eb5d5537ca79c2a3

Apparently PTS decided those tests aren't worth running previously and now `release` is broken.

----

* Fixes https://github.com/gradle/gradle-private/issues/3760