### PR TITLE
Ensure we acquire localhost address before we time

### DIFF
--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/registry/DaemonRegistryServicesTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/registry/DaemonRegistryServicesTest.groovy
@@ -54,12 +54,14 @@ class DaemonRegistryServicesTest extends Specification {
 
     def "the registry can be concurrently written to"() {
         when:
+        // obtain localhost address ahead of time as the first call in a JVM can take multiple secs in some systems
+        def localhost = Inet6Address.getLocalHost()
         def registry = registry("someDir").get(DaemonRegistry)
         5.times { idx ->
             concurrent.start {
                 def context = new DefaultDaemonContext("$idx", new File("$idx"), new File("$idx"), idx, 5000, [], false, DaemonParameters.Priority.NORMAL)
                 registry.store(new DaemonInfo(
-                    new SocketInetAddress(Inet6Address.getLocalHost(), (int)(8888 + idx)), context, "foo-$idx".bytes, Idle))
+                    new SocketInetAddress(localhost, (int)(8888 + idx)), context, "foo-$idx".bytes, Idle))
             }
         }
         concurrent.finished()


### PR DESCRIPTION
This fixes flakiness in time-sensitive test.

In some systems, InetAddress.getLocalHost() can take multiple seconds the first time it is invoked in a VM.

This change ensure we acquire the localhost address before we spawn the threads to attempt to write to the daemon registry.

"Luckily", this test had been failing consistently for me. 

See also: 
* https://bugs.openjdk.org/browse/JDK-8143378
* https://stackoverflow.com/questions/39636792/jvm-takes-a-long-time-to-resolve-ip-address-for-localhost/39698914#39698914