### PR TITLE
Add API for modifying all consumable/resolvable configurations instead of all configurations

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ConfigurationContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ConfigurationContainer.java
@@ -18,6 +18,7 @@ package org.gradle.api.artifacts;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.internal.HasInternalProtocol;
 
@@ -130,7 +131,9 @@ public interface ConfigurationContainer extends NamedDomainObjectContainer<Confi
      * any such configurations subsequently added to this collection.
      *
      * @param action The action to be executed
+     * @since 8.2
      */
+    @Incubating
     void allConsumable(Action<? super Configuration> action);
 
     /**
@@ -138,6 +141,8 @@ public interface ConfigurationContainer extends NamedDomainObjectContainer<Confi
      * any such configurations subsequently added to this collection.
      *
      * @param action The action to be executed
+     * @since 8.2
      */
+    @Incubating
     void allResolvable(Action<? super Configuration> action);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ConfigurationContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ConfigurationContainer.java
@@ -124,4 +124,20 @@ public interface ConfigurationContainer extends NamedDomainObjectContainer<Confi
      * @return The configuration.
      */
     Configuration detachedConfiguration(Dependency... dependencies);
+
+    /**
+     * Similar to {@link #all(Action)}, executes the given action against all <strong>consumable</strong> configurations in this collection, or
+     * any such configurations subsequently added to this collection.
+     *
+     * @param action The action to be executed
+     */
+    void allConsumable(Action<? super Configuration> action);
+
+    /**
+     * Similar to {@link #all(Action)}, executes the given action against all <strong>resolvable</strong> configurations in this collection, or
+     * any such configurations subsequently added to this collection.
+     *
+     * @param action The action to be executed
+     */
+    void allResolvable(Action<? super Configuration> action);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
@@ -177,4 +177,14 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
                     .nagUser();
         }
     }
+    
+    @Override
+    public void allConsumable(Action<? super Configuration> action) {
+        matching(Configuration::isCanBeConsumed).all(action);
+    }
+
+    @Override
+    public void allResolvable(Action<? super Configuration> action) {
+        matching(Configuration::isCanBeResolved).all(action);
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
@@ -177,7 +177,7 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
                     .nagUser();
         }
     }
-    
+
     @Override
     public void allConsumable(Action<? super Configuration> action) {
         matching(Configuration::isCanBeConsumed).all(action);


### PR DESCRIPTION
Indiscriminate use of calls to methods only applicable to resolvable or consumable configurations inside of actions passed `configurations.all` is a major headache when trying to restrict `DefaultConfiguration` method calls to the [proper allowed usage](https://github.com/gradle/gradle/pull/24183).

Adding some shortcuts to the API can serve as quick replacements for this pattern by plugins and can help discourage this sort of overly broad usage. 