### PR TITLE
Fix buildPath to return a colon-prefixed path in ProjectComponentIdentifier

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ToPlannedTaskConverter.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ToPlannedTaskConverter.java
@@ -65,7 +65,7 @@ public class ToPlannedTaskConverter implements ToPlannedNodeConverter {
 
             @Override
             public String toString() {
-                return "Task " + delegate.getTaskPath();
+                return "Task " + delegate.getIdentityPath();
             }
         };
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformBuildOperationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformBuildOperationIntegrationTest.groovy
@@ -1000,7 +1000,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         def expectedTransformId2 = new PlannedTransformStepIdentityWithoutId([
             consumerBuildPath: ":",
             consumerProjectPath: ":consumer",
-            componentId: [buildPath: "included", projectPath: ":nested-producer"],
+            componentId: [buildPath: ":included", projectPath: ":nested-producer"],
             sourceAttributes: [color: "blue", artifactType: "jar"],
             targetAttributes: [color: "green", artifactType: "jar"],
             capabilities: [[group: "included", name: "nested-producer", version: "unspecified"]],
@@ -1087,7 +1087,7 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         def expectedTransformId = new PlannedTransformStepIdentityWithoutId([
             consumerBuildPath: ":included",
             consumerProjectPath: ":consumer",
-            componentId: [buildPath: "included", projectPath: ":producer"],
+            componentId: [buildPath: ":included", projectPath: ":producer"],
             sourceAttributes: [color: "blue", artifactType: "jar"],
             targetAttributes: [color: "green", artifactType: "jar"],
             capabilities: [[group: "colored", name: "producer", version: "unspecified"]],

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNode.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNode.java
@@ -280,7 +280,9 @@ public abstract class TransformationNode extends CreationOrderedNode implements 
             return new org.gradle.operations.dependencies.variants.ProjectComponentIdentifier() {
                 @Override
                 public String getBuildPath() {
-                    return projectComponentIdentifier.getBuild().getName();
+                    // TODO: this should use a proper build path once it is available on BuildIdentifier
+                    String buildName = projectComponentIdentifier.getBuild().getName();
+                    return buildName.startsWith(":") ? buildName : (":" + buildName);
                 }
 
                 @Override


### PR DESCRIPTION
The Scan plugin requires a build path to store in the event. However, due to the full build path not being available on the `BuildIdentifier`, the plugin works around this by prefixing the build name with a colon (`:`).

The logic of forming a proper build path should belong to the build tool. For now, we start doing the prefixing of the build name on the Gradle side. Later we will introduce a complete solution to working with actual build paths regardless of the composite-project nesting level.

This change is effectively a bug fix for the `getBuildPath` method that was introduced in the new build operations as a part of Gradle 8.1.