### PR TITLE
Fix accessors generation for applied kotlin scripts

### DIFF
--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslRegressionsTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslRegressionsTest.kt
@@ -204,11 +204,21 @@ class GradleKotlinDslRegressionsTest : AbstractPluginIntegrationTest() {
     @Issue("https://github.com/gradle/gradle/issues/24481")
     fun `applied project scripts don't have project accessors`() {
         withFile("applied.gradle.kts", """
-           println(java.sourceCompatibility)
+            println(java.sourceCompatibility)
         """)
         withBuildScript("""
             plugins { java }
             apply(from = "applied.gradle.kts")
+        """)
+        buildAndFail("help").apply {
+            assertHasErrorOutput("Unresolved reference: sourceCompatibility")
+        }
+
+        withFile("applied.gradle.kts", """
+            buildscript {
+                dependencies {}
+            }
+            println(java.sourceCompatibility)
         """)
         buildAndFail("help").apply {
             assertHasErrorOutput("Unresolved reference: sourceCompatibility")

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslRegressionsTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslRegressionsTest.kt
@@ -190,12 +190,28 @@ class GradleKotlinDslRegressionsTest : AbstractPluginIntegrationTest() {
         }
     }
 
+    @Test
     @Issue("https://youtrack.jetbrains.com/issue/KT-55880")
     @Issue("https://github.com/gradle/gradle/issues/23491")
     fun `compiling standalone scripts does not emit a warning at info level`() {
         withBuildScript("""println("test")""")
         build("help", "--info").apply {
             assertNotOutput("is not supposed to be used along with regular Kotlin sources, and will be ignored in the future versions by default. (Use -Xallow-any-scripts-in-source-roots command line option to opt-in for the old behavior.)")
+        }
+    }
+
+    @Test
+    @Issue("https://github.com/gradle/gradle/issues/24481")
+    fun `applied project scripts don't have project accessors`() {
+        withFile("applied.gradle.kts", """
+           println(java.sourceCompatibility)
+        """)
+        withBuildScript("""
+            plugins { java }
+            apply(from = "applied.gradle.kts")
+        """)
+        buildAndFail("help").apply {
+            assertHasErrorOutput("Unresolved reference: sourceCompatibility")
         }
     }
 }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/Interpreter.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/Interpreter.kt
@@ -32,12 +32,10 @@ import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.exceptions.LocationAwareException
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.service.ServiceRegistry
-import org.gradle.kotlin.dsl.accessors.ProjectAccessorsClassPathGenerator
 import org.gradle.kotlin.dsl.assignment.internal.KotlinDslAssignment
 import org.gradle.kotlin.dsl.support.KotlinScriptHost
 import org.gradle.kotlin.dsl.support.ScriptCompilationException
 import org.gradle.kotlin.dsl.support.loggerFor
-import org.gradle.kotlin.dsl.support.serviceOf
 import org.gradle.kotlin.dsl.support.serviceRegistryOf
 import org.gradle.plugin.management.internal.PluginRequests
 import java.io.File
@@ -107,6 +105,10 @@ class Interpreter(val host: Host) {
          * already be implied by [ProgramId.parentClassLoader].
          */
         fun stage1BlocksAccessorsFor(
+            scriptHost: KotlinScriptHost<*>
+        ): ClassPath
+
+        fun accessorsClassPathFor(
             scriptHost: KotlinScriptHost<*>
         ): ClassPath
 
@@ -439,14 +441,8 @@ class Interpreter(val host: Host) {
             eval(specializedProgram, scriptHost)
         }
 
-        override fun accessorsClassPathFor(scriptHost: KotlinScriptHost<*>): ClassPath {
-            val project = scriptHost.target as Project
-            val projectAccessorsClassPathGenerator = project.serviceOf<ProjectAccessorsClassPathGenerator>()
-            return projectAccessorsClassPathGenerator.projectAccessorsClassPath(
-                project,
-                host.compilationClassPathOf(scriptHost.targetScope)
-            ).bin
-        }
+        override fun accessorsClassPathFor(scriptHost: KotlinScriptHost<*>): ClassPath =
+            host.accessorsClassPathFor(scriptHost)
 
         override fun compileSecondStageOf(
             program: ExecutableProgram.StagedProgram,

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/Interpreter.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/Interpreter.kt
@@ -254,8 +254,8 @@ class Interpreter(val host: Host) {
 
         // TODO: consider computing stage 1 accessors only when there's a buildscript or plugins block
         // TODO: consider splitting buildscript/plugins block accessors
-        val stage1BlocksAccessorsClassPath = when {
-            requiresAccessors(programTarget) -> host.stage1BlocksAccessorsFor(scriptHost)
+        val stage1BlocksAccessorsClassPath = when (programTarget) {
+            ProgramTarget.Project -> host.stage1BlocksAccessorsFor(scriptHost)
             else -> ClassPath.EMPTY
         }
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/ResidualProgramCompiler.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/ResidualProgramCompiler.kt
@@ -486,7 +486,7 @@ class ResidualProgramCompiler(
         LDC(programTarget.name + "/" + programKind.name + "/stage2")
         // Move HashCode value to a static field so it's cached across invocations
         loadHashCode(originalSourceHash)
-        if (requiresAccessors(programTarget)) emitAccessorsClassPathForScriptHost()
+        if (requiresSecondStageAccessors(programTarget, programKind)) emitAccessorsClassPathForScriptHost()
         else GETSTATIC(ClassPath::EMPTY)
         invokeHost(
             ExecutableProgram.Host::evaluateSecondStageOf.name,
@@ -499,6 +499,10 @@ class ResidualProgramCompiler(
                 ")V"
         )
     }
+
+    private
+    fun requiresSecondStageAccessors(programTarget: ProgramTarget, programKind: ProgramKind) =
+        programTarget == ProgramTarget.Project && programKind == ProgramKind.TopLevel
 
     private
     val stagedProgram = Type.getType(ExecutableProgram.StagedProgram::class.java)
@@ -786,8 +790,3 @@ class ResidualProgramCompiler(
     fun implicitReceiverOf(template: KClass<*>) =
         template.annotations.filterIsInstance<ImplicitReceiver>().map { it.type }.firstOrNull()
 }
-
-
-internal
-fun requiresAccessors(programTarget: ProgramTarget) =
-    programTarget == ProgramTarget.Project

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptEvaluator.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptEvaluator.kt
@@ -51,6 +51,7 @@ import org.gradle.internal.scripts.CompileScriptBuildOperationType.Details
 import org.gradle.internal.scripts.CompileScriptBuildOperationType.Result
 import org.gradle.internal.scripts.ScriptExecutionListener
 import org.gradle.internal.snapshot.ValueSnapshot
+import org.gradle.kotlin.dsl.accessors.ProjectAccessorsClassPathGenerator
 import org.gradle.kotlin.dsl.accessors.Stage1BlocksAccessorClassPathGenerator
 import org.gradle.kotlin.dsl.cache.KotlinDslWorkspaceProvider
 import org.gradle.kotlin.dsl.execution.CompiledScript
@@ -160,6 +161,15 @@ class StandardKotlinScriptEvaluator(
                 val stage1BlocksAccessorClassPathGenerator = it.serviceOf<Stage1BlocksAccessorClassPathGenerator>()
                 stage1BlocksAccessorClassPathGenerator.stage1BlocksAccessorClassPath(it).bin
             } ?: ClassPath.EMPTY
+
+        override fun accessorsClassPathFor(scriptHost: KotlinScriptHost<*>): ClassPath {
+            val project = scriptHost.target as Project
+            val projectAccessorsClassPathGenerator = project.serviceOf<ProjectAccessorsClassPathGenerator>()
+            return projectAccessorsClassPathGenerator.projectAccessorsClassPath(
+                project,
+                compilationClassPathOf(scriptHost.targetScope)
+            ).bin
+        }
 
         override fun runCompileBuildOperation(scriptPath: String, stage: String, action: () -> String): String =
 

--- a/subprojects/kotlin-dsl/src/testFixtures/kotlin/org/gradle/kotlin/dsl/fixtures/SimplifiedKotlinScriptEvaluator.kt
+++ b/subprojects/kotlin-dsl/src/testFixtures/kotlin/org/gradle/kotlin/dsl/fixtures/SimplifiedKotlinScriptEvaluator.kt
@@ -167,6 +167,9 @@ class SimplifiedKotlinScriptEvaluator(
         override fun stage1BlocksAccessorsFor(scriptHost: KotlinScriptHost<*>): ClassPath =
             ClassPath.EMPTY
 
+        override fun accessorsClassPathFor(scriptHost: KotlinScriptHost<*>): ClassPath =
+            ClassPath.EMPTY
+
         override fun startCompilerOperation(description: String): AutoCloseable =
             mock()
 


### PR DESCRIPTION
* Follow up for https://github.com/gradle/gradle/pull/24427
* Fixes https://github.com/gradle/gradle/issues/24481

https://github.com/gradle/gradle/pull/24427 while adding version catalog accessors to `buildscript {}` blocks of applied scripts (`ProgramKind.ScriptPlugin`) mistakenly enabled stage2 (script body) accessors availability in applied scripts with a `buildscript {}` block.

This PR fixes that by disabling stage2 accessors for applied scripts and adds a regression test to make sure this doesn't happen again.

It also makes a small refactoring in KTS `Interpreter` and `ResidualProgramCompiler` to align how stage1 and stage2 accessors are generated to reduce the complexity.
