### PR TITLE
Use ResolveContext instead of ConfigurationInternal in resolve pipeline

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyManagementResultsAsInputsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyManagementResultsAsInputsIntegrationTest.groovy
@@ -649,7 +649,7 @@ class DependencyManagementResultsAsInputsIntegrationTest extends AbstractHttpDep
             if (Boolean.getBoolean("externalDependency")) {
                 dependencies { implementation 'org.external:external-tool:1.0' }
             }
-            configurations.runtimeClasspath.returnAllVariants = true
+            configurations.runtimeClasspath.resolutionStrategy.returnAllVariants = true
         """
 
         when: "Task without changes is executed & not skipped"

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ConfigurationResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ConfigurationResolver.java
@@ -16,30 +16,30 @@
 package org.gradle.api.internal.artifacts;
 
 import org.gradle.api.artifacts.ResolveException;
-import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.artifacts.repositories.ResolutionAwareRepository;
 
 import java.util.List;
 
 public interface ConfigurationResolver {
-    /**
-     * Traverses enough of the graph to calculate the build dependencies of the given configuration. All failures are packaged in the result.
-     */
-    void resolveBuildDependencies(ConfigurationInternal configuration, ResolverResults result);
 
     /**
-     * Traverses the full dependency graph of the given configuration. All failures are packaged in the result.
+     * Traverses enough of the graph to calculate the build dependencies of the given resolve context. All failures are packaged in the result.
      */
-    void resolveGraph(ConfigurationInternal configuration, ResolverResults results) throws ResolveException;
+    void resolveBuildDependencies(ResolveContext configuration, ResolverResults result);
 
     /**
-     * Calculates the artifacts to include in the result for the given configuration. All failures are packaged in the result.
-     * Must be called using the same result instance as was passed to {@link #resolveGraph(ConfigurationInternal, ResolverResults)}.
+     * Traverses the full dependency graph of the given resolve context. All failures are packaged in the result.
      */
-    void resolveArtifacts(ConfigurationInternal configuration, ResolverResults results) throws ResolveException;
+    void resolveGraph(ResolveContext resolveContext, ResolverResults results) throws ResolveException;
 
     /**
-     * Returns the list of repositories available to resolve a given configuration. This is used for reporting only.
+     * Calculates the artifacts to include in the result for the given resolve context. All failures are packaged in the result.
+     * Must be called using the same result instance as was passed to {@link #resolveGraph(ResolveContext, ResolverResults)}.
+     */
+    void resolveArtifacts(ResolveContext resolveContext, ResolverResults results) throws ResolveException;
+
+    /**
+     * Returns the list of repositories available to resolve a given resolve context. This is used for reporting only.
      */
     List<ResolutionAwareRepository> getRepositories();
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultImmutableModuleIdentifierFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultImmutableModuleIdentifierFactory.java
@@ -58,9 +58,4 @@ public class DefaultImmutableModuleIdentifierFactory implements ImmutableModuleI
         }
         return identifier;
     }
-
-    @Override
-    public ModuleVersionIdentifier moduleWithVersion(Module module) {
-        return moduleWithVersion(module.getGroup(), module.getName(), module.getVersion());
-    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ImmutableModuleIdentifierFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ImmutableModuleIdentifierFactory.java
@@ -24,6 +24,5 @@ import org.gradle.internal.service.scopes.ServiceScope;
 public interface ImmutableModuleIdentifierFactory {
     ModuleIdentifier module(String group, String name);
     ModuleVersionIdentifier moduleWithVersion(String group, String name, String version);
-    ModuleVersionIdentifier moduleWithVersion(Module module);
     ModuleVersionIdentifier moduleWithVersion(ModuleIdentifier targetModuleId, String version);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolveContext.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolveContext.java
@@ -15,27 +15,38 @@
  */
 package org.gradle.api.internal.artifacts;
 
-import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
 import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal;
+import org.gradle.api.internal.artifacts.transform.ExtraExecutionGraphDependenciesResolverFactory;
+import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.internal.component.local.model.LocalComponentMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
+import org.gradle.util.Path;
 
 import java.util.List;
 
 /**
  * Represents something that can be resolved.
  */
-public interface ResolveContext {
+public interface ResolveContext extends DependencyMetaDataProvider {
 
     String getName();
 
     String getDisplayName();
 
+    String getPath();
+
+    Path getIdentityPath();
+
     ResolutionStrategyInternal getResolutionStrategy();
+
+    boolean hasDependencies();
 
     LocalComponentMetadata toRootComponentMetaData();
 
-    AttributeContainer getAttributes();
+    AttributeContainerInternal getAttributes();
+
+    ExtraExecutionGraphDependenciesResolverFactory getDependenciesResolver();
 
     /**
      * Returns the synthetic dependencies for this context. These dependencies are generated
@@ -44,4 +55,6 @@ public interface ResolveContext {
      * (task dependencies, execution, ...)
      */
     List<? extends DependencyMetadata> getSyntheticDependencies();
+
+    int getEstimatedGraphSize();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolveContext.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolveContext.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.artifacts;
 
+import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
 import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal;
 import org.gradle.api.internal.artifacts.transform.ExtraExecutionGraphDependenciesResolverFactory;
@@ -34,9 +35,11 @@ public interface ResolveContext extends DependencyMetaDataProvider {
 
     String getDisplayName();
 
-    String getPath();
-
     Path getIdentityPath();
+
+    Path getProjectPath();
+
+    DomainObjectContext getDomainObjectContext();
 
     ResolutionStrategyInternal getResolutionStrategy();
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolveContext.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolveContext.java
@@ -59,5 +59,10 @@ public interface ResolveContext extends DependencyMetaDataProvider {
      */
     List<? extends DependencyMetadata> getSyntheticDependencies();
 
+    /**
+     * This method is a heuristic that gives an idea of the "size" of the graph. The larger
+     * the graph is, the higher the risk of internal resizes exists, so we try to estimate
+     * the size of the graph to avoid maps resizing.
+     */
     int getEstimatedGraphSize();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
@@ -23,20 +23,18 @@ import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.artifacts.ResolveException;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.ResolveContext;
-import org.gradle.api.internal.artifacts.transform.ExtraExecutionGraphDependenciesResolverFactory;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.FinalizableValue;
 import org.gradle.internal.deprecation.DeprecatableConfiguration;
-import org.gradle.util.Path;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
-public interface ConfigurationInternal extends ResolveContext, DeprecatableConfiguration, DependencyMetaDataProvider, FinalizableValue, Configuration {
+public interface ConfigurationInternal extends ResolveContext, DeprecatableConfiguration, FinalizableValue, Configuration {
     enum InternalState {
         UNRESOLVED,
         BUILD_DEPENDENCIES_RESOLVED,
@@ -45,18 +43,7 @@ public interface ConfigurationInternal extends ResolveContext, DeprecatableConfi
     }
 
     @Override
-    ResolutionStrategyInternal getResolutionStrategy();
-
-    @Override
     AttributeContainerInternal getAttributes();
-
-    String getPath();
-
-    Path getIdentityPath();
-
-    void setReturnAllVariants(boolean returnAllVariants);
-
-    boolean getReturnAllVariants();
 
     /**
      * Runs any registered dependency actions for this Configuration, and any parent Configuration.
@@ -103,8 +90,6 @@ public interface ConfigurationInternal extends ResolveContext, DeprecatableConfi
      * superconfigurations.
      */
     Set<ExcludeRule> getAllExcludeRules();
-
-    ExtraExecutionGraphDependenciesResolverFactory getDependenciesResolver();
 
     @Nullable
     ConfigurationInternal getConsistentResolutionSource();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -216,7 +216,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     private final ConfigurationsProvider configurationsProvider;
 
     private final Path identityPath;
-    private final Path path;
+    private final Path projectPath;
 
     // These fields are not covered by mutation lock
     private final String name;
@@ -309,7 +309,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         this.domainObjectCollectionFactory = domainObjectCollectionFactory;
         this.calculatedValueContainerFactory = calculatedValueContainerFactory;
         this.identityPath = domainObjectContext.identityPath(name);
-        this.path = domainObjectContext.projectPath(name);
+        this.projectPath = domainObjectContext.projectPath(name);
         this.name = name;
         this.configurationsProvider = configurationsProvider;
         this.resolver = resolver;
@@ -576,7 +576,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
 
     @Override
     protected void appendContents(TreeFormatter formatter) {
-        formatter.node("configuration: " + getIdentityPath());
+        formatter.node("configuration: " + identityPath);
     }
 
     @Override
@@ -1004,7 +1004,8 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
      */
     @Override
     public int getEstimatedGraphSize() {
-        return (int) (512 * Math.log(getAllDependencies().size()));
+        int estimate = (int) (512 * Math.log(getAllDependencies().size()));
+        return Math.max(10, estimate);
     }
 
     private synchronized void initAllDependencies() {
@@ -1466,13 +1467,18 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     }
 
     @Override
-    public String getPath() {
-        return path.getPath();
+    public Path getProjectPath() {
+        return projectPath;
     }
 
     @Override
     public Path getIdentityPath() {
         return identityPath;
+    }
+
+    @Override
+    public DomainObjectContext getDomainObjectContext() {
+        return domainObjectContext;
     }
 
     @Override
@@ -2132,12 +2138,13 @@ since users cannot create non-legacy configurations and there is no current publ
 
         @Override
         public String getPath() {
-            return path.getPath();
+            // TODO: Can we update this to identityPath?
+            return projectPath.getPath();
         }
 
         @Override
         public String toString() {
-            return "dependencies '" + getIdentityPath() + "'";
+            return "dependencies '" + identityPath + "'";
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -997,13 +997,10 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         return !getAllDependencies().isEmpty();
     }
 
-    /**
-     * This method is a heuristic that gives an idea of the "size" of the graph. The larger
-     * the graph is, the higher the risk of internal resizes exists, so we try to estimate
-     * the size of the graph to avoid maps resizing.
-     */
     @Override
     public int getEstimatedGraphSize() {
+        // TODO #24641: Why are the numbers and operations here the way they are?
+        //  Are they up-to-date? We should be able to test if these values are still optimal.
         int estimate = (int) (512 * Math.log(getAllDependencies().size()));
         return Math.max(10, estimate);
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionStrategyInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionStrategyInternal.java
@@ -106,4 +106,8 @@ public interface ResolutionStrategyInternal extends ResolutionStrategy {
     boolean isFailingOnChangingVersions();
 
     boolean isDependencyVerificationEnabled();
+
+    void setReturnAllVariants(boolean returnAllVariants);
+
+    boolean getReturnAllVariants();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/ArtifactFile.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/ArtifactFile.java
@@ -29,7 +29,7 @@ public class ArtifactFile {
     private String classifier;
     private String extension;
 
-    public ArtifactFile(File file, String version) {
+    public ArtifactFile(File file, @Nullable String version) {
         this(file.getName(), version);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/FileSystemPublishArtifact.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/FileSystemPublishArtifact.java
@@ -21,6 +21,7 @@ import org.gradle.api.file.FileSystemLocation;
 import org.gradle.api.internal.tasks.TaskDependencyInternal;
 import org.gradle.api.tasks.TaskDependency;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Date;
 
@@ -30,7 +31,7 @@ public class FileSystemPublishArtifact implements PublishArtifactInternal {
     private final String version;
     private ArtifactFile artifactFile;
 
-    public FileSystemPublishArtifact(final FileSystemLocation fileSystemLocation, final String version) {
+    public FileSystemPublishArtifact(FileSystemLocation fileSystemLocation, @Nullable String version) {
         this.fileSystemLocation = fileSystemLocation;
         this.version = version;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
@@ -19,7 +19,6 @@ package org.gradle.api.internal.artifacts.ivyservice;
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.UnresolvedDependency;
 import org.gradle.api.artifacts.component.BuildIdentifier;
-import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentSelector;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.internal.artifacts.ArtifactDependencyResolver;
@@ -71,6 +70,7 @@ import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.locking.DependencyLockingArtifactVisitor;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.work.WorkerLeaseService;
+import org.gradle.util.Path;
 
 import java.util.Collections;
 import java.util.List;
@@ -174,12 +174,10 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
         visitors.add(fileDependencyVisitor);
         visitors.add(artifactsBuilder);
         if (resolutionStrategy.getConflictResolution() == ConflictResolution.strict) {
-            ProjectComponentIdentifier projectId = resolveContext.getModule().getProjectId();
-            // projectId is null for DefaultModule used in settings
-            String projectPath = projectId != null
-                ? projectId.getProjectPath()
-                : "";
-            visitors.add(new FailOnVersionConflictArtifactsVisitor(projectPath, resolveContext.getName()));
+            Path projectPath = resolveContext.getDomainObjectContext().getProjectPath();
+            // projectPath is null for settings execution
+            String path = projectPath != null ? projectPath.getPath() : "";
+            visitors.add(new FailOnVersionConflictArtifactsVisitor(path, resolveContext.getName()));
         }
         DependencyLockingArtifactVisitor lockingVisitor = null;
         if (resolutionStrategy.isDependencyLockingEnabled()) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
@@ -271,7 +271,8 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
                 return BuildOperationDescriptor
                     .displayName(displayName)
                     .progressDisplayName(displayName)
-                    .details(new ResolveArtifactsDetails(resolveContext.getPath()));
+                    // TODO: Can we update this to use the identity path?
+                    .details(new ResolveArtifactsDetails(resolveContext.getProjectPath().toString()));
             }
         });
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
@@ -28,7 +28,7 @@ import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.DependencyGraphNodeResult;
 import org.gradle.api.internal.artifacts.ResolveArtifactsBuildOperationType;
-import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
+import org.gradle.api.internal.artifacts.ResolveContext;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.DependencyVerificationOverride;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.CompositeResolvedArtifactSet;
@@ -77,7 +77,7 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
     private final static ResolveArtifactsBuildOperationType.Result RESULT = new ResolveArtifactsBuildOperationType.Result() {
     };
 
-    private final ConfigurationInternal configuration;
+    private final ResolveContext resolveContext;
     private final Set<UnresolvedDependency> unresolvedDependencies;
     private final VisitedArtifactsResults artifactResults;
     private final VisitedFileDependencyResults fileDependencyResults;
@@ -94,9 +94,9 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
     private SelectedArtifactResults artifactsForThisConfiguration;
     private DependencyVerificationException dependencyVerificationException;
 
-    public DefaultLenientConfiguration(ConfigurationInternal configuration, boolean selectFromAllVariants, Set<UnresolvedDependency> unresolvedDependencies, VisitedArtifactsResults artifactResults, VisitedFileDependencyResults fileDependencyResults, TransientConfigurationResultsLoader transientConfigurationResultsLoader, ArtifactTransforms artifactTransforms, BuildOperationExecutor buildOperationExecutor, DependencyVerificationOverride dependencyVerificationOverride, WorkerLeaseService workerLeaseService) {
-        this.configuration = configuration;
-        this.implicitAttributes = configuration.getAttributes().asImmutable();
+    public DefaultLenientConfiguration(ResolveContext resolveContext, boolean selectFromAllVariants, Set<UnresolvedDependency> unresolvedDependencies, VisitedArtifactsResults artifactResults, VisitedFileDependencyResults fileDependencyResults, TransientConfigurationResultsLoader transientConfigurationResultsLoader, ArtifactTransforms artifactTransforms, BuildOperationExecutor buildOperationExecutor, DependencyVerificationOverride dependencyVerificationOverride, WorkerLeaseService workerLeaseService) {
+        this.resolveContext = resolveContext;
+        this.implicitAttributes = resolveContext.getAttributes().asImmutable();
         this.selectFromAllVariants = selectFromAllVariants;
         this.unresolvedDependencies = unresolvedDependencies;
         this.artifactResults = artifactResults;
@@ -110,7 +110,7 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
 
     private SelectedArtifactResults getSelectedArtifacts() {
         if (artifactsForThisConfiguration == null) {
-            artifactsForThisConfiguration = artifactResults.selectLenient(Specs.satisfyAll(), artifactTransforms.variantSelector(implicitAttributes, false, selectFromAllVariants, configuration.getDependenciesResolver()));
+            artifactsForThisConfiguration = artifactResults.selectLenient(Specs.satisfyAll(), artifactTransforms.variantSelector(implicitAttributes, false, selectFromAllVariants, resolveContext.getDependenciesResolver()));
         }
         return artifactsForThisConfiguration;
     }
@@ -125,7 +125,7 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
 
     @Override
     public SelectedArtifactSet select(final Spec<? super Dependency> dependencySpec, final AttributeContainerInternal requestedAttributes, final Spec<? super ComponentIdentifier> componentSpec, boolean allowNoMatchingVariants, boolean selectFromAllVariants) {
-        VariantSelector selector = artifactTransforms.variantSelector(requestedAttributes, allowNoMatchingVariants, selectFromAllVariants, configuration.getDependenciesResolver());
+        VariantSelector selector = artifactTransforms.variantSelector(requestedAttributes, allowNoMatchingVariants, selectFromAllVariants, resolveContext.getDependenciesResolver());
         SelectedArtifactResults artifactResults = this.artifactResults.selectLenient(componentSpec, selector);
 
         return new SelectedArtifactSet() {
@@ -159,7 +159,7 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
         for (UnresolvedDependency unresolvedDependency : unresolvedDependencies) {
             failures.add(unresolvedDependency.getProblem());
         }
-        return new ResolveException(configuration.getDisplayName(), failures);
+        return new ResolveException(resolveContext.getDisplayName(), failures);
     }
 
     public boolean hasError() {
@@ -256,7 +256,7 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
                     throw dependencyVerificationException;
                 } else {
                     try {
-                        dependencyVerificationOverride.artifactsAccessed(configuration.getDisplayName());
+                        dependencyVerificationOverride.artifactsAccessed(resolveContext.getDisplayName());
                     } catch (DependencyVerificationException e) {
                         dependencyVerificationException = e;
                         throw e;
@@ -267,11 +267,11 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
 
             @Override
             public BuildOperationDescriptor.Builder description() {
-                String displayName = "Resolve files of " + configuration.getIdentityPath();
+                String displayName = "Resolve files of " + resolveContext.getIdentityPath();
                 return BuildOperationDescriptor
                     .displayName(displayName)
                     .progressDisplayName(displayName)
-                    .details(new ResolveArtifactsDetails(configuration.getPath()));
+                    .details(new ResolveArtifactsDetails(resolveContext.getPath()));
             }
         });
     }
@@ -321,8 +321,8 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
         ParallelResolveArtifactSet.wrap(CompositeResolvedArtifactSet.of(artifactSets), buildOperationExecutor).visit(visitor);
     }
 
-    public ConfigurationInternal getConfiguration() {
-        return configuration;
+    public ResolveContext getResolveContext() {
+        return resolveContext;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultResolvedConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultResolvedConfiguration.java
@@ -61,7 +61,11 @@ public class DefaultResolvedConfiguration implements ResolvedConfiguration {
         configuration.select(dependencySpec).visitArtifacts(visitor, false);
         Collection<Throwable> failures = visitor.getFailures();
         if (!failures.isEmpty()) {
-            throw new DefaultLenientConfiguration.ArtifactResolveException("files", configuration.getConfiguration().getIdentityPath().toString(), configuration.getConfiguration().getDisplayName(), failures);
+            throw new DefaultLenientConfiguration.ArtifactResolveException(
+                "files",
+                configuration.getResolveContext().getIdentityPath().toString(),
+                configuration.getResolveContext().getDisplayName(), failures
+            );
         }
         return visitor.getFiles();
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ErrorHandlingConfigurationResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ErrorHandlingConfigurationResolver.java
@@ -60,42 +60,42 @@ public class ErrorHandlingConfigurationResolver implements ConfigurationResolver
     }
 
     @Override
-    public void resolveBuildDependencies(ConfigurationInternal configuration, ResolverResults results) {
+    public void resolveBuildDependencies(ResolveContext resolveContext, ResolverResults results) {
         try {
-            delegate.resolveBuildDependencies(configuration, results);
+            delegate.resolveBuildDependencies(resolveContext, results);
         } catch (Exception e) {
-            results.failed(wrapException(e, configuration));
-            BrokenResolvedConfiguration broken = new BrokenResolvedConfiguration(e, configuration);
+            results.failed(wrapException(e, resolveContext));
+            BrokenResolvedConfiguration broken = new BrokenResolvedConfiguration(e, resolveContext);
             results.artifactsResolved(broken, broken);
         }
     }
 
     @Override
-    public void resolveGraph(ConfigurationInternal configuration, ResolverResults results) throws ResolveException {
+    public void resolveGraph(ResolveContext resolveContext, ResolverResults results) throws ResolveException {
         try {
-            delegate.resolveGraph(configuration, results);
+            delegate.resolveGraph(resolveContext, results);
         } catch (Exception e) {
-            results.failed(wrapException(e, configuration));
-            BrokenResolvedConfiguration broken = new BrokenResolvedConfiguration(e, configuration);
+            results.failed(wrapException(e, resolveContext));
+            BrokenResolvedConfiguration broken = new BrokenResolvedConfiguration(e, resolveContext);
             results.artifactsResolved(broken, broken);
             return;
         }
 
-        ResolutionResult wrappedResult = new ErrorHandlingResolutionResult(results.getResolutionResult(), configuration);
+        ResolutionResult wrappedResult = new ErrorHandlingResolutionResult(results.getResolutionResult(), resolveContext);
         results.graphResolved(wrappedResult, results.getResolvedLocalComponents(), results.getVisitedArtifacts());
     }
 
     @Override
-    public void resolveArtifacts(ConfigurationInternal configuration, ResolverResults results) throws ResolveException {
+    public void resolveArtifacts(ResolveContext resolveContext, ResolverResults results) throws ResolveException {
         try {
-            delegate.resolveArtifacts(configuration, results);
+            delegate.resolveArtifacts(resolveContext, results);
         } catch (Exception e) {
-            BrokenResolvedConfiguration broken = new BrokenResolvedConfiguration(e, configuration);
+            BrokenResolvedConfiguration broken = new BrokenResolvedConfiguration(e, resolveContext);
             results.artifactsResolved(broken, broken);
             return;
         }
 
-        ResolvedConfiguration wrappedConfiguration = new ErrorHandlingResolvedConfiguration(results.getResolvedConfiguration(), configuration);
+        ResolvedConfiguration wrappedConfiguration = new ErrorHandlingResolvedConfiguration(results.getResolvedConfiguration(), resolveContext);
         results.artifactsResolved(wrappedConfiguration, results.getVisitedArtifacts());
     }
 
@@ -268,12 +268,12 @@ public class ErrorHandlingConfigurationResolver implements ConfigurationResolver
 
     private static class ErrorHandlingResolvedConfiguration implements ResolvedConfiguration {
         private final ResolvedConfiguration resolvedConfiguration;
-        private final ConfigurationInternal configuration;
+        private final ResolveContext resolveContext;
 
         public ErrorHandlingResolvedConfiguration(ResolvedConfiguration resolvedConfiguration,
-                                                  ConfigurationInternal configuration) {
+                                                  ResolveContext resolveContext) {
             this.resolvedConfiguration = resolvedConfiguration;
-            this.configuration = configuration;
+            this.resolveContext = resolveContext;
         }
 
         @Override
@@ -284,9 +284,9 @@ public class ErrorHandlingConfigurationResolver implements ConfigurationResolver
         @Override
         public LenientConfiguration getLenientConfiguration() {
             try {
-                return new ErrorHandlingLenientConfiguration(resolvedConfiguration.getLenientConfiguration(), configuration);
+                return new ErrorHandlingLenientConfiguration(resolvedConfiguration.getLenientConfiguration(), resolveContext);
             } catch (Exception e) {
-                throw wrapException(e, configuration);
+                throw wrapException(e, resolveContext);
             }
         }
 
@@ -295,7 +295,7 @@ public class ErrorHandlingConfigurationResolver implements ConfigurationResolver
             try {
                 resolvedConfiguration.rethrowFailure();
             } catch (Exception e) {
-                throw wrapException(e, configuration);
+                throw wrapException(e, resolveContext);
             }
         }
 
@@ -304,7 +304,7 @@ public class ErrorHandlingConfigurationResolver implements ConfigurationResolver
             try {
                 return resolvedConfiguration.getFiles();
             } catch (ResolveException e) {
-                throw wrapException(e, configuration);
+                throw wrapException(e, resolveContext);
             }
         }
 
@@ -313,7 +313,7 @@ public class ErrorHandlingConfigurationResolver implements ConfigurationResolver
             try {
                 return resolvedConfiguration.getFiles(dependencySpec);
             } catch (Exception e) {
-                throw wrapException(e, configuration);
+                throw wrapException(e, resolveContext);
             }
         }
 
@@ -322,7 +322,7 @@ public class ErrorHandlingConfigurationResolver implements ConfigurationResolver
             try {
                 return resolvedConfiguration.getFirstLevelModuleDependencies();
             } catch (Exception e) {
-                throw wrapException(e, configuration);
+                throw wrapException(e, resolveContext);
             }
         }
 
@@ -331,7 +331,7 @@ public class ErrorHandlingConfigurationResolver implements ConfigurationResolver
             try {
                 return resolvedConfiguration.getFirstLevelModuleDependencies(dependencySpec);
             } catch (Exception e) {
-                throw wrapException(e, configuration);
+                throw wrapException(e, resolveContext);
             }
         }
 
@@ -340,18 +340,18 @@ public class ErrorHandlingConfigurationResolver implements ConfigurationResolver
             try {
                 return resolvedConfiguration.getResolvedArtifacts();
             } catch (Exception e) {
-                throw wrapException(e, configuration);
+                throw wrapException(e, resolveContext);
             }
         }
     }
 
     private static class BrokenResolvedConfiguration implements ResolvedConfiguration, VisitedArtifactSet, SelectedArtifactSet {
         private final Throwable ex;
-        private final ConfigurationInternal configuration;
+        private final ResolveContext resolveContext;
 
-        public BrokenResolvedConfiguration(Throwable ex, ConfigurationInternal configuration) {
+        public BrokenResolvedConfiguration(Throwable ex, ResolveContext resolveContext) {
             this.ex = ex;
-            this.configuration = configuration;
+            this.resolveContext = resolveContext;
         }
 
         @Override
@@ -361,37 +361,37 @@ public class ErrorHandlingConfigurationResolver implements ConfigurationResolver
 
         @Override
         public LenientConfiguration getLenientConfiguration() {
-            throw wrapException(ex, configuration);
+            throw wrapException(ex, resolveContext);
         }
 
         @Override
         public void rethrowFailure() throws ResolveException {
-            throw wrapException(ex, configuration);
+            throw wrapException(ex, resolveContext);
         }
 
         @Override
         public Set<File> getFiles() throws ResolveException {
-            throw wrapException(ex, configuration);
+            throw wrapException(ex, resolveContext);
         }
 
         @Override
         public Set<File> getFiles(Spec<? super Dependency> dependencySpec) throws ResolveException {
-            throw wrapException(ex, configuration);
+            throw wrapException(ex, resolveContext);
         }
 
         @Override
         public Set<ResolvedDependency> getFirstLevelModuleDependencies() throws ResolveException {
-            throw wrapException(ex, configuration);
+            throw wrapException(ex, resolveContext);
         }
 
         @Override
         public Set<ResolvedDependency> getFirstLevelModuleDependencies(Spec<? super Dependency> dependencySpec) throws ResolveException {
-            throw wrapException(ex, configuration);
+            throw wrapException(ex, resolveContext);
         }
 
         @Override
         public Set<ResolvedArtifact> getResolvedArtifacts() throws ResolveException {
-            throw wrapException(ex, configuration);
+            throw wrapException(ex, resolveContext);
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/InMemoryResolutionResultBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/InMemoryResolutionResultBuilder.java
@@ -17,7 +17,7 @@
 package org.gradle.api.internal.artifacts.ivyservice;
 
 import org.gradle.api.artifacts.result.ResolutionResult;
-import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
+import org.gradle.api.internal.artifacts.ResolveContext;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphSelector;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphVisitor;
@@ -28,7 +28,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.Default
  * Dependency graph visitor that will build a {@link ResolutionResult} eagerly.
  * It is designed to be used during resolution for build dependencies.
  *
- * @see DefaultConfigurationResolver#resolveBuildDependencies(ConfigurationInternal, org.gradle.api.internal.artifacts.ResolverResults)
+ * @see DefaultConfigurationResolver#resolveBuildDependencies(ResolveContext, org.gradle.api.internal.artifacts.ResolverResults)
  */
 public class InMemoryResolutionResultBuilder implements DependencyGraphVisitor {
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolver.java
@@ -29,9 +29,9 @@ import org.gradle.api.artifacts.result.ResolutionResult;
 import org.gradle.api.internal.artifacts.ConfigurationResolver;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.Module;
+import org.gradle.api.internal.artifacts.ResolveContext;
 import org.gradle.api.internal.artifacts.ResolverResults;
 import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory;
-import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingState;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor;
@@ -69,48 +69,48 @@ public class ShortCircuitEmptyConfigurationResolver implements ConfigurationReso
     }
 
     @Override
-    public void resolveBuildDependencies(ConfigurationInternal configuration, ResolverResults result) {
-        if (configuration.getAllDependencies().isEmpty()) {
-            emptyGraph(configuration, result, false);
+    public void resolveBuildDependencies(ResolveContext resolveContext, ResolverResults result) {
+        if (!resolveContext.hasDependencies()) {
+            emptyGraph(resolveContext, result, false);
         } else {
-            delegate.resolveBuildDependencies(configuration, result);
+            delegate.resolveBuildDependencies(resolveContext, result);
         }
     }
 
     @Override
-    public void resolveGraph(ConfigurationInternal configuration, ResolverResults results) throws ResolveException {
-        if (configuration.getAllDependencies().isEmpty()) {
-            emptyGraph(configuration, results, true);
+    public void resolveGraph(ResolveContext resolveContext, ResolverResults results) throws ResolveException {
+        if (!resolveContext.hasDependencies()) {
+            emptyGraph(resolveContext, results, true);
         } else {
-            delegate.resolveGraph(configuration, results);
+            delegate.resolveGraph(resolveContext, results);
         }
     }
 
-    private void emptyGraph(ConfigurationInternal configuration, ResolverResults results, boolean verifyLocking) {
-        if (verifyLocking && configuration.getResolutionStrategy().isDependencyLockingEnabled()) {
-            DependencyLockingProvider dependencyLockingProvider = configuration.getResolutionStrategy().getDependencyLockingProvider();
-            DependencyLockingState lockingState = dependencyLockingProvider.loadLockState(configuration.getName());
+    private void emptyGraph(ResolveContext resolveContext, ResolverResults results, boolean verifyLocking) {
+        if (verifyLocking && resolveContext.getResolutionStrategy().isDependencyLockingEnabled()) {
+            DependencyLockingProvider dependencyLockingProvider = resolveContext.getResolutionStrategy().getDependencyLockingProvider();
+            DependencyLockingState lockingState = dependencyLockingProvider.loadLockState(resolveContext.getName());
             if (lockingState.mustValidateLockState() && !lockingState.getLockedDependencies().isEmpty()) {
                 // Invalid lock state, need to do a real resolution to gather locking failures
-                delegate.resolveGraph(configuration, results);
+                delegate.resolveGraph(resolveContext, results);
                 return;
             }
-            dependencyLockingProvider.persistResolvedDependencies(configuration.getName(), Collections.emptySet(), Collections.emptySet());
+            dependencyLockingProvider.persistResolvedDependencies(resolveContext.getName(), Collections.emptySet(), Collections.emptySet());
         }
-        Module module = configuration.getModule();
+        Module module = resolveContext.getModule();
         ModuleVersionIdentifier id = moduleIdentifierFactory.moduleWithVersion(module);
         ComponentIdentifier componentIdentifier = componentIdentifierFactory.createComponentIdentifier(module);
-        ResolutionResult emptyResult = DefaultResolutionResultBuilder.empty(id, componentIdentifier, configuration.getAttributes());
+        ResolutionResult emptyResult = DefaultResolutionResultBuilder.empty(id, componentIdentifier, resolveContext.getAttributes());
         ResolvedLocalComponentsResult emptyProjectResult = new ResolvedLocalComponentsResultGraphVisitor(thisBuild);
         results.graphResolved(emptyResult, emptyProjectResult, EmptyResults.INSTANCE);
     }
 
     @Override
-    public void resolveArtifacts(ConfigurationInternal configuration, ResolverResults results) throws ResolveException {
-        if (configuration.getAllDependencies().isEmpty() && results.getVisitedArtifacts() == EmptyResults.INSTANCE) {
+    public void resolveArtifacts(ResolveContext resolveContext, ResolverResults results) throws ResolveException {
+        if (!resolveContext.hasDependencies() && results.getVisitedArtifacts() == EmptyResults.INSTANCE) {
             results.artifactsResolved(new EmptyResolvedConfiguration(), EmptyResults.INSTANCE);
         } else {
-            delegate.resolveArtifacts(configuration, results);
+            delegate.resolveArtifacts(resolveContext, results);
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolver.java
@@ -98,7 +98,7 @@ public class ShortCircuitEmptyConfigurationResolver implements ConfigurationReso
             dependencyLockingProvider.persistResolvedDependencies(resolveContext.getName(), Collections.emptySet(), Collections.emptySet());
         }
         Module module = resolveContext.getModule();
-        ModuleVersionIdentifier id = moduleIdentifierFactory.moduleWithVersion(module);
+        ModuleVersionIdentifier id = moduleIdentifierFactory.moduleWithVersion(module.getGroup(), module.getName(), module.getVersion());
         ComponentIdentifier componentIdentifier = componentIdentifierFactory.createComponentIdentifier(module);
         ResolutionResult emptyResult = DefaultResolutionResultBuilder.empty(id, componentIdentifier, resolveContext.getAttributes());
         ResolvedLocalComponentsResult emptyProjectResult = new ResolvedLocalComponentsResultGraphVisitor(thisBuild);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
@@ -87,7 +87,7 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
     private boolean failOnChangingVersions;
     private boolean verifyDependencies = true;
     private final Property<Boolean> useGlobalDependencySubstitutionRules;
-
+    private boolean returnAllVariants = false;
 
     public DefaultResolutionStrategy(DependencySubstitutionRules globalDependencySubstitutionRules,
                                      VcsResolver vcsResolver,
@@ -388,5 +388,16 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
     public ResolutionStrategy enableDependencyVerification() {
         verifyDependencies = true;
         return this;
+    }
+
+    @Override
+    public void setReturnAllVariants(boolean returnAllVariants) {
+        mutationValidator.validateMutation(STRATEGY);
+        this.returnAllVariants = returnAllVariants;
+    }
+
+    @Override
+    public boolean getReturnAllVariants() {
+        return this.returnAllVariants;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -22,7 +22,6 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
-import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ComponentSelector;
@@ -134,7 +133,7 @@ public class DependencyGraphBuilder {
         IdGenerator<Long> idGenerator = new LongIdGenerator();
         LocalComponentMetadata metadata = resolveContext.toRootComponentMetaData();
 
-        int graphSize = estimateSize(resolveContext);
+        int graphSize = resolveContext.getEstimatedGraphSize();
         ResolutionStrategyInternal resolutionStrategy = resolveContext.getResolutionStrategy();
 
         List<? extends DependencyMetadata> syntheticDependencies = includeSyntheticDependencies ?
@@ -148,19 +147,6 @@ public class DependencyGraphBuilder {
         validateGraph(resolveState, resolutionStrategy.isFailingOnDynamicVersions(), resolutionStrategy.isFailingOnChangingVersions());
 
         assembleResult(resolveState, modelVisitor);
-    }
-
-    /**
-     * This method is a heuristic that gives an idea of the "size" of the graph. The larger
-     * the graph is, the higher the risk of internal resizes exists, so we try to estimate
-     * the size of the graph to avoid maps resizing.
-     */
-    private static int estimateSize(ResolveContext resolveContext) {
-        int estimate = 0;
-        if (resolveContext instanceof Configuration) {
-            estimate = (int) (512 * Math.log(((Configuration) resolveContext).getAllDependencies().size()));
-        }
-        return Math.max(10, estimate);
     }
 
     /**

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
@@ -129,7 +129,7 @@ class DefaultConfigurationContainerSpec extends Specification {
 
         then:
         compile.name == "compile"
-        compile.path == ":compile"
+        compile.incoming.path == ":compile"
         compile instanceof DefaultConfiguration
 
         and:
@@ -163,7 +163,7 @@ class DefaultConfigurationContainerSpec extends Specification {
         then:
         configurationContainer.getByName("compile") == compile
         compile.description == "I compile!"
-        compile.path == ":compile"
+        compile.incoming.path == ":compile"
     }
 
     def "creates detached"() {
@@ -183,6 +183,6 @@ class DefaultConfigurationContainerSpec extends Specification {
         detached.getHierarchy() == [detached] as Set
         [dependency1, dependency2].each { detached.getDependencies().contains(it) }
         detached.getDependencies().size() == 2
-        detached.path == ":detachedConfiguration1"
+        detached.incoming.path == ":detachedConfiguration1"
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolverSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolverSpec.groovy
@@ -16,15 +16,13 @@
 package org.gradle.api.internal.artifacts.ivyservice
 
 import org.gradle.api.artifacts.Dependency
-import org.gradle.api.artifacts.DependencyConstraintSet
-import org.gradle.api.artifacts.DependencySet
 import org.gradle.api.artifacts.component.BuildIdentifier
 import org.gradle.api.internal.artifacts.ConfigurationResolver
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultResolverResults
+import org.gradle.api.internal.artifacts.ResolveContext
 import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory
-import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal
 import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingState
@@ -37,9 +35,7 @@ import spock.lang.Specification
 class ShortCircuitEmptyConfigurationResolverSpec extends Specification {
 
     def delegate = Mock(ConfigurationResolver)
-    def configuration = Stub(ConfigurationInternal)
-    def dependencies = Stub(DependencySet)
-    def dependencyConstraints = Stub(DependencyConstraintSet)
+    def resolveContext = Stub(ResolveContext)
     def componentIdentifierFactory = Mock(ComponentIdentifierFactory)
     def results = new DefaultResolverResults()
     def moduleIdentifierFactory = new DefaultImmutableModuleIdentifierFactory()
@@ -51,13 +47,10 @@ class ShortCircuitEmptyConfigurationResolverSpec extends Specification {
         def artifactVisitor = Mock(ArtifactVisitor)
 
         given:
-        dependencies.isEmpty() >> true
-        dependencyConstraints.isEmpty() >> true
-        configuration.getAllDependencies() >> dependencies
-        configuration.getAllDependencyConstraints() >> dependencyConstraints
+        resolveContext.hasDependencies() >> false
 
         when:
-        dependencyResolver.resolveBuildDependencies(configuration, results)
+        dependencyResolver.resolveBuildDependencies(resolveContext, results)
 
         then:
         def localComponentsResult = results.resolvedLocalComponents
@@ -79,13 +72,10 @@ class ShortCircuitEmptyConfigurationResolverSpec extends Specification {
         def artifactVisitor = Mock(ArtifactVisitor)
 
         given:
-        dependencies.isEmpty() >> true
-        dependencyConstraints.isEmpty() >> true
-        configuration.getAllDependencies() >> dependencies
-        configuration.getAllDependencyConstraints() >> dependencyConstraints
+        resolveContext.hasDependencies() >> false
 
         when:
-        dependencyResolver.resolveGraph(configuration, results)
+        dependencyResolver.resolveGraph(resolveContext, results)
 
         then:
         def result = results.resolutionResult
@@ -109,14 +99,11 @@ class ShortCircuitEmptyConfigurationResolverSpec extends Specification {
 
     def "returns empty result when no dependencies"() {
         given:
-        dependencies.isEmpty() >> true
-        dependencyConstraints.isEmpty() >> true
-        configuration.getAllDependencies() >> dependencies
-        configuration.getAllDependencyConstraints() >> dependencyConstraints
+        resolveContext.hasDependencies() >> false
 
         when:
-        dependencyResolver.resolveGraph(configuration, results)
-        dependencyResolver.resolveArtifacts(configuration, results)
+        dependencyResolver.resolveGraph(resolveContext, results)
+        dependencyResolver.resolveArtifacts(resolveContext, results)
 
         then:
         def resolvedConfig = results.resolvedConfiguration
@@ -135,15 +122,12 @@ class ShortCircuitEmptyConfigurationResolverSpec extends Specification {
         given:
         ResolutionStrategyInternal resolutionStrategy = Mock()
 
-        configuration.name >> 'lockedConf'
-        configuration.resolutionStrategy >> resolutionStrategy
-        dependencies.isEmpty() >> true
-        dependencyConstraints.isEmpty() >> true
-        configuration.getAllDependencies() >> dependencies
-        configuration.getAllDependencyConstraints() >> dependencyConstraints
+        resolveContext.name >> 'lockedConf'
+        resolveContext.resolutionStrategy >> resolutionStrategy
+        resolveContext.hasDependencies() >> false
 
         when:
-        dependencyResolver.resolveBuildDependencies(configuration, results)
+        dependencyResolver.resolveBuildDependencies(resolveContext, results)
 
         then:
 
@@ -156,15 +140,12 @@ class ShortCircuitEmptyConfigurationResolverSpec extends Specification {
         DependencyLockingProvider lockingProvider = Mock()
         DependencyLockingState lockingState = Mock()
 
-        configuration.name >> 'lockedConf'
-        configuration.resolutionStrategy >> resolutionStrategy
-        dependencies.isEmpty() >> true
-        dependencyConstraints.isEmpty() >> true
-        configuration.getAllDependencies() >> dependencies
-        configuration.getAllDependencyConstraints() >> dependencyConstraints
+        resolveContext.name >> 'lockedConf'
+        resolveContext.resolutionStrategy >> resolutionStrategy
+        resolveContext.hasDependencies() >> false
 
         when:
-        dependencyResolver.resolveGraph(configuration, results)
+        dependencyResolver.resolveGraph(resolveContext, results)
 
         then:
 
@@ -181,15 +162,12 @@ class ShortCircuitEmptyConfigurationResolverSpec extends Specification {
         DependencyLockingProvider lockingProvider = Mock()
         DependencyLockingState lockingState = Mock()
 
-        configuration.name >> 'lockedConf'
-        configuration.resolutionStrategy >> resolutionStrategy
-        dependencies.isEmpty() >> true
-        dependencyConstraints.isEmpty() >> true
-        configuration.getAllDependencies() >> dependencies
-        configuration.getAllDependencyConstraints() >> dependencyConstraints
+        resolveContext.name >> 'lockedConf'
+        resolveContext.resolutionStrategy >> resolutionStrategy
+        resolveContext.hasDependencies() >> false
 
         when:
-        dependencyResolver.resolveGraph(configuration, results)
+        dependencyResolver.resolveGraph(resolveContext, results)
 
         then:
         1 * resolutionStrategy.dependencyLockingEnabled >> true
@@ -197,42 +175,39 @@ class ShortCircuitEmptyConfigurationResolverSpec extends Specification {
         1 * lockingProvider.loadLockState('lockedConf') >> lockingState
         1 * lockingState.mustValidateLockState() >> true
         1 * lockingState.lockedDependencies >> [DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId('org', 'foo'), '1.0')]
-        1 * delegate.resolveGraph(configuration, results)
+        1 * delegate.resolveGraph(resolveContext, results)
     }
 
     def "delegates to backing service to resolve build dependencies when there are one or more dependencies"() {
         given:
-        dependencies.isEmpty() >> false
-        configuration.getAllDependencies() >> dependencies
+        resolveContext.hasDependencies() >> true
 
         when:
-        dependencyResolver.resolveBuildDependencies(configuration, results)
+        dependencyResolver.resolveBuildDependencies(resolveContext, results)
 
         then:
-        1 * delegate.resolveBuildDependencies(configuration, results)
+        1 * delegate.resolveBuildDependencies(resolveContext, results)
     }
 
     def "delegates to backing service to resolve graph when there are one or more dependencies"() {
         given:
-        dependencies.isEmpty() >> false
-        configuration.getAllDependencies() >> dependencies
+        resolveContext.hasDependencies() >> true
 
         when:
-        dependencyResolver.resolveGraph(configuration, results)
+        dependencyResolver.resolveGraph(resolveContext, results)
 
         then:
-        1 * delegate.resolveGraph(configuration, results)
+        1 * delegate.resolveGraph(resolveContext, results)
     }
 
     def "delegates to backing service to resolve artifacts when there are one or more dependencies"() {
         given:
-        dependencies.isEmpty() >> false
-        configuration.getAllDependencies() >> dependencies
+        resolveContext.hasDependencies() >> true
 
         when:
-        dependencyResolver.resolveArtifacts(configuration, results)
+        dependencyResolver.resolveArtifacts(resolveContext, results)
 
         then:
-        1 * delegate.resolveArtifacts(configuration, results)
+        1 * delegate.resolveArtifacts(resolveContext, results)
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -17,7 +17,6 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine
 
 import org.apache.ivy.core.module.id.ModuleRevisionId
 import org.gradle.api.Action
-import org.gradle.api.artifacts.DependencySet
 import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.ResolveException
@@ -27,7 +26,7 @@ import org.gradle.api.internal.artifacts.ComponentSelectorConverter
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
-import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal
+import org.gradle.api.internal.artifacts.ResolveContext
 import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.artifacts.dsl.ModuleReplacementsData
@@ -80,7 +79,7 @@ import static org.gradle.internal.component.external.model.DefaultModuleComponen
 import static org.gradle.internal.component.local.model.TestComponentIdentifiers.newProjectId
 
 class DependencyGraphBuilderTest extends Specification {
-    def configuration = Mock(ConfigurationInternal) {
+    def resolveContext = Mock(ResolveContext) {
         getResolutionStrategy() >> Stub(ResolutionStrategyInternal)
     }
     def conflictResolver = Mock(ModuleConflictResolver)
@@ -121,17 +120,15 @@ class DependencyGraphBuilderTest extends Specification {
     DependencyGraphBuilder builder
 
     def setup() {
-        _ * configuration.name >> 'root'
-        _ * configuration.path >> 'root'
-        _ * configuration.allDependencies >> Stub(DependencySet)
-        _ * configuration.toRootComponentMetaData() >> root
+        _ * resolveContext.name >> 'root'
+        _ * resolveContext.toRootComponentMetaData() >> root
 
         builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleConflictHandler, capabilitiesConflictHandler, Specs.satisfyAll(), attributesSchema, moduleExclusions, buildOperationProcessor, dependencySubstitutionApplicator, componentSelectorConverter, AttributeTestUtil.attributesFactory(), versionSelectorScheme, versionComparator.asVersionComparator(), new VersionParser())
     }
 
     private TestGraphVisitor resolve(DependencyGraphBuilder builder = this.builder) {
         def graphVisitor = new TestGraphVisitor()
-        builder.resolve(configuration, graphVisitor, false)
+        builder.resolve(resolveContext, graphVisitor, false)
         return graphVisitor
     }
 

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
@@ -152,7 +152,7 @@ public abstract class DependencyInsightReportTask extends DefaultTask {
                         "In order to use the '--all-variants' option, the configuration must not be resolved before this task is executed."
                     );
                 }
-                configurationInternal.setReturnAllVariants(true);
+                configurationInternal.getResolutionStrategy().setReturnAllVariants(true);
             }
             configurationName = configuration.getName();
             configurationDescription = configuration.toString();


### PR DESCRIPTION
ResolveContext models 'something that can be resolved'. We update the resolution pipeline to use this type instead of the more generalized 'ConfigurationInternal' so that in the future we may not need a full configuration to perform a resolution.

This further allows us to start splitting the configuration type into separate types for resolvable, consumable, and declarable