### PR TITLE
Fix disabling of performance monitoring via system property

### DIFF
--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/health/HealthExpirationStrategy.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/health/HealthExpirationStrategy.java
@@ -88,6 +88,7 @@ public class HealthExpirationStrategy implements DaemonExpirationStrategy {
 
     @Override
     public DaemonExpirationResult checkExpiration() {
+        // We cannot check this in the constructor since system properties are copied to the daemon after initialization.
         if (!Boolean.parseBoolean(System.getProperty(ENABLE_PERFORMANCE_MONITORING, "true"))) {
             return DaemonExpirationResult.NOT_TRIGGERED;
         }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/health/HealthExpirationStrategy.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/health/HealthExpirationStrategy.java
@@ -75,7 +75,6 @@ public class HealthExpirationStrategy implements DaemonExpirationStrategy {
     private final DaemonHealthStats stats;
     private final GarbageCollectorMonitoringStrategy strategy;
     private final Logger logger;
-    private final boolean enabled;
 
     public HealthExpirationStrategy(DaemonHealthStats stats, GarbageCollectorMonitoringStrategy strategy) {
         this(stats, strategy, LoggerFactory.getLogger(HealthExpirationStrategy.class));
@@ -85,12 +84,11 @@ public class HealthExpirationStrategy implements DaemonExpirationStrategy {
         this.stats = stats;
         this.strategy = strategy;
         this.logger = logger;
-        this.enabled = Boolean.parseBoolean(System.getProperty(ENABLE_PERFORMANCE_MONITORING, "true"));
     }
 
     @Override
     public DaemonExpirationResult checkExpiration() {
-        if (!enabled) {
+        if (!Boolean.parseBoolean(System.getProperty(ENABLE_PERFORMANCE_MONITORING, "true"))) {
             return DaemonExpirationResult.NOT_TRIGGERED;
         }
 


### PR DESCRIPTION
The HealthExpirationStrategy is constructed before the system properties from the launcher are set in the daemon We handle this by checking if the property is set later, in 'checkExpiration'


Fixes #24283