### PR TITLE
Encrypt configuration cache unconditionally

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ systemProp.gradle.internal.testdistribution.writeTraceFile=true
 systemProp.gradle.internal.testdistribution.queryResponseTimeout=PT20S
 
 # Default performance baseline
-defaultPerformanceBaselines=8.1-commit-f6b887c2
+defaultPerformanceBaselines=8.1-commit-e09d337b7da

--- a/subprojects/base-services/src/main/java/org/gradle/util/internal/EncryptionAlgorithm.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/internal/EncryptionAlgorithm.java
@@ -55,8 +55,11 @@ public interface EncryptionAlgorithm {
     }
 
     class EncryptionException extends RuntimeException {
-        public EncryptionException(Exception cause) {
-            super(cause);
+        public EncryptionException(String message, Throwable cause) {
+            super(message, cause);
+        }
+        public EncryptionException(Throwable cause) {
+            super(null, cause);
         }
     }
 

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheEncryptionIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheEncryptionIntegrationTest.groovy
@@ -176,7 +176,7 @@ Error loading encryption key from Java keystore at ${keyStorePath}
         given:
         def configurationCache = newConfigurationCacheFixture()
         runWithEncryption()
-        KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType())
+        KeyStore ks = KeyStore.getInstance(KeyStoreKeySource.KEYSTORE_TYPE)
         keyStorePath.withInputStream { ks.load(it, keyStorePassword.toCharArray()) }
         ks.deleteEntry("gradle-secret")
         keyStorePath.withOutputStream { ks.store(it, keyStorePassword.toCharArray()) }

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheEncryptionIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheEncryptionIntegrationTest.groovy
@@ -19,70 +19,51 @@ package org.gradle.configurationcache
 import com.google.common.primitives.Bytes
 import groovy.transform.EqualsAndHashCode
 import groovy.transform.ToString
-import spock.lang.Ignore
+import org.gradle.internal.nativeintegration.filesystem.FileSystem
+import org.gradle.test.fixtures.file.TestFile
+import org.gradle.testfixtures.internal.NativeServicesTestFixture
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 
-import java.nio.charset.StandardCharsets
 import java.nio.file.FileVisitOption
 import java.nio.file.Files
 import java.nio.file.Path
+import java.security.KeyStore
 import java.util.stream.Stream
 
 import static org.gradle.initialization.IGradlePropertiesLoader.ENV_PROJECT_PROPERTIES_PREFIX
-import static org.gradle.configurationcache.EnvironmentVarKeySource.GRADLE_ENCRYPTION_KEY_ENV_KEY
-import static org.gradle.util.Matchers.containsLine
-import static org.gradle.util.Matchers.matchesRegexp
 
-@Ignore("Disabled in 8.1")
 class ConfigurationCacheEncryptionIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
-    String encryptionKeyText
-    String encryptionKeyAsBase64
+    TestFile keyStoreFolder
+    TestFile keyStorePath
+    String keyStorePassword
+    String keyPassword
 
     def setup() {
-        encryptionKeyText = "01234567890123456789012345678901"
-        encryptionKeyAsBase64 = Base64.encoder.encodeToString(encryptionKeyText.getBytes(StandardCharsets.UTF_8))
+        keyStoreFolder = new TestFile(testDirectory, "keystores")
+        keyStorePath = new TestFile(keyStoreFolder, "test.keystore")
+        keyStorePassword = "gradle-keystore-pwd"
+        keyPassword = "gradle-key-pwd"
     }
 
