### PR TITLE
Support implNote for shared libraries javadoc

### DIFF
--- a/build-logic/publishing/src/main/kotlin/gradlebuild.publish-public-libraries.gradle.kts
+++ b/build-logic/publishing/src/main/kotlin/gradlebuild.publish-public-libraries.gradle.kts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import org.gradle.external.javadoc.StandardJavadocDocletOptions
 import java.time.Year
 
 plugins {
@@ -73,6 +74,10 @@ signing {
 fun configureJavadocVariant() {
     java {
         withJavadocJar()
+    }
+    tasks.named<Javadoc>("javadoc") {
+        // See GradleJavadocsPlugin.generateJavadocs() and the javadocsAll task
+        (options as StandardJavadocDocletOptions).tags("apiNote:a:API Note:", "implSpec:a:Implementation Requirements:", "implNote:a:Implementation Note:")
     }
 }
 


### PR DESCRIPTION
Add support for using `implNote` and related tags for the regular javadoc tasks that we run when publishing single JARs.

Fixes https://github.com/gradle/gradle-private/issues/3791