### PR TITLE
Allow `notCompatibleWithConfigurationCache` tasks to configure others

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheTaskExecutionIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheTaskExecutionIntegrationTest.groovy
@@ -20,6 +20,35 @@ import spock.lang.Issue
 
 class ConfigurationCacheTaskExecutionIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
 
+    @Issue("https://github.com/gradle/gradle/issues/24411")
+    def "task marked not compatible may cause configuration of other tasks without failing build"() {
+        given:
+        buildFile("""
+            tasks.register("innocent") { task ->
+                // This task calls getProject() as part of its configuration.
+                println("Materialized task \${task.name} from project \${task.project.name}")
+            }
+
+            tasks.register("offender") {
+                notCompatibleWithConfigurationCache("calls getProject")
+                // This task reaches out to other task at execution time and triggers its configuration.
+                doLast { task ->
+                    println(task.project.tasks.named("innocent").get())
+                }
+            }
+        """)
+
+        when:
+        configurationCacheRun("offender")
+
+        then:
+        problems.assertResultHasProblems(result) {
+            withProblemsWithStackTraceCount(2)
+            withProblem("Build file 'build.gradle': line 11: invocation of 'Task.project' at execution time is unsupported.")
+            withProblem("Build file 'build.gradle': line 4: execution of task ':offender' caused invocation of 'Task.project' in other task at execution time which is unsupported.")
+        }
+    }
+
     @Issue('https://github.com/gradle/gradle/issues/22522')
     def "reports problem for extra property accessed at execution time"() {
         given:

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheServices.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheServices.kt
@@ -29,6 +29,7 @@ import org.gradle.configurationcache.serialization.beans.BeanConstructors
 import org.gradle.configurationcache.services.RemoteScriptUpToDateChecker
 import org.gradle.internal.buildtree.BuildModelParameters
 import org.gradle.internal.event.ListenerManager
+import org.gradle.internal.execution.WorkExecutionTracker
 import org.gradle.internal.resource.connector.ResourceConnectorFactory
 import org.gradle.internal.resource.connector.ResourceConnectorSpecification
 import org.gradle.internal.resource.transfer.ExternalResourceConnector
@@ -113,13 +114,14 @@ class ConfigurationCacheServices : AbstractPluginServiceRegistry() {
             modelParameters: BuildModelParameters,
             /** In non-CC builds, [ConfigurationCacheStartParameter] is not registered; accepting a list here is a way to ignore its absence. */
             configurationCacheStartParameter: List<ConfigurationCacheStartParameter>,
-            listenerManager: ListenerManager
+            listenerManager: ListenerManager,
+            workExecutionTracker: WorkExecutionTracker,
         ): TaskExecutionAccessChecker {
             val broadcast = listenerManager.getBroadcaster(TaskExecutionAccessListener::class.java)
             return when {
-                !modelParameters.isConfigurationCache -> TaskExecutionAccessCheckers.TaskStateBased(broadcast)
-                configurationCacheStartParameter.single().taskExecutionAccessPreStable -> TaskExecutionAccessCheckers.TaskStateBased(broadcast)
-                else -> TaskExecutionAccessCheckers.ConfigurationTimeBarrierBased(configurationTimeBarrier, broadcast)
+                !modelParameters.isConfigurationCache -> TaskExecutionAccessCheckers.TaskStateBased(broadcast, workExecutionTracker)
+                configurationCacheStartParameter.single().taskExecutionAccessPreStable -> TaskExecutionAccessCheckers.TaskStateBased(broadcast, workExecutionTracker)
+                else -> TaskExecutionAccessCheckers.ConfigurationTimeBarrierBased(configurationTimeBarrier, broadcast, workExecutionTracker)
             }
         }
     }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DeprecatedFeaturesListener.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DeprecatedFeaturesListener.kt
@@ -40,8 +40,8 @@ class DeprecatedFeaturesListener(
         }
     }
 
