### PR TITLE
Drop duplicates from GMM

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
@@ -73,6 +73,7 @@ public enum CacheLayout {
         .changedTo(97, "6.8-rc-1")
         .changedTo(99, "7.5-rc-1")
         .changedTo(100, "8.0-milestone-5")
+        .changedTo(101_123_346, "8.1-rc-1")
     ),
 
     RESOURCES(ROOT, "resources", introducedIn("1.9-rc-1")),

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParser.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser;
 
+import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.gson.stream.JsonReader;
@@ -53,7 +54,9 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 import static com.google.gson.stream.JsonToken.BOOLEAN;
 import static com.google.gson.stream.JsonToken.END_ARRAY;
@@ -292,7 +295,7 @@ public class GradleModuleMetadataParser {
     }
 
     private List<ModuleDependency> consumeDependencies(JsonReader reader) throws IOException {
-        List<ModuleDependency> dependencies = new ArrayList<>();
+        Set<ModuleDependency> dependencies = new LinkedHashSet<>();
         reader.beginArray();
         while (reader.peek() != END_ARRAY) {
             String group = null;
@@ -357,7 +360,7 @@ public class GradleModuleMetadataParser {
             dependencies.add(new ModuleDependency(group, module, version, excludes, reason, attributes, requestedCapabilities, endorseStrictVersions, artifactSelector));
         }
         reader.endArray();
-        return dependencies;
+        return new ArrayList<>(dependencies);
     }
 
     private IvyArtifactName consumeArtifactSelector(JsonReader reader) throws IOException {
@@ -433,7 +436,7 @@ public class GradleModuleMetadataParser {
     }
 
     private List<ModuleDependencyConstraint> consumeDependencyConstraints(JsonReader reader) throws IOException {
-        List<ModuleDependencyConstraint> dependencies = new ArrayList<>();
+        Set<ModuleDependencyConstraint> dependencies = new LinkedHashSet<>();
         reader.beginArray();
         while (reader.peek() != END_ARRAY) {
             String group = null;
@@ -473,7 +476,7 @@ public class GradleModuleMetadataParser {
             dependencies.add(new ModuleDependencyConstraint(group, module, version, reason, attributes));
         }
         reader.endArray();
-        return dependencies;
+        return new ArrayList<>(dependencies);
     }
 
     private ImmutableVersionConstraint consumeVersion(JsonReader reader) throws IOException {
@@ -641,6 +644,33 @@ public class GradleModuleMetadataParser {
             this.endorsing = endorsing;
             this.artifact = artifact;
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            ModuleDependency that = (ModuleDependency) o;
+            return Objects.equal(group, that.group)
+                && Objects.equal(module, that.module)
+                && Objects.equal(versionConstraint, that.versionConstraint)
+                && Objects.equal(excludes, that.excludes)
+                && Objects.equal(reason, that.reason)
+                && Objects.equal(attributes, that.attributes)
+                && Objects.equal(requestedCapabilities, that.requestedCapabilities)
+                && Objects.equal(endorsing, that.endorsing)
+                && Objects.equal(artifact, that.artifact);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(group, module, versionConstraint, excludes, reason, attributes, endorsing, artifact);
+        }
+
     }
 
     private static class ModuleDependencyConstraint {
@@ -656,6 +686,27 @@ public class GradleModuleMetadataParser {
             this.versionConstraint = versionConstraint;
             this.reason = reason;
             this.attributes = attributes;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            ModuleDependencyConstraint that = (ModuleDependencyConstraint) o;
+            return Objects.equal(group, that.group)
+                && Objects.equal(module, that.module)
+                && Objects.equal(versionConstraint, that.versionConstraint)
+                && Objects.equal(reason, that.reason)
+                && Objects.equal(attributes, that.attributes);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(group, module, versionConstraint, reason, attributes);
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParser.java
@@ -294,6 +294,15 @@ public class GradleModuleMetadataParser {
         return ImmutableList.of(new ModuleDependency(group, module, new DefaultImmutableVersionConstraint(version), ImmutableList.of(), null, ImmutableAttributes.EMPTY, Collections.emptyList(), false, null));
     }
 
+    /**
+     * Consume the dependencies of a given variant.
+     * <p>
+     * This method needs to remove any duplicates from said dependencies.
+     *
+     * @param reader The Json to read from
+     * @return a list of dependencies
+     * @throws IOException when the reader fails
+     */
     private List<ModuleDependency> consumeDependencies(JsonReader reader) throws IOException {
         Set<ModuleDependency> dependencies = new LinkedHashSet<>();
         reader.beginArray();
@@ -435,6 +444,15 @@ public class GradleModuleMetadataParser {
         return capabilities.build();
     }
 
+    /**
+     * Consume the dependency constraints of a given variant.
+     * <p>
+     * This method needs to remove any duplicates from said constraints.
+     *
+     * @param reader The Json to read from
+     * @return a list of dependencies
+     * @throws IOException when the reader fails
+     */
     private List<ModuleDependencyConstraint> consumeDependencyConstraints(JsonReader reader) throws IOException {
         Set<ModuleDependencyConstraint> dependencies = new LinkedHashSet<>();
         reader.beginArray();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParser.java
@@ -450,7 +450,7 @@ public class GradleModuleMetadataParser {
      * This method needs to remove any duplicates from said constraints.
      *
      * @param reader The Json to read from
-     * @return a list of dependencies
+     * @return a list of constraints
      * @throws IOException when the reader fails
      */
     private List<ModuleDependencyConstraint> consumeDependencyConstraints(JsonReader reader) throws IOException {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
@@ -321,12 +321,18 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
 
         @Override
         public void addDependency(String group, String module, VersionConstraint versionConstraint, List<ExcludeMetadata> excludes, String reason, ImmutableAttributes attributes, List<? extends Capability> requestedCapabilities, boolean endorsing, @Nullable IvyArtifactName artifact) {
-            dependencies.add(new DependencyImpl(group, module, versionConstraint, excludes, reason, attributes, requestedCapabilities, endorsing, artifact));
+            DependencyImpl dependency = new DependencyImpl(group, module, versionConstraint, excludes, reason, attributes, requestedCapabilities, endorsing, artifact);
+            if (!dependencies.contains(dependency)) {
+                dependencies.add(dependency);
+            }
         }
 
         @Override
         public void addDependencyConstraint(String group, String module, VersionConstraint versionConstraint, String reason, ImmutableAttributes attributes) {
-            dependencyConstraints.add(new DependencyConstraintImpl(group, module, versionConstraint, reason, attributes));
+            DependencyConstraintImpl constraint = new DependencyConstraintImpl(group, module, versionConstraint, reason, attributes);
+            if (!dependencyConstraints.contains(constraint)) {
+                dependencyConstraints.add(constraint);
+            }
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
@@ -321,18 +321,12 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
 
         @Override
         public void addDependency(String group, String module, VersionConstraint versionConstraint, List<ExcludeMetadata> excludes, String reason, ImmutableAttributes attributes, List<? extends Capability> requestedCapabilities, boolean endorsing, @Nullable IvyArtifactName artifact) {
-            DependencyImpl dependency = new DependencyImpl(group, module, versionConstraint, excludes, reason, attributes, requestedCapabilities, endorsing, artifact);
-            if (!dependencies.contains(dependency)) {
-                dependencies.add(dependency);
-            }
+            dependencies.add(new DependencyImpl(group, module, versionConstraint, excludes, reason, attributes, requestedCapabilities, endorsing, artifact));
         }
 
         @Override
         public void addDependencyConstraint(String group, String module, VersionConstraint versionConstraint, String reason, ImmutableAttributes attributes) {
-            DependencyConstraintImpl constraint = new DependencyConstraintImpl(group, module, versionConstraint, reason, attributes);
-            if (!dependencyConstraints.contains(constraint)) {
-                dependencyConstraints.add(constraint);
-            }
+            dependencyConstraints.add(new DependencyConstraintImpl(group, module, versionConstraint, reason, attributes));
         }
 
         @Override
@@ -532,12 +526,14 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
                 && Objects.equal(excludes, that.excludes)
                 && Objects.equal(reason, that.reason)
                 && Objects.equal(attributes, that.attributes)
-                && Objects.equal(requestedCapabilities, that.requestedCapabilities);
+                && Objects.equal(requestedCapabilities, that.requestedCapabilities)
+                && Objects.equal(endorsing, that.endorsing)
+                && Objects.equal(dependencyArtifact, that.dependencyArtifact);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hashCode(group, module, versionConstraint, excludes, reason, attributes);
+            return Objects.hashCode(group, module, versionConstraint, excludes, reason, attributes, endorsing, dependencyArtifact);
         }
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
@@ -53,7 +53,7 @@ class CacheLayoutTest extends Specification {
         CacheLayout cacheLayout = CacheLayout.META_DATA
 
         then:
-        def expectedVersion = 100
+        def expectedVersion = 101_123_346
         cacheLayout.name == 'metadata'
         cacheLayout.key == "metadata-2.${expectedVersion}"
         cacheLayout.version == CacheVersion.parse("2.${expectedVersion}")

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParserTest.groovy
@@ -871,6 +871,24 @@ class GradleModuleMetadataParserTest extends Specification {
         json.replace('"formatVersion": "1.1"', '"formatVersion": "' + metadataVersion + '"')
     }
 
+    def "new hierarchy in ModuleDependency is added to equals and hashcode"() {
+        when:
+        // If this test fails, you added a type hierarchy to GradleModuleMetadataParser.ModuleDependency, update this test _after_ making sure it is considered by hashcode and equals
+        def modDepClass = GradleModuleMetadataParser.ModuleDependency.class
+
+        then:
+        modDepClass.getSuperclass() == Object.class
+    }
+
+    def "new hierarchy in ModuleDependencyConstraint is added to equals and hashcode"() {
+        when:
+        // If this test fails, you added a type hierarchy to GradleModuleMetadataParser.ModuleDependency, update this test _after_ making sure it is considered by hashcode and equals
+        def modDepClass = GradleModuleMetadataParser.ModuleDependencyConstraint.class
+
+        then:
+        modDepClass.getSuperclass() == Object.class
+    }
+
     def "new fields in ModuleDependency are added to equals and hashcode"() {
         when:
         // If this test fails, you added a field to GradleModuleMetadataParser.ModuleDependency, add it here _after_ making sure it is considered by hashcode and equals

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParserTest.groovy
@@ -33,6 +33,8 @@ import org.gradle.util.TestUtil
 import org.junit.Rule
 import spock.lang.Specification
 
+import java.util.stream.Collectors
+
 import static org.gradle.util.AttributeTestUtil.attributes
 
 class GradleModuleMetadataParserTest extends Specification {
@@ -867,6 +869,32 @@ class GradleModuleMetadataParserTest extends Specification {
 
     String replaceMetadataVersion(String json, String metadataVersion) {
         json.replace('"formatVersion": "1.1"', '"formatVersion": "' + metadataVersion + '"')
+    }
+
+    def "new fields in ModuleDependency are added to equals and hashcode"() {
+        when:
+        // If this test fails, you added a field to GradleModuleMetadataParser.ModuleDependency, add it here _after_ making sure it is considered by hashcode and equals
+        def knownFields = ["group", "module", "versionConstraint", "excludes", "reason", "attributes", "requestedCapabilities", "endorsing", "artifact"]
+        def modDepClass = GradleModuleMetadataParser.ModuleDependency.class
+        def newFields = Arrays.stream(modDepClass.getDeclaredFields()).filter { !knownFields.contains(it.getName()) }
+            .map { it.getName() }
+            .collect(Collectors.toList())
+
+        then:
+        newFields == []
+    }
+
+    def "new fields in ModuleDependencyConstraint are added to equals and hashcode"() {
+        when:
+        // If this test fails, you added a field to GradleModuleMetadataParser.ModuleDependencyConstraint, add it here _after_ making sure it is considered by hashcode and equals
+        def knownFields = ["group", "module", "versionConstraint", "reason", "attributes"]
+        def modDepClass = GradleModuleMetadataParser.ModuleDependencyConstraint.class
+        def newFields = Arrays.stream(modDepClass.getDeclaredFields()).filter { !knownFields.contains(it.getName()) }
+            .map { it.getName() }
+            .collect(Collectors.toList())
+
+        then:
+        newFields == []
     }
 
     def resource(String content) {


### PR DESCRIPTION
When parsing Gradle Module Metadata, Gradle drops duplicate dependencies
 and constraints declarations.
 This is now consistent with the way Maven metadata is handled.

 Note that this only applies to strict duplicates, declaring a
 dependency on different variants or capabilites remain supported.

 Fixes #24037