### PR TITLE
Adds a current year binding, so that the copyright notice in the geneated wrapper scripts can always be current

### DIFF
--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/plugins/DefaultJavaAppStartScriptGenerationDetails.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/plugins/DefaultJavaAppStartScriptGenerationDetails.java
@@ -33,9 +33,11 @@ public final class DefaultJavaAppStartScriptGenerationDetails implements JavaApp
     private final List<String> modulePath;
     private final String scriptRelPath;
     private final String appNameSystemProperty;
+    private final String currentYear;
 
     public DefaultJavaAppStartScriptGenerationDetails(String applicationName, String optsEnvironmentVar, String exitEnvironmentVar, String mainClassName,
-                                                      List<String> defaultJvmOpts, List<String> classpath, List<String> modulePath, String scriptRelPath, @Nullable String appNameSystemProperty) {
+                                                      List<String> defaultJvmOpts, List<String> classpath, List<String> modulePath, String scriptRelPath,
+                                                      @Nullable String appNameSystemProperty, String currentYear) {
         this.applicationName = applicationName;
         this.optsEnvironmentVar = optsEnvironmentVar;
         this.exitEnvironmentVar = exitEnvironmentVar;
@@ -45,6 +47,7 @@ public final class DefaultJavaAppStartScriptGenerationDetails implements JavaApp
         this.modulePath = modulePath;
         this.scriptRelPath = scriptRelPath;
         this.appNameSystemProperty = appNameSystemProperty;
+        this.currentYear = currentYear;
     }
 
     @Override
@@ -91,6 +94,11 @@ public final class DefaultJavaAppStartScriptGenerationDetails implements JavaApp
     @Nullable
     public String getAppNameSystemProperty() {
         return appNameSystemProperty;
+    }
+
+    @Override
+    public String getCurrentYear() {
+        return currentYear;
     }
 
     @SuppressWarnings("RedundantIfStatement")

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/plugins/StartScriptGenerator.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/plugins/StartScriptGenerator.java
@@ -46,6 +46,7 @@ public class StartScriptGenerator {
     private Iterable<String> modulePath = Collections.emptyList();
     private String scriptRelPath;
     private String appNameSystemProperty;
+    private String currentYear;
 
     private final ScriptGenerator unixStartScriptGenerator;
     private final ScriptGenerator windowsStartScriptGenerator;
@@ -87,6 +88,10 @@ public class StartScriptGenerator {
         this.appNameSystemProperty = appNameSystemProperty;
     }
 
+    public void setCurrentYear(String currentYear) {
+        this.currentYear = currentYear;
+    }
+
     public StartScriptGenerator() {
         this(new UnixStartScriptGenerator(), new WindowsStartScriptGenerator());
     }
@@ -102,7 +107,7 @@ public class StartScriptGenerator {
     }
 
     private JavaAppStartScriptGenerationDetails createStartScriptGenerationDetails() {
-        return new DefaultJavaAppStartScriptGenerationDetails(applicationName, optsEnvironmentVar, exitEnvironmentVar, mainClassName, CollectionUtils.toStringList(defaultJvmOpts), CollectionUtils.toStringList(classpath), CollectionUtils.toStringList(modulePath), scriptRelPath, appNameSystemProperty);
+        return new DefaultJavaAppStartScriptGenerationDetails(applicationName, optsEnvironmentVar, exitEnvironmentVar, mainClassName, CollectionUtils.toStringList(defaultJvmOpts), CollectionUtils.toStringList(classpath), CollectionUtils.toStringList(modulePath), scriptRelPath, appNameSystemProperty, currentYear);
     }
 
     public void generateUnixScript(final File unixScript) {

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/plugins/StartScriptTemplateBindingFactory.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/plugins/StartScriptTemplateBindingFactory.java
@@ -59,8 +59,8 @@ public class StartScriptTemplateBindingFactory implements Transformer<Map<String
         binding.put(ScriptBindingParameter.APP_HOME_REL_PATH.getKey(), createJoinedAppHomeRelativePath(details.getScriptRelPath()));
         binding.put(ScriptBindingParameter.CLASSPATH.getKey(), createJoinedPath(details.getClasspath()));
         binding.put(ScriptBindingParameter.MODULE_PATH.getKey(), createJoinedPath(details.getModulePath()));
+        binding.put(ScriptBindingParameter.CURRENT_YEAR.getKey(), details.getCurrentYear());
         return binding;
-
     }
 
     private String createJoinedPath(Iterable<String> path) {
@@ -164,7 +164,8 @@ public class StartScriptTemplateBindingFactory implements Transformer<Map<String
         APP_NAME_SYS_PROP("appNameSystemProperty"),
         APP_HOME_REL_PATH("appHomeRelativePath"),
         CLASSPATH("classpath"),
-        MODULE_PATH("modulePath");
+        MODULE_PATH("modulePath"),
+        CURRENT_YEAR("currentYear");
 
         private final String key;
 

--- a/subprojects/plugins/src/main/java/org/gradle/jvm/application/scripts/JavaAppStartScriptGenerationDetails.java
+++ b/subprojects/plugins/src/main/java/org/gradle/jvm/application/scripts/JavaAppStartScriptGenerationDetails.java
@@ -16,6 +16,8 @@
 
 package org.gradle.jvm.application.scripts;
 
+import org.gradle.api.Incubating;
+
 import javax.annotation.Nullable;
 import java.util.List;
 
@@ -65,5 +67,13 @@ public interface JavaAppStartScriptGenerationDetails {
      */
     @Nullable
     String getAppNameSystemProperty();
+
+    /**
+     * Returns the current year, as a string.
+     *
+     * @since 8.2
+     */
+    @Incubating
+    String getCurrentYear();
 }
 

--- a/subprojects/plugins/src/main/java/org/gradle/jvm/application/tasks/CreateStartScripts.java
+++ b/subprojects/plugins/src/main/java/org/gradle/jvm/application/tasks/CreateStartScripts.java
@@ -43,6 +43,7 @@ import org.gradle.work.DisableCachingByDefault;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.io.File;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.stream.Collectors;
 
@@ -380,6 +381,7 @@ public abstract class CreateStartScripts extends ConventionTask {
         }
         generator.generateUnixScript(getUnixScript());
         generator.generateWindowsScript(getWindowsScript());
+        generator.setCurrentYear(String.valueOf(LocalDateTime.now().getYear()));
     }
 
     private String fullMainArgument() {


### PR DESCRIPTION
Note that this commit is the first of 2 needed to implement this change.  Need to get the new method into the API of a snapshot to update the current wrapper, to make this new method available to the build-logic in order to actually update the templates and make use of this new data.
