### PR TITLE
WIP: Enable load-after-store for all tests

### DIFF
--- a/subprojects/core/build.gradle.kts
+++ b/subprojects/core/build.gradle.kts
@@ -217,7 +217,3 @@ tasks.compileTestGroovy {
 integTest.usesJavadocCodeSnippets = true
 testFilesCleanup.reportOnly = true
 
-// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
-tasks.configCacheIntegTest {
-    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
-}

--- a/subprojects/docs/build.gradle
+++ b/subprojects/docs/build.gradle
@@ -595,8 +595,6 @@ tasks.named("docsTest") { task ->
     testClassesDirs = sourceSets.docsTest.output.classesDirs
     // 'integTest.samplesdir' is set to an absolute path by the 'org.gradle.samples' plugin
     systemProperties.clear()
-    // Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
-    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
 
     filter {
         // workaround for https://github.com/gradle/dotcom/issues/5958

--- a/subprojects/file-collections/build.gradle.kts
+++ b/subprojects/file-collections/build.gradle.kts
@@ -48,7 +48,3 @@ packageCycles {
     excludePatterns.add("org/gradle/api/internal/file/collections/**")
 }
 
-// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
-tasks.configCacheIntegTest {
-    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
-}

--- a/subprojects/file-watching/build.gradle.kts
+++ b/subprojects/file-watching/build.gradle.kts
@@ -31,7 +31,3 @@ dependencies {
     integTestDistributionRuntimeOnly(project(":distributions-core"))
 }
 
-// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
-tasks.configCacheIntegTest {
-    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
-}

--- a/subprojects/kotlin-dsl-integ-tests/build.gradle.kts
+++ b/subprojects/kotlin-dsl-integ-tests/build.gradle.kts
@@ -30,8 +30,3 @@ dependencies {
 }
 
 testFilesCleanup.reportOnly = true
-
-// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
-tasks.configCacheIntegTest {
-    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
-}

--- a/subprojects/kotlin-dsl-plugins/build.gradle.kts
+++ b/subprojects/kotlin-dsl-plugins/build.gradle.kts
@@ -98,8 +98,3 @@ pluginPublish {
         pluginClass = "org.gradle.kotlin.dsl.plugins.precompiled.PrecompiledScriptPlugins"
     )
 }
-
-// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
-tasks.configCacheIntegTest {
-    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
-}

--- a/subprojects/language-java/build.gradle.kts
+++ b/subprojects/language-java/build.gradle.kts
@@ -91,8 +91,3 @@ packageCycles {
 }
 
 integTest.usesJavadocCodeSnippets = true
-
-// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
-tasks.configCacheIntegTest {
-    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
-}

--- a/subprojects/language-native/build.gradle.kts
+++ b/subprojects/language-native/build.gradle.kts
@@ -73,7 +73,3 @@ packageCycles {
 
 integTest.usesJavadocCodeSnippets = true
 
-// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
-tasks.configCacheIntegTest {
-    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
-}

--- a/subprojects/launcher/build.gradle.kts
+++ b/subprojects/launcher/build.gradle.kts
@@ -89,7 +89,3 @@ strictCompile {
 
 testFilesCleanup.reportOnly = true
 
-// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
-tasks.configCacheIntegTest {
-    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
-}

--- a/subprojects/logging/build.gradle.kts
+++ b/subprojects/logging/build.gradle.kts
@@ -47,8 +47,3 @@ packageCycles {
     excludePatterns.add("org/gradle/internal/featurelifecycle/**")
     excludePatterns.add("org/gradle/util/**")
 }
-
-// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
-tasks.configCacheIntegTest {
-    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
-}

--- a/subprojects/model-core/build.gradle.kts
+++ b/subprojects/model-core/build.gradle.kts
@@ -69,7 +69,3 @@ packageCycles {
     excludePatterns.add("org/gradle/api/internal/plugins/*")
 }
 
-// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
-tasks.configCacheIntegTest {
-    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
-}

--- a/subprojects/plugin-development/build.gradle.kts
+++ b/subprojects/plugin-development/build.gradle.kts
@@ -61,8 +61,3 @@ integTest.usesJavadocCodeSnippets = true
 strictCompile {
     ignoreDeprecations()
 }
-
-// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
-tasks.configCacheIntegTest {
-    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
-}

--- a/subprojects/plugin-use/build.gradle.kts
+++ b/subprojects/plugin-use/build.gradle.kts
@@ -30,7 +30,3 @@ testFilesCleanup.reportOnly = true
 
 description = """Provides functionality for resolving and managing plugins during their application to projects."""
 
-// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
-tasks.configCacheIntegTest {
-    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
-}

--- a/subprojects/process-services/build.gradle.kts
+++ b/subprojects/process-services/build.gradle.kts
@@ -25,7 +25,3 @@ packageCycles {
     excludePatterns.add("org/gradle/process/internal/**")
 }
 
-// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
-tasks.configCacheIntegTest {
-    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
-}

--- a/subprojects/samples/build.gradle.kts
+++ b/subprojects/samples/build.gradle.kts
@@ -25,7 +25,3 @@ dependencies {
 
 testFilesCleanup.reportOnly = true
 
-// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
-tasks.configCacheIntegTest {
-    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
-}

--- a/subprojects/scala/build.gradle.kts
+++ b/subprojects/scala/build.gradle.kts
@@ -64,7 +64,3 @@ packageCycles {
 
 integTest.usesJavadocCodeSnippets = true
 
-// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
-tasks.configCacheIntegTest {
-    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
-}

--- a/subprojects/test-kit/build.gradle.kts
+++ b/subprojects/test-kit/build.gradle.kts
@@ -61,11 +61,6 @@ tasks.integMultiVersionTest {
     systemProperty("org.gradle.integtest.testkit.compatibility", "all")
 }
 
-// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
-tasks.configCacheIntegTest {
-    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
-}
-
 tasks {
     withType<Test>().configureEach {
         if (project.isBundleGroovy4) {

--- a/subprojects/testing-jvm/build.gradle.kts
+++ b/subprojects/testing-jvm/build.gradle.kts
@@ -55,8 +55,3 @@ packageCycles {
 }
 
 integTest.usesJavadocCodeSnippets = true
-
-// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
-tasks.configCacheIntegTest {
-    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
-}

--- a/subprojects/testing-native/build.gradle.kts
+++ b/subprojects/testing-native/build.gradle.kts
@@ -40,7 +40,3 @@ dependencies {
     integTestDistributionRuntimeOnly(project(":distributions-native"))
 }
 
-// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
-tasks.configCacheIntegTest {
-    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
-}

--- a/subprojects/workers/build.gradle.kts
+++ b/subprojects/workers/build.gradle.kts
@@ -47,8 +47,3 @@ dependencies {
     }
     integTestDistributionRuntimeOnly(project(":distributions-core"))
 }
-
-// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
-tasks.configCacheIntegTest {
-    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
-}


### PR DESCRIPTION
(to get a sense of how many tests are broken per project and find good candidates for a fix-it-day)

This will not be merged, no review is requested.
