### PR TITLE
Initial implementation of launcher JVM auto-detection

### DIFF
--- a/subprojects/launcher/build.gradle.kts
+++ b/subprojects/launcher/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     implementation(project(":tooling-api"))
     implementation(project(":file-watching"))
     implementation(project(":problems"))
+    implementation(project(":file-temp"))
 
     implementation(libs.groovy) // for 'ReleaseInfo.getVersion()'
     implementation(libs.slf4jApi)
@@ -37,6 +38,7 @@ dependencies {
     implementation(libs.commonsLang)
     implementation(libs.asm)
     implementation(libs.ant)
+    implementation(libs.nativePlatform)
 
     runtimeOnly(libs.asm)
     runtimeOnly(libs.commonsIo)

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/SupportedBuildJvmIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/SupportedBuildJvmIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.launcher
 
+import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.internal.jvm.Jvm
@@ -94,4 +95,27 @@ class SupportedBuildJvmIntegrationTest extends AbstractIntegrationSpec {
         where:
         jdk << AvailableJavaHomes.getJdks("1.6", "1.7")
     }
+
+    @Requires(adhoc = { AvailableJavaHomes.getJdks("8", "11") })
+    def "daemon uses requested jvm version"() {
+        given:
+        executer.withJavaHome(AvailableJavaHomes.getJdk(JavaVersion.VERSION_1_8).javaHome)
+
+        when:
+        buildFile << """
+            task verify {
+                assert System.getProperty("java.version").startsWith("11")
+            }
+        """
+        file("gradle.properties") << """
+            org.gradle.experimental.daemon.jvm.version=11
+        """
+
+        then:
+        executer
+            .withToolchainDetectionEnabled()
+            .withArgument("-Porg.gradle.java.installations.paths=${AvailableJavaHomes.getJdk(JavaVersion.VERSION_11).javaHome}")
+        succeeds("verify")
+    }
+
 }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/BuildActionsFactory.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/BuildActionsFactory.java
@@ -17,10 +17,13 @@
 package org.gradle.launcher.cli;
 
 import com.google.common.annotations.VisibleForTesting;
+import net.rubygrapefruit.platform.WindowsRegistry;
 import org.gradle.StartParameter;
 import org.gradle.api.Action;
+import org.gradle.api.JavaVersion;
 import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.internal.file.FileCollectionFactory;
+import org.gradle.api.internal.file.temp.TemporaryFileProvider;
 import org.gradle.cli.CommandLineParser;
 import org.gradle.cli.ParsedCommandLine;
 import org.gradle.configuration.GradleLauncherMetaData;
@@ -33,6 +36,8 @@ import org.gradle.internal.agents.AgentStatus;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.concurrent.Stoppable;
+import org.gradle.internal.jvm.Jvm;
+import org.gradle.internal.jvm.inspection.JvmInstallationMetadata;
 import org.gradle.internal.jvm.inspection.JvmVersionDetector;
 import org.gradle.internal.logging.events.OutputEventListener;
 import org.gradle.internal.nativeintegration.services.NativeServices;
@@ -55,6 +60,7 @@ import org.gradle.launcher.exec.BuildActionExecuter;
 import org.gradle.launcher.exec.BuildActionParameters;
 import org.gradle.launcher.exec.BuildExecuter;
 import org.gradle.launcher.exec.DefaultBuildActionParameters;
+import org.gradle.process.internal.ExecFactory;
 
 import java.lang.management.ManagementFactory;
 import java.util.UUID;
