### PR TITLE
Make ToPlannedNodeConverterRegistry thread safe

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ToPlannedNodeConverter.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ToPlannedNodeConverter.java
@@ -41,7 +41,9 @@ public interface ToPlannedNodeConverter {
     NodeIdentity getNodeIdentity(Node node);
 
     /**
-     * Returns true if the given {@link Node} is not an actual executable node but only represents a node from another execution plan.
+     * Returns true if the given {@link Node} is from the same execution plan.
+     * <p>
+     * A node can be in another execution plan if it is, for instance, from an included build ({@link TaskInAnotherBuild}).
      */
     boolean isInSamePlan(Node node);
 


### PR DESCRIPTION
The `ToPlannedNodeConverterRegistry` is used during work graph population to find converters from nodes to `PlannedNode`s for build operations. It also caches its lookup results.

The registry was converted to be a Gradle user home-level service. This means that multiple included builds could be using this service concurrently for their work graph resolution.

This is a bug introduced while Gradle 8.1 was in development and should be fixed before the RC is out.