### PR TITLE
Let version catalog accessors be available in buildscript block of applied KTS scripts

### DIFF
--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/Interpreter.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/Interpreter.kt
@@ -253,7 +253,7 @@ class Interpreter(val host: Host) {
         // TODO: consider computing stage 1 accessors only when there's a buildscript or plugins block
         // TODO: consider splitting buildscript/plugins block accessors
         val stage1BlocksAccessorsClassPath = when {
-            requiresAccessors(programTarget, programKind) -> host.stage1BlocksAccessorsFor(scriptHost)
+            requiresAccessors(programTarget) -> host.stage1BlocksAccessorsFor(scriptHost)
             else -> ClassPath.EMPTY
         }
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/PartialEvaluator.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/PartialEvaluator.kt
@@ -98,20 +98,11 @@ class PartialEvaluator(
 
         when (programTarget) {
 
-            ProgramTarget.Project -> when (programKind) {
-
-                ProgramKind.TopLevel -> Static(
-                    SetupEmbeddedKotlin,
-                    CollectProjectScriptDependencies(fragmentHolderSourceFor(program)),
-                    defaultStageTransition()
-                )
-
-                ProgramKind.ScriptPlugin -> Static(
-                    SetupEmbeddedKotlin,
-                    Eval(fragmentHolderSourceFor(program)),
-                    defaultStageTransition()
-                )
-            }
+            ProgramTarget.Project -> Static(
+                SetupEmbeddedKotlin,
+                CollectProjectScriptDependencies(fragmentHolderSourceFor(program)),
+                defaultStageTransition()
+            )
 
             else -> Static(
                 SetupEmbeddedKotlin,
@@ -187,23 +178,12 @@ class PartialEvaluator(
 
             when (programTarget) {
 
-                ProgramTarget.Project ->
-
-                    when (programKind) {
-                        ProgramKind.TopLevel -> Static(
-                            SetupEmbeddedKotlin,
-                            CollectProjectScriptDependencies(fragmentHolderSourceFor(stage1)),
-                            ApplyDefaultPluginRequests,
-                            ApplyBasePlugins
-                        )
-
-                        ProgramKind.ScriptPlugin -> Static(
-                            SetupEmbeddedKotlin,
-                            Eval(fragmentHolderSourceFor(stage1)),
-                            ApplyDefaultPluginRequests,
-                            ApplyBasePlugins
-                        )
-                    }
+                ProgramTarget.Project -> Static(
+                    SetupEmbeddedKotlin,
+                    CollectProjectScriptDependencies(fragmentHolderSourceFor(stage1)),
+                    ApplyDefaultPluginRequests,
+                    ApplyBasePlugins
+                )
 
                 else -> reduceBuildscriptProgram(stage1)
             }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/ResidualProgramCompiler.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/ResidualProgramCompiler.kt
@@ -486,7 +486,8 @@ class ResidualProgramCompiler(
         LDC(programTarget.name + "/" + programKind.name + "/stage2")
         // Move HashCode value to a static field so it's cached across invocations
         loadHashCode(originalSourceHash)
-        if (requiresAccessors()) emitAccessorsClassPathForScriptHost() else GETSTATIC(ClassPath::EMPTY)
+        if (requiresAccessors(programTarget)) emitAccessorsClassPathForScriptHost()
+        else GETSTATIC(ClassPath::EMPTY)
         invokeHost(
             ExecutableProgram.Host::evaluateSecondStageOf.name,
             "(" +
@@ -524,10 +525,6 @@ class ResidualProgramCompiler(
         Type.getType(ProgramTarget::class.java),
         Type.getType(ClassPath::class.java)
     )
-
-    private
-    fun requiresAccessors() =
-        requiresAccessors(programTarget, programKind)
 
     private
     fun MethodVisitor.emitAccessorsClassPathForScriptHost() {
@@ -792,5 +789,5 @@ class ResidualProgramCompiler(
 
 
 internal
-fun requiresAccessors(programTarget: ProgramTarget, programKind: ProgramKind) =
-    programTarget == ProgramTarget.Project && programKind == ProgramKind.TopLevel
+fun requiresAccessors(programTarget: ProgramTarget) =
+    programTarget == ProgramTarget.Project

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/PartialEvaluatorTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/PartialEvaluatorTest.kt
@@ -428,7 +428,7 @@ class PartialEvaluatorTest {
             isResidualProgram(
                 Static(
                     SetupEmbeddedKotlin,
-                    Eval(fragment.source),
+                    CollectProjectScriptDependencies(fragment.source),
                     CloseTargetScope
                 )
             )
@@ -458,7 +458,7 @@ class PartialEvaluatorTest {
                 Dynamic(
                     Static(
                         SetupEmbeddedKotlin,
-                        Eval(buildscriptFragment.source),
+                        CollectProjectScriptDependencies(buildscriptFragment.source),
                         ApplyDefaultPluginRequests,
                         ApplyBasePlugins
                     ),


### PR DESCRIPTION
* Follow up to https://github.com/gradle/gradle/pull/23639
* Fixes https://github.com/gradle/gradle/issues/24426