### PR TITLE
Clean up STABLE_CONFIGURATION_CACHE setup for process tests

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheValueSourceIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheValueSourceIntegrationTest.groovy
@@ -437,9 +437,6 @@ class ConfigurationCacheValueSourceIntegrationTest extends AbstractConfiguration
         def configurationCache = newConfigurationCacheFixture()
         ShellScript testScript = ShellScript.builder().printText("Hello, world").writeTo(testDirectory, "script")
 
-        settingsFile("""
-            enableFeaturePreview("STABLE_CONFIGURATION_CACHE")
-        """)
         buildFile.text = """
             import ${ByteArrayOutputStream.name}
             import org.gradle.api.provider.*

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/process/AbstractProcessIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/process/AbstractProcessIntegrationTest.groovy
@@ -18,19 +18,7 @@ package org.gradle.configurationcache.inputs.process
 
 import org.gradle.configurationcache.AbstractConfigurationCacheIntegrationTest
 import org.gradle.configurationcache.fixtures.ExternalProcessFixture
-import org.gradle.integtests.fixtures.GroovyBuildScriptLanguage
 
 abstract class AbstractProcessIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
     ExternalProcessFixture execOperationsFixture = new ExternalProcessFixture(testDirectory)
-
-    def settingsFileWithStableConfigurationCache() {
-        settingsFileWithStableConfigurationCache("")
-    }
-
-    def settingsFileWithStableConfigurationCache(@GroovyBuildScriptLanguage String script) {
-        settingsFile << script
-        settingsFile << """
-            enableFeaturePreview('STABLE_CONFIGURATION_CACHE')
-        """
-    }
 }

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/process/ProcessInBuildScriptIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/process/ProcessInBuildScriptIntegrationTest.groovy
@@ -25,7 +25,6 @@ import static org.gradle.configurationcache.fixtures.ExternalProcessFixture.stri
 class ProcessInBuildScriptIntegrationTest extends AbstractProcessIntegrationTest {
     def "using #snippetsFactory.summary in #location.toLowerCase() #file is a problem"() {
         given:
-        settingsFileWithStableConfigurationCache()
         def snippets = snippetsFactory.newSnippets(execOperationsFixture)
         testDirectory.file(file) << """
             ${snippets.imports}
@@ -81,7 +80,6 @@ class ProcessInBuildScriptIntegrationTest extends AbstractProcessIntegrationTest
         testDirectory.file(file) << """
             ${snippets.imports}
 
-            enableFeaturePreview("STABLE_CONFIGURATION_CACHE")
             ${snippets.body}
         """
 

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/process/ProcessInInitScriptIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/process/ProcessInInitScriptIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.configurationcache.inputs.process
 
-import spock.lang.Ignore
 
 import static org.gradle.configurationcache.fixtures.ExternalProcessFixture.exec
 import static org.gradle.configurationcache.fixtures.ExternalProcessFixture.javaexec
@@ -25,7 +24,6 @@ import static org.gradle.configurationcache.fixtures.ExternalProcessFixture.runt
 import static org.gradle.configurationcache.fixtures.ExternalProcessFixture.stringArrayExecute
 
 class ProcessInInitScriptIntegrationTest extends AbstractProcessIntegrationTest {
-    @Ignore("init scripts are evaluated too early for feature flag to take effect")
     def "using #snippetsFactory.summary in initialization script #file is a problem"() {
         given:
         def snippets = snippetsFactory.newSnippets(execOperationsFixture)

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/process/ProcessInPluginBuildScriptIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/process/ProcessInPluginBuildScriptIntegrationTest.groovy
@@ -25,7 +25,7 @@ import static org.gradle.configurationcache.fixtures.ExternalProcessFixture.stri
 class ProcessInPluginBuildScriptIntegrationTest extends AbstractProcessIntegrationTest {
     def "using #snippetsFactory.summary in included plugin settings #file is a problem"() {
         given:
-        settingsFileWithStableConfigurationCache("""
+        settingsFile("""
             pluginManagement {
                 includeBuild('included')
             }
@@ -62,7 +62,7 @@ class ProcessInPluginBuildScriptIntegrationTest extends AbstractProcessIntegrati
 
     def "using #snippetsFactory.summary in included plugin build #file is a problem"() {
         given:
-        settingsFileWithStableConfigurationCache("""
+        settingsFile("""
             pluginManagement {
                 includeBuild('included')
             }

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/process/ProcessInPluginIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/process/ProcessInPluginIntegrationTest.groovy
@@ -21,7 +21,6 @@ import org.gradle.api.Project
 import org.gradle.api.initialization.Settings
 import org.gradle.process.ExecOperations
 import org.gradle.test.fixtures.dsl.GradleDsl
-import spock.lang.Ignore
 
 import javax.inject.Inject
 
@@ -34,7 +33,6 @@ import static org.gradle.configurationcache.fixtures.ExternalProcessFixture.stri
 class ProcessInPluginIntegrationTest extends AbstractProcessIntegrationTest {
     def "using #snippetsFactory.summary in convention plugin #file is a problem"() {
         given:
-        settingsFileWithStableConfigurationCache()
         def snippets = snippetsFactory.newSnippets(execOperationsFixture)
         testDirectory.file("buildSrc/build.gradle.kts") << """
             plugins {
@@ -85,7 +83,6 @@ class ProcessInPluginIntegrationTest extends AbstractProcessIntegrationTest {
 
     def "using #snippetsFactory.summary in java project plugin application is a problem"() {
         given:
-        settingsFileWithStableConfigurationCache()
         def snippets = snippetsFactory.newSnippets(execOperationsFixture)
         testDirectory.file("buildSrc/src/main/java/SneakyPlugin.java") << """
             import ${ExecOperations.name};
@@ -129,7 +126,6 @@ class ProcessInPluginIntegrationTest extends AbstractProcessIntegrationTest {
         runtimeExec().java                   | _
     }
 
-    @Ignore("settings plugins are applied too early for feature flag to take effect")
     def "using #snippetsFactory.summary in java settings plugin application is a problem"() {
         given:
         def snippets = snippetsFactory.newSnippets(execOperationsFixture)

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/process/ProcessInTaskIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/process/ProcessInTaskIntegrationTest.groovy
@@ -35,7 +35,6 @@ import static org.gradle.configurationcache.fixtures.ExternalProcessFixture.stri
 class ProcessInTaskIntegrationTest extends AbstractProcessIntegrationTest {
     def "using #snippetsFactory.summary in task configuration is a problem"() {
         given:
-        settingsFileWithStableConfigurationCache()
         def snippets = snippetsFactory.newSnippets(execOperationsFixture)
         testDirectory.file("buildSrc/src/main/java/SneakyTask.java") << """
             import ${DefaultTask.name};
@@ -83,7 +82,6 @@ class ProcessInTaskIntegrationTest extends AbstractProcessIntegrationTest {
 
     def "using #snippetsFactory.summary in task action is not a problem"() {
         given:
-        settingsFileWithStableConfigurationCache()
         def snippets = snippetsFactory.newSnippets(execOperationsFixture)
         testDirectory.file("buildSrc/src/main/java/SneakyTask.java") << """
             import ${DefaultTask.name};
@@ -124,7 +122,6 @@ class ProcessInTaskIntegrationTest extends AbstractProcessIntegrationTest {
 
     def "using #snippetsFactory.summary in task action of buildSrc is not a problem"() {
         given:
-        settingsFileWithStableConfigurationCache()
         def snippets = snippetsFactory.newSnippets(execOperationsFixture)
         testDirectory.file("buildSrc/build.gradle") << """
             import ${DefaultTask.name};
@@ -168,7 +165,6 @@ class ProcessInTaskIntegrationTest extends AbstractProcessIntegrationTest {
 
     def "using #snippetsFactory.summary in worker task action of buildSrc is not a problem"() {
         given:
-        settingsFileWithStableConfigurationCache()
         def snippets = snippetsFactory.newSnippets(execOperationsFixture)
         testDirectory.file("buildSrc/build.gradle") << """
             import ${DefaultTask.name}
@@ -262,7 +258,7 @@ class ProcessInTaskIntegrationTest extends AbstractProcessIntegrationTest {
             println("Applied script plugin")
         """
 
-        settingsFileWithStableConfigurationCache("""
+        settingsFile("""
             pluginManagement {
                 includeBuild('included')
             }
@@ -291,7 +287,6 @@ class ProcessInTaskIntegrationTest extends AbstractProcessIntegrationTest {
 
     def "using #snippetsFactory.summary in task up-to-date is not a problem"() {
         given:
-        settingsFileWithStableConfigurationCache()
         def snippets = snippetsFactory.newSnippets(execOperationsFixture)
         testDirectory.file("buildSrc/src/main/java/SneakyTask.java") << """
             import ${DefaultTask.name};
@@ -337,7 +332,6 @@ class ProcessInTaskIntegrationTest extends AbstractProcessIntegrationTest {
 
     def "using #snippetsFactory.summary in up-to-date task of buildSrc is not a problem"() {
         given:
-        settingsFileWithStableConfigurationCache()
         def snippets = snippetsFactory.newSnippets(execOperationsFixture)
         testDirectory.file("buildSrc/build.gradle") << """
             import ${DefaultTask.name};

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/process/ProcessInTransformIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/process/ProcessInTransformIntegrationTest.groovy
@@ -30,7 +30,6 @@ import static org.gradle.configurationcache.fixtures.ExternalProcessFixture.proc
 class ProcessInTransformIntegrationTest extends AbstractProcessIntegrationTest {
     def "using #snippetsFactory.summary in transform action with #task is not a problem"(SnippetsFactory snippetsFactory, String task) {
         given:
-        settingsFileWithStableConfigurationCache()
         getTransformFixture(snippetsFactory.newSnippets(execOperationsFixture)).tap {
             withTransformPlugin(testDirectory.createDir("buildSrc"))
             withJavaLibrarySubproject(testDirectory.createDir("subproject"))
@@ -71,8 +70,6 @@ class ProcessInTransformIntegrationTest extends AbstractProcessIntegrationTest {
 
     def "using #snippetsFactory.summary in transform action with #task of buildSrc build is not a problem"(SnippetsFactory snippetsFactory, String task) {
         given:
-        settingsFileWithStableConfigurationCache()
-
         createDir("buildSrc") {
             getTransformFixture(snippetsFactory.newSnippets(execOperationsFixture)).tap {
                 withTransformPlugin(dir("transform-plugin"))

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/process/instrument/AbstractProcessInstrumentationIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/process/instrument/AbstractProcessInstrumentationIntegrationTest.groovy
@@ -30,7 +30,6 @@ abstract class AbstractProcessInstrumentationIntegrationTest extends AbstractCon
 
     def setup() {
         testDirectory.createDir(pwd)
-        settingsFile("enableFeaturePreview('STABLE_CONFIGURATION_CACHE')")
     }
 
 

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/FilesInTransformIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/FilesInTransformIntegrationTest.groovy
@@ -29,7 +29,6 @@ class FilesInTransformIntegrationTest extends AbstractProcessIntegrationTest {
 
     def "reading a file in transform action with #task does not create a build input"() {
         given:
-        settingsFileWithStableConfigurationCache()
         getTransformFixture().tap {
             withTransformPlugin(testDirectory.createDir("buildSrc"))
             withJavaLibrarySubproject(testDirectory.createDir("subproject"))
@@ -63,8 +62,6 @@ class FilesInTransformIntegrationTest extends AbstractProcessIntegrationTest {
 
     def "reading a file in transform action with #task of buildSrc build does not create a build input"() {
         given:
-        settingsFileWithStableConfigurationCache()
-
         createDir("buildSrc") {
             getTransformFixture().tap {
                 withTransformPlugin(dir("transform-plugin"))

--- a/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginBackgroundJobExecutorsIntegrationTest.groovy
+++ b/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginBackgroundJobExecutorsIntegrationTest.groovy
@@ -379,8 +379,6 @@ class GradleEnterprisePluginBackgroundJobExecutorsIntegrationTest extends Abstra
         given:
         ShellScript script = ShellScript.builder().printText("Hello, world").writeTo(testDirectory, "script")
 
-        withStableConfigurationCacheEnabled()
-
         buildFile << """
             import ${CompletableFuture.name}
 
@@ -406,8 +404,6 @@ class GradleEnterprisePluginBackgroundJobExecutorsIntegrationTest extends Abstra
     def "background job can execute external process with Gradle API at configuration time"() {
         given:
         ShellScript script = ShellScript.builder().printText("Hello, world").writeTo(testDirectory, "script")
-
-        withStableConfigurationCacheEnabled()
 
         buildFile << """
             import ${CompletableFuture.name}
@@ -441,11 +437,5 @@ class GradleEnterprisePluginBackgroundJobExecutorsIntegrationTest extends Abstra
 
     private static String getExecutors() {
         return """(gradle.extensions.serviceRef.get()._requiredServices.backgroundJobExecutors)"""
-    }
-
-    private withStableConfigurationCacheEnabled() {
-        settingsFile("""
-            enableFeaturePreview("STABLE_CONFIGURATION_CACHE")
-        """)
     }
 }


### PR DESCRIPTION
We used to only complain about external processes when the feature is enabled, but since the configuration cache became stable in 8.1 the nagging is enabled regardless of the feature status.

This commit removes all setups of STABLE_CONFIGURATION_CACHE related to the external process tests, as it is no longer needed.