### PR TITLE
Revert classpath ordering of distribution-loaded test framework classes

### DIFF
--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformEnvironmentIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformEnvironmentIntegrationTest.groovy
@@ -18,6 +18,8 @@ package org.gradle.testing.junitplatform
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import spock.lang.IgnoreIf
 
 import static org.hamcrest.CoreMatchers.containsString
 
@@ -83,6 +85,9 @@ class JUnitPlatformEnvironmentIntegrationTest extends AbstractIntegrationSpec {
             .assertExecutionFailedWithCause(containsString('consider adding an engine implementation JAR to the classpath'))
     }
 
+    // When running embedded with test distribution, the remote distribution has a newer version of
+    // junit-platform-launcher which is not compatible with the junit jupiter jars we test against.
+    @IgnoreIf({ GradleContextualExecuter.embedded })
     def "automatically loads framework dependencies from distribution"() {
         given:
         buildFile << """

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformIntegrationSpec.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformIntegrationSpec.groovy
@@ -30,13 +30,13 @@ class JUnitPlatformIntegrationSpec extends AbstractIntegrationSpec {
         """)
     }
 
-    def buildScriptWithJupiterDependencies(script) {
+    def buildScriptWithJupiterDependencies(script, String version = LATEST_JUPITER_VERSION) {
         buildScript("""
             apply plugin: 'java'
 
             ${mavenCentralRepository()}
             dependencies {
-                testImplementation 'org.junit.jupiter:junit-jupiter:${LATEST_JUPITER_VERSION}'
+                testImplementation 'org.junit.jupiter:junit-jupiter:${version}'
             }
             $script
         """)

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/detection/ForkedTestClasspathFactory.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/detection/ForkedTestClasspathFactory.java
@@ -203,8 +203,8 @@ public class ForkedTestClasspathFactory {
      */
     private ImmutableList<File> pathWithAdditionalModules(Iterable<? extends File> testFiles, List<TestFrameworkDistributionModule> additionalModules) {
         return ImmutableList.<File>builder()
-            .addAll(loadDistributionFiles(additionalModules))
             .addAll(testFiles)
+            .addAll(loadDistributionFiles(additionalModules))
             .build();
     }
 

--- a/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/detection/ForkedTestClasspathFactoryTest.groovy
+++ b/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/detection/ForkedTestClasspathFactoryTest.groovy
@@ -68,7 +68,7 @@ class ForkedTestClasspathFactoryTest extends Specification {
         def classpath = underTest.create([new File("cls.jar")], [new File("mod.jar")], framework, false)
 
         then:
-        classpath.applicationClasspath == [new File("app-cls-external.jar"), new File("app-mod-external.jar"), new File("cls.jar")]
+        classpath.applicationClasspath == [new File("cls.jar"), new File("app-cls-external.jar"), new File("app-mod-external.jar")]
         classpath.applicationModulepath == [new File("mod.jar")]
         classpath.implementationClasspath.size() == NUM_INTERNAL_JARS + NUM_EXTERNAL_JARS + 2
         classpath.implementationClasspath.findAll { it.toString().endsWith("-internal.jar") }.size() == NUM_INTERNAL_JARS
@@ -83,8 +83,8 @@ class ForkedTestClasspathFactoryTest extends Specification {
         def classpath = underTest.create([new File("cls.jar")], [new File("mod.jar")], framework, true)
 
         then:
-        classpath.applicationClasspath == [new File("app-cls-external.jar"), new File("cls.jar")]
-        classpath.applicationModulepath == [new File("app-mod-external.jar"), new File("mod.jar")]
+        classpath.applicationClasspath == [new File("cls.jar"), new File("app-cls-external.jar")]
+        classpath.applicationModulepath == [new File("mod.jar"), new File("app-mod-external.jar")]
         classpath.implementationClasspath.size() == NUM_INTERNAL_JARS + NUM_EXTERNAL_JARS + 1
         classpath.implementationClasspath.findAll { it.toString().endsWith("-internal.jar") }.size() == NUM_INTERNAL_JARS
         classpath.implementationClasspath.findAll { it.toString().endsWith("-external.jar") }.size() == NUM_EXTERNAL_JARS + 1
@@ -138,8 +138,8 @@ class ForkedTestClasspathFactoryTest extends Specification {
 
         then:
         if (loadsAll) {
-            assert classpath.applicationClasspath.take(2) == ["a", "b"].collect { new File("$it-external.jar") }
-            assert classpath.applicationModulepath.take(2) == ["c", "d"].collect { new File("$it-external.jar") }
+            assert classpath.applicationClasspath.takeRight(2) == ["a", "b"].collect { new File("$it-external.jar") }
+            assert classpath.applicationModulepath.takeRight(2) == ["c", "d"].collect { new File("$it-external.jar") }
             assert classpath.implementationClasspath.takeRight(2) == ["e", "f"].collect { new URL("file://$it-external.jar") }
             assert classpath.implementationModulepath == ["g", "h"].collect { new URL("file://$it-external.jar") }
         } else {
@@ -190,8 +190,8 @@ class ForkedTestClasspathFactoryTest extends Specification {
 
         then:
         if (loadsAll) {
-            assert classpath.applicationClasspath.take(2) == ["a", "b"].collect { new File("$it-external.jar") }
-            assert classpath.applicationModulepath.take(2) == ["c", "d"].collect { new File("$it-external.jar") }
+            assert classpath.applicationClasspath.takeRight(2) == ["a", "b"].collect { new File("$it-external.jar") }
+            assert classpath.applicationModulepath.takeRight(2) == ["c", "d"].collect { new File("$it-external.jar") }
             assert classpath.implementationClasspath.takeRight(2) == ["e", "f"].collect { new URL("file://$it-external.jar") }
             assert classpath.implementationModulepath == ["g", "h"].collect { new URL("file://$it-external.jar") }
         } else {


### PR DESCRIPTION
When running embedded integration tests with test distribution, the junit-platform-launcher jar which is loaded from the gradle distribution is different than the version we usually test against. This version is incompatible with older versions of junit-platform-commons and junit-platform-engine jars pulled in by the corresponding junit jupiter versions.

To resolve this, we reversed the ordering of distribution loaded test framework jars to ensure our versions of these junit-platform-launcher dependencies came first on the classpath. This turned out to break the newest version of junit jupiter, which we do not test against, leading to a regression.

This reverses the order and ignores the embedded tests which break when testing against older versions of junit jupiter.

<!--- The issue this PR addresses -->
Fixes #24429