### PR TITLE
Implement production component logic on jvm features

### DIFF
--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/HelpTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/HelpTaskIntegrationTest.groovy
@@ -371,7 +371,7 @@ Options
 ${builtInOptions}
 
 Description
-     Assembles a jar archive containing the main classes.
+     Assembles a jar archive containing the classes of the 'main' feature.
 
 Group
      build
@@ -394,7 +394,7 @@ Options
 ${builtInOptions}
 
 Description
-     Assembles a jar archive containing the main classes.
+     Assembles a jar archive containing the classes of the 'main' feature.
 
 Group
      build

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/OutgoingVariantsReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/OutgoingVariantsReportTaskIntegrationTest.groovy
@@ -231,7 +231,7 @@ Attributes
         result.groupedOutput.task(":outgoingVariants").assertOutputContains """--------------------------------------------------
 Variant apiElements
 --------------------------------------------------
-API elements for main.
+API elements for the 'main' feature.
 
 Capabilities
     - org:myLib:1.0 (default capability)
@@ -298,7 +298,7 @@ Artifacts
 --------------------------------------------------
 Variant runtimeElements
 --------------------------------------------------
-Elements of runtime for main.
+Runtime elements for the 'main' feature.
 
 Capabilities
     - org:myLib:1.0 (default capability)
@@ -389,7 +389,7 @@ Artifacts
         result.groupedOutput.task(":outgoingVariants").assertOutputContains("""--------------------------------------------------
 Variant apiElements
 --------------------------------------------------
-API elements for main.
+API elements for the 'main' feature.
 
 Capabilities
     - org:myLib:1.0 (default capability)
@@ -471,7 +471,7 @@ Artifacts
 --------------------------------------------------
 Variant runtimeElements
 --------------------------------------------------
-Elements of runtime for main.
+Runtime elements for the 'main' feature.
 
 Capabilities
     - org:myLib:1.0 (default capability)
