### PR TITLE
Ignore configuration files for ASDF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ atlassian-ide-plugin.xml
 # Added GE support maven support to the maven build in .teamcity, per the GE docs, this dir is NOT to be committed
 .teamcity/.mvn/.gradle-enterprise/
 /discoclient.properties
+
+# Ignore local configuration files for asdf, allowing the JDK to be configured for project (https://asdf-vm.com)
+.tool-versions


### PR DESCRIPTION
With ASDF (https://asdf-vm.com), a local `.tool-versions` file can specify the JDK version to use for the project, ensuring that the correct JDK is used.