### PR TITLE
Update wrapper to 8.2-20230323231436+0000

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.2-20230318094953+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.2-20230323231436+0000-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
To include Build cache NG changes: https://github.com/gradle/gradle/pull/23684.