### PR TITLE
Allow convention mapping to work with Property properties

### DIFF
--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/ProviderConventionMappingIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/ProviderConventionMappingIntegrationTest.groovy
@@ -51,26 +51,26 @@ class ProviderConventionMappingIntegrationTest extends AbstractIntegrationSpec {
         expectDocumentedFailure()
     }
 
-    def "emits deprecation warning when convention mapping is used with Property"() {
+    def "convention mapping can be used with Property"() {
         buildFile << """
             abstract class MyTask extends DefaultTask {
                 @Internal abstract Property<String> getFoo()
+                @Internal abstract Property<String> getBar()
 
                 @TaskAction
                 void useIt() {
-                    // convention mapping for Property is already ignored
-                    assert foo.get() == "other"
+                    assert foo.get() == "foobar"
+                    assert bar.get() == "foobar"
                 }
             }
             tasks.register("mytask", MyTask) {
-                conventionMapping.map("foo", { project.objects.property(String).convention("foobar") })
-                foo.convention("other")
+                conventionMapping.map("foo") { "foobar" }
+                conventionMapping.map("bar") { providers.provider { "foobar" } }
             }
         """
 
         expect:
-        runAndFail 'mytask'
-        expectDocumentedFailure()
+        succeeds 'mytask'
     }
 
     def "emits deprecation warning when convention mapping is used with MapProperty"() {
@@ -117,7 +117,7 @@ class ProviderConventionMappingIntegrationTest extends AbstractIntegrationSpec {
         expectDocumentedFailure()
     }
 
-    def "emits deprecation warning when convention mapping is used with Provider in a ConventionTask"() {
+    def "convention mapping works with Property in a ConventionTask"() {
         buildFile << """
             abstract class MyTask extends org.gradle.api.internal.ConventionTask {
                 @Internal abstract Property<String> getFoo()
@@ -135,8 +135,7 @@ class ProviderConventionMappingIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
-        runAndFail 'mytask'
-        expectDocumentedFailure()
+        succeeds 'mytask'
     }
 
     def "emits deprecation warning when convention mapping is used with Provider in domain object other than task"() {

--- a/subprojects/model-core/src/main/java/org/gradle/internal/extensibility/ConventionAwareHelper.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/extensibility/ConventionAwareHelper.java
@@ -18,18 +18,17 @@ package org.gradle.internal.extensibility;
 
 import groovy.lang.Closure;
 import groovy.lang.MissingPropertyException;
-import org.apache.commons.lang.StringUtils;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.internal.ConventionMapping;
 import org.gradle.api.internal.IConventionAware;
 import org.gradle.api.internal.provider.DefaultProvider;
 import org.gradle.api.provider.Property;
-import org.gradle.api.provider.Provider;
 import org.gradle.internal.Cast;
 import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.deprecation.DocumentedFailure;
 import org.gradle.internal.reflect.JavaPropertyReflectionUtil;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.HashMap;
@@ -67,41 +66,23 @@ public class ConventionAwareHelper implements ConventionMapping, org.gradle.api.
 
         // When there's a Property, use its `.convention()` method instead
         Class<? extends IConventionAware> sourceType = _source.getClass();
-        Method getter;
-        try {
-            getter = sourceType.getMethod("get" + StringUtils.capitalize(propertyName));
-        } catch (NoSuchMethodException e) {
-            getter = null;
-        }
-        if (getter != null
-            && Property.class.isAssignableFrom(getter.getReturnType())) {
-            // TODO Only enable this behavior when code is compiled against "old" versions of Gradle
-            // if (GradleApiVersionDetector.getApiVersion(sourceType) >= 9.0) {
-            //     throw RuntimeException("New code is not allowed to use convention mapping to set conventions for Property types");
-            // }
+        Method getter = JavaPropertyReflectionUtil.findGetterMethod(sourceType, propertyName);
+        if (getter != null && Property.class.isAssignableFrom(getter.getReturnType())) {
             Property<Object> property;
             try {
                 property = Cast.uncheckedNonnullCast(getter.invoke(_source));
-            } catch (Exception e) {
-                throw new RuntimeException(e);
+            } catch (InvocationTargetException | IllegalAccessException e) {
+                throw new IllegalStateException(String.format("Could not access property %s.%s", sourceType.getSimpleName(), propertyName), e);
             }
-            property.convention(new DefaultProvider<>(() -> {
-                Object conventionValue = mapping.getValue(_convention, _source);
-                if (conventionValue instanceof Provider) {
-                    return ((Provider<?>) conventionValue).get();
-                } else {
-                    return conventionValue;
-                }
-            }));
-            // TODO Should this fall throuhg here, and register the mapping in _mapping, or not?
+            property.convention(new DefaultProvider<>(() -> mapping.getValue(_convention, _source)));
         } else if (_ineligiblePropertyNames.contains(propertyName)) {
             throw DocumentedFailure.builder()
                 .withSummary("Using internal convention mapping with a Provider backed property.")
                 .withUpgradeGuideSection(7, "convention_mapping")
                 .build();
+        } else {
+            _mappings.put(propertyName, mapping);
         }
-
-        _mappings.put(propertyName, mapping);
         return mapping;
     }
 

--- a/subprojects/model-core/src/main/java/org/gradle/internal/extensibility/ConventionAwareHelper.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/extensibility/ConventionAwareHelper.java
@@ -65,6 +65,8 @@ public class ConventionAwareHelper implements ConventionMapping, org.gradle.api.
         }
 
         // When there's a Property, use its `.convention()` method instead
+        // This is something we added to support properties migrated in the future from
+        // Java bean to Property where old code uses ConventionMapping to set conventions.
         Class<? extends IConventionAware> sourceType = _source.getClass();
         Method getter = JavaPropertyReflectionUtil.findGetterMethod(sourceType, propertyName);
         if (getter != null && Property.class.isAssignableFrom(getter.getReturnType())) {

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/JavaPropertyReflectionUtil.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/JavaPropertyReflectionUtil.java
@@ -66,7 +66,7 @@ public class JavaPropertyReflectionUtil {
     }
 
     @Nullable
-    private static Method findGetterMethod(Class<?> target, String property) {
+    public static Method findGetterMethod(Class<?> target, String property) {
         Method[] methods = target.getMethods();
         String getter = toMethodName("get", property);
         String iser = toMethodName("is", property);


### PR DESCRIPTION
When upgrading JavaBean-style task properties to provider-style lazy properties (`Property`), we need to keep old plugins working. One aspect of this is any convention mapping they might set. This PR offers a simple way to set `Property` 
conventions via `ConventionMapping.map()`.

The purpose here is solely to retain backwards compatibility, it is not a goal to keep `ConventionMapping` working for any new code that is compiled against `Property`-style properties.

Fixes https://github.com/gradle/gradle-private/issues/3806.
