### PR TITLE
Forbid blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Gradle Discussion Forums
     url: https://discuss.gradle.org


### PR DESCRIPTION
Turning the option off would ensure we have automatic triage labels on new issues and make support team processes a bit smoother