-    def "configuration cache can be loaded without errors if encryption is #status, #encryptionTransformation"() {
+    def "configuration cache can be loaded without errors using #encryptionTransformation"() {
         given:
         def additionalOpts = [
             "-Dorg.gradle.configuration-cache.internal.encryption-alg=${encryptionTransformation}"
         ]
         def configurationCache = newConfigurationCacheFixture()
-        runWithEncryption(status, ["help"], additionalOpts)
+        runWithEncryption(true, ["help"], additionalOpts)
 
         when:
-        runWithEncryption(status, ["help"], additionalOpts)
+        runWithEncryption(true, ["help"], additionalOpts)
 
         then:
         configurationCache.assertStateLoaded()
 
         where:
-        status      | encryptionTransformation
-        false       | ""
-        true        | "AES/ECB/PKCS5PADDING"
-        true        | "AES/CBC/PKCS5PADDING"
-    }
-
-    def "configuration cache encryption is #status with option #options"() {
-        given:
-        def configurationCache = newConfigurationCacheFixture()
-
-        when:
-        runWithEncryption(status, ["help"], ["--info"] + options)
-
-        then:
-        configurationCache.assertStateStored()
-        status == containsLine(result.output, "Encryption of the configuration cache is enabled.")
-
-        where:
-        status  | options
-        true    | []
-        false   | ["--no-configuration-cache-encryption"]
-        true    | ["--configuration-cache-encryption"]
-        true    | ["-Dorg.gradle.configuration-cache.encryption=true"]
-        false   | ["-Dorg.gradle.configuration-cache.encryption=false"]
-        true    | ["--configuration-cache-encryption", "-Dorg.gradle.configuration-cache.encryption=false"]
-        false   | ["--no-configuration-cache-encryption", "-Dorg.gradle.configuration-cache.encryption=true"]
+        _ | encryptionTransformation
+        _ | "AES/ECB/PKCS5PADDING"
+        _ | "AES/CBC/PKCS5PADDING"
     }
 
     def "configuration cache is #encrypted if enabled=#enabled"() {
@@ -162,107 +143,94 @@ class ConfigurationCacheEncryptionIntegrationTest extends AbstractConfigurationC
         }
     }
 
