### PR TITLE
Update tested Kotlin versions

### DIFF
--- a/gradle/dependency-management/kotlin-versions.properties
+++ b/gradle/dependency-management/kotlin-versions.properties
@@ -1,2 +1,2 @@
 # Generated - Update by running `./gradlew updateKotlinVersions`
-latests=1.6.10,1.6.21,1.7.0,1.7.22,1.8.0,1.8.10,1.8.20-RC
+latests=1.6.10,1.6.21,1.7.0,1.7.22,1.8.0,1.8.10,1.8.20-RC2


### PR DESCRIPTION
from 1.8.20-RC to 1.8.20-RC2

See https://github.com/JetBrains/kotlin/releases/tag/v1.8.20-RC2
