### PR TITLE
Refine clean up rules for Check/Promotion project

### DIFF
--- a/.teamcity/src/main/kotlin/common/extensions.kt
+++ b/.teamcity/src/main/kotlin/common/extensions.kt
@@ -31,6 +31,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.BuildTypeSettings
 import jetbrains.buildServer.configs.kotlin.v2019_2.CheckoutMode
 import jetbrains.buildServer.configs.kotlin.v2019_2.Dependencies
 import jetbrains.buildServer.configs.kotlin.v2019_2.FailureAction
+import jetbrains.buildServer.configs.kotlin.v2019_2.Project
 import jetbrains.buildServer.configs.kotlin.v2019_2.RelativeId
 import jetbrains.buildServer.configs.kotlin.v2019_2.Requirements
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.GradleBuildStep
@@ -273,3 +274,27 @@ fun BuildType.killProcessStep(stepName: String, os: Os, arch: Arch = Arch.AMD64)
 }
 
 fun String.toCapitalized() = this.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
+
+/**
+ * Define clean up rules for the project.
+ * See https://www.jetbrains.com/help/teamcity/teamcity-data-clean-up.html#Clean-up+Rules
+ *
+ * @param historyDays days number of days to store build history .
+ * @param artifactsDays number of days to store artifacts. In the stored history, artifacts older than this number will be cleaned up.
+ * @param artifactPatterns patterns for artifacts clean-up. If not specified, all artifacts will be removed.
+ */
+fun Project.cleanupRule(historyDays: Int, artifactsDays: Int, artifactsPatterns: String? = null) {
+    features {
+        this@cleanupRule.cleanup {
+            baseRule {
+                history(days = historyDays)
+            }
+            baseRule {
+                artifacts(
+                    days = artifactsDays,
+                    artifactPatterns = artifactsPatterns
+                )
+            }
+        }
+    }
+}

--- a/.teamcity/src/main/kotlin/projects/CheckProject.kt
+++ b/.teamcity/src/main/kotlin/projects/CheckProject.kt
@@ -1,5 +1,6 @@
 package projects
 
+import common.cleanupRule
 import common.hiddenArtifactDestination
 import configurations.PerformanceTestsPass
 import configurations.StagePasses
@@ -65,18 +66,12 @@ class CheckProject(
     buildTypesOrder = buildTypes
     subProjectsOrder = subProjects
 
-    cleanup {
-        baseRule {
-            history(days = 14)
-        }
-        baseRule {
-            artifacts(
-                days = 14,
-                artifactPatterns = """
+    cleanupRule(
+        historyDays = 14,
+        artifactsDays = 7,
+        artifactsPatterns = """
                 +:**/*
                 +:$hiddenArtifactDestination/**/*"
-                """.trimIndent()
-            )
-        }
-    }
+        """.trimIndent()
+    )
 })

--- a/.teamcity/src/main/kotlin/promotion/PromotionProject.kt
+++ b/.teamcity/src/main/kotlin/promotion/PromotionProject.kt
@@ -3,12 +3,15 @@ package promotion
 import common.BuildToolBuildJvm
 import common.Os
 import common.VersionedSettingsBranch
+import common.cleanupRule
 import common.javaHome
 import jetbrains.buildServer.configs.kotlin.v2019_2.Project
 
 class PromotionProject(branch: VersionedSettingsBranch) : Project({
     id("Promotion")
     name = "Promotion"
+
+    cleanupRule(historyDays = 14, artifactsDays = 7)
 
     buildType(SanityCheck)
     buildType(PublishNightlySnapshot(branch))


### PR DESCRIPTION
Part of https://github.com/gradle/dev-infrastructure/issues/735

In the past,

- History cleanup rule in Check project: 14 days
- Artifacts cleanup rule in Check project: 14 days
- History cleanup rule in Promotion project: 28 days
- Artifacts cleanup rule in Promotion project: 28 days

Now we change it to:

- History cleanup rule in Check project: 14 days
- Artifacts cleanup rule in Check project: 7 days
- History cleanup rule in Promotion project: 14 days
- Artifacts cleanup rule in Promotion project: 7 days
