### PR TITLE
Make configuration deprecation usage immutable

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/metadata/ProjectMetadataController.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/metadata/ProjectMetadataController.kt
@@ -151,7 +151,7 @@ class ProjectMetadataController(
 
         return DefaultLocalConfigurationMetadata(
             configurationName, configurationName, componentId, true, true, setOf(configurationName), configurationAttributes,
-            ImmutableCapabilities.EMPTY, true, null, true, dependencies, emptySet(), emptyList(),
+            ImmutableCapabilities.EMPTY, true, false, true, dependencies, emptySet(), emptyList(),
             variants, factory, emptyList()
         )
     }

--- a/subprojects/core-api/src/main/java/org/gradle/internal/deprecation/DeprecatableConfiguration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/internal/deprecation/DeprecatableConfiguration.java
@@ -19,9 +19,7 @@ package org.gradle.internal.deprecation;
 import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.Configuration;
 
-import javax.annotation.Nullable;
 import java.util.List;
-import java.util.function.Function;
 
 /**
  * This internal interface extends {@link Configuration} adding functionality to allow plugins to deprecate
@@ -40,78 +38,85 @@ import java.util.function.Function;
  */
 @SuppressWarnings("JavadocReference")
 public interface DeprecatableConfiguration extends Configuration {
+
     /**
-     * @return configurations that should be used to declare dependencies instead of this configuration.
-     *         Returns 'null' if this configuration is not deprecated for declaration.
+     * Get configurations that should be used to declare dependencies instead of this configuration.
+     *
+     * <p>The returned value is undefined if the configuration is not deprecated for declaration.</p>
      */
-    @Nullable
     List<String> getDeclarationAlternatives();
 
     /**
-     * @return deprecation message builder to be used for nagging when this configuration is consumed.
-     *         Returns 'null' if this configuration is not deprecated for consumption.
+     * Get configurations that should be used to consume a component instead of consuming this configuration.
+     *
+     * <p>The returned value is undefined if the configuration is not deprecated for resolution.</p>
      */
-    @Nullable
-    DeprecationMessageBuilder.WithDocumentation getConsumptionDeprecation();
-
-    /**
-     * @return configurations that should be used to consume a component instead of consuming this configuration.
-     *         Returns 'null' if this configuration is not deprecated for resolution.
-     */
-    @Nullable
     List<String> getResolutionAlternatives();
 
     /**
-     * Allows plugins to deprecate the consumability property (canBeConsumed() == true) of a configuration that will be changed in the next major Gradle version.
-     *
-     * @param deprecation deprecation message builder to use for nagging upon consumption of this configuration
-     * @return this configuration
+     * Set the configuration which should be used for dependency declaration instead of this configuration.
+     * Does nothing if this configuration is not deprecated for declaration.
      */
-    DeprecatableConfiguration deprecateForConsumption(Function<DeprecationMessageBuilder.DeprecateConfiguration, DeprecationMessageBuilder.WithDocumentation> deprecation);
+    void addDeclarationAlternatives(String... alternativesForDeclaring);
 
     /**
-     * Convenience method for {@link #deprecateForConsumption(Function)} which uses the default messaging behavior.
-     *
-     * @return this configuration
-    */
-    default DeprecatableConfiguration deprecateForConsumption() {
-        return deprecateForConsumption(depSpec -> DeprecationLogger.deprecateConfiguration(getName())
+     * Set the configuration which should be used for dependency resolution instead of this configuration.
+     * Does nothing if this configuration is not deprecated for resolution.
+     */
+    void addResolutionAlternatives(String... alternativesForResolving);
+
+    /**
+     * If this configuration is deprecated for consumption, emit a deprecation warning.
+     */
+    default void maybeEmitConsumptionDeprecation() {
+        if (isDeprecatedForConsumption()) {
+            DeprecationLogger.deprecateConfiguration(getName())
                 .forConsumption()
                 .willBecomeAnErrorInGradle9()
-                .withUserManual("dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations"));
+                .withUserManual("dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations")
+                .nagUser();
+        }
     }
 
     /**
-     * Allows plugins to deprecate the resolvability property (canBeResolved() == true) of a configuration that will be changed in the next major Gradle version.
-     *
-     * @param alternativesForResolving alternative configurations that can be used for dependency resolution
-     * @return this configuration
+     * If this configuration is deprecated for declaration, emit a deprecation warning.
      */
-    DeprecatableConfiguration deprecateForResolution(String... alternativesForResolving);
+    default void maybeEmitDeclarationDeprecation() {
+        if (isDeprecatedForDeclarationAgainst()) {
+            DeprecationLogger.deprecateConfiguration(getName())
+                .forDependencyDeclaration()
+                .replaceWith(getDeclarationAlternatives())
+                .willBecomeAnErrorInGradle9()
+                .withUpgradeGuideSection(5, "dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations")
+                .nagUser();
+        }
+    }
 
     /**
-     * Allows plugins to deprecate a configuration that will be removed in the next major Gradle version.
-     *
-     * @param alternativesForDeclaring alternative configurations that can be used to declare dependencies
-     * @return this configuration
+     * If this configuration is deprecated for resolution, emit a deprecation warning.
      */
-    DeprecatableConfiguration deprecateForDeclarationAgainst(String... alternativesForDeclaring);
+    default void maybeEmitResolutionDeprecation() {
+        if (isDeprecatedForResolution()) {
+            DeprecationLogger.deprecateConfiguration(getName()
+                ).forResolution()
+                .replaceWith(getResolutionAlternatives())
+                .willBecomeAnErrorInGradle9()
+                .withUpgradeGuideSection(5, "dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations")
+                .nagUser();
+        }
+    }
 
     boolean isDeprecatedForConsumption();
     boolean isDeprecatedForResolution();
     boolean isDeprecatedForDeclarationAgainst();
 
     default boolean canSafelyBeResolved() {
-        if (!isCanBeResolved()) {
-            return false;
-        }
-        List<String> resolutionAlternatives = getResolutionAlternatives();
-        return resolutionAlternatives == null;
+        return isCanBeResolved() && !isDeprecatedForResolution();
     }
 
     /**
      * Prevents any calls to methods that change this configuration's allowed usage (e.g. {@link #setCanBeConsumed(boolean)},
-     * {@link #setCanBeResolved(boolean)}, {@link #deprecateForResolution(String...)}) from succeeding; and causes them
+     * {@link #setCanBeResolved(boolean)}, {@link #setCanBeDeclaredAgainst(boolean)}) from succeeding; and causes them
      * to throw an exception.
      */
     void preventUsageMutation();

--- a/subprojects/core-api/src/main/java/org/gradle/internal/deprecation/DeprecatableConfiguration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/internal/deprecation/DeprecatableConfiguration.java
@@ -42,26 +42,28 @@ public interface DeprecatableConfiguration extends Configuration {
     /**
      * Return the names of configurations that should be used to declare dependencies instead of this configuration.
      *
-     * <p>The returned value is undefined if the configuration is not deprecated for declaration.</p>
+     * <p>This property is only relevant if this configuration deprecated for declaration.</p>
      */
     List<String> getDeclarationAlternatives();
 
     /**
-     * Get configurations that should be used to consume a component instead of consuming this configuration.
+     * Return the names of configurations that should be used to consume a component instead of consuming this configuration.
      *
-     * <p>The returned value is undefined if the configuration is not deprecated for resolution.</p>
+     * <p>This property is only relevant if this configuration deprecated for resolution.</p>
      */
     List<String> getResolutionAlternatives();
 
     /**
      * Sets suggested configurations which can be used for dependency declaration instead of this configuration.
-     * Does nothing if this configuration is not deprecated for declaration.
+     *
+     * <p>This property is only relevant if this configuration deprecated for declaration.</p>
      */
     void addDeclarationAlternatives(String... alternativesForDeclaring);
 
     /**
      * Sets suggested configurations which can be used for dependency resolution instead of this configuration.
-     * Does nothing if this configuration is not deprecated for resolution.
+     *
+     * <p>This property is only relevant if this configuration deprecated for resolution.</p>
      */
     void addResolutionAlternatives(String... alternativesForResolving);
 
@@ -97,8 +99,8 @@ public interface DeprecatableConfiguration extends Configuration {
      */
     default void maybeEmitResolutionDeprecation() {
         if (isDeprecatedForResolution()) {
-            DeprecationLogger.deprecateConfiguration(getName()
-                ).forResolution()
+            DeprecationLogger.deprecateConfiguration(getName())
+                .forResolution()
                 .replaceWith(getResolutionAlternatives())
                 .willBecomeAnErrorInGradle9()
                 .withUpgradeGuideSection(5, "dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations")

--- a/subprojects/core-api/src/main/java/org/gradle/internal/deprecation/DeprecatableConfiguration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/internal/deprecation/DeprecatableConfiguration.java
@@ -40,7 +40,7 @@ import java.util.List;
 public interface DeprecatableConfiguration extends Configuration {
 
     /**
-     * Get configurations that should be used to declare dependencies instead of this configuration.
+     * Return the names of configurations that should be used to declare dependencies instead of this configuration.
      *
      * <p>The returned value is undefined if the configuration is not deprecated for declaration.</p>
      */
@@ -54,13 +54,13 @@ public interface DeprecatableConfiguration extends Configuration {
     List<String> getResolutionAlternatives();
 
     /**
-     * Set the configuration which should be used for dependency declaration instead of this configuration.
+     * Sets suggested configurations which can be used for dependency declaration instead of this configuration.
      * Does nothing if this configuration is not deprecated for declaration.
      */
     void addDeclarationAlternatives(String... alternativesForDeclaring);
 
     /**
-     * Set the configuration which should be used for dependency resolution instead of this configuration.
+     * Sets suggested configurations which can be used for dependency resolution instead of this configuration.
      * Does nothing if this configuration is not deprecated for resolution.
      */
     void addResolutionAlternatives(String... alternativesForResolving);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationRoles.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationRoles.java
@@ -67,16 +67,9 @@ public enum ConfigurationRoles implements ConfigurationRole {
     /**
      * Meant to be used only for declaring dependencies.
      *
-     * AKA {@code INTENDED_DECLARABLE}.
+     * AKA {@code DECLARABLE}.
      */
-    BUCKET(false, false, true),
-
-    /**
-     * Meant for configurations which cannot do anything.
-     *
-     * Used for configurations which will be removed in future versions.
-     */
-    NONE(false, false, false);
+    BUCKET(false, false, true);
 
     private final boolean consumable;
     private final boolean resolvable;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationRoles.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationRoles.java
@@ -69,7 +69,14 @@ public enum ConfigurationRoles implements ConfigurationRole {
      *
      * AKA {@code INTENDED_DECLARABLE}.
      */
-    BUCKET(false, false, true);
+    BUCKET(false, false, true),
+
+    /**
+     * Meant for configurations which cannot do anything.
+     *
+     * Used for configurations which will be removed in future versions.
+     */
+    NONE(false, false, false);
 
     private final boolean consumable;
     private final boolean resolvable;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationRolesForMigration.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationRolesForMigration.java
@@ -39,7 +39,29 @@ public enum ConfigurationRolesForMigration implements ConfigurationRole {
     @Deprecated
     RESOLVABLE_BUCKET_TO_RESOLVABLE(ConfigurationRoles.RESOLVABLE_BUCKET, ConfigurationRoles.RESOLVABLE),
     @Deprecated
-    CONSUMABLE_BUCKET_TO_CONSUMABLE(ConfigurationRoles.CONSUMABLE_BUCKET, ConfigurationRoles.CONSUMABLE);
+    INTENDED_CONSUMABLE_BUCKET_TO_INTENDED_CONSUMABLE(ConfigurationRoles.CONSUMABLE_BUCKET, ConfigurationRoles.CONSUMABLE),
+
+    /**
+     * A resolvable bucket that will become a bucket in the next major version.
+     */
+    @SuppressWarnings("deprecation")
+    RESOLVABLE_BUCKET_TO_BUCKET(ConfigurationRoles.RESOLVABLE_BUCKET, ConfigurationRoles.BUCKET),
+
+    /**
+     * A resolvable bucket configuration that will be removed in the next major version.
+     */
+    @SuppressWarnings("deprecation")
+    RESOLVABLE_BUCKET_TO_NONE(ConfigurationRoles.RESOLVABLE_BUCKET, ConfigurationRoles.NONE),
+
+    /**
+     * A bucket configuration that will be removed in the next major version.
+     */
+    BUCKET_TO_NONE(ConfigurationRoles.BUCKET, ConfigurationRoles.NONE),
+
+    /**
+     * A resolvable configuration that will be removed in the next major version.
+     */
+    RESOLVABLE_TO_NONE(ConfigurationRoles.RESOLVABLE, ConfigurationRoles.NONE);
 
     private final boolean consumable;
     private final boolean resolvable;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationRolesForMigration.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationRolesForMigration.java
@@ -39,29 +39,13 @@ public enum ConfigurationRolesForMigration implements ConfigurationRole {
     @Deprecated
     RESOLVABLE_BUCKET_TO_RESOLVABLE(ConfigurationRoles.RESOLVABLE_BUCKET, ConfigurationRoles.RESOLVABLE),
     @Deprecated
-    INTENDED_CONSUMABLE_BUCKET_TO_INTENDED_CONSUMABLE(ConfigurationRoles.CONSUMABLE_BUCKET, ConfigurationRoles.CONSUMABLE),
+    CONSUMABLE_BUCKET_TO_CONSUMABLE(ConfigurationRoles.CONSUMABLE_BUCKET, ConfigurationRoles.CONSUMABLE),
 
     /**
      * A resolvable bucket that will become a bucket in the next major version.
      */
     @SuppressWarnings("deprecation")
-    RESOLVABLE_BUCKET_TO_BUCKET(ConfigurationRoles.RESOLVABLE_BUCKET, ConfigurationRoles.BUCKET),
-
-    /**
-     * A resolvable bucket configuration that will be removed in the next major version.
-     */
-    @SuppressWarnings("deprecation")
-    RESOLVABLE_BUCKET_TO_NONE(ConfigurationRoles.RESOLVABLE_BUCKET, ConfigurationRoles.NONE),
-
-    /**
-     * A bucket configuration that will be removed in the next major version.
-     */
-    BUCKET_TO_NONE(ConfigurationRoles.BUCKET, ConfigurationRoles.NONE),
-
-    /**
-     * A resolvable configuration that will be removed in the next major version.
-     */
-    RESOLVABLE_TO_NONE(ConfigurationRoles.RESOLVABLE, ConfigurationRoles.NONE);
+    RESOLVABLE_BUCKET_TO_BUCKET(ConfigurationRoles.RESOLVABLE_BUCKET, ConfigurationRoles.BUCKET);
 
     private final boolean consumable;
     private final boolean resolvable;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
@@ -26,11 +26,10 @@ import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.internal.artifacts.CachingDependencyResolveContext;
 import org.gradle.api.internal.artifacts.DependencyResolveContext;
 import org.gradle.api.internal.project.ProjectInternal;
-import org.gradle.api.internal.tasks.TaskDependencyInternal;
-import org.gradle.internal.deprecation.DeprecatableConfiguration;
 import org.gradle.api.internal.tasks.DefaultTaskDependencyFactory;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
-import org.gradle.internal.deprecation.DeprecationMessageBuilder;
+import org.gradle.api.internal.tasks.TaskDependencyInternal;
+import org.gradle.internal.deprecation.DeprecatableConfiguration;
 import org.gradle.internal.exceptions.ConfigurationNotConsumableException;
 import org.gradle.util.internal.GUtil;
 
@@ -91,10 +90,7 @@ public class DefaultProjectDependency extends AbstractModuleDependency implement
     }
 
     private void warnIfConfigurationIsDeprecated(DeprecatableConfiguration selectedConfiguration) {
-        DeprecationMessageBuilder.WithDocumentation consumptionDeprecation = selectedConfiguration.getConsumptionDeprecation();
-        if (consumptionDeprecation != null) {
-            consumptionDeprecation.nagUser();
-        }
+        selectedConfiguration.maybeEmitConsumptionDeprecation();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
@@ -85,12 +85,8 @@ public class DefaultProjectDependency extends AbstractModuleDependency implement
         if (!selectedConfiguration.isCanBeConsumed()) {
             throw new ConfigurationNotConsumableException(dependencyProject.getDisplayName(), selectedConfiguration.getName());
         }
-        warnIfConfigurationIsDeprecated((DeprecatableConfiguration) selectedConfiguration);
+        ((DeprecatableConfiguration) selectedConfiguration).maybeEmitConsumptionDeprecation();
         return selectedConfiguration;
-    }
-
-    private void warnIfConfigurationIsDeprecated(DeprecatableConfiguration selectedConfiguration) {
-        selectedConfiguration.maybeEmitConsumptionDeprecation();
     }
 
     @Override

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleUsageIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRoleUsageIntegrationTest.groovy
@@ -117,7 +117,7 @@ class ConfigurationRoleUsageIntegrationTest extends AbstractIntegrationSpec impl
         given:
         buildFile << """
             configurations {
-                createWithRole("testConf", org.gradle.api.internal.artifacts.configurations.ConfigurationRolesForMigration.BUCKET_TO_NONE) {
+                createWithRole("testConf", org.gradle.api.internal.artifacts.configurations.ConfigurationRolesForMigration.RESOLVABLE_BUCKET_TO_RESOLVABLE) {
                     addDeclarationAlternatives("anotherConf")
                 }
             }
@@ -138,7 +138,7 @@ class ConfigurationRoleUsageIntegrationTest extends AbstractIntegrationSpec impl
         buildFile << """
             configurations {
                 deps
-                createWithRole("testConf", org.gradle.api.internal.artifacts.configurations.ConfigurationRolesForMigration.RESOLVABLE_TO_NONE) {
+                createWithRole("testConf", org.gradle.api.internal.artifacts.configurations.ConfigurationRolesForMigration.LEGACY_TO_CONSUMABLE) {
                     addResolutionAlternatives("anotherConf")
                     extendsFrom(deps)
                 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/DeprecatedConfigurationUsageIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/DeprecatedConfigurationUsageIntegrationTest.groovy
@@ -25,7 +25,7 @@ class DeprecatedConfigurationUsageIntegrationTest extends AbstractIntegrationSpe
         given:
         buildFile << """
             import org.gradle.api.internal.artifacts.configurations.ConfigurationRole
-            
+
             configurations.$role('custom')
             configurations.custom.$methodCall
         """
@@ -57,7 +57,7 @@ class DeprecatedConfigurationUsageIntegrationTest extends AbstractIntegrationSpe
         given:
         buildFile << """
             import org.gradle.api.internal.artifacts.configurations.ConfigurationRole
-            
+
             configurations.$role('custom')
             configurations.custom.$methodCall
         """
@@ -81,7 +81,7 @@ class DeprecatedConfigurationUsageIntegrationTest extends AbstractIntegrationSpe
         given:
         buildFile << """
             import org.gradle.api.internal.artifacts.configurations.ConfigurationRole
-            
+
             configurations.$role('custom')
             configurations.custom.$methodCall
         """
@@ -111,7 +111,7 @@ class DeprecatedConfigurationUsageIntegrationTest extends AbstractIntegrationSpe
         given:
         buildFile << """
             import org.gradle.api.internal.artifacts.configurations.ConfigurationRole
-            
+
             configurations.$role('custom')
             configurations.custom.$methodCall
         """
@@ -129,45 +129,45 @@ class DeprecatedConfigurationUsageIntegrationTest extends AbstractIntegrationSpe
         given:
         buildFile << """
             import org.gradle.api.internal.artifacts.configurations.ConfigurationRole
-            
+
             ConfigurationRole customRole = new ConfigurationRole() {
                 @Override
                 String getName() {
                     return "custom"
                 }
-    
+
                 @Override
                 boolean isConsumable() {
                     return true
                 }
-    
+
                 @Override
                 boolean isResolvable() {
                     return false
                 }
-    
+
                 @Override
                 boolean isDeclarableAgainst() {
                     return false
                 }
-    
+
                 @Override
                 boolean isConsumptionDeprecated() {
                     return true
                 }
-    
+
                 @Override
                 boolean isResolutionDeprecated() {
                     return false
                 }
-    
+
                 @Override
                 boolean isDeclarationAgainstDeprecated() {
                     return false
                 }
             }
             configurations.createWithRole('custom', customRole)
-            
+
             configurations.custom.attributes {
                 attribute(Attribute.of('foo', String), 'bar')
             }
@@ -184,9 +184,7 @@ This method is only meant to be called on configurations which allow the (non-de
         given:
         buildFile << """
             configurations {
-                custom {
-                    deprecateForConsumption()
-                    
+                createWithRole('foo', org.gradle.api.internal.artifacts.configurations.ConfigurationRolesForMigration.LEGACY_TO_RESOLVABLE_BUCKET) {
                     attributes {
                         attribute(Attribute.of('foo', String), 'bar')
                     }
@@ -201,9 +199,7 @@ This method is only meant to be called on configurations which allow the (non-de
     def "configuration explicitly deprecated for resolution will warn if resolved, but not fail"() {
         buildFile << """
             configurations {
-                foo {
-                    deprecateForResolution()
-                }
+                createWithRole('foo', org.gradle.api.internal.artifacts.configurations.ConfigurationRolesForMigration.RESOLVABLE_BUCKET_TO_BUCKET)
             }
 
             ${mavenCentralRepository()}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyConstraintSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyConstraintSet.java
@@ -22,11 +22,8 @@ import org.gradle.api.artifacts.DependencyConstraint;
 import org.gradle.api.artifacts.DependencyConstraintSet;
 import org.gradle.api.internal.DelegatingDomainObjectSet;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
-import org.gradle.internal.deprecation.DeprecatableConfiguration;
-import org.gradle.internal.deprecation.DeprecationLogger;
 
 import java.util.Collection;
-import java.util.List;
 
 public class DefaultDependencyConstraintSet extends DelegatingDomainObjectSet<DependencyConstraint> implements DependencyConstraintSet {
     private final Describable displayName;
@@ -46,23 +43,13 @@ public class DefaultDependencyConstraintSet extends DelegatingDomainObjectSet<De
     @Override
     public boolean add(final DependencyConstraint dependencyConstraint) {
         assertConfigurationIsDeclarableAgainst();
-        warnIfConfigurationIsDeprecated();
+        clientConfiguration.maybeEmitDeclarationDeprecation();
         return addInternalDependencyConstraint(dependencyConstraint);
     }
 
     // For internal use only, allows adding a dependency constraint without issuing a deprecation warning
     public boolean addInternalDependencyConstraint(DependencyConstraint dependencyConstraint) {
         return super.add(dependencyConstraint);
-    }
-
-    private void warnIfConfigurationIsDeprecated() {
-        List<String> alternatives = ((DeprecatableConfiguration) clientConfiguration).getDeclarationAlternatives();
-        if (alternatives != null) {
-            DeprecationLogger.deprecateConfiguration(clientConfiguration.getName()).forDependencyDeclaration().replaceWith(alternatives)
-                .willBecomeAnErrorInGradle9()
-                .withUpgradeGuideSection(5, "dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations")
-                .nagUser();
-        }
     }
 
     private void assertConfigurationIsDeclarableAgainst() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencySet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencySet.java
@@ -29,10 +29,8 @@ import org.gradle.api.internal.artifacts.configurations.MutationValidator;
 import org.gradle.api.internal.artifacts.dependencies.AbstractModuleDependency;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.internal.Actions;
-import org.gradle.internal.deprecation.DeprecationLogger;
 
 import java.util.Collection;
-import java.util.List;
 
 public class DefaultDependencySet extends DelegatingDomainObjectSet<Dependency> implements DependencySet {
     private final Describable displayName;
@@ -63,22 +61,11 @@ public class DefaultDependencySet extends DelegatingDomainObjectSet<Dependency> 
     @Override
     public boolean add(final Dependency o) {
         assertConfigurationIsDeclarableAgainst();
-        warnIfConfigurationIsDeprecated();
+        clientConfiguration.maybeEmitDeclarationDeprecation();
         if (o instanceof AbstractModuleDependency) {
             ((AbstractModuleDependency) o).addMutationValidator(mutationValidator);
         }
         return super.add(o);
-    }
-
-    private void warnIfConfigurationIsDeprecated() {
-        List<String> alternatives = clientConfiguration.getDeclarationAlternatives();
-
-        if (alternatives != null) {
-            DeprecationLogger.deprecateConfiguration(clientConfiguration.getName()).forDependencyDeclaration().replaceWith(alternatives)
-                .willBecomeAnErrorInGradle9()
-                .withUpgradeGuideSection(5, "dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations")
-                .nagUser();
-        }
     }
 
     private void assertConfigurationIsDeclarableAgainst() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -2019,12 +2019,10 @@ since users cannot create non-legacy configurations and there is no current publ
     }
 
     @Override
-    @Nullable
     public List<String> getDeclarationAlternatives() {
         return declarationAlternatives;
     }
 
-    @Nullable
     @Override
     public List<String> getResolutionAlternatives() {
         return resolutionAlternatives;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -119,9 +119,7 @@ import org.gradle.internal.component.external.model.ProjectDerivedCapability;
 import org.gradle.internal.component.local.model.LocalComponentMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.LocalComponentDependencyMetadata;
-import org.gradle.internal.deprecation.DeprecatableConfiguration;
 import org.gradle.internal.deprecation.DeprecationLogger;
-import org.gradle.internal.deprecation.DeprecationMessageBuilder;
 import org.gradle.internal.deprecation.DocumentedFailure;
 import org.gradle.internal.event.ListenerBroadcast;
 import org.gradle.internal.lazy.Lazy;
@@ -157,7 +155,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -239,9 +236,9 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     private boolean canBeConsumed;
     private boolean canBeResolved;
     private boolean canBeDeclaredAgainst;
-    private boolean consumptionDeprecated;
-    private boolean resolutionDeprecated;
-    private boolean declarationDeprecated;
+    private final boolean consumptionDeprecated;
+    private final boolean resolutionDeprecated;
+    private final boolean declarationDeprecated;
     private boolean usageCanBeMutated = true;
     private final ConfigurationRole roleAtCreation;
 
@@ -261,9 +258,8 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
 
     private Action<? super ConfigurationInternal> beforeLocking;
 
-    private List<String> declarationAlternatives;
-    private DeprecationMessageBuilder.WithDocumentation consumptionDeprecation;
-    private List<String> resolutionAlternatives;
+    private List<String> declarationAlternatives = ImmutableList.of();
+    private List<String> resolutionAlternatives = ImmutableList.of();
 
     private final CalculatedModelValue<ResolveState> currentResolveState;
 
@@ -354,19 +350,9 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         this.canBeConsumed = roleAtCreation.isConsumable();
         this.canBeResolved = roleAtCreation.isResolvable();
         this.canBeDeclaredAgainst = roleAtCreation.isDeclarableAgainst();
-
-        // Calling these during construction is not ideal, but we'd have to call the deprecateForConsumption(), etc.
-        // methods anyway even if replicated the code inside these methods here, so at least this keeps a single
-        // code path for the deprecation.
-        if (roleAtCreation.isConsumptionDeprecated()) {
-            deprecateForConsumption();
-        }
-        if (roleAtCreation.isResolutionDeprecated()) {
-            deprecateForResolution();
-        }
-        if (roleAtCreation.isDeclarationAgainstDeprecated()) {
-            deprecateForDeclarationAgainst();
-        }
+        this.consumptionDeprecated = roleAtCreation.isConsumptionDeprecated();
+        this.resolutionDeprecated = roleAtCreation.isResolutionDeprecated();
+        this.declarationDeprecated = roleAtCreation.isDeclarationAgainstDeprecated();
 
         if (lockUsage) {
             preventUsageMutation();
@@ -682,7 +668,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
 
     private ResolveState resolveToStateOrLater(final InternalState requestedState) {
         assertIsResolvable();
-        warnIfConfigurationIsDeprecatedForResolving();
+        maybeEmitResolutionDeprecation();
         logIfImproperConfiguration();
 
         ResolveState currentState = currentResolveState.get();
@@ -703,15 +689,6 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
             }
         }
         return resolveExclusively(requestedState);
-    }
-
-    private void warnIfConfigurationIsDeprecatedForResolving() {
-        if (resolutionAlternatives != null) {
-            DeprecationLogger.deprecateConfiguration(this.name).forResolution().replaceWith(resolutionAlternatives)
-                    .willBecomeAnErrorInGradle9()
-                    .withUpgradeGuideSection(5, "dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations")
-                    .nagUser();
-        }
     }
 
     private ResolveState resolveExclusively(InternalState requestedState) {
@@ -1344,9 +1321,9 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
      */
     private DefaultConfiguration createCopy(Set<Dependency> dependencies, Set<DependencyConstraint> dependencyConstraints) {
         // Begin by allowing everything, and setting deprecations for disallowed roles in a new role implementation
-        boolean deprecateConsumption = !canBeConsumed || consumptionDeprecation != null;
-        boolean deprecateResolution = !canBeResolved || resolutionAlternatives != null;
-        boolean deprecateDeclarationAgainst = !canBeDeclaredAgainst || declarationAlternatives != null;
+        boolean deprecateConsumption = !canBeConsumed || consumptionDeprecated;
+        boolean deprecateResolution = !canBeResolved || resolutionDeprecated;
+        boolean deprecateDeclarationAgainst = !canBeDeclaredAgainst || declarationDeprecated;
         ConfigurationRole adjustedCurrentUsage = new CopiedConfigurationRole(deprecateConsumption, deprecateResolution, deprecateDeclarationAgainst);
 
         DefaultConfiguration copiedConfiguration = newConfiguration(adjustedCurrentUsage, this.usageCanBeMutated);
@@ -1361,14 +1338,8 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         copiedConfiguration.withDependencyActions = withDependencyActions;
         copiedConfiguration.dependencyResolutionListeners = dependencyResolutionListeners.copy();
 
-        copiedConfiguration.declarationAlternatives =
-            canBeDeclaredAgainst || declarationAlternatives != null ? declarationAlternatives : Collections.emptyList();
-        copiedConfiguration.resolutionAlternatives =
-            canBeResolved || resolutionAlternatives != null ? resolutionAlternatives : Collections.emptyList();
-        copiedConfiguration.consumptionDeprecation =
-            canBeConsumed || consumptionDeprecation != null ? consumptionDeprecation
-                : DeprecationLogger.deprecateConfiguration(name).forConsumption()
-                    .willBecomeAnErrorInGradle9().undocumented();
+        copiedConfiguration.declarationAlternatives = declarationAlternatives;
+        copiedConfiguration.resolutionAlternatives = resolutionAlternatives;
 
         copiedConfiguration.getArtifacts().addAll(getAllArtifacts());
 
@@ -2055,47 +2026,24 @@ since users cannot create non-legacy configurations and there is no current publ
 
     @Nullable
     @Override
-    public DeprecationMessageBuilder.WithDocumentation getConsumptionDeprecation() {
-        return consumptionDeprecation;
-    }
-
-    @Nullable
-    @Override
     public List<String> getResolutionAlternatives() {
         return resolutionAlternatives;
     }
 
     @Override
-    public DeprecatableConfiguration deprecateForDeclarationAgainst(String... alternativesForDeclaring) {
-        validateMutation(MutationType.USAGE);
-        this.declarationAlternatives = ImmutableList.copyOf(alternativesForDeclaring);
-        if (!declarationDeprecated) {
-            maybeWarnOnChangingUsage("deprecated for declaration against", true);
-        }
-        declarationDeprecated = true;
-        return this;
+    public void addDeclarationAlternatives(String... alternativesForDeclaring) {
+        this.declarationAlternatives = ImmutableList.<String>builder()
+            .addAll(declarationAlternatives)
+            .addAll(Arrays.asList(alternativesForDeclaring))
+            .build();
     }
 
     @Override
-    public DeprecatableConfiguration deprecateForResolution(String... alternativesForResolving) {
-        validateMutation(MutationType.USAGE);
-        this.resolutionAlternatives = ImmutableList.copyOf(alternativesForResolving);
-        if (!consumptionDeprecated) {
-            maybeWarnOnChangingUsage("deprecated for resolution", true);
-        }
-        resolutionDeprecated = true;
-        return this;
-    }
-
-    @Override
-    public DeprecatableConfiguration deprecateForConsumption(Function<DeprecationMessageBuilder.DeprecateConfiguration, DeprecationMessageBuilder.WithDocumentation> deprecation) {
-        validateMutation(MutationType.USAGE);
-        this.consumptionDeprecation = deprecation.apply(DeprecationLogger.deprecateConfiguration(name).forConsumption());
-        if (!consumptionDeprecated) {
-            maybeWarnOnChangingUsage("deprecated for consumption", true);
-        }
-        consumptionDeprecated = true;
-        return this;
+    public void addResolutionAlternatives(String... alternativesForResolving) {
+        this.resolutionAlternatives = ImmutableList.<String>builder()
+            .addAll(resolutionAlternatives)
+            .addAll(Arrays.asList(alternativesForResolving))
+            .build();
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultArtifactHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultArtifactHandler.java
@@ -89,9 +89,9 @@ public class DefaultArtifactHandler implements ArtifactHandler, MethodMixIn {
      * Exists only to maintain the existing fully deprecated logic in Gradle 8.0 - DO NOT USE.
      */
     private boolean isFullyDeprecated(DeprecatableConfiguration configuration) {
-        return configuration.getDeclarationAlternatives() != null &&
-                (!configuration.isCanBeConsumed() || configuration.getConsumptionDeprecation() != null) &&
-                (!configuration.isCanBeResolved() || configuration.getResolutionAlternatives() != null);
+        return configuration.isDeprecatedForDeclarationAgainst() &&
+            (!configuration.isCanBeConsumed() || configuration.isDeprecatedForConsumption()) &&
+            (!configuration.isCanBeResolved() || configuration.isDeprecatedForResolution());
     }
 
     private void assertConfigurationIsValidForArtifacts(DeprecatableConfiguration configuration) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalConfigurationMetadataBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalConfigurationMetadataBuilder.java
@@ -124,7 +124,7 @@ public class DefaultLocalConfigurationMetadataBuilder implements LocalConfigurat
             attributes,
             ImmutableCapabilities.of(Configurations.collectCapabilities(configuration, Sets.newHashSet(), Sets.newHashSet())),
             configuration.isCanBeConsumed(),
-            configuration.getConsumptionDeprecation(),
+            configuration.isDeprecatedForConsumption(),
             configuration.isCanBeResolved(),
             maybeForceDependencies(dependencies.dependencies, attributes),
             dependencies.files,

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractConfigurationMetadata.java
@@ -30,7 +30,6 @@ import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.component.model.ModuleConfigurationMetadata;
 import org.gradle.internal.component.model.VariantResolveMetadata;
-import org.gradle.internal.deprecation.DeprecationMessageBuilder;
 
 import java.util.List;
 import java.util.Set;
@@ -132,11 +131,6 @@ public abstract class AbstractConfigurationMetadata implements ModuleConfigurati
     @Override
     public boolean isCanBeConsumed() {
         return true;
-    }
-
-    @Override
-    public DeprecationMessageBuilder.WithDocumentation getConsumptionDeprecation() {
-        return null;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractVariantBackedConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractVariantBackedConfigurationMetadata.java
@@ -32,7 +32,6 @@ import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.component.model.ModuleConfigurationMetadata;
 import org.gradle.internal.component.model.VariantResolveMetadata;
-import org.gradle.internal.deprecation.DeprecationMessageBuilder;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -119,11 +118,6 @@ class AbstractVariantBackedConfigurationMetadata implements ModuleConfigurationM
     @Override
     public boolean isCanBeConsumed() {
         return true;
-    }
-
-    @Override
-    public DeprecationMessageBuilder.WithDocumentation getConsumptionDeprecation() {
-        return null;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyRuleAwareWithBaseConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyRuleAwareWithBaseConfigurationMetadata.java
@@ -30,7 +30,6 @@ import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.component.model.ModuleConfigurationMetadata;
 import org.gradle.internal.component.model.VariantResolveMetadata;
-import org.gradle.internal.deprecation.DeprecationMessageBuilder;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -160,11 +159,6 @@ class LazyRuleAwareWithBaseConfigurationMetadata implements ModuleConfigurationM
     @Override
     public boolean isCanBeResolved() {
         return false;
-    }
-
-    @Override
-    public DeprecationMessageBuilder.WithDocumentation getConsumptionDeprecation() {
-        return null;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalConfigurationMetadata.java
@@ -29,12 +29,10 @@ import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.component.model.LocalOriginDependencyMetadata;
-import org.gradle.internal.deprecation.DeprecationMessageBuilder;
 import org.gradle.internal.model.CalculatedValueContainer;
 import org.gradle.internal.model.CalculatedValueContainerFactory;
 import org.gradle.internal.model.ModelContainer;
 
-import javax.annotation.Nullable;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -55,7 +53,7 @@ public final class DefaultLocalConfigurationMetadata implements LocalConfigurati
     private final ImmutableSet<String> hierarchy;
     private final ImmutableAttributes attributes;
     private final boolean canBeConsumed;
-    private final DeprecationMessageBuilder.WithDocumentation consumptionDeprecation;
+    private final boolean deprecatedForConsumption;
     private final boolean canBeResolved;
     private final ImmutableCapabilities capabilities;
     private final List<LocalOriginDependencyMetadata> configurationDependencies;
@@ -80,7 +78,7 @@ public final class DefaultLocalConfigurationMetadata implements LocalConfigurati
         ImmutableAttributes attributes,
         ImmutableCapabilities capabilities,
         boolean canBeConsumed,
-        @Nullable DeprecationMessageBuilder.WithDocumentation consumptionDeprecation,
+        boolean deprecatedForConsumption,
         boolean canBeResolved,
         List<LocalOriginDependencyMetadata> configurationDependencies,
         Set<LocalFileDependencyMetadata> configurationFileDependencies,
@@ -92,7 +90,7 @@ public final class DefaultLocalConfigurationMetadata implements LocalConfigurati
         LocalComponentMetadata component
     ) {
         this(
-            name, description, componentId, visible, transitive, hierarchy, attributes, capabilities, canBeConsumed, consumptionDeprecation,
+            name, description, componentId, visible, transitive, hierarchy, attributes, capabilities, canBeConsumed, deprecatedForConsumption,
             canBeResolved, configurationDependencies, configurationFileDependencies, configurationExcludes, variants, factory,
             getLazyArtifacts(definedArtifacts, name, description, hierarchy, model, factory, component)
         );
@@ -111,7 +109,7 @@ public final class DefaultLocalConfigurationMetadata implements LocalConfigurati
         ImmutableAttributes attributes,
         ImmutableCapabilities capabilities,
         boolean canBeConsumed,
-        @Nullable DeprecationMessageBuilder.WithDocumentation consumptionDeprecation,
+        boolean deprecatedForConsumption,
         boolean canBeResolved,
         List<LocalOriginDependencyMetadata> configurationDependencies,
         Set<LocalFileDependencyMetadata> configurationFileDependencies,
@@ -121,7 +119,7 @@ public final class DefaultLocalConfigurationMetadata implements LocalConfigurati
         List<LocalComponentArtifactMetadata> artifacts
     ) {
         this(
-            name, description, componentId, visible, transitive, hierarchy, attributes, capabilities, canBeConsumed, consumptionDeprecation,
+            name, description, componentId, visible, transitive, hierarchy, attributes, capabilities, canBeConsumed, deprecatedForConsumption,
             canBeResolved, configurationDependencies, configurationFileDependencies, configurationExcludes, variants, factory,
             factory.create(Describables.of(description, "artifacts"), ImmutableList.copyOf(artifacts))
         );
@@ -137,7 +135,7 @@ public final class DefaultLocalConfigurationMetadata implements LocalConfigurati
         ImmutableAttributes attributes,
         ImmutableCapabilities capabilities,
         boolean canBeConsumed,
-        @Nullable DeprecationMessageBuilder.WithDocumentation consumptionDeprecation,
+        boolean deprecatedForConsumption,
         boolean canBeResolved,
         List<LocalOriginDependencyMetadata> configurationDependencies,
         Set<LocalFileDependencyMetadata> configurationFileDependencies,
@@ -155,7 +153,7 @@ public final class DefaultLocalConfigurationMetadata implements LocalConfigurati
         this.attributes = attributes;
         this.capabilities = capabilities;
         this.canBeConsumed = canBeConsumed;
-        this.consumptionDeprecation = consumptionDeprecation;
+        this.deprecatedForConsumption = deprecatedForConsumption;
         this.canBeResolved = canBeResolved;
         this.configurationDependencies = configurationDependencies;
         this.configurationFileDependencies = configurationFileDependencies;
@@ -222,7 +220,7 @@ public final class DefaultLocalConfigurationMetadata implements LocalConfigurati
 
         return new DefaultLocalConfigurationMetadata(
             name, description, componentId, visible, transitive, hierarchy, attributes, capabilities,
-            canBeConsumed, consumptionDeprecation, canBeResolved,
+            canBeConsumed, deprecatedForConsumption, canBeResolved,
             configurationDependencies, configurationFileDependencies, configurationExcludes,
             copiedVariants.build(), factory, copiedArtifacts
         );
@@ -274,8 +272,8 @@ public final class DefaultLocalConfigurationMetadata implements LocalConfigurati
     }
 
     @Override
-    public DeprecationMessageBuilder.WithDocumentation getConsumptionDeprecation() {
-        return consumptionDeprecation;
+    public boolean isDeprecatedForConsumption() {
+        return deprecatedForConsumption;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ConfigurationGraphResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ConfigurationGraphResolveMetadata.java
@@ -16,9 +16,6 @@
 
 package org.gradle.internal.component.model;
 
-import org.gradle.internal.deprecation.DeprecationMessageBuilder;
-
-import javax.annotation.Nullable;
 import java.util.Set;
 
 /**
@@ -31,6 +28,7 @@ public interface ConfigurationGraphResolveMetadata extends VariantGraphResolveMe
 
     boolean isVisible();
 
-    @Nullable
-    DeprecationMessageBuilder.WithDocumentation getConsumptionDeprecation();
+    default boolean isDeprecatedForConsumption() {
+        return false;
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ConfigurationMetadata.java
@@ -23,9 +23,7 @@ import org.gradle.api.capabilities.CapabilitiesMetadata;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.external.model.maven.MavenDependencyDescriptor;
-import org.gradle.internal.deprecation.DeprecationMessageBuilder;
 
-import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Set;
 
@@ -88,9 +86,6 @@ public interface ConfigurationMetadata extends VariantArtifactGraphResolveMetada
     boolean isVisible();
 
     boolean isCanBeConsumed();
-
-    @Nullable
-    DeprecationMessageBuilder.WithDocumentation getConsumptionDeprecation();
 
     boolean isCanBeResolved();
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
@@ -28,7 +28,7 @@ import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.IncompatibleConfigurationSelectionException;
-import org.gradle.internal.deprecation.DeprecationMessageBuilder;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.exceptions.ConfigurationNotConsumableException;
 import org.gradle.util.internal.GUtil;
 
@@ -170,9 +170,13 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
         if (!toConfiguration.isCanBeConsumed()) {
             throw new ConfigurationNotConsumableException(targetComponent.toString(), toConfiguration.getName());
         }
-        DeprecationMessageBuilder.WithDocumentation consumptionDeprecation = toConfiguration.getConsumptionDeprecation();
-        if (consumptionDeprecation != null) {
-            consumptionDeprecation.nagUser();
+
+        if (toConfiguration.isDeprecatedForConsumption()) {
+            DeprecationLogger.deprecateConfiguration(toConfiguration.getName())
+                .forConsumption()
+                .willBecomeAnErrorInGradle9()
+                .withUserManual("dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations")
+                .nagUser();
         }
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/ConfigurationRolesSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/ConfigurationRolesSpec.groovy
@@ -42,7 +42,6 @@ class ConfigurationRolesSpec extends Specification {
 
         where:
         consumable  | resolvable    | declarableAgainst
-        false       | false         | false
         true        | true          | false
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/ConfigurationRolesSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/ConfigurationRolesSpec.groovy
@@ -42,6 +42,7 @@ class ConfigurationRolesSpec extends Specification {
 
         where:
         consumable  | resolvable    | declarableAgainst
+        false       | false         | false
         true        | true          | false
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/UsageDescriberSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/UsageDescriberSpec.groovy
@@ -30,42 +30,7 @@ class UsageDescriberSpec extends Specification {
 
     def "can describe usage for role which allows nothing"() {
         given:
-        def role = new ConfigurationRole() {
-            @Override
-            String getName() {
-                return "test"
-            }
-
-            @Override
-            boolean isConsumable() {
-                return false
-            }
-
-            @Override
-            boolean isResolvable() {
-                return false
-            }
-
-            @Override
-            boolean isDeclarableAgainst() {
-                return false
-            }
-
-            @Override
-            boolean isConsumptionDeprecated() {
-                return false
-            }
-
-            @Override
-            boolean isResolutionDeprecated() {
-                return false
-            }
-
-            @Override
-            boolean isDeclarationAgainstDeprecated() {
-                return false
-            }
-        }
+        def role = new TestConfigurationRole("test", false, false, false, false, false, false)
 
         expect:
         UsageDescriber.describeRole(role) == "\tThis configuration does not allow any usage"

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -1025,7 +1025,7 @@ class DependencyGraphBuilderTest extends Specification {
         def artifacts = [new PublishArtifactLocalArtifactMetadata(componentId, new DefaultPublishArtifact("art1", "zip", "art", null, new Date(), new File("art1.zip")))]
         def defaultConfiguration = new DefaultLocalConfigurationMetadata(
             "default", "defaultConfig", componentId, true, true, ["default"] as Set, attributes, ImmutableCapabilities.EMPTY,
-            true, null, true, [], [] as Set, [],
+            true, false, true, [], [] as Set, [],
             [] as Set, TestUtil.calculatedValueContainerFactory(), artifacts
         )
 
@@ -1040,13 +1040,13 @@ class DependencyGraphBuilderTest extends Specification {
         def artifacts = [new PublishArtifactLocalArtifactMetadata(componentId, new DefaultPublishArtifact("art1", "zip", "art", null, new Date(), new File("art1.zip")))]
         def defaultConfiguration = new DefaultLocalConfigurationMetadata(
             "default", "defaultConfig", componentId, true, true, ["default"] as Set, attributes, ImmutableCapabilities.EMPTY,
-            true, null, true, [], [] as Set, [],
+            true, false, true, [], [] as Set, [],
             [] as Set, TestUtil.calculatedValueContainerFactory(), artifacts
         )
 
         def rootConfiguration = new DefaultLocalConfigurationMetadata(
             "root", "rootConfig", componentId, true, true, ["default", "root"] as Set, attributes, ImmutableCapabilities.EMPTY,
-            true, null, true, defaultConfiguration.getDependencies(), [] as Set, [],
+            true, false, true, defaultConfiguration.getDependencies(), [] as Set, [],
             [] as Set, TestUtil.calculatedValueContainerFactory(), []
         )
 

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/configurations/TestConfigurationRole.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/configurations/TestConfigurationRole.groovy
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.configurations
+
+/**
+ * Allows tests to declare arbitrary roles.
+ */
+class TestConfigurationRole implements ConfigurationRole {
+
+    final String name
+    final boolean consumable
+    final boolean resolvable
+    final boolean declarableAgainst
+    final boolean consumptionDeprecated
+    final boolean resolutionDeprecated
+    final boolean declarationDeprecated
+
+    TestConfigurationRole(
+        String name,
+        boolean consumable,
+        boolean resolvable,
+        boolean declarableAgainst,
+        boolean consumptionDeprecated,
+        boolean resolutionDeprecated,
+        boolean declarationDeprecated
+    ) {
+        this.name = name
+        this.consumable = consumable
+        this.resolvable = resolvable
+        this.declarableAgainst = declarableAgainst
+        this.consumptionDeprecated = consumptionDeprecated
+        this.resolutionDeprecated = resolutionDeprecated
+        this.declarationDeprecated = declarationDeprecated
+    }
+
+    @Override
+    String getName() {
+        return name
+    }
+
+    @Override
+    boolean isConsumable() {
+        return consumable
+    }
+
+    @Override
+    boolean isResolvable() {
+        return resolvable
+    }
+
+    @Override
+    boolean isDeclarableAgainst() {
+        return declarableAgainst
+    }
+
+    @Override
+    boolean isConsumptionDeprecated() {
+        return consumptionDeprecated
+    }
+
+    @Override
+    boolean isResolutionDeprecated() {
+        return resolutionDeprecated
+    }
+
+    @Override
+    boolean isDeclarationAgainstDeprecated() {
+        return declarationDeprecated
+    }
+}

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/reporting/dependencies/HtmlDependencyReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/reporting/dependencies/HtmlDependencyReportTaskIntegrationTest.groovy
@@ -563,10 +563,7 @@ rootProject.name = 'root'
                maven { url "${mavenRepo.uri}" }
             }
             configurations {
-                compileOnly.deprecateForResolution('compileClasspath')
-                compileOnly.deprecateForConsumption { builder ->
-                    builder.willBecomeAnErrorInGradle9().withUpgradeGuideSection(8, "foo")
-                }
+                createWithRole('compileOnly', org.gradle.api.internal.artifacts.configurations.ConfigurationRolesForMigration.RESOLVABLE_BUCKET_TO_BUCKET)
             }
             dependencies {
                 compileOnly 'foo:foo:1.0'

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyReportTaskIntegrationTest.groovy
@@ -1037,7 +1037,7 @@ compileClasspath - Compile classpath for source set 'main'.
         buildFile << """
             subprojects {
                 configurations {
-                    compile.deprecateForDeclarationAgainst('implementation')
+                    createWithRole('compile', org.gradle.api.internal.artifacts.configurations.ConfigurationRolesForMigration.BUCKET_TO_NONE)
                     'default' { extendsFrom compile }
                 }
                 group = "group"
@@ -1048,7 +1048,7 @@ compileClasspath - Compile classpath for source set 'main'.
             }
         """
 
-        executer.expectDocumentedDeprecationWarning("The compile configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 9.0. Please use the implementation configuration instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_5.html#dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations")
+        executer.expectDocumentedDeprecationWarning("The compile configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 9.0. Please use another configuration instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_5.html#dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations")
 
         expect:
         succeeds ':a:dependencies'
@@ -1086,10 +1086,7 @@ compileClasspath - Compile classpath for source set 'main'.
                maven { url "${mavenRepo.uri}" }
             }
             configurations {
-                compileOnly.deprecateForResolution("compileClasspath")
-                compileOnly.deprecateForConsumption { builder ->
-                    builder.willBecomeAnErrorInGradle9().withUpgradeGuideSection(8, "foo")
-                }
+                createWithRole('compileOnly', org.gradle.api.internal.artifacts.configurations.ConfigurationRolesForMigration.RESOLVABLE_BUCKET_TO_BUCKET)
                 implementation.extendsFrom compileOnly
             }
             dependencies {

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyReportTaskIntegrationTest.groovy
@@ -1037,7 +1037,7 @@ compileClasspath - Compile classpath for source set 'main'.
         buildFile << """
             subprojects {
                 configurations {
-                    createWithRole('compile', org.gradle.api.internal.artifacts.configurations.ConfigurationRolesForMigration.BUCKET_TO_NONE)
+                    createWithRole('compile', org.gradle.api.internal.artifacts.configurations.ConfigurationRolesForMigration.RESOLVABLE_BUCKET_TO_RESOLVABLE)
                     'default' { extendsFrom compile }
                 }
                 group = "group"

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/ConfigurationDetails.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/ConfigurationDetails.java
@@ -38,7 +38,7 @@ public class ConfigurationDetails {
     }
 
     private static boolean canBeResolved(Configuration configuration) {
-        boolean isDeprecatedForResolving = ((DeprecatableConfiguration) configuration).getResolutionAlternatives() != null;
+        boolean isDeprecatedForResolving = ((DeprecatableConfiguration) configuration).isDeprecatedForResolution();
         return configuration.isCanBeResolved() && !isDeprecatedForResolving;
     }
 

--- a/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/DefaultProjectSchemaProvider.kt
+++ b/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/DefaultProjectSchemaProvider.kt
@@ -257,7 +257,7 @@ fun accessibleConfigurationsOf(project: Project) =
 
 private
 fun toConfigurationEntry(configuration: Configuration) = (configuration as DeprecatableConfiguration).run {
-    ConfigurationEntry(name, declarationAlternatives ?: listOf())
+    ConfigurationEntry(name, declarationAlternatives)
 }
 
 

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryFeatureCompilationIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryFeatureCompilationIntegrationTest.groovy
@@ -628,9 +628,9 @@ class JavaLibraryFeatureCompilationIntegrationTest extends AbstractIntegrationSp
                     assert it.canBeResolved == false
                     assert it.canBeDeclaredAgainst == true
 
-                    assert it.declarationAlternatives == []
-                    assert it.resolutionAlternatives == null
-                    assert it.consumptionDeprecation == null
+                    assert it.deprecatedForDeclarationAgainst == true
+                    assert it.deprecatedForResolution == false
+                    assert it.deprecatedForConsumption == false
                 }
             }
         """


### PR DESCRIPTION
Configuration roles cannot be immutable since we have public methods to change their role, but the deprecation status can be immutable and fixed on creation since there are no public deprecation mutating methods.

Also adds new migration roles which allow us to deprecate certain configurations entirely. This will be useful when removing some configurations, like the war plugin's provided configurations
