### PR TITLE
Fix execution plan resolution in build operation

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildOperationFiringBuildWorkPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildOperationFiringBuildWorkPreparer.java
@@ -36,6 +36,7 @@ import org.gradle.internal.taskgraph.NodeIdentity;
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.IdentityHashMap;
 import java.util.List;
@@ -144,6 +145,9 @@ public class BuildOperationFiringBuildWorkPreparer implements BuildWorkPreparer 
 
         private static class CalculateTaskGraphResult implements Result, CustomOperationTraceSerialization {
 
+            private final Set<NodeIdentity.NodeType> tasksOnly = EnumSet.of(NodeIdentity.NodeType.TASK);
+            private final Set<NodeIdentity.NodeType> tasksAndTransforms = EnumSet.of(NodeIdentity.NodeType.TASK, NodeIdentity.NodeType.TRANSFORM_STEP);
+
             private final Set<Task> requestedTasks;
             private final Set<Task> filteredTasks;
             private final List<PlannedNode> plannedNodes;
@@ -174,12 +178,19 @@ public class BuildOperationFiringBuildWorkPreparer implements BuildWorkPreparer 
 
             @Override
             public List<PlannedNode> getExecutionPlan(Set<NodeIdentity.NodeType> types) {
-                if (EnumSet.allOf(NodeIdentity.NodeType.class).equals(types)) {
+                if (types.isEmpty()) {
+                    return Collections.emptyList();
+                }
+
+                if (tasksOnly.equals(types)) {
+                    return getTaskExecutionPlan();
+                }
+
+                if (tasksAndTransforms.equals(types)) {
                     return plannedNodes;
                 }
-                return plannedNodes.stream()
-                    .filter(node -> types.contains(node.getNodeIdentity().getNodeType()))
-                    .collect(Collectors.toList());
+
+                throw new IllegalArgumentException("Unsupported node types: " + types);
             }
 
             @Override
@@ -190,6 +201,53 @@ public class BuildOperationFiringBuildWorkPreparer implements BuildWorkPreparer 
                 builder.put("taskPlan", getTaskPlan());
                 builder.put("executionPlan", getExecutionPlan(EnumSet.allOf(NodeIdentity.NodeType.class)));
                 return builder.build();
+            }
+
+            private List<PlannedNode> getTaskExecutionPlan() {
+                return plannedNodes.stream()
+                    .filter(PlannedTask.class::isInstance)
+                    .map(n -> filterOnlyTaskDependencies((PlannedTask) n))
+                    .collect(Collectors.toList());
+            }
+
+            private static PlannedTask filterOnlyTaskDependencies(PlannedTask plannedTask) {
+                return new PlannedTask() {
+                    @Override
+                    public NodeIdentity getNodeIdentity() {
+                        return plannedTask.getNodeIdentity();
+                    }
+
+                    @Override
+                    public List<? extends NodeIdentity> getNodeDependencies() {
+                        // This is correct only because task dependencies were already transitively resolved for the original PlannedTask implementation
+                        return plannedTask.getDependencies();
+                    }
+
+                    @Override
+                    public TaskIdentity getTask() {
+                        return plannedTask.getTask();
+                    }
+
+                    @Override
+                    public List<TaskIdentity> getDependencies() {
+                        return plannedTask.getDependencies();
+                    }
+
+                    @Override
+                    public List<TaskIdentity> getMustRunAfter() {
+                        return plannedTask.getMustRunAfter();
+                    }
+
+                    @Override
+                    public List<TaskIdentity> getShouldRunAfter() {
+                        return plannedTask.getShouldRunAfter();
+                    }
+
+                    @Override
+                    public List<TaskIdentity> getFinalizedBy() {
+                        return plannedTask.getFinalizedBy();
+                    }
+                };
             }
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildOperationFiringBuildWorkPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildOperationFiringBuildWorkPreparer.java
@@ -145,8 +145,8 @@ public class BuildOperationFiringBuildWorkPreparer implements BuildWorkPreparer 
 
         private static class CalculateTaskGraphResult implements Result, CustomOperationTraceSerialization {
 
-            private final Set<NodeIdentity.NodeType> tasksOnly = EnumSet.of(NodeIdentity.NodeType.TASK);
-            private final Set<NodeIdentity.NodeType> tasksAndTransforms = EnumSet.of(NodeIdentity.NodeType.TASK, NodeIdentity.NodeType.TRANSFORM_STEP);
+            private static final Set<NodeIdentity.NodeType> TASKS_ONLY = EnumSet.of(NodeIdentity.NodeType.TASK);
+            private static final Set<NodeIdentity.NodeType> TASKS_AND_TRANSFORMS = EnumSet.of(NodeIdentity.NodeType.TASK, NodeIdentity.NodeType.TRANSFORM_STEP);
 
             private final Set<Task> requestedTasks;
             private final Set<Task> filteredTasks;
@@ -182,11 +182,11 @@ public class BuildOperationFiringBuildWorkPreparer implements BuildWorkPreparer 
                     return Collections.emptyList();
                 }
 
-                if (tasksOnly.equals(types)) {
+                if (TASKS_ONLY.equals(types)) {
                     return getTaskExecutionPlan();
                 }
 
-                if (tasksAndTransforms.equals(types)) {
+                if (TASKS_AND_TRANSFORMS.equals(types)) {
                     return plannedNodes;
                 }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformBuildOperationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformBuildOperationIntegrationTest.groovy
@@ -73,6 +73,25 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
             allprojects {
                 group = "colored"
             }
+
+            import org.gradle.api.services.BuildService
+            import org.gradle.api.services.BuildServiceParameters
+            import org.gradle.internal.operations.*
+            import org.gradle.internal.taskgraph.*
+
+            abstract class LoggingListener implements BuildOperationListener, BuildService<BuildServiceParameters.None> {
+                void started(BuildOperationDescriptor buildOperation, OperationStartEvent startEvent) { throw new RuntimeException() }
+                void progress(OperationIdentifier operationIdentifier, OperationProgressEvent progressEvent) { throw new RuntimeException() }
+                void finished(BuildOperationDescriptor buildOperation, OperationFinishEvent finishEvent) {
+                    if (finishEvent.result instanceof CalculateTaskGraphBuildOperationType.Result) {
+                        def plannedTasks = finishEvent.result.getExecutionPlan([NodeIdentity.NodeType.TASK] as Set)
+                        println("Task-only execution plan: " + plannedTasks.collect { "PlannedTask('\${it.nodeIdentity}', deps=\${it.nodeDependencies})" })
+                    }
+                }
+            }
+
+            def listener = gradle.sharedServices.registerIfAbsent("listener", LoggingListener) { }
+            services.get(BuildEventsListenerRegistry).onOperationCompletion(listener)
         """
     }
 
@@ -123,6 +142,8 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
 
         then:
         executedAndNotSkipped(":consumer:resolve")
+
+        outputContains("Task-only execution plan: [PlannedTask('Task :producer:producer', deps=[]), PlannedTask('Task :consumer:resolve', deps=[Task :producer:producer])]")
 
         result.groupedOutput.transform("MakeGreen")
             .assertOutputContains("processing [producer.jar]")
@@ -184,6 +205,8 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
 
         then:
         executedAndNotSkipped(":consumer:resolve")
+
+        outputContains("Task-only execution plan: [PlannedTask('Task :producer:producer', deps=[]), PlannedTask('Task :consumer:resolve', deps=[Task :producer:producer])]")
 
         result.groupedOutput.transform("MakeColor")
             .assertOutputContains("processing [producer.jar]")
@@ -266,6 +289,8 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
 
         then:
         executedAndNotSkipped(":consumer:resolve")
+
+        outputContains("Task-only execution plan: [PlannedTask('Task :producer:producer', deps=[]), PlannedTask('Task :consumer:resolve', deps=[Task :producer:producer])]")
 
         result.groupedOutput.transform("MakeGreen")
             .assertOutputContains("processing producer.jar using [producer.jar.red, test-4.2.jar]")
@@ -357,6 +382,8 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         then:
         executedAndNotSkipped(":consumer:resolve")
 
+        outputContains("Task-only execution plan: [PlannedTask('Task :producer:producer', deps=[]), PlannedTask('Task :consumer:resolve', deps=[Task :producer:producer])]")
+
         result.groupedOutput.transform("MakeGreen")
             .assertOutputContains("processing producer.jar using [test-4.2.jar]")
 
@@ -415,6 +442,8 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
 
         then:
         executedAndNotSkipped(":consumer:resolve")
+
+        outputContains("Task-only execution plan: [PlannedTask('Task :producer:producer', deps=[]), PlannedTask('Task :consumer:resolve', deps=[Task :producer:producer])]")
 
         result.groupedOutput.transform("MakeRed")
             .assertOutputContains("processing [producer.jar]")
@@ -538,6 +567,8 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
 
         then:
         executedAndNotSkipped(":consumer:resolve")
+
+        outputContains("Task-only execution plan: [PlannedTask('Task :producer:producer', deps=[]), PlannedTask('Task :consumer:resolve', deps=[Task :producer:producer])]")
 
         result.groupedOutput.transform("MakeColor")
             .assertOutputContains("processing [producer.jar]")
@@ -667,6 +698,8 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         then:
         executedAndNotSkipped(":consumer:resolve")
 
+        outputContains("Task-only execution plan: [PlannedTask('Task :producer:producer', deps=[]), PlannedTask('Task :consumer:resolve', deps=[Task :producer:producer])]")
+
         result.groupedOutput.transform("MakeGreen", "producer.out1.jar (project :producer)")
             .assertOutputContains("processing [producer.out1.jar]")
         result.groupedOutput.transform("MakeGreen", "producer.out2.jar (project :producer)")
@@ -764,6 +797,8 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
 
         then:
         failureCauseContains("failed making green: producer.jar")
+
+        outputContains("Task-only execution plan: [PlannedTask('Task :producer:producer', deps=[]), PlannedTask('Task :consumer:resolve', deps=[Task :producer:producer])]")
 
         result.groupedOutput.transform("MakeGreen", "producer.jar (project :producer)")
             .assertOutputContains("processing [producer.jar]")

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/internal/taskgraph/CalculateTaskGraphBuildOperationType.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/internal/taskgraph/CalculateTaskGraphBuildOperationType.java
@@ -121,10 +121,12 @@ public final class CalculateTaskGraphBuildOperationType implements BuildOperatio
         List<PlannedTask> getTaskPlan();
 
         /**
-         * Returns all identifiable nodes of requested types in the execution graph in no particular order.
+         * Returns an execution plan consisting of nodes of the given types.
          * <p>
-         * Identities of dependencies could be of any type.
+         * The graph is represented as a list of nodes (in no particular order) and their {@link PlannedNode#getNodeDependencies() dependencies}.
+         * The dependencies of each node are the closest nodes in the plan whose type is in the given set.
          *
+         * @param types an inclusive range-subset of node types starting with the {@link NodeIdentity.NodeType#TASK TASK}, such as {@code [TASK, TRANSFORM_STEP]}
          * @since 8.1
          */
         List<PlannedNode> getExecutionPlan(Set<NodeIdentity.NodeType> types);


### PR DESCRIPTION
In the original implementation, the behavior of the `getExecutionPlan(Set<NodeIdentity.NodeType> types)` is not entirely sound with respect to the possible argument combinations.

This PR fixes the behavior and adds stricter validations of the provided arguments.