### PR TITLE
Let tests use extensions instead of conventions - part 3

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/codenarc/CodeNarcPluginIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/codenarc/CodeNarcPluginIntegrationTest.groovy
@@ -47,7 +47,7 @@ class CodeNarcPluginIntegrationTest extends WellBehavedPluginTest {
                 assert task instanceof CodeNarc
                 task.with {
                     assert description == "Run CodeNarc analysis for ${sourceSet.name} classes"
-                    assert source as List == sourceSet.allGroovy  as List
+                    assert source as List == sourceSet.groovy  as List
                     assert codenarcClasspath == project.configurations.codenarc
                     assert config.inputFiles.singleFile == project.file("config/codenarc/codenarc.xml")
                     assert configFile == project.file("config/codenarc/codenarc.xml")
@@ -111,7 +111,7 @@ class CodeNarcPluginIntegrationTest extends WellBehavedPluginTest {
                 assert task instanceof CodeNarc
                 task.with {
                     assert description == "Run CodeNarc analysis for ${sourceSet.name} classes"
-                    assert source as List == sourceSet.allGroovy as List
+                    assert source as List == sourceSet.groovy as List
                     assert codenarcClasspath == project.configurations.codenarc
                     assert config.inputFiles.singleFile == project.file("codenarc-config")
                     assert configFile == project.file("codenarc-config")

--- a/subprojects/docs/src/snippets/java/customDirs/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/java/customDirs/groovy/build.gradle
@@ -51,16 +51,17 @@ sourceSets {
 
 // tag::custom-report-dirs[]
 reporting.baseDir = "my-reports"
-testResultsDirName = "$buildDir/my-test-results"
+java.testResultsDir = layout.buildDirectory.dir("my-test-results")
+
 
 tasks.register('showDirs') {
     def rootDir = project.rootDir
-    def reportsDir = project.reportsDir
-    def testResultsDir = project.testResultsDir
+    def reportsDir = project.reporting.baseDirectory
+    def testResultsDir = project.java.testResultsDir
 
     doLast {
-        logger.quiet(rootDir.toPath().relativize(reportsDir.toPath()).toString())
-        logger.quiet(rootDir.toPath().relativize(testResultsDir.toPath()).toString())
+        logger.quiet(rootDir.toPath().relativize(reportsDir.get().asFile.toPath()).toString())
+        logger.quiet(rootDir.toPath().relativize(testResultsDir.get().asFile.toPath()).toString())
     }
 }
 // end::custom-report-dirs[]

--- a/subprojects/docs/src/snippets/java/customDirs/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java/customDirs/kotlin/build.gradle.kts
@@ -52,7 +52,7 @@ sourceSets {
 
 // tag::custom-report-dirs[]
 reporting.baseDir = file("my-reports")
-project.setProperty("testResultsDirName", "$buildDir/my-test-results")
+java.testResultsDir.set(layout.buildDirectory.dir("my-test-results"))
 
 tasks.register("showDirs") {
     val rootDir = project.rootDir

--- a/subprojects/docs/src/snippets/kotlinDsl/noAccessors/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/kotlinDsl/noAccessors/kotlin/build.gradle.kts
@@ -30,7 +30,7 @@ configure<SourceSetContainer> {
 }
 // end::project-container-extension[]
 
-configure<JavaPluginConvention> {
+configure<JavaPluginExtension> {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
 }

--- a/subprojects/docs/src/snippets/scala/customizedLayout/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/scala/customizedLayout/kotlin/build.gradle.kts
@@ -17,17 +17,13 @@ dependencies {
 // tag::custom-source-locations[]
 sourceSets {
     main {
-        withConvention(ScalaSourceSet::class) {
-            scala {
-                setSrcDirs(listOf("src/scala"))
-            }
+        scala {
+            setSrcDirs(listOf("src/scala"))
         }
     }
     test {
-        withConvention(ScalaSourceSet::class) {
-            scala {
-                setSrcDirs(listOf("test/scala"))
-            }
+        scala {
+            setSrcDirs(listOf("test/scala"))
         }
     }
 }

--- a/subprojects/docs/src/snippets/testing/junit-xml-results/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/testing/junit-xml-results/groovy/build.gradle
@@ -19,7 +19,7 @@ test {
 // end::configure-location-task[]
 
 // tag::configure-location-convention[]
-testResultsDirName = "$buildDir/junit-xml"
+java.testResultsDir = layout.buildDirectory.dir("junit-xml")
 // end::configure-location-convention[]
 
 // tag::configure-content[]

--- a/subprojects/docs/src/snippets/testing/junit-xml-results/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/testing/junit-xml-results/kotlin/build.gradle.kts
@@ -19,7 +19,7 @@ tasks.test {
 // end::configure-location-task[]
 
 // tag::configure-location-convention[]
-project.setProperty("testResultsDirName", "$buildDir/junit-xml")
+java.testResultsDir.set(layout.buildDirectory.dir("junit-xml"))
 // end::configure-location-convention[]
 
 // tag::configure-content[]

--- a/subprojects/docs/src/snippets/tutorial/manifest/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/tutorial/manifest/groovy/build.gradle
@@ -13,12 +13,12 @@ jar {
 // end::add-to-manifest[]
 
 // tag::custom-manifest[]
-ext.sharedManifest = manifest {
+def sharedManifest = java.manifest {
     attributes("Implementation-Title": "Gradle",
                "Implementation-Version": version)
 }
 tasks.register('fooJar', Jar) {
-    manifest = project.manifest {
+    manifest = java.manifest {
         from sharedManifest
     }
 }

--- a/subprojects/docs/src/snippets/tutorial/manifest/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/tutorial/manifest/kotlin/build.gradle.kts
@@ -15,7 +15,7 @@ tasks.jar {
 // end::add-to-manifest[]
 
 // tag::custom-manifest[]
-val sharedManifest = the<JavaPluginConvention>().manifest {
+val sharedManifest = java.manifest {
     attributes (
         "Implementation-Title" to "Gradle",
         "Implementation-Version" to version
@@ -23,7 +23,7 @@ val sharedManifest = the<JavaPluginConvention>().manifest {
 }
 
 tasks.register<Jar>("fooJar") {
-    manifest = project.the<JavaPluginConvention>().manifest {
+    manifest = java.manifest {
         from(sharedManifest)
     }
 }

--- a/subprojects/ear/src/integTest/groovy/org/gradle/plugins/ear/EarPluginIntegrationTest.groovy
+++ b/subprojects/ear/src/integTest/groovy/org/gradle/plugins/ear/EarPluginIntegrationTest.groovy
@@ -179,7 +179,7 @@ apply plugin: 'ear'
 ear {
     ${descriptorConfig}
     deploymentDescriptor {
-        applicationName = 'descriptor modification will not have any affect when application.xml already exists in source'
+        applicationName = 'descriptor modification will not have any effect when application.xml already exists in source'
     }
 }
 """
@@ -194,9 +194,9 @@ ear {
         ear.assertFileContent("META-INF/application.xml", applicationXml)
 
         where:
-        location    | descriptorConfig   | appDirectory
-        "specified" | "appDirName 'app'" | "app"
-        "default"   | ""                 | "src/main/application"
+        location    | descriptorConfig             | appDirectory
+        "specified" | "appDirectory = file('app')" | "app"
+        "default"   | ""                           | "src/main/application"
     }
 
     @ToBeFixedForConfigurationCache(because = "Entry META-INF/application.xml is a duplicate")

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseJavaProjectIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseJavaProjectIntegrationTest.groovy
@@ -25,7 +25,7 @@ class EclipseJavaProjectIntegrationTest extends AbstractEclipseIntegrationSpec {
         buildFile << """
             apply plugin: 'java'
             apply plugin: 'eclipse'
-            targetCompatibility = $version
+            java.targetCompatibility = $version
         """
 
         when:
@@ -86,7 +86,7 @@ class EclipseJavaProjectIntegrationTest extends AbstractEclipseIntegrationSpec {
         buildFile << """
             apply plugin: 'java'
             apply plugin: 'eclipse'
-            targetCompatibility = $version
+            java.targetCompatibility = $version
         """
 
         when:

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpEarProjectIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpEarProjectIntegrationTest.groovy
@@ -93,7 +93,9 @@ class EclipseWtpEarProjectIntegrationTest extends AbstractEclipseIntegrationSpec
                deploy 'org.example:lib2-impl:2.0'
            }
 
-           libDirName = 'APP-INF/lib'
+           ear {
+               libDirName = 'APP-INF/lib'
+           }
         """
 
         when:

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpModelIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpModelIntegrationTest.groovy
@@ -399,7 +399,7 @@ project(':contrib') {
 
           sourceSets.main.java.srcDirs 'yyySource', 'xxxSource'
 
-          appDirName = 'nonexistentAppDir'
+          ear.appDirectory = file 'nonexistentAppDir'
 
           eclipse.wtp.component {
             resource sourcePath: 'xxxResource', deployPath: 'deploy-xxx'
@@ -430,7 +430,7 @@ project(':contrib') {
           apply plugin: 'ear'
           apply plugin: 'eclipse-wtp'
 
-          appDirName = 'coolAppDir'
+          ear.appDirectory = file 'coolAppDir'
 """
         //then
         def component = getComponentFile().text

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/eclipse/EclipseModelBuilderTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/eclipse/EclipseModelBuilderTest.groovy
@@ -163,11 +163,11 @@ class EclipseModelBuilderTest extends AbstractProjectBuilderSpec {
         pluginType << [JavaPlugin, GroovyPlugin, ScalaPlugin]
     }
 
-    def "custom #type language level derived Java plugin convention"() {
+    def "custom #type language level derived Java plugin extension"() {
         given:
         def modelBuilder = createEclipseModelBuilder()
         project.plugins.apply(JavaPlugin)
-        project."$compatibilityProperty" = "1.2"
+        project.java."$compatibilityProperty" = "1.2"
 
         when:
         def eclipseModel = modelBuilder.buildAll("org.gradle.tooling.model.eclipse.EclipseProject", project)
@@ -181,12 +181,12 @@ class EclipseModelBuilderTest extends AbstractProjectBuilderSpec {
         "target" | "targetCompatibility" | "targetBytecodeVersion"
     }
 
-    def "#type language level derived from eclipse jdt overrules java plugin convention configuration"() {
+    def "#type language level derived from eclipse jdt overrules java plugin extension configuration"() {
         given:
         def modelBuilder = createEclipseModelBuilder()
         project.plugins.apply(JavaPlugin)
         project.plugins.apply(EclipsePlugin)
-        project."$compatibilityProperty" = "1.2"
+        project.java."$compatibilityProperty" = "1.2"
         project.eclipse.jdt."$compatibilityProperty" = "1.3"
 
         when:
@@ -209,7 +209,7 @@ class EclipseModelBuilderTest extends AbstractProjectBuilderSpec {
         child1.eclipse.jdt."$compatibilityProperty" = "1.2"
         child2.plugins.apply(JavaPlugin)
         child2.plugins.apply(EclipsePlugin)
-        child2."$compatibilityProperty" = "1.3"
+        child2.java."$compatibilityProperty" = "1.3"
         child2.eclipse.jdt."$compatibilityProperty" = "1.1"
 
         when:

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ApplicationIntegrationSpec.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ApplicationIntegrationSpec.groovy
@@ -345,7 +345,7 @@ class Main {
 
         and:
         buildFile << """
-            applicationDistribution.from("src/somewhere-else") {
+            application.applicationDistribution.from("src/somewhere-else") {
                 include "**/r2.*"
             }
         """
@@ -375,7 +375,7 @@ class Main {
                 }
             }
 
-            applicationDistribution.from(createDocs) {
+            application.applicationDistribution.from(createDocs) {
                 into "docs"
                 rename 'readme(.*)', 'READ-ME\$1'
             }

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinDslJvmDefaultIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinDslJvmDefaultIntegrationTest.kt
@@ -99,7 +99,7 @@ class KotlinDslJvmDefaultIntegrationTest : AbstractPluginIntegrationTest() {
     @Test
     fun `kotlin-dsl java and groovy consumers can use kotlin interface default methods directly`() {
 
-        withSettings(
+        file("settings.gradle.kts").appendText(
             """
             include("kotlin-dsl-producer")
             include("java-consumer")

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
@@ -902,7 +902,7 @@ class PrecompiledScriptPluginIntegrationTest : AbstractPluginIntegrationTest() {
     @Issue("https://github.com/gradle/gradle/issues/23564")
     fun `respects offline start parameter on synthetic builds for accessors generation`() {
 
-        withSettings("""include("producer", "consumer")""")
+        file("settings.gradle.kts").appendText("""include("producer", "consumer")""")
 
         withKotlinDslPluginIn("producer")
         withFile("producer/src/main/kotlin/offline.gradle.kts", """

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecMainClassIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecMainClassIntegrationTest.groovy
@@ -73,10 +73,10 @@ class JavaExecMainClassIntegrationTest extends AbstractIntegrationSpec {
             def resolveMainClassName = tasks.register('resolveMainClassName', ResolveMainClassName) {
                 classpath.from(compileJava)
                 mainClassFromBootExtension.set(
-                    project.convention.findByType(BootExtension.class)?.mainClassName
+                    project.extensions.findByType(BootExtension.class)?.mainClassName
                 )
                 mainClassFromJavaApplication.set(
-                    project.convention.findByType(JavaApplication.class)?.mainClass
+                    project.extensions.findByType(JavaApplication.class)?.mainClass
                 )
                 mainClassFile = layout.buildDirectory.file('mainClass.txt')
             }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/ApplicationPluginConvention.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/ApplicationPluginConvention.java
@@ -79,8 +79,10 @@ public abstract class ApplicationPluginConvention {
      *     id 'application'
      * }
      *
-     * applicationDistribution.from("some/dir") {
-     *   include "*.txt"
+     * application {
+     *     applicationDistribution.from("some/dir") {
+     *       include "*.txt"
+     *     }
      * }
      * </pre>
      * <p>

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaApplication.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaApplication.java
@@ -91,8 +91,10 @@ public interface JavaApplication {
      *     id 'application'
      * }
      *
-     * applicationDistribution.from("some/dir") {
-     *   include "*.txt"
+     * application {
+     *     applicationDistribution.from("some/dir") {
+     *       include "*.txt"
+     *     }
      * }
      * </pre>
      * <p>

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ShadowPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ShadowPluginSmokeTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.smoketests
 import spock.lang.Issue
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
 class ShadowPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
 
     @Issue('https://plugins.gradle.org/plugin/com.github.johnrengelman.shadow')

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/SpringBootPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/SpringBootPluginSmokeTest.groovy
@@ -35,7 +35,9 @@ class SpringBootPluginSmokeTest extends AbstractPluginValidatingSmokeTest implem
 
             ${mavenCentralRepository()}
 
-            project.setProperty('applicationDefaultJvmArgs', ['-DFOO=42'])
+            application {
+                applicationDefaultJvmArgs = ['-DFOO=42']
+            }
 
             dependencies {
                 implementation 'org.springframework.boot:spring-boot-starter'


### PR DESCRIPTION
This PR changes tests to use extensions instead of conventions where available.

This was extracted from a PR that grown too big for a reasonable review:
* https://github.com/gradle/gradle/pull/24231

This is a follow up to 
* https://github.com/gradle/gradle/pull/24199
* https://github.com/gradle/gradle/pull/24266