### PR TITLE
Dependency insight load after store compatibility

### DIFF
--- a/subprojects/diagnostics/build.gradle.kts
+++ b/subprojects/diagnostics/build.gradle.kts
@@ -54,8 +54,3 @@ packageCycles {
     excludePatterns.add("org/gradle/api/reporting/dependencies/internal/*")
     excludePatterns.add("org/gradle/api/plugins/internal/*")
 }
-
-// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
-tasks.configCacheIntegTest {
-    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
-}

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.tasks.diagnostics
 import groovy.transform.CompileStatic
 import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import org.gradle.integtests.resolve.locking.LockfileFixture
 
@@ -299,6 +300,7 @@ org:leaf:1.0
 """
     }
 
+    @ToBeFixedForConfigurationCache(because = "StyledTextOutput is not serializable")
     def "displays information about conflicting modules when failOnVersionConflict is used"() {
         given:
         mavenRepo.module("org", "leaf1").publish()
@@ -370,6 +372,7 @@ org:leaf2:1.5 -> 2.5
 """
     }
 
+    @ToBeFixedForConfigurationCache(because = "StyledTextOutput is not serializable")
     def "displays information about conflicting modules when failOnVersionConflict is used and afterResolve is used"() {
         given:
         mavenRepo.module("org", "leaf1").publish()

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyReportTaskIntegrationTest.groovy
@@ -237,8 +237,9 @@ config
             }
 
             task resolveConf {
+                def foo = configurations.foo
                 doLast {
-                    configurations.foo.each { println it }
+                    foo.each { println it }
                 }
             }
         """

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
@@ -40,6 +40,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionS
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
@@ -121,10 +122,15 @@ public abstract class DependencyInsightReportTask extends DefaultTask {
     private final Property<Boolean> showingAllVariants = getProject().getObjects().property(Boolean.class);
     private transient Configuration configuration;
     private final Property<ResolvedComponentResult> rootComponentProperty = getProject().getObjects().property(ResolvedComponentResult.class);
+
+    // this field is named with a starting `z` to be serialized after `rootComponentProperty`
+    // because the serialization of `rootComponentProperty` can still trigger callback that can affect
+    // a value of `configuration.getAttributes()`.
+    // TODO:configuration-cache find a way to clean up this #23732
+    private Provider<AttributeContainer> zConfigurationAttributes;
     private ResolutionErrorRenderer errorHandler;
     private String configurationName;
     private String configurationDescription;
-    private AttributeContainer configurationAttributes;
 
     /**
      * The root component of the dependency graph to be inspected.
@@ -150,7 +156,8 @@ public abstract class DependencyInsightReportTask extends DefaultTask {
             }
             configurationName = configuration.getName();
             configurationDescription = configuration.toString();
-            configurationAttributes = configuration.getAttributes();
+            zConfigurationAttributes = getProject().provider(configuration::getAttributes);
+
             ResolvableDependenciesInternal incoming = (ResolvableDependenciesInternal) configuration.getIncoming();
             ResolutionResult result = incoming.getResolutionResult(errorHandler);
             rootComponentProperty.set(result.getRootComponent());
@@ -320,7 +327,7 @@ public abstract class DependencyInsightReportTask extends DefaultTask {
         GraphRenderer renderer = new GraphRenderer(output);
         DependencyInsightReporter reporter = new DependencyInsightReporter(getVersionSelectorScheme(), getVersionComparator(), getVersionParser());
         Collection<RenderableDependency> itemsToRender = reporter.convertToRenderableItems(selectedDependencies, isShowSinglePathToDependency());
-        RootDependencyRenderer rootRenderer = new RootDependencyRenderer(this, configurationAttributes, getAttributesFactory());
+        RootDependencyRenderer rootRenderer = new RootDependencyRenderer(this, zConfigurationAttributes.get(), getAttributesFactory());
         ReplaceProjectWithConfigurationNameRenderer dependenciesRenderer = new ReplaceProjectWithConfigurationNameRenderer(configurationName);
         DependencyGraphsRenderer dependencyGraphRenderer = new DependencyGraphsRenderer(output, renderer, rootRenderer, dependenciesRenderer);
         dependencyGraphRenderer.setShowSinglePath(showSinglePathToDependency);

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -170,6 +170,7 @@ public abstract class JavaBasePlugin implements Plugin<Project> {
 
     private void configureLibraryElements(TaskProvider<JavaCompile> compileTaskProvider, SourceSet sourceSet, ConfigurationContainer configurations, ObjectFactory objectFactory) {
         ConfigurationInternal compileClasspath = (ConfigurationInternal) configurations.getByName(sourceSet.getCompileClasspathConfigurationName());
+        // TODO:configuration-cache this is a callback that affects configuration attributes #23732
         compileClasspath.beforeLocking(conf -> {
             AttributeContainerInternal attributes = conf.getAttributes();
             if (!attributes.contains(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE)) {


### PR DESCRIPTION
Fixes #23732

This PR is enabling load-after-store in `diagnostics` project. To do it, I'm using a workaround(if name it politely :)) to change an order of fields serialization in `DependencyInsightTask`.
Also couple of tests marked as ToBeFixedWithCC because it's using error reporting, and to make it work with load-after-store we need to serialize `DependencyInsightTask.resolutionErrorRenderer` or it's state, somehow. I've also failed to serialize error output `StyledTextOutput`. Are there any hints to handle it?