-    def "new configuration cache entry if was encrypted but encryption is off"() {
+    def "build fails if keystore password is incorrect"() {
         given:
-        def configurationCache = newConfigurationCacheFixture()
-        runWithEncryption(true)
+        runWithEncryption()
 
         when:
-        runWithEncryption(false)
+        keyStorePassword = "foobar"
+        fails(*(["help", "--configuration-cache"] + encryptionOptions))
+
+        then:
+        result.assertHasErrorOutput """
+Error loading encryption key from Java keystore at ${keyStorePath}
+> Integrity check failed: java.security.UnrecoverableKeyException: Failed PKCS12 integrity checking
+"""
+    }
+
+    def "new configuration cache entry if keystore is not found"() {
+        given:
+        def configurationCache = newConfigurationCacheFixture()
+        runWithEncryption()
+        keyStorePath.delete()
+
+        when:
+        runWithEncryption()
 
         then:
         configurationCache.assertStateStored()
         outputContains("Calculating task graph as no configuration cache is available for tasks: help")
     }
 
-    def "new configuration cache entry if was not encrypted but encryption is on"() {
+    def "new configuration cache entry if key is not found"() {
         given:
         def configurationCache = newConfigurationCacheFixture()
-        runWithEncryption(false)
+        runWithEncryption()
+        KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType())
+        keyStorePath.withInputStream { ks.load(it, keyStorePassword.toCharArray()) }
+        ks.deleteEntry("gradle-secret")
+        keyStorePath.withOutputStream { ks.store(it, keyStorePassword.toCharArray()) }
 
         when:
-        runWithEncryption(true)
+        runWithEncryption()
 
         then:
         configurationCache.assertStateStored()
         outputContains("Calculating task graph as no configuration cache is available for tasks: help")
     }
 
-    def "encryption disabled if requested but key in env var is not present"() {
+    @Requires(TestPrecondition.NOT_WINDOWS)
+    def "build fails if keystore cannot be created"() {
         given:
-        def configurationCache = newConfigurationCacheFixture()
+        def fs = NativeServicesTestFixture.instance.get(FileSystem)
+        assert keyStoreFolder.mkdir()
+        fs.chmod(keyStoreFolder, 0444)
 
         when:
-        runWithEncryption(true, ["help"], [], [(GRADLE_ENCRYPTION_KEY_ENV_KEY): ""])
+        fails(*(["help", "--configuration-cache"] + encryptionOptions))
 
         then:
-        configurationCache.assertStateStored()
-        outputContains("Encryption was requested but could not be enabled")
-    }
+        result.assertHasErrorOutput """
+Error loading encryption key from Java keystore at ${keyStorePath}
+> ${keyStorePath} (Permission denied)
+"""
 
-    def "encryption disabled if requested but key in env var is invalid"() {
-        given:
-        def configurationCache = newConfigurationCacheFixture()
-        def invalidEncryptionKey = Base64.encoder.encodeToString((encryptionKeyText + "foo").getBytes(StandardCharsets.UTF_8))
-
-        when:
-        runWithEncryption(true, ["help"], [], [(GRADLE_ENCRYPTION_KEY_ENV_KEY): invalidEncryptionKey])
-
-        then:
-        configurationCache.assertStateStored()
-        outputContains("Encryption was requested but could not be enabled")
-        containsLine(result.output, matchesRegexp(".*java.security.InvalidKeyException.*"))
-        outputContains("Calculating task graph as no configuration cache is available for tasks: help")
-    }
-
-    def "encryption disabled if requested but key is not long enough"() {
-        given:
-        def configurationCache = newConfigurationCacheFixture()
-        def insufficientlyLongEncryptionKey = Base64.encoder.encodeToString("01234567".getBytes(StandardCharsets.UTF_8))
-
-        when:
-        runWithEncryption(true, ["help"], [], [(GRADLE_ENCRYPTION_KEY_ENV_KEY): insufficientlyLongEncryptionKey])
-
-        then:
-        configurationCache.assertStateStored()
-        outputContains("Encryption was requested but could not be enabled")
-        containsLine(result.output, matchesRegexp(".*Encryption key length is \\d* bytes, but must be at least \\d* bytes long"))
-        outputContains("Calculating task graph as no configuration cache is available for tasks: help")
-    }
-
-    def "new configuration cache entry if env var key changes"() {
-        given:
-        def configurationCache = newConfigurationCacheFixture()
-        def differentKey = "O6lTi7qNmAAIookBZGqHqyDph882NPQOXW5P5K2yupM="
-
-        when:
-        runWithEncryption(true, ["help"], [], [(GRADLE_ENCRYPTION_KEY_ENV_KEY): this.encryptionKeyAsBase64])
-
-        then:
-        configurationCache.assertStateStored()
-
-        when:
-        runWithEncryption(true, ["help"], [], [(GRADLE_ENCRYPTION_KEY_ENV_KEY): differentKey])
-
-        then:
-        configurationCache.assertStateStored()
+        cleanup:
+        fs.chmod(keyStoreFolder, 0666)
     }
 
     void runWithEncryption(
-        boolean enabled,
+        boolean enabled = true,
         List<String> tasks = ["help"],
         List<String> additionalArgs = [],
         Map<String, String> envVars = [:]
     ) {
-        def args = [
-            "--${enabled ? "" : "no-"}configuration-cache-encryption"
-        ]
-        def allArgs = tasks + args + additionalArgs
-        if (enabled && !envVars.containsKey(GRADLE_ENCRYPTION_KEY_ENV_KEY)) {
-            envVars << [(GRADLE_ENCRYPTION_KEY_ENV_KEY): encryptionKeyAsBase64]
-        }
+        def allArgs = tasks + getEncryptionOptions(enabled) + additionalArgs
         executer.withEnvironmentVars(envVars)
         configurationCacheRun(*allArgs)
+    }
+
+    private List<String> getEncryptionOptions(boolean enabled = true) {
+        if (!enabled) {
+            return [
+                "-Dorg.gradle.configuration-cache.internal.encryption=false"
+            ]
+        }
+        return [
+            '-s',
+            "-Dorg.gradle.configuration-cache.internal.key-store-path=${keyStorePath}",
+            "-Dorg.gradle.configuration-cache.internal.key-store-password=${keyStorePassword}"
+        ]
     }
 
     private boolean isSubArray(byte[] contents, byte[] toFind) {

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheEncryptionIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheEncryptionIntegrationTest.groovy
@@ -160,9 +160,9 @@ class ConfigurationCacheEncryptionIntegrationTest extends AbstractConfigurationC
         def keyStoreFile = findKeystoreFile()
 
         KeyStore ks = KeyStore.getInstance(KeyStoreKeySource.KEYSTORE_TYPE)
-        keyStoreFile.withInputStream { ks.load(it, new char[0]) }
+        keyStoreFile.withInputStream { ks.load(it, new char[]{'c', 'c'}) }
         ks.deleteEntry("gradle-secret")
-        keyStoreFile.withOutputStream { ks.store(it, new char[0]) }
+        keyStoreFile.withOutputStream { ks.store(it, new char[]{'c', 'c'}) }
 
         when:
         runWithEncryption()

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/EncryptionService.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/EncryptionService.kt
@@ -183,7 +183,8 @@ class KeyStoreKeySource(
 
     private
     fun computeSecretKey(): SecretKey {
-        val ks = KeyStore.getInstance(KeyStore.getDefaultType())
+        // JKS does not support non-PrivateKeys
+        val ks = KeyStore.getInstance(KEYSTORE_TYPE)
         val key: SecretKey
         val alias = keyAlias
         if (keyStorePath.isFile) {
@@ -221,6 +222,7 @@ class KeyStoreKeySource(
     }
 
     companion object {
+        const val KEYSTORE_TYPE = "pkcs12"
         fun fromKeyStore(
             encryptionAlgorithm: String,
             keyStorePath: File,

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/EncryptionService.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/EncryptionService.kt
@@ -107,8 +107,8 @@ class DefaultEncryptionService(
     fun secretKeyFrom(keySource: KeyStoreKeySource, cacheBuilderFactory: GlobalScopedCacheBuilderFactory) =
         cacheBuilderFactory
             .run { keySource.customKeyStoreDir?.let { createCacheBuilderFactory(it) } ?: this }
-            .createCacheBuilder("keystore")
-            .withDisplayName("Gradle keystore")
+            .createCacheBuilder("cc-keystore")
+            .withDisplayName("Gradle Configuration Cache keystore")
             .withInitializer {
                 keySource.createKeyStoreAndGenerateKey(keyStoreFile())
             }
@@ -202,7 +202,7 @@ class KeyStoreKeySource(
 
     val sourceDescription: String
         get() = customKeyStoreDir?.let { "custom Java keystore at $it" }
-            ?: "default Gradle keystore"
+            ?: "default Gradle configuration cache keystore"
 
     fun createKeyStoreAndGenerateKey(keyStoreFile: File): SecretKey {
         logger.debug("No keystore found")

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/EncryptionService.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/EncryptionService.kt
@@ -202,7 +202,7 @@ class KeyStoreKeySource(
 
     fun createKeyStoreAndGenerateKey(keyStoreFile: File): SecretKey {
         logger.debug("No keystore found")
-        keyStore.load(null, null)
+        keyStore.load(null, KEYSTORE_PASSWORD)
         return generateKey(keyStoreFile, keyAlias).also {
             logger.debug("Key added to a new keystore at {}", keyStoreFile)
         }
@@ -211,7 +211,7 @@ class KeyStoreKeySource(
     fun loadSecretKeyFromExistingKeystore(keyStoreFile: File): SecretKey {
         logger.info("Loading keystore from {}", keyStoreFile)
         keyStoreFile.inputStream().use { fis ->
-            keyStore.load(fis, null)
+            keyStore.load(fis, KEYSTORE_PASSWORD)
         }
         val entry = keyStore.getEntry(keyAlias, keyProtection) as KeyStore.SecretKeyEntry?
         if (entry != null) {
@@ -232,7 +232,7 @@ class KeyStoreKeySource(
         val entry = KeyStore.SecretKeyEntry(newKey)
         keyStore.setEntry(alias, entry, keyProtection)
         keyStoreFile.outputStream().use { fos ->
-            keyStore.store(fos, null)
+            keyStore.store(fos, KEYSTORE_PASSWORD)
         }
         return newKey
     }
@@ -240,5 +240,6 @@ class KeyStoreKeySource(
     companion object {
         // JKS does not support non-PrivateKeys
         const val KEYSTORE_TYPE = "pkcs12"
+        val KEYSTORE_PASSWORD = charArrayOf('c', 'c')
     }
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/initialization/ConfigurationCacheStartParameter.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/initialization/ConfigurationCacheStartParameter.kt
@@ -45,7 +45,15 @@ class ConfigurationCacheStartParameter(
 
     val taskExecutionAccessPreStable: Boolean = options.getOption(InternalFlag("org.gradle.configuration-cache.internal.task-execution-access-pre-stable")).get()
 
-    val encryptionRequested: Boolean = startParameter.isConfigurationCacheEncryption
+    val encryptionRequested: Boolean = options.getOption(InternalFlag("org.gradle.configuration-cache.internal.encryption", true)).get()
+
+    val keystorePath: String? = options.getOption(StringInternalOption("org.gradle.configuration-cache.internal.key-store-path", null)).get()
+
+    val keystorePassword: String? = options.getOption(StringInternalOption("org.gradle.configuration-cache.internal.key-store-password", null)).get()
+
+    val keyAlias: String = options.getOption(StringInternalOption("org.gradle.configuration-cache.internal.key-alias", "gradle-secret")).get()
+
+    val keyPassword: String = options.getOption(StringInternalOption("org.gradle.configuration-cache.internal.key-password", "")).get()
 
     val encryptionAlgorithm: String = options.getOption(StringInternalOption("org.gradle.configuration-cache.internal.encryption-alg", SupportedEncryptionAlgorithm.AES_ECB_PADDING.transformation)).get()
 

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/initialization/ConfigurationCacheStartParameter.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/initialization/ConfigurationCacheStartParameter.kt
@@ -23,9 +23,9 @@ import org.gradle.configurationcache.extensions.unsafeLazy
 import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheProblemsOption
 import org.gradle.initialization.layout.BuildLayout
 import org.gradle.internal.Factory
-import org.gradle.internal.buildoption.StringInternalOption
 import org.gradle.internal.buildoption.InternalFlag
 import org.gradle.internal.buildoption.InternalOptions
+import org.gradle.internal.buildoption.StringInternalOption
 import org.gradle.internal.buildtree.BuildModelParameters
 import org.gradle.internal.deprecation.DeprecationLogger
 import org.gradle.internal.service.scopes.Scopes
@@ -41,21 +41,15 @@ class ConfigurationCacheStartParameter(
     options: InternalOptions,
     private val modelParameters: BuildModelParameters
 ) {
-    val loadAfterStore: Boolean = !modelParameters.isRequiresBuildModel && options.getOption(InternalFlag("org.gradle.configuration-cache.internal.load-after-store", true)).get()
+    val loadAfterStore: Boolean = !modelParameters.isRequiresBuildModel && options.getInternalFlag("org.gradle.configuration-cache.internal.load-after-store", true)
 
-    val taskExecutionAccessPreStable: Boolean = options.getOption(InternalFlag("org.gradle.configuration-cache.internal.task-execution-access-pre-stable")).get()
+    val taskExecutionAccessPreStable: Boolean = options.getInternalFlag("org.gradle.configuration-cache.internal.task-execution-access-pre-stable")
 
-    val encryptionRequested: Boolean = options.getOption(InternalFlag("org.gradle.configuration-cache.internal.encryption", true)).get()
+    val encryptionRequested: Boolean = options.getInternalFlag("org.gradle.configuration-cache.internal.encryption", true)
 
-    val keystorePath: String? = options.getOption(StringInternalOption("org.gradle.configuration-cache.internal.key-store-path", null)).get()
+    val keystoreDir: String? = options.getInternalString("org.gradle.configuration-cache.internal.key-store-dir", null)
 
-    val keystorePassword: String? = options.getOption(StringInternalOption("org.gradle.configuration-cache.internal.key-store-password", null)).get()
-
-    val keyAlias: String = options.getOption(StringInternalOption("org.gradle.configuration-cache.internal.key-alias", "gradle-secret")).get()
-
-    val keyPassword: String = options.getOption(StringInternalOption("org.gradle.configuration-cache.internal.key-password", "")).get()
-
-    val encryptionAlgorithm: String = options.getOption(StringInternalOption("org.gradle.configuration-cache.internal.encryption-alg", SupportedEncryptionAlgorithm.AES_ECB_PADDING.transformation)).get()
+    val encryptionAlgorithm: String = options.getInternalString("org.gradle.configuration-cache.internal.encryption-alg", SupportedEncryptionAlgorithm.AES_ECB_PADDING.transformation)
 
     val gradleProperties: Map<String, Any?>
         get() = startParameter.projectProperties
@@ -131,3 +125,13 @@ class ConfigurationCacheStartParameter(
     val isNoBuildScan: Boolean
         get() = startParameter.isNoBuildScan
 }
+
+
+private
+fun InternalOptions.getInternalFlag(systemPropertyName: String, defaultValue: Boolean = false): Boolean =
+    getOption(InternalFlag(systemPropertyName, defaultValue)).get()
+
+
+private
+fun InternalOptions.getInternalString(systemPropertyName: String, defaultValue: String?) =
+    getOption(StringInternalOption(systemPropertyName, defaultValue)).get()

--- a/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
@@ -34,7 +34,6 @@ public class StartParameterInternal extends StartParameter {
     private Option.Value<Boolean> configurationCache = Option.Value.defaultValue(false);
     private Option.Value<Boolean> isolatedProjects = Option.Value.defaultValue(false);
     private ConfigurationCacheProblemsOption.Value configurationCacheProblems = ConfigurationCacheProblemsOption.Value.FAIL;
-    private boolean configurationCacheEncryption = false;
     private boolean configurationCacheDebug;
     private int configurationCacheMaxProblems = 512;
     private boolean configurationCacheRecreateCache;
@@ -206,13 +205,5 @@ public class StartParameterInternal extends StartParameter {
 
     public Duration getContinuousBuildQuietPeriod() {
         return continuousBuildQuietPeriod;
-    }
-
-    public void setConfigurationCacheEncryption(boolean value) {
-        this.configurationCacheEncryption = value;
-    }
-
-    public boolean isConfigurationCacheEncryption() {
-        return configurationCacheEncryption;
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ConfigurationCacheGradleExecuter.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ConfigurationCacheGradleExecuter.groovy
@@ -22,8 +22,6 @@ import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheQu
 import org.gradle.test.fixtures.file.TestDirectoryProvider
 import org.gradle.util.GradleVersion
 
-import static org.gradle.configurationcache.EnvironmentVarKeySource.GRADLE_ENCRYPTION_KEY_ENV_KEY
-
 
 class ConfigurationCacheGradleExecuter extends DaemonGradleExecuter {
 
@@ -55,12 +53,5 @@ class ConfigurationCacheGradleExecuter extends DaemonGradleExecuter {
         } else {
             return args + CONFIGURATION_CACHE_ARGS
         }
-    }
-
-    @Override
-    protected void transformInvocation(GradleInvocation invocation) {
-        // make an encryption key available so encryption can be in place
-        invocation.environmentVars.putIfAbsent(GRADLE_ENCRYPTION_KEY_ENV_KEY, (0..<32).collect {it % 10 }.join())
-        super.transformInvocation(invocation)
     }
 }

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/action/BuildActionSerializer.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/action/BuildActionSerializer.java
@@ -151,7 +151,6 @@ public class BuildActionSerializer {
             encoder.writeBoolean(startParameter.isConfigurationCacheDebug());
             encoder.writeBoolean(startParameter.isConfigurationCacheRecreateCache());
             encoder.writeBoolean(startParameter.isConfigurationCacheQuiet());
-            encoder.writeBoolean(startParameter.isConfigurationCacheEncryption());
             encoder.writeBoolean(startParameter.isConfigureOnDemand());
             encoder.writeBoolean(startParameter.isContinuous());
             encoder.writeLong(startParameter.getContinuousBuildQuietPeriod().toMillis());
@@ -241,7 +240,6 @@ public class BuildActionSerializer {
             startParameter.setConfigurationCacheDebug(decoder.readBoolean());
             startParameter.setConfigurationCacheRecreateCache(decoder.readBoolean());
             startParameter.setConfigurationCacheQuiet(decoder.readBoolean());
-            startParameter.setConfigurationCacheEncryption(decoder.readBoolean());
             startParameter.setConfigureOnDemand(decoder.readBoolean());
             startParameter.setContinuous(decoder.readBoolean());
             startParameter.setContinuousBuildQuietPeriod(Duration.ofMillis(decoder.readLong()));

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/FileLockManager.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/FileLockManager.java
@@ -16,10 +16,13 @@
 package org.gradle.cache;
 
 import org.gradle.api.Action;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 import javax.annotation.Nullable;
 import java.io.File;
 
+@ServiceScope(Scope.Global.class)
 public interface FileLockManager {
     /**
      * Creates a lock for the given file with the given mode. Acquires a lock with the given mode, which is held until the lock is


### PR DESCRIPTION
- Replace env vars with keystore as source of encryption keys.
- Unconditionally encrypt the CC state files

Fixes: https://github.com/gradle/gradle/issues/23866