-    override fun onProjectAccess(invocationDescription: String, task: TaskInternal) {
-        if (isStableConfigurationCacheEnabled()) {
+    override fun onProjectAccess(invocationDescription: String, task: TaskInternal, runningTask: TaskInternal?) {
+        if (isStableConfigurationCacheEnabled() && shouldReportInContext(task, runningTask)) {
             DeprecationLogger.deprecateAction("Invocation of $invocationDescription at execution time")
                 .willBecomeAnErrorInGradle9()
                 .withUpgradeGuideSection(7, "task_project")
@@ -49,20 +49,25 @@ class DeprecatedFeaturesListener(
         }
     }
 
-    override fun onTaskDependenciesAccess(invocationDescription: String, task: TaskInternal) {
-        if (isStableConfigurationCacheEnabled()) {
+    override fun onTaskDependenciesAccess(invocationDescription: String, task: TaskInternal, runningTask: TaskInternal?) {
+        if (isStableConfigurationCacheEnabled() && shouldReportInContext(task, runningTask)) {
             throwUnsupported("Invocation of $invocationDescription at execution time")
         }
     }
 
-    override fun onConventionAccess(invocationDescription: String, task: TaskInternal) {
-        if (isStableConfigurationCacheEnabled()) {
+    override fun onConventionAccess(invocationDescription: String, task: TaskInternal, runningTask: TaskInternal?) {
+        if (isStableConfigurationCacheEnabled() && shouldReportInContext(task, runningTask)) {
             DeprecationLogger.deprecateAction("Invocation of $invocationDescription at execution time")
                 .willBecomeAnErrorInGradle9()
                 .withUpgradeGuideSection(8, "task_convention")
                 .nagUser()
         }
     }
+
+    // Only nag about tasks that are actually executing, but not tasks that are configured by the executing tasks.
+    // A task is unlikely to reach out to other tasks without violating other constraints.
+    private
+    fun shouldReportInContext(task: TaskInternal, runningTask: TaskInternal?) = runningTask == null || task == runningTask
 
     private
     fun isStableConfigurationCacheEnabled(): Boolean =

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/TaskExecutionAccessCheckers.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/TaskExecutionAccessCheckers.kt
@@ -21,28 +21,33 @@ import org.gradle.api.internal.provider.ConfigurationTimeBarrier
 import org.gradle.api.internal.tasks.TaskExecutionAccessChecker
 import org.gradle.api.internal.tasks.execution.TaskExecutionAccessListener
 import org.gradle.configurationcache.serialization.Workarounds
+import org.gradle.internal.execution.WorkExecutionTracker
 
 
 abstract class AbstractTaskProjectAccessChecker(
-    private val broadcaster: TaskExecutionAccessListener
+    private val broadcaster: TaskExecutionAccessListener,
+    private val workExecutionTracker: WorkExecutionTracker
 ) : TaskExecutionAccessChecker {
     override fun notifyProjectAccess(task: TaskInternal) {
         if (shouldReportExecutionTimeAccess(task)) {
-            broadcaster.onProjectAccess("Task.project", task)
+            broadcaster.onProjectAccess("Task.project", task, currentTask())
         }
     }
 
     override fun notifyTaskDependenciesAccess(task: TaskInternal, invocationDescription: String) {
         if (shouldReportExecutionTimeAccess(task)) {
-            broadcaster.onTaskDependenciesAccess(invocationDescription, task)
+            broadcaster.onTaskDependenciesAccess(invocationDescription, task, currentTask())
         }
     }
 
     override fun notifyConventionAccess(task: TaskInternal, invocationDescription: String) {
         if (shouldReportExecutionTimeAccess(task)) {
-            broadcaster.onConventionAccess(invocationDescription, task)
+            broadcaster.onConventionAccess(invocationDescription, task, currentTask())
         }
     }
+
+    private
+    fun currentTask() = workExecutionTracker.currentTask.orElse(null)
 
     protected
     abstract fun shouldReportExecutionTimeAccess(task: TaskInternal): Boolean
@@ -51,14 +56,15 @@ abstract class AbstractTaskProjectAccessChecker(
 
 object TaskExecutionAccessCheckers {
 
-    class TaskStateBased(broadcaster: TaskExecutionAccessListener) : AbstractTaskProjectAccessChecker(broadcaster) {
+    class TaskStateBased(broadcaster: TaskExecutionAccessListener, workExecutionTracker: WorkExecutionTracker) : AbstractTaskProjectAccessChecker(broadcaster, workExecutionTracker) {
         override fun shouldReportExecutionTimeAccess(task: TaskInternal): Boolean = task.state.executing
     }
 
     class ConfigurationTimeBarrierBased(
         private val configurationTimeBarrier: ConfigurationTimeBarrier,
-        broadcaster: TaskExecutionAccessListener
-    ) : AbstractTaskProjectAccessChecker(broadcaster) {
+        broadcaster: TaskExecutionAccessListener,
+        workExecutionTracker: WorkExecutionTracker
+    ) : AbstractTaskProjectAccessChecker(broadcaster, workExecutionTracker) {
 
         override fun shouldReportExecutionTimeAccess(task: TaskInternal): Boolean =
             !configurationTimeBarrier.isAtConfigurationTime && !Workarounds.canAccessProjectAtExecutionTime(task)

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecutionAccessListener.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecutionAccessListener.java
@@ -20,6 +20,8 @@ import org.gradle.api.internal.TaskInternal;
 import org.gradle.internal.service.scopes.EventScope;
 import org.gradle.internal.service.scopes.Scopes;
 
+import javax.annotation.Nullable;
+
 
 @EventScope(Scopes.Build.class)
 public interface TaskExecutionAccessListener {
@@ -27,16 +29,16 @@ public interface TaskExecutionAccessListener {
     /**
      * Called when accessing the project during task execution.
      */
-    void onProjectAccess(String invocationDescription, TaskInternal task);
+    void onProjectAccess(String invocationDescription, TaskInternal task, @Nullable TaskInternal runningTask);
 
     /**
      * Called when accessing task dependencies during task execution.
      */
-    void onTaskDependenciesAccess(String invocationDescription, TaskInternal task);
+    void onTaskDependenciesAccess(String invocationDescription, TaskInternal task, @Nullable TaskInternal runningTask);
 
     /**
      * Called when accessing the convention object during task execution.
      */
-    void onConventionAccess(String invocationDescription, TaskInternal task);
+    void onConventionAccess(String invocationDescription, TaskInternal task, @Nullable TaskInternal runningTask);
 
 }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/test/fixtures/AbstractProjectBuilderSpec.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/test/fixtures/AbstractProjectBuilderSpec.groovy
@@ -26,6 +26,7 @@ import org.gradle.api.internal.tasks.TaskStateInternal
 import org.gradle.api.internal.tasks.execution.DefaultTaskExecutionContext
 import org.gradle.api.internal.tasks.properties.DefaultTaskProperties
 import org.gradle.execution.ProjectExecutionServices
+import org.gradle.execution.plan.LocalTaskNode
 import org.gradle.internal.execution.BuildOutputCleanupRegistry
 import org.gradle.internal.execution.WorkValidationContext
 import org.gradle.internal.execution.impl.DefaultWorkValidationContext
@@ -85,10 +86,11 @@ abstract class AbstractProjectBuilderSpec extends Specification {
     }
 
     void execute(Task task) {
+        def workValidationContext = new DefaultWorkValidationContext(documentationRegistry, WorkValidationContext.TypeOriginInspector.NO_OP)
         def taskExecutionContext = new DefaultTaskExecutionContext(
-            null,
+            new LocalTaskNode(task as TaskInternal, workValidationContext, { null }),
             DefaultTaskProperties.resolve(executionServices.get(PropertyWalker), executionServices.get(FileCollectionFactory), task as TaskInternal),
-            new DefaultWorkValidationContext(documentationRegistry, WorkValidationContext.TypeOriginInspector.NO_OP),
+            workValidationContext,
             { context -> }
         )
         project.gradle.services.get(BuildOutputCleanupRegistry).resolveOutputs()

--- a/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativeDependentComponentsReportIntegrationTest.groovy
+++ b/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativeDependentComponentsReportIntegrationTest.groovy
@@ -195,7 +195,6 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
         output.contains('Some non-buildable components were not shown, use --non-buildable or --all to show them.')
     }
 
-    @ToBeFixedForConfigurationCache(because = "native tasks")
     def "displays dependents across projects in a build"() {
         given:
         settingsFile.text = multiProjectSettings()
@@ -221,7 +220,6 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
     }
 
     @IgnoreIf({ GradleContextualExecuter.isParallel() })
-    @ToBeFixedForConfigurationCache(because = ":dependentComponents")
     def "can show dependent components in parallel"() {
         given: 'a multiproject build'
         settingsFile.text = multiProjectSettings()
@@ -399,7 +397,6 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
             '''.stripIndent().trim()
     }
 
-    @ToBeFixedForConfigurationCache(because = "native tasks")
     def "circular dependencies across projects are handled gracefully"() {
         given:
         settingsFile.text = multiProjectSettings()


### PR DESCRIPTION
Fixes #24411.

