### PR TITLE
Emit deprecation warning upon creating a configuration named the same as a potential detachedConfiguration

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DetachedConfigurationsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DetachedConfigurationsIntegrationTest.groovy
@@ -133,4 +133,20 @@ class DetachedConfigurationsIntegrationTest extends AbstractIntegrationSpec {
         expect:
         run "checkDependencies"
     }
+
+    def "configurations container reserves name #name for detached configurations"() {
+        given:
+        buildFile << """
+            configurations {
+                $name
+            }
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning("Configuration name '$name' is reserved for detached configurations. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Use a different name for this configuration. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#reserved_configuration_names")
+        succeeds "help"
+
+        where:
+        name << ["detachedConfiguration", "detachedConfiguration1", "detachedConfiguration22902"]
+    }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DetachedConfigurationsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DetachedConfigurationsIntegrationTest.groovy
@@ -143,7 +143,7 @@ class DetachedConfigurationsIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
-        executer.expectDocumentedDeprecationWarning("Creating a configuration named '$name' (which begins with 'detachedConfiguration' and is optionally followed by a number) has been deprecated. This is scheduled to be removed in Gradle 9.0. Use a different name for this configuration. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#reserved_configuration_names")
+        executer.expectDocumentedDeprecationWarning("Creating a configuration with a name that starts with 'detachedConfiguration' has been deprecated. This is scheduled to be removed in Gradle 9.0. Use a different name for the configuration '$name'. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#reserved_configuration_names")
         succeeds "help"
 
         where:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DetachedConfigurationsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DetachedConfigurationsIntegrationTest.groovy
@@ -143,7 +143,7 @@ class DetachedConfigurationsIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
-        executer.expectDocumentedDeprecationWarning("Configuration name '$name' is reserved for detached configurations. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Use a different name for this configuration. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#reserved_configuration_names")
+        executer.expectDocumentedDeprecationWarning("Creating a configuration named '$name' (which begins with 'detachedConfiguration' and is optionally followed by a number) has been deprecated. This is scheduled to be removed in Gradle 9.0. Use a different name for this configuration. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#reserved_configuration_names")
         succeeds "help"
 
         where:

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
@@ -186,8 +186,8 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
 
     private void validateNameIsAllowed(String name) {
         if (RESERVED_NAMES_FOR_DETACHED_CONFS.matcher(name).matches()) {
-            String message = String.format("Configuration name '%s' is reserved for detached configurations.", name);
-            DeprecationLogger.deprecateBehaviour(message)
+            String message = String.format("Creating a configuration named '%s' (which begins with 'detachedConfiguration' and is optionally followed by a number)", name);
+            DeprecationLogger.deprecateAction(message)
                     .withAdvice("Use a different name for this configuration.")
                     .willBeRemovedInGradle9()
                     .withUpgradeGuideSection(8, "reserved_configuration_names")

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
@@ -186,9 +186,8 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
 
     private void validateNameIsAllowed(String name) {
         if (RESERVED_NAMES_FOR_DETACHED_CONFS.matcher(name).matches()) {
-            String message = String.format("Creating a configuration named '%s' (which begins with 'detachedConfiguration' and is optionally followed by a number)", name);
-            DeprecationLogger.deprecateAction(message)
-                    .withAdvice("Use a different name for this configuration.")
+            DeprecationLogger.deprecateAction("Creating a configuration with a name that starts with 'detachedConfiguration'")
+                    .withAdvice(String.format("Use a different name for the configuration '%s'.", name))
                     .willBeRemovedInGradle9()
                     .withUpgradeGuideSection(8, "reserved_configuration_names")
                     .nagUser();

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
@@ -86,6 +86,13 @@ This change is part of a larger ongoing effort to make the intended behavior of 
 
 The ability to change the allowed usage of a configuration after creation will be removed in Gradle 9.0.
 
+[[reserved_configuration_names]]
+==== Reserved configuration names
+
+Configuration names "detachedConfiguration" and "detachedConfigurationX" (where X is any integer) are reserved for internal use when creating detached configurations.
+
+The ability to create non-detached configurations with these names will be removed in Gradle 9.0.
+
 [[java_extension_without_java_component]]
 ==== Calling select methods on the `JavaPluginExtension` without the `java` component present
 


### PR DESCRIPTION
Failure here has nothing to do with this change.