### PR TITLE
Add `/` to codeowners file for dev-prod codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -80,9 +80,9 @@ subprojects/docs/src/docs/userguide/troubleshooting/version_catalog_problems.ado
 .teamcity/                   @gradle/bt-developer-productivity
 .github/                     @gradle/bt-developer-productivity
 gradle/shared-with-buildSrc/ @gradle/bt-developer-productivity
-build-logic/                 @gradle/bt-developer-productivity
-build-logic-commons/         @gradle/bt-developer-productivity
-build-logic-settings/        @gradle/bt-developer-productivity
+/build-logic/                 @gradle/bt-developer-productivity
+/build-logic-commons/         @gradle/bt-developer-productivity
+/build-logic-settings/        @gradle/bt-developer-productivity
 subprojects/*/build.gradle*  @gradle/bt-developer-productivity
-build.gradle*                @gradle/bt-developer-productivity
-settings.gradle*              @gradle/bt-developer-productivity
+/build.gradle*                @gradle/bt-developer-productivity
+/settings.gradle*              @gradle/bt-developer-productivity


### PR DESCRIPTION
According to this example [here](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file), that is what we should do to not match build files in samples.