### PR TITLE
Add kotlin-dsl code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -56,6 +56,18 @@ subprojects/signing/                        @gradle/bt-jvm
 subprojects/testing-base/                   @gradle/bt-jvm
 subprojects/version-control/                @gradle/bt-jvm
 
+# Kotlin DSL
+build-logic/kotlin-dsl/                                                                 @eskatos @jbartok
+subprojects/kotlin-dsl/                                                                 @eskatos @jbartok
+subprojects/kotlin-dsl-integ-tests/                                                     @eskatos @jbartok
+subprojects/kotlin-dsl-plugins/                                                         @eskatos @jbartok
+subprojects/kotlin-dsl-provider-plugins/                                                @eskatos @jbartok
+subprojects/kotlin-dsl-tooling-builders/                                                @eskatos @jbartok
+subprojects/kotlin-dsl-tooling-models/                                                  @eskatos @jbartok
+subprojects/docs/src/snippets/kotlinDsl/                                                @eskatos @jbartok
+subprojects/docs/src/docs/userguide/api/kotlin_dsl.adoc                                 @eskatos @jbartok
+subprojects/docs/src/docs/userguide/migration/migrating_from_groovy_to_kotlin_dsl.adoc  @eskatos @jbartok
+
 # Documentation
 subprojects/docs/src/docs/release/notes.md  @hythloda
 subprojects/docs/                           @hythloda


### PR DESCRIPTION
Not a team handle but at least it reflects current reality and will be useful.