### PR TITLE
Avoid applying java-base when applying jvm-test-suite

### DIFF
--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -406,6 +406,7 @@ public abstract class JavaBasePlugin implements Plugin<Project> {
         Provider<JavaToolchainSpec> toolchainOverrideSpec = project.provider(() ->
             TestExecutableUtils.getExecutableToolchainSpec(test, objectFactory));
         test.getJavaLauncher().convention(getToolchainTool(project, JavaToolchainService::launcherFor, toolchainOverrideSpec));
+        test.getModularity().getInferModulePath().convention(javaPluginExtension.getModularity().getInferModulePath());
     }
 
     private <T> Provider<T> getToolchainTool(

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JvmTestSuitePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JvmTestSuitePlugin.java
@@ -69,8 +69,6 @@ public abstract class JvmTestSuitePlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         project.getPluginManager().apply("org.gradle.test-suite-base");
-        project.getPluginManager().apply("org.gradle.java-base");
-        JavaPluginExtension java = project.getExtensions().getByType(JavaPluginExtension.class);
         TestingExtension testing = project.getExtensions().getByType(TestingExtension.class);
         ExtensiblePolymorphicDomainObjectContainer<TestSuite> testSuites = testing.getSuites();
         testSuites.registerBinding(JvmTestSuite.class, DefaultJvmTestSuite.class);
@@ -93,7 +91,6 @@ public abstract class JvmTestSuitePlugin implements Plugin<Project> {
                     .nagUser();
                 return JavaPluginHelper.getDefaultTestSuite(project).getSources().getRuntimeClasspath();
             });
-            test.getModularity().getInferModulePath().convention(java.getModularity().getInferModulePath());
         });
 
         testSuites.withType(JvmTestSuite.class).all(testSuite -> {


### PR DESCRIPTION
This removes the dependency between these two plugins
