### PR TITLE
Update wrapper to latest nightly

### DIFF
--- a/build-logic/build-init-samples/src/main/kotlin/gradlebuild/samples/SamplesGenerator.kt
+++ b/build-logic/build-init-samples/src/main/kotlin/gradlebuild/samples/SamplesGenerator.kt
@@ -198,10 +198,6 @@ Enter selection (default: JUnit 4) [1..4]
         """.trimIndent() else ""
         val nativeTestTaskPrefix = if (descriptor.language === Language.SWIFT) "xc" else "run"
         val classesUpToDate = if (descriptor.language === Language.KOTLIN) " UP-TO-DATE" else ""
-        val inspectClassesForKotlinICTask = if (descriptor.language === Language.KOTLIN) """
-     > Task :$subprojectName:inspectClassesForKotlinIC
-
-        """.trimIndent() else ""
         projectLayoutSetupRegistry.templateOperationFactory.newTemplateOperation()
             .withTemplate(templateFolder.template("$templateFragment-build.out"))
             .withTarget(settings.target.file("../tests/build.out").asFile)
@@ -212,7 +208,6 @@ Enter selection (default: JUnit 4) [1..4]
             .withBinding("nativeTestTaskPrefix", nativeTestTaskPrefix)
             .withBinding("tasksExecuted", "" + tasksExecuted(descriptor))
             .withBinding("classesUpToDate", "" + classesUpToDate)
-            .withBinding("inspectClassesForKotlinICTask", "" + inspectClassesForKotlinICTask)
             .create().generate()
         projectLayoutSetupRegistry.templateOperationFactory.newTemplateOperation()
             .withTemplate(templateFolder.template("build.sample.conf"))
@@ -223,9 +218,6 @@ Enter selection (default: JUnit 4) [1..4]
     private
     fun tasksExecuted(descriptor: CompositeProjectInitDescriptor): Int {
         var tasksExecuted = if (descriptor.componentType === ComponentType.LIBRARY) 4 else 7
-        if (descriptor.language === Language.KOTLIN) {
-            tasksExecuted++
-        }
         return tasksExecuted
     }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.1-20230311005433+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.2-20230313235452+0000-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.2-20230313235452+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.2-20230315151536+0000-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/subprojects/docs/src/samples/readme-templates/application-build.out.template
+++ b/subprojects/docs/src/samples/readme-templates/application-build.out.template
@@ -1,7 +1,7 @@
 ${extraCompileJava.raw}> Task :${subprojectName.raw}:compile${language.raw}
 > Task :${subprojectName.raw}:processResources NO-SOURCE
 > Task :${subprojectName.raw}:classes${classesUpToDate.raw}
-${inspectClassesForKotlinICTask.raw}> Task :${subprojectName.raw}:jar
+> Task :${subprojectName.raw}:jar
 > Task :${subprojectName.raw}:startScripts
 > Task :${subprojectName.raw}:distTar
 > Task :${subprojectName.raw}:distZip

--- a/subprojects/docs/src/samples/readme-templates/library-build.out.template
+++ b/subprojects/docs/src/samples/readme-templates/library-build.out.template
@@ -1,7 +1,7 @@
 ${extraCompileJava.raw}> Task :${subprojectName.raw}:compile${language.raw}
 > Task :${subprojectName.raw}:processResources NO-SOURCE
 > Task :${subprojectName.raw}:classes${classesUpToDate.raw}
-${inspectClassesForKotlinICTask.raw}> Task :${subprojectName.raw}:jar
+> Task :${subprojectName.raw}:jar
 > Task :${subprojectName.raw}:assemble
 ${extraCompileTestJava.raw}> Task :${subprojectName.raw}:compileTest${language.raw}
 > Task :${subprojectName.raw}:processTestResources NO-SOURCE


### PR DESCRIPTION
Brings in the `kotlin-dsl` plugin version and fix the `w: Classpath entry points to a non-existent location: ../build-logic/basics/build/classes/java/main` warning.

This also brings CC encryption by default.

This is the first 8.2 wrapper on `master`.
