### PR TITLE
Annotate transform-related packages and types with NonNullApi

### DIFF
--- a/subprojects/architecture-test/src/test/java/org/gradle/architecture/test/ArchUnitFixture.java
+++ b/subprojects/architecture-test/src/test/java/org/gradle/architecture/test/ArchUnitFixture.java
@@ -189,14 +189,15 @@ public interface ArchUnitFixture {
         return new AnnotatedMaybeInSupertypePredicate(predicate);
     }
 
-    static ArchCondition<JavaClass> beAnnotatedMaybeInPackageWith(final Class<? extends Annotation> annotationType) {
-        return ArchConditions.be(annotatedMaybeInPackageWith(annotationType));
+    static ArchCondition<JavaClass> beAnnotatedOrInPackageAnnotatedWith(Class<? extends Annotation> annotationType) {
+        return ArchConditions.be(annotatedOrInPackageAnnotatedWith(annotationType));
     }
 
-    static DescribedPredicate<JavaClass> annotatedMaybeInPackageWith(final Class<? extends Annotation> annotationType) {
-        String annotationTypeName = annotationType.getName();
-        DescribedPredicate<HasType> typeNameMatches = GET_RAW_TYPE.then(GET_NAME).is(equalTo(annotationTypeName));
-        return new AnnotatedMaybeInPackagePredicate(typeNameMatches.as("@" + annotationTypeName));
+    /**
+     * Either the class is directly annotated with the given annotation type or the class is in a package that is annotated with the given annotation type.
+     */
+    static DescribedPredicate<JavaClass> annotatedOrInPackageAnnotatedWith(Class<? extends Annotation> annotationType) {
+        return new AnnotatedOrInPackageAnnotatedPredicate(annotationType);
     }
 
     class HaveOnlyArgumentsOrReturnTypesThatAre extends ArchCondition<JavaMethod> {
@@ -353,17 +354,17 @@ public interface ArchUnitFixture {
         }
     }
 
-    class AnnotatedMaybeInPackagePredicate extends DescribedPredicate<JavaClass> {
-        private final DescribedPredicate<? super JavaAnnotation<?>> predicate;
+    class AnnotatedOrInPackageAnnotatedPredicate extends DescribedPredicate<JavaClass> {
+        private final Class<? extends Annotation> annotationType;
 
-        AnnotatedMaybeInPackagePredicate(DescribedPredicate<? super JavaAnnotation<?>> predicate) {
-            super("annotated, maybe in the package, with " + predicate.getDescription());
-            this.predicate = predicate;
+        AnnotatedOrInPackageAnnotatedPredicate(Class<? extends Annotation> annotationType) {
+            super("annotated (directly or via its package) with @" + annotationType.getName());
+            this.annotationType = annotationType;
         }
 
         @Override
         public boolean test(JavaClass input) {
-            return input.isAnnotatedWith(predicate) || input.getPackage().isAnnotatedWith(predicate);
+            return input.isAnnotatedWith(annotationType) || input.getPackage().isAnnotatedWith(annotationType);
         }
     }
 }

--- a/subprojects/architecture-test/src/test/java/org/gradle/architecture/test/ArchUnitFixtureTest.java
+++ b/subprojects/architecture-test/src/test/java/org/gradle/architecture/test/ArchUnitFixtureTest.java
@@ -23,6 +23,7 @@ import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ConditionEvent;
 import com.tngtech.archunit.lang.ConditionEvents;
+import org.gradle.api.NonNullApi;
 import org.gradlebuild.AbstractClass;
 import org.gradlebuild.AllowedMethodTypesClass;
 import org.gradlebuild.ConcreteClass;
@@ -133,6 +134,16 @@ public class ArchUnitFixtureTest {
                 "org.gradlebuild.WrongNullable.returnsNull() is using forbidden Nullable annotations: org.jetbrains.annotations.Nullable",
                 "parameter 0 for org.gradlebuild.WrongNullable.acceptsNull(java.lang.String) is using forbidden Nullable annotations: org.jetbrains.annotations.Nullable"
         );
+    }
+
+    @Test
+    public void checks_for_annotation_presence() {
+        ArchCondition<JavaClass> condition = ArchUnitFixture.beAnnotatedMaybeInPackageWith(NonNullApi.class);
+        assertNoViolation(checkClassCondition(condition, org.gradlebuild.nonnullapi.notinpackage.OwnNonNullApi.class));
+        ConditionEvent event = checkClassCondition(condition, org.gradlebuild.nonnullapi.notinpackage.NoOwnNonNullApi.class);
+        assertTrue(event.isViolation());
+        assertThat(eventDescription(event)).startsWith("Class <org.gradlebuild.nonnullapi.notinpackage.NoOwnNonNullApi> is not annotated, maybe in the package, with @org.gradle.api.NonNullApi");
+        // Cannot test on-package (not on the class) annotation, due to `ClasFileImporter` limitations
     }
 
     private static String eventDescription(ConditionEvent event) {

--- a/subprojects/architecture-test/src/test/java/org/gradle/architecture/test/ArchUnitFixtureTest.java
+++ b/subprojects/architecture-test/src/test/java/org/gradle/architecture/test/ArchUnitFixtureTest.java
@@ -138,11 +138,11 @@ public class ArchUnitFixtureTest {
 
     @Test
     public void checks_for_annotation_presence() {
-        ArchCondition<JavaClass> condition = ArchUnitFixture.beAnnotatedMaybeInPackageWith(NonNullApi.class);
+        ArchCondition<JavaClass> condition = ArchUnitFixture.beAnnotatedOrInPackageAnnotatedWith(NonNullApi.class);
         assertNoViolation(checkClassCondition(condition, org.gradlebuild.nonnullapi.notinpackage.OwnNonNullApi.class));
         ConditionEvent event = checkClassCondition(condition, org.gradlebuild.nonnullapi.notinpackage.NoOwnNonNullApi.class);
         assertTrue(event.isViolation());
-        assertThat(eventDescription(event)).startsWith("Class <org.gradlebuild.nonnullapi.notinpackage.NoOwnNonNullApi> is not annotated, maybe in the package, with @org.gradle.api.NonNullApi");
+        assertThat(eventDescription(event)).startsWith("Class <org.gradlebuild.nonnullapi.notinpackage.NoOwnNonNullApi> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi");
         // Cannot test on-package (not on the class) annotation, due to `ClasFileImporter` limitations
     }
 

--- a/subprojects/architecture-test/src/test/java/org/gradle/architecture/test/BuildOperationsApiTest.java
+++ b/subprojects/architecture-test/src/test/java/org/gradle/architecture/test/BuildOperationsApiTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.architecture.test;
+
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+import org.gradle.api.NonNullApi;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static org.gradle.architecture.test.ArchUnitFixture.beAnnotatedMaybeInPackageWith;
+
+@AnalyzeClasses(packages = "org.gradle.operations")
+public class BuildOperationsApiTest {
+
+    @ArchTest
+    public static final ArchRule classes_in_operations_package_are_annotated_with_non_null_api =
+        classes().should(beAnnotatedMaybeInPackageWith(NonNullApi.class));
+}

--- a/subprojects/architecture-test/src/test/java/org/gradle/architecture/test/BuildOperationsApiTest.java
+++ b/subprojects/architecture-test/src/test/java/org/gradle/architecture/test/BuildOperationsApiTest.java
@@ -22,12 +22,12 @@ import com.tngtech.archunit.lang.ArchRule;
 import org.gradle.api.NonNullApi;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
-import static org.gradle.architecture.test.ArchUnitFixture.beAnnotatedMaybeInPackageWith;
+import static org.gradle.architecture.test.ArchUnitFixture.beAnnotatedOrInPackageAnnotatedWith;
 
 @AnalyzeClasses(packages = "org.gradle.operations")
 public class BuildOperationsApiTest {
 
     @ArchTest
     public static final ArchRule classes_in_operations_package_are_annotated_with_non_null_api =
-        classes().should(beAnnotatedMaybeInPackageWith(NonNullApi.class));
+        classes().should(beAnnotatedOrInPackageAnnotatedWith(NonNullApi.class));
 }

--- a/subprojects/architecture-test/src/test/java/org/gradlebuild/nonnullapi/notinpackage/NoOwnNonNullApi.java
+++ b/subprojects/architecture-test/src/test/java/org/gradlebuild/nonnullapi/notinpackage/NoOwnNonNullApi.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradlebuild.nonnullapi.notinpackage;
+
+public interface NoOwnNonNullApi {
+}

--- a/subprojects/architecture-test/src/test/java/org/gradlebuild/nonnullapi/notinpackage/OwnNonNullApi.java
+++ b/subprojects/architecture-test/src/test/java/org/gradlebuild/nonnullapi/notinpackage/OwnNonNullApi.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradlebuild.nonnullapi.notinpackage;
+
+import org.gradle.api.NonNullApi;
+
+@NonNullApi
+public interface OwnNonNullApi {
+}

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ToPlannedNodeConverter.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ToPlannedNodeConverter.java
@@ -16,6 +16,7 @@
 
 package org.gradle.execution.plan;
 
+import org.gradle.api.NonNullApi;
 import org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType;
 import org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType.TaskIdentity;
 import org.gradle.internal.taskgraph.NodeIdentity;
@@ -28,6 +29,7 @@ import java.util.List;
  * Each implementation of this interface is responsible for nodes of {@link #getSupportedNodeType()}.
  * The converter can obtain the node identity for each node of the supported type via {@link #getNodeIdentity(Node)}.
  */
+@NonNullApi
 public interface ToPlannedNodeConverter {
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ToPlannedTaskConverter.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ToPlannedTaskConverter.java
@@ -16,6 +16,7 @@
 
 package org.gradle.execution.plan;
 
+import org.gradle.api.NonNullApi;
 import org.gradle.initialization.DefaultPlannedTask;
 import org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType;
 import org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType.TaskIdentity;
@@ -31,6 +32,7 @@ import java.util.stream.Collectors;
  * <p>
  * Only can convert {@link LocalTaskNode}s to {@link org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType.PlannedTask}s.
  */
+@NonNullApi
 public class ToPlannedTaskConverter implements ToPlannedNodeConverter {
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildOperationFiringBuildWorkPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildOperationFiringBuildWorkPreparer.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.build;
 
 import com.google.common.collect.ImmutableMap;
+import org.gradle.api.NonNullApi;
 import org.gradle.api.Task;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.execution.plan.ExecutionPlan;
@@ -34,6 +35,7 @@ import org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType.TaskId
 import org.gradle.internal.taskgraph.NodeIdentity;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -53,6 +55,7 @@ import static org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType
 import static org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType.PlannedTask;
 import static org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType.Result;
 
+@NonNullApi
 public class BuildOperationFiringBuildWorkPreparer implements BuildWorkPreparer {
     private final BuildOperationExecutor buildOperationExecutor;
     private final BuildWorkPreparer delegate;
@@ -305,6 +308,7 @@ public class BuildOperationFiringBuildWorkPreparer implements BuildWorkPreparer 
                 });
         }
 
+        @Nullable
         private NodeIdentity identifyAsDependencyNode(Node node, Predicate<NodeIdentity> isDependencyNode) {
             ToPlannedNodeConverter converter = converterRegistry.getConverter(node);
             if (converter == null) {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ToPlannedNodeConverterRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ToPlannedNodeConverterRegistry.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.service.scopes;
 
 import com.google.common.collect.ImmutableList;
+import org.gradle.api.NonNullApi;
 import org.gradle.execution.plan.Node;
 import org.gradle.execution.plan.ToPlannedNodeConverter;
 import org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType;
@@ -32,6 +33,7 @@ import java.util.concurrent.ConcurrentMap;
  * <p>
  * All the available converters are expected to support disjoint set of {@link Node node types}.
  */
+@NonNullApi
 public class ToPlannedNodeConverterRegistry {
 
     private static final ToPlannedNodeConverter MISSING_MARKER = new MissingToPlannedNodeConverter();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ToPlannedTransformStepConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ToPlannedTransformStepConverter.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.transform;
 
+import org.gradle.api.NonNullApi;
 import org.gradle.execution.plan.Node;
 import org.gradle.execution.plan.ToPlannedNodeConverter;
 import org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType;
@@ -24,6 +25,7 @@ import org.gradle.operations.dependencies.transforms.PlannedTransformStepIdentit
 /**
  * A converter from {@link TransformationNode} to {@link CalculateTaskGraphBuildOperationType.PlannedNode}.
  */
+@NonNullApi
 public class ToPlannedTransformStepConverter implements ToPlannedNodeConverter {
 
     @Override

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/internal/taskgraph/package-info.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/internal/taskgraph/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Build operations and data types for execution plan.
+ */
+@org.gradle.api.NonNullApi
+package org.gradle.internal.taskgraph;

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/operations/dependencies/configurations/package-info.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/operations/dependencies/configurations/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Build operations and data types for configurations.
+ */
+@org.gradle.api.NonNullApi
+package org.gradle.operations.dependencies.configurations;

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/operations/dependencies/transforms/package-info.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/operations/dependencies/transforms/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Build operations and data types for artifact transforms.
+ */
+@org.gradle.api.NonNullApi
+package org.gradle.operations.dependencies.transforms;

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/operations/dependencies/variants/package-info.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/operations/dependencies/variants/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Build operations and data types for component variants.
+ */
+@org.gradle.api.NonNullApi
+package org.gradle.operations.dependencies.variants;


### PR DESCRIPTION
Annotated:
- All existing sub-packages of `org.gradle.operations`
- Some related classes that are in larger packages that are out-of-scope for nullability annotation for now

Additionally, a new ArchTest was added that makes sure that all classes in `org.gradle.operations` are annotated with `@NonNullApi` either directly or via the package.