### PR TITLE
Disable Kotlin DSL script compilation avoidance

### DIFF
--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/BuildServices.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/BuildServices.kt
@@ -46,7 +46,7 @@ import org.gradle.plugin.use.internal.PluginRequestApplicator
 
 
 internal
-const val BUILDSCRIPT_COMPILE_AVOIDANCE_ENABLED = true
+const val BUILDSCRIPT_COMPILE_AVOIDANCE_ENABLED = false
 
 
 internal


### PR DESCRIPTION
While investigating cache misses that created excess of script compilation we found evidence that indicate that compile avoidance for Kotlin is the culprit. With some sets of inputs it produces seemingly changing hashes. This causes too much recompilation (misses), root cause unknown at this point.

When investigating the issue, we also found gaps in the logic, that would cause Kotlin scripts to not be recompiled when they should.
* e.g. https://github.com/gradle/gradle/issues/24352

Given this can be either a performance penalty or produce incorrect results, we are going to disable Kotlin script compilation avoidance starting with 8.1 RC1 so we can get feedback on all the rest in that release. We will most likely enable it back for 8.2, but probably with a switch to turn it off … to be followed upon.
