### PR TITLE
Consolidate usage fields into single bitwise field to trim memory

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -236,7 +236,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     private boolean insideBeforeResolve;
 
     private boolean dependenciesModified;
-    private byte allowedUsage = Usage.EVERYTHING_ALLOWED_NOTHING_DEPRECATED;
+    private byte allowedUsage = Usage.EVERY_NONDEPRECATED_USAGE;
     private boolean usageCanBeMutated = true;
     private final ConfigurationRole roleAtCreation;
 
@@ -2452,7 +2452,7 @@ since users cannot create non-legacy configurations and there is no current publ
         DEPRECATED_FOR_RESOLUTION((byte) 16),
         DEPRECATED_FOR_DECLARATION_AGAINST((byte) 32);
 
-        private static final byte EVERYTHING_ALLOWED_NOTHING_DEPRECATED = (byte) (CONSUMABLE.mask | RESOLVABLE.mask | DECLARABLE_AGAINST.mask);
+        private static final byte EVERY_NONDEPRECATED_USAGE = (byte) (CONSUMABLE.mask | RESOLVABLE.mask | DECLARABLE_AGAINST.mask);
 
         private final byte mask;
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -2452,7 +2452,7 @@ since users cannot create non-legacy configurations and there is no current publ
         DEPRECATED_FOR_RESOLUTION((byte) 16),
         DEPRECATED_FOR_DECLARATION_AGAINST((byte) 32);
 
-        private static final byte EVERYTHING_ALLOWED_NOTHING_DEPRECATED = 7; // consumable & resolvable & declarable_against
+        private static final byte EVERYTHING_ALLOWED_NOTHING_DEPRECATED = (byte) (CONSUMABLE.mask | RESOLVABLE.mask | DECLARABLE_AGAINST.mask);
 
         private final byte mask;
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -2473,7 +2473,7 @@ since users cannot create non-legacy configurations and there is no current publ
         }
 
         public boolean isEnabled(DefaultConfiguration configuration) {
-            return (mask & configuration.allowedUsage) > 0;
+            return (mask & configuration.allowedUsage) != 0;
         }
     }
 }


### PR DESCRIPTION
Don't know if we'd definitely want to do this or not, but it was quick to implement and test.  No performance regression, and probably some marginal memory savings for large builds with lots of confs at the cost of marginally more complex code.

It's here for consideration.