### PR TITLE
De-incubate the org.gradle.language.jvm.tasks package

### DIFF
--- a/subprojects/language-jvm/src/main/java/org/gradle/language/jvm/tasks/package-info.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/language/jvm/tasks/package-info.java
@@ -17,5 +17,4 @@
 /**
  * Tasks for support for JVM languages.
  */
-@org.gradle.api.Incubating
 package org.gradle.language.jvm.tasks;


### PR DESCRIPTION
The last substantial change to the one task in this package (ProcessResources)  occurred 4 years ago.  The package has been incubating since 2013.
