### PR TITLE
Change CI so dependencies fail the promotion stage immediately

### DIFF
--- a/.teamcity/src/main/kotlin/promotion/BasePublishGradleDistribution.kt
+++ b/.teamcity/src/main/kotlin/promotion/BasePublishGradleDistribution.kt
@@ -19,6 +19,7 @@ package promotion
 import common.gradleWrapper
 import common.promotionBuildParameters
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
+import jetbrains.buildServer.configs.kotlin.v2019_2.FailureAction
 import jetbrains.buildServer.configs.kotlin.v2019_2.RelativeId
 import vcsroots.gradlePromotionMaster
 
@@ -47,6 +48,8 @@ abstract class BasePublishGradleDistribution(
         dependencies {
             snapshot(RelativeId("Check_Stage_${this@BasePublishGradleDistribution.triggerName}_Trigger")) {
                 synchronizeRevisions = false
+                onDependencyFailure = FailureAction.FAIL_TO_START
+                onDependencyCancel = FailureAction.FAIL_TO_START
             }
         }
 


### PR DESCRIPTION
Currently, promotion tasks like [Nightly Snapshot](https://builds.gradle.org/buildConfiguration/Gradle_Master_Promotion_Nightly?mode=builds#all-projects) have a setting that will not stop the promotion immediately in case of a dependant failure.

@blindpirate, this got me thinking: might this be a reasonable choice after all, as performance tests can stop a promotion from happening.