### PR TITLE
Allow matching test frameworks to be configured, even after the frame work is finalized.

### DIFF
--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
@@ -60,6 +60,15 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
         return state instanceof FinalizedValue;
     }
 
+    /**
+     * A simple getter that checks if this property is still mutable.
+     *
+     * @return {@code true} unless this property has been finalized, or {@link #disallowChanges()} has been called
+     */
+    public boolean isMutable() {
+        return state.isMutable();
+    }
+
     @Override
     public boolean calculatePresence(ValueConsumer consumer) {
         beforeRead(producer, consumer);
@@ -339,6 +348,8 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
         public abstract void beforeMutate(DisplayName displayName);
 
         public abstract ValueConsumer forUpstream(ValueConsumer consumer);
+
+        public abstract boolean isMutable();
     }
 
     private static class NonFinalizedValue<S> extends FinalizationState<S> {
@@ -447,6 +458,11 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
             this.convention = convention;
         }
 
+        @Override
+        public boolean isMutable() {
+            return !disallowChanges;
+        }
+
         private String cannotFinalizeValueOf(DisplayName displayName, String reason) {
             return cannot("finalize", displayName, reason);
         }
@@ -533,6 +549,11 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
         @Override
         void setConvention(S convention) {
             throw unexpected();
+        }
+
+        @Override
+        public boolean isMutable() {
+            return false;
         }
 
         private UnsupportedOperationException unexpected() {

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/TestSuitesIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/TestSuitesIntegrationTest.groovy
@@ -412,7 +412,7 @@ class TestSuitesIntegrationTest extends AbstractIntegrationSpec {
 
         expect:
         fails("help")
-        failure.assertHasCause("The value for task ':integTest' property 'testFrameworkProperty' cannot be changed any further.")
+        failure.assertHasCause("The value for task ':integTest' property 'testFrameworkProperty' is final and cannot be changed any further.")
     }
 
     def "task configuration overrules test suite configuration with test suite set test framework"() {
@@ -444,7 +444,7 @@ class TestSuitesIntegrationTest extends AbstractIntegrationSpec {
 
         expect:
         fails("help")
-        failure.assertHasCause("The value for task ':integTest' property 'testFrameworkProperty' cannot be changed any further.")
+        failure.assertHasCause("The value for task ':integTest' property 'testFrameworkProperty' is final and cannot be changed any further.")
     }
 
     @Issue("https://github.com/gradle/gradle/issues/18622")

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -1058,7 +1058,7 @@ public abstract class Test extends AbstractTestTask implements JavaForkOptions, 
     }
 
     void useTestFramework(TestFramework testFramework) {
-        if (((DefaultProperty<?>) this.testFramework).isFinalized()) {
+        if (!((DefaultProperty<?>) this.testFramework).isMutable()) {
             Class<?> currentFramework = this.testFramework.get().getClass();
             Class<?> newFramework = testFramework.getClass();
             if (currentFramework == newFramework) {


### PR DESCRIPTION
This fixes the scenarios where a task rule is configuring the test task using the same test framework as the test suite associated with the task (i.e. only configuring the framework options) either before or after the test suite is configured.  Previously, doing this at all caused an error, even though this is arguably a reasonable thing to do.  We now allow this _only_ if the test framework matches.  We still error if the task rule sets the framework (and configures it) with a different test framework than the test suite either before or after the test suite is configured.

Fixes #24331

