### PR TITLE
Fix JavaExecDebugIntegrationTest

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecActionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecActionFactory.java
@@ -630,12 +630,12 @@ public abstract class DefaultExecActionFactory implements ExecFactory {
 
         @Override
         public void installJvmArgs(Iterable<?> jvmArgs) {
-            delegate.installJvmArgs(jvmArgs);
+            throw new UnsupportedOperationException();
         }
 
         @Override
         public void checkDebugConfiguration(Iterable<?> arguments) {
-            delegate.checkDebugConfiguration(arguments);
+            throw new UnsupportedOperationException();
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecActionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecActionFactory.java
@@ -627,5 +627,15 @@ public abstract class DefaultExecActionFactory implements ExecFactory {
         public boolean isCompatibleWith(JavaForkOptions options) {
             return delegate.isCompatibleWith(options);
         }
+
+        @Override
+        public void installJvmArgs(Iterable<?> jvmArgs) {
+            delegate.installJvmArgs(jvmArgs);
+        }
+
+        @Override
+        public void checkDebugConfiguration(Iterable<?> arguments) {
+            delegate.checkDebugConfiguration(arguments);
+        }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecActionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecActionFactory.java
@@ -629,7 +629,7 @@ public abstract class DefaultExecActionFactory implements ExecFactory {
         }
 
         @Override
-        public void installJvmArgs(Iterable<?> jvmArgs) {
+        public void setExtraJvmArgs(Iterable<?> jvmArgs) {
             throw new UnsupportedOperationException();
         }
 

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaForkOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaForkOptions.java
@@ -241,8 +241,8 @@ public class DefaultJavaForkOptions extends DefaultProcessForkOptions implements
     }
 
     @Override
-    public void installJvmArgs(Iterable<?> arguments) {
-        options.installJvmArgs(arguments);
+    public void setExtraJvmArgs(Iterable<?> arguments) {
+        options.setExtraJvmArgs(arguments);
     }
 
     private static boolean hasJvmArgumentProviders(JavaForkOptions forkOptions) {

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaForkOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaForkOptions.java
@@ -235,6 +235,14 @@ public class DefaultJavaForkOptions extends DefaultProcessForkOptions implements
             && getBootstrapClasspath().getFiles().containsAll(options.getBootstrapClasspath().getFiles());
     }
 
+    public void checkDebugConfiguration(Iterable<?> arguments) {
+        options.checkDebugConfiguration(arguments);
+    }
+
+    public void installJvmArgs(Iterable<?> arguments) {
+        options.installJvmArgs(arguments);
+    }
+
     private static boolean hasJvmArgumentProviders(JavaForkOptions forkOptions) {
         return forkOptions instanceof DefaultJavaForkOptions
             && hasJvmArgumentProviders((DefaultJavaForkOptions) forkOptions);

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaForkOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaForkOptions.java
@@ -235,10 +235,12 @@ public class DefaultJavaForkOptions extends DefaultProcessForkOptions implements
             && getBootstrapClasspath().getFiles().containsAll(options.getBootstrapClasspath().getFiles());
     }
 
+    @Override
     public void checkDebugConfiguration(Iterable<?> arguments) {
         options.checkDebugConfiguration(arguments);
     }
 
+    @Override
     public void installJvmArgs(Iterable<?> arguments) {
         options.installJvmArgs(arguments);
     }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/JavaForkOptionsInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/JavaForkOptionsInternal.java
@@ -25,4 +25,14 @@ public interface JavaForkOptionsInternal extends JavaForkOptions {
      */
     boolean isCompatibleWith(JavaForkOptions options);
 
+    /**
+     * Sets extra JVM arguments to a Java process without checking debug configuration.
+     * */
+    void installJvmArgs(Iterable<?> jvmArgs);
+
+
+    /**
+     * Checks supplied JVM arguments with purpose to ignore debug configuration in favor of the supplied arguments.
+     * */
+    void checkDebugConfiguration(Iterable<?> arguments);
 }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/JavaForkOptionsInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/JavaForkOptionsInternal.java
@@ -27,12 +27,12 @@ public interface JavaForkOptionsInternal extends JavaForkOptions {
 
     /**
      * Sets extra JVM arguments to a Java process without checking debug configuration.
-     * */
-    void installJvmArgs(Iterable<?> jvmArgs);
+     */
+    void setExtraJvmArgs(Iterable<?> jvmArgs);
 
 
     /**
      * Checks supplied JVM arguments with purpose to ignore debug configuration in favor of the supplied arguments.
-     * */
+     */
     void checkDebugConfiguration(Iterable<?> arguments);
 }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/JvmOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/JvmOptions.java
@@ -199,7 +199,35 @@ public class JvmOptions {
         jvmArgs(arguments);
     }
 
+    public void installJvmArgs(Iterable<?> arguments) {
+        extraJvmArgs.clear();
+        addExtraJvmArgs(arguments);
+    }
+
+    public void checkDebugConfiguration(Iterable<?> arguments) {
+        List<String> debugArgs = new ArrayList<>();
+        for (Object extraJvmArg : arguments) {
+            String extraJvmArgString = extraJvmArg.toString();
+            if (extraJvmArgString.equals("-Xdebug") || extraJvmArgString.startsWith("-Xrunjdwp") || extraJvmArgString.startsWith("-agentlib:jdwp")) {
+                debugArgs.add(extraJvmArgString);
+            }
+        }
+        if (!debugArgs.isEmpty() && debugOptions.getEnabled().get()) {
+            LOGGER.warn("Debug configuration ignored in favor of the supplied JVM arguments: " + debugArgs);
+            debugOptions.getEnabled().set(false);
+        }
+    }
+
     public void jvmArgs(Iterable<?> arguments) {
+        addExtraJvmArgs(arguments);
+        checkDebugConfiguration(extraJvmArgs);
+    }
+
+    public void jvmArgs(Object... arguments) {
+        jvmArgs(Arrays.asList(arguments));
+    }
+
+    private void addExtraJvmArgs(Iterable<?> arguments) {
         for (Object argument : arguments) {
             String argStr = argument.toString();
 
@@ -226,22 +254,6 @@ public class JvmOptions {
                 extraJvmArgs.add(argument);
             }
         }
-
-        List<String> debugArgs = new ArrayList<>();
-        for (Object extraJvmArg : extraJvmArgs) {
-            String extraJvmArgString = extraJvmArg.toString();
-            if (extraJvmArgString.equals("-Xdebug") || extraJvmArgString.startsWith("-Xrunjdwp") || extraJvmArgString.startsWith("-agentlib:jdwp")) {
-                debugArgs.add(extraJvmArgString);
-            }
-        }
-        if (!debugArgs.isEmpty() && debugOptions.getEnabled().get()) {
-            LOGGER.warn("Debug configuration ignored in favor of the supplied JVM arguments: " + debugArgs);
-            debugOptions.getEnabled().set(false);
-        }
-    }
-
-    public void jvmArgs(Object... arguments) {
-        jvmArgs(Arrays.asList(arguments));
     }
 
     public Map<String, Object> getMutableSystemProperties() {

--- a/subprojects/core/src/main/java/org/gradle/process/internal/JvmOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/JvmOptions.java
@@ -199,7 +199,7 @@ public class JvmOptions {
         jvmArgs(arguments);
     }
 
-    public void installJvmArgs(Iterable<?> arguments) {
+    public void setExtraJvmArgs(Iterable<?> arguments) {
         extraJvmArgs.clear();
         addExtraJvmArgs(arguments);
     }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/JvmOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/JvmOptions.java
@@ -205,17 +205,28 @@ public class JvmOptions {
     }
 
     public void checkDebugConfiguration(Iterable<?> arguments) {
-        List<String> debugArgs = new ArrayList<>();
-        for (Object extraJvmArg : arguments) {
-            String extraJvmArgString = extraJvmArg.toString();
-            if (extraJvmArgString.equals("-Xdebug") || extraJvmArgString.startsWith("-Xrunjdwp") || extraJvmArgString.startsWith("-agentlib:jdwp")) {
-                debugArgs.add(extraJvmArgString);
-            }
-        }
+        List<String> debugArgs = collectDebugArgs(arguments);
         if (!debugArgs.isEmpty() && debugOptions.getEnabled().get()) {
             LOGGER.warn("Debug configuration ignored in favor of the supplied JVM arguments: " + debugArgs);
             debugOptions.getEnabled().set(false);
         }
+    }
+
+    private static List<String> collectDebugArgs(Iterable<?> arguments) {
+        List<String> debugArgs = new ArrayList<>();
+        for (Object extraJvmArg : arguments) {
+            String extraJvmArgString = extraJvmArg.toString();
+            if (isDebugArg(extraJvmArgString)) {
+                debugArgs.add(extraJvmArgString);
+            }
+        }
+        return debugArgs;
+    }
+
+    private static boolean isDebugArg(String extraJvmArgString) {
+        return extraJvmArgString.equals("-Xdebug")
+            || extraJvmArgString.startsWith("-Xrunjdwp")
+            || extraJvmArgString.startsWith("-agentlib:jdwp");
     }
 
     public void jvmArgs(Iterable<?> arguments) {

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/JavaExec.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/JavaExec.java
@@ -151,7 +151,7 @@ public abstract class JavaExec extends ConventionTask implements JavaExecSpec {
 
         List<String> jvmArgs = jvmArguments.getOrNull();
         if (jvmArgs != null) {
-            javaExecSpec.installJvmArgs(jvmArgs);
+            javaExecSpec.setExtraJvmArgs(jvmArgs);
         }
 
         JavaExecAction javaExecAction = getExecActionFactory().newJavaExecAction();

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/JavaExec.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/JavaExec.java
@@ -151,7 +151,7 @@ public abstract class JavaExec extends ConventionTask implements JavaExecSpec {
 
         List<String> jvmArgs = jvmArguments.getOrNull();
         if (jvmArgs != null) {
-            javaExecSpec.setJvmArgs(jvmArgs);
+            javaExecSpec.installJvmArgs(jvmArgs);
         }
 
         JavaExecAction javaExecAction = getExecActionFactory().newJavaExecAction();
@@ -207,7 +207,8 @@ public abstract class JavaExec extends ConventionTask implements JavaExecSpec {
      */
     @Override
     public void setJvmArgs(List<String> arguments) {
-        jvmArguments.set(arguments);
+        jvmArguments.empty();
+        jvmArgs(arguments);
     }
 
     /**
@@ -227,6 +228,7 @@ public abstract class JavaExec extends ConventionTask implements JavaExecSpec {
         for (Object arg : arguments) {
             jvmArguments.add(arg.toString());
         }
+        javaExecSpec.checkDebugConfiguration(arguments);
         return this;
     }
 
@@ -235,9 +237,7 @@ public abstract class JavaExec extends ConventionTask implements JavaExecSpec {
      */
     @Override
     public JavaExec jvmArgs(Object... arguments) {
-        for (Object arg : arguments) {
-            jvmArguments.add(arg.toString());
-        }
+        jvmArgs(Arrays.asList(arguments));
         return this;
     }
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/JavaExec.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/JavaExec.java
@@ -225,11 +225,15 @@ public abstract class JavaExec extends ConventionTask implements JavaExecSpec {
      */
     @Override
     public JavaExec jvmArgs(Iterable<?> arguments) {
+        addJvmArguments(arguments);
+        javaExecSpec.checkDebugConfiguration(arguments);
+        return this;
+    }
+
+    private void addJvmArguments(Iterable<?> arguments) {
         for (Object arg : arguments) {
             jvmArguments.add(arg.toString());
         }
-        javaExecSpec.checkDebugConfiguration(arguments);
-        return this;
     }
 
     /**


### PR DESCRIPTION
`JavaExecSpec.setJvmArgs()` is leads to mutation of DebugOptions property if debug options is presented, what makes it impossible to use `JavaExecSpec.setJvmArgs()` at execution time