### PR TITLE
Allow to configure Kotlin DSL script compiler to fail on warnings

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -62,6 +62,23 @@ More details can be found in the dedicated section of the [Gradle Wrapper](gradl
 Progress is now displayed during [Java toolchains discovery](userguide/jvm/toochains.html#auto_detection).
 This can be useful during a cold-start of Gradle for users who have environments with a lot of JVM installations in them.
 
+### Kotlin DSL improvements
+
+Gradle's [Kotlin DSL](userguide/kotlin_dsl.html) provides an alternative syntax to the Groovy DSL with an enhanced editing experience in supported IDEs — superior content assistance, refactoring documentation, and more.
+
+#### Fail on script compilation warnings
+
+Gradle [Kotlin DSL scripts](userguide/kotlin_dsl.html#sec:scripts) are compiled by Gradle during the configuration phase of your build.
+Deprecation warnings found by the Kotlin compiler are reported on the console when compiling the scripts.
+
+It is now possible to configure your build to fail on any warning emitted during script compilation by setting the `org.gradle.kotlin.dsl.allWarningsAsErrors` Gradle property to `true`:
+
+```properties
+# gradle.properties
+org.gradle.kotlin.dsl.allWarningsAsErrors=true
+```
+
+More details can be found in the dedicated section of the [Kotlin DSL](userguide/kotlin_dsl.html#sec:compilation_warnings) user manual chapter.
 
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ADD RELEASE FEATURES ABOVE

--- a/subprojects/docs/src/docs/userguide/api/kotlin_dsl.adoc
+++ b/subprojects/docs/src/docs/userguide/api/kotlin_dsl.adoc
@@ -184,6 +184,25 @@ Use of internal Kotlin DSL APIs in plugins and build scripts has the potential t
 The link:{kotlinDslPath}/[Kotlin DSL API] extends the <<authoring_maintainable_build_scripts#sec:avoiding_gradle_internal_apis,Gradle public API>> with the types listed in the https://gradle.github.io/kotlin-dsl-docs/api/[corresponding API docs] that are in the `org.gradle.kotlin.dsl` or `org.gradle.kotlin.dsl.plugins.dsl` packages (but not subpackages of those).
 ====
 
+[[sec:compilation_warnings]]
+=== Compilation warnings
+
+Gradle Kotlin DSL scripts are compiled by Gradle during the configuration phase of your build.
+Deprecation warnings found by the Kotlin compiler are reported on the console when compiling the scripts.
+
+[source,text]
+----
+> Configure project :
+w: build.gradle.kts:4:5: 'getter for uploadTaskName: String!' is deprecated. Deprecated in Java
+----
+
+It is possible to configure your build to fail on any warning emitted during script compilation by <<build_environment#sec:gradle_configuration_properties,setting>> the `org.gradle.kotlin.dsl.allWarningsAsErrors` Gradle property to `true`:
+
+[source,properties]
+----
+# gradle.properties
+org.gradle.kotlin.dsl.allWarningsAsErrors=true
+----
 
 [[sec:configuring_plugins]]
 [[type-safe-accessors]]

--- a/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/CompilePrecompiledScriptPluginPlugins.kt
+++ b/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/CompilePrecompiledScriptPluginPlugins.kt
@@ -103,8 +103,8 @@ abstract class CompilePrecompiledScriptPluginPlugins @Inject constructor(
                     ),
                     classPathFiles.filter { it.exists() },
                     logger,
-                    { it } // TODO: translate paths
-                )
+                    allWarningsAsErrors = false
+                ) { it } // TODO: translate paths
         }
     }
 

--- a/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinStandaloneScriptWarningsIntegrationTest.kt
+++ b/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinStandaloneScriptWarningsIntegrationTest.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.integration
+
+import org.gradle.integtests.fixtures.executer.ExecutionFailure
+import org.gradle.kotlin.dsl.fixtures.AbstractKotlinIntegrationTest
+import org.gradle.kotlin.dsl.fixtures.clickableUrlFor
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+
+
+class KotlinStandaloneScriptWarningsIntegrationTest : AbstractKotlinIntegrationTest() {
+
+    @Before
+    fun setup() {
+        withFile("gradle.properties", "org.gradle.kotlin.dsl.allWarningsAsErrors=true")
+        executer.beforeExecute { noDeprecationChecks() }
+    }
+
+    @Test
+    fun `fails on warning in project script`() {
+        val script = withBuildScript(scriptContentWithWarning)
+        buildAndFail("help").apply {
+            assertHasWarningLineFor(script)
+            assertHasDetailedErrorOutput()
+        }
+    }
+
+    @Test
+    fun `fails on warning in settings script`() {
+        val script = withSettings(scriptContentWithWarning)
+        buildAndFail("help").apply {
+            assertHasWarningLineFor(script)
+            assertHasDetailedErrorOutput()
+        }
+    }
+
+    @Test
+    fun `fails on warning in initialization script`() {
+        val script = withFile("my-init.gradle.kts", scriptContentWithWarning)
+        buildAndFail("help", "-I", script.name).apply {
+            assertHasWarningLineFor(script)
+            assertHasDetailedErrorOutput()
+        }
+    }
+
+    @Test
+    fun `fails on warning in applied script`() {
+        val script = withFile("my-script.gradle.kts", scriptContentWithWarning)
+        withBuildScript("""apply(from = "${script.name}")""")
+        buildAndFail("help").apply {
+            assertHasWarningLineFor(script)
+            assertHasDetailedErrorOutput()
+        }
+    }
+
+    private
+    val scriptContentWithWarning =
+        """
+        @Deprecated("BECAUSE")
+        class SomeDeprecatedType
+        SomeDeprecatedType()
+        """.trimIndent()
+
+    private
+    fun ExecutionFailure.assertHasWarningLineFor(script: File) =
+        assertHasErrorOutput("w: ${clickableUrlFor(script)}:3:1: 'SomeDeprecatedType' is deprecated. BECAUSE")
+
+    private
+    fun ExecutionFailure.assertHasDetailedErrorOutput() =
+        assertHasErrorOutput(
+            """
+            * What went wrong:
+            Script compilation error:
+
+              Line 3: SomeDeprecatedType()
+                      ^ 'SomeDeprecatedType' is deprecated. BECAUSE
+
+            1 error
+            """.trimIndent()
+        )
+}

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ApiExtensionsJar.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ApiExtensionsJar.kt
@@ -21,6 +21,7 @@ import org.gradle.kotlin.dsl.support.compileToDirectory
 import org.gradle.kotlin.dsl.support.zipTo
 
 import org.gradle.api.internal.file.temp.TemporaryFileProvider
+import org.gradle.kotlin.dsl.support.EmbeddedKotlinCompilerWarning
 import org.gradle.kotlin.dsl.support.bytecode.GradleJvmVersion
 
 import java.io.File