@@ -65,16 +71,24 @@ class BuildActionsFactory implements CommandLineActionCreator {
     private final JvmVersionDetector jvmVersionDetector;
     private final FileCollectionFactory fileCollectionFactory;
     private final ServiceRegistry basicServices;
+    private final DaemonJvmSelector daemonJvmSelector;
 
     public BuildActionsFactory(ServiceRegistry loggingServices) {
+
         basicServices = ServiceRegistryBuilder.builder()
             .parent(loggingServices)
             .parent(NativeServices.getInstance())
             .provider(new BasicGlobalScopeServices()).build();
+
         this.loggingServices = loggingServices;
-        fileCollectionFactory = basicServices.get(FileCollectionFactory.class);
-        parametersConverter = new ParametersConverter(new BuildLayoutFactory(), basicServices.get(FileCollectionFactory.class));
-        jvmVersionDetector = basicServices.get(JvmVersionDetector.class);
+        this.fileCollectionFactory = basicServices.get(FileCollectionFactory.class);
+        this.parametersConverter = new ParametersConverter(new BuildLayoutFactory(), basicServices.get(FileCollectionFactory.class));
+        this.jvmVersionDetector = basicServices.get(JvmVersionDetector.class);
+        this.daemonJvmSelector = new DaemonJvmSelector(
+            basicServices.get(ExecFactory.class),
+            basicServices.get(TemporaryFileProvider.class),
+            basicServices.get(WindowsRegistry.class)
+        );
     }
 
     @Override
@@ -86,7 +100,19 @@ class BuildActionsFactory implements CommandLineActionCreator {
     public Action<? super ExecutionListener> createAction(CommandLineParser parser, ParsedCommandLine commandLine) {
         Parameters parameters = parametersConverter.convert(commandLine, null);
 
-        parameters.getDaemonParameters().applyDefaultsFor(jvmVersionDetector.getJavaVersion(parameters.getDaemonParameters().getEffectiveJvm()));
+        JavaVersion version;
+        // Only auto-detect JVM a javaHome was not explicitly set.
+        if (parameters.getDaemonParameters().getJvm() == null &&
+            parameters.getDaemonParameters().getJvmVersion() != null
+        ) {
+            Integer requestedVersion = parameters.getDaemonParameters().getJvmVersion();
+            JvmInstallationMetadata installation = daemonJvmSelector.getDaemonJvmInstallation(requestedVersion);
+            parameters.getDaemonParameters().setJvm(Jvm.forHome(installation.getJavaHome().toFile()));
+            version = installation.getLanguageVersion();
+        } else {
+            version = jvmVersionDetector.getJavaVersion(parameters.getDaemonParameters().getEffectiveJvm());
+        }
+        parameters.getDaemonParameters().applyDefaultsFor(version);
 
         if (parameters.getDaemonParameters().isStop()) {
             return Actions.toAction(stopAllDaemons(parameters.getDaemonParameters()));

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/BuildActionsFactory.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/BuildActionsFactory.java
@@ -106,7 +106,7 @@ class BuildActionsFactory implements CommandLineActionCreator {
             parameters.getDaemonParameters().getJvmVersion() != null
         ) {
             Integer requestedVersion = parameters.getDaemonParameters().getJvmVersion();
-            JvmInstallationMetadata installation = daemonJvmSelector.getDaemonJvmInstallation(requestedVersion);
+            JvmInstallationMetadata installation = daemonJvmSelector.getDaemonJvmInstallation(requestedVersion, parameters);
             parameters.getDaemonParameters().setJvm(Jvm.forHome(installation.getJavaHome().toFile()));
             version = installation.getLanguageVersion();
         } else {

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/DaemonJvmSelector.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/DaemonJvmSelector.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.launcher.cli;
+
+import com.google.common.collect.Lists;
+import net.rubygrapefruit.platform.WindowsRegistry;
+import org.gradle.api.GradleException;
+import org.gradle.api.JavaVersion;
+import org.gradle.api.internal.file.FileResolver;
+import org.gradle.api.internal.file.IdentityFileResolver;
+import org.gradle.api.internal.file.temp.TemporaryFileProvider;
+import org.gradle.api.internal.provider.DefaultProviderFactory;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.internal.jvm.Jvm;
+import org.gradle.internal.jvm.inspection.CachingJvmMetadataDetector;
+import org.gradle.internal.jvm.inspection.DefaultJvmMetadataDetector;
+import org.gradle.internal.jvm.inspection.JvmInstallationMetadata;
+import org.gradle.internal.jvm.inspection.JvmInstallationMetadataComparator;
+import org.gradle.internal.jvm.inspection.JvmMetadataDetector;
+import org.gradle.internal.os.OperatingSystem;
+import org.gradle.jvm.toolchain.internal.AsdfInstallationSupplier;
+import org.gradle.jvm.toolchain.internal.CurrentInstallationSupplier;
+import org.gradle.jvm.toolchain.internal.EnvironmentVariableListInstallationSupplier;
+import org.gradle.jvm.toolchain.internal.InstallationSupplier;
+import org.gradle.jvm.toolchain.internal.IntellijInstallationSupplier;
+import org.gradle.jvm.toolchain.internal.JabbaInstallationSupplier;
+import org.gradle.jvm.toolchain.internal.JavaInstallationRegistry;
+import org.gradle.jvm.toolchain.internal.LinuxInstallationSupplier;
+import org.gradle.jvm.toolchain.internal.LocationListInstallationSupplier;
+import org.gradle.jvm.toolchain.internal.MavenToolchainsInstallationSupplier;
+import org.gradle.jvm.toolchain.internal.OsXInstallationSupplier;
+import org.gradle.jvm.toolchain.internal.SdkmanInstallationSupplier;
+import org.gradle.jvm.toolchain.internal.WindowsInstallationSupplier;
+import org.gradle.process.internal.ExecFactory;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+/**
+ * Daemon JVM auto-detection implementation for use in the launcher.
+ */
+public class DaemonJvmSelector {
+    private final JavaInstallationRegistry registry;
+    private final JvmMetadataDetector detector;
+
+    public DaemonJvmSelector(
+        ExecFactory execHandleFactory,
+        TemporaryFileProvider temporaryFileProvider,
+        WindowsRegistry windowsRegistry
+    ) {
+        List<InstallationSupplier> installationSuppliers = defaultInstallationSuppliers(new BasicProviderFactory(), execHandleFactory, windowsRegistry);
+
+        this.registry = new JavaInstallationRegistry(installationSuppliers, null, OperatingSystem.current());
+
+        // TODO: This cache probably doesn't do much in the launcher. We should be caching something to disk here so ideally we
+        // can skip the entire detection process
+        this.detector = new CachingJvmMetadataDetector(
+            new DefaultJvmMetadataDetector(execHandleFactory, temporaryFileProvider));
+    }
+
+    public JvmInstallationMetadata getDaemonJvmInstallation(int version) {
+        Optional<JvmInstallationMetadata> installation = getInstallation(it -> it.getLanguageVersion().isCompatibleWith(JavaVersion.toVersion(version)));
+        if (!installation.isPresent()) {
+            throw new GradleException("No valid JVM installation found compatible with Java " + version + ".");
+        }
+        return installation.get();
+    }
+
+    private Optional<JvmInstallationMetadata> getInstallation(Predicate<? super JvmInstallationMetadata> criteria) {
+        // TODO: What are the performance implications of doing this in the launcher?
+        return registry.listInstallations().stream()
+            .map(detector::getMetadata)
+            .filter(JvmInstallationMetadata::isValidInstallation)
+            .filter(criteria)
+            .min(new JvmInstallationMetadataComparator(Jvm.current().getJavaHome()));
+    }
+
+    // TODO: We should standardize our installation suppliers across AvailableJavaHomes, this, and PlatformJvmServices.
+    private static List<InstallationSupplier> defaultInstallationSuppliers(ProviderFactory providerFactory, ExecFactory execFactory, WindowsRegistry windowsRegistry) {
+
+        // TODO: Also leverage the AutoInstalledInstallationSupplier by moving it to a
+        // subproject accessible from here. This will require moving a few other things around.
+
+        FileResolver resolver = new IdentityFileResolver();
+        return Lists.newArrayList(
+            new AsdfInstallationSupplier(providerFactory),
+            new CurrentInstallationSupplier(providerFactory),
+            new EnvironmentVariableListInstallationSupplier(providerFactory, resolver),
+            new IntellijInstallationSupplier(providerFactory, resolver),
+            new JabbaInstallationSupplier(providerFactory),
+            new LinuxInstallationSupplier(providerFactory),
+            new LocationListInstallationSupplier(providerFactory, resolver),
+            new MavenToolchainsInstallationSupplier(providerFactory, resolver),
+            new OsXInstallationSupplier(execFactory, providerFactory, OperatingSystem.current()),
+            new SdkmanInstallationSupplier(providerFactory),
+            new WindowsInstallationSupplier(windowsRegistry, OperatingSystem.current(), providerFactory)
+        );
+    }
+
+    /**
+     * A {@link org.gradle.api.provider.ProviderFactory} which only provides
+     * environment variables, system properties, and Gradle properties. A fully featured
+     * provider factory is not otherwise available at this service scope.
+     */
+    private static class BasicProviderFactory extends DefaultProviderFactory {
+        @Override
+        public Provider<String> environmentVariable(Provider<String> variableName) {
+            return variableName.map(System::getenv);
+        }
+
+        @Override
+        public Provider<String> systemProperty(Provider<String> propertyName) {
+            return propertyName.map(System::getProperty);
+        }
+
+        @Override
+        public Provider<String> gradleProperty(Provider<String> propertyName) {
+            return systemProperty(propertyName);
+        }
+    }
+
+}

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/client/JvmVersionValidator.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/client/JvmVersionValidator.java
@@ -23,6 +23,7 @@ import org.gradle.internal.jvm.inspection.JvmVersionDetector;
 import org.gradle.launcher.daemon.configuration.DaemonParameters;
 
 public class JvmVersionValidator {
+
     private final JvmVersionDetector versionDetector;
 
     public JvmVersionValidator(JvmVersionDetector versionDetector) {
@@ -35,6 +36,6 @@ public class JvmVersionValidator {
         }
 
         JavaVersion javaVersion = versionDetector.getJavaVersion(parameters.getEffectiveJvm());
-        UnsupportedJavaRuntimeException.assertUsingVersion("Gradle", JavaVersion.VERSION_1_8, javaVersion);
+        UnsupportedJavaRuntimeException.assertUsingVersion("Gradle", DaemonParameters.MIN_SUPPORTED_JVM_VERSION, javaVersion);
     }
 }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonBuildOptions.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonBuildOptions.java
@@ -23,6 +23,7 @@ import org.gradle.internal.buildoption.BuildOption;
 import org.gradle.internal.buildoption.BuildOptionSet;
 import org.gradle.internal.buildoption.CommandLineOptionConfiguration;
 import org.gradle.internal.buildoption.EnabledOnlyBooleanBuildOption;
+import org.gradle.internal.buildoption.IntegerBuildOption;
 import org.gradle.internal.buildoption.Origin;
 import org.gradle.internal.buildoption.StringBuildOption;
 import org.gradle.internal.jvm.JavaHomeException;
@@ -42,6 +43,7 @@ public class DaemonBuildOptions extends BuildOptionSet<DaemonParameters> {
         new BaseDirOption(),
         new JvmArgsOption(),
         new JavaHomeOption(),
+        new JvmVersionOption(),
         new DebugOption(),
         new DebugHostOption(),
         new DebugPortOption(),
@@ -143,6 +145,24 @@ public class DaemonBuildOptions extends BuildOptionSet<DaemonParameters> {
             } catch (JavaHomeException e) {
                 origin.handleInvalidValue(value, "Java home supplied seems to be invalid");
             }
+        }
+    }
+
+    public static class JvmVersionOption extends IntegerBuildOption<DaemonParameters> {
+        public static final String GRADLE_PROPERTY = "org.gradle.experimental.daemon.jvm.version";
+
+        public JvmVersionOption() {
+            super(GRADLE_PROPERTY);
+        }
+
+        @Override
+        public void applyTo(int value, DaemonParameters settings, Origin origin) {
+            int minAllowed = Integer.parseInt(DaemonParameters.MIN_SUPPORTED_JVM_VERSION.getMajorVersion());
+
+            if (value < minAllowed) {
+                origin.handleInvalidValue(Integer.toString(value), "Daemon JVM version must be at least " + minAllowed);
+            }
+            settings.setJvmVersion(value);
         }
     }
 

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java
@@ -36,6 +36,7 @@ import java.util.Set;
 public class DaemonParameters {
     static final int DEFAULT_IDLE_TIMEOUT = 3 * 60 * 60 * 1000;
     public static final int DEFAULT_PERIODIC_CHECK_INTERVAL_MILLIS = 10 * 1000;
+    public static final JavaVersion MIN_SUPPORTED_JVM_VERSION = JavaVersion.VERSION_1_8;
 
     public static final List<String> DEFAULT_JVM_ARGS = ImmutableList.of("-Xmx512m", "-Xms256m", "-XX:MaxPermSize=384m", "-XX:+HeapDumpOnOutOfMemoryError");
     public static final List<String> DEFAULT_JVM_8_ARGS = ImmutableList.of("-Xmx512m", "-Xms256m", "-XX:MaxMetaspaceSize=384m", "-XX:+HeapDumpOnOutOfMemoryError");
@@ -57,7 +58,8 @@ public class DaemonParameters {
     private boolean stop;
     private boolean status;
     private Priority priority = Priority.NORMAL;
-    private JavaInfo jvm = Jvm.current();
+    private JavaInfo jvm;
+    private Integer jvmVersion;
 
     public DaemonParameters(BuildLayoutResult layout, FileCollectionFactory fileCollectionFactory) {
         this(layout, fileCollectionFactory, Collections.<String, String>emptyMap());
@@ -117,13 +119,25 @@ public class DaemonParameters {
     }
 
     public JavaInfo getEffectiveJvm() {
-        return jvm;
+        return jvm != null ? jvm : Jvm.current();
     }
 
     @Nullable
-    public DaemonParameters setJvm(JavaInfo jvm) {
-        this.jvm = jvm == null ? Jvm.current() : jvm;
-        return this;
+    public JavaInfo getJvm() {
+        return jvm;
+    }
+
+    public void setJvm(@Nullable JavaInfo jvm) {
+        this.jvm = jvm;
+    }
+
+    public void setJvmVersion(@Nullable Integer version) {
+        this.jvmVersion = version;
+    }
+
+    @Nullable
+    public Integer getJvmVersion() {
+        return jvmVersion;
     }
 
     public void applyDefaultsFor(JavaVersion javaVersion) {


### PR DESCRIPTION
AKA "Toolchains for Daemon"

Adds a new experimental gradle property for configuring the minimum version of Java to use to run the Gradle Daemon. Adds one integration test to verify functionality

Questions:
- How is this affected by Java Serialization? Do we use Java serialization to communicate between the launcher and daemon processes?
  - If so, does java serialization work between Java versions? If not, can we avoid Java serialization?
- What are the performance implications of running auto-detection in the launcher?
  - It is probably slow. We probably want to cache the result.
  - What if someone messes with our cached value?


To be clear I'm not expecting a review on this. This requires some extra thought, but I thought I'd bring it to yall's attention 