### PR TITLE
Repack build logic inputs without transformation to match old behavior

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/classpath/BuildScriptClasspathIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/classpath/BuildScriptClasspathIntegrationSpec.groovy
@@ -16,12 +16,10 @@
 
 package org.gradle.internal.classpath
 
-
 import org.gradle.api.internal.cache.CacheConfigurationsInternal
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.integtests.fixtures.cache.FileAccessTimeJournalFixture
-import org.gradle.integtests.fixtures.executer.AbstractGradleExecuter
 import org.gradle.integtests.fixtures.executer.ArtifactBuilder
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.server.http.HttpServer
@@ -96,7 +94,6 @@ class BuildScriptClasspathIntegrationSpec extends AbstractIntegrationSpec implem
         loopNumber << (1..6).toList()
     }
 
-    @IgnoreIf({ AbstractGradleExecuter.agentInstrumentationEnabled }) // Agent-based instrumentation doesn't expose cached JARs
     def "build script classloader copies jar files to cache"() {
         given:
         createBuildFileThatPrintsClasspathURLs("""

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultCachedClasspathTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultCachedClasspathTransformer.java
@@ -112,7 +112,7 @@ public class DefaultCachedClasspathTransformer implements CachedClasspathTransfo
                 if (!agentStatus.isAgentInstrumentationEnabled()) {
                     return instrumentingPipeline(InstrumentingClasspathFileTransformer.instrumentForLoadingWithClassLoader());
                 }
-                return agentInstrumentingPipeline(copyingPipeline(), instrumentingPipeline(InstrumentingClasspathFileTransformer.instrumentForLoadingWithAgent()));
+                return agentInstrumentingPipeline(normalizingPipeline(), instrumentingPipeline(InstrumentingClasspathFileTransformer.instrumentForLoadingWithAgent()));
             default:
                 throw new IllegalArgumentException();
         }
@@ -120,6 +120,10 @@ public class DefaultCachedClasspathTransformer implements CachedClasspathTransfo
 
     private TransformPipeline copyingPipeline() {
         return cp -> transformFiles(cp, new CopyingClasspathFileTransformer(globalCacheLocations));
+    }
+
+    private TransformPipeline normalizingPipeline() {
+        return instrumentingPipeline(InstrumentingClasspathFileTransformer.normalizeWithoutInstrumenting(globalCacheLocations));
     }
 
     private TransformPipeline instrumentingPipeline(InstrumentingClasspathFileTransformer.Policy policy) {


### PR DESCRIPTION
This normalizes the classpath JARs and fixes some issues in the compilation avoidance that were hampered by non-deterministic non-instrumented JARs.