@@ -120,7 +121,8 @@ fun compileKotlinApiExtensionsTo(
         "gradle-api-extensions",
         sourceFiles,
         logger,
-        classPath = classPath
+        classPath = classPath,
+        onCompilerWarning = EmbeddedKotlinCompilerWarning.DEBUG
     )
 
     if (!success) {

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/Interpreter.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/Interpreter.kt
@@ -142,6 +142,8 @@ class Interpreter(val host: Host) {
 
         val jvmTarget: JavaVersion
 
+        val allWarningsAsErrors: Boolean
+
         fun serviceRegistryFor(programTarget: ProgramTarget, target: Any): ServiceRegistry = when (programTarget) {
             ProgramTarget.Project -> serviceRegistryOf(target as Project)
             ProgramTarget.Settings -> serviceRegistryOf(target as Settings)
@@ -319,6 +321,7 @@ class Interpreter(val host: Host) {
                 ResidualProgramCompiler(
                     outputDir = cachedDir,
                     jvmTarget = host.jvmTarget,
+                    allWarningsAsErrors = host.allWarningsAsErrors,
                     classPath = compilationClassPath,
                     originalSourceHash = programId.sourceHash,
                     programKind = programKind,
@@ -478,6 +481,7 @@ class Interpreter(val host: Host) {
                                 ResidualProgramCompiler(
                                     outputDir,
                                     host.jvmTarget,
+                                    host.allWarningsAsErrors,
                                     compilationClassPath,
                                     sourceHash,
                                     programKind,

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/ResidualProgramCompiler.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/ResidualProgramCompiler.kt
@@ -85,6 +85,7 @@ internal
 class ResidualProgramCompiler(
     private val outputDir: File,
     private val jvmTarget: JavaVersion,
+    private val allWarningsAsErrors: Boolean,
     private val classPath: ClassPath = ClassPath.EMPTY,
     private val originalSourceHash: HashCode,
     private val programKind: ProgramKind,
@@ -714,7 +715,7 @@ class ResidualProgramCompiler(
                 scriptFile,
                 scriptDefinition,
                 compileClassPath.asFiles,
-                messageCollectorFor(logger) { path ->
+                messageCollectorFor(logger, allWarningsAsErrors) { path ->
                     if (path == scriptFile.path) originalPath
                     else path
                 }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/BuildServices.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/BuildServices.kt
@@ -27,6 +27,7 @@ import org.gradle.api.internal.initialization.loadercache.DefaultClasspathHasher
 import org.gradle.cache.internal.GeneratedGradleJarCache
 import org.gradle.groovy.scripts.internal.ScriptSourceHasher
 import org.gradle.initialization.ClassLoaderScopeRegistry
+import org.gradle.initialization.GradlePropertiesController
 import org.gradle.internal.classloader.ClasspathHasher
 import org.gradle.internal.classpath.CachedClasspathTransformer
 import org.gradle.internal.event.ListenerManager
@@ -106,7 +107,8 @@ object BuildServices {
         workspaceProvider: KotlinDslWorkspaceProvider,
         @Suppress("UNUSED_PARAMETER") kotlinCompilerContextDisposer: KotlinCompilerContextDisposer,
         fileCollectionFactory: FileCollectionFactory,
-        inputFingerprinter: InputFingerprinter
+        inputFingerprinter: InputFingerprinter,
+        gradlePropertiesController: GradlePropertiesController,
     ): KotlinScriptEvaluator =
 
         StandardKotlinScriptEvaluator(
@@ -127,7 +129,8 @@ object BuildServices {
             executionEngine,
             workspaceProvider,
             fileCollectionFactory,
-            inputFingerprinter
+            inputFingerprinter,
+            gradlePropertiesController,
         )
 
     @Suppress("unused")

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/TestWithCompiler.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/TestWithCompiler.kt
@@ -75,6 +75,7 @@ abstract class TestWithCompiler : TestWithTempFiles() {
         ResidualProgramCompiler(
             outputDir,
             JavaVersion.current(),
+            false,
             testRuntimeClassPath,
             sourceHash,
             programKind,

--- a/subprojects/kotlin-dsl/src/testFixtures/kotlin/org/gradle/kotlin/dsl/fixtures/SimplifiedKotlinScriptEvaluator.kt
+++ b/subprojects/kotlin-dsl/src/testFixtures/kotlin/org/gradle/kotlin/dsl/fixtures/SimplifiedKotlinScriptEvaluator.kt
@@ -208,6 +208,9 @@ class SimplifiedKotlinScriptEvaluator(
 
         override val jvmTarget: JavaVersion
             get() = JavaVersion.current()
+
+        override val allWarningsAsErrors: Boolean
+            get() = false
     }
 }
 


### PR DESCRIPTION
* Follow up to https://github.com/gradle/gradle/pull/23720
* Fixes https://github.com/gradle/gradle/issues/24530