### PR TITLE
Ensure flow actions cannot depend on tasks (yet)

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheFlowScopeIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheFlowScopeIntegrationTest.groovy
@@ -74,7 +74,57 @@ class ConfigurationCacheFlowScopeIntegrationTest extends AbstractConfigurationCa
         outputDoesNotContain 'Bean.value = 43'
     }
 
-    def '#target #injectionStyle with #parameter can react to task execution result'() {
+    def 'flow actions cannot depend on tasks'() {
+        given:
+        buildFile '''
+            import org.gradle.api.flow.*
+            import org.gradle.api.services.*
+            import org.gradle.api.tasks.*
+
+            class FlowActionPlugin implements Plugin<Project> {
+                final FlowScope flowScope
+                final FlowProviders flowProviders
+                @Inject FlowActionPlugin(FlowScope flowScope, FlowProviders flowProviders) {
+                    this.flowScope = flowScope
+                    this.flowProviders = flowProviders
+                }
+                void apply(Project target) {
+                    def producer = target.tasks.register('producer', Producer) {
+                        outputFile = target.layout.buildDirectory.file('out')
+                    }
+                    flowScope.always(PrintAction) {
+                        parameters.text = producer.flatMap { it.outputFile }.map { it.asFile.text }
+                    }
+                }
+            }
+
+            abstract class Producer extends DefaultTask {
+                @OutputFile abstract RegularFileProperty getOutputFile()
+                @TaskAction def produce() {
+                    outputFile.get().asFile << "42"
+                }
+            }
+
+            class PrintAction implements FlowAction<Parameters> {
+                interface Parameters extends FlowParameters {
+                    @Input Property<String> getText()
+                }
+                void execute(Parameters parameters) {
+                    println(parameters.text.get())
+                }
+            }
+
+            apply type: FlowActionPlugin
+        '''
+
+        when:
+        configurationCacheFails 'producer'
+
+        then:
+        failureCauseContains "Property 'text' cannot carry a dependency on task ':producer' as these are not yet supported."
+    }
+
+    def '#target #injectionStyle with #parameter can react to build work result'() {
         given:
         def configCache = newConfigurationCacheFixture()
 
@@ -228,7 +278,7 @@ class ConfigurationCacheFlowScopeIntegrationTest extends AbstractConfigurationCa
 
                 interface Parameters extends FlowParameters {
                     @ServiceReference("lamp") Property<LavaLamp> getLamp()
-                    Property<String> getColor()
+                    @Input Property<String> getColor()
                 }
 
                 void execute(Parameters parameters) {
@@ -516,7 +566,7 @@ class ConfigurationCacheFlowScopeIntegrationTest extends AbstractConfigurationCa
         failureDescriptionStartsWith "Configuration cache problems found in this build"
     }
 
-    def "value source with task result provider cannot be obtained at configuration time"() {
+    def "value source with build work result provider cannot be obtained at configuration time"() {
         given:
         buildFile("""
         import org.gradle.api.provider.*

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheFlowScopeIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheFlowScopeIntegrationTest.groovy
@@ -28,6 +28,7 @@ class ConfigurationCacheFlowScopeIntegrationTest extends AbstractConfigurationCa
         buildFile '''
             import org.gradle.api.flow.*
             import org.gradle.api.services.*
+            import java.util.concurrent.atomic.AtomicInteger
 
             class FlowActionPlugin implements Plugin<Project> {
                 final FlowScope flowScope
@@ -48,16 +49,16 @@ class ConfigurationCacheFlowScopeIntegrationTest extends AbstractConfigurationCa
             }
 
             class Bean {
-                int value = 41
+                AtomicInteger value = new AtomicInteger(41)
             }
 
             class IncrementAndPrint implements FlowAction<Parameters> {
                 interface Parameters extends FlowParameters {
-                    Property<Bean> getBean()
+                    @Input Property<Bean> getBean()
                 }
                 void execute(Parameters parameters) {
                     parameters.with {
-                        println("Bean.value = " + (++bean.get().value))
+                        println("Bean.value = " + bean.get().value.incrementAndGet())
                     }
                 }
             }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/flow/FlowParametersInstantiator.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/flow/FlowParametersInstantiator.kt
@@ -16,17 +16,22 @@
 
 package org.gradle.configurationcache.flow
 
+import com.google.common.collect.ImmutableMap
+import org.gradle.api.Task
 import org.gradle.api.flow.FlowParameters
 import org.gradle.api.internal.DocumentationRegistry
+import org.gradle.api.internal.tasks.AbstractTaskDependencyResolveContext
 import org.gradle.api.internal.tasks.properties.InspectionSchemeFactory
 import org.gradle.api.services.ServiceReference
 import org.gradle.api.tasks.Input
 import org.gradle.internal.instantiation.InstantiatorFactory
 import org.gradle.internal.properties.PropertyValue
 import org.gradle.internal.properties.PropertyVisitor
+import org.gradle.internal.reflect.DefaultTypeValidationContext
 import org.gradle.internal.reflect.ProblemRecordingTypeValidationContext
-import org.gradle.internal.reflect.problems.ValidationProblemId
+import org.gradle.internal.reflect.validation.Severity
 import org.gradle.internal.reflect.validation.TypeValidationProblem
+import org.gradle.internal.reflect.validation.TypeValidationProblemRenderer
 import org.gradle.internal.service.ServiceRegistry
 import org.gradle.internal.service.scopes.Scopes
 import org.gradle.internal.service.scopes.ServiceScope
@@ -49,13 +54,15 @@ class FlowParametersInstantiator(
 
     private
     fun <P : FlowParameters> validate(type: Class<P>, parameters: P) {
+        val problems = ImmutableMap.builder<String, Severity>()
         inspection.propertyWalker.visitProperties(
             parameters,
             object : ProblemRecordingTypeValidationContext(DocumentationRegistry(), type, { Optional.empty() }) {
                 override fun recordProblem(problem: TypeValidationProblem) {
-                    if (problem.id != ValidationProblemId.MISSING_ANNOTATION) {
-                        TODO("${where(problem)}: ${problem.shortDescription}")
-                    }
+                    problems.put(
+                        TypeValidationProblemRenderer.renderMinimalInformationAbout(problem),
+                        problem.severity
+                    )
                 }
             },
             object : PropertyVisitor {
@@ -64,9 +71,24 @@ class FlowParametersInstantiator(
                 }
 
                 override fun visitInputProperty(propertyName: String, value: PropertyValue, optional: Boolean) {
+
+                    val taskDependencies = value.taskDependencies
+                    taskDependencies.visitDependencies(
+                        object : AbstractTaskDependencyResolveContext() {
+                            override fun add(dependency: Any) {
+                                problems.put(
+                                    "Property '$propertyName' cannot carry a dependency on $dependency as these are not yet supported.",
+                                    Severity.ERROR
+                                )
+                            }
+
+                            override fun getTask(): Task? = null
+                        }
+                    )
                 }
             }
         )
+        DefaultTypeValidationContext.throwOnProblemsOf(type, problems.build())
     }
 
     private

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultNodeValidator.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultNodeValidator.java
@@ -73,14 +73,18 @@ public class DefaultNodeValidator implements NodeValidator {
     }
 
     private void reportErrors(List<TypeValidationProblem> problems, TaskInternal task, WorkValidationContext validationContext) {
-        ImmutableSet<String> uniqueErrors = problems.stream()
-                .filter(problem -> !problem.getSeverity().isWarning())
-                .map(TypeValidationProblemRenderer::renderMinimalInformationAbout)
-                .collect(ImmutableSet.toImmutableSet());
+        ImmutableSet<String> uniqueErrors = getUniqueErrors(problems);
         if (!uniqueErrors.isEmpty()) {
             throw WorkValidationException.forProblems(uniqueErrors)
-                    .withSummaryForContext(task.toString(), validationContext)
-                    .get();
+                .withSummaryForContext(task.toString(), validationContext)
+                .get();
         }
+    }
+
+    private static ImmutableSet<String> getUniqueErrors(List<TypeValidationProblem> problems) {
+        return problems.stream()
+            .filter(problem -> !problem.getSeverity().isWarning())
+            .map(TypeValidationProblemRenderer::renderMinimalInformationAbout)
+            .collect(ImmutableSet.toImmutableSet());
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationRegistrationFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationRegistrationFactory.java
@@ -16,8 +16,6 @@
 
 package org.gradle.api.internal.artifacts.transform;
 
-import com.google.common.collect.ImmutableMap;
-import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.transform.CacheableTransform;
 import org.gradle.api.artifacts.transform.InputArtifact;
 import org.gradle.api.artifacts.transform.InputArtifactDependencies;
@@ -30,7 +28,6 @@ import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileLookup;
 import org.gradle.api.internal.tasks.properties.FileParameterUtils;
-import org.gradle.internal.exceptions.DefaultMultiCauseException;
 import org.gradle.internal.execution.InputFingerprinter;
 import org.gradle.internal.fingerprint.DirectorySensitivity;
 import org.gradle.internal.fingerprint.FileNormalizer;
@@ -49,13 +46,10 @@ import org.gradle.internal.properties.annotations.TypeMetadata;
 import org.gradle.internal.properties.annotations.TypeMetadataStore;
 import org.gradle.internal.properties.bean.PropertyWalker;
 import org.gradle.internal.reflect.DefaultTypeValidationContext;
-import org.gradle.internal.reflect.validation.Severity;
 import org.gradle.internal.service.ServiceLookup;
-import org.gradle.model.internal.type.ModelType;
 
 import javax.annotation.Nullable;
 import java.lang.annotation.Annotation;
-import java.util.stream.Collectors;
 
 public class DefaultTransformationRegistrationFactory implements TransformationRegistrationFactory {
 
@@ -137,19 +131,7 @@ public class DefaultTransformationRegistrationFactory implements TransformationR
                 DefaultTransformer.validateInputFileNormalizer(propertyMetadata.getPropertyName(), dependenciesNormalizer, cacheable, validationContext);
             }
         }
-        ImmutableMap<String, Severity> validationMessages = validationContext.getProblems();
-        if (!validationMessages.isEmpty()) {
-            String formatString = validationMessages.size() == 1
-                ? "A problem was found with the configuration of %s."
-                : "Some problems were found with the configuration of %s.";
-            throw new DefaultMultiCauseException(
-                String.format(formatString, ModelType.of(implementation).getDisplayName()),
-                validationMessages.keySet().stream()
-                    .sorted()
-                    .map(InvalidUserDataException::new)
-                    .collect(Collectors.toList())
-            );
-        }
+        DefaultTypeValidationContext.throwOnProblemsOf(implementation, validationContext.getProblems());
         Transformer transformer = new DefaultTransformer(
             implementation,
             parameterObject,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationRegistrationFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationRegistrationFactory.java
@@ -198,14 +198,14 @@ public class DefaultTransformationRegistrationFactory implements TransformationR
 
         @Override
         public void visitInputFileProperty(
-                String propertyName,
-                boolean optional,
-                InputBehavior behavior,
-                DirectorySensitivity directorySensitivity,
-                LineEndingSensitivity lineEndingSensitivity,
-                @Nullable FileNormalizer fileNormalizer,
-                PropertyValue value,
-                InputFilePropertyType filePropertyType
+            String propertyName,
+            boolean optional,
+            InputBehavior behavior,
+            DirectorySensitivity directorySensitivity,
+            LineEndingSensitivity lineEndingSensitivity,
+            @Nullable FileNormalizer fileNormalizer,
+            PropertyValue value,
+            InputFilePropertyType filePropertyType
         ) {
             this.normalizer = fileNormalizer;
             this.directorySensitivity = directorySensitivity;

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/DefaultTypeValidationProblemBuilder.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/DefaultTypeValidationProblemBuilder.java
@@ -47,7 +47,7 @@ public class DefaultTypeValidationProblemBuilder extends AbstractValidationProbl
         return new TypeValidationProblem(
             problemId,
             severity,
-            typeIrrelevantInErrorMessage ? TypeValidationProblemLocation.irrelevant() :  TypeValidationProblemLocation.inType(type, pluginId),
+            typeIrrelevantInErrorMessage ? TypeValidationProblemLocation.irrelevant() : TypeValidationProblemLocation.inType(type, pluginId),
             shortProblemDescription,
             longDescription,
             reason,

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/ReplayingTypeValidationContext.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/ReplayingTypeValidationContext.java
@@ -34,7 +34,7 @@ public class ReplayingTypeValidationContext implements TypeValidationContext {
     public void visitPropertyProblem(Action<? super PropertyProblemBuilder> problemSpec) {
         problems.add((ownerProperty, validationContext) -> validationContext.visitPropertyProblem(builder -> {
             problemSpec.execute(builder);
-            ((PropertyProblemBuilderInternal)builder).forOwner(ownerProperty);
+            ((PropertyProblemBuilderInternal) builder).forOwner(ownerProperty);
         }));
     }
 

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/TypeValidationContext.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/TypeValidationContext.java
@@ -24,6 +24,7 @@ public interface TypeValidationContext {
      * Visits a validation problem associated with the given type.
      * Callers are encourages to provide as much information as they can on
      * the problem following the problem builder instructions.
+     *
      * @param problemSpec the problem builder
      */
     void visitTypeProblem(Action<? super TypeProblemBuilder> problemSpec);
@@ -32,6 +33,7 @@ public interface TypeValidationContext {
      * Visits a validation problem associated with the given property.
      * Callers are encourages to provide as much information as they can on
      * the problem following the problem builder instructions.
+     *
      * @param problemSpec the problem builder
      */
     void visitPropertyProblem(Action<? super PropertyProblemBuilder> problemSpec);
@@ -41,7 +43,7 @@ public interface TypeValidationContext {
         public void visitTypeProblem(Action<? super TypeProblemBuilder> problemSpec) {}
 
         @Override
-        public void visitPropertyProblem(Action<? super PropertyProblemBuilder> problemSpec) { }
+        public void visitPropertyProblem(Action<? super PropertyProblemBuilder> problemSpec) {}
     };
 
 }


### PR DESCRIPTION
And expect flow action properties to be explicitly annotated with either `@Input` or `@ServiceReference` for future proofness.