### PR TITLE
Unignore tests on platforms where it shouldn't fail

### DIFF
--- a/subprojects/wrapper/src/crossVersionTest/groovy/org/gradle/integtests/wrapper/WrapperCrossVersionIntegrationTest.groovy
+++ b/subprojects/wrapper/src/crossVersionTest/groovy/org/gradle/integtests/wrapper/WrapperCrossVersionIntegrationTest.groovy
@@ -24,8 +24,8 @@ import org.gradle.integtests.fixtures.executer.GradleExecuter
 import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext
 import org.gradle.util.GradleVersion
 import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 import org.junit.Assume
-import spock.lang.Ignore
 import spock.lang.IgnoreIf
 
 @SuppressWarnings("IntegrationTestFixtures")
@@ -46,7 +46,9 @@ class WrapperCrossVersionIntegrationTest extends CrossVersionIntegrationSpec {
     }
 
     @IgnoreIf({ GradleContextualExecuter.embedded }) // wrapperExecuter requires a real distribution
-    @Ignore('https://github.com/gradle/gradle-private/issues/3758')
+    @IgnoreIf(
+        value = { TestPrecondition.WINDOWS.fulfilled && !TestPrecondition.JDK11_OR_LATER.fulfilled },
+        reason = 'https://github.com/gradle/gradle-private/issues/3758')
     void canUseWrapperFromCurrentVersionToRunPreviousVersion() {
         when:
         GradleExecuter executer = prepareWrapperExecuter(current, previous).withWarningMode(null)
@@ -148,4 +150,3 @@ task hello {
         new DaemonLogsAnalyzer(executer.daemonBaseDir, executionVersion.version.version).killAll()
     }
 }
-

--- a/subprojects/wrapper/src/crossVersionTest/groovy/org/gradle/integtests/wrapper/WrapperPropertiesLoaderCrossVersionTest.groovy
+++ b/subprojects/wrapper/src/crossVersionTest/groovy/org/gradle/integtests/wrapper/WrapperPropertiesLoaderCrossVersionTest.groovy
@@ -21,7 +21,8 @@ import org.gradle.integtests.fixtures.daemon.DaemonLogsAnalyzer
 import org.gradle.integtests.fixtures.executer.GradleDistribution
 import org.gradle.integtests.fixtures.executer.GradleExecuter
 import org.gradle.util.GradleVersion
-import spock.lang.Ignore
+import org.gradle.util.TestPrecondition
+import spock.lang.IgnoreIf
 import spock.lang.Issue
 
 import static org.junit.Assume.assumeTrue
@@ -31,7 +32,9 @@ import static org.junit.Assume.assumeTrue
 class WrapperPropertiesLoaderCrossVersionTest extends CrossVersionIntegrationSpec {
 
     @Issue('https://github.com/gradle/gradle/issues/11173')
-    @Ignore('https://github.com/gradle/gradle-private/issues/3758')
+    @IgnoreIf(
+        value = { TestPrecondition.WINDOWS.fulfilled && !TestPrecondition.JDK11_OR_LATER.fulfilled },
+        reason = 'https://github.com/gradle/gradle-private/issues/3758')
     void "System properties defined in gradle.properties are available in buildSrc and in included builds"() {
         given:
         GradleDistribution wrapperVersion = previous
@@ -108,4 +111,3 @@ class WrapperPropertiesLoaderCrossVersionTest extends CrossVersionIntegrationSpe
         new DaemonLogsAnalyzer(executer.daemonBaseDir, executionVersion.version.version).killAll()
     }
 }
-


### PR DESCRIPTION
Only Windows with Java 8 (and 9, 10, 12 on which we don't test) is affected.

Part of gradle/gradle-private#3758