### PR TITLE
Let tests use extensions instead of conventions - part 2

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/AbstractPmdPluginVersionIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/AbstractPmdPluginVersionIntegrationTest.groovy
@@ -38,19 +38,19 @@ class AbstractPmdPluginVersionIntegrationTest extends MultiVersionIntegrationSpe
      */
     String requiredSourceCompatibility() {
         if (versionNumber < VersionNumber.parse('6.0.0') && TestPrecondition.JDK9_OR_LATER.isFulfilled()) {
-            "sourceCompatibility = 1.8"
+            "java.sourceCompatibility = 1.8"
         } else if (versionNumber < VersionNumber.parse('6.4.0') && TestPrecondition.JDK10_OR_LATER.isFulfilled()) {
-            "sourceCompatibility = 9"
+            "java.sourceCompatibility = 9"
         } else if (versionNumber < VersionNumber.parse('6.6.0') && TestPrecondition.JDK11_OR_LATER.isFulfilled()) {
-            "sourceCompatibility = 10"
+            "java.sourceCompatibility = 10"
         } else if (versionNumber < VersionNumber.parse('6.13.0') && TestPrecondition.JDK12_OR_LATER.isFulfilled()) {
-            "sourceCompatibility = 11"
+            "java.sourceCompatibility = 11"
         } else if (versionNumber < VersionNumber.parse('6.18.0') && TestPrecondition.JDK13_OR_LATER.isFulfilled()) {
-            "sourceCompatibility = 12"
+            "java.sourceCompatibility = 12"
         } else if (versionNumber < VersionNumber.parse('6.22.0') && TestPrecondition.JDK14_OR_LATER.isFulfilled()) {
-            "sourceCompatibility = 13"
+            "java.sourceCompatibility = 13"
         } else if (versionNumber < VersionNumber.parse('6.48.0') && TestPrecondition.JDK19_OR_LATER.isFulfilled()) {
-            "sourceCompatibility = 18"
+            "java.sourceCompatibility = 18"
         } else {
             "" // do not set a source compatibility for the DEFAULT_PMD_VERSION running on latest Java, this way we will catch if it breaks with a new Java version
         }

--- a/subprojects/core/src/integTest/groovy/org/gradle/JansiEndUserIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/JansiEndUserIntegrationTest.groovy
@@ -139,7 +139,7 @@ class JansiEndUserIntegrationTest extends AbstractIntegrationSpec {
 
     static String annotationProcessorDependency(File repoDir, String processorDependency) {
         """
-            sourceCompatibility = '1.7'
+            java.sourceCompatibility = '1.7'
 
             repositories {
                 maven {
@@ -200,7 +200,7 @@ class JansiEndUserIntegrationTest extends AbstractIntegrationSpec {
 
                 group = '$group'
                 version = '$version'
-                sourceCompatibility = '1.7'
+                java.sourceCompatibility = '1.7'
 
                 dependencies {
                     implementation 'org.fusesource.jansi:jansi:$JANSI_VERSION'

--- a/subprojects/docs/src/snippets/ear/earCustomized/groovy/ear/build.gradle
+++ b/subprojects/docs/src/snippets/ear/earCustomized/groovy/ear/build.gradle
@@ -17,8 +17,7 @@ dependencies {
 
 ear {
     appDirectory = file('src/main/app')  // use application metadata found in this folder
-    // put dependent libraries into APP-INF/lib inside the generated EAR
-    libDirName 'APP-INF/lib'
+    libDirName 'APP-INF/lib' // put dependent libraries into APP-INF/lib inside the generated EAR
     deploymentDescriptor {  // custom entries for application.xml:
 //      fileName = "application.xml"  // same as the default value
 //      version = "6"  // same as the default value

--- a/subprojects/docs/src/snippets/ear/earCustomized/kotlin/ear/build.gradle.kts
+++ b/subprojects/docs/src/snippets/ear/earCustomized/kotlin/ear/build.gradle.kts
@@ -15,13 +15,9 @@ dependencies {
     earlib(group = "log4j", name = "log4j", version = "1.2.15", ext = "jar")
 }
 
-tasks.named<Ear>("ear") {
+tasks.ear {
     appDirectory.set(file("src/main/app"))  // use application metadata found in this folder
-}
-
-ear {
-    // put dependent libraries into APP-INF/lib inside the generated EAR
-    libDirName = "APP-INF/lib"
+    libDirName = "APP-INF/lib" // put dependent libraries into APP-INF/lib inside the generated EAR
     deploymentDescriptor {  // custom entries for application.xml:
 //      fileName = "application.xml"  // same as the default value
 //      version = "6"  // same as the default value

--- a/subprojects/docs/src/snippets/java/customDirs/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/java/customDirs/groovy/build.gradle
@@ -2,9 +2,11 @@ plugins {
     id 'java'
 }
 
-sourceCompatibility = '1.8'
-targetCompatibility = '1.8'
 version = '1.2.1'
+java {
+    sourceCompatibility = '1.8'
+    targetCompatibility = '1.8'
+}
 
 repositories {
     mavenCentral()

--- a/subprojects/docs/src/snippets/mavenMigration/basic/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/mavenMigration/basic/groovy/build.gradle
@@ -3,9 +3,12 @@ plugins {
     id 'checkstyle'
 }
 
-sourceCompatibility = '1.8'
-targetCompatibility = '1.8'
 version = '1.2.1'
+
+java {
+    sourceCompatibility = '1.8'
+    targetCompatibility = '1.8'
+}
 
 ext {
     currentBuildNumber = '1234'

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r210/ConventionsExtensionsCrossVersionFixture.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r210/ConventionsExtensionsCrossVersionFixture.groovy
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.integtests.fixtures.compatibility
+package org.gradle.plugins.ide.tooling.r210
 
 import org.gradle.api.JavaVersion
 import org.gradle.util.GradleVersion

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r210/ToolingApiEclipseModelCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r210/ToolingApiEclipseModelCrossVersionSpec.groovy
@@ -21,7 +21,8 @@ import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.tooling.model.UnsupportedMethodException
 import org.gradle.tooling.model.eclipse.EclipseProject
-import org.gradle.util.GradleVersion
+
+import static org.gradle.integtests.fixtures.compatibility.ConventionsExtensionsCrossVersionFixture.javaSourceCompatibility
 
 @TargetGradleVersion(">=2.10")
 class ToolingApiEclipseModelCrossVersionSpec extends ToolingApiSpecification {
@@ -114,21 +115,5 @@ class ToolingApiEclipseModelCrossVersionSpec extends ToolingApiSpecification {
         subprojectA.javaSourceSettings.sourceLanguageLevel == JavaVersion.VERSION_1_1
         subprojectB.javaSourceSettings.sourceLanguageLevel == JavaVersion.VERSION_1_2
         subprojectC.javaSourceSettings.sourceLanguageLevel == JavaVersion.VERSION_1_3
-    }
-
-    static String javaSourceCompatibility(GradleVersion targetVersion, JavaVersion javaVersion) {
-        return javaCompatibility(targetVersion, javaVersion, 'source')
-    }
-
-    static String javaTargetCompatibility(GradleVersion targetVersion, JavaVersion javaVersion) {
-        return javaCompatibility(targetVersion, javaVersion, 'target')
-    }
-
-    private static String javaCompatibility(GradleVersion targetVersion, JavaVersion javaVersion, String compatibility) {
-        if (targetVersion >= GradleVersion.version("5.0")) {
-            return "java.${compatibility}Compatibility = JavaVersion.${javaVersion.name()}"
-        } else {
-            return "${compatibility}Compatibility = '${javaVersion.toString()}'"
-        }
     }
 }

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r210/ToolingApiEclipseModelCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r210/ToolingApiEclipseModelCrossVersionSpec.groovy
@@ -22,7 +22,7 @@ import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.tooling.model.UnsupportedMethodException
 import org.gradle.tooling.model.eclipse.EclipseProject
 
-import static org.gradle.integtests.fixtures.compatibility.ConventionsExtensionsCrossVersionFixture.javaSourceCompatibility
+import static org.gradle.plugins.ide.tooling.r210.ConventionsExtensionsCrossVersionFixture.javaSourceCompatibility
 
 @TargetGradleVersion(">=2.10")
 class ToolingApiEclipseModelCrossVersionSpec extends ToolingApiSpecification {

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r210/ToolingApiEclipseModelCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r210/ToolingApiEclipseModelCrossVersionSpec.groovy
@@ -117,10 +117,18 @@ class ToolingApiEclipseModelCrossVersionSpec extends ToolingApiSpecification {
     }
 
     static String javaSourceCompatibility(GradleVersion targetVersion, JavaVersion javaVersion) {
+        return javaCompatibility(targetVersion, javaVersion, 'source')
+    }
+
+    static String javaTargetCompatibility(GradleVersion targetVersion, JavaVersion javaVersion) {
+        return javaCompatibility(targetVersion, javaVersion, 'target')
+    }
+
+    private static String javaCompatibility(GradleVersion targetVersion, JavaVersion javaVersion, String compatibility) {
         if (targetVersion >= GradleVersion.version("5.0")) {
-            return "java.sourceCompatibility = JavaVersion.${javaVersion.name()}"
+            return "java.${compatibility}Compatibility = JavaVersion.${javaVersion.name()}"
         } else {
-            return "sourceCompatibility = ${javaVersion.toString()}"
+            return "${compatibility}Compatibility = '${javaVersion.toString()}'"
         }
     }
 }

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r211/ToolingApiEclipseModelCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r211/ToolingApiEclipseModelCrossVersionSpec.groovy
@@ -22,7 +22,7 @@ import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.tooling.model.UnsupportedMethodException
 import org.gradle.tooling.model.eclipse.EclipseProject
 
-import static org.gradle.integtests.fixtures.compatibility.ConventionsExtensionsCrossVersionFixture.javaTargetCompatibility
+import static org.gradle.plugins.ide.tooling.r210.ConventionsExtensionsCrossVersionFixture.javaTargetCompatibility
 
 @TargetGradleVersion(">=2.11")
 class ToolingApiEclipseModelCrossVersionSpec extends ToolingApiSpecification {

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r211/ToolingApiEclipseModelCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r211/ToolingApiEclipseModelCrossVersionSpec.groovy
@@ -21,7 +21,8 @@ import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.tooling.model.UnsupportedMethodException
 import org.gradle.tooling.model.eclipse.EclipseProject
-import static org.gradle.plugins.ide.tooling.r210.ToolingApiEclipseModelCrossVersionSpec.javaTargetCompatibility
+
+import static org.gradle.integtests.fixtures.compatibility.ConventionsExtensionsCrossVersionFixture.javaTargetCompatibility
 
 @TargetGradleVersion(">=2.11")
 class ToolingApiEclipseModelCrossVersionSpec extends ToolingApiSpecification {

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r211/ToolingApiEclipseModelCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r211/ToolingApiEclipseModelCrossVersionSpec.groovy
@@ -21,6 +21,7 @@ import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.tooling.model.UnsupportedMethodException
 import org.gradle.tooling.model.eclipse.EclipseProject
+import static org.gradle.plugins.ide.tooling.r210.ToolingApiEclipseModelCrossVersionSpec.javaTargetCompatibility
 
 @TargetGradleVersion(">=2.11")
 class ToolingApiEclipseModelCrossVersionSpec extends ToolingApiSpecification {
@@ -60,7 +61,7 @@ description = org.gradle.internal.jvm.Jvm.current().javaHome.toString()
         given:
         buildFile << """
         apply plugin:'java'
-        targetCompatibility = 1.5
+        ${javaTargetCompatibility(targetVersion, JavaVersion.VERSION_1_5)}
 """
         when:
         EclipseProject rootProject = loadToolingModel(EclipseProject)
@@ -75,7 +76,7 @@ description = org.gradle.internal.jvm.Jvm.current().javaHome.toString()
         apply plugin:'java'
         apply plugin:'eclipse'
 
-        targetCompatibility = 1.6
+        ${javaTargetCompatibility(targetVersion, JavaVersion.VERSION_1_6)}
 
         eclipse {
             jdt {
@@ -119,7 +120,7 @@ description = org.gradle.internal.jvm.Jvm.current().javaHome.toString()
         buildFile << """
             project(':subproject-a') {
                 apply plugin: 'java'
-                targetCompatibility = 1.1
+                ${javaTargetCompatibility(targetVersion, JavaVersion.VERSION_1_1)}
             }
             project(':subproject-b') {
                 apply plugin: 'java'
@@ -133,7 +134,7 @@ description = org.gradle.internal.jvm.Jvm.current().javaHome.toString()
             project(':subproject-c') {
                 apply plugin: 'java'
                 apply plugin: 'eclipse'
-                targetCompatibility = 1.6
+                ${javaTargetCompatibility(targetVersion, JavaVersion.VERSION_1_6)}
                 eclipse {
                     jdt {
                         targetCompatibility = 1.3

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r211/ToolingApiIdeaModelCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r211/ToolingApiIdeaModelCrossVersionSpec.groovy
@@ -21,9 +21,9 @@ import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.tooling.model.UnsupportedMethodException
 import org.gradle.tooling.model.idea.IdeaProject
-import org.gradle.util.GradleVersion
 
-import static org.gradle.plugins.ide.tooling.r210.ToolingApiEclipseModelCrossVersionSpec.javaSourceCompatibility
+import static org.gradle.integtests.fixtures.compatibility.ConventionsExtensionsCrossVersionFixture.javaSourceCompatibility
+import static org.gradle.integtests.fixtures.compatibility.ConventionsExtensionsCrossVersionFixture.javaTargetCompatibility
 
 @TargetGradleVersion(">=2.11")
 class ToolingApiIdeaModelCrossVersionSpec extends ToolingApiSpecification {
@@ -223,7 +223,7 @@ description = org.gradle.internal.jvm.Jvm.current().javaHome.toString()
             allprojects {
                 apply plugin:'java'
                 apply plugin:'idea'
-                ${javaTargetCompatibility(JavaVersion.VERSION_1_5)}
+                ${javaTargetCompatibility(targetVersion, JavaVersion.VERSION_1_5)}
             }
 
         """
@@ -248,7 +248,7 @@ description = org.gradle.internal.jvm.Jvm.current().javaHome.toString()
             allprojects {
                 apply plugin:'java'
                 apply plugin:'idea'
-                ${javaTargetCompatibility(JavaVersion.VERSION_1_5)}
+                ${javaTargetCompatibility(targetVersion, JavaVersion.VERSION_1_5)}
             }
 
         """
@@ -269,21 +269,21 @@ description = org.gradle.internal.jvm.Jvm.current().javaHome.toString()
         settingsFile << "\ninclude 'root', 'child1', ':child2:child3', 'child4'"
         buildFile << """
             apply plugin:'java'
-            ${javaTargetCompatibility(JavaVersion.VERSION_1_5)}
+            ${javaTargetCompatibility(targetVersion, JavaVersion.VERSION_1_5)}
 
             project(':child1') {
                 apply plugin:'java'
-                ${javaTargetCompatibility(JavaVersion.VERSION_1_5)}
+                ${javaTargetCompatibility(targetVersion, JavaVersion.VERSION_1_5)}
             }
 
             project(':child2') {
                 apply plugin:'java'
-                ${javaTargetCompatibility(JavaVersion.VERSION_1_6)}
+                ${javaTargetCompatibility(targetVersion, JavaVersion.VERSION_1_6)}
             }
 
             project(':child2:child3') {
                 apply plugin:'java'
-                ${javaTargetCompatibility(JavaVersion.VERSION_1_7)}
+                ${javaTargetCompatibility(targetVersion, JavaVersion.VERSION_1_7)}
             }
             project(':child4') {
             }
@@ -315,13 +315,5 @@ description = org.gradle.internal.jvm.Jvm.current().javaHome.toString()
 
     private JavaVersion getDefaultIdeaPluginLanguageLevelForJavaProjects() {
         return JavaVersion.current()
-    }
-
-    private String javaTargetCompatibility(JavaVersion javaVersion) {
-        if (targetVersion >= GradleVersion.version("5.0")) {
-            return "java.targetCompatibility = JavaVersion.${javaVersion.name()}"
-        } else {
-            return "targetCompatibility = ${javaVersion.toString()}"
-        }
     }
 }

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r211/ToolingApiIdeaModelCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r211/ToolingApiIdeaModelCrossVersionSpec.groovy
@@ -22,8 +22,8 @@ import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.tooling.model.UnsupportedMethodException
 import org.gradle.tooling.model.idea.IdeaProject
 
-import static org.gradle.integtests.fixtures.compatibility.ConventionsExtensionsCrossVersionFixture.javaSourceCompatibility
-import static org.gradle.integtests.fixtures.compatibility.ConventionsExtensionsCrossVersionFixture.javaTargetCompatibility
+import static org.gradle.plugins.ide.tooling.r210.ConventionsExtensionsCrossVersionFixture.javaSourceCompatibility
+import static org.gradle.plugins.ide.tooling.r210.ConventionsExtensionsCrossVersionFixture.javaTargetCompatibility
 
 @TargetGradleVersion(">=2.11")
 class ToolingApiIdeaModelCrossVersionSpec extends ToolingApiSpecification {

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r212/ToolingApiIdeaModelCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r212/ToolingApiIdeaModelCrossVersionSpec.groovy
@@ -20,7 +20,8 @@ import org.gradle.api.JavaVersion
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.tooling.model.idea.IdeaProject
-import static org.gradle.plugins.ide.tooling.r210.ToolingApiEclipseModelCrossVersionSpec.javaSourceCompatibility
+
+import static org.gradle.integtests.fixtures.compatibility.ConventionsExtensionsCrossVersionFixture.javaSourceCompatibility
 
 @TargetGradleVersion(">=2.12")
 class ToolingApiIdeaModelCrossVersionSpec extends ToolingApiSpecification {

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r212/ToolingApiIdeaModelCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r212/ToolingApiIdeaModelCrossVersionSpec.groovy
@@ -21,7 +21,7 @@ import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.tooling.model.idea.IdeaProject
 
-import static org.gradle.integtests.fixtures.compatibility.ConventionsExtensionsCrossVersionFixture.javaSourceCompatibility
+import static org.gradle.plugins.ide.tooling.r210.ConventionsExtensionsCrossVersionFixture.javaSourceCompatibility
 
 @TargetGradleVersion(">=2.12")
 class ToolingApiIdeaModelCrossVersionSpec extends ToolingApiSpecification {

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r30/ToolingApiEclipseModelClasspathContainerCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r30/ToolingApiEclipseModelClasspathContainerCrossVersionSpec.groovy
@@ -25,7 +25,7 @@ import org.gradle.tooling.model.eclipse.EclipseClasspathContainer
 import org.gradle.tooling.model.eclipse.EclipseProject
 import spock.lang.Issue
 
-import static org.gradle.integtests.fixtures.compatibility.ConventionsExtensionsCrossVersionFixture.javaTargetCompatibility
+import static org.gradle.plugins.ide.tooling.r210.ConventionsExtensionsCrossVersionFixture.javaTargetCompatibility
 
 @ToolingApiVersion('>=3.0')
 @TargetGradleVersion('>=3.0')

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r30/ToolingApiEclipseModelClasspathContainerCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r30/ToolingApiEclipseModelClasspathContainerCrossVersionSpec.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.plugins.ide.tooling.r30
 
+import org.gradle.api.JavaVersion
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.integtests.tooling.fixture.ToolingApiVersion
@@ -23,6 +24,7 @@ import org.gradle.tooling.model.UnsupportedMethodException
 import org.gradle.tooling.model.eclipse.EclipseClasspathContainer
 import org.gradle.tooling.model.eclipse.EclipseProject
 import spock.lang.Issue
+import static org.gradle.plugins.ide.tooling.r210.ToolingApiEclipseModelCrossVersionSpec.javaTargetCompatibility
 
 @ToolingApiVersion('>=3.0')
 @TargetGradleVersion('>=3.0')
@@ -148,7 +150,7 @@ class ToolingApiEclipseModelClasspathContainerCrossVersionSpec extends ToolingAp
         buildFile <<
         """apply plugin: 'java'
            apply plugin: 'eclipse'
-           targetCompatibility = 1.4
+           ${javaTargetCompatibility(targetVersion, JavaVersion.VERSION_1_4)}
         """
 
         when:
@@ -182,7 +184,7 @@ class ToolingApiEclipseModelClasspathContainerCrossVersionSpec extends ToolingAp
         buildFile <<
         """apply plugin: 'java'
            apply plugin: 'eclipse'
-           targetCompatibility = 1.4
+           ${javaTargetCompatibility(targetVersion, JavaVersion.VERSION_1_4)}
            eclipse {
                jdt {
                     javaRuntimeName = "customJavaRuntime"

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r30/ToolingApiEclipseModelClasspathContainerCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r30/ToolingApiEclipseModelClasspathContainerCrossVersionSpec.groovy
@@ -24,7 +24,8 @@ import org.gradle.tooling.model.UnsupportedMethodException
 import org.gradle.tooling.model.eclipse.EclipseClasspathContainer
 import org.gradle.tooling.model.eclipse.EclipseProject
 import spock.lang.Issue
-import static org.gradle.plugins.ide.tooling.r210.ToolingApiEclipseModelCrossVersionSpec.javaTargetCompatibility
+
+import static org.gradle.integtests.fixtures.compatibility.ConventionsExtensionsCrossVersionFixture.javaTargetCompatibility
 
 @ToolingApiVersion('>=3.0')
 @TargetGradleVersion('>=3.0')

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest.groovy
@@ -389,8 +389,10 @@ apply plugin: 'eclipse'
         runEclipseTask '''
 apply plugin: 'java'
 apply plugin: 'eclipse'
+java {
     sourceCompatibility = 1.4
     targetCompatibility = 1.3
+}
 '''
         def jdt = parseJdtFile()
         assert jdt.contains('source=1.4')
@@ -403,8 +405,10 @@ apply plugin: 'eclipse'
         runEclipseTask '''
 apply plugin: 'java'
 apply plugin: 'eclipse'
-sourceCompatibility = 1.4
-targetCompatibility = 1.5
+java {
+    sourceCompatibility = 1.4
+    targetCompatibility = 1.5
+}
 eclipse {
     jdt {
         sourceCompatibility = 1.3

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseJavaProjectIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseJavaProjectIntegrationTest.groovy
@@ -55,7 +55,7 @@ class EclipseJavaProjectIntegrationTest extends AbstractEclipseIntegrationSpec {
         buildFile << """
             apply plugin: 'java'
             apply plugin: 'eclipse'
-            sourceCompatibility = $version
+            java.sourceCompatibility = $version
         """
 
         when:

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpJavaProjectIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpJavaProjectIntegrationTest.groovy
@@ -32,7 +32,7 @@ class EclipseWtpJavaProjectIntegrationTest extends AbstractEclipseIntegrationSpe
 
            ${mavenCentralRepository()}
 
-           sourceCompatibility = 1.6
+           java.sourceCompatibility = 1.6
 
            dependencies {
                implementation 'com.google.guava:guava:18.0'

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpWebAndJavaProjectIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpWebAndJavaProjectIntegrationTest.groovy
@@ -36,7 +36,7 @@ class EclipseWtpWebAndJavaProjectIntegrationTest extends AbstractEclipseIntegrat
            project(':web') {
                apply plugin: 'war'
 
-               sourceCompatibility = 1.6
+               java.sourceCompatibility = 1.6
 
                dependencies {
                    providedCompile 'javax.servlet:javax.servlet-api:3.1.0'
@@ -48,7 +48,7 @@ class EclipseWtpWebAndJavaProjectIntegrationTest extends AbstractEclipseIntegrat
             project(':java') {
                 apply plugin: 'java'
 
-                sourceCompatibility = 1.6
+                java.sourceCompatibility = 1.6
 
                 dependencies {
                     implementation 'com.google.guava:guava:18.0'

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpWebProjectIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpWebProjectIntegrationTest.groovy
@@ -32,7 +32,7 @@ class EclipseWtpWebProjectIntegrationTest extends AbstractEclipseIntegrationSpec
         """apply plugin: 'war'
            apply plugin: 'eclipse-wtp'
 
-           sourceCompatibility = 1.6
+           java.sourceCompatibility = 1.6
 
            ${mavenCentralRepository()}
 

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/build.gradle
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/build.gradle
@@ -20,7 +20,7 @@ allprojects {
     group = 'org.gradle'
 
     plugins.withType(JavaBasePlugin) {
-        sourceCompatibility = 1.5
+        java.sourceCompatibility = 1.5
     }
 }
 

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/common/build.gradle
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/common/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'java'
 
-sourceCompatibility = 1.6
+java.sourceCompatibility = 1.6
 
 configurations {
     provided

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/webAppJava6/build.gradle
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/webAppJava6/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'war'
 
-sourceCompatibility = 6
+java.sourceCompatibility = 6
 
 dependencies {
     implementation project(":common")

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/idea/IdeaIntegrationTest/canCreateAndDeleteMetaData/build.gradle
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/idea/IdeaIntegrationTest/canCreateAndDeleteMetaData/build.gradle
@@ -26,7 +26,7 @@ subprojects {
 
     group = 'org.gradle'
     version = '1.0'
-    sourceCompatibility = '1.6'
+    java.sourceCompatibility = '1.6'
 }
 
 cleanIdea.doLast {

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/idea/IdeaIntegrationTest/worksWithNonStandardLayout/root/build.gradle
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/idea/IdeaIntegrationTest/worksWithNonStandardLayout/root/build.gradle
@@ -2,7 +2,7 @@ allprojects {
     apply plugin: 'java'
     apply plugin: 'idea'
 
-    sourceCompatibility = 1.5
+    java.sourceCompatibility = 1.5
 }
 
 idea.project.jdkName = '1.7'

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ApplicationIntegrationSpec.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ApplicationIntegrationSpec.groovy
@@ -78,7 +78,7 @@ class Main {
 
     def canUseDefaultJvmArgsToPassMultipleOptionsToJvmWhenRunningScript() {
         file("build.gradle") << '''
-applicationDefaultJvmArgs = ['-DtestValue=value', '-DtestValue2=some value', '-DtestValue3=some value']
+application.applicationDefaultJvmArgs = ['-DtestValue=value', '-DtestValue2=some value', '-DtestValue3=some value']
 '''
         file('src/main/java/org/gradle/test/Main.java') << '''
 package org.gradle.test;
@@ -113,7 +113,7 @@ class Main {
 
     def canUseBothDefaultJvmArgsAndEnvironmentVariableToPassOptionsToJvmWhenRunningScript() {
         file("build.gradle") << '''
-applicationDefaultJvmArgs = ['-Dvar1=value1', '-Dvar2=some value2']
+application.applicationDefaultJvmArgs = ['-Dvar1=value1', '-Dvar2=some value2']
 '''
         file('src/main/java/org/gradle/test/Main.java') << '''
 package org.gradle.test;
@@ -153,7 +153,7 @@ class Main {
         def testValue2 = OperatingSystem.current().windows ? 'some value$PATH' : 'some value\\\\$PATH'
         def testValue3 = 'some value%PATH%'
         file("build.gradle") << '''
-            applicationDefaultJvmArgs = [
+            application.applicationDefaultJvmArgs = [
                 '-DtestValue=value',
                 '-DtestValue2=some value$PATH',
                 '-DtestValue3=some value%PATH%',
@@ -191,7 +191,7 @@ class Main {
 
     def "can customize application name"() {
         file('build.gradle') << '''
-applicationName = 'mega-app'
+application.applicationName = 'mega-app'
 '''
         file('src/main/java/org/gradle/test/Main.java') << '''
 package org.gradle.test;

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/compatibility/ConventionsExtensionsCrossVersionFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/compatibility/ConventionsExtensionsCrossVersionFixture.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures.compatibility
+
+import org.gradle.api.JavaVersion
+import org.gradle.util.GradleVersion
+
+/**
+ * Cross version testing fixture for accessing extensions and conventions.
+ */
+class ConventionsExtensionsCrossVersionFixture {
+
+    static String javaSourceCompatibility(GradleVersion targetVersion, JavaVersion javaVersion) {
+        return javaCompatibility(targetVersion, javaVersion, 'source')
+    }
+
+    static String javaTargetCompatibility(GradleVersion targetVersion, JavaVersion javaVersion) {
+        return javaCompatibility(targetVersion, javaVersion, 'target')
+    }
+
+    private static String javaCompatibility(GradleVersion targetVersion, JavaVersion javaVersion, String compatibility) {
+        if (targetVersion >= GradleVersion.version("5.0")) {
+            return "java.${compatibility}Compatibility = JavaVersion.${javaVersion.name()}"
+        } else {
+            return "${compatibility}Compatibility = '${javaVersion.toString()}'"
+        }
+    }
+}

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginIntegrationTest.groovy
@@ -66,9 +66,11 @@ class ApplicationPluginIntegrationTest extends WellBehavedPluginTest {
     def "can generate starts script generation with custom user configuration"() {
         given:
         buildFile << """
-applicationName = 'myApp'
-applicationDefaultJvmArgs = ["-Dgreeting.language=en", "-DappId=\${project.name - ':'}"]
-"""
+        application {
+            applicationName = 'myApp'
+            applicationDefaultJvmArgs = ["-Dgreeting.language=en", "-DappId=\${project.name - ':'}"]
+        }
+        """
 
         when:
         succeeds('startScripts')
@@ -266,7 +268,7 @@ dependencies {
     def "executables can be placed at the root of the distribution"() {
         given:
         buildFile << """
-executableDir = ''
+application.executableDir = ''
 """
         when:
         run "installDist"
@@ -284,7 +286,7 @@ executableDir = ''
     def "executables can be placed in a custom directory"() {
         given:
         buildFile << """
-executableDir = 'foo/bar'
+application.executableDir = 'foo/bar'
 """
         when:
         run "installDist"
@@ -468,7 +470,7 @@ dependencies {
     def "run task honors applicationDefaultJvmArgs"() {
         given:
         buildFile """
-            applicationDefaultJvmArgs = ['-DFOO=42']
+            application.applicationDefaultJvmArgs = ['-DFOO=42']
         """
         when:
         succeeds 'run'
@@ -480,7 +482,7 @@ dependencies {
     def "can use APP_HOME in DEFAULT_JVM_OPTS with custom start script"() {
         given:
         buildFile << """
-applicationDefaultJvmArgs = ["-DappHomeSystemProp=REPLACE_THIS_WITH_APP_HOME"]
+application.applicationDefaultJvmArgs = ["-DappHomeSystemProp=REPLACE_THIS_WITH_APP_HOME"]
 
 startScripts {
     doLast {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginUnixShellsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginUnixShellsIntegrationTest.groovy
@@ -249,7 +249,7 @@ application {
 
     private void extendBuildFileWithAppHomeProperty() {
         buildFile << """
-applicationDefaultJvmArgs = ["-DappHomeSystemProp=REPLACE_THIS_WITH_APP_HOME"]
+application.applicationDefaultJvmArgs = ["-DappHomeSystemProp=REPLACE_THIS_WITH_APP_HOME"]
 
 startScripts {
     doLast {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/AbstractIncrementalCompileIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/AbstractIncrementalCompileIntegrationTest.groovy
@@ -34,7 +34,7 @@ abstract class AbstractIncrementalCompileIntegrationTest extends AbstractIntegra
         file("src/main/${language.name}/Test.${language.name}") << 'public class Test{}'
         buildFile << """
             apply plugin: '${language.name}'
-            sourceCompatibility = 1.7
+            java.sourceCompatibility = '1.7'
             ${language.compileTaskName}.options.debug = true
             ${language.compileTaskName}.options.incremental = true
             ${language.projectGroovyDependencies()}
@@ -47,7 +47,7 @@ abstract class AbstractIncrementalCompileIntegrationTest extends AbstractIntegra
         executedAndNotSkipped ":${language.compileTaskName}"
 
         when:
-        buildFile << 'sourceCompatibility = 1.8\n'
+        buildFile << 'java.sourceCompatibility = 1.8\n'
         succeeds ":${language.compileTaskName}"
 
         then:

--- a/subprojects/scala/src/integTest/groovy/org/gradle/integtests/ScalaAnnotationProcessingIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/integtests/ScalaAnnotationProcessingIntegrationTest.groovy
@@ -181,7 +181,7 @@ class ScalaAnnotationProcessingIntegrationTest extends AbstractIntegrationSpec {
 
     static String annotationProcessorDependency(File repoDir, String processorDependency) {
         """
-            sourceCompatibility = '1.7'
+            java.sourceCompatibility = '1.7'
 
             repositories {
                 maven {
@@ -266,7 +266,7 @@ class ScalaAnnotationProcessingIntegrationTest extends AbstractIntegrationSpec {
 
                 group = '$group'
                 version = '$version'
-                sourceCompatibility = '1.7'
+                java.sourceCompatibility = '1.7'
 
                 publishing {
                    publications {

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/ScalaCompilationFixture.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/ScalaCompilationFixture.groovy
@@ -107,8 +107,10 @@ class ScalaCompilationFixture {
                 }
             }
 
-            sourceCompatibility = '${sourceCompatibility}'
-            targetCompatibility = '${sourceCompatibility}'
+            java {
+                sourceCompatibility = '${sourceCompatibility}'
+                targetCompatibility = '${sourceCompatibility}'
+            }
         """.stripIndent()
     }
 

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/UpToDateScalaCompileIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/UpToDateScalaCompileIntegrationTest.groovy
@@ -103,8 +103,10 @@ class UpToDateScalaCompileIntegrationTest extends AbstractIntegrationSpec implem
                 zincVersion = "${zincVersion}"
             }
 
-            sourceCompatibility = '1.7'
-            targetCompatibility = '1.7'
+            java {
+                sourceCompatibility = '1.7'
+                targetCompatibility = '1.7'
+            }
         """.stripIndent()
     }
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskIntegrationTest.groovy
@@ -544,8 +544,10 @@ class TestTaskIntegrationTest extends JUnitMultiVersionIntegrationSpec {
                 testImplementation 'junit:junit:4.13'
             }
 
-            sourceCompatibility = 1.9
-            targetCompatibility = 1.9
+            java {
+                sourceCompatibility = 1.9
+                targetCompatibility = 1.9
+            }
         """
     }
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskJdkRelocationIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskJdkRelocationIntegrationTest.groovy
@@ -68,8 +68,10 @@ class TestTaskJdkRelocationIntegrationTest extends AbstractTaskRelocationIntegra
                 testImplementation "junit:junit:4.13"
             }
 
-            sourceCompatibility = "1.7"
-            targetCompatibility = "1.7"
+            java {
+                sourceCompatibility = "1.7"
+                targetCompatibility = "1.7"
+            }
 
             test {
                 executable "${TextUtil.escapeString(originalJavaExecutable)}"

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r25/TestProgressCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r25/TestProgressCrossVersionSpec.groovy
@@ -503,7 +503,7 @@ class TestProgressCrossVersionSpec extends ToolingApiSpecification implements Wi
         if (targetVersion >= GradleVersion.version("5.0")) {
             return "java.sourceCompatibility = JavaVersion.${javaVersion.name()}"
         } else {
-            return "sourceCompatibility = ${javaVersion.toString()}"
+            return "sourceCompatibility = '${javaVersion.toString()}'"
         }
     }
 }

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r25/TestProgressCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r25/TestProgressCrossVersionSpec.groovy
@@ -37,8 +37,6 @@ import org.gradle.util.GradleVersion
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 
-import static org.gradle.integtests.fixtures.compatibility.ConventionsExtensionsCrossVersionFixture.javaSourceCompatibility
-
 class TestProgressCrossVersionSpec extends ToolingApiSpecification implements WithOldConfigurationsSupport {
     def "receive test progress events when requesting a model"() {
         given:
@@ -485,7 +483,7 @@ class TestProgressCrossVersionSpec extends ToolingApiSpecification implements Wi
     def goodCode() {
         buildFile << """
             apply plugin: 'java'
-            ${javaSourceCompatibility(targetVersion, JavaVersion.VERSION_1_7)}
+            ${javaSourceCompatibility(JavaVersion.VERSION_1_7)}
             ${mavenCentralRepository()}
             dependencies { ${testImplementationConfiguration} 'junit:junit:4.13' }
             compileTestJava.options.fork = true  // forked as 'Gradle Test Executor 1'
@@ -499,5 +497,13 @@ class TestProgressCrossVersionSpec extends ToolingApiSpecification implements Wi
                 }
             }
         """
+    }
+
+    private String javaSourceCompatibility(JavaVersion javaVersion) {
+        if (targetVersion >= GradleVersion.version("5.0")) {
+            return "java.sourceCompatibility = JavaVersion.${javaVersion.name()}"
+        } else {
+            return "sourceCompatibility = '${javaVersion.toString()}'"
+        }
     }
 }

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r25/TestProgressCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r25/TestProgressCrossVersionSpec.groovy
@@ -37,6 +37,8 @@ import org.gradle.util.GradleVersion
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 
+import static org.gradle.integtests.fixtures.compatibility.ConventionsExtensionsCrossVersionFixture.javaSourceCompatibility
+
 class TestProgressCrossVersionSpec extends ToolingApiSpecification implements WithOldConfigurationsSupport {
     def "receive test progress events when requesting a model"() {
         given:
@@ -483,7 +485,7 @@ class TestProgressCrossVersionSpec extends ToolingApiSpecification implements Wi
     def goodCode() {
         buildFile << """
             apply plugin: 'java'
-            ${javaSourceCompatibility(JavaVersion.VERSION_1_7)}
+            ${javaSourceCompatibility(targetVersion, JavaVersion.VERSION_1_7)}
             ${mavenCentralRepository()}
             dependencies { ${testImplementationConfiguration} 'junit:junit:4.13' }
             compileTestJava.options.fork = true  // forked as 'Gradle Test Executor 1'
@@ -497,13 +499,5 @@ class TestProgressCrossVersionSpec extends ToolingApiSpecification implements Wi
                 }
             }
         """
-    }
-
-    private String javaSourceCompatibility(JavaVersion javaVersion) {
-        if (targetVersion >= GradleVersion.version("5.0")) {
-            return "java.sourceCompatibility = JavaVersion.${javaVersion.name()}"
-        } else {
-            return "sourceCompatibility = '${javaVersion.toString()}'"
-        }
     }
 }


### PR DESCRIPTION
This PR changes tests to use extensions instead of conventions where available.

This was extracted from a PR that grown too big for a reasonable review:
* https://github.com/gradle/gradle/pull/24231

This is a follow up to 
* https://github.com/gradle/gradle/pull/24199