### PR TITLE
Remove finalization from test framework properties

### DIFF
--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmTestSuite.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmTestSuite.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.VisibleForTesting;
 import groovy.lang.GroovySystem;
 import org.gradle.api.Action;
 import org.gradle.api.ExtensiblePolymorphicDomainObjectContainer;
+import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.ExternalModuleDependency;
@@ -44,6 +45,7 @@ import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.api.tasks.testing.Test;
+import org.gradle.internal.Pair;
 import org.gradle.util.internal.VersionNumber;
 
 import javax.inject.Inject;
@@ -138,6 +140,24 @@ public abstract class DefaultJvmTestSuite implements JvmTestSuite {
         }
     }
 
+    private static class CachingTestFrameworkTransformer implements Transformer<TestFramework, VersionedTestingFramework> {
+        private final Transformer<TestFramework, TestingFramework> mapToTestFramework;
+        private Pair<TestingFramework, TestFramework> currentMapping;
+
+        public CachingTestFrameworkTransformer(Transformer<TestFramework, TestingFramework> mapToTestFramework) {
+            this.mapToTestFramework = mapToTestFramework;
+        }
+
+        @Override
+        public TestFramework transform(VersionedTestingFramework vtf) {
+            if (currentMapping == null || currentMapping.getLeft() != vtf.getFramework()) {
+                currentMapping = Pair.of(vtf.getFramework(), mapToTestFramework.transform(vtf.getFramework()));
+            }
+
+            return currentMapping.getRight();
+        }
+    }
+
     private final ExtensiblePolymorphicDomainObjectContainer<JvmTestSuiteTarget> targets;
     private final SourceSet sourceSet;
     private final String name;
@@ -172,7 +192,6 @@ public abstract class DefaultJvmTestSuite implements JvmTestSuite {
             // and add dependencies automatically.
             getTestSuiteTestingFramework().convention(new VersionedTestingFramework(TestingFramework.JUNIT_JUPITER, TestingFramework.JUNIT_JUPITER.getDefaultVersion()));
         }
-        getTestSuiteTestingFramework().finalizeValueOnRead(); // The framework set on the SUITE is finalized upon read, even for the default suite
 
         addDefaultTestTarget();
 
@@ -196,34 +215,31 @@ public abstract class DefaultJvmTestSuite implements JvmTestSuite {
     }
 
     private void initializeTestFramework(String name, Test task) {
-        Provider<TestFramework> mapTestingFrameworkToTestFramework = getTestSuiteTestingFramework().map(vtf -> {
-            switch (vtf.getFramework()) {
-                case JUNIT4:
-                    return new JUnitTestFramework(task, (DefaultTestFilter) task.getFilter(), false);
-                case KOTLIN_TEST: // fall-through
-                case JUNIT_JUPITER: // fall-through
-                case SPOCK:
-                    return new JUnitPlatformTestFramework((DefaultTestFilter) task.getFilter(), false);
-                case TESTNG:
-                    return new TestNGTestFramework(task, (DefaultTestFilter) task.getFilter(), getObjectFactory());
-                default:
-                    throw new IllegalStateException("do not know how to handle " + vtf);
-            }
-        });
+        Provider<TestFramework> mapTestingFrameworkToTestFramework = getTestSuiteTestingFramework().map(
+            new CachingTestFrameworkTransformer(framework -> {
+                switch (framework) {
+                    case JUNIT4:
+                        return new JUnitTestFramework(task, (DefaultTestFilter) task.getFilter(), false);
+                    case KOTLIN_TEST: // fall-through
+                    case JUNIT_JUPITER: // fall-through
+                    case SPOCK:
+                        return new JUnitPlatformTestFramework((DefaultTestFilter) task.getFilter(), false);
+                    case TESTNG:
+                        return new TestNGTestFramework(task, (DefaultTestFilter) task.getFilter(), getObjectFactory());
+                    default:
+                        throw new IllegalStateException("do not know how to handle " + framework);
+                }
+            })
+        );
 
         if (name.equals(JvmTestSuitePlugin.DEFAULT_TEST_SUITE_NAME)) {
             // In order to maintain compatibility for the default test suite, we need to load JUnit4 from the Gradle distribution
             // instead of including it in testImplementation.
-            task.getTestFrameworkProperty().convention(mapTestingFrameworkToTestFramework.orElse(getProviderFactory().provider(() -> new JUnitTestFramework(task, (DefaultTestFilter) task.getFilter(), true))));
-            // We can't disallow changes to the test framework yet because we need to allow the test task to be configured without the test suite
-            task.getTestFrameworkProperty().finalizeValueOnRead();
+            TestFramework defaultFramework = new JUnitTestFramework(task, (DefaultTestFilter) task.getFilter(), true);
+            task.getTestFrameworkProperty().convention(mapTestingFrameworkToTestFramework.orElse(getProviderFactory().provider(() -> defaultFramework)));
         } else {
             // The Test task's testing framework is derived from the test suite's testing framework
             task.getTestFrameworkProperty().convention(mapTestingFrameworkToTestFramework);
-            // The Test task cannot override the testing framework chosen by the test suite
-            task.getTestFrameworkProperty().disallowChanges();
-            // The Test task's testing framework is locked in as soon as its needed
-            task.getTestFrameworkProperty().finalizeValueOnRead();
         }
     }
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmTestSuite.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmTestSuite.java
@@ -142,7 +142,8 @@ public abstract class DefaultJvmTestSuite implements JvmTestSuite {
 
     private static class CachingTestFrameworkTransformer implements Transformer<TestFramework, VersionedTestingFramework> {
         private final Transformer<TestFramework, TestingFramework> mapToTestFramework;
-        private Pair<TestingFramework, TestFramework> currentMapping;
+        // This is the current mapping from TestingFramework to TestFramework (i.e. right -> left)
+        private Pair<TestFramework, TestingFramework> currentMapping;
 
         public CachingTestFrameworkTransformer(Transformer<TestFramework, TestingFramework> mapToTestFramework) {
             this.mapToTestFramework = mapToTestFramework;
@@ -150,11 +151,11 @@ public abstract class DefaultJvmTestSuite implements JvmTestSuite {
 
         @Override
         public TestFramework transform(VersionedTestingFramework vtf) {
-            if (currentMapping == null || currentMapping.getLeft() != vtf.getFramework()) {
-                currentMapping = Pair.of(vtf.getFramework(), mapToTestFramework.transform(vtf.getFramework()));
+            if (currentMapping == null || currentMapping.right() != vtf.getFramework()) {
+                currentMapping = Pair.of(mapToTestFramework.transform(vtf.getFramework()), vtf.getFramework());
             }
 
-            return currentMapping.getRight();
+            return currentMapping.left();
         }
     }
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskIntegrationTest.groovy
@@ -338,36 +338,6 @@ class TestTaskIntegrationTest extends JUnitMultiVersionIntegrationSpec {
         succeeds("test")
     }
 
-    def "options cannot be set prior to changing test framework for the default test task"() {
-        ignoreWhenJUnitPlatform()
-
-        given:
-        file('src/test/java/MyTest.java') << junitJupiterStandaloneTestClass()
-
-        settingsFile << "rootProject.name = 'Sample'"
-        buildFile << """apply plugin: 'java'
-
-            ${mavenCentralRepository()}
-            dependencies {
-                testImplementation 'org.junit.jupiter:junit-jupiter:${JUnitCoverage.LATEST_JUPITER_VERSION}'
-            }
-
-            test {
-                options {
-                    excludeCategories = ["Slow"]
-                }
-            }
-
-            test {
-                useJUnitPlatform()
-            }
-        """.stripIndent()
-
-        expect:
-        fails("test")
-        failure.assertHasCause("The value for task ':test' property 'testFrameworkProperty' is final and cannot be changed any further.")
-    }
-
     def "options can be set prior to setting same test framework for a custom test task"() {
         ignoreWhenJUnitPlatform()
 
@@ -400,33 +370,6 @@ class TestTaskIntegrationTest extends JUnitMultiVersionIntegrationSpec {
 
         expect:
         succeeds("customTest")
-    }
-
-    def "options cannot be set prior to changing test framework for a custom test task"() {
-        ignoreWhenJUnitPlatform()
-
-        given:
-        file('src/test/java/MyTest.java') << junitJupiterStandaloneTestClass()
-
-        settingsFile << "rootProject.name = 'Sample'"
-        buildFile << """apply plugin: 'java'
-
-            ${mavenCentralRepository()}
-            dependencies {
-                testImplementation 'org.junit.jupiter:junit-jupiter:${JUnitCoverage.LATEST_JUPITER_VERSION}'
-            }
-
-            tasks.create('customTest', Test) {
-                options {
-                    excludeCategories = ["Slow"]
-                }
-                useJUnitPlatform()
-            }
-        """.stripIndent()
-
-        expect:
-        fails("customTest")
-        failure.assertHasCause("The value for this property is final and cannot be changed any further.")
     }
 
     def "options configured after setting test framework works"() {

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/TestSuitesIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/TestSuitesIntegrationTest.groovy
@@ -383,70 +383,6 @@ class TestSuitesIntegrationTest extends AbstractIntegrationSpec {
         succeeds("integTest")
     }
 
-    def "task configuration overrules test suite configuration"() {
-        buildFile << """
-            plugins {
-                id 'java'
-            }
-
-            ${mavenCentralRepository()}
-
-            testing {
-                suites {
-                    integTest(JvmTestSuite) {
-                        // uses junit jupiter by default
-                        targets {
-                            all {
-                                testTask.configure {
-                                    useJUnit()
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            // force integTest to be configured
-            tasks.named("integTest").get()
-        """
-
-        expect:
-        fails("help")
-        failure.assertHasCause("The value for task ':integTest' property 'testFrameworkProperty' cannot be changed any further.")
-    }
-
-    def "task configuration overrules test suite configuration with test suite set test framework"() {
-        buildFile << """
-            plugins {
-                id 'java'
-            }
-
-            ${mavenCentralRepository()}
-
-            testing {
-                suites {
-                    integTest(JvmTestSuite) {
-                        useJUnit()
-                        targets {
-                            all {
-                                testTask.configure {
-                                    useJUnitPlatform()
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            // force integTest to be configured
-            tasks.named("integTest").get()
-        """
-
-        expect:
-        fails("help")
-        failure.assertHasCause("The value for task ':integTest' property 'testFrameworkProperty' cannot be changed any further.")
-    }
-
     @Issue("https://github.com/gradle/gradle/issues/18622")
     def "custom Test tasks eagerly realized prior to Java and Test Suite plugin application do not fail to be configured when combined with test suites"() {
         buildFile << """
@@ -530,35 +466,6 @@ class TestSuitesIntegrationTest extends AbstractIntegrationSpec {
             tasks.register('assertSameFrameworkInstance') {
                 doLast {
                     assert first.getOrNull() === second.getOrNull()
-                }
-            }""".stripIndent()
-
-        expect:
-        succeeds("assertSameFrameworkInstance")
-    }
-
-    def "multiple getTestingFramework() calls on a test suite return same instance even when calling useJUnit"() {
-        given:
-        buildFile << """
-            plugins {
-                id 'java'
-            }
-
-            def first = testing.suites.test.getTestSuiteTestingFramework()
-
-            testing {
-                suites {
-                    test {
-                        useJUnit()
-                    }
-                }
-            }
-
-            def second = testing.suites.test.getTestSuiteTestingFramework()
-
-            tasks.register('assertSameFrameworkInstance') {
-                doLast {
-                    assert first.get() === second.get()
                 }
             }""".stripIndent()
 

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -1055,13 +1055,19 @@ public abstract class Test extends AbstractTestTask implements JavaForkOptions, 
         applyOptions(TestNGOptions.class, testFrameworkConfigure);
     }
 
+    /**
+     * Set the framework, only if it is being changed to a new value.
+     *
+     * If we are setting a framework to its existing value, no-op so as not to overwrite existing options here.
+     * We need to allow this especially for the default test task, so that existing builds that configure options and
+     * then call useJunit() don't clear out their options.
+     *
+     * @param testFramework
+     */
     void useTestFramework(TestFramework testFramework) {
         Class<?> currentFramework = this.testFramework.get().getClass();
         Class<?> newFramework = testFramework.getClass();
         if (currentFramework == newFramework) {
-            // We are setting a framework to its existing value, no-op so as not to overwrite existing options here.
-            // We need to allow this especially for the default test task, so that existing builds that configure options and
-            // then call useJunit() don't clear out their options.
             return;
         }
 

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -30,7 +30,6 @@ import org.gradle.api.file.FileTree;
 import org.gradle.api.file.FileTreeElement;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.classpath.ModuleRegistry;
-import org.gradle.api.internal.provider.DefaultProperty;
 import org.gradle.api.internal.tasks.testing.JvmTestExecutionSpec;
 import org.gradle.api.internal.tasks.testing.TestExecutableUtils;
 import org.gradle.api.internal.tasks.testing.TestExecuter;
@@ -197,7 +196,6 @@ public abstract class Test extends AbstractTestTask implements JavaForkOptions, 
         javaLauncher = objectFactory.property(JavaLauncher.class).convention(createJavaLauncherConvention());
         javaLauncher.finalizeValueOnRead();
         testFramework = objectFactory.property(TestFramework.class).convention(new JUnitTestFramework(this, (DefaultTestFilter) getFilter(), true));
-        testFramework.finalizeValueOnRead();
     }
 
     private Provider<JavaLauncher> createJavaLauncherConvention() {
@@ -1058,15 +1056,13 @@ public abstract class Test extends AbstractTestTask implements JavaForkOptions, 
     }
 
     void useTestFramework(TestFramework testFramework) {
-        if (((DefaultProperty<?>) this.testFramework).isFinalized()) {
-            Class<?> currentFramework = this.testFramework.get().getClass();
-            Class<?> newFramework = testFramework.getClass();
-            if (currentFramework == newFramework) {
-                // We are setting a finalized framework to its existing value, no-op so as not to trigger a failure here.
-                // We need to allow this especially for the default test task, so that existing builds that configure options and
-                // then call useJunit() afterwards don't fail
-                return;
-            }
+        Class<?> currentFramework = this.testFramework.get().getClass();
+        Class<?> newFramework = testFramework.getClass();
+        if (currentFramework == newFramework) {
+            // We are setting a framework to its existing value, no-op so as not to overwrite existing options here.
+            // We need to allow this especially for the default test task, so that existing builds that configure options and
+            // then call useJunit() don't clear out their options.
+            return;
         }
 
         this.testFramework.set(testFramework);


### PR DESCRIPTION
Rather than try to capture all of the different possible ways to configure the test framework and handle finalization in the face of those ways, this just removes the finalization, so exceptions won't be thrown, but there could be scenarios where the test framework could be overwritten, potentially losing options.

Fixes #24331 

