### PR TITLE
Deprecate and remove unnecessary DefaultConfiguration methods

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
@@ -436,6 +436,7 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
      *
      * @return All the configurations belonging to the configuration container that this set belongs to itself.
      */
+    @Deprecated
     Set<Configuration> getAll();
 
     /**

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationDefaultsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationDefaultsIntegrationTest.groovy
@@ -362,4 +362,19 @@ task check {
         expect:
         succeeds ":check"
     }
+
+    def "configuration getAll is deprecated"() {
+        given:
+        buildFile << """
+            configurations {
+                conf {
+                    getAll()
+                }
+            }
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning("Calling the Configuration.getAll() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use the configurations container to access the set of configurations instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_configuration_get_all")
+        succeeds "help"
+    }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleUsageIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleUsageIntegrationTest.groovy
@@ -430,12 +430,15 @@ class ConfigurationRoleUsageIntegrationTest extends AbstractIntegrationSpec impl
             configurations {
                 assert !findByName('custom')
                 def result = maybeCreateWithRole('custom', ConfigurationRoles.INTENDED_RESOLVABLE, true, false)
-                assert !result.isUsageMutable()
+                result.canBeResolved = !result.canBeResolved
             }
         """
 
         expect:
-        succeeds 'help'
+        fails 'help'
+
+        and:
+        assertUsageLockedFailure('custom', 'Intended Resolvable')
     }
 
     def "maybeCreateWithRole can lock existing roles"() {
@@ -449,14 +452,16 @@ class ConfigurationRoleUsageIntegrationTest extends AbstractIntegrationSpec impl
 
             configurations {
                 def existing = findByName('implementation')
-                assert existing.isUsageMutable()
                 def result = maybeCreateWithRole('implementation', ConfigurationRoles.LEGACY, true, false)
-                assert !result.isUsageMutable()
+                result.canBeResolved = !result.canBeResolved
             }
         """
 
         expect:
-        succeeds 'help'
+        fails 'help'
+
+        and:
+        assertUsageLockedFailure('implementation', 'Intended Bucket')
     }
 
     def "can update all roles for non-locked configurations"() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
@@ -99,12 +99,6 @@ public interface ConfigurationInternal extends ResolveContext, DeprecatableConfi
     List<? extends GradleException> preventFromFurtherMutationLenient();
 
     /**
-     * Reports whether this configuration uses {@link org.gradle.api.Incubating Incubating} attributes types, such as {@link org.gradle.api.attributes.Category#VERIFICATION}.
-     * @return
-     */
-    boolean isIncubating();
-
-    /**
      * Gets the complete set of exclude rules including those contributed by
      * superconfigurations.
      */

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -549,8 +549,15 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         }
     }
 
+    @Deprecated
     @Override
     public Set<Configuration> getAll() {
+        DeprecationLogger.deprecateAction("Calling the Configuration.getAll() method")
+                .withAdvice("Use the configurations container to access the set of configurations instead.")
+                .willBeRemovedInGradle9()
+                .withUpgradeGuideSection(8, "deprecated_configuration_get_all")
+                .nagUser();
+
         return ImmutableSet.copyOf(configurationsProvider.getAll());
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -89,7 +89,6 @@ import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributeContainerWithErrorMessage;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
-import org.gradle.api.internal.attributes.IncubatingAttributesChecker;
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.file.AbstractFileCollection;
 import org.gradle.api.internal.file.FileCollectionFactory;
@@ -1265,11 +1264,6 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     }
 
     @Override
-    public boolean isIncubating() {
-        return IncubatingAttributesChecker.isAnyIncubating(getAttributes());
-    }
-
-    @Override
     public void outgoing(Action<? super ConfigurationPublications> action) {
         action.execute(outgoing);
     }
@@ -1778,11 +1772,6 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     @Override
     public void preventUsageMutation() {
         usageCanBeMutated = false;
-    }
-
-    @VisibleForTesting
-    public boolean isUsageMutable() {
-        return usageCanBeMutated;
     }
 
     @SuppressWarnings("deprecation")

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
@@ -180,7 +180,6 @@ class DefaultConfigurationContainerSpec extends Specification {
         then:
         detached.name == "detachedConfiguration1"
         detached.getAll() == [detached] as Set
-        detached.getHierarchy() == [detached] as Set
         [dependency1, dependency2].each { detached.getDependencies().contains(it) }
         detached.getDependencies().size() == 2
         detached.path == ":detachedConfiguration1"

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
@@ -180,6 +180,7 @@ class DefaultConfigurationContainerSpec extends Specification {
         then:
         detached.name == "detachedConfiguration1"
         detached.getAll() == [detached] as Set
+        detached.getHierarchy() == [detached] as Set
         [dependency1, dependency2].each { detached.getDependencies().contains(it) }
         detached.getDependencies().size() == 2
         detached.path == ":detachedConfiguration1"

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
@@ -138,6 +138,15 @@ Some of them still registers conventions for backwards compatibility.
 Registering conventions does not emit a deprecation warning yet to provide a migration window.
 Future Gradle versions will do.
 
+[[deprecated_configuration_get_all]]
+==== `link:{javadocPath}/org/gradle/api/artifacts/Configuration.html[CompileOptions]` method deprecations
+
+The following method on `Configuration` is deprecated for removal:
+
+- `getAll()`
+
+Obtain the set of all configurations from the project's `configurations` container instead.
+
 [[changes_8.1]]
 == Upgrading from 8.0 and earlier
 

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
@@ -139,7 +139,7 @@ Registering conventions does not emit a deprecation warning yet to provide a mig
 Future Gradle versions will do.
 
 [[deprecated_configuration_get_all]]
-==== `link:{javadocPath}/org/gradle/api/artifacts/Configuration.html[CompileOptions]` method deprecations
+==== `link:{javadocPath}/org/gradle/api/artifacts/Configuration.html[Configuration]` method deprecations
 
 The following method on `Configuration` is deprecated for removal:
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/ConfigurationDeprecatedExtensions.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/ConfigurationDeprecatedExtensions.kt
@@ -377,6 +377,7 @@ fun <T : Configuration> NamedDomainObjectProvider<T>.withDependencies(action: De
 /**
  * See [Configuration.all].
  */
+@Suppress("DEPRECATION")
 @Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().all"), level = DeprecationLevel.HIDDEN)
 val <T : Configuration> NamedDomainObjectProvider<T>.all: Set<Configuration>
     get() = get().all


### PR DESCRIPTION
- Deprecate the configuration.getAll method
- Remove internal isIncubating and isUsageMutable methods