### PR TITLE
Fix nested map properties with non-string keys

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/NestedInputIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/NestedInputIntegrationTest.groovy
@@ -782,6 +782,23 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
         output.contains("Input property 'nested.key1' has been removed for task ':myTask'")
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/24594")
+    def "nested map with non-string key works"() {
+        buildFile << """
+            abstract class CustomTask extends DefaultTask {
+                @Nested
+                abstract MapProperty<Integer, Object> getMap()
+            }
+
+            tasks.register("customTask", CustomTask) {
+                map.put(100, "example")
+            }
+        """
+
+        expect:
+        succeeds("customTask")
+    }
+
 
     private static String namedBeanClass() {
         """

--- a/subprojects/model-core/src/main/java/org/gradle/internal/properties/annotations/AbstractTypeMetadataWalker.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/properties/annotations/AbstractTypeMetadataWalker.java
@@ -148,13 +148,14 @@ abstract class AbstractTypeMetadataWalker<T, V extends TypeMetadataWalker.TypeMe
             );
         }
 
-        @SuppressWarnings("unchecked")
+
         @Override
         protected void walkNestedMap(Object node, String qualifiedName, BiConsumer<String, Object> handler) {
-            ((Map<String, Object>) node).forEach((key, value) -> {
+            ((Map<?, ?>) node).forEach((key, value) -> {
                 checkNotNull(key, "Null keys in nested map '%s' are not allowed.", qualifiedName);
-                checkNotNullNestedCollectionValue(qualifiedName, key, value);
-                handler.accept(key, value);
+                String stringKey = key.toString();
+                checkNotNullNestedCollectionValue(qualifiedName, stringKey, value);
+                handler.accept(stringKey, value);
             });
         }
 


### PR DESCRIPTION
Fixes #24594

### Context
Previously, non-string keys were converted to String by calling toString() during property walking. This call was accidentally dropped when property walking was updated recently. This change reverts to calling toString().
