### PR TITLE
Reduce log output from configuration cache encryption

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
@@ -114,9 +114,6 @@ class DefaultConfigurationCache internal constructor(
         get() = cacheAction == ConfigurationCacheAction.LOAD
 
     override fun initializeCacheEntry() {
-        if (encryptionService.isEncrypting) {
-            log("Encryption of the configuration cache is enabled.")
-        }
         cacheAction = determineCacheAction()
         problems.action(cacheAction)
     }


### PR DESCRIPTION
- Don't log about encryption being enabled
- Warn when encryption is disabled
- Decrease priority of key related output from `info` to `debug`