### PR TITLE
Add warning when a tag/category is both included and excluded

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/TestNGExecutionResult.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/TestNGExecutionResult.groovy
@@ -154,7 +154,7 @@ class TestNgTestClassExecutionResult implements TestClassExecutionResult {
     }
 
     @Override
-    TestClassExecutionResult assertTestsExecuted(String[] ... testNames) {
+    TestClassExecutionResult assertTestsExecuted(TestCase ... testCases) {
         throw new UnsupportedOperationException("Unsupported.  Implement if you need it.")
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/TestNGExecutionResult.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/TestNGExecutionResult.groovy
@@ -153,6 +153,11 @@ class TestNgTestClassExecutionResult implements TestClassExecutionResult {
         this
     }
 
+    @Override
+    TestClassExecutionResult assertTestsExecuted(String[] ... testNames) {
+        throw new UnsupportedOperationException("Unsupported.  Implement if you need it.")
+    }
+
     TestClassExecutionResult assertTestPassed(String name) {
         def testMethodNode = findTestMethod(name)
         assert testMethodNode.@status as String == 'PASS'

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/junitplatform/JUnitPlatformTestRewriter.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/junitplatform/JUnitPlatformTestRewriter.groovy
@@ -18,6 +18,8 @@ package org.gradle.test.fixtures.junitplatform
 
 import groovy.io.FileType
 
+import java.util.regex.Pattern
+
 class JUnitPlatformTestRewriter {
 
     private static final Map REPLACEMENTS = Collections.unmodifiableMap([
@@ -44,15 +46,46 @@ class JUnitPlatformTestRewriter {
         'junit.framework.Assert': 'org.junit.jupiter.api.Assertions',
         'Assert.': 'Assertions.',
         'Assume.': 'Assumptions.',
+        'org.junit.experimental.categories.Category': 'org.junit.jupiter.api.Tag'
+    ])
+
+    private static final List<Closure> TRANSFORMS = Collections.unmodifiableList([
+        { String string ->
+            // This transform translates '@Category(...)' lines into one or more '@Tag()' lines using the name of the category class as the tag
+            // For example:
+            // @Category(org.gradle.Foo.class) -> @Tag("org.gradle.Foo")
+            // @Category({org.gradle.Foo.class, org.gradle.Bar.class}) -> @Tag("org.gradle.Foo")\n@Tag("org.gradle.Bar")
+
+            // First, capture the list of categories inside the category tag, which may be a single category
+            // or a list of categories inside '{...}'
+            StringBuilder result = new StringBuilder()
+            Pattern categoryTagPattern = Pattern.compile('@Category\\(\\{?([^}]*)}?\\)\n')
+            def matcher = categoryTagPattern.matcher(string)
+
+            // Then, replace each category class with an @Tag() annotation using the class name as the tag
+            int previous = 0
+            while (matcher.find()) {
+                def categories = matcher.group(1)
+                // prepend everything from the end of the previous @Category match until the beginning of the current @Category match
+                result.append(string, previous, matcher.start())
+                // append the transformed @Tag annotations
+                result.append(categories.replaceAll(',?\\s*([^,\\s]+)\\.class', '@Tag("$1")\n'))
+                previous = matcher.end()
+            }
+            // append everything after the last @Category match
+            result.append(string, previous, string.length())
+            return result.toString()
+        }
     ])
 
     static rewriteWithJupiter(File projectDir, String dependencyVersion) {
+        replaceCategoriesWithTagsInBuildFile(projectDir)
         rewriteBuildFileWithJupiter(projectDir, dependencyVersion)
         rewriteJavaFilesWithJupiterAnno(projectDir)
         rewriteJavaModuleFileWithJupiterRequires(projectDir)
     }
 
-    static replaceCategoriesWithTags(File projectDir) {
+    static replaceCategoriesWithTagsInBuildFile(File projectDir) {
         // http://junit.org/junit5/docs/current/user-guide/#migrating-from-junit4-categories-support
         File buildFile = new File(projectDir, 'build.gradle')
         if (buildFile.exists()) {
@@ -64,6 +97,7 @@ class JUnitPlatformTestRewriter {
     }
 
     static rewriteWithVintage(File projectDir, String dependencyVersion) {
+        replaceCategoriesWithTagsInBuildFile(projectDir)
         rewriteBuildFileWithVintage(projectDir, dependencyVersion)
     }
 
@@ -80,6 +114,9 @@ class JUnitPlatformTestRewriter {
             String text = it.text
             REPLACEMENTS.each { key, value ->
                 text = text.replace(key, value)
+            }
+            TRANSFORMS.each { transform ->
+                text = transform(text)
             }
             it.text = text
         }

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/test/fixtures/junitplatform/JUnitPlatformTestRewriterTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/test/fixtures/junitplatform/JUnitPlatformTestRewriterTest.groovy
@@ -94,6 +94,17 @@ tasks.named("test") {
         OLD3    | NEW3
     }
 
+    def 'java source file with categories is rewritten to tags'() {
+        given:
+        temporaryFolder.testDirectory.file('src/test/java/Test.java') << TEST_WITH_CATEGORIES
+
+        when:
+        JUnitPlatformTestRewriter.rewriteJavaFilesWithJupiterAnno(temporaryFolder.testDirectory)
+
+        then:
+        temporaryFolder.testDirectory.file('src/test/java/Test.java').text == TEST_WITH_TAGS
+    }
+
     static final String OLD1 = '''
 package org.gradle;
 
@@ -195,6 +206,44 @@ public class Junit4Test {
 
     @Test
     @Disabled
+    public void broken() {
+        throw new RuntimeException();
+    }
+}
+'''
+
+    static final String TEST_WITH_CATEGORIES = '''
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category({org.gradle.Category1.class, org.gradle.Category2.class})
+public class Junit4Test {
+    @Test
+    public void ok() {
+    }
+
+    @Test
+    @Category(org.gradle.Category3.class)
+    public void broken() {
+        throw new RuntimeException();
+    }
+}
+'''
+    static final String TEST_WITH_TAGS = '''
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
+
+@Tag("org.gradle.Category1")
+@Tag("org.gradle.Category2")
+public class Junit4Test {
+    @Test
+    public void ok() {
+    }
+
+    @Test
+    @Tag("org.gradle.Category3")
     public void broken() {
         throw new RuntimeException();
     }

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/DefaultTestExecutionResult.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/DefaultTestExecutionResult.groovy
@@ -114,6 +114,10 @@ class DefaultTestExecutionResult implements TestExecutionResult {
         testNames.collect { removeParentheses(it) } as String[]
     }
 
+    static String[][] removeAllParentheses(String[]... testNames) {
+        testNames.collect { [removeParentheses(it[0]), it[1]] } as String[][]
+    }
+
     private class DefaultTestClassExecutionResult implements TestClassExecutionResult {
         List<TestClassExecutionResult> testClassResults
 
@@ -122,6 +126,11 @@ class DefaultTestExecutionResult implements TestExecutionResult {
         }
 
         TestClassExecutionResult assertTestsExecuted(String... testNames) {
+            testClassResults*.assertTestsExecuted(removeAllParentheses(testNames))
+            this
+        }
+
+        TestClassExecutionResult assertTestsExecuted(String[]... testNames) {
             testClassResults*.assertTestsExecuted(removeAllParentheses(testNames))
             this
         }

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/DefaultTestExecutionResult.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/DefaultTestExecutionResult.groovy
@@ -15,6 +15,9 @@
  */
 package org.gradle.integtests.fixtures
 
+import groovy.transform.EqualsAndHashCode
+import groovy.transform.ToString
+import org.gradle.integtests.fixtures.TestClassExecutionResult.TestCase
 import org.gradle.test.fixtures.file.TestFile
 import org.hamcrest.Matcher
 
@@ -118,6 +121,40 @@ class DefaultTestExecutionResult implements TestExecutionResult {
         testNames.collect { [removeParentheses(it[0]), it[1]] } as String[][]
     }
 
+    static TestCase testCase(String name) {
+        return new DefaultTestCase(name)
+    }
+
+    static TestCase testCase(String name, String displayName) {
+        return new DefaultTestCase(name, displayName)
+    }
+
+    static TestCase testCase(String name, String displayName, List<String> messages) {
+        return new DefaultTestCase(name, displayName, messages)
+    }
+
+    @ToString
+    @EqualsAndHashCode(includes = ['name', 'displayName'])
+    private static class DefaultTestCase implements TestCase {
+        String name
+        String displayName
+        List<String> messages
+
+        DefaultTestCase(String name) {
+            this(name, name)
+        }
+
+        DefaultTestCase(String name, String displayName) {
+            this(name, displayName, [])
+        }
+
+        DefaultTestCase(String name, String displayName, List<String> messages) {
+            this.name = removeParentheses(name)
+            this.displayName = removeParentheses(displayName)
+            this.messages = messages
+        }
+    }
+
     private class DefaultTestClassExecutionResult implements TestClassExecutionResult {
         List<TestClassExecutionResult> testClassResults
 
@@ -130,8 +167,9 @@ class DefaultTestExecutionResult implements TestExecutionResult {
             this
         }
 
-        TestClassExecutionResult assertTestsExecuted(String[]... testNames) {
-            testClassResults*.assertTestsExecuted(removeAllParentheses(testNames))
+        @Override
+        TestClassExecutionResult assertTestsExecuted(TestCase... testCases) {
+            testClassResults*.assertTestsExecuted(testCases)
             this
         }
 

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/HtmlTestExecutionResult.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/HtmlTestExecutionResult.groovy
@@ -162,6 +162,14 @@ class HtmlTestExecutionResult implements TestExecutionResult {
             return this
         }
 
+        @Override
+        TestClassExecutionResult assertTestsExecuted(String[]... testNames) {
+            def executedAndNotSkipped = testsExecuted - testsSkipped
+            assert executedAndNotSkipped.containsAll(testNames.collect { new TestCase(it[0], it[1]) })
+            assert executedAndNotSkipped.size() == testNames.size()
+            return this
+        }
+
         TestClassExecutionResult assertTestCount(int tests, int failures, int errors) {
             assert tests == testsExecuted.size()
             assert failures == testsFailures.size()

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/HtmlTestExecutionResult.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/HtmlTestExecutionResult.groovy
@@ -15,15 +15,13 @@
  */
 package org.gradle.integtests.fixtures
 
-import groovy.transform.EqualsAndHashCode
-import groovy.transform.ToString
 import org.gradle.internal.FileUtils
 import org.gradle.util.internal.TextUtil
 import org.hamcrest.Matcher
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 
-import static org.gradle.integtests.fixtures.DefaultTestExecutionResult.removeParentheses
+import static org.gradle.integtests.fixtures.DefaultTestExecutionResult.testCase
 import static org.hamcrest.CoreMatchers.hasItems
 import static org.hamcrest.CoreMatchers.not
 import static org.hamcrest.MatcherAssert.assertThat
@@ -91,28 +89,6 @@ class HtmlTestExecutionResult implements TestExecutionResult {
         return getExecutedTestClasses().size()
     }
 
-    @ToString
-    @EqualsAndHashCode(includes = ['name', 'displayName'])
-    private static class TestCase {
-        String name
-        String displayName
-        List<String> messages
-
-        TestCase(String name) {
-            this(name, name)
-        }
-
-        TestCase(String name, String displayName) {
-            this(name, displayName, [])
-        }
-
-        TestCase(String name, String displayName, List<String> messages) {
-            this.name = removeParentheses(name)
-            this.displayName = removeParentheses(displayName)
-            this.messages = messages
-        }
-    }
-
     private static class HtmlTestClassExecutionResult implements TestClassExecutionResult {
         private String classDisplayName
         private File htmlFile
@@ -133,7 +109,7 @@ class HtmlTestExecutionResult implements TestExecutionResult {
                 def testDisplayName = it.textNodes().first().wholeText.trim()
                 def testName = hasMethodNameColumn() ? it.nextElementSibling().text() : testDisplayName
                 def failureMessage = getFailureMessages(testName)
-                def testCase = new TestCase(testName, testDisplayName, failureMessage)
+                def testCase = testCase(testName, testDisplayName, failureMessage)
                 testsExecuted << testCase
                 target << testCase
             }
@@ -156,17 +132,14 @@ class HtmlTestExecutionResult implements TestExecutionResult {
         }
 
         TestClassExecutionResult assertTestsExecuted(String... testNames) {
-            def executedAndNotSkipped = testsExecuted - testsSkipped
-            assert executedAndNotSkipped.containsAll(testNames.collect { new TestCase(it) })
-            assert executedAndNotSkipped.size() == testNames.size()
-            return this
+            return assertTestsExecuted(testNames.collect { testCase(it) } as TestCase[])
         }
 
         @Override
-        TestClassExecutionResult assertTestsExecuted(String[]... testNames) {
+        TestClassExecutionResult assertTestsExecuted(TestCase... testCases) {
             def executedAndNotSkipped = testsExecuted - testsSkipped
-            assert executedAndNotSkipped.containsAll(testNames.collect { new TestCase(it[0], it[1]) })
-            assert executedAndNotSkipped.size() == testNames.size()
+            assert executedAndNotSkipped.containsAll(testCases)
+            assert executedAndNotSkipped.size() == testCases.size()
             return this
         }
 
@@ -181,13 +154,13 @@ class HtmlTestExecutionResult implements TestExecutionResult {
         }
 
         TestClassExecutionResult assertTestsSkipped(String... testNames) {
-            assert testsSkipped == testNames.collect { new TestCase(it) } as Set
+            assert testsSkipped == testNames.collect { testCase(it) } as Set
             return this
         }
 
         @Override
         TestClassExecutionResult assertTestPassed(String name, String displayName) {
-            assert testsSucceeded.contains(new TestCase(name, displayName))
+            assert testsSucceeded.contains(testCase(name, displayName))
             return this
         }
 
@@ -196,7 +169,7 @@ class HtmlTestExecutionResult implements TestExecutionResult {
         }
 
         TestClassExecutionResult assertTestPassed(String name) {
-            assert testsSucceeded.contains(new TestCase(name))
+            assert testsSucceeded.contains(testCase(name))
             return this
         }
 
@@ -235,7 +208,7 @@ class HtmlTestExecutionResult implements TestExecutionResult {
 
         @Override
         TestClassExecutionResult assertTestSkipped(String name, String displayName) {
-            assert testsSkipped.contains(new TestCase(name, displayName))
+            assert testsSkipped.contains(testCase(name, displayName))
             return this
         }
 
@@ -258,7 +231,7 @@ class HtmlTestExecutionResult implements TestExecutionResult {
         }
 
         TestClassExecutionResult assertTestSkipped(String name) {
-            assert testsSkipped.contains(new TestCase(name))
+            assert testsSkipped.contains(testCase(name))
             return this
         }
 

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/JUnitTestClassExecutionResult.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/JUnitTestClassExecutionResult.groovy
@@ -53,14 +53,14 @@ class JUnitTestClassExecutionResult implements TestClassExecutionResult {
     }
 
     /**
-     * Note that the JUnit XML schema currently does not support display names, so this extra data is effectively ignored for
+     * Note that the JUnit XML schema currently does not support both name and display name, so this extra data is effectively ignored for
      * XML test reports.  See https://github.com/junit-team/junit5/issues/373 for further information.
      *
      * This method exists for compatibility purposes, but is equivalent to {@link #assertTestsExecuted(java.lang.String[])}.
      */
     @Override
-    TestClassExecutionResult assertTestsExecuted(String[] ... testNames) {
-        return assertTestsExecuted(testNames.collect { it[1] } as String[])
+    TestClassExecutionResult assertTestsExecuted(TestCase... testCases) {
+        return assertTestsExecuted(testCases.collect { it.displayName } as String[])
     }
 
     TestClassExecutionResult assertTestCount(int tests, int failures, int errors) {

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/JUnitTestClassExecutionResult.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/JUnitTestClassExecutionResult.groovy
@@ -52,6 +52,17 @@ class JUnitTestClassExecutionResult implements TestClassExecutionResult {
         this
     }
 
+    /**
+     * Note that the JUnit XML schema currently does not support display names, so this extra data is effectively ignored for
+     * XML test reports.  See https://github.com/junit-team/junit5/issues/373 for further information.
+     *
+     * This method exists for compatibility purposes, but is equivalent to {@link #assertTestsExecuted(java.lang.String[])}.
+     */
+    @Override
+    TestClassExecutionResult assertTestsExecuted(String[] ... testNames) {
+        return assertTestsExecuted(testNames.collect { it[1] } as String[])
+    }
+
     TestClassExecutionResult assertTestCount(int tests, int failures, int errors) {
         assert testClassNode.@tests == tests
         assert testClassNode.@failures == failures

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/TestClassExecutionResult.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/TestClassExecutionResult.java
@@ -24,6 +24,14 @@ public interface TestClassExecutionResult {
      */
     TestClassExecutionResult assertTestsExecuted(String... testNames);
 
+    /**
+     * Asserts that the given tests (and only the given tests) were executed for the given test class.
+     *
+     * Tests are provided as a two element string array of [name, displayName].  This supports JUnit5 parameterized tests
+     * where the test name and display name may not match.
+     */
+    TestClassExecutionResult assertTestsExecuted(String[]... testNames);
+
     TestClassExecutionResult assertTestCount(int tests, int failures, int errors);
 
     int getTestCount();

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/TestClassExecutionResult.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/integtests/fixtures/TestClassExecutionResult.java
@@ -18,6 +18,8 @@ package org.gradle.integtests.fixtures;
 
 import org.hamcrest.Matcher;
 
+import java.util.List;
+
 public interface TestClassExecutionResult {
     /**
      * Asserts that the given tests (and only the given tests) were executed for the given test class.
@@ -27,10 +29,9 @@ public interface TestClassExecutionResult {
     /**
      * Asserts that the given tests (and only the given tests) were executed for the given test class.
      *
-     * Tests are provided as a two element string array of [name, displayName].  This supports JUnit5 parameterized tests
-     * where the test name and display name may not match.
+     * This supports JUnit5 parameterized tests where the test name and display name may not match.
      */
-    TestClassExecutionResult assertTestsExecuted(String[]... testNames);
+    TestClassExecutionResult assertTestsExecuted(TestCase... testCases);
 
     TestClassExecutionResult assertTestCount(int tests, int failures, int errors);
 
@@ -89,4 +90,10 @@ public interface TestClassExecutionResult {
     TestClassExecutionResult assertExecutionFailedWithCause(Matcher<? super String> causeMatcher);
 
     TestClassExecutionResult assertDisplayName(String classDisplayName);
+
+    interface TestCase {
+        String getName();
+        String getDisplayName();
+        List<String> getMessages();
+    }
 }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/JUnitMultiVersionIntegrationSpec.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/JUnitMultiVersionIntegrationSpec.groovy
@@ -23,7 +23,6 @@ import org.junit.Assume
 
 import java.util.regex.Pattern
 
-import static org.gradle.test.fixtures.junitplatform.JUnitPlatformTestRewriter.replaceCategoriesWithTags
 import static org.gradle.test.fixtures.junitplatform.JUnitPlatformTestRewriter.rewriteWithJupiter
 import static org.gradle.test.fixtures.junitplatform.JUnitPlatformTestRewriter.rewriteWithVintage
 
@@ -74,7 +73,6 @@ abstract class JUnitMultiVersionIntegrationSpec extends MultiVersionIntegrationS
         if (isJupiter()) {
             rewriteWithJupiter(executer.workingDir, dependencyVersion)
         } else if (isVintage()) {
-            replaceCategoriesWithTags(executer.workingDir)
             rewriteWithVintage(executer.workingDir, dependencyVersion)
         }
     }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec.groovy
@@ -104,9 +104,9 @@ class JUnitCategoriesCoverageIntegrationSpec extends JUnitMultiVersionIntegratio
         result.assertTestClassesExecuted('org.gradle.SomeLocaleTests')
         result.testClass("org.gradle.SomeLocaleTests").assertTestCount(3, 0, 0)
         result.testClass("org.gradle.SomeLocaleTests").assertTestsExecuted(
-            ['ok1(Locale)[1]', 'French'] as String[],
-            ['ok1(Locale)[2]', 'German'] as String[],
-            ['ok1(Locale)[3]', 'English'] as String[]
+            result.testCase('ok1(Locale)[1]', 'French'),
+            result.testCase('ok1(Locale)[2]', 'German'),
+            result.testCase('ok1(Locale)[3]', 'English')
         )
     }
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec.groovy
@@ -20,12 +20,13 @@ import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import org.gradle.integtests.fixtures.TargetCoverage
 import org.gradle.integtests.fixtures.TestResources
 import org.gradle.testing.fixture.JUnitMultiVersionIntegrationSpec
+import org.junit.Assume
 import org.junit.Rule
 
 import static org.gradle.testing.fixture.JUnitCoverage.CATEGORIES
-import static org.gradle.testing.fixture.JUnitCoverage.JUNIT_VINTAGE
+import static org.gradle.testing.fixture.JUnitCoverage.JUNIT_VINTAGE_JUPITER
 
-@TargetCoverage({ CATEGORIES + JUNIT_VINTAGE })
+@TargetCoverage({ CATEGORIES + JUNIT_VINTAGE_JUPITER })
 class JUnitCategoriesCoverageIntegrationSpec extends JUnitMultiVersionIntegrationSpec {
 
     @Rule TestResources resources = new TestResources(temporaryFolder)
@@ -41,16 +42,27 @@ class JUnitCategoriesCoverageIntegrationSpec extends JUnitMultiVersionIntegratio
 
         then:
         DefaultTestExecutionResult result = new DefaultTestExecutionResult(testDirectory)
-        result.assertTestClassesExecuted('org.gradle.CatATests', 'org.gradle.CatBTests', 'org.gradle.CatADTests', 'org.gradle.MixedTests')
-        result.testClass("org.gradle.CatATests").assertTestCount(4, 0, 0)
-        result.testClass("org.gradle.CatATests").assertTestsExecuted('catAOk1', 'catAOk2', 'catAOk3', 'catAOk4')
-        result.testClass("org.gradle.CatBTests").assertTestCount(4, 0, 0)
-        result.testClass("org.gradle.CatBTests").assertTestsExecuted('catBOk1', 'catBOk2', 'catBOk3', 'catBOk4')
-        result.testClass("org.gradle.CatADTests").assertTestCount(2, 0, 0)
-        result.testClass("org.gradle.CatADTests").assertTestsExecuted('catAOk1', 'catAOk2')
-        result.testClass("org.gradle.MixedTests").assertTestCount(3, 0, 0)
-        result.testClass("org.gradle.MixedTests").assertTestsExecuted('catAOk1', 'catBOk2')
-        result.testClass("org.gradle.MixedTests").assertTestsSkipped('someIgnoredTest')
+        if (isJupiter()) {
+            result.assertTestClassesExecuted('org.gradle.CatATests', 'org.gradle.CatADTests', 'org.gradle.MixedTests')
+            result.testClass("org.gradle.CatATests").assertTestCount(4, 0, 0)
+            result.testClass("org.gradle.CatATests").assertTestsExecuted('catAOk1', 'catAOk2', 'catAOk3', 'catAOk4')
+            result.testClass("org.gradle.CatADTests").assertTestCount(3, 0, 0)
+            result.testClass("org.gradle.CatADTests").assertTestsExecuted('catAOk1', 'catAOk2', 'catDOk4')
+            result.testClass("org.gradle.MixedTests").assertTestCount(2, 0, 0)
+            result.testClass("org.gradle.MixedTests").assertTestsExecuted('catAOk1')
+            result.testClass("org.gradle.MixedTests").assertTestsSkipped('someIgnoredTest')
+        } else {
+            result.assertTestClassesExecuted('org.gradle.CatATests', 'org.gradle.CatBTests', 'org.gradle.CatADTests', 'org.gradle.MixedTests')
+            result.testClass("org.gradle.CatATests").assertTestCount(4, 0, 0)
+            result.testClass("org.gradle.CatATests").assertTestsExecuted('catAOk1', 'catAOk2', 'catAOk3', 'catAOk4')
+            result.testClass("org.gradle.CatBTests").assertTestCount(4, 0, 0)
+            result.testClass("org.gradle.CatBTests").assertTestsExecuted('catBOk1', 'catBOk2', 'catBOk3', 'catBOk4')
+            result.testClass("org.gradle.CatADTests").assertTestCount(2, 0, 0)
+            result.testClass("org.gradle.CatADTests").assertTestsExecuted('catAOk1', 'catAOk2')
+            result.testClass("org.gradle.MixedTests").assertTestCount(3, 0, 0)
+            result.testClass("org.gradle.MixedTests").assertTestsExecuted('catAOk1', 'catBOk2')
+            result.testClass("org.gradle.MixedTests").assertTestsSkipped('someIgnoredTest')
+        }
     }
 
     def canSpecifyExcludesOnly() {
@@ -69,6 +81,8 @@ class JUnitCategoriesCoverageIntegrationSpec extends JUnitMultiVersionIntegratio
     }
 
     def canCombineCategoriesWithCustomRunner() {
+        Assume.assumeFalse(isJupiter())
+
         when:
         run('test')
 
@@ -79,7 +93,26 @@ class JUnitCategoriesCoverageIntegrationSpec extends JUnitMultiVersionIntegratio
         result.testClass("org.gradle.SomeLocaleTests").assertTestsExecuted('ok1 [de]', 'ok1 [en]', 'ok1 [fr]')
     }
 
+    def canCombineTagsWithCustomExtension() {
+        Assume.assumeTrue(isJupiter())
+
+        when:
+        run('test')
+
+        then:
+        DefaultTestExecutionResult result = new DefaultTestExecutionResult(testDirectory)
+        result.assertTestClassesExecuted('org.gradle.SomeLocaleTests')
+        result.testClass("org.gradle.SomeLocaleTests").assertTestCount(3, 0, 0)
+        result.testClass("org.gradle.SomeLocaleTests").assertTestsExecuted(
+            ['ok1(Locale)[1]', 'French'] as String[],
+            ['ok1(Locale)[2]', 'German'] as String[],
+            ['ok1(Locale)[3]', 'English'] as String[]
+        )
+    }
+
     def canRunParameterizedTestsWithCategories() {
+        Assume.assumeFalse(isJupiter())
+
         when:
         run('test')
 
@@ -92,6 +125,85 @@ class JUnitCategoriesCoverageIntegrationSpec extends JUnitMultiVersionIntegratio
         result.assertTestClassesExecuted(expectedTestClasses as String[])
         expectedTestClasses.each {
             result.testClass(it).assertTestCount(1, 0, 0)
+        }
+    }
+
+    def canRunParameterizedTestsWithTags() {
+        Assume.assumeTrue(isJupiter())
+
+        when:
+        run('test')
+
+        then:
+        def expectedTestClasses = ['org.gradle.NestedTestsWithTags$TagOnMethodNoParam', 'org.gradle.NestedTestsWithTags$TagOnMethod', 'org.gradle.NestedTestsWithTags$TagOnClass']
+        DefaultTestExecutionResult result = new DefaultTestExecutionResult(testDirectory)
+        result.assertTestClassesExecuted(expectedTestClasses as String[])
+        expectedTestClasses.each {
+            result.testClass(it).assertTestCount(1, 0, 0)
+        }
+    }
+
+    def warningWhenSpecifyingConflictingIncludeAndExcludeCategory() {
+        when:
+        run('test')
+
+        then:
+        assertOutputContainsCategoryOrTagWarning('org.gradle.CategoryC')
+
+        and:
+        DefaultTestExecutionResult result = new DefaultTestExecutionResult(testDirectory)
+        if (isJupiter()) {
+            result.assertTestClassesExecuted('org.gradle.CatATests', 'org.gradle.CatADTests', 'org.gradle.MixedTests')
+            result.testClass("org.gradle.CatATests").assertTestCount(4, 0, 0)
+            result.testClass("org.gradle.CatATests").assertTestsExecuted('catAOk1', 'catAOk2', 'catAOk3', 'catAOk4')
+            result.testClass("org.gradle.CatADTests").assertTestCount(3, 0, 0)
+            result.testClass("org.gradle.CatADTests").assertTestsExecuted('catAOk1', 'catAOk2', 'catDOk4')
+            result.testClass("org.gradle.MixedTests").assertTestCount(2, 0, 0)
+            result.testClass("org.gradle.MixedTests").assertTestsExecuted('catAOk1')
+            result.testClass("org.gradle.MixedTests").assertTestsSkipped('someIgnoredTest')
+        } else {
+            result.assertTestClassesExecuted('org.gradle.CatATests', 'org.gradle.CatBTests', 'org.gradle.CatADTests', 'org.gradle.MixedTests')
+            result.testClass("org.gradle.CatATests").assertTestCount(4, 0, 0)
+            result.testClass("org.gradle.CatATests").assertTestsExecuted('catAOk1', 'catAOk2', 'catAOk3', 'catAOk4')
+            result.testClass("org.gradle.CatBTests").assertTestCount(4, 0, 0)
+            result.testClass("org.gradle.CatBTests").assertTestsExecuted('catBOk1', 'catBOk2', 'catBOk3', 'catBOk4')
+            result.testClass("org.gradle.CatADTests").assertTestCount(2, 0, 0)
+            result.testClass("org.gradle.CatADTests").assertTestsExecuted('catAOk1', 'catAOk2')
+            result.testClass("org.gradle.MixedTests").assertTestCount(3, 0, 0)
+            result.testClass("org.gradle.MixedTests").assertTestsExecuted('catAOk1', 'catBOk2')
+            result.testClass("org.gradle.MixedTests").assertTestsSkipped('someIgnoredTest')
+        }
+
+    }
+
+    def warningWhenSpecifyingMultipleConflictingIncludeAndExcludeCategories() {
+        when:
+        run('test')
+
+        then:
+        assertOutputContainsCategoryOrTagWarning('org.gradle.CategoryA', 'org.gradle.CategoryC')
+
+        and:
+        DefaultTestExecutionResult result = new DefaultTestExecutionResult(testDirectory)
+        result.assertNoTestClassesExecuted()
+    }
+
+    private void assertOutputContainsCategoryOrTagWarning(String... categories) {
+        String singular
+        String plural
+        if (isJUnitPlatform()) {
+            singular = "tag"
+            plural = "tags"
+        } else {
+            singular = "category"
+            plural = "categories"
+        }
+
+        if (categories.size() == 1) {
+            outputContains("The ${singular} '${categories[0]}' is both included and excluded.")
+        } else {
+            String allCategories = categories.collect {"'${it}'" }.join(", ")
+            outputContains("The ${plural} ${allCategories} are both included and excluded.")
         }
     }
 }

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/canCombineTagsWithCustomExtension/build.gradle
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/canCombineTagsWithCustomExtension/build.gradle
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+apply plugin: "java"
+
+repositories {
+    mavenCentral()
+}
+
+test {
+    useJUnitPlatform {
+        excludeTags 'org.gradle.CategoryA'
+    }
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/canCombineTagsWithCustomExtension/src/test/java/org/gradle/Locales.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/canCombineTagsWithCustomExtension/src/test/java/org/gradle/Locales.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle;
+
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Stream;
+
+public class Locales implements TestTemplateInvocationContextProvider {
+    @Override
+    public boolean supportsTestTemplate(ExtensionContext context) {
+        return true;
+    }
+
+    @Override
+    public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(
+        ExtensionContext context) {
+
+        return Stream.of(invocationContext(Locale.FRENCH), invocationContext(Locale.GERMAN), invocationContext(Locale.ENGLISH));
+    }
+
+    private TestTemplateInvocationContext invocationContext(Locale locale) {
+        return new TestTemplateInvocationContext() {
+            @Override
+            public String getDisplayName(int invocationIndex) {
+                return locale.getDisplayName();
+            }
+
+            @Override
+            public List<Extension> getAdditionalExtensions() {
+                return Collections.singletonList(new ParameterResolver() {
+                    @Override
+                    public boolean supportsParameter(ParameterContext parameterContext,
+                                                     ExtensionContext extensionContext) {
+                        return parameterContext.getParameter().getType().equals(Locale.class);
+                    }
+
+                    @Override
+                    public Object resolveParameter(ParameterContext parameterContext,
+                                                   ExtensionContext extensionContext) {
+                        return locale;
+                    }
+                });
+            }
+        };
+    }
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/canCombineTagsWithCustomExtension/src/test/java/org/gradle/SomeLocaleTests.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/canCombineTagsWithCustomExtension/src/test/java/org/gradle/SomeLocaleTests.java
@@ -1,0 +1,21 @@
+package org.gradle;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Locale;
+
+@ExtendWith(org.gradle.Locales.class)
+public class SomeLocaleTests {
+    @TestTemplate
+    public void ok1(Locale locale) {
+        System.out.println("Locale in use: " + locale);
+    }
+
+    @TestTemplate
+    @Tag("org.gradle.CategoryA")
+    public void ok2(Locale locale) {
+        System.out.println("Locale in use: " + locale);
+    }
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/canCombineTagsWithCustomExtension/src/test/java/org/gradle/SomeMoreLocalTests.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/canCombineTagsWithCustomExtension/src/test/java/org/gradle/SomeMoreLocalTests.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Locale;
+
+@ExtendWith(org.gradle.Locales.class)
+@Tag("org.gradle.CategoryA")
+public class SomeMoreLocalTests {
+    @TestTemplate
+    public void someMoreTest1(Locale locale) {
+        System.out.println("Locale in use: " + locale);
+    }
+
+    @TestTemplate
+    public void someMoreTest2(Locale locale) {
+        System.out.println("Locale in use: " + locale);
+    }
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/canRunParameterizedTestsWithTags/build.gradle
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/canRunParameterizedTestsWithTags/build.gradle
@@ -1,0 +1,14 @@
+apply plugin: "java"
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter-params")
+}
+test {
+    useJUnitPlatform {
+        includeTags 'org.gradle.SomeCategory'
+    }
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/canRunParameterizedTestsWithTags/src/test/java/org/gradle/NestedTestsWithTags.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/canRunParameterizedTestsWithTags/src/test/java/org/gradle/NestedTestsWithTags.java
@@ -1,0 +1,53 @@
+package org.gradle;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class NestedTestsWithTags {
+
+    @Tag("org.gradle.SomeCategory")
+    public static class TagOnClass {
+        @ParameterizedTest
+        @ValueSource(strings = {"tag on class"})
+        public void run(String param) {
+            System.err.println("executed " + param);
+        }
+    }
+
+    public static class TagOnMethod {
+        @ParameterizedTest
+        @ValueSource(strings = {"tag on method"})
+        @Tag("org.gradle.SomeCategory")
+        public void run(String param) {
+            System.err.println("executed " + param);
+        }
+
+        @Test
+        public void filteredOut() {
+            throw new AssertionError("should be filtered out");
+        }
+    }
+
+    public static class TagOnMethodNoParam {
+        @Test
+        @Tag("org.gradle.SomeCategory")
+        public void run() {
+            System.err.println("executed tag on method (no param)");
+        }
+
+        @Test
+        public void filteredOut() {
+            throw new AssertionError("should be filtered out");
+        }
+    }
+
+    public static class Untagged {
+        @ParameterizedTest
+        @ValueSource(strings = {"untagged"})
+        public void run(String param) {
+            System.err.println("executed " + param);
+        }
+    }
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingConflictingIncludeAndExcludeCategory/build.gradle
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingConflictingIncludeAndExcludeCategory/build.gradle
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+apply plugin: "java"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType(Test).configureEach {
+    useJUnit {
+        includeCategories 'org.gradle.CategoryC'
+    }
+}
+
+test {
+    useJUnit {
+        includeCategories 'org.gradle.CategoryA'
+        excludeCategories 'org.gradle.CategoryC'
+    }
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingConflictingIncludeAndExcludeCategory/src/test/java/org/gradle/CatACTests.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingConflictingIncludeAndExcludeCategory/src/test/java/org/gradle/CatACTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category({org.gradle.CategoryA.class, org.gradle.CategoryC.class})
+public class CatACTests {
+
+    @Test
+    public void catABOk1() {
+    }
+
+    @Test
+    public void catABOk2() {
+    }
+
+    @Test
+    public void catABOk3() {
+    }
+
+    @Test
+    public void catABOk4() {
+    }
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingConflictingIncludeAndExcludeCategory/src/test/java/org/gradle/CatADTests.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingConflictingIncludeAndExcludeCategory/src/test/java/org/gradle/CatADTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+
+@Category(org.gradle.CategoryA.class)
+public class CatADTests {
+
+    @Test
+    public void catAOk1() {
+    }
+
+    @Test
+    public void catAOk2() {
+    }
+
+    @Test
+    @Category(org.gradle.CategoryC.class)
+    public void catCOk3() {
+    }
+
+    @Test
+    @Category(org.gradle.CategoryD.class)
+    public void catDOk4() {
+    }
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingConflictingIncludeAndExcludeCategory/src/test/java/org/gradle/CatATests.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingConflictingIncludeAndExcludeCategory/src/test/java/org/gradle/CatATests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+
+@Category(org.gradle.CategoryA.class)
+public class CatATests {
+
+    @Test
+    public void catAOk1() {
+    }
+
+    @Test
+    public void catAOk2() {
+    }
+
+    @Test
+    public void catAOk3() {
+    }
+
+    @Test
+    public void catAOk4() {
+    }
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingConflictingIncludeAndExcludeCategory/src/test/java/org/gradle/CatBTests.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingConflictingIncludeAndExcludeCategory/src/test/java/org/gradle/CatBTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(org.gradle.CategoryB.class)
+public class CatBTests {
+
+    @Test
+    public void catBOk1() {
+    }
+
+    @Test
+    public void catBOk2() {
+    }
+
+    @Test
+    public void catBOk3() {
+    }
+
+    @Test
+    public void catBOk4() {
+    }
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingConflictingIncludeAndExcludeCategory/src/test/java/org/gradle/CatCBTests.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingConflictingIncludeAndExcludeCategory/src/test/java/org/gradle/CatCBTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+
+@Category(org.gradle.CategoryC.class)
+public class CatCBTests {
+
+    @Test
+    public void catCOk1() {
+    }
+
+    @Test
+    public void catCOk2() {
+    }
+
+    @Test
+    @Category(org.gradle.CategoryA.class)
+    public void catAOk3() {
+    }
+
+    @Test
+    @Category(org.gradle.CategoryB.class)
+    public void catBOk4() {
+    }
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingConflictingIncludeAndExcludeCategory/src/test/java/org/gradle/CatCTests.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingConflictingIncludeAndExcludeCategory/src/test/java/org/gradle/CatCTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(CategoryC.class)
+public class CatCTests {
+
+    @Test
+    public void catCOk1() {
+    }
+
+    @Test
+    public void catCOk2() {
+    }
+
+    @Test
+    public void catCOk3() {
+    }
+
+    @Test
+    public void catCOk4() {
+    }
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingConflictingIncludeAndExcludeCategory/src/test/java/org/gradle/CatDTests.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingConflictingIncludeAndExcludeCategory/src/test/java/org/gradle/CatDTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(CategoryD.class)
+public class CatDTests {
+
+    @Test
+    public void catDOk1() {
+    }
+
+    @Test
+    public void catDOk2() {
+    }
+
+    @Test
+    public void catDOk3() {
+    }
+
+    @Test
+    public void catDOk4() {
+    }
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingConflictingIncludeAndExcludeCategory/src/test/java/org/gradle/CatZTests.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingConflictingIncludeAndExcludeCategory/src/test/java/org/gradle/CatZTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(CategoryZ.class)
+public class CatZTests {
+
+    @Test
+    public void catZOk1() {
+    }
+
+    @Test
+    public void catZOk2() {
+    }
+
+    @Test
+    public void catZOk3() {
+    }
+
+    @Test
+    public void catZOk4() {
+    }
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingConflictingIncludeAndExcludeCategory/src/test/java/org/gradle/CategoryA.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingConflictingIncludeAndExcludeCategory/src/test/java/org/gradle/CategoryA.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle;
+
+public interface CategoryA{
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingConflictingIncludeAndExcludeCategory/src/test/java/org/gradle/CategoryB.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingConflictingIncludeAndExcludeCategory/src/test/java/org/gradle/CategoryB.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle;
+
+public interface CategoryB extends org.gradle.CategoryA{
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingConflictingIncludeAndExcludeCategory/src/test/java/org/gradle/CategoryC.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingConflictingIncludeAndExcludeCategory/src/test/java/org/gradle/CategoryC.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle;
+
+public interface CategoryC{
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingConflictingIncludeAndExcludeCategory/src/test/java/org/gradle/CategoryD.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingConflictingIncludeAndExcludeCategory/src/test/java/org/gradle/CategoryD.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle;
+
+public interface CategoryD extends org.gradle.CategoryC{
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingConflictingIncludeAndExcludeCategory/src/test/java/org/gradle/CategoryZ.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingConflictingIncludeAndExcludeCategory/src/test/java/org/gradle/CategoryZ.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle;
+
+public interface CategoryZ {
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingConflictingIncludeAndExcludeCategory/src/test/java/org/gradle/MixedTests.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingConflictingIncludeAndExcludeCategory/src/test/java/org/gradle/MixedTests.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+
+public class MixedTests {
+
+    @Category(org.gradle.CategoryA.class)
+    @Test
+    public void catAOk1() {
+    }
+
+    @Category(org.gradle.CategoryB.class)
+    @Test
+    public void catBOk2() {
+    }
+
+    @Category(org.gradle.CategoryA.class)
+    @Ignore
+    @Test
+    public void someIgnoredTest() {
+    }
+
+    @Test
+    public void noCatOk4() {
+    }
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingConflictingIncludeAndExcludeCategory/src/test/java/org/gradle/NoCatTests.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingConflictingIncludeAndExcludeCategory/src/test/java/org/gradle/NoCatTests.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle;
+
+import org.junit.Test;
+
+public class NoCatTests {
+
+    @Test
+    public void noCatOk1() {
+    }
+
+    @Test
+    public void noCatOk2() {
+    }
+
+    @Test
+    public void noCatOk3() {
+    }
+
+    @Test
+    public void noCatOk4() {
+    }
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingMultipleConflictingIncludeAndExcludeCategories/build.gradle
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingMultipleConflictingIncludeAndExcludeCategories/build.gradle
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+apply plugin: "java"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType(Test).configureEach {
+    useJUnit {
+        includeCategories 'org.gradle.CategoryC'
+        excludeCategories 'org.gradle.CategoryA'
+    }
+}
+
+test {
+    useJUnit {
+        includeCategories 'org.gradle.CategoryA'
+        excludeCategories 'org.gradle.CategoryC'
+    }
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingMultipleConflictingIncludeAndExcludeCategories/src/test/java/org/gradle/CatACTests.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingMultipleConflictingIncludeAndExcludeCategories/src/test/java/org/gradle/CatACTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category({org.gradle.CategoryA.class, org.gradle.CategoryC.class})
+public class CatACTests {
+
+    @Test
+    public void catABOk1() {
+    }
+
+    @Test
+    public void catABOk2() {
+    }
+
+    @Test
+    public void catABOk3() {
+    }
+
+    @Test
+    public void catABOk4() {
+    }
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingMultipleConflictingIncludeAndExcludeCategories/src/test/java/org/gradle/CatADTests.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingMultipleConflictingIncludeAndExcludeCategories/src/test/java/org/gradle/CatADTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+
+@Category(org.gradle.CategoryA.class)
+public class CatADTests {
+
+    @Test
+    public void catAOk1() {
+    }
+
+    @Test
+    public void catAOk2() {
+    }
+
+    @Test
+    @Category(org.gradle.CategoryC.class)
+    public void catCOk3() {
+    }
+
+    @Test
+    @Category(org.gradle.CategoryD.class)
+    public void catDOk4() {
+    }
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingMultipleConflictingIncludeAndExcludeCategories/src/test/java/org/gradle/CatATests.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingMultipleConflictingIncludeAndExcludeCategories/src/test/java/org/gradle/CatATests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+
+@Category(org.gradle.CategoryA.class)
+public class CatATests {
+
+    @Test
+    public void catAOk1() {
+    }
+
+    @Test
+    public void catAOk2() {
+    }
+
+    @Test
+    public void catAOk3() {
+    }
+
+    @Test
+    public void catAOk4() {
+    }
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingMultipleConflictingIncludeAndExcludeCategories/src/test/java/org/gradle/CatBTests.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingMultipleConflictingIncludeAndExcludeCategories/src/test/java/org/gradle/CatBTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(org.gradle.CategoryB.class)
+public class CatBTests {
+
+    @Test
+    public void catBOk1() {
+    }
+
+    @Test
+    public void catBOk2() {
+    }
+
+    @Test
+    public void catBOk3() {
+    }
+
+    @Test
+    public void catBOk4() {
+    }
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingMultipleConflictingIncludeAndExcludeCategories/src/test/java/org/gradle/CatCBTests.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingMultipleConflictingIncludeAndExcludeCategories/src/test/java/org/gradle/CatCBTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+
+@Category(org.gradle.CategoryC.class)
+public class CatCBTests {
+
+    @Test
+    public void catCOk1() {
+    }
+
+    @Test
+    public void catCOk2() {
+    }
+
+    @Test
+    @Category(org.gradle.CategoryA.class)
+    public void catAOk3() {
+    }
+
+    @Test
+    @Category(org.gradle.CategoryB.class)
+    public void catBOk4() {
+    }
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingMultipleConflictingIncludeAndExcludeCategories/src/test/java/org/gradle/CatCTests.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingMultipleConflictingIncludeAndExcludeCategories/src/test/java/org/gradle/CatCTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(CategoryC.class)
+public class CatCTests {
+
+    @Test
+    public void catCOk1() {
+    }
+
+    @Test
+    public void catCOk2() {
+    }
+
+    @Test
+    public void catCOk3() {
+    }
+
+    @Test
+    public void catCOk4() {
+    }
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingMultipleConflictingIncludeAndExcludeCategories/src/test/java/org/gradle/CatDTests.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingMultipleConflictingIncludeAndExcludeCategories/src/test/java/org/gradle/CatDTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(CategoryD.class)
+public class CatDTests {
+
+    @Test
+    public void catDOk1() {
+    }
+
+    @Test
+    public void catDOk2() {
+    }
+
+    @Test
+    public void catDOk3() {
+    }
+
+    @Test
+    public void catDOk4() {
+    }
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingMultipleConflictingIncludeAndExcludeCategories/src/test/java/org/gradle/CatZTests.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingMultipleConflictingIncludeAndExcludeCategories/src/test/java/org/gradle/CatZTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(CategoryZ.class)
+public class CatZTests {
+
+    @Test
+    public void catZOk1() {
+    }
+
+    @Test
+    public void catZOk2() {
+    }
+
+    @Test
+    public void catZOk3() {
+    }
+
+    @Test
+    public void catZOk4() {
+    }
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingMultipleConflictingIncludeAndExcludeCategories/src/test/java/org/gradle/CategoryA.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingMultipleConflictingIncludeAndExcludeCategories/src/test/java/org/gradle/CategoryA.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle;
+
+public interface CategoryA{
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingMultipleConflictingIncludeAndExcludeCategories/src/test/java/org/gradle/CategoryB.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingMultipleConflictingIncludeAndExcludeCategories/src/test/java/org/gradle/CategoryB.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle;
+
+public interface CategoryB extends org.gradle.CategoryA{
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingMultipleConflictingIncludeAndExcludeCategories/src/test/java/org/gradle/CategoryC.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingMultipleConflictingIncludeAndExcludeCategories/src/test/java/org/gradle/CategoryC.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle;
+
+public interface CategoryC{
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingMultipleConflictingIncludeAndExcludeCategories/src/test/java/org/gradle/CategoryD.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingMultipleConflictingIncludeAndExcludeCategories/src/test/java/org/gradle/CategoryD.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle;
+
+public interface CategoryD extends org.gradle.CategoryC{
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingMultipleConflictingIncludeAndExcludeCategories/src/test/java/org/gradle/CategoryZ.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingMultipleConflictingIncludeAndExcludeCategories/src/test/java/org/gradle/CategoryZ.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle;
+
+public interface CategoryZ {
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingMultipleConflictingIncludeAndExcludeCategories/src/test/java/org/gradle/MixedTests.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingMultipleConflictingIncludeAndExcludeCategories/src/test/java/org/gradle/MixedTests.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+
+public class MixedTests {
+
+    @Category(org.gradle.CategoryA.class)
+    @Test
+    public void catAOk1() {
+    }
+
+    @Category(org.gradle.CategoryB.class)
+    @Test
+    public void catBOk2() {
+    }
+
+    @Category(org.gradle.CategoryA.class)
+    @Ignore
+    @Test
+    public void someIgnoredTest() {
+    }
+
+    @Test
+    public void noCatOk4() {
+    }
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingMultipleConflictingIncludeAndExcludeCategories/src/test/java/org/gradle/NoCatTests.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/warningWhenSpecifyingMultipleConflictingIncludeAndExcludeCategories/src/test/java/org/gradle/NoCatTests.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle;
+
+import org.junit.Test;
+
+public class NoCatTests {
+
+    @Test
+    public void noCatOk1() {
+    }
+
+    @Test
+    public void noCatOk2() {
+    }
+
+    @Test
+    public void noCatOk3() {
+    }
+
+    @Test
+    public void noCatOk4() {
+    }
+}

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestFramework.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestFramework.java
@@ -16,12 +16,15 @@
 
 package org.gradle.api.internal.tasks.testing.junit;
 
+import com.google.common.collect.Sets;
 import org.gradle.api.Action;
 import org.gradle.api.internal.tasks.testing.TestFramework;
 import org.gradle.api.internal.tasks.testing.TestFrameworkDistributionModule;
 import org.gradle.api.internal.tasks.testing.WorkerTestClassProcessorFactory;
 import org.gradle.api.internal.tasks.testing.detection.ClassFileExtractionManager;
 import org.gradle.api.internal.tasks.testing.filter.DefaultTestFilter;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.api.tasks.testing.TestFilter;
 import org.gradle.api.tasks.testing.junit.JUnitOptions;
@@ -33,10 +36,13 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @UsedByScanPlugin("test-retry")
 public class JUnitTestFramework implements TestFramework {
+    private static final Logger LOGGER = Logging.getLogger(JUnitTestFramework.class);
 
     private static final List<TestFrameworkDistributionModule> DISTRIBUTION_MODULES =
         Collections.singletonList(new TestFrameworkDistributionModule(
@@ -79,6 +85,7 @@ public class JUnitTestFramework implements TestFramework {
 
     @Override
     public WorkerTestClassProcessorFactory getProcessorFactory() {
+        validateOptions();
         return new JUnitTestClassProcessorFactory(new JUnitSpec(
             filter.toSpec(), options.getIncludeCategories(), options.getExcludeCategories()));
     }
@@ -123,4 +130,20 @@ public class JUnitTestFramework implements TestFramework {
         detector = null;
     }
 
+    private void validateOptions() {
+        Set<String> intersection = Sets.newHashSet(options.getIncludeCategories());
+        intersection.retainAll(options.getExcludeCategories());
+        if (!intersection.isEmpty()) {
+            if (intersection.size() == 1) {
+                LOGGER.warn("The category '" + intersection.iterator().next() + "' is both included and excluded.  " +
+                    "This will result in the category being excluded, but may not be what was intended.  " +
+                    "Please either include or exclude the category, but not both.");
+            } else {
+                String allCategories = intersection.stream().sorted().map(s -> "'" + s + "'").collect(Collectors.joining(", "));
+                LOGGER.warn("The categories " + allCategories + " are both included and excluded.  " +
+                    "This will result in the categories being excluded, but may not be what was intended. " +
+                    "Please either include or exclude the categories, but not both.");
+            }
+        }
+    }
 }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestFramework.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestFramework.java
@@ -136,13 +136,13 @@ public class JUnitTestFramework implements TestFramework {
         if (!intersection.isEmpty()) {
             if (intersection.size() == 1) {
                 LOGGER.warn("The category '" + intersection.iterator().next() + "' is both included and excluded.  " +
-                    "This will result in the category being excluded, but may not be what was intended.  " +
-                    "Please either include or exclude the category, but not both.");
+                    "This will result in the category being excluded, which may not be what was intended.  " +
+                    "Please either include or exclude the category but not both.");
             } else {
                 String allCategories = intersection.stream().sorted().map(s -> "'" + s + "'").collect(Collectors.joining(", "));
                 LOGGER.warn("The categories " + allCategories + " are both included and excluded.  " +
-                    "This will result in the categories being excluded, but may not be what was intended. " +
-                    "Please either include or exclude the categories, but not both.");
+                    "This will result in the categories being excluded, which may not be what was intended. " +
+                    "Please either include or exclude the categories but not both.");
             }
         }
     }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestFramework.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestFramework.java
@@ -137,13 +137,13 @@ public class JUnitPlatformTestFramework implements TestFramework {
         if (!intersection.isEmpty()) {
             if (intersection.size() == 1) {
                 LOGGER.warn("The tag '" + intersection.iterator().next() + "' is both included and excluded.  " +
-                    "This will result in the tag being excluded, but may not be what was intended.  " +
-                    "Please either include or exclude the tag, but not both.");
+                    "This will result in the tag being excluded, which may not be what was intended.  " +
+                    "Please either include or exclude the tag but not both.");
             } else {
                 String allTags = intersection.stream().sorted().map(s -> "'" + s + "'").collect(Collectors.joining(", "));
                 LOGGER.warn("The tags " + allTags + " are both included and excluded.  " +
-                    "This will result in the tags being excluded, but may not be what was intended.  " +
-                    "Please either include or exclude the tags, but not both.");
+                    "This will result in the tags being excluded, which may not be what was intended.  " +
+                    "Please either include or exclude the tags but not both.");
             }
         }
     }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestFramework.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestFramework.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.tasks.testing.junitplatform;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
 import org.gradle.api.Action;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.internal.tasks.testing.TestFramework;
@@ -24,6 +25,8 @@ import org.gradle.api.internal.tasks.testing.TestFrameworkDistributionModule;
 import org.gradle.api.internal.tasks.testing.WorkerTestClassProcessorFactory;
 import org.gradle.api.internal.tasks.testing.detection.TestFrameworkDetector;
 import org.gradle.api.internal.tasks.testing.filter.DefaultTestFilter;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.testing.TestFilter;
 import org.gradle.api.tasks.testing.junitplatform.JUnitPlatformOptions;
 import org.gradle.internal.jvm.UnsupportedJavaRuntimeException;
@@ -32,10 +35,13 @@ import org.gradle.process.internal.worker.WorkerProcessBuilder;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @UsedByScanPlugin("test-retry")
 public class JUnitPlatformTestFramework implements TestFramework {
+    private static final Logger LOGGER = Logging.getLogger(JUnitPlatformTestFramework.class);
 
     private static final List<TestFrameworkDistributionModule> DISTRIBUTION_MODULES =
         ImmutableList.of(
@@ -88,6 +94,7 @@ public class JUnitPlatformTestFramework implements TestFramework {
         if (!JavaVersion.current().isJava8Compatible()) {
             throw new UnsupportedJavaRuntimeException("Running JUnit Platform requires Java 8+, please configure your test java executable with Java 8 or higher.");
         }
+        validateOptions();
         return new JUnitPlatformTestClassProcessorFactory(new JUnitPlatformSpec(
             filter.toSpec(), options.getIncludeEngines(), options.getExcludeEngines(),
             options.getIncludeTags(), options.getExcludeTags()
@@ -124,4 +131,20 @@ public class JUnitPlatformTestFramework implements TestFramework {
         // this test framework doesn't hold any state
     }
 
+    private void validateOptions() {
+        Set<String> intersection = Sets.newHashSet(options.getIncludeTags());
+        intersection.retainAll(options.getExcludeTags());
+        if (!intersection.isEmpty()) {
+            if (intersection.size() == 1) {
+                LOGGER.warn("The tag '" + intersection.iterator().next() + "' is both included and excluded.  " +
+                    "This will result in the tag being excluded, but may not be what was intended.  " +
+                    "Please either include or exclude the tag, but not both.");
+            } else {
+                String allTags = intersection.stream().sorted().map(s -> "'" + s + "'").collect(Collectors.joining(", "));
+                LOGGER.warn("The tags " + allTags + " are both included and excluded.  " +
+                    "This will result in the tags being excluded, but may not be what was intended.  " +
+                    "Please either include or exclude the tags, but not both.");
+            }
+        }
+    }
 }


### PR DESCRIPTION
If a tag or a category appears in the list of both includes _and_ excludes, it is likely not intentional.  We want to emit a warning so that the user knows that this conflicting configuration has occurred and can ensure that the intended behavior is configured.

Note that this also surfaced the fact that we were not testing JUnit5 tags in the multiversion junit category test (i.e. we were testing JUnit5 "vintage", which uses categories in the tests, but not JUnit5 tags).  This adds coverage for tags in that test along with the infrastructure to support it.