### PR TITLE
Fix cache layout value

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
@@ -73,7 +73,7 @@ public enum CacheLayout {
         .changedTo(97, "6.8-rc-1")
         .changedTo(99, "7.5-rc-1")
         .changedTo(100, "8.0-milestone-5")
-        .changedTo(101_123_346, "8.1-rc-1")
+        .changedTo(105, "8.1-rc-1")
     ),
 
     RESOURCES(ROOT, "resources", introducedIn("1.9-rc-1")),

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
@@ -53,7 +53,7 @@ class CacheLayoutTest extends Specification {
         CacheLayout cacheLayout = CacheLayout.META_DATA
 
         then:
-        def expectedVersion = 101_123_346
+        def expectedVersion = 105
         cacheLayout.name == 'metadata'
         cacheLayout.key == "metadata-2.${expectedVersion}"
         cacheLayout.version == CacheVersion.parse("2.${expectedVersion}")


### PR DESCRIPTION
Leaving a gap as backporting this will require a new version for Gradle 7.x

Issue #24037