### PR TITLE
Don't nag about reported problems

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DeprecatedFeaturesListener.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DeprecatedFeaturesListener.kt
@@ -18,60 +18,78 @@ package org.gradle.configurationcache
 
 import org.gradle.api.internal.BuildScopeListenerRegistrationListener
 import org.gradle.api.internal.FeaturePreviews
+import org.gradle.api.internal.FeaturePreviews.Feature.STABLE_CONFIGURATION_CACHE
 import org.gradle.api.internal.TaskInternal
 import org.gradle.api.internal.tasks.execution.TaskExecutionAccessListener
 import org.gradle.internal.buildoption.FeatureFlags
+import org.gradle.internal.buildtree.BuildModelParameters
 import org.gradle.internal.deprecation.DeprecationLogger
 import org.gradle.internal.service.scopes.ListenerService
+import org.gradle.internal.service.scopes.Scopes
+import org.gradle.internal.service.scopes.ServiceScope
 
 
+/**
+ * Reports deprecations when [FeaturePreviews.Feature.STABLE_CONFIGURATION_CACHE] is enabled
+ * but the configuration cache is not (since the deprecated features are already reported as problems
+ * in that case).
+ */
 @ListenerService
+@ServiceScope(Scopes.BuildTree::class)
 internal
 class DeprecatedFeaturesListener(
-    private val featureFlags: FeatureFlags
+    private val featureFlags: FeatureFlags,
+    private val buildModelParameters: BuildModelParameters
 ) : BuildScopeListenerRegistrationListener, TaskExecutionAccessListener {
 
     override fun onBuildScopeListenerRegistration(listener: Any, invocationDescription: String, invocationSource: Any) {
-        if (isStableConfigurationCacheEnabled()) {
-            DeprecationLogger.deprecateAction("Listener registration using $invocationDescription()")
-                .willBecomeAnErrorInGradle9()
-                .withUpgradeGuideSection(7, "task_execution_events")
-                .nagUser()
+        if (shouldNag()) {
+            nagUserAbout("Listener registration using $invocationDescription()", 7, "task_execution_events")
         }
     }
 
     override fun onProjectAccess(invocationDescription: String, task: TaskInternal, runningTask: TaskInternal?) {
-        if (isStableConfigurationCacheEnabled() && shouldReportInContext(task, runningTask)) {
-            DeprecationLogger.deprecateAction("Invocation of $invocationDescription at execution time")
-                .willBecomeAnErrorInGradle9()
-                .withUpgradeGuideSection(7, "task_project")
-                .nagUser()
+        if (shouldNagFor(task, runningTask)) {
+            nagUserAbout("Invocation of $invocationDescription at execution time", 7, "task_project")
         }
     }
 
     override fun onTaskDependenciesAccess(invocationDescription: String, task: TaskInternal, runningTask: TaskInternal?) {
-        if (isStableConfigurationCacheEnabled() && shouldReportInContext(task, runningTask)) {
+        if (shouldNagFor(task, runningTask)) {
             throwUnsupported("Invocation of $invocationDescription at execution time")
         }
     }
 
     override fun onConventionAccess(invocationDescription: String, task: TaskInternal, runningTask: TaskInternal?) {
-        if (isStableConfigurationCacheEnabled() && shouldReportInContext(task, runningTask)) {
-            DeprecationLogger.deprecateAction("Invocation of $invocationDescription at execution time")
-                .willBecomeAnErrorInGradle9()
-                .withUpgradeGuideSection(8, "task_convention")
-                .nagUser()
+        if (shouldNagFor(task, runningTask)) {
+            nagUserAbout("Invocation of $invocationDescription at execution time", 8, "task_convention")
         }
     }
 
-    // Only nag about tasks that are actually executing, but not tasks that are configured by the executing tasks.
-    // A task is unlikely to reach out to other tasks without violating other constraints.
     private
-    fun shouldReportInContext(task: TaskInternal, runningTask: TaskInternal?) = runningTask == null || task == runningTask
+    fun nagUserAbout(action: String, upgradeGuideMajorVersion: Int, upgradeGuideSection: String) {
+        DeprecationLogger.deprecateAction(action)
+            .willBecomeAnErrorInGradle9()
+            .withUpgradeGuideSection(upgradeGuideMajorVersion, upgradeGuideSection)
+            .nagUser()
+    }
 
     private
-    fun isStableConfigurationCacheEnabled(): Boolean =
-        featureFlags.isEnabled(FeaturePreviews.Feature.STABLE_CONFIGURATION_CACHE)
+    fun shouldNagFor(task: TaskInternal, runningTask: TaskInternal?) =
+        shouldNag() && shouldReportInContext(task, runningTask)
+
+    private
+    fun shouldNag(): Boolean =
+        // TODO:configuration-cache - this listener shouldn't be registered when cc is enabled
+        !buildModelParameters.isConfigurationCache && featureFlags.isEnabled(STABLE_CONFIGURATION_CACHE)
+
+    /**
+     * Only nag about tasks that are actually executing, but not tasks that are configured by the executing tasks.
+     * A task is unlikely to reach out to other tasks without violating other constraints.
+     **/
+    private
+    fun shouldReportInContext(task: TaskInternal, runningTask: TaskInternal?) =
+        runningTask == null || task === runningTask
 
     private
     fun throwUnsupported(reason: String): Nothing =

--- a/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
@@ -973,10 +973,14 @@ Support for these features will be added in later Gradle releases.
 [[config_cache:not_yet_implemented:secrets]]
 === Handling of credentials and secrets
 
-The configuration cache has currently no option to hide secrets that are used as inputs.
-It means that they end up in the serialized configuration cache entry.
+The configuration cache has currently no option to prevent storing secrets that are used as inputs, and so they might end up in the serialized configuration cache entry which, by default, is stored under `.gradle/configuration-cache` in your project directory.
 
-This means that you should:
+To mitigate the risk of accidental exposure, Gradle encrypts the configuration cache.
+Gradle transparently generates a machine-specific secret key as required, caches it under the
+`<<directory_layout.adoc#dir:gradle_user_home,GRADLE_USER_HOME>>` directory and uses it to encrypt the data in the project specific caches.
+
+
+To enhance security further, make sure to:
 
 * Either secure access to configuration cache entries that may contain secrets
 * Or leverage `<<directory_layout.adoc#dir:gradle_user_home,GRADLE_USER_HOME>>/gradle.properties` for storing secrets.

--- a/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
@@ -204,7 +204,7 @@ They are deleted if they haven't been used for 7 days.
 [[config_cache:stable]]
 == Stable configuration cache
 
-Working towards the stabilization of configuration caching we implement some strictness behind a feature flag when it is too disruptive for early adopters.
+Working towards the stabilization of configuration caching we implemented some strictness behind a feature flag when it was considered too disruptive for early adopters.
 
 You can enable that feature flag as follows:
 
@@ -217,6 +217,12 @@ The `STABLE_CONFIGURATION_CACHE` feature flag enables the following:
 
 Undeclared shared build service usage::
 When enabled, tasks using a <<build_services#build_services, shared build service>> without declaring the requirement via the `Task.usesService` method will emit a deprecation warning.
+
+In addition, when the configuration cache is not enabled but the feature flag is present, deprecations for the following <<config_cache:requirements, configuration cache requirements>> are also enabled:
+
+* <<config_cache:requirements:build_listeners, Registering build listeners>>
+* <<config_cache:requirements:use_project_during_execution, Using the `Project` object at execution time>>
+* <<config_cache:requirements:task_extensions, Using task extensions and conventions at execution time>>
 
 It is recommended to enable it as soon as possible in order to be ready for when we remove the flag and make the linked features the default.
 
@@ -830,6 +836,12 @@ Tasks should not directly access the state of another task instance.
 Instead, tasks should be connected using <<lazy_configuration#working_with_task_dependencies_in_lazy_properties, inputs and outputs relationships>>.
 
 Note that this requirement makes it unsupported to write tasks that configure other tasks at execution time.
+
+[[config_cache:requirements:task_extensions]]
+=== Accessing task extensions or conventions
+
+Tasks should not access conventions and extensions, including extra properties, at execution time.
+Instead, any value that's relevant for the execution of the task should be modeled as a task property.
 
 [[config_cache:requirements:build_listeners]]
 === Using build listeners

--- a/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
@@ -982,8 +982,8 @@ Gradle transparently generates a machine-specific secret key as required, caches
 
 To enhance security further, make sure to:
 
-* Either secure access to configuration cache entries that may contain secrets
-* Or leverage `<<directory_layout.adoc#dir:gradle_user_home,GRADLE_USER_HOME>>/gradle.properties` for storing secrets.
+* secure access to configuration cache entries;
+* leverage `<<directory_layout.adoc#dir:gradle_user_home,GRADLE_USER_HOME>>/gradle.properties` for storing secrets.
 The content of that file is not part of the configuration cache, only its fingerprint.
 If you store secrets in that file, care must be taken to protect access to the file content.
 


### PR DESCRIPTION
When the configuration cache is enabled, the deprecations enabled by the `STABLE_CONFIGURATION_CACHE` feature preview are already reported as problems.

Fixes #24406