@@ -576,7 +576,7 @@ Artifacts
         result.groupedOutput.task(":outgoingVariants").assertOutputContains("""--------------------------------------------------
 Variant apiElements
 --------------------------------------------------
-API elements for main.
+API elements for the 'main' feature.
 
 Capabilities
     - org:myLib:1.0 (default capability)
@@ -658,7 +658,7 @@ Artifacts
 --------------------------------------------------
 Variant runtimeElements
 --------------------------------------------------
-Elements of runtime for main.
+Runtime elements for the 'main' feature.
 
 Capabilities
     - org:myLib:1.0 (default capability)
@@ -756,7 +756,7 @@ Artifacts
         result.groupedOutput.task(":outgoingVariants").assertOutputContains("""--------------------------------------------------
 Variant runtimeElements
 --------------------------------------------------
-Elements of runtime for main.
+Runtime elements for the 'main' feature.
 
 Capabilities
     - org:myLib:1.0 (default capability)
@@ -826,7 +826,7 @@ Secondary Variants (*)
         result.groupedOutput.task(":outgoingVariants").assertOutputContains("""--------------------------------------------------
 Variant apiElements
 --------------------------------------------------
-API elements for main.
+API elements for the 'main' feature.
 
 Capabilities
     - org:myLib:1.0 (default capability)
@@ -893,7 +893,7 @@ Artifacts
 --------------------------------------------------
 Variant runtimeElements
 --------------------------------------------------
-Elements of runtime for main.
+Runtime elements for the 'main' feature.
 
 Capabilities
     - org:myLib:1.0 (default capability)
@@ -978,7 +978,7 @@ Artifacts
         result.groupedOutput.task(":outgoingVariants").assertOutputContains("""--------------------------------------------------
 Variant apiElements
 --------------------------------------------------
-API elements for main.
+API elements for the 'main' feature.
 
 Capabilities
     - org:myLib:1.0 (default capability)
@@ -1045,7 +1045,7 @@ Artifacts
 --------------------------------------------------
 Variant runtimeElements
 --------------------------------------------------
-Elements of runtime for main.
+Runtime elements for the 'main' feature.
 
 Capabilities
     - org:myLib:1.0 (default capability)
@@ -1127,7 +1127,7 @@ Artifacts
         result.groupedOutput.task(":outgoingVariants").assertOutputContains("""--------------------------------------------------
 Variant runtimeElements
 --------------------------------------------------
-Elements of runtime for main.
+Runtime elements for the 'main' feature.
 
 Capabilities
     - org.test:extra:1.0
@@ -1159,7 +1159,7 @@ Capabilities
         result.groupedOutput.task(":outgoingVariants").assertOutputContains("""--------------------------------------------------
 Variant runtimeElements
 --------------------------------------------------
-Elements of runtime for main.
+Runtime elements for the 'main' feature.
 
 Capabilities
     - org:myLib:1.0 (default capability)
@@ -1240,7 +1240,7 @@ Secondary Variants (*)
         result.groupedOutput.task(":outgoingVariants").assertOutputContains("""--------------------------------------------------
 Variant apiElements
 --------------------------------------------------
-API elements for main.
+API elements for the 'main' feature.
 
 Capabilities
     - org:myLib:1.0 (default capability)
@@ -1307,7 +1307,7 @@ Artifacts
 --------------------------------------------------
 Variant runtimeElements
 --------------------------------------------------
-Elements of runtime for main.
+Runtime elements for the 'main' feature.
 
 Capabilities
     - org:myLib:1.0 (default capability)

--- a/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/variant_model.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/variant_model.adoc
@@ -258,7 +258,7 @@ Here is the output of the `outgoingVariants` task on a freshly generated `java-l
 --------------------------------------------------
 Variant apiElements
 --------------------------------------------------
-Description = API elements for main.
+API elements for the 'main' feature.
 
 Capabilities
     - new-java-library:lib:unspecified (default capability)
@@ -305,7 +305,7 @@ Artifacts
 --------------------------------------------------
 Variant runtimeElements
 --------------------------------------------------
-Description = Elements of runtime for main.
+Runtime elements for the 'main' feature.
 
 Capabilities
     - new-java-library:lib:unspecified (default capability)

--- a/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced-published/tests/outgoingVariants.out
+++ b/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced-published/tests/outgoingVariants.out
@@ -2,7 +2,7 @@
 --------------------------------------------------
 Variant apiElements
 --------------------------------------------------
-Description = API elements for main.
+API elements for the 'main' feature.
 
 Attributes
     - org.gradle.category            = library
@@ -41,7 +41,7 @@ Artifacts
 --------------------------------------------------
 Variant runtimeElements
 --------------------------------------------------
-Description = Elements of runtime for main.
+Runtime elements for the 'main' feature.
 
 Attributes
     - org.gradle.category            = library

--- a/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced/tests/outgoingVariants.out
+++ b/subprojects/docs/src/snippets/dependencyManagement/modelingFeatures-crossProjectPublications-advanced/tests/outgoingVariants.out
@@ -2,7 +2,7 @@
 --------------------------------------------------
 Variant apiElements
 --------------------------------------------------
-Description = API elements for main.
+API elements for the 'main' feature.
 
 Attributes
     - org.gradle.category            = library
@@ -41,7 +41,7 @@ Artifacts
 --------------------------------------------------
 Variant runtimeElements
 --------------------------------------------------
-Description = Elements of runtime for main.
+Runtime elements for the 'main' feature.
 
 Attributes
     - org.gradle.category            = library

--- a/subprojects/docs/src/snippets/kotlinDsl/configurations-and-dependencies-declarative/tests/dependencies.out
+++ b/subprojects/docs/src/snippets/kotlinDsl/configurations-and-dependencies-declarative/tests/dependencies.out
@@ -1,14 +1,14 @@
 compileClasspath - Compile classpath for source set 'main'.
 \--- com.example:lib:1.1 FAILED
 
-implementation - Implementation only dependencies for source set 'main'. (n)
+implementation - Implementation dependencies for the 'main' feature. (n)
 \--- com.example:lib:1.1 (n)
 
 runtimeClasspath - Runtime classpath of source set 'main'.
 +--- com.example:lib:1.1 FAILED
 \--- com.example:runtime:1.0 FAILED
 
-runtimeOnly - Runtime only dependencies for source set 'main'. (n)
+runtimeOnly - Runtime-only dependencies for the 'main' feature. (n)
 \--- com.example:runtime:1.0 (n)
 
 testCompileClasspath - Compile classpath for source set 'test'.

--- a/subprojects/docs/src/snippets/kotlinDsl/configurations-and-dependencies-imperative/tests/dependencies.out
+++ b/subprojects/docs/src/snippets/kotlinDsl/configurations-and-dependencies-imperative/tests/dependencies.out
@@ -1,14 +1,14 @@
 compileClasspath - Compile classpath for source set 'main'.
 \--- com.example:lib:1.1 FAILED
 
-implementation - Implementation only dependencies for source set 'main'. (n)
+implementation - Implementation dependencies for the 'main' feature. (n)
 \--- com.example:lib:1.1 (n)
 
 runtimeClasspath - Runtime classpath of source set 'main'.
 +--- com.example:lib:1.1 FAILED
 \--- com.example:runtime:1.0 FAILED
 
-runtimeOnly - Runtime only dependencies for source set 'main'. (n)
+runtimeOnly - Runtime-only dependencies for the 'main' feature. (n)
 \--- com.example:runtime:1.0 (n)
 
 testCompileClasspath - Compile classpath for source set 'test'.

--- a/subprojects/ear/src/main/java/org/gradle/plugins/ear/EarPlugin.java
+++ b/subprojects/ear/src/main/java/org/gradle/plugins/ear/EarPlugin.java
@@ -31,8 +31,9 @@ import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.plugins.JavaPlugin;
-import org.gradle.api.plugins.internal.JavaPluginHelper;
 import org.gradle.api.plugins.PluginContainer;
+import org.gradle.api.plugins.internal.JavaPluginHelper;
+import org.gradle.api.plugins.jvm.internal.JvmFeatureInternal;
 import org.gradle.api.plugins.jvm.internal.JvmPluginServices;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.jvm.component.internal.JvmSoftwareComponentInternal;
@@ -94,13 +95,13 @@ public abstract class EarPlugin implements Plugin<Project> {
 
     private void wireEarTaskConventionsWithJavaPluginApplied(final Project project, PluginContainer plugins) {
         plugins.withType(JavaPlugin.class, javaPlugin -> {
-            final JvmSoftwareComponentInternal component = JavaPluginHelper.getJavaComponent(project);
+            final JvmFeatureInternal mainFeature = JavaPluginHelper.getJavaComponent(project).getMainFeature();
             project.getTasks().withType(Ear.class).configureEach(task -> {
                 task.dependsOn((Callable<FileCollection>) () ->
-                    component.getSourceSet().getRuntimeClasspath()
+                    mainFeature.getSourceSet().getRuntimeClasspath()
                 );
                 task.from((Callable<FileCollection>) () ->
-                    component.getMainOutput()
+                    mainFeature.getOutput()
                 );
             });
         });
@@ -114,7 +115,7 @@ public abstract class EarPlugin implements Plugin<Project> {
 
             plugins.withType(JavaPlugin.class, javaPlugin -> {
                 final JvmSoftwareComponentInternal component = JavaPluginHelper.getJavaComponent(project);
-                    component.getSourceSet().getResources().srcDir(task.getAppDirectory());
+                component.getMainFeature().getSourceSet().getResources().srcDir(task.getAppDirectory());
             });
         });
 

--- a/subprojects/ear/src/main/java/org/gradle/plugins/ear/EarPlugin.java
+++ b/subprojects/ear/src/main/java/org/gradle/plugins/ear/EarPlugin.java
@@ -101,7 +101,7 @@ public abstract class EarPlugin implements Plugin<Project> {
                     mainFeature.getSourceSet().getRuntimeClasspath()
                 );
                 task.from((Callable<FileCollection>) () ->
-                    mainFeature.getOutput()
+                    mainFeature.getSourceSet().getOutput()
                 );
             });
         });

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipseWtpPlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipseWtpPlugin.java
@@ -159,7 +159,7 @@ public abstract class EclipseWtpPlugin extends IdePlugin {
 
                 Set<Configuration> libConfigurations = component.getLibConfigurations();
 
-                libConfigurations.add(JavaPluginHelper.getJavaComponent(project).getRuntimeClasspathConfiguration());
+                libConfigurations.add(JavaPluginHelper.getJavaComponent(project).getMainFeature().getRuntimeClasspathConfiguration());
                 component.setClassesDeployPath("/");
                 ((IConventionAware) component).getConventionMapping().map("libDeployPath", new Callable<String>() {
                     @Override
@@ -182,7 +182,7 @@ public abstract class EclipseWtpPlugin extends IdePlugin {
                 Set<Configuration> libConfigurations = component.getLibConfigurations();
                 Set<Configuration> minusConfigurations = component.getMinusConfigurations();
 
-                libConfigurations.add(JavaPluginHelper.getJavaComponent(project).getRuntimeClasspathConfiguration());
+                libConfigurations.add(JavaPluginHelper.getJavaComponent(project).getMainFeature().getRuntimeClasspathConfiguration());
                 minusConfigurations.add(project.getConfigurations().getByName("providedRuntime"));
                 component.setClassesDeployPath("/WEB-INF/classes");
                 ConventionMapping convention = ((IConventionAware) component).getConventionMapping();

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/IdeaPlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/IdeaPlugin.java
@@ -42,12 +42,12 @@ import org.gradle.api.plugins.JvmTestSuitePlugin;
 import org.gradle.api.plugins.WarPlugin;
 import org.gradle.api.plugins.internal.JavaPluginHelper;
 import org.gradle.api.plugins.jvm.JvmTestSuite;
+import org.gradle.api.plugins.jvm.internal.JvmFeatureInternal;
 import org.gradle.api.plugins.scala.ScalaBasePlugin;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.xml.XmlTransformer;
-import org.gradle.jvm.component.internal.JvmSoftwareComponentInternal;
 import org.gradle.plugins.ide.api.XmlFileContentMerger;
 import org.gradle.plugins.ide.idea.internal.IdeaModuleMetadata;
 import org.gradle.plugins.ide.idea.internal.IdeaScalaConfigurer;
@@ -363,18 +363,18 @@ public abstract class IdeaPlugin extends IdePlugin {
     }
 
     private void configureIdeaModuleForJava(final Project project) {
-        JvmSoftwareComponentInternal javaComponent = JavaPluginHelper.getJavaComponent(project);
+        JvmFeatureInternal mainFeature = JavaPluginHelper.getJavaComponent(project).getMainFeature();
         JvmTestSuite defaultTestSuite = JavaPluginHelper.getDefaultTestSuite(project);
 
         project.getTasks().withType(GenerateIdeaModule.class).configureEach(ideaModule -> {
             // Dependencies
             ideaModule.dependsOn((Callable<FileCollection>) () ->
-                javaComponent.getMainOutput().getDirs().plus(defaultTestSuite.getSources().getOutput().getDirs())
+                mainFeature.getOutput().getDirs().plus(defaultTestSuite.getSources().getOutput().getDirs())
             );
         });
 
         // Defaults
-        setupScopes(javaComponent, defaultTestSuite);
+        setupScopes(mainFeature, defaultTestSuite);
 
         // Convention
         ConventionMapping convention = ((IConventionAware) ideaModel.getModule()).getConventionMapping();
@@ -426,7 +426,7 @@ public abstract class IdeaPlugin extends IdePlugin {
         });
     }
 
-    private void setupScopes(JvmSoftwareComponentInternal javaComponent, JvmTestSuite defaultTestSuite) {
+    private void setupScopes(JvmFeatureInternal mainFeature, JvmTestSuite defaultTestSuite) {
         Map<String, Map<String, Collection<Configuration>>> scopes = Maps.newLinkedHashMap();
         for (GeneratedIdeaScope scope : GeneratedIdeaScope.values()) {
             Map<String, Collection<Configuration>> plusMinus = Maps.newLinkedHashMap();
@@ -436,10 +436,10 @@ public abstract class IdeaPlugin extends IdePlugin {
         }
 
         Collection<Configuration> provided = scopes.get(GeneratedIdeaScope.PROVIDED.name()).get(IdeaDependenciesProvider.SCOPE_PLUS);
-        provided.add(javaComponent.getCompileClasspathConfiguration());
+        provided.add(mainFeature.getCompileClasspathConfiguration());
 
         Collection<Configuration> runtime = scopes.get(GeneratedIdeaScope.RUNTIME.name()).get(IdeaDependenciesProvider.SCOPE_PLUS);
-        runtime.add(javaComponent.getRuntimeClasspathConfiguration());
+        runtime.add(mainFeature.getRuntimeClasspathConfiguration());
 
         ConfigurationContainer configurations = project.getConfigurations();
         Collection<Configuration> test = scopes.get(GeneratedIdeaScope.TEST.name()).get(IdeaDependenciesProvider.SCOPE_PLUS);

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/IdeaPlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/IdeaPlugin.java
@@ -369,7 +369,7 @@ public abstract class IdeaPlugin extends IdePlugin {
         project.getTasks().withType(GenerateIdeaModule.class).configureEach(ideaModule -> {
             // Dependencies
             ideaModule.dependsOn((Callable<FileCollection>) () ->
-                mainFeature.getOutput().getDirs().plus(defaultTestSuite.getSources().getOutput().getDirs())
+                mainFeature.getSourceSet().getOutput().getDirs().plus(defaultTestSuite.getSources().getOutput().getDirs())
             );
         });
 

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/DependencyManagementIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/DependencyManagementIntegrationTest.kt
@@ -102,7 +102,7 @@ class DependencyManagementIntegrationTest : AbstractKotlinIntegrationTest() {
                 output,
                 containsMultiLineString(
                     """
-                api - API dependencies for source set 'main'. (n)
+                api - API dependencies for the 'main' feature. (n)
                 +--- in-block:accessor (n)
                 +--- in-block:accessor-with-action (n)
                 +--- in-block:string-invoke (n)

--- a/subprojects/platform-jvm/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSet.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSet.java
@@ -141,7 +141,7 @@ public abstract class DefaultSourceSet implements SourceSet {
         return baseName;
     }
 
-    private String configurationNameOf(String baseName) {
+    public String configurationNameOf(String baseName) {
         return StringUtils.uncapitalize(getTaskBaseName() + StringUtils.capitalize(baseName));
     }
 

--- a/subprojects/platform-jvm/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSet.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSet.java
@@ -141,6 +141,12 @@ public abstract class DefaultSourceSet implements SourceSet {
         return baseName;
     }
 
+    /**
+     * Determines the name of a configuration owned by this source set, with the given {@code baseName}.
+     *
+     * <p>If this is the main source set, returns the uncapitalized {@code baseName}, otherwise, returns the
+     * base name prefixed with this source set's name.</p>
+     */
     public String configurationNameOf(String baseName) {
         return StringUtils.uncapitalize(getTaskBaseName() + StringUtils.capitalize(baseName));
     }

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java
@@ -178,7 +178,7 @@ public abstract class JavaGradlePluginPlugin implements Plugin<Project> {
     }
 
     private GradlePluginDevelopmentExtension createExtension(Project project) {
-        SourceSet defaultPluginSourceSet = JavaPluginHelper.getJavaComponent(project).getSourceSet();
+        SourceSet defaultPluginSourceSet = JavaPluginHelper.getJavaComponent(project).getMainFeature().getSourceSet();
         SourceSet defaultTestSourceSet = JavaPluginHelper.getDefaultTestSuite(project).getSources();
         return project.getExtensions().create(EXTENSION_NAME, GradlePluginDevelopmentExtension.class, project, defaultPluginSourceSet, defaultTestSourceSet);
     }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/ApplicationPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/ApplicationPlugin.java
@@ -31,6 +31,7 @@ import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.internal.DefaultApplicationPluginConvention;
 import org.gradle.api.plugins.internal.DefaultJavaApplication;
 import org.gradle.api.plugins.internal.JavaPluginHelper;
+import org.gradle.api.plugins.jvm.internal.JvmFeatureInternal;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.JavaExec;
@@ -41,7 +42,6 @@ import org.gradle.api.tasks.application.CreateStartScripts;
 import org.gradle.api.tasks.bundling.Jar;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.api.tasks.internal.JavaExecExecutableUtils;
-import org.gradle.jvm.component.internal.JvmSoftwareComponentInternal;
 import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.jvm.toolchain.JavaToolchainService;
 import org.gradle.jvm.toolchain.JavaToolchainSpec;
@@ -74,17 +74,17 @@ public abstract class ApplicationPlugin implements Plugin<Project> {
         project.getPluginManager().apply(JavaPlugin.class);
         project.getPluginManager().apply(DistributionPlugin.class);
 
-        JvmSoftwareComponentInternal component = JavaPluginHelper.getJavaComponent(project);
+        JvmFeatureInternal mainFeature = JavaPluginHelper.getJavaComponent(project).getMainFeature();
 
         JavaApplication extension = addExtension(project);
-        addRunTask(project, component, extension);
-        addCreateScriptsTask(project, component, extension);
-        configureJavaCompileTask(component.getMainCompileJavaTask(), extension);
+        addRunTask(project, mainFeature, extension);
+        addCreateScriptsTask(project, mainFeature, extension);
+        configureJavaCompileTask(mainFeature.getCompileJavaTask(), extension);
         configureInstallTask(project.getProviders(), tasks.named(TASK_INSTALL_NAME, Sync.class), extension);
 
         DistributionContainer distributions = project.getExtensions().getByType(DistributionContainer.class);
         Distribution mainDistribution = distributions.getByName(DistributionPlugin.MAIN_DISTRIBUTION_NAME);
-        configureDistribution(project, component, mainDistribution, extension);
+        configureDistribution(project, mainFeature, mainDistribution, extension);
     }
 
     private void configureJavaCompileTask(TaskProvider<JavaCompile> javaCompile, JavaApplication pluginExtension) {
@@ -141,16 +141,16 @@ public abstract class ApplicationPlugin implements Plugin<Project> {
         return project.getExtensions().create(JavaApplication.class, "application", DefaultJavaApplication.class, pluginConvention);
     }
 
-    private void addRunTask(Project project, JvmSoftwareComponentInternal component, JavaApplication pluginExtension) {
+    private void addRunTask(Project project, JvmFeatureInternal mainFeature, JavaApplication pluginExtension) {
         project.getTasks().register(TASK_RUN_NAME, JavaExec.class, run -> {
             run.setDescription("Runs this project as a JVM application");
             run.setGroup(APPLICATION_GROUP);
 
             FileCollection runtimeClasspath = project.files().from((Callable<FileCollection>) () -> {
                 if (run.getMainModule().isPresent()) {
-                    return jarsOnlyRuntimeClasspath(component);
+                    return jarsOnlyRuntimeClasspath(mainFeature);
                 } else {
-                    return runtimeClasspath(component);
+                    return runtimeClasspath(mainFeature);
                 }
             });
             run.setClasspath(runtimeClasspath);
@@ -179,10 +179,10 @@ public abstract class ApplicationPlugin implements Plugin<Project> {
     }
 
     // @Todo: refactor this task configuration to extend a copy task and use replace tokens
-    private void addCreateScriptsTask(Project project, JvmSoftwareComponentInternal component, JavaApplication pluginExtension) {
+    private void addCreateScriptsTask(Project project, JvmFeatureInternal mainFeature, JavaApplication pluginExtension) {
         project.getTasks().register(TASK_START_SCRIPTS_NAME, CreateStartScripts.class, startScripts -> {
             startScripts.setDescription("Creates OS specific scripts to run the project as a JVM application.");
-            startScripts.setClasspath(jarsOnlyRuntimeClasspath(component));
+            startScripts.setClasspath(jarsOnlyRuntimeClasspath(mainFeature));
 
             startScripts.getMainModule().set(pluginExtension.getMainModule());
             startScripts.getMainClass().set(pluginExtension.getMainClass());
@@ -200,25 +200,25 @@ public abstract class ApplicationPlugin implements Plugin<Project> {
         });
     }
 
-    private FileCollection runtimeClasspath(JvmSoftwareComponentInternal component) {
-        return component.getSourceSet().getRuntimeClasspath();
+    private FileCollection runtimeClasspath(JvmFeatureInternal mainFeature) {
+        return mainFeature.getSourceSet().getRuntimeClasspath();
     }
 
-    private FileCollection jarsOnlyRuntimeClasspath(JvmSoftwareComponentInternal component) {
-        return component.getMainJarTask().get().getOutputs().getFiles().plus(component.getRuntimeClasspathConfiguration());
+    private FileCollection jarsOnlyRuntimeClasspath(JvmFeatureInternal mainFeature) {
+        return mainFeature.getJarTask().get().getOutputs().getFiles().plus(mainFeature.getRuntimeClasspathConfiguration());
     }
 
-    private CopySpec configureDistribution(Project project, JvmSoftwareComponentInternal component, Distribution mainDistribution, JavaApplication pluginExtension) {
+    private CopySpec configureDistribution(Project project, JvmFeatureInternal mainFeature, Distribution mainDistribution, JavaApplication pluginExtension) {
         mainDistribution.getDistributionBaseName().convention(project.provider(pluginExtension::getApplicationName));
         CopySpec distSpec = mainDistribution.getContents();
 
-        TaskProvider<Jar> jar = component.getMainJarTask();
+        TaskProvider<Jar> jar = mainFeature.getJarTask();
         TaskProvider<Task> startScripts = project.getTasks().named(TASK_START_SCRIPTS_NAME);
 
         CopySpec libChildSpec = project.copySpec();
         libChildSpec.into("lib");
         libChildSpec.from(jar);
-        libChildSpec.from(component.getRuntimeClasspathConfiguration());
+        libChildSpec.from(mainFeature.getRuntimeClasspathConfiguration());
 
         CopySpec binChildSpec = project.copySpec();
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/GroovyPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/GroovyPlugin.java
@@ -20,9 +20,9 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.plugins.internal.JavaPluginHelper;
+import org.gradle.api.plugins.jvm.internal.JvmFeatureInternal;
 import org.gradle.api.tasks.GroovySourceDirectorySet;
 import org.gradle.api.tasks.javadoc.Groovydoc;
-import org.gradle.jvm.component.internal.JvmSoftwareComponentInternal;
 
 /**
  * <p>A {@link Plugin} which extends the {@link JavaPlugin} to provide support for compiling and documenting Groovy
@@ -45,10 +45,10 @@ public abstract class GroovyPlugin implements Plugin<Project> {
             groovyDoc.setDescription("Generates Groovydoc API documentation for the main source code.");
             groovyDoc.setGroup(JavaBasePlugin.DOCUMENTATION_GROUP);
 
-            JvmSoftwareComponentInternal component = JavaPluginHelper.getJavaComponent(project);
-            groovyDoc.setClasspath(component.getMainOutput().plus(component.getSourceSet().getCompileClasspath()));
+            JvmFeatureInternal mainFeature = JavaPluginHelper.getJavaComponent(project).getMainFeature();
+            groovyDoc.setClasspath(mainFeature.getOutput().plus(mainFeature.getSourceSet().getCompileClasspath()));
 
-            SourceDirectorySet groovySourceSet = component.getSourceSet().getExtensions().getByType(GroovySourceDirectorySet.class);
+            SourceDirectorySet groovySourceSet = mainFeature.getSourceSet().getExtensions().getByType(GroovySourceDirectorySet.class);
             groovyDoc.setSource(groovySourceSet);
         });
     }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/GroovyPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/GroovyPlugin.java
@@ -46,7 +46,7 @@ public abstract class GroovyPlugin implements Plugin<Project> {
             groovyDoc.setGroup(JavaBasePlugin.DOCUMENTATION_GROUP);
 
             JvmFeatureInternal mainFeature = JavaPluginHelper.getJavaComponent(project).getMainFeature();
-            groovyDoc.setClasspath(mainFeature.getOutput().plus(mainFeature.getSourceSet().getCompileClasspath()));
+            groovyDoc.setClasspath(mainFeature.getSourceSet().getOutput().plus(mainFeature.getSourceSet().getCompileClasspath()));
 
             SourceDirectorySet groovySourceSet = mainFeature.getSourceSet().getExtensions().getByType(GroovySourceDirectorySet.class);
             groovyDoc.setSource(groovySourceSet);

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaLibraryDistributionPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaLibraryDistributionPlugin.java
@@ -22,7 +22,7 @@ import org.gradle.api.distribution.DistributionContainer;
 import org.gradle.api.distribution.plugins.DistributionPlugin;
 import org.gradle.api.file.CopySpec;
 import org.gradle.api.plugins.internal.JavaPluginHelper;
-import org.gradle.jvm.component.internal.JvmSoftwareComponentInternal;
+import org.gradle.api.plugins.jvm.internal.JvmFeatureInternal;
 
 /**
  * A {@link Plugin} which package a Java project as a distribution including the JAR and runtime dependencies.
@@ -37,14 +37,14 @@ public abstract class JavaLibraryDistributionPlugin implements Plugin<Project> {
 
         DistributionContainer distributionContainer = (DistributionContainer)project.getExtensions().getByName("distributions");
         distributionContainer.named(DistributionPlugin.MAIN_DISTRIBUTION_NAME).configure(dist -> {
-            JvmSoftwareComponentInternal component = JavaPluginHelper.getJavaComponent(project);
+            JvmFeatureInternal mainFeature = JavaPluginHelper.getJavaComponent(project).getMainFeature();
             CopySpec childSpec = project.copySpec();
-            childSpec.from(component.getMainJarTask());
+            childSpec.from(mainFeature.getJarTask());
             childSpec.from(project.file("src/dist"));
 
             CopySpec libSpec = project.copySpec();
             libSpec.into("lib");
-            libSpec.from(component.getRuntimeClasspathConfiguration());
+            libSpec.from(mainFeature.getRuntimeClasspathConfiguration());
 
             childSpec.with(libSpec);
             dist.getContents().with(childSpec);

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -256,7 +256,7 @@ public abstract class JavaPlugin implements Plugin<Project> {
 
         // Set the 'java' component as the project's default.
         Configuration defaultConfiguration = project.getConfigurations().getByName(Dependency.DEFAULT_CONFIGURATION);
-        defaultConfiguration.extendsFrom(component.getRuntimeElementsConfiguration());
+        defaultConfiguration.extendsFrom(component.getMainFeature().getRuntimeElementsConfiguration());
         ((SoftwareComponentContainerInternal) project.getComponents()).getMainComponent().convention(component);
 
         JavaPluginExtension javaExtension = project.getExtensions().getByType(JavaPluginExtension.class);
@@ -302,7 +302,7 @@ public abstract class JavaPlugin implements Plugin<Project> {
             // relies on the main source set being created before the tests. So, this code here cannot live in the
             // JvmTestSuitePlugin and must live here, so that we can ensure we register this test suite after we've
             // created the main source set.
-            final SourceSet mainSourceSet = component.getSourceSet();
+            final SourceSet mainSourceSet = component.getMainFeature().getSourceSet();
             final FileCollection mainSourceSetOutput = mainSourceSet.getOutput();
             final FileCollection testSourceSetOutput = testSourceSet.getOutput();
             testSourceSet.setCompileClasspath(project.getObjects().fileCollection().from(mainSourceSetOutput, testCompileClasspathConfiguration));
@@ -320,7 +320,7 @@ public abstract class JavaPlugin implements Plugin<Project> {
 
     private static void configureDiagnostics(Project project, JvmSoftwareComponentInternal component) {
         project.getTasks().withType(DependencyInsightReportTask.class).configureEach(task -> {
-            new DslObject(task).getConventionMapping().map("configuration", component::getCompileClasspathConfiguration);
+            new DslObject(task).getConventionMapping().map("configuration", component.getMainFeature()::getCompileClasspathConfiguration);
         });
     }
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaTestFixturesPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaTestFixturesPlugin.java
@@ -69,9 +69,11 @@ public abstract class JavaTestFixturesPlugin implements Plugin<Project> {
                 testFixturesSourceSet,
                 Collections.singletonList(new ProjectDerivedCapability(project, TEST_FIXTURES_FEATURE_NAME)),
                 (ProjectInternal) project,
-                "test fixtures",
-                role
+                role,
+                false
             );
+
+            feature.withApi();
 
             DefaultJvmSoftwareComponent component = (DefaultJvmSoftwareComponent) JavaPluginHelper.getJavaComponent(project);
             component.addVariantsFromConfiguration(feature.getApiElementsConfiguration(), new JavaConfigurationVariantMapping("compile", true));

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/WarPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/WarPlugin.java
@@ -33,10 +33,10 @@ import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.internal.DefaultWarPluginConvention;
 import org.gradle.api.plugins.internal.JavaPluginHelper;
 import org.gradle.api.plugins.jvm.JvmTestSuite;
+import org.gradle.api.plugins.jvm.internal.JvmFeatureInternal;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.War;
 import org.gradle.internal.deprecation.DeprecationLogger;
-import org.gradle.jvm.component.internal.JvmSoftwareComponentInternal;
 
 import javax.inject.Inject;
 import java.util.concurrent.Callable;
@@ -64,7 +64,7 @@ public abstract class WarPlugin implements Plugin<Project> {
     private final ImmutableAttributesFactory attributesFactory;
 
     private Project project;
-    private JvmSoftwareComponentInternal component;
+    private JvmFeatureInternal mainFeature;
 
     @Inject
     public WarPlugin(ObjectFactory objectFactory, ImmutableAttributesFactory attributesFactory) {
@@ -76,7 +76,7 @@ public abstract class WarPlugin implements Plugin<Project> {
     public void apply(final Project project) {
         project.getPluginManager().apply(JavaPlugin.class);
         this.project = project;
-        this.component = JavaPluginHelper.getJavaComponent(project);
+        this.mainFeature = JavaPluginHelper.getJavaComponent(project).getMainFeature();
 
         final WarPluginConvention pluginConvention = objectFactory.newInstance(DefaultWarPluginConvention.class, project);
         DeprecationLogger.whileDisabled(() -> project.getConvention().getPlugins().put("war", pluginConvention));
@@ -84,10 +84,10 @@ public abstract class WarPlugin implements Plugin<Project> {
         project.getTasks().withType(War.class).configureEach(task -> {
             task.getWebAppDirectory().convention(project.getLayout().dir(project.provider(() -> pluginConvention.getWebAppDir())));
             task.from(task.getWebAppDirectory());
-            task.dependsOn((Callable) () -> component.getSourceSet().getRuntimeClasspath());
+            task.dependsOn((Callable) () -> mainFeature.getSourceSet().getRuntimeClasspath());
             task.classpath((Callable) () -> {
                 Configuration providedRuntime = project.getConfigurations().getByName(PROVIDED_RUNTIME_CONFIGURATION_NAME);
-                return component.getSourceSet().getRuntimeClasspath().minus(providedRuntime);
+                return mainFeature.getSourceSet().getRuntimeClasspath().minus(providedRuntime);
             });
         });
 
@@ -98,7 +98,7 @@ public abstract class WarPlugin implements Plugin<Project> {
 
         PublishArtifact warArtifact = new LazyPublishArtifact(war, ((ProjectInternal) project).getFileResolver(), ((ProjectInternal) project).getTaskDependencyFactory());
         project.getExtensions().getByType(DefaultArtifactPublicationSet.class).addCandidate(warArtifact);
-        configureConfigurations(((ProjectInternal) project).getConfigurations(), component);
+        configureConfigurations(((ProjectInternal) project).getConfigurations(), mainFeature);
         configureComponent(project, warArtifact);
     }
 
@@ -114,10 +114,10 @@ public abstract class WarPlugin implements Plugin<Project> {
             .withUpgradeGuideSection(8, "war_plugin_configure_configurations")
             .nagUser();
 
-        configureConfigurations((RoleBasedConfigurationContainerInternal) configurationContainer, component);
+        configureConfigurations((RoleBasedConfigurationContainerInternal) configurationContainer, mainFeature);
     }
 
-    private void configureConfigurations(RoleBasedConfigurationContainerInternal configurationContainer, JvmSoftwareComponentInternal component) {
+    private void configureConfigurations(RoleBasedConfigurationContainerInternal configurationContainer, JvmFeatureInternal mainFeature) {
         Configuration providedCompileConfiguration = configurationContainer.resolvableBucket(PROVIDED_COMPILE_CONFIGURATION_NAME).setVisible(false).
             setDescription("Additional compile classpath for libraries that should not be part of the WAR archive.");
 
@@ -125,9 +125,9 @@ public abstract class WarPlugin implements Plugin<Project> {
             extendsFrom(providedCompileConfiguration).
             setDescription("Additional runtime classpath for libraries that should not be part of the WAR archive.");
 
-        component.getImplementationConfiguration().extendsFrom(providedCompileConfiguration);
-        component.getRuntimeClasspathConfiguration().extendsFrom(providedRuntimeConfiguration);
-        component.getRuntimeElementsConfiguration().extendsFrom(providedRuntimeConfiguration);
+        mainFeature.getImplementationConfiguration().extendsFrom(providedCompileConfiguration);
+        mainFeature.getRuntimeClasspathConfiguration().extendsFrom(providedRuntimeConfiguration);
+        mainFeature.getRuntimeElementsConfiguration().extendsFrom(providedRuntimeConfiguration);
 
         JvmTestSuite defaultTestSuite = JavaPluginHelper.getDefaultTestSuite(project);
         configurationContainer.getByName(defaultTestSuite.getSources().getRuntimeClasspathConfigurationName()).extendsFrom(providedRuntimeConfiguration);

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultAdhocSoftwareComponent.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultAdhocSoftwareComponent.java
@@ -73,6 +73,10 @@ public class DefaultAdhocSoftwareComponent implements AdhocComponentWithVariants
         return builder.build();
     }
 
+    protected boolean isPublished(Configuration outgoingConfiguration) {
+        return variants.containsKey(outgoingConfiguration);
+    }
+
     @Override
     public void finalizeValue() {
         finalized = true;

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultAdhocSoftwareComponent.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultAdhocSoftwareComponent.java
@@ -73,7 +73,7 @@ public class DefaultAdhocSoftwareComponent implements AdhocComponentWithVariants
         return builder.build();
     }
 
-    protected boolean isPublished(Configuration outgoingConfiguration) {
+    protected boolean isRegisteredAsLegacyVariant(Configuration outgoingConfiguration) {
         return variants.containsKey(outgoingConfiguration);
     }
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaFeatureSpec.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaFeatureSpec.java
@@ -89,15 +89,8 @@ public class DefaultJavaFeatureSpec implements FeatureSpecInternal {
 
         @SuppressWarnings("deprecation")
         ConfigurationRole role = ConfigurationRolesForMigration.INTENDED_CONSUMABLE_BUCKET_TO_INTENDED_CONSUMABLE;
-
-        JvmFeatureInternal feature = new DefaultJvmFeature(
-            name,
-            sourceSet,
-            capabilities,
-            project,
-            "'" + name + "' feature",
-            role
-        );
+        JvmFeatureInternal feature = new DefaultJvmFeature(name, sourceSet, capabilities, project, role, SourceSet.isMain(sourceSet));
+        feature.withApi();
 
         AdhocComponentWithVariants component = findJavaComponent();
         if (withJavadocJar && component != null) {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginExtension.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginExtension.java
@@ -35,13 +35,13 @@ import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.plugins.JavaResolutionConsistency;
 import org.gradle.api.plugins.jvm.JvmTestSuite;
+import org.gradle.api.plugins.jvm.internal.JvmFeatureInternal;
 import org.gradle.api.reporting.ReportingExtension;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.internal.Actions;
 import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.jvm.DefaultModularitySpec;
-import org.gradle.jvm.component.internal.JvmSoftwareComponentInternal;
 import org.gradle.jvm.toolchain.JavaToolchainSpec;
 import org.gradle.jvm.toolchain.internal.DefaultToolchainSpec;
 import org.gradle.jvm.toolchain.internal.JavaToolchainSpecInternal;
@@ -294,11 +294,11 @@ public class DefaultJavaPluginExtension implements JavaPluginExtension {
             this.configurations = configurations;
 
             if (project.getPlugins().hasPlugin(JavaPlugin.class)) {
-                JvmSoftwareComponentInternal component = JavaPluginHelper.getJavaComponent(project);
+                JvmFeatureInternal mainFeature = JavaPluginHelper.getJavaComponent(project).getMainFeature();
                 JvmTestSuite defaultTestSuite = JavaPluginHelper.getDefaultTestSuite(project);
 
-                mainCompileClasspath = component.getCompileClasspathConfiguration();
-                mainRuntimeClasspath = component.getRuntimeClasspathConfiguration();
+                mainCompileClasspath = mainFeature.getCompileClasspathConfiguration();
+                mainRuntimeClasspath = mainFeature.getRuntimeClasspathConfiguration();
                 testCompileClasspath = findConfiguration(defaultTestSuite.getSources().getCompileClasspathConfigurationName());
                 testRuntimeClasspath = findConfiguration(defaultTestSuite.getSources().getRuntimeClasspathConfigurationName());
             } else {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmFeature.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmFeature.java
@@ -35,7 +35,6 @@ import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.plugins.internal.JvmPluginsHelper;
 import org.gradle.api.tasks.SourceSet;
-import org.gradle.api.tasks.SourceSetOutput;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.Jar;
@@ -161,29 +160,28 @@ public class DefaultJvmFeature implements JvmFeatureInternal {
         JvmPluginsHelper.configureJavaDocTask("'" + name + "' feature", sourceSet, tasks, javaPluginExtension);
     }
 
-    /**
-     * This method is one of the primary reasons that we want to deprecate the "extending" behavior. It updates
-     * the main source set and test source set to "extend" this feature. That means any dependencies declared on
-     * this feature's dependency configurations will be available locally, during compilation and runtime, to the main
-     * production code and default test suite. However, when publishing the production code, these dependencies will
-     * not be included in its consumable variants. Therefore, the main code is compiled _and tested_ against
-     * dependencies which will not necessarily be available at runtime when it is consumed from other projects
-     * or in its published form.
-     *
-     * <p>This leads to a case where, in order for the production code to not throw NoClassDefFoundErrors during runtime,
-     * it must detect the presence of the dependencies added by this feature, and then conditionally enable and disable
-     * certain optional behavior. We do not want to promote this pattern.</p>
-     *
-     * <p>A much safer pattern would be to create normal features as opposed to an "extending" feature. Then, the normal
-     * feature would have a project dependency on the main feature. It would provide an extra jar with any additional code,
-     * and also bring along any extra dependencies that code requires. The main feature would then be able to detect the
-     * presence of the feature through some {@code ServiceLoader} mechanism, as opposed to detecting the existence of
-     * dependencies directly.</p>
-     *
-     * <p>This pattern is also more flexible than the "extending" pattern in that it allows features to extend arbitrary
-     * features as opposed to just the main feature.</p>
-     */
     void doExtendProductionCode() {
+        // This method is one of the primary reasons that we want to deprecate the "extending" behavior. It updates
+        // the main source set and test source set to "extend" this feature. That means any dependencies declared on
+        // this feature's dependency configurations will be available locally, during compilation and runtime, to the main
+        // production code and default test suite. However, when publishing the production code, these dependencies will
+        // not be included in its consumable variants. Therefore, the main code is compiled _and tested_ against
+        // dependencies which will not necessarily be available at runtime when it is consumed from other projects
+        // or in its published form.
+        //
+        // This leads to a case where, in order for the production code to not throw NoClassDefFoundErrors during runtime,
+        // it must detect the presence of the dependencies added by this feature, and then conditionally enable and disable
+        // certain optional behavior. We do not want to promote this pattern.
+        //
+        // A much safer pattern would be to create normal features as opposed to an "extending" feature. Then, the normal
+        // feature would have a project dependency on the main feature. It would provide an extra jar with any additional code,
+        // and also bring along any extra dependencies that code requires. The main feature would then be able to detect the
+        // presence of the feature through some {@code ServiceLoader} mechanism, as opposed to detecting the existence of
+        // dependencies directly.
+        //
+        // This pattern is also more flexible than the "extending" pattern in that it allows features to extend arbitrary
+        // features as opposed to just the main feature.
+
         ConfigurationContainer configurations = project.getConfigurations();
         SourceSet mainSourceSet = project.getExtensions().findByType(JavaPluginExtension.class)
             .getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME);
@@ -346,11 +344,6 @@ public class DefaultJvmFeature implements JvmFeatureInternal {
     @Override
     public TaskProvider<JavaCompile> getCompileJavaTask() {
         return compileJava;
-    }
-
-    @Override
-    public SourceSetOutput getOutput() {
-        return sourceSet.getOutput();
     }
 
     @Override

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/JvmFeatureInternal.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/JvmFeatureInternal.java
@@ -18,7 +18,6 @@ package org.gradle.api.plugins.jvm.internal;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.capabilities.CapabilitiesMetadata;
 import org.gradle.api.tasks.SourceSet;
-import org.gradle.api.tasks.SourceSetOutput;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.Jar;
 import org.gradle.api.tasks.compile.JavaCompile;
@@ -114,14 +113,6 @@ public interface JvmFeatureInternal {
      * @return A provider which supplies the feature's {@link JavaCompile} task.
      */
     TaskProvider<JavaCompile> getCompileJavaTask();
-
-    /**
-     * Get the resources and compilation outputs for this feature which are used as
-     * inputs for the {@link #getJarTask() jar} task.
-     *
-     * @return The source set outputs.
-     */
-    SourceSetOutput getOutput();
 
     /**
      * Get this feature's backing source set.

--- a/subprojects/plugins/src/main/java/org/gradle/jvm/component/internal/DefaultJvmSoftwareComponent.java
+++ b/subprojects/plugins/src/main/java/org/gradle/jvm/component/internal/DefaultJvmSoftwareComponent.java
@@ -16,21 +16,17 @@
 
 package org.gradle.jvm.component.internal;
 
-import com.google.common.collect.ImmutableList;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.artifacts.ConfigurationPublications;
-import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
 import org.gradle.api.attributes.Bundling;
 import org.gradle.api.attributes.Category;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.attributes.VerificationType;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationRoles;
-import org.gradle.api.internal.artifacts.configurations.RoleBasedConfigurationContainerInternal;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationRolesForMigration;
-import org.gradle.api.internal.artifacts.dsl.LazyPublishArtifact;
+import org.gradle.api.internal.artifacts.configurations.RoleBasedConfigurationContainerInternal;
 import org.gradle.api.internal.plugins.DefaultArtifactPublicationSet;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.model.ObjectFactory;
@@ -40,8 +36,8 @@ import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.plugins.PluginContainer;
 import org.gradle.api.plugins.internal.DefaultAdhocSoftwareComponent;
 import org.gradle.api.plugins.internal.JavaConfigurationVariantMapping;
-import org.gradle.api.plugins.internal.JvmPluginsHelper;
-import org.gradle.api.plugins.jvm.internal.JvmPluginServices;
+import org.gradle.api.plugins.jvm.internal.DefaultJvmFeature;
+import org.gradle.api.plugins.jvm.internal.JvmFeatureInternal;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.internal.versionmapping.VersionMappingStrategyInternal;
@@ -52,99 +48,57 @@ import org.gradle.api.publish.maven.internal.publication.MavenPublicationInterna
 import org.gradle.api.publish.plugins.PublishingPlugin;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
-import org.gradle.api.tasks.SourceSetOutput;
-import org.gradle.api.tasks.TaskContainer;
-import org.gradle.api.tasks.TaskProvider;
-import org.gradle.api.tasks.bundling.Jar;
-import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.internal.reflect.Instantiator;
 
 import javax.inject.Inject;
-
-import static org.gradle.api.attributes.DocsType.JAVADOC;
-import static org.gradle.api.attributes.DocsType.SOURCES;
+import java.util.Collections;
 
 /**
- * The software component created by the Java plugin. This component owns the consumable configurations which contribute to
- * this component's variants. Additionally, this component also owns its base {@link SourceSet} and transitively any domain
- * objects which are created by the {@link BasePlugin} on the source set's behalf. This includes the source set's resolvable
- * configurations and buckets, as well as any associated tasks.
+ * The software component created by the Java plugin. This component owns the main {@link JvmFeatureInternal} which itself
+ * is responsible for compiling and packaging the main production jar. Therefore, this component transitively owns the
+ * corresponding source set and any domain objects which are created by the {@link BasePlugin} on the source set's behalf.
+ * This includes the source set's resolvable configurations and buckets, as well as any associated tasks.
  */
 public class DefaultJvmSoftwareComponent extends DefaultAdhocSoftwareComponent implements JvmSoftwareComponentInternal {
 
     private static final String SOURCE_ELEMENTS_VARIANT_NAME_SUFFIX = "SourceElements";
 
-    private final SourceSet sourceSet;
-
-    // Services
-    private final ProjectInternal project;
-    private final JvmPluginServices jvmPluginServices;
-
-    // Tasks
-    private final TaskProvider<JavaCompile> compileJava;
-    private final TaskProvider<Jar> jar;
-
-    // Dependency configurations
-    private final Configuration implementation;
-    private final Configuration runtimeOnly;
-    private final Configuration compileOnly;
-
-    // Resolvable configurations
-    private final Configuration runtimeClasspath;
-    private final Configuration compileClasspath;
-
-    // Outgoing variants
-    private final Configuration runtimeElements;
-    private final Configuration apiElements;
-
-    // Configurable outgoing variants
-    private Configuration javadocElements;
-    private Configuration sourcesElements;
+    private final JvmFeatureInternal mainFeature;
 
     @Inject
     public DefaultJvmSoftwareComponent(
         String componentName,
         String sourceSetName,
-        Project proj,
-        JvmPluginServices jvmPluginServices,
+        Project project,
         ObjectFactory objectFactory,
         ProviderFactory providerFactory,
         Instantiator instantiator
     ) {
         super(componentName, instantiator);
-        this.project = (ProjectInternal) proj;
 
-        this.jvmPluginServices = jvmPluginServices;
-
-        TaskContainer tasks = project.getTasks();
-        RoleBasedConfigurationContainerInternal configurations = project.getConfigurations();
+        RoleBasedConfigurationContainerInternal configurations = ((ProjectInternal) project).getConfigurations();
         PluginContainer plugins = project.getPlugins();
         ExtensionContainer extensions = project.getExtensions();
 
         JavaPluginExtension javaExtension = getJavaPluginExtension(extensions);
-        this.sourceSet = createSourceSet(sourceSetName, javaExtension.getSourceSets());
+        SourceSet sourceSet = createSourceSet(sourceSetName, javaExtension.getSourceSets());
 
-        this.compileJava = tasks.named(sourceSet.getCompileJavaTaskName(), JavaCompile.class);
-        this.jar = registerJarTask(tasks, sourceSet);
+        this.mainFeature = new DefaultJvmFeature(
+            sourceSetName, sourceSet, Collections.emptyList(),
+            (ProjectInternal) project, ConfigurationRoles.INTENDED_CONSUMABLE, false);
 
-        this.implementation = configurations.getByName(sourceSet.getImplementationConfigurationName());
-        this.compileOnly = configurations.getByName(sourceSet.getCompileOnlyConfigurationName());
-        this.runtimeOnly = configurations.getByName(sourceSet.getRuntimeOnlyConfigurationName());
+        // TODO: Should all features also have this variant? Why just the main feature?
+        createSourceElements(configurations, providerFactory, objectFactory, mainFeature);
 
-        this.runtimeClasspath = configurations.getByName(sourceSet.getRuntimeClasspathConfigurationName());
-        this.compileClasspath = configurations.getByName(sourceSet.getCompileClasspathConfigurationName());
+        // Build the main jar when running `assemble`.
+        extensions.getByType(DefaultArtifactPublicationSet.class)
+            .addCandidate(mainFeature.getRuntimeElementsConfiguration().getArtifacts().iterator().next());
 
-        PublishArtifact jarArtifact = configureArchives(project, jar, tasks, extensions);
-        this.runtimeElements = createRuntimeElements(configurations, sourceSet, jarArtifact);
-        this.apiElements = createApiElements(configurations, sourceSet, jarArtifact);
-        createSourceElements(configurations, providerFactory, objectFactory, sourceSet);
-
-        JvmPluginsHelper.configureJavaDocTask("main code", sourceSet, tasks, javaExtension);
         configurePublishing(plugins, extensions, sourceSet);
 
         // Register the consumable configurations as providing variants for consumption.
-        addVariantsFromConfiguration(apiElements, new JavaConfigurationVariantMapping("compile", false));
-        addVariantsFromConfiguration(runtimeElements, new JavaConfigurationVariantMapping("runtime", false));
+        addVariantsFromConfiguration(mainFeature.getApiElementsConfiguration(), new JavaConfigurationVariantMapping("compile", false));
+        addVariantsFromConfiguration(mainFeature.getRuntimeElementsConfiguration(), new JavaConfigurationVariantMapping("runtime", false));
     }
 
     private static JavaPluginExtension getJavaPluginExtension(ExtensionContainer extensions) {
@@ -163,82 +117,18 @@ public class DefaultJvmSoftwareComponent extends DefaultAdhocSoftwareComponent i
         return sourceSets.create(name);
     }
 
-    private static TaskProvider<Jar> registerJarTask(TaskContainer tasks, SourceSet sourceSet) {
-        return tasks.register(sourceSet.getJarTaskName(), Jar.class, jar -> {
-            jar.setDescription("Assembles a jar archive containing the main classes.");
-            jar.setGroup(BasePlugin.BUILD_GROUP);
-            jar.from(sourceSet.getOutput());
-        });
-    }
-
-    private static PublishArtifact configureArchives(Project project, TaskProvider<Jar> jarTaskProvider, TaskContainer tasks, ExtensionContainer extensions) {
-        PublishArtifact jarArtifact = new LazyPublishArtifact(jarTaskProvider, ((ProjectInternal) project).getFileResolver(), ((ProjectInternal) project).getTaskDependencyFactory());
-        extensions.getByType(DefaultArtifactPublicationSet.class).addCandidate(jarArtifact);
-        return jarArtifact;
-    }
-
-    private static void addJarArtifactToConfiguration(Configuration configuration, PublishArtifact jarArtifact) {
-        ConfigurationPublications publications = configuration.getOutgoing();
-
-        // Configure an implicit variant
-        publications.getArtifacts().add(jarArtifact);
-        publications.getAttributes().attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.JAR_TYPE);
-    }
-
-    private Configuration createRuntimeElements(
-        RoleBasedConfigurationContainerInternal configurations,
-        SourceSet sourceSet,
-        PublishArtifact jarArtifact
-    ) {
-        Configuration runtimeElementsConfiguration = configurations.maybeCreateWithRole(
-            sourceSet.getRuntimeElementsConfigurationName(), ConfigurationRoles.INTENDED_CONSUMABLE, false, false);
-
-        runtimeElementsConfiguration.setVisible(false);
-        jvmPluginServices.useDefaultTargetPlatformInference(runtimeElementsConfiguration, compileJava);
-        jvmPluginServices.configureAsRuntimeElements(runtimeElementsConfiguration);
-        runtimeElementsConfiguration.setDescription("Elements of runtime for main.");
-
-        runtimeElementsConfiguration.extendsFrom(implementation, runtimeOnly);
-
-        // Configure variants
-        addJarArtifactToConfiguration(runtimeElementsConfiguration, jarArtifact);
-        jvmPluginServices.configureClassesDirectoryVariant(runtimeElementsConfiguration, sourceSet);
-        jvmPluginServices.configureResourcesDirectoryVariant(runtimeElementsConfiguration, sourceSet);
-
-        return runtimeElementsConfiguration;
-    }
-
-    private Configuration createApiElements(
-        RoleBasedConfigurationContainerInternal configurations,
-        SourceSet sourceSet,
-        PublishArtifact jarArtifact
-    ) {
-        Configuration apiElementsConfiguration = configurations.maybeCreateWithRole(
-            sourceSet.getApiElementsConfigurationName(), ConfigurationRoles.INTENDED_CONSUMABLE, false, false);
-
-        apiElementsConfiguration.setVisible(false);
-        jvmPluginServices.useDefaultTargetPlatformInference(apiElementsConfiguration, compileJava);
-        jvmPluginServices.configureAsApiElements(apiElementsConfiguration);
-        apiElementsConfiguration.setDescription("API elements for main.");
-
-        // Configure variants
-        addJarArtifactToConfiguration(apiElementsConfiguration, jarArtifact);
-
-        return apiElementsConfiguration;
-    }
-
-    private Configuration createSourceElements(RoleBasedConfigurationContainerInternal configurations, ProviderFactory providerFactory, ObjectFactory objectFactory, SourceSet sourceSet) {
+    private Configuration createSourceElements(RoleBasedConfigurationContainerInternal configurations, ProviderFactory providerFactory, ObjectFactory objectFactory, JvmFeatureInternal feature) {
 
         // TODO: Why are we using this non-standard name? For the `java` component, this
         // equates to `mainSourceElements` instead of `sourceElements` as one would expect.
         // Can we change this name without breaking compatibility? Is the variant name part
         // of the component's API?
-        String variantName = sourceSet.getName() + SOURCE_ELEMENTS_VARIANT_NAME_SUFFIX;
+        String variantName = feature.getSourceSet().getName() + SOURCE_ELEMENTS_VARIANT_NAME_SUFFIX;
 
         @SuppressWarnings("deprecation") Configuration variant = configurations.createWithRole(variantName, ConfigurationRolesForMigration.INTENDED_CONSUMABLE_BUCKET_TO_INTENDED_CONSUMABLE);
         variant.setDescription("List of source directories contained in the Main SourceSet.");
         variant.setVisible(false);
-        variant.extendsFrom(implementation);
+        variant.extendsFrom(mainFeature.getImplementationConfiguration());
 
         variant.attributes(attributes -> {
             attributes.attribute(Bundling.BUNDLING_ATTRIBUTE, objectFactory.named(Bundling.class, Bundling.EXTERNAL));
@@ -247,13 +137,15 @@ public class DefaultJvmSoftwareComponent extends DefaultAdhocSoftwareComponent i
         });
 
         variant.getOutgoing().artifacts(
-            sourceSet.getAllSource().getSourceDirectories().getElements().flatMap(e -> providerFactory.provider(() -> e)),
+            feature.getSourceSet().getAllSource().getSourceDirectories().getElements().flatMap(e -> providerFactory.provider(() -> e)),
             artifact -> artifact.setType(ArtifactTypeDefinition.DIRECTORY_TYPE)
         );
 
         return variant;
     }
 
+    // TODO: This approach is not necessarily correct for non-main features. All publications will attempt to use the main feature's
+    // compile and runtime classpaths for version mapping, even if a non-main feature is being published.
     private static void configurePublishing(PluginContainer plugins, ExtensionContainer extensions, SourceSet sourceSet) {
         plugins.withType(PublishingPlugin.class, plugin -> {
             PublishingExtension publishing = extensions.getByType(PublishingExtension.class);
@@ -272,92 +164,33 @@ public class DefaultJvmSoftwareComponent extends DefaultAdhocSoftwareComponent i
         });
     }
 
+    // TODO: The component itself should not be concerned with configuring the sources and javadoc jars
+    // of its features. It should lazily react to the variants of the feature being added and configure
+    // itself to in turn advertise those variants. However, this requires a more complete variant API,
+    // which is still being designed. For now, we'll add the variants manually.
+
     @Override
     public void withJavadocJar() {
-        if (javadocElements != null) {
-            return;
+        mainFeature.withJavadocJar();
+
+        Configuration javadocElements = mainFeature.getJavadocElementsConfiguration();
+        if (!isPublished(javadocElements)) {
+            addVariantsFromConfiguration(javadocElements, new JavaConfigurationVariantMapping("runtime", true));
         }
-        this.javadocElements = JvmPluginsHelper.createDocumentationVariantWithArtifact(
-            sourceSet.getJavadocElementsConfigurationName(),
-            null,
-            JAVADOC,
-            ImmutableList.of(),
-            sourceSet.getJavadocJarTaskName(),
-            project.getTasks().named(sourceSet.getJavadocTaskName()),
-            project
-        );
-        addVariantsFromConfiguration(javadocElements, new JavaConfigurationVariantMapping("runtime", true));
     }
 
     @Override
     public void withSourcesJar() {
-        if (sourcesElements != null) {
-            return;
+        mainFeature.withSourcesJar();
+
+        Configuration sourcesElements = mainFeature.getSourcesElementsConfiguration();
+        if (!isPublished(sourcesElements)) {
+            addVariantsFromConfiguration(sourcesElements, new JavaConfigurationVariantMapping("runtime", true));
         }
-        this.sourcesElements = JvmPluginsHelper.createDocumentationVariantWithArtifact(
-            sourceSet.getSourcesElementsConfigurationName(),
-            null,
-            SOURCES,
-            ImmutableList.of(),
-            sourceSet.getSourcesJarTaskName(),
-            sourceSet.getAllSource(),
-            project
-        );
-        addVariantsFromConfiguration(sourcesElements, new JavaConfigurationVariantMapping("runtime", true));
     }
 
     @Override
-    public TaskProvider<Jar> getMainJarTask() {
-        return jar;
-    }
-
-    @Override
-    public TaskProvider<JavaCompile> getMainCompileJavaTask() {
-        return compileJava;
-    }
-
-    @Override
-    public SourceSetOutput getMainOutput() {
-        return sourceSet.getOutput();
-    }
-
-    @Override
-    public SourceSet getSourceSet() {
-        return sourceSet;
-    }
-
-    @Override
-    public Configuration getImplementationConfiguration() {
-        return implementation;
-    }
-
-    @Override
-    public Configuration getRuntimeOnlyConfiguration() {
-        return runtimeOnly;
-    }
-
-    @Override
-    public Configuration getCompileOnlyConfiguration() {
-        return compileOnly;
-    }
-
-    @Override
-    public Configuration getRuntimeClasspathConfiguration() {
-        return runtimeClasspath;
-    }
-
-    @Override
-    public Configuration getCompileClasspathConfiguration() {
-        return compileClasspath;
-    }
-
-    @Override
-    public Configuration getRuntimeElementsConfiguration() {
-        return runtimeElements;
-    }
-
-    @Override
-    public Configuration getApiElementsConfiguration() {
-        return apiElements;
+    public JvmFeatureInternal getMainFeature() {
+        return mainFeature;
     }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/jvm/component/internal/DefaultJvmSoftwareComponent.java
+++ b/subprojects/plugins/src/main/java/org/gradle/jvm/component/internal/DefaultJvmSoftwareComponent.java
@@ -174,7 +174,7 @@ public class DefaultJvmSoftwareComponent extends DefaultAdhocSoftwareComponent i
         mainFeature.withJavadocJar();
 
         Configuration javadocElements = mainFeature.getJavadocElementsConfiguration();
-        if (!isPublished(javadocElements)) {
+        if (!isRegisteredAsLegacyVariant(javadocElements)) {
             addVariantsFromConfiguration(javadocElements, new JavaConfigurationVariantMapping("runtime", true));
         }
     }
@@ -184,7 +184,7 @@ public class DefaultJvmSoftwareComponent extends DefaultAdhocSoftwareComponent i
         mainFeature.withSourcesJar();
 
         Configuration sourcesElements = mainFeature.getSourcesElementsConfiguration();
-        if (!isPublished(sourcesElements)) {
+        if (!isRegisteredAsLegacyVariant(sourcesElements)) {
             addVariantsFromConfiguration(sourcesElements, new JavaConfigurationVariantMapping("runtime", true));
         }
     }

--- a/subprojects/plugins/src/main/java/org/gradle/jvm/component/internal/JvmSoftwareComponentInternal.java
+++ b/subprojects/plugins/src/main/java/org/gradle/jvm/component/internal/JvmSoftwareComponentInternal.java
@@ -16,30 +16,22 @@
 
 package org.gradle.jvm.component.internal;
 
-import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.component.SoftwareComponent;
-import org.gradle.api.tasks.SourceSet;
-import org.gradle.api.tasks.SourceSetOutput;
-import org.gradle.api.tasks.TaskProvider;
-import org.gradle.api.tasks.bundling.Jar;
-import org.gradle.api.tasks.compile.JavaCompile;
+import org.gradle.api.plugins.jvm.internal.JvmFeatureInternal;
 
 /**
  * A {@link SoftwareComponent} which produces variants intended for use within the JVM ecosystem.
- * <p>
- * TODO: There is currently no public interface for this type of component, as the JVM component
+ *
+ * <p>TODO: There is currently no public interface for this type of component, as the JVM component
  * infrastructure is still under construction. The main blocker for publicizing this component
- * is the lack of multi-target functionality. This interface currently exposes the
- * {@link #getMainJarTask()}, {@link #getSourceSet()}, {@link #getImplementationConfiguration()},
- * etc. methods, which imply that this component only supports a single compilation target. A
- * multi-target component would not expose these methods at the top-level, but would instead
- * encapsulate them within some kind of {@code targets} or {@code pipelines} container.
- * <p>
- * TODO: Before publicizing this component, we also need to consider how component extensibility works.
+ * is the lack of a proper variant API and support for dynamically adding Features to a component.</p>
+ *
+ * <p>TODO: Before publicizing this component, we also need to consider how component extensibility works.
  * For example, for the java-library plugin we have the additional {@code api} and {@code compileOnlyApi}
- * dependency configurations. Do we expect that plugin to write a new component interface and extend this in
- * order to add the proper getter methods? What about the concrete component class which implements that new
- * interface? Does it extend the default implementation class? Is there a way we can avoid Java inheritance?
+ * dependency configurations. Do we expect that plugin to write a new feature interface and extend a base
+ * interface in order to add the proper getter methods? What about the concrete feature class which implements
+ * that new interface? Does it extend the default implementation class? Is there a way we can avoid
+ * Java inheritance?</p>
  */
 public interface JvmSoftwareComponentInternal extends SoftwareComponent {
 
@@ -61,104 +53,11 @@ public interface JvmSoftwareComponentInternal extends SoftwareComponent {
      */
     void withSourcesJar();
 
-    /**
-     * Get the {@link Jar} task which assembles the resources and compilation outputs into
-     * a single artifact.
-     *
-     * @return A provider which supplies the component's {@link Jar} task.
-     */
-    TaskProvider<Jar> getMainJarTask();
+    // TODO: Future iterations of this component should support dynamically adding new features.
 
     /**
-     * Get the {@link JavaCompile} task which compiles the Java source files into classes.
-     *
-     * @return A provider which supplies the component's {@link JavaCompile} task.
+     * Get the feature which encapsulates all logic and domain objects for building the production software product.
      */
-    TaskProvider<JavaCompile> getMainCompileJavaTask();
-
-    // TODO: This could use a better name. "output" can be confused with a
-    // component's "real" outputs, which are its variants.
-    /**
-     * Get the resources and compilation outputs for this component which are used as
-     * inputs for the {@link #getMainJarTask() main jar} task.
-     *
-     * @return The source set outputs.
-     */
-    SourceSetOutput getMainOutput();
-
-    /**
-     * Get this component's backing source set.
-     * <p>
-     * {@link SourceSet#getOutput()} and the classpath-returning methods on the returned
-     * source set should ideally be avoided in favor of the similarly-named methods on
-     * this component. The concept of source sets having a single set of outputs is only
-     * relevant for single-target components.
-     *
-     * @return This component's source set.
-     */
-    SourceSet getSourceSet();
-
-    /**
-     * Gets the dependency configuration for which to declare dependencies internal to the component.
-     * Dependencies declared on this configuration are present during compilation and runtime, but are not
-     * exposed as part of the component's API variant.
-     *
-     * @return The {@code implementation} configuration.
-     */
-    Configuration getImplementationConfiguration();
-
-    /**
-     * Gets the dependency configuration for which to declare runtime-only dependencies.
-     * Dependencies declared on this configuration are present only during runtime, are not
-     * present during compilation, and are not exposed as part of the component's API variant.
-     *
-     * @return The {@code runtimeOnly} configuration.
-     */
-    Configuration getRuntimeOnlyConfiguration();
-
-    /**
-     * Gets the dependency configuration for which to declare compile-only dependencies.
-     * Dependencies declared on this configuration are present only during compilation, are not
-     * present during runtime, and are not exposed as part of the component's API variant.
-     *
-     * @return The {@code compileOnly} configuration.
-     */
-    Configuration getCompileOnlyConfiguration();
-
-    /**
-     * Get the resolvable configuration containing the resolved runtime dependencies
-     * for this component. This configuration does not contain the artifacts from the
-     * component's compilation itself.
-     *
-     * @return The {@code runtimeClasspath} configuration.
-     */
-    Configuration getRuntimeClasspathConfiguration();
-
-    /**
-     * Get the resolvable configuration containing the resolved compile dependencies
-     * for this component.
-     *
-     * @return The {@code compileClasspath} configuration.
-     */
-    Configuration getCompileClasspathConfiguration();
-
-    /**
-     * Get the consumable configuration which produces the {@code runtimeElements} variant of this component.
-     * This configuration includes all runtime dependencies as well as the component's
-     * compilation outputs, but does not include {@code compileOnly} dependencies.
-     *
-     * @return The {@code runtimeElements} configuration.
-     */
-    Configuration getRuntimeElementsConfiguration();
-
-    /**
-     * Get the consumable configuration which produces the {@code apiElements} variant of this component.
-     * This configuration includes all API compilation dependencies as well as the component's
-     * compilation outputs, but does not include {@code implementation}, {@code compileOnly},
-     * or {@code runtimeOnly} dependencies.
-     *
-     * @return The {@code apiElements} configuration.
-     */
-    Configuration getApiElementsConfiguration();
+    JvmFeatureInternal getMainFeature();
 
 }

--- a/subprojects/plugins/src/test/groovy/org/gradle/jvm/component/internal/DefaultJvmSoftwareComponentTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/jvm/component/internal/DefaultJvmSoftwareComponentTest.groovy
@@ -23,12 +23,18 @@ import org.gradle.api.attributes.Usage
 import org.gradle.api.internal.tasks.JvmConstants
 import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.plugins.jvm.internal.DefaultJvmFeature
 import org.gradle.api.reflect.ObjectInstantiationException
 import org.gradle.api.tasks.SourceSet
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 
 /**
  * Tests {@link DefaultJvmSoftwareComponent}.
+ *
+ * TODO: This tests a lot of the functionality of the {@link DefaultJvmFeature}. We should probably
+ *       move some of the testing to another feature-specific test class. However, given that the
+ *       DefaultJvmFeature itself is probably going to change heavily when adding multi-target support,
+ *       we should wait to avoid rework.
  */
 class DefaultJvmSoftwareComponentTest extends AbstractProjectBuilderSpec {
 
@@ -59,19 +65,20 @@ class DefaultJvmSoftwareComponentTest extends AbstractProjectBuilderSpec {
         def component = project.objects.newInstance(DefaultJvmSoftwareComponent, "name", "main")
 
         then:
-        component.sourceSet == ext.sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME)
-        component.mainOutput == component.getSourceSet().getOutput()
-        component.runtimeClasspathConfiguration == project.configurations.getByName(JvmConstants.RUNTIME_CLASSPATH_CONFIGURATION_NAME)
-        component.compileClasspathConfiguration == project.configurations.getByName(JvmConstants.COMPILE_CLASSPATH_CONFIGURATION_NAME)
-        component.runtimeElementsConfiguration == project.configurations.getByName(JvmConstants.RUNTIME_ELEMENTS_CONFIGURATION_NAME)
-        component.apiElementsConfiguration == project.configurations.getByName(JvmConstants.API_ELEMENTS_CONFIGURATION_NAME)
+        component.mainFeature instanceof DefaultJvmFeature
+        component.mainFeature.sourceSet == ext.sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME)
+        component.mainFeature.output == component.mainFeature.getSourceSet().getOutput()
+        component.mainFeature.runtimeClasspathConfiguration == project.configurations.getByName(JvmConstants.RUNTIME_CLASSPATH_CONFIGURATION_NAME)
+        component.mainFeature.compileClasspathConfiguration == project.configurations.getByName(JvmConstants.COMPILE_CLASSPATH_CONFIGURATION_NAME)
+        component.mainFeature.runtimeElementsConfiguration == project.configurations.getByName(JvmConstants.RUNTIME_ELEMENTS_CONFIGURATION_NAME)
+        component.mainFeature.apiElementsConfiguration == project.configurations.getByName(JvmConstants.API_ELEMENTS_CONFIGURATION_NAME)
         project.configurations.getByName('mainSourceElements')
-        component.implementationConfiguration == project.configurations.getByName(JvmConstants.IMPLEMENTATION_CONFIGURATION_NAME)
-        component.runtimeOnlyConfiguration == project.configurations.getByName(JvmConstants.RUNTIME_ONLY_CONFIGURATION_NAME)
-        component.compileOnlyConfiguration == project.configurations.getByName(JvmConstants.COMPILE_ONLY_CONFIGURATION_NAME)
+        component.mainFeature.implementationConfiguration == project.configurations.getByName(JvmConstants.IMPLEMENTATION_CONFIGURATION_NAME)
+        component.mainFeature.runtimeOnlyConfiguration == project.configurations.getByName(JvmConstants.RUNTIME_ONLY_CONFIGURATION_NAME)
+        component.mainFeature.compileOnlyConfiguration == project.configurations.getByName(JvmConstants.COMPILE_ONLY_CONFIGURATION_NAME)
         project.configurations.getByName(JvmConstants.ANNOTATION_PROCESSOR_CONFIGURATION_NAME)
-        component.mainCompileJavaTask.get() == project.tasks.getByName(JvmConstants.COMPILE_JAVA_TASK_NAME)
-        component.mainJarTask.get() == project.tasks.getByName(JvmConstants.JAR_TASK_NAME)
+        component.mainFeature.compileJavaTask.get() == project.tasks.getByName(JvmConstants.COMPILE_JAVA_TASK_NAME)
+        component.mainFeature.jarTask.get() == project.tasks.getByName(JvmConstants.JAR_TASK_NAME)
         project.tasks.getByName(JvmConstants.JAVADOC_TASK_NAME)
         project.tasks.getByName(JvmConstants.PROCESS_RESOURCES_TASK_NAME)
     }
@@ -103,19 +110,20 @@ class DefaultJvmSoftwareComponentTest extends AbstractProjectBuilderSpec {
         def component = project.objects.newInstance(DefaultJvmSoftwareComponent, "name", "feature")
 
         then:
-        component.sourceSet == ext.sourceSets.getByName('feature')
-        component.mainOutput == component.getSourceSet().getOutput()
-        component.runtimeClasspathConfiguration == project.configurations.getByName('featureRuntimeClasspath')
-        component.compileClasspathConfiguration == project.configurations.getByName('featureCompileClasspath')
-        component.runtimeElementsConfiguration == project.configurations.getByName('featureRuntimeElements')
-        component.apiElementsConfiguration == project.configurations.getByName('featureApiElements')
+        component.mainFeature instanceof DefaultJvmFeature
+        component.mainFeature.sourceSet == ext.sourceSets.getByName('feature')
+        component.mainFeature.output == component.mainFeature.getSourceSet().getOutput()
+        component.mainFeature.runtimeClasspathConfiguration == project.configurations.getByName('featureRuntimeClasspath')
+        component.mainFeature.compileClasspathConfiguration == project.configurations.getByName('featureCompileClasspath')
+        component.mainFeature.runtimeElementsConfiguration == project.configurations.getByName('featureRuntimeElements')
+        component.mainFeature.apiElementsConfiguration == project.configurations.getByName('featureApiElements')
         project.configurations.getByName('featureSourceElements')
-        component.implementationConfiguration == project.configurations.getByName('featureImplementation')
-        component.runtimeOnlyConfiguration == project.configurations.getByName('featureRuntimeOnly')
-        component.compileOnlyConfiguration == project.configurations.getByName('featureCompileOnly')
+        component.mainFeature.implementationConfiguration == project.configurations.getByName('featureImplementation')
+        component.mainFeature.runtimeOnlyConfiguration == project.configurations.getByName('featureRuntimeOnly')
+        component.mainFeature.compileOnlyConfiguration == project.configurations.getByName('featureCompileOnly')
         project.configurations.getByName('featureAnnotationProcessor')
-        component.mainCompileJavaTask.get() == project.tasks.getByName('compileFeatureJava')
-        component.mainJarTask.get() == project.tasks.getByName('featureJar')
+        component.mainFeature.compileJavaTask.get() == project.tasks.getByName('compileFeatureJava')
+        component.mainFeature.jarTask.get() == project.tasks.getByName('featureJar')
         project.tasks.getByName('featureJavadoc')
         project.tasks.getByName('processFeatureResources')
     }
@@ -175,7 +183,7 @@ class DefaultJvmSoftwareComponentTest extends AbstractProjectBuilderSpec {
         (configuration.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE) as Category).name == Category.DOCUMENTATION
         (configuration.attributes.getAttribute(Bundling.BUNDLING_ATTRIBUTE) as Bundling).name == Bundling.EXTERNAL
         (configuration.attributes.getAttribute(DocsType.DOCS_TYPE_ATTRIBUTE) as DocsType).name == DocsType.JAVADOC
-        project.tasks.getByName(component.sourceSet.javadocJarTaskName)
+        project.tasks.getByName(component.mainFeature.sourceSet.javadocJarTaskName)
         component.usages.find { it.name == JvmConstants.JAVADOC_ELEMENTS_CONFIGURATION_NAME}
     }
 
@@ -204,7 +212,7 @@ class DefaultJvmSoftwareComponentTest extends AbstractProjectBuilderSpec {
         (configuration.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE) as Category).name == Category.DOCUMENTATION
         (configuration.attributes.getAttribute(Bundling.BUNDLING_ATTRIBUTE) as Bundling).name == Bundling.EXTERNAL
         (configuration.attributes.getAttribute(DocsType.DOCS_TYPE_ATTRIBUTE) as DocsType).name == DocsType.SOURCES
-        project.tasks.getByName(component.sourceSet.sourcesJarTaskName)
+        project.tasks.getByName(component.mainFeature.sourceSet.sourcesJarTaskName)
         component.usages.find { it.name == JvmConstants.SOURCES_ELEMENTS_CONFIGURATION_NAME}
     }
 

--- a/subprojects/plugins/src/test/groovy/org/gradle/jvm/component/internal/DefaultJvmSoftwareComponentTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/jvm/component/internal/DefaultJvmSoftwareComponentTest.groovy
@@ -67,7 +67,6 @@ class DefaultJvmSoftwareComponentTest extends AbstractProjectBuilderSpec {
         then:
         component.mainFeature instanceof DefaultJvmFeature
         component.mainFeature.sourceSet == ext.sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME)
-        component.mainFeature.output == component.mainFeature.getSourceSet().getOutput()
         component.mainFeature.runtimeClasspathConfiguration == project.configurations.getByName(JvmConstants.RUNTIME_CLASSPATH_CONFIGURATION_NAME)
         component.mainFeature.compileClasspathConfiguration == project.configurations.getByName(JvmConstants.COMPILE_CLASSPATH_CONFIGURATION_NAME)
         component.mainFeature.runtimeElementsConfiguration == project.configurations.getByName(JvmConstants.RUNTIME_ELEMENTS_CONFIGURATION_NAME)
@@ -112,7 +111,6 @@ class DefaultJvmSoftwareComponentTest extends AbstractProjectBuilderSpec {
         then:
         component.mainFeature instanceof DefaultJvmFeature
         component.mainFeature.sourceSet == ext.sourceSets.getByName('feature')
-        component.mainFeature.output == component.mainFeature.getSourceSet().getOutput()
         component.mainFeature.runtimeClasspathConfiguration == project.configurations.getByName('featureRuntimeClasspath')
         component.mainFeature.compileClasspathConfiguration == project.configurations.getByName('featureCompileClasspath')
         component.mainFeature.runtimeElementsConfiguration == project.configurations.getByName('featureRuntimeElements')

--- a/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaPlugin.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaPlugin.java
@@ -25,11 +25,11 @@ import org.gradle.api.file.RegularFile;
 import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.internal.JavaPluginHelper;
+import org.gradle.api.plugins.jvm.internal.JvmFeatureInternal;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.ScalaSourceDirectorySet;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.scala.ScalaDoc;
-import org.gradle.jvm.component.internal.JvmSoftwareComponentInternal;
 import org.gradle.language.scala.tasks.AbstractScalaCompile;
 
 import java.util.concurrent.Callable;
@@ -49,12 +49,12 @@ public abstract class ScalaPlugin implements Plugin<Project> {
         project.getPluginManager().apply(ScalaBasePlugin.class);
         project.getPluginManager().apply(JavaPlugin.class);
 
-        JvmSoftwareComponentInternal component = JavaPluginHelper.getJavaComponent(project);
+        JvmFeatureInternal mainFeature = JavaPluginHelper.getJavaComponent(project).getMainFeature();
 
-        configureScaladoc(project, component);
+        configureScaladoc(project, mainFeature);
 
         final Configuration incrementalAnalysisElements = project.getConfigurations().getByName("incrementalScalaAnalysisElements");
-        String compileTaskName = component.getSourceSet().getCompileTaskName("scala");
+        String compileTaskName = mainFeature.getSourceSet().getCompileTaskName("scala");
         final TaskProvider<AbstractScalaCompile> compileScala = project.getTasks().withType(AbstractScalaCompile.class).named(compileTaskName);
         final Provider<RegularFile> compileScalaMapping = project.getLayout().getBuildDirectory().file("tmp/scala/compilerAnalysis/" + compileTaskName + ".mapping");
         compileScala.configure(task -> task.getAnalysisMappingFile().set(compileScalaMapping));
@@ -62,16 +62,16 @@ public abstract class ScalaPlugin implements Plugin<Project> {
             compileScalaMapping, configurablePublishArtifact -> configurablePublishArtifact.builtBy(compileScala));
     }
 
-    private static void configureScaladoc(final Project project, final JvmSoftwareComponentInternal component) {
+    private static void configureScaladoc(final Project project, final JvmFeatureInternal feature) {
         project.getTasks().withType(ScalaDoc.class).configureEach(scalaDoc -> {
             scalaDoc.getConventionMapping().map("classpath", (Callable<FileCollection>) () -> {
                 ConfigurableFileCollection files = project.files();
-                files.from(component.getMainOutput());
-                files.from(component.getSourceSet().getCompileClasspath());
+                files.from(feature.getOutput());
+                files.from(feature.getSourceSet().getCompileClasspath());
                 return files;
             });
-            scalaDoc.setSource(component.getSourceSet().getExtensions().getByType(ScalaSourceDirectorySet.class));
-            scalaDoc.getCompilationOutputs().from(component.getMainOutput());
+            scalaDoc.setSource(feature.getSourceSet().getExtensions().getByType(ScalaSourceDirectorySet.class));
+            scalaDoc.getCompilationOutputs().from(feature.getOutput());
         });
         project.getTasks().register(SCALA_DOC_TASK_NAME, ScalaDoc.class, scalaDoc -> {
             scalaDoc.setDescription("Generates Scaladoc for the main source code.");

--- a/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaPlugin.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaPlugin.java
@@ -66,12 +66,12 @@ public abstract class ScalaPlugin implements Plugin<Project> {
         project.getTasks().withType(ScalaDoc.class).configureEach(scalaDoc -> {
             scalaDoc.getConventionMapping().map("classpath", (Callable<FileCollection>) () -> {
                 ConfigurableFileCollection files = project.files();
-                files.from(feature.getOutput());
+                files.from(feature.getSourceSet().getOutput());
                 files.from(feature.getSourceSet().getCompileClasspath());
                 return files;
             });
             scalaDoc.setSource(feature.getSourceSet().getExtensions().getByType(ScalaSourceDirectorySet.class));
-            scalaDoc.getCompilationOutputs().from(feature.getOutput());
+            scalaDoc.getCompilationOutputs().from(feature.getSourceSet().getOutput());
         });
         project.getTasks().register(SCALA_DOC_TASK_NAME, ScalaDoc.class, scalaDoc -> {
             scalaDoc.setDescription("Generates Scaladoc for the main source code.");


### PR DESCRIPTION
Re-implements the logic to build the production jar on top of JvmFeatures since much of the logic is shared between these two concepts. This reduces duplication and ensures the production logic and user-created features behave the same

Future work involves updating JVM software components to be multi-feature aware and dynamically advertise the variants of its features. Furthermore, we should deprecate calling registerFeature without a proper JVM component present and update registerFeature to add its features to the component to leverage the auto-variant-advertising functionality. Finally, we should remove the "extending" behavior of registerFeature when using the main source set.