### PR TITLE
Smoke test AGP nightlies

### DIFF
--- a/build-logic/build-update-utils/build.gradle.kts
+++ b/build-logic/build-update-utils/build.gradle.kts
@@ -7,5 +7,6 @@ description = "Provides plugins that create update tasks for the Gradle build"
 
 dependencies {
     implementation("com.google.code.gson:gson")
+    implementation("org.jsoup:jsoup")
     implementation(project(":basics"))
 }

--- a/build-logic/build-update-utils/src/main/kotlin/gradlebuild.update-versions.gradle.kts
+++ b/build-logic/build-update-utils/src/main/kotlin/gradlebuild.update-versions.gradle.kts
@@ -32,7 +32,6 @@ tasks.register<UpdateReleasedVersions>("updateReleasedVersionsToLatestNightly") 
 tasks.register<UpdateAgpVersions>("updateAgpVersions") {
     comment = " Generated - Update by running `./gradlew updateAgpVersions`"
     minimumSupportedMinor = "7.3"
-    fetchNightly = false
     propertiesFile = layout.projectDirectory.file("gradle/dependency-management/agp-versions.properties")
     compatibilityDocFile = layout.projectDirectory.file("subprojects/docs/src/docs/userguide/compatibility.adoc")
 }

--- a/gradle/dependency-management/agp-versions.properties
+++ b/gradle/dependency-management/agp-versions.properties
@@ -1,2 +1,4 @@
 # Generated - Update by running `./gradlew updateAgpVersions`
-latests=7.3.1,7.4.2,8.0.2,8.1.0-beta03,8.2.0-alpha04
+latests=7.3.1,7.4.2,8.0.2,8.1.0-beta04,8.2.0-alpha06
+nightlyBuildId=10247337
+nightlyVersion=8.2.0-dev

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractPluginValidatingSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractPluginValidatingSmokeTest.groovy
@@ -66,7 +66,7 @@ abstract class AbstractPluginValidatingSmokeTest extends AbstractSmokeTest imple
         configureValidation(id, version)
 
         expect:
-        performValidation()
+        performValidation(version)
 
         where:
         iterations << iterations()
@@ -77,8 +77,11 @@ abstract class AbstractPluginValidatingSmokeTest extends AbstractSmokeTest imple
         allPlugins.alwaysPasses = true
     }
 
-    void performValidation() {
-        allPlugins.performValidation()
+    void performValidation(String version) {
+        allPlugins.performValidation(getValidationExtraParameters(version))
     }
 
+    protected List<String> getValidationExtraParameters(String version) {
+        return []
+    }
 }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -94,7 +94,7 @@ abstract class AbstractSmokeTest extends Specification {
         // https://developer.android.com/studio/releases/build-tools
         static androidTools = "33.0.2"
         // https://developer.android.com/studio/releases/gradle-plugin
-        static androidGradle = Versions.of(*AGP_VERSIONS.latests)
+        static androidGradle = Versions.of(*AGP_VERSIONS.latestsPlusNightly)
 
         // https://search.maven.org/search?q=g:org.jetbrains.kotlin%20AND%20a:kotlin-project&core=gav
         static kotlin = Versions.of(*KOTLIN_VERSIONS.latests)

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
@@ -439,6 +439,15 @@ class AndroidPluginsSmokeTest extends AbstractPluginValidatingSmokeTest implemen
     }
 
     @Override
+    protected List<String> getValidationExtraParameters(String version) {
+        if (AGP_VERSIONS.isAgpNightly(version)) {
+            def init = AGP_VERSIONS.createAgpNightlyRepositoryInitScript()
+            return ["-I", init.canonicalPath]
+        }
+        return super.getValidationExtraParameters(version)
+    }
+
+    @Override
     void configureValidation(String testedPluginId, String version) {
         AGP_VERSIONS.assumeCurrentJavaVersionIsSupportedBy(version)
         if (testedPluginId != 'com.android.reporting') {

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/android-kotlin-example-kotlin-dsl/app/build.gradle.kts
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/android-kotlin-example-kotlin-dsl/app/build.gradle.kts
@@ -32,9 +32,6 @@ android {
         versionName = "1.0"
         testInstrumentationRunner = "android.support.test.runner.AndroidJUnitRunner"
     }
-    buildFeatures {
-        viewBinding = true
-    }
     buildTypes {
         getByName("release") {
             isMinifyEnabled = false

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/android-kotlin-example/app/build.gradle
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/android-kotlin-example/app/build.gradle
@@ -16,9 +16,6 @@ android {
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
-    buildFeatures {
-        viewBinding true
-    }
     buildTypes {
         release {
             minifyEnabled false


### PR DESCRIPTION
This PR adds support for fetching the latest AGP nightly snapshot and enables smoke testing it.

It also updates tested AGP versions as follows:

* from 8.1.0-beta03 to 8.1.0-beta04
* from 8.2.0-alpha04 to 8.2.0-alpha06
* introducing 8.2.0-dev nightly
