### PR TITLE
Temporarily disable the configuration cache when `--write-verification-metadata` is used

### DIFF
--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultNestedBuildTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultNestedBuildTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.artifacts.component.BuildIdentifier
 import org.gradle.api.internal.BuildDefinition
 import org.gradle.api.internal.DocumentationRegistry
 import org.gradle.api.internal.GradleInternal
+import org.gradle.api.logging.LogLevel
 import org.gradle.initialization.exception.ExceptionAnalyser
 import org.gradle.internal.build.BuildLifecycleController
 import org.gradle.internal.build.BuildModelControllerServices
@@ -76,7 +77,7 @@ class DefaultNestedBuildTest extends Specification {
 
     def "runs action and does not finish build"() {
         given:
-        services.add(new BuildModelParameters(false, false, false, false, false, false, false))
+        services.add(new BuildModelParameters(false, false, false, false, false, false, false, LogLevel.DEBUG))
         def build = build()
 
         when:

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheDependencyResolutionFeaturesIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheDependencyResolutionFeaturesIntegrationTest.groovy
@@ -730,7 +730,6 @@ class ConfigurationCacheDependencyResolutionFeaturesIntegrationTest extends Abst
         configurationCacheRun("resolve1", "--write-verification-metadata", "sha256")
 
         then:
-        configurationCache.assertStateStored()
         def verificationFile = file("gradle/verification-metadata.xml")
         verificationFile.isFile()
 

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultBuildTreeModelControllerServices.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultBuildTreeModelControllerServices.kt
@@ -19,6 +19,7 @@ package org.gradle.configurationcache
 import org.gradle.api.GradleException
 import org.gradle.api.internal.BuildType
 import org.gradle.api.internal.StartParameterInternal
+import org.gradle.api.logging.LogLevel
 import org.gradle.configurationcache.initialization.ConfigurationCacheInjectedClasspathInstrumentationStrategy
 import org.gradle.configurationcache.initialization.ConfigurationCacheStartParameter
 import org.gradle.configurationcache.initialization.DefaultConfigurationCacheProblemsListener
@@ -31,6 +32,7 @@ import org.gradle.configurationcache.serialization.codecs.jos.JavaSerializationE
 import org.gradle.configurationcache.services.ConfigurationCacheEnvironmentChangeTracker
 import org.gradle.configurationcache.services.VintageEnvironmentChangeTracker
 import org.gradle.execution.selection.BuildTaskSelector
+import org.gradle.initialization.StartParameterBuildOptions
 import org.gradle.internal.build.BuildStateRegistry
 import org.gradle.internal.buildoption.DefaultInternalOptions
 import org.gradle.internal.buildoption.InternalFlag
@@ -67,13 +69,20 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
         val isolatedProjects = startParameter.isolatedProjects.get()
         val parallelToolingActions = (isolatedProjects || requirements.startParameter.isParallelProjectExecutionEnabled) && options.getOption(parallelBuilding).get()
         val invalidateCoupledProjects = isolatedProjects && options.getOption(invalidateCoupledProjects).get()
+        val configurationCacheLogLevel = if (startParameter.isConfigurationCacheQuiet) LogLevel.INFO else LogLevel.LIFECYCLE
         val modelParameters = if (requirements.isCreatesModel) {
             // When creating a model, disable certain features - only enable configure on demand and configuration cache when isolated projects is enabled
-            BuildModelParameters(isolatedProjects, isolatedProjects, isolatedProjects, true, isolatedProjects, parallelToolingActions, invalidateCoupledProjects)
+            BuildModelParameters(isolatedProjects, isolatedProjects, isolatedProjects, true, isolatedProjects, parallelToolingActions, invalidateCoupledProjects, configurationCacheLogLevel)
         } else {
-            val configurationCache = startParameter.configurationCache.get() || isolatedProjects
-            val configureOnDemand = startParameter.isConfigureOnDemand || isolatedProjects
-            BuildModelParameters(configureOnDemand, configurationCache, isolatedProjects, false, false, parallelToolingActions, invalidateCoupledProjects)
+            val configurationCache = isolatedProjects || startParameter.configurationCache.get()
+            val configureOnDemand = isolatedProjects || startParameter.isConfigureOnDemand
+            if (configurationCache && startParameter.writeDependencyVerifications.isNotEmpty()) {
+                // Disable configuration cache when writing dependency metadata file, it is currently not entirely supported
+                logger.log(configurationCacheLogLevel, "{} as configuration cache cannot be reused due to --{}", requirements.actionDisplayName.capitalizedDisplayName, StartParameterBuildOptions.DependencyVerificationWriteOption.LONG_OPTION)
+                BuildModelParameters(configureOnDemand, false, false, false, false, parallelToolingActions, invalidateCoupledProjects, configurationCacheLogLevel)
+            } else {
+                BuildModelParameters(configureOnDemand, configurationCache, isolatedProjects, false, false, parallelToolingActions, invalidateCoupledProjects, configurationCacheLogLevel)
+            }
         }
 
         if (!startParameter.isConfigurationCacheQuiet) {
@@ -98,7 +107,7 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
         return BuildTreeModelControllerServices.Supplier { registration ->
             registration.add(BuildType::class.java, BuildType.TASKS)
             // Configuration cache is not supported for nested build trees
-            val buildModelParameters = BuildModelParameters(startParameter.isConfigureOnDemand, false, false, true, false, false, false)
+            val buildModelParameters = BuildModelParameters(startParameter.isConfigureOnDemand, false, false, true, false, false, false, LogLevel.LIFECYCLE)
             val requirements = RunTasksRequirements(startParameter)
             registerServices(registration, buildModelParameters, requirements)
         }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
@@ -226,15 +226,6 @@ class DefaultConfigurationCache internal constructor(
             ConfigurationCacheAction.STORE
         }
 
-        startParameter.isWriteDependencyVerifications -> {
-            logBootstrapSummary(
-                "{} as configuration cache cannot be reused due to {}",
-                buildActionModelRequirements.actionDisplayName.capitalizedDisplayName,
-                "--write-verification-metadata"
-            )
-            ConfigurationCacheAction.STORE
-        }
-
         else -> {
             when (val checkedFingerprint = checkFingerprint()) {
                 is CheckedFingerprint.NotFound -> {
@@ -532,10 +523,7 @@ class DefaultConfigurationCache internal constructor(
 
     private
     val configurationCacheLogLevel: LogLevel
-        get() = when (startParameter.isQuiet) {
-            true -> LogLevel.INFO
-            else -> LogLevel.LIFECYCLE
-        }
+        get() = startParameter.configurationCacheLogLevel
 }
 
 

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/initialization/ConfigurationCacheStartParameter.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/initialization/ConfigurationCacheStartParameter.kt
@@ -18,6 +18,7 @@ package org.gradle.configurationcache.initialization
 
 import org.gradle.StartParameter
 import org.gradle.api.internal.StartParameterInternal
+import org.gradle.api.logging.LogLevel
 import org.gradle.configurationcache.extensions.unsafeLazy
 import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheProblemsOption
 import org.gradle.initialization.layout.BuildLayout
@@ -38,7 +39,7 @@ class ConfigurationCacheStartParameter(
     private val buildLayout: BuildLayout,
     private val startParameter: StartParameterInternal,
     options: InternalOptions,
-    modelParameters: BuildModelParameters
+    private val modelParameters: BuildModelParameters
 ) {
     val loadAfterStore: Boolean = !modelParameters.isRequiresBuildModel && options.getOption(InternalFlag("org.gradle.configuration-cache.internal.load-after-store", true)).get()
 
@@ -50,6 +51,9 @@ class ConfigurationCacheStartParameter(
 
     val gradleProperties: Map<String, Any?>
         get() = startParameter.projectProperties
+
+    val configurationCacheLogLevel: LogLevel
+        get() = modelParameters.configurationCacheLogLevel
 
     val isQuiet: Boolean
         get() = startParameter.isConfigurationCacheQuiet
@@ -96,9 +100,6 @@ class ConfigurationCacheStartParameter(
 
     val isUpdateDependencyLocks
         get() = startParameter.lockedDependenciesToUpdate.isNotEmpty()
-
-    val isWriteDependencyVerifications
-        get() = startParameter.writeDependencyVerifications.isNotEmpty()
 
     val requestedTaskNames: List<String> by unsafeLazy {
         startParameter.taskNames

--- a/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/ConfigurationCacheKeyTest.kt
+++ b/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/ConfigurationCacheKeyTest.kt
@@ -17,6 +17,7 @@
 package org.gradle.configurationcache
 
 import org.gradle.api.internal.StartParameterInternal
+import org.gradle.api.logging.LogLevel
 import org.gradle.configurationcache.initialization.ConfigurationCacheStartParameter
 import org.gradle.initialization.layout.BuildLayout
 import org.gradle.internal.buildoption.DefaultInternalOptions
@@ -135,7 +136,7 @@ class ConfigurationCacheKeyTest {
                 ),
                 startParameter,
                 DefaultInternalOptions(mapOf()),
-                BuildModelParameters(false, true, false, false, false, false, false)
+                BuildModelParameters(false, true, false, false, false, false, false, LogLevel.LIFECYCLE)
             ),
             RunTasksRequirements(startParameter),
             object : EncryptionConfiguration {

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildModelParameters.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildModelParameters.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.buildtree;
 
+import org.gradle.api.logging.LogLevel;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
@@ -28,6 +29,7 @@ public class BuildModelParameters {
     private final boolean intermediateModelCache;
     private final boolean parallelToolingApiActions;
     private final boolean invalidateCoupledProjects;
+    private final LogLevel configurationCacheLogLevel;
 
     public BuildModelParameters(
         boolean configureOnDemand,
@@ -36,7 +38,8 @@ public class BuildModelParameters {
         boolean requiresBuildModel,
         boolean intermediateModelCache,
         boolean parallelToolingApiActions,
-        boolean invalidateCoupledProjects
+        boolean invalidateCoupledProjects,
+        LogLevel configurationCacheLogLevel
     ) {
         this.configureOnDemand = configureOnDemand;
         this.configurationCache = configurationCache;
@@ -45,6 +48,7 @@ public class BuildModelParameters {
         this.intermediateModelCache = intermediateModelCache;
         this.parallelToolingApiActions = parallelToolingApiActions;
         this.invalidateCoupledProjects = invalidateCoupledProjects;
+        this.configurationCacheLogLevel = configurationCacheLogLevel;
     }
 
     /**
@@ -62,6 +66,10 @@ public class BuildModelParameters {
 
     public boolean isConfigurationCache() {
         return configurationCache;
+    }
+
+    public LogLevel getConfigurationCacheLogLevel() {
+        return configurationCacheLogLevel;
     }
 
     public boolean isIsolatedProjects() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureWriteIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureWriteIntegTest.groovy
@@ -48,9 +48,6 @@ class DependencyVerificationSignatureWriteIntegTest extends AbstractSignatureVer
         serveValidKey()
         writeVerificationMetadata()
 
-        //TODO: remove this once dependency verification stops triggering dependency resolution at execution time
-        executer.withBuildJvmOpts("-Dorg.gradle.configuration-cache.internal.task-execution-access-pre-stable=true")
-
         succeeds ":help"
 
         then:
@@ -91,9 +88,6 @@ class DependencyVerificationSignatureWriteIntegTest extends AbstractSignatureVer
 
         when:
         writeVerificationMetadata()
-
-        //TODO: remove this once dependency verification stops triggering dependency resolution at execution time
-        executer.withBuildJvmOpts("-Dorg.gradle.configuration-cache.internal.task-execution-access-pre-stable=true")
 
         succeeds ":help"
 
@@ -152,9 +146,6 @@ class DependencyVerificationSignatureWriteIntegTest extends AbstractSignatureVer
         when:
         serveValidKey()
         writeVerificationMetadata()
-
-        //TODO: remove this once dependency verification stops triggering dependency resolution at execution time
-        executer.withBuildJvmOpts("-Dorg.gradle.configuration-cache.internal.task-execution-access-pre-stable=true")
 
         succeeds ":help"
 
@@ -259,9 +250,6 @@ class DependencyVerificationSignatureWriteIntegTest extends AbstractSignatureVer
         when:
         writeVerificationMetadata()
 
-        //TODO: remove this once dependency verification stops triggering dependency resolution at execution time
-        executer.withBuildJvmOpts("-Dorg.gradle.configuration-cache.internal.task-execution-access-pre-stable=true")
-
         succeeds ":help"
 
         then:
@@ -313,9 +301,6 @@ class DependencyVerificationSignatureWriteIntegTest extends AbstractSignatureVer
         serveValidKey()
         keyServerFixture.registerPublicKey(keyring.publicKey)
         writeVerificationMetadata()
-
-        //TODO: remove this once dependency verification stops triggering dependency resolution at execution time
-        executer.withBuildJvmOpts("-Dorg.gradle.configuration-cache.internal.task-execution-access-pre-stable=true")
 
         succeeds ":help", "--export-keys"
 
@@ -425,9 +410,6 @@ class DependencyVerificationSignatureWriteIntegTest extends AbstractSignatureVer
         when:
         writeVerificationMetadata()
 
-        //TODO: remove this once dependency verification stops triggering dependency resolution at execution time
-        executer.withBuildJvmOpts("-Dorg.gradle.configuration-cache.internal.task-execution-access-pre-stable=true")
-
         succeeds ":help", "--export-keys"
 
         then:
@@ -456,9 +438,6 @@ class DependencyVerificationSignatureWriteIntegTest extends AbstractSignatureVer
         """
 
         when:
-        //TODO: remove this once dependency verification stops triggering dependency resolution at execution time
-        executer.withBuildJvmOpts("-Dorg.gradle.configuration-cache.internal.task-execution-access-pre-stable=true")
-
         serveValidKey()
         keyServerFixture.registerPublicKey(keyring.publicKey)
         succeeds "build", "--export-keys"

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationWritingIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationWritingIntegTest.groovy
@@ -178,9 +178,6 @@ class DependencyVerificationWritingIntegTest extends AbstractDependencyVerificat
         when:
         writeVerificationMetadata()
 
-        //TODO: remove this once dependency verification stops triggering dependency resolution at execution time
-        executer.withBuildJvmOpts("-Dorg.gradle.configuration-cache.internal.task-execution-access-pre-stable=true")
-
         run ":help"
 
         then:
@@ -284,9 +281,6 @@ class DependencyVerificationWritingIntegTest extends AbstractDependencyVerificat
         when:
         writeVerificationMetadata()
 
-        //TODO: remove this once dependency verification stops triggering dependency resolution at execution time
-        executer.withBuildJvmOpts("-Dorg.gradle.configuration-cache.internal.task-execution-access-pre-stable=true")
-
         run ":help"
 
         then:
@@ -338,9 +332,6 @@ class DependencyVerificationWritingIntegTest extends AbstractDependencyVerificat
         """
 
         when:
-        //TODO: remove this once dependency verification stops triggering dependency resolution at execution time
-        executer.withBuildJvmOpts("-Dorg.gradle.configuration-cache.internal.task-execution-access-pre-stable=true")
-
         writeVerificationMetadata()
         run ":help"
 
@@ -387,9 +378,6 @@ class DependencyVerificationWritingIntegTest extends AbstractDependencyVerificat
 
         when:
         writeVerificationMetadata()
-
-        //TODO: remove this once dependency verification stops triggering dependency resolution at execution time
-        executer.withBuildJvmOpts("-Dorg.gradle.configuration-cache.internal.task-execution-access-pre-stable=true")
 
         run ":help"
 
@@ -469,9 +457,6 @@ class DependencyVerificationWritingIntegTest extends AbstractDependencyVerificat
         when:
         writeVerificationMetadata()
 
-        //TODO: remove this once dependency verification stops triggering dependency resolution at execution time
-        executer.withBuildJvmOpts("-Dorg.gradle.configuration-cache.internal.task-execution-access-pre-stable=true")
-
         succeeds ':help'
 
         then:
@@ -515,9 +500,6 @@ class DependencyVerificationWritingIntegTest extends AbstractDependencyVerificat
         uncheckedModule("org", "bar")
 
         when:
-        //TODO: remove this once dependency verification stops triggering dependency resolution at execution time
-        executer.withBuildJvmOpts("-Dorg.gradle.configuration-cache.internal.task-execution-access-pre-stable=true")
-
         writeVerificationMetadata()
         succeeds ":help"
 
@@ -550,9 +532,6 @@ class DependencyVerificationWritingIntegTest extends AbstractDependencyVerificat
         uncheckedModule("org", "bar")
 
         when:
-        //TODO: remove this once dependency verification stops triggering dependency resolution at execution time
-        executer.withBuildJvmOpts("-Dorg.gradle.configuration-cache.internal.task-execution-access-pre-stable=true")
-
         writeVerificationMetadata()
         succeeds ":help"
 
@@ -673,9 +652,6 @@ class DependencyVerificationWritingIntegTest extends AbstractDependencyVerificat
         """
 
         when:
-        //TODO: remove this once dependency verification stops triggering dependency resolution at execution time
-        executer.withBuildJvmOpts("-Dorg.gradle.configuration-cache.internal.task-execution-access-pre-stable=true")
-
         writeVerificationMetadata()
         run ":help"
 
@@ -717,9 +693,6 @@ class DependencyVerificationWritingIntegTest extends AbstractDependencyVerificat
         when:
         writeVerificationMetadata()
 
-        //TODO: remove this once dependency verification stops triggering dependency resolution at execution time
-        executer.withBuildJvmOpts("-Dorg.gradle.configuration-cache.internal.task-execution-access-pre-stable=true")
-
         run ":help"
 
         then:
@@ -754,9 +727,6 @@ class DependencyVerificationWritingIntegTest extends AbstractDependencyVerificat
             }
         """
         when:
-        //TODO: remove this once dependency verification stops triggering dependency resolution at execution time
-        executer.withBuildJvmOpts("-Dorg.gradle.configuration-cache.internal.task-execution-access-pre-stable=true")
-
         writeVerificationMetadata()
         run ":help"
 
@@ -806,9 +776,6 @@ class DependencyVerificationWritingIntegTest extends AbstractDependencyVerificat
             executer.stop()
         }
         writeVerificationMetadata()
-
-        //TODO: remove this once dependency verification stops triggering dependency resolution at execution time
-        executer.withBuildJvmOpts("-Dorg.gradle.configuration-cache.internal.task-execution-access-pre-stable=true")
 
         run ":help"
 
@@ -1283,9 +1250,6 @@ class DependencyVerificationWritingIntegTest extends AbstractDependencyVerificat
         when:
         writeVerificationMetadata()
 
-        //TODO: remove this once dependency verification stops triggering dependency resolution at execution time
-        executer.withBuildJvmOpts("-Dorg.gradle.configuration-cache.internal.task-execution-access-pre-stable=true")
-
         run ":help"
 
         then:
@@ -1302,9 +1266,6 @@ class DependencyVerificationWritingIntegTest extends AbstractDependencyVerificat
             }
         """
         writeVerificationMetadata()
-
-        //TODO: remove this once dependency verification stops triggering dependency resolution at execution time
-        executer.withBuildJvmOpts("-Dorg.gradle.configuration-cache.internal.task-execution-access-pre-stable=true")
 
         run ":help"
 
@@ -1340,9 +1301,6 @@ class DependencyVerificationWritingIntegTest extends AbstractDependencyVerificat
         }
 
         writeVerificationMetadata()
-
-        //TODO: remove this once dependency verification stops triggering dependency resolution at execution time
-        executer.withBuildJvmOpts("-Dorg.gradle.configuration-cache.internal.task-execution-access-pre-stable=true")
 
         run ":help", "--offline"
 
@@ -1390,9 +1348,6 @@ class DependencyVerificationWritingIntegTest extends AbstractDependencyVerificat
         when:
         writeVerificationMetadata()
 
-        //TODO: remove this once dependency verification stops triggering dependency resolution at execution time
-        executer.withBuildJvmOpts("-Dorg.gradle.configuration-cache.internal.task-execution-access-pre-stable=true")
-
         run ":help"
 
         then:
@@ -1432,9 +1387,6 @@ class DependencyVerificationWritingIntegTest extends AbstractDependencyVerificat
 
         when:
         writeVerificationMetadata()
-
-        //TODO: remove this once dependency verification stops triggering dependency resolution at execution time
-        executer.withBuildJvmOpts("-Dorg.gradle.configuration-cache.internal.task-execution-access-pre-stable=true")
 
         run ":help"
 


### PR DESCRIPTION

<!--- The issue this PR addresses -->
Fixes #?

### Context

There are currently a number of issues with the `--write-verification-metadata` implementation when the configuration cache is enabled. These will be fixed later and the configuration cache re-enabled.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
