### PR TITLE
Fixes for artifact transforms when configuration cache is enabled

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildConfigurationAttributesResolveIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildConfigurationAttributesResolveIntegrationTest.groovy
@@ -107,6 +107,7 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
                 project(':b', 'test:b:') {
                     artifact(name: 'b-transitive')
                     edge('com.acme.external:external:1.0', ':includedBuild', 'com.acme.external:external:2.0-SNAPSHOT') {
+                        compositeSubstitute()
                         artifact(name: 'c-foo', fileName: 'c-foo.jar')
                     }
                 }
@@ -124,6 +125,7 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
                 project(':b', 'test:b:') {
                     artifact(name: 'b-transitive')
                     edge('com.acme.external:external:1.0', ':includedBuild', 'com.acme.external:external:2.0-SNAPSHOT') {
+                        compositeSubstitute()
                         artifact(name: 'c-bar', fileName: 'c-bar.jar')
                     }
                 }
@@ -216,6 +218,7 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
                     artifact(name: 'b-transitive')
                     module('com.acme.external:external:1.2') {
                         edge('com.acme.external:c:0.1', ':includedBuild', 'com.acme.external:c:2.0-SNAPSHOT') {
+                            compositeSubstitute()
                             artifact(name: 'c-foo', fileName: 'c-foo.jar')
                         }
                     }
@@ -235,6 +238,7 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
                     artifact(name: 'b-transitive')
                     module('com.acme.external:external:1.2') {
                         edge('com.acme.external:c:0.1', ':includedBuild', 'com.acme.external:c:2.0-SNAPSHOT') {
+                            compositeSubstitute()
                             artifact(name: 'c-bar', fileName: 'c-bar.jar')
                         }
                     }
@@ -324,6 +328,7 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
                     artifact(name: 'b-transitive')
                     module('com.acme.external:external:1.2') {
                         edge('com.acme.external:c:0.1', ':includedBuild', 'com.acme.external:c:2.0-SNAPSHOT') {
+                            compositeSubstitute()
                             artifact(name: 'c-foo', fileName: 'c-foo.jar')
                         }
                     }
@@ -347,6 +352,7 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
                     artifact(name: 'b-transitive')
                     module('com.acme.external:external:1.2') {
                         edge('com.acme.external:c:0.1', ':includedBuild', 'com.acme.external:c:2.0-SNAPSHOT') {
+                            compositeSubstitute()
                             artifact(name: 'c-bar', fileName: 'c-bar.jar')
                         }
                     }
@@ -438,6 +444,7 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
                 project(':b', 'test:b:') {
                     artifact(name: 'b-transitive')
                     edge('com.acme.external:external:1.0', ':includedBuild', 'com.acme.external:external:2.0-SNAPSHOT') {
+                        compositeSubstitute()
                         artifact(name: 'c-foo', fileName: 'c-foo.jar')
                     }
                 }
@@ -455,6 +462,7 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
                 project(':b', 'test:b:') {
                     artifact(name: 'b-transitive')
                     edge('com.acme.external:external:1.0', ':includedBuild', 'com.acme.external:external:2.0-SNAPSHOT') {
+                        compositeSubstitute()
                         artifact(name: 'c-bar', fileName: 'c-bar.jar')
                     }
                 }
@@ -567,6 +575,7 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
                 project(':b', 'test:b:') {
                     artifact(name: 'b-transitive')
                     edge('com.acme.external:external:1.0', ':includedBuild', 'com.acme.external:external:2.0-SNAPSHOT') {
+                        compositeSubstitute()
                         artifact(name: 'c-foo', fileName: 'c-foo.jar')
                     }
                 }
@@ -584,6 +593,7 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
                 project(':b', 'test:b:') {
                     artifact(name: 'b-transitive')
                     edge('com.acme.external:external:1.0', ':includedBuild', 'com.acme.external:external:2.0-SNAPSHOT') {
+                        compositeSubstitute()
                         artifact(name: 'c-bar', fileName: 'c-bar.jar')
                     }
                 }
@@ -802,6 +812,7 @@ All of them match the consumer attributes:
                 project(':b', 'test:b:') {
                     artifact(name: 'b-transitive')
                     edge('com.acme.external:external:1.0', ':includedBuild', 'com.acme.external:external:2.0-SNAPSHOT') {
+                        compositeSubstitute()
                         artifact(name: 'c-foo', fileName: 'c-foo.jar')
                     }
                 }
@@ -819,6 +830,7 @@ All of them match the consumer attributes:
                 project(':b', 'test:b:') {
                     artifact(name: 'b-transitive')
                     edge('com.acme.external:external:1.0', ':includedBuild', 'com.acme.external:external:2.0-SNAPSHOT') {
+                        compositeSubstitute()
                         artifact(name: 'c-bar', fileName: 'c-bar.jar')
                     }
                 }

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyGraphIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyGraphIntegrationTest.groovy
@@ -395,6 +395,7 @@ class CompositeBuildDependencyGraphIntegrationTest extends AbstractCompositeBuil
         checkGraph {
             module("org.external:external-dep:1.0") {
                 edge("org.test:buildB:1.0", ":buildB", "org.test:buildB:2.0") {
+                    forced()
                     compositeSubstitute()
                 }
             }
@@ -431,9 +432,11 @@ class CompositeBuildDependencyGraphIntegrationTest extends AbstractCompositeBuil
         checkGraph {
             module("org.external:external-dep:1.0") {
                 edge("org.test:something:1.0", ":buildB", "org.test:buildB:2.0") {
+                    selectedByRule()
                     compositeSubstitute()
                 }
                 edge("org.other:something-else:1.0", ":buildB:b1", "org.test:b1:2.0") {
+                    selectedByRule()
                     compositeSubstitute()
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
@@ -260,7 +260,11 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
             root(":", ":depsub:") {
                 edge("org.utils:impl:1.3", "org.utils:impl:1.3") {
                     selectedByRule()
-                    module("org.utils:api:1.3").selectedByRule()
+                    forced()
+                    module("org.utils:api:1.3") {
+                        selectedByRule()
+                        forced()
+                    }
                 }
             }
         }
@@ -661,6 +665,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
             root(":impl", "depsub:impl:") {
                 edge("org.utils:api:1.5", ":api", "depsub:api:") {
                     variant("default")
+                    forced()
                     selectedByRule()
                 }
             }
@@ -861,12 +866,16 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
         then:
         resolve.expectGraph {
             root(":impl", "depsub:impl:") {
-                edge("org.utils:dep1:1.5", "org.utils:dep1:2.0").byConflictResolution("between versions 1.6 and 2.0")
+                edge("org.utils:dep1:1.5", "org.utils:dep1:2.0") {
+                    byConflictResolution("between versions 1.6 and 2.0")
+                    selectedByRule()
+                }
                 edge("org.utils:dep1:2.0", "org.utils:dep1:2.0")
 
                 edge("org.utils:dep2:1.5", ":dep2", "org.utils:dep2:3.0") {
                     variant "default"
-                    selectedByRule().byConflictResolution("between versions 3.0 and 2.0")
+                    selectedByRule()
+                    byConflictResolution("between versions 3.0 and 2.0")
                 }
                 edge("org.utils:dep2:2.0", "org.utils:dep2:3.0")
 
@@ -932,7 +941,10 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
                 module("org.utils:b:1.3") {
                     module("org.utils:a:1.3")
                 }
-                edge("org.utils:a:1.2", "org.utils:a:1.3").byConflictResolution("between versions 1.3 and 1.2.1")
+                edge("org.utils:a:1.2", "org.utils:a:1.3") {
+                    selectedByRule()
+                    byConflictResolution("between versions 1.3 and 1.2.1")
+                }
             }
         }
     }
@@ -1349,6 +1361,7 @@ Required by:
         resolve.expectGraph {
             root(":", ":depsub:") {
                 edge("org:a:1.0", "org:c:2.0") {
+                    selectedByRule()
                     byConflictResolution("between versions 2.0 and 1.1")
                 }
                 module("org:a:2.0") {
@@ -1467,6 +1480,7 @@ configurations.all {
             root(":", ":depsub:") {
                 project(':sub', 'org.test:sub:0.0.1') {
                     configuration = 'default'
+                    selectedByRule()
                 }
                 edge('foo:bar:1', 'org.test:sub:0.0.1')
             }
@@ -1537,6 +1551,7 @@ configurations.all {
             root(":", ":depsub:") {
                 edge('org:lib:1.0', 'org:lib:1.1') {
                     selectedByRule()
+                    byConflictResolution("between versions 1.1 and 1.0")
                 }
                 module('org:other:1.0') {
                     module('org:lib:1.1')

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/LocalExcludeResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/LocalExcludeResolveIntegrationTest.groovy
@@ -69,8 +69,9 @@ dependencies {
 }
 
 task check {
+    def files = configurations.compile
     doLast {
-        assert configurations.compile.collect { it.name } == [${resolvedJars.collect { "'$it'" }.join(", ")}]
+        assert files.collect { it.name } == [${resolvedJars.collect { "'$it'" }.join(", ")}]
     }
 }
 """
@@ -115,14 +116,12 @@ dependencies {
     excluded 'org.gradle.test:direct:1.0'
 }
 
-def checkDeps(config, expectedDependencies) {
-    assert config*.name as Set == expectedDependencies as Set
-}
-
 task test {
+    def excluded = configurations.excluded
+    def extendedExcluded = configurations.extendedExcluded
     doLast {
-        checkDeps configurations.excluded, ['external-1.0.jar']
-        checkDeps configurations.extendedExcluded, ['external-1.0.jar']
+        assert excluded*.name == ['external-1.0.jar']
+        assert extendedExcluded*.name == ['external-1.0.jar']
     }
 }
 """
@@ -161,8 +160,9 @@ dependencies {
 }
 
 task check {
+    def files = configurations.compile
     doLast {
-        assert configurations.compile.collect { it.name } == [${expectedJars.collect { "'${it}.jar'" }.join(", ")}]
+        assert files.collect { it.name } == [${expectedJars.collect { "'${it}.jar'" }.join(", ")}]
     }
 }
 """
@@ -256,8 +256,9 @@ task check {
             }
 
             task resolve() {
+                def files = configurations.foo
                 doLast {
-                    configurations.foo.resolve()
+                    files.files
                 }
             }
         """
@@ -293,8 +294,9 @@ def checkDeps(config, expectedDependencies) {
 }
 
 task test {
+    def files = configurations.excluded
     doLast {
-        assert configurations.excluded.collect { it.name } == ['external-1.0.jar']
+        assert files.collect { it.name } == ['external-1.0.jar']
     }
 }
 """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ModuleDependencyExcludeResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ModuleDependencyExcludeResolveIntegrationTest.groovy
@@ -439,6 +439,7 @@ task check(type: Sync) {
                     edge("b:b:1.0", "b:b:2.0")
                     module("c:c:1.0") {
                         module("b:b:2.0") {
+                            byConflictResolution("between versions 2.0 and 1.0")
                             // 'd' is NOT excluded, because the exclude in 'a:a:1.0 --depends-on--> b:b:1.0' only excludes 'e'
                             module("d:d:1.0")
                         }
@@ -527,7 +528,9 @@ task check(type: Sync) {
                 module('org.test:depD:1.0') {
                     module('org.test:depC:1.0') {
                         module('org.test:depB:1.0') {
-                            module('org.test:depA:1.0')
+                            module('org.test:depA:1.0') {
+                                byConstraint()
+                            }
                         }
                     }
                 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
@@ -138,9 +138,11 @@ project(":b") {
         resolve.expectGraph {
             root(":b", "test:b:") {
                 project(":a", 'test:a:') {
+                    notRequested()
                     byReason('can provide a dependency reason for project dependencies too')
                     variant('runtime')
                     module('org.other:externalA:1.2') {
+                        notRequested()
                         byReason('also check dependency reasons')
                         variant('runtime', ['org.gradle.status': 'release', 'org.gradle.category': 'library', 'org.gradle.usage': 'java-runtime', 'org.gradle.libraryelements': 'jar'])
                     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishedRichVersionConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishedRichVersionConstraintsIntegrationTest.groovy
@@ -105,7 +105,9 @@ class PublishedRichVersionConstraintsIntegrationTest extends AbstractModuleDepen
                 edge("org:foo:{strictly [1.0,1.2]}", "org:foo:1.2")
                 edge('org:bar:1.0', 'org:bar:1.0') {
                     edge("org:foo:{strictly [1.1,1.3]}", "org:foo:1.2") {
+                        notRequested()
                         byAncestor()
+                        byReason("didn't match version 1.3")
                     }
                 }
             }
@@ -162,7 +164,9 @@ class PublishedRichVersionConstraintsIntegrationTest extends AbstractModuleDepen
         resolve.expectGraph {
             root(":", ":test:") {
                 module('org:bar:1') {
-                    edge("org:foo:{prefer 1.1}", "org:foo:1.1")
+                    edge("org:foo:{prefer 1.1}", "org:foo:1.1") {
+                        byReason("didn't match version 2.0")
+                    }
                 }
                 module('org:baz:1') {
                     edge("org:foo:{prefer 1.0}", "org:foo:1.1")
@@ -208,7 +212,9 @@ class PublishedRichVersionConstraintsIntegrationTest extends AbstractModuleDepen
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge('org:foo:{strictly 17}', 'org:foo:17')
+                edge('org:foo:{strictly 17}', 'org:foo:17') {
+                    byAncestor()
+                }
                 module('org:bar:1.0') {
                     edge("org:foo:{strictly 15}", "org:foo:17")
                 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RichVersionConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RichVersionConstraintsIntegrationTest.groovy
@@ -86,7 +86,9 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:foo", "org:foo:1.0")
+                edge("org:foo", "org:foo:1.0") {
+                    byConstraint()
+                }
                 constraint("org:foo:{strictly 1.0}", "org:foo:1.0")
             }
         }
@@ -138,6 +140,7 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
                 constraint("org:foo:{prefer 1.0.0}", "org:foo:1.1.0")
                 constraint("org:foo:{prefer 1.1.0}", "org:foo:1.1.0")
                 edge("org:foo:[1.0.0,2.0.0)", "org:foo:1.1.0") {
+                    notRequested()
                     byConstraint()
                     byReason("didn't match version 2.0.0")
                 }
@@ -311,7 +314,9 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge "org:foo:{strictly 1.0}", "org:foo:1.0"
+                edge ("org:foo:{strictly 1.0}", "org:foo:1.0") {
+                    byAncestor()
+                }
                 edge("org:bar:1.0", "org:bar:1.0") {
                     edge "org:foo:1.0", "org:foo:1.0"
                 }
@@ -420,6 +425,8 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
                         if (transitiveDependencyVersion != resolvedVersion) {
                             byAncestor()
                         }
+                        maybeRequested()
+                        maybeByReason("didn't match version 1.3")
                     }
                 }
             }
@@ -619,7 +626,9 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
                 project(':other', 'test:other:') {
                     configuration 'conf'
                     edge('org:foo:{strictly [17,18]}', 'org:foo:16') {
+                        notRequested()
                         byAncestor()
+                        byReason("didn't match versions 18, 17")
                     }
                     noArtifacts()
                 }
@@ -739,7 +748,10 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:foo:{require $notation; reject 1.1}", "org:foo:1.0").byReason("rejected version 1.1")
+                edge("org:foo:{require $notation; reject 1.1}", "org:foo:1.0") {
+                    notRequested()
+                    byReason("rejected version 1.1")
+                }
             }
         }
 
@@ -829,7 +841,10 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:foo:{require [1.0,); reject [1.2, 1.5]}", "org:foo:1.1").byReason("rejected versions 1.5, 1.4, 1.3, 1.2")
+                edge("org:foo:{require [1.0,); reject [1.2, 1.5]}", "org:foo:1.1") {
+                    notRequested()
+                    byReason("rejected versions 1.5, 1.4, 1.3, 1.2")
+                }
             }
         }
     }
@@ -912,7 +927,10 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
         resolve.expectGraph {
             root(":", ":test:") {
                 String rejectedVersions = (selected + 1..5).collect { "1.${it}" }.reverse().join(", ")
-                edge("org:foo:{require $notation; reject ${rejects.join(' & ')}}", "org:foo:1.$selected").byReason("rejected versions ${rejectedVersions}")
+                edge("org:foo:{require $notation; reject ${rejects.join(' & ')}}", "org:foo:1.$selected") {
+                    notRequested()
+                    byReason("rejected versions ${rejectedVersions}")
+                }
             }
         }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionConflictResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionConflictResolutionIntegrationTest.groovy
@@ -251,12 +251,15 @@ dependencies {
             root(":", ":test:") {
                 module("org:one:1.0") {
                     edge("org:control:1.0", "org:control:1.2") {
-                        edge("org:dep:2.5", "org:dep:2.5")
+                        byConflictResolution("between versions 1.2 and 1.0")
+                        module("org:dep:2.5")
                     }
                 }
                 module("org:two:1.0") {
                     module("org:dep-2.0-bringer:1.0") {
-                        edge("org:dep:2.0", "org:dep:2.5").byConflictResolution("between versions 2.5 and 2.0")
+                        edge("org:dep:2.0", "org:dep:2.5") {
+                            byConflictResolution("between versions 2.5 and 2.0")
+                        }
                     }
                     module("org:control-1.2-bringer:1.0") {
                         module("org:control:1.2")
@@ -327,8 +330,11 @@ dependencies {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                module("org:child:2")
+                module("org:child:2") {
+                    byConflictResolution("between versions 2 and 1")
+                }
                 edge("org:parent:1", "org:parent:2") {
+                    byConflictResolution("between versions 2 and 1")
                     module("org:child:2")
                 }
                 module("org:dep:2") {
@@ -364,7 +370,9 @@ dependencies {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:external:1.2", "org:external:1.4")
+                edge("org:external:1.2", "org:external:1.4") {
+                    byConflictResolution("between versions 1.2 and 1.4")
+                }
                 module("org:dep:2.2") {
                     edge("org:external:[1.3,)", "org:external:1.4")
                 }
@@ -425,7 +433,9 @@ dependencies {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:external:1.2", "org:external:1.4")
+                edge("org:external:1.2", "org:external:1.4") {
+                    byConflictResolution("between versions 1.4 and 1.2")
+                }
                 module("org:dep:2.2") {
                     module("org:external:1.4")
                 }
@@ -488,7 +498,10 @@ project(':tool') {
         resolve.expectGraph {
             root(":tool", "test:tool:") {
                 project(":api", "test:api:") {
-                    edge("org:foo:1.4.4", "org:foo:1.4.9")
+                    edge("org:foo:1.4.4", "org:foo:1.4.9") {
+                        forced()
+                        byReason("didn't match version 1.6.0")
+                    }
                 }
                 project(":impl", "test:impl:") {
                     edge("org:foo:1.4.1", "org:foo:1.4.9")
@@ -591,6 +604,7 @@ configurations.all {
                 edge("org:a:1.0", "org:a:2.0")
                 module("org:a:2.0") {
                     configuration = "default"
+                    byConflictResolution("between versions 2.0 and 1.0")
                     module("org:b:2.0") {
                         edge("org:a:1.0", "org:a:2.0")
                     }
@@ -646,7 +660,9 @@ configurations.all {
         resolve.expectGraph {
             root(":", ":test:") {
                 module("org:a:1.0") {
-                    edge("org:in-conflict:1.0", "org:in-conflict:2.0")
+                    edge("org:in-conflict:1.0", "org:in-conflict:2.0") {
+                        byConflictResolution("between versions 2.0 and 1.0")
+                    }
                 }
                 module("org:b:1.0") {
                     module("org:b-child:1.0") {
@@ -835,10 +851,14 @@ dependencies {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                module("org:a:2")
+                module("org:a:2") {
+                    byConflictResolution("between versions 2 and 1")
+                }
                 edge("org:a:1", "org:a:2") {
                     module("org:b:1") {
-                        edge("org:c:1", "org:c:2")
+                        edge("org:c:1", "org:c:2") {
+                            byConflictResolution("between versions 2 and 1")
+                        }
                     }
                 }
                 module("org:c:2")
@@ -946,7 +966,9 @@ dependencies {
         resolve.expectGraph {
             root(":", ":test:") {
                 module("org:a:1.0") {
-                    edge("org:leaf:[2,6]", "org:leaf:6")
+                    edge("org:leaf:[2,6]", "org:leaf:6") {
+                        byReason("didn't match versions 10, 9, 8, 7")
+                    }
                 }
                 module("org:b:1.0") {
                     edge("org:leaf:[4,8]", "org:leaf:6")
@@ -986,7 +1008,9 @@ dependencies {
         resolve.expectGraph {
             root(":", ":test:") {
                 module("org:a:1.0") {
-                    edge("org:leaf:[2,6]", "org:leaf:5")
+                    edge("org:leaf:[2,6]", "org:leaf:5") {
+                        byReason("didn't match versions 10, 9, 8, 7")
+                    }
                 }
                 module("org:b:1.0") {
                     edge("org:leaf:[4,8]", "org:leaf:5")
@@ -1027,7 +1051,9 @@ dependencies {
         resolve.expectGraph {
             root(":", ":test:") {
                 module("org:a:1.0") {
-                    edge("org:leaf:[2,6]", "org:leaf:6")
+                    edge("org:leaf:[2,6]", "org:leaf:6") {
+                        byReason("didn't match versions 10, 9, 8, 7")
+                    }
                 }
                 module("org:b:1.0") {
                     edge("org:leaf:[4,8]", "org:leaf:6")
@@ -1065,7 +1091,10 @@ dependencies {
         resolve.expectGraph {
             root(":", ":test:") {
                 module("org:a:1.0") {
-                    edge("org:leaf:[2,6]", "org:leaf:5")
+                    edge("org:leaf:[2,6]", "org:leaf:5") {
+                        byReason("didn't match versions 10, 9, 8, 7")
+                        byReason("didn't match versions 10, 9, 8, 7, 6")
+                    }
                 }
                 module("org:b:1.0") {
                     edge("org:leaf:[4,8]", "org:leaf:5")
@@ -1115,14 +1144,14 @@ dependencies {
             root(":", ":test:") {
                 module("org:a:1.0") {
                     edge("org:leaf:[2,6]", "org:leaf:5") {
+                        notRequested()
                         byReason("didn't match versions 10, 9, 8, 7")
+                        byReason("didn't match versions 10, 9, 8, 7, 6")
                     }
                 }
                 module("org:b:1.0") {
                     module("org:b2:1.0") {
-                        edge("org:leaf:[3,5]", "org:leaf:5") {
-                            byReason("didn't match versions 10, 9, 8, 7, 6")
-                        }
+                        edge("org:leaf:[3,5]", "org:leaf:5")
                     }
                 }
                 module("org:c:1.0") {
@@ -1165,14 +1194,14 @@ dependencies {
             root(":", ":test:") {
                 module("org:a:1.0") {
                     edge("org:leaf:[2,3]", "org:leaf:8") {
+                        notRequested()
+                        byReason("didn't match versions 10, 9")
                         byReason("didn't match versions 10, 9, 8, 7, 6, 5, 4")
-                        byReason("conflict resolution: between versions 3 and 8")
+                        byConflictResolution("between versions 3 and 8")
                     }
                 }
                 module("org:b:1.0") {
-                    edge("org:leaf:[5,8]", "org:leaf:8") {
-                        byReason("didn't match versions 10, 9")
-                    }
+                    edge("org:leaf:[5,8]", "org:leaf:8")
                 }
             }
         }
@@ -1276,19 +1305,18 @@ dependencies {
             root(":", ":test:") {
                 module("org:a:1.0") {
                     edge("org:leaf:[2,6]", "org:leaf:8") {
+                        notRequested()
+                        byReason("didn't match versions 10, 9")
                         byReason("didn't match versions 10, 9, 8, 7")
-                        byReason("conflict resolution: between versions 8 and 4")
+                        byReason("didn't match versions 10, 9, 8, 7, 6, 5")
+                        byConflictResolution("between versions 8 and 4")
                     }
                 }
                 module("org:b:1.0") {
-                    edge("org:leaf:[3,4]", "org:leaf:8") {
-                        byReason("didn't match versions 10, 9, 8, 7, 6, 5")
-                    }
+                    edge("org:leaf:[3,4]", "org:leaf:8")
                 }
                 module("org:c:1.0") {
-                    edge("org:leaf:[7,8]", "org:leaf:8") {
-                        byReason("didn't match versions 10, 9")
-                    }
+                    edge("org:leaf:[7,8]", "org:leaf:8")
                 }
             }
         }
@@ -1363,7 +1391,11 @@ dependencies {
         resolve.expectGraph {
             root(":", ":test:") {
                 module("org:a:1.0") {
-                    edge("org:leaf:[1,12]", "org:leaf:7")
+                    edge("org:leaf:[1,12]", "org:leaf:7") {
+                        byReason("didn't match versions 12, 11")
+                        byReason("didn't match versions 12, 11, 10, 9")
+                        byReason("didn't match versions 12, 11, 10, 9, 8")
+                    }
                 }
                 module("org:b:1.0") {
                     edge("org:leaf:[3,8]", "org:leaf:7")
@@ -1409,7 +1441,9 @@ dependencies {
         resolve.expectGraph {
             root(":", ":test:") {
                 module("org:a:1.0") {
-                    edge("org:leaf:[2,6]", "org:leaf:6")
+                    edge("org:leaf:[2,6]", "org:leaf:6") {
+                        byReason("didn't match versions 10, 9, 8, 7")
+                    }
                 }
                 module("org:b:1.0") {
                     edge("org:leaf:[5,)", "org:leaf:6")
@@ -1446,7 +1480,10 @@ dependencies {
         resolve.expectGraph {
             root(":", ":test:") {
                 module("org:a:1.0") {
-                    edge("org:leaf:[1.2,1.6]", "org:leaf:1.10")
+                    edge("org:leaf:[1.2,1.6]", "org:leaf:1.10") {
+                        byConflictResolution("between versions 1.6 and 1.10")
+                        byReason("didn't match versions 1.10, 1.9, 1.8, 1.7")
+                    }
                 }
                 module("org:b:1.0") {
                     edge("org:leaf:1.+", "org:leaf:1.10")
@@ -1537,13 +1574,17 @@ dependencies {
         resolve.expectGraph {
             root(":", ":test:") {
                 module("org:a:1.0") {
-                    edge("org:leaf:[2,6]", "org:leaf:6")
+                    edge("org:leaf:[2,6]", "org:leaf:6") {
+                        byReason("didn't match versions 10, 9, 8, 7")
+                    }
                 }
                 module("org:b:1.0") {
                     edge("org:leaf:[4,8]", "org:leaf:6")
                 }
                 module("org:c:1.0") {
-                    edge("org:leaf2:[3,4]", "org:leaf2:4")
+                    edge("org:leaf2:[3,4]", "org:leaf2:4") {
+                        byReason("didn't match versions 10, 9, 8, 7, 6, 5")
+                    }
                 }
                 module("org:d:1.0") {
                     edge("org:leaf2:[1,7]", "org:leaf2:4")
@@ -1587,13 +1628,14 @@ dependencies {
             root(":", ":test:") {
                 module("org:a:1.0") {
                     edge("org:leaf:[1,8]", "org:leaf:6") {
+                        notRequested()
                         byReason("didn't match versions 10, 9")
+                        byReason("didn't match versions 10, 9, 8, 7")
+                        module("org:zdep:6")
                     }
                     edge("org:c:1.0", "org:c:1.1") {
-                        edge("org:leaf:[4,6]", "org:leaf:6") {
-                            byReason("didn't match versions 10, 9, 8, 7")
-                            module("org:zdep:6")
-                        }
+                        byConflictResolution("between versions 1.1 and 1.0")
+                        edge("org:leaf:[4,6]", "org:leaf:6")
                     }
                 }
                 module("org:b:1.0") {
@@ -1634,7 +1676,10 @@ dependencies {
         resolve.expectGraph {
             root(":", ":test:") {
                 edge("org:a:1.0", "org:a:2.0") {
-                    edge("org:e:[4,8]", "org:e:8")
+                    byConflictResolution("between versions 2.0 and 1.0")
+                    edge("org:e:[4,8]", "org:e:8") {
+                        byReason("didn't match versions 10, 9")
+                    }
                 }
                 module("org:b:1.0") {
                     edge("org:e:[1,10]", "org:e:8")
@@ -1677,7 +1722,9 @@ dependencies {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:a:1.0", "org:a:2.0")
+                edge("org:a:1.0", "org:a:2.0") {
+                    byConflictResolution("between versions 2.0 and 1.0")
+                }
                 module("org:b:1.0") {
                     module("org:a:2.0")
                 }
@@ -1721,7 +1768,10 @@ dependencies {
         resolve.expectGraph {
             root(":", ":test:") {
                 edge("org:a:1.0", "org:a:2.0") {
-                    module("org:c:2.0")
+                    byConflictResolution("between versions 2.0 and 1.0")
+                    module("org:c:2.0") {
+                        byConflictResolution("between versions 2.0 and 1.0")
+                    }
                 }
                 edge("org:c:1.0", "org:c:2.0")
                 module("org:d:1.0") {
@@ -1761,7 +1811,9 @@ dependencies {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:a:1.0", "org:a:2.0")
+                edge("org:a:1.0", "org:a:2.0") {
+                    byConflictResolution("between versions 2.0 and 1.0")
+                }
                 module("org:c:1.0") {
                     edge("org:a:1.0", "org:a:2.0")
                 }
@@ -1801,10 +1853,13 @@ dependencies {
         resolve.expectGraph {
             root(":", ":test:") {
                 edge("org:a:[1,3]", "org:a:3") {
+                    notRequested()
                     byReason("didn't match version 4")
                     module("org:e:3")
                 }
-                edge("org:b:1", "org:b:2")
+                edge("org:b:1", "org:b:2") {
+                    byConflictResolution("between versions 2 and 1")
+                }
                 module("org:c:1") {
                     module("org:d:1") {
                         module("org:b:2")
@@ -1843,7 +1898,9 @@ dependencies {
         resolve.expectGraph {
             root(":", ":test:") {
                 module("org:a:1")
-                edge("org:b:1", "org:b:2")
+                edge("org:b:1", "org:b:2") {
+                    byConflictResolution("between versions 2 and 1")
+                }
                 module("org:c:1") {
                     module("org:d:1") {
                         module("org:b:2")
@@ -1880,7 +1937,9 @@ dependencies {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:a:1", "org:a:2")
+                edge("org:a:1", "org:a:2") {
+                    byConflictResolution("between versions 2 and 1")
+                }
                 module("org:b:1")
                 module("org:c:1") {
                     module("org:a:2")

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/AlignmentIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/AlignmentIntegrationTest.groovy
@@ -53,9 +53,14 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
             root(":", ":test:") {
                 edge("org:xml:1.0", "org:xml:1.1") {
                     byConstraint("belongs to platform org:platform:1.1")
-                    module('org:core:1.1')
+                    byConflictResolution("between versions 1.1 and 1.0")
+                    module('org:core:1.1') {
+                        byConstraint("belongs to platform org:platform:1.1")
+                        byConflictResolution("between versions 1.1 and 1.0")
+                    }
                 }
                 module("org:json:1.1") {
+                    byConstraint("belongs to platform org:platform:1.1")
                     module('org:core:1.1')
                 }
             }
@@ -100,13 +105,19 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
             root(":", ":test:") {
                 edge("org:xml:1.0", "org:xml:1.1") {
                     byConstraint("belongs to platform org:platform:1.1")
-                    module('org:core:1.1')
+                    byConflictResolution("between versions 1.1 and 1.0")
+                    module('org:core:1.1') {
+                        byConstraint("belongs to platform org:platform:1.1")
+                        byConflictResolution("between versions 1.1 and 1.0")
+                    }
                 }
                 module("org:json:1.1") {
+                    byConstraint("belongs to platform org:platform:1.1")
                     module('org:core:1.1')
                 }
                 module("outside:module:1.0") {
-                    edge('org:core:1.0', 'org:core:1.1').byConflictResolution("between versions 1.1 and 1.0")
+                    byConstraint("belongs to platform outside:platform:1.0")
+                    edge('org:core:1.0', 'org:core:1.1')
                 }
             }
         }
@@ -146,10 +157,15 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
             root(":", ":test:") {
                 edge("org:xml:1.0", "org:xml:1.1") {
                     byConstraint("belongs to platform org:platform:1.1")
+                    byConflictResolution("between versions 1.1 and 1.0")
                 }
                 edge("org:json:1.0", "org:json:1.1") {
                     byConstraint("belongs to platform org:platform:1.1")
-                    module('org:core:1.1')
+                    byConflictResolution("between versions 1.1 and 1.0")
+                    module('org:core:1.1') {
+                        byConstraint("belongs to platform org:platform:1.1")
+                        byConflictResolution("between versions 1.1 and 1.0")
+                    }
                 }
                 module('org:core:1.1')
             }
@@ -185,11 +201,14 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
         resolve.expectGraph {
             root(":", ":test:") {
                 module("org:xml:1.0") {
-                    edge('org:core:1.0', 'org:core:1.1')
-                        .byConflictResolution("between versions 1.1 and 1.0")
-                        .byConstraint("belongs to platform org:platform:1.1")
+                    byConstraint("belongs to platform org:platform:1.1")
+                    edge('org:core:1.0', 'org:core:1.1') {
+                        byConstraint("belongs to platform org:platform:1.1")
+                        byConflictResolution("between versions 1.1 and 1.0")
+                    }
                 }
                 module("org:json:1.1") {
+                    byConstraint("belongs to platform org:platform:1.1")
                     module('org:core:1.1')
                 }
             }
@@ -226,10 +245,14 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
         resolve.expectGraph {
             root(":", ":test:") {
                 edge("org:xml:1.0", "org:xml:1.1") {
-                    module('org:core:1.0')
                     byConstraint("belongs to platform org:platform:1.1")
+                    byConflictResolution("between versions 1.1 and 1.0")
+                    module('org:core:1.0') {
+                        byConstraint("belongs to platform org:platform:1.1")
+                    }
                 }
                 module("org:json:1.1") {
+                    byConstraint("belongs to platform org:platform:1.1")
                     module('org:core:1.0')
                 }
             }
@@ -276,12 +299,22 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                module('org:core:2.9.4')
-                edge('org:databind:2.7.9', 'org:databind:2.9.4').byConstraint("belongs to platform org:platform:2.9.4.1")
+                module('org:core:2.9.4') {
+                    byConstraint("belongs to platform org:platform:2.9.4.1")
+                    byConflictResolution("between versions 2.9.4 and 2.7.9")
+                }
+                edge('org:databind:2.7.9', 'org:databind:2.9.4') {
+                    byConflictResolution("between versions 2.9.4 and 2.7.9")
+                    byConstraint("belongs to platform org:platform:2.9.4.1")
+                }
                 module('org:kt:2.9.4.1') {
+                    byConstraint("belongs to platform org:platform:2.9.4.1")
                     module('org:databind:2.9.4') {
-                        module('org:core:2.9.4').byConstraint("belongs to platform org:platform:2.9.4.1")
-                        edge('org:annotations:2.9.0', 'org:annotations:2.9.4').byConstraint("belongs to platform org:platform:2.9.4.1")
+                        module('org:core:2.9.4')
+                        edge('org:annotations:2.9.0', 'org:annotations:2.9.4') {
+                            byConstraint("belongs to platform org:platform:2.9.4.1")
+                            byConflictResolution("between versions 2.9.4 and 2.9.0")
+                        }
                     }
                 }
             }
@@ -326,12 +359,22 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                module('org:core:2.9.4').byConstraint("belongs to platform org:platform:2.9.4.1")
-                edge('org:databind:2.7.9', 'org:databind:2.9.4').byConstraint("belongs to platform org:platform:2.9.4.1")
+                module('org:core:2.9.4') {
+                    byConstraint("belongs to platform org:platform:2.9.4.1")
+                    byConflictResolution("between versions 2.9.4 and 2.7.9")
+                }
+                edge('org:databind:2.7.9', 'org:databind:2.9.4') {
+                    byConstraint("belongs to platform org:platform:2.9.4.1")
+                    byConflictResolution("between versions 2.9.4 and 2.7.9")
+                }
                 module('org:kt:2.9.4.1') {
+                    byConstraint("belongs to platform org:platform:2.9.4.1")
                     module('org:databind:2.9.4') {
                         module('org:core:2.9.4').byConstraint("belongs to platform org:platform:2.9.4.1")
-                        edge('org:annotations:2.9.0', 'org:annotations:2.9.4').byConstraint("belongs to platform org:platform:2.9.4.1")
+                        edge('org:annotations:2.9.0', 'org:annotations:2.9.4') {
+                            byConstraint("belongs to platform org:platform:2.9.4.1")
+                            byConflictResolution("between versions 2.9.4 and 2.9.0")
+                        }
                     }
                 }
             }
@@ -420,9 +463,15 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
         resolve.expectGraph {
             root(":", ":test:") {
                 module('org:core:2.9.4') {
-                    edge("org:platform:2.9.4", "org:platform:2.9.4.1")
+                    byConstraint()
+                    byConflictResolution("between versions 2.9.4 and 2.7.9")
+                    edge("org:platform:2.9.4", "org:platform:2.9.4.1") {
+                        byConflictResolution("between versions 2.9.4.1 and 2.9.4")
+                    }
                 }
                 edge('org:databind:2.7.9', 'org:databind:2.9.4') {
+                    byConstraint()
+                    byConflictResolution("between versions 2.9.4 and 2.7.9")
                     edge("org:platform:2.9.4", "org:platform:2.9.4.1")
                 }
                 module('org:kt:2.9.4.1') {
@@ -436,6 +485,8 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
                     module('org:databind:2.9.4') {
                         module('org:core:2.9.4')
                         edge('org:annotations:2.9.0', 'org:annotations:2.9.4') {
+                            byConstraint()
+                            byConflictResolution("between versions 2.9.4 and 2.9.0")
                             edge("org:platform:2.9.4", "org:platform:2.9.4.1")
                         }
                     }
@@ -486,17 +537,27 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
             root(":", ":test:") {
                 edge("org:xml:1.0", "org:xml:1.1") {
                     byConstraint("belongs to platform org:platform:1.1")
-                    module('org:core:1.1')
+                    byConflictResolution("between versions 1.1 and 1.0")
+                    module('org:core:1.1') {
+                        byConstraint("belongs to platform org:platform:1.1")
+                        byConflictResolution("between versions 1.1 and 1.0")
+                    }
                 }
                 module("org:json:1.1") {
+                    byConstraint("belongs to platform org:platform:1.1")
                     module('org:core:1.1')
                 }
 
                 edge("org2:xml:1.0", "org2:xml:1.1") {
                     byConstraint("belongs to platform org2:platform:1.1")
-                    module('org2:core:1.1')
+                    byConflictResolution("between versions 1.1 and 1.0")
+                    module('org2:core:1.1') {
+                        byConstraint("belongs to platform org2:platform:1.1")
+                        byConflictResolution("between versions 1.1 and 1.0")
+                    }
                 }
                 module("org2:json:1.1") {
+                    byConstraint("belongs to platform org2:platform:1.1")
                     module('org2:core:1.1')
                 }
             }
@@ -542,7 +603,10 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
         resolve.expectGraph {
             root(":", ":test:") {
                 module('org:xml:1.0') {
-                    module('org:core:1.0')
+                    byConstraint("belongs to platform org:platform:1.0")
+                    module('org:core:1.0') {
+                        byConstraint("belongs to platform org:platform:1.0")
+                    }
                 }
                 module('org2:foo:1.0') {
                     edge('org4:a:1.0', 'org4:a:1.1') {
@@ -611,12 +675,13 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
             root(":", ":test:") {
                 edge("org:xml:1.0", "org:xml:1.0") {
                     byConstraint("belongs to platform org:platform:1.1")
-                    // byReason("version 1.1 is buggy") // TODO CC: uncomment when we collect rejection from component selection rule
                     edge('org:core:1.0', 'org:core:1.1') {
+                        byConstraint("belongs to platform org:platform:1.1")
                         byConflictResolution("between versions 1.1 and 1.0")
                     }
                 }
                 module("org:json:1.1") {
+                    byConstraint("belongs to platform org:platform:1.1")
                     module('org:core:1.1')
                 }
             }
@@ -657,9 +722,16 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
                 edge("org:xml:1.0", "org:xml:1.1") {
                     byConstraint("belongs to platform org:platform:1.1")
                     byConstraint("belongs to platform org:platform2:1.1")
-                    module('org:core:1.1')
+                    byConflictResolution("between versions 1.1 and 1.0")
+                    module('org:core:1.1') {
+                        byConstraint("belongs to platform org:platform:1.1")
+                        byConstraint("belongs to platform org:platform2:1.1")
+                        byConflictResolution("between versions 1.1 and 1.0")
+                    }
                 }
                 module("org:json:1.1") {
+                    byConstraint("belongs to platform org:platform:1.1")
+                    byConstraint("belongs to platform org:platform2:1.1")
                     module('org:core:1.1')
                 }
             }
@@ -741,8 +813,13 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
         resolve.expectGraph {
             root(":", ":test:") {
                 edge("org.apache.groovy:xml:2.4", "org.apache.groovy:xml:2.5") {
+                    byConstraint()
+                    byConflictResolution("between versions 2.5 and 2.4")
                     module("org.apache.groovy:core:2.5") {
+                        byConstraint()
+                        byConflictResolution("between versions 2.5 and 2.4")
                         module("org.apache.groovy:platform:2.5") {
+                            byConflictResolution("between versions 2.5 and 2.4")
                             noArtifacts()
                             module("org.apache.groovy:platform:2.5")          // The way the rule is defined, it is applied to the platform itself.
                             module("org.springframework:spring-platform:1.0") // This is not good practice, but we keep this to describe the current behavior.
@@ -760,11 +837,13 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
                     module("org.springframework:spring-platform:1.0")
                 }
                 module("org.apache.groovy:json:2.5") {
+                    byConstraint()
                     module("org.apache.groovy:core:2.5")
                     module("org.apache.groovy:platform:2.5")
                     module("org.springframework:spring-platform:1.0")
                 }
                 edge("org.springframework:core:1.0", "org.springframework:core:1.1") {
+                    byConstraint()
                     byConflictResolution("between versions 1.1 and 1.0")
                 }
             }
@@ -838,7 +917,12 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
         resolve.expectGraph {
             root(":", ":test:") {
                 edge("org.apache.groovy:xml:2.4", "org.apache.groovy:xml:2.5") {
+                    byConstraint("belongs to platform org.apache.groovy:platform:2.5")
+                    byConflictResolution("between versions 2.5 and 2.4")
                     module("org.apache.groovy:core:2.5") {
+                        byConstraint()
+                        byConstraint("belongs to platform org.apache.groovy:platform:2.5")
+                        byConflictResolution("between versions 2.5 and 2.4")
                         module("org.springframework:spring-platform:1.0") {
                             noArtifacts()
                             constraint("org.apache.groovy:core:2.4", "org.apache.groovy:core:2.5")
@@ -848,10 +932,12 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
                     module("org.springframework:spring-platform:1.0")
                 }
                 module("org.apache.groovy:json:2.5") {
+                    byConstraint("belongs to platform org.apache.groovy:platform:2.5")
                     module("org.apache.groovy:core:2.5")
                     module("org.springframework:spring-platform:1.0")
                 }
                 edge("org.springframework:core:1.0", "org.springframework:core:1.1") {
+                    byConstraint()
                     byConflictResolution("between versions 1.1 and 1.0")
                 }
             }
@@ -896,9 +982,14 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
             root(":", ":test:") {
                 edge("org:xml:1.0", "org:xml:1.1") {
                     byConstraint("belongs to platform org:platform:1.1")
-                    module('org:core:1.1')
+                    byConflictResolution("between versions 1.1 and 1.0")
+                    module('org:core:1.1') {
+                        byConstraint("belongs to platform org:platform:1.1")
+                        byConflictResolution("between versions 1.1 and 1.0")
+                    }
                 }
                 module("org:json:1.1") {
+                    byConstraint("belongs to platform org:platform:1.1")
                     module('org:core:1.1')
                 }
             }
@@ -913,9 +1004,14 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
             root(":", ":test:") {
                 edge("org:xml:1.0", "org:xml:1.1") {
                     byConstraint("belongs to platform org:platform:1.1")
-                    module('org:core:1.1')
+                    byConflictResolution("between versions 1.1 and 1.0")
+                    module('org:core:1.1') {
+                        byConstraint("belongs to platform org:platform:1.1")
+                        byConflictResolution("between versions 1.1 and 1.0")
+                    }
                 }
                 module("org:json:1.1") {
+                    byConstraint("belongs to platform org:platform:1.1")
                     module('org:core:1.1')
                 }
             }
@@ -1019,13 +1115,18 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
         resolve.expectGraph {
             root(":", ":test:") {
                 module('org:core:2.9.4') {
+                    byConstraint()
+                    byConflictResolution("between versions 2.9.4 and 2.7.9")
                     edge("org:platform:2.9.4", "org:platform:2.9.4.1")
                 }
                 edge('org:databind:2.7.9', 'org:databind:2.9.4') {
+                    byConstraint()
+                    byConflictResolution("between versions 2.9.4 and 2.7.9")
                     edge("org:platform:2.9.4", "org:platform:2.9.4.1")
                 }
                 module('org:kt:2.9.4.1') {
                     module("org:platform:2.9.4.1") {
+                        byConflictResolution("between versions 2.9.4.1 and 2.9.4")
                         noArtifacts()
                         constraint("org:core:2.9.4")
                         constraint("org:databind:2.9.4")
@@ -1035,6 +1136,8 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
                     module('org:databind:2.9.4') {
                         module('org:core:2.9.4')
                         edge('org:annotations:2.9.0', 'org:annotations:2.9.4') {
+                            byConstraint()
+                            byConflictResolution("between versions 2.9.4 and 2.9.0")
                             edge("org:platform:2.9.4", "org:platform:2.9.4.1")
                         }
                     }
@@ -1051,13 +1154,18 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
         resolve.expectGraph {
             root(":", ":test:") {
                 module('org:core:2.9.4') {
+                    byConstraint()
+                    byConflictResolution("between versions 2.9.4 and 2.7.9")
                     edge("org:platform:2.9.4", "org:platform:2.9.4.1")
                 }
                 edge('org:databind:2.7.9', 'org:databind:2.9.4') {
+                    byConstraint()
+                    byConflictResolution("between versions 2.9.4 and 2.7.9")
                     edge("org:platform:2.9.4", "org:platform:2.9.4.1")
                 }
                 module('org:kt:2.9.4.1') {
                     module("org:platform:2.9.4.1") {
+                        byConflictResolution("between versions 2.9.4.1 and 2.9.4")
                         noArtifacts()
                         constraint("org:core:2.9.4")
                         constraint("org:databind:2.9.4")
@@ -1067,6 +1175,8 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
                     module('org:databind:2.9.4') {
                         module('org:core:2.9.4')
                         edge('org:annotations:2.9.0', 'org:annotations:2.9.4') {
+                            byConstraint()
+                            byConflictResolution("between versions 2.9.4 and 2.9.0")
                             edge("org:platform:2.9.4", "org:platform:2.9.4.1")
                         }
                     }
@@ -1108,7 +1218,10 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
         resolve.expectGraph {
             root(":", ":test:") {
                 module("org:member2:1.1") {
-                    module("org:member1:1.1")
+                    byConstraint("belongs to platform org:platform:1.1")
+                    module("org:member1:1.1") {
+                        byConstraint("belongs to platform org:platform:1.1")
+                    }
                 }
             }
         }
@@ -1146,6 +1259,7 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
         resolve.expectGraph {
             root(":", ":test:") {
                 edge("org:foo:1.0", "org:foo:1.1") {
+                    byConflictResolution("between versions 1.1 and 1.0")
                     byConstraint("belongs to platform org:platform:1.1")
                 }
             }
@@ -1195,6 +1309,7 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
                 module("start:start:1.0") {
                     edge("org:foo:1.0", "org:foo:1.1") {
                         byConstraint("belongs to platform org:platform:1.1")
+                        byConflictResolution("between versions 1.1 and 1.0")
                         module("org:bar:1.1") {
                             byConstraint("belongs to platform org:platform:1.1")
                         }
@@ -1282,14 +1397,22 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
                 module("start:start:1.0") {
                     edge("org:foo:1.2", "org:foo:1.5") {
                         byConstraint("belongs to platform org:platform:1.5")
+                        selectedByRule("substitution from 'org:foo:[1.2,)' to 'org:foo:1.0'")
+                        byConflictResolution("between versions 1.0 and 1.5")
                         module("org:bar:1.5") {
+                            selectedByRule("substitution from 'org:bar:[1.2,)' to 'org:bar:1.0'")
+                            byConflictResolution("between versions 1.5 and 1.0")
                             byConstraint("belongs to platform org:platform:1.5")
                         }
                         module("org:baz:1.5") {
                             module("org:fooBar:1.5") {
                                 byConstraint("belongs to platform org:platform:1.5")
+                                selectedByRule("substitution from 'org:fooBar:[1.2,)' to 'org:fooBar:1.0'")
+                                byConflictResolution("between versions 1.5 and 1.0")
                             }
                             byConstraint("belongs to platform org:platform:1.5")
+                            selectedByRule("substitution from 'org:baz:[1.2,)' to 'org:baz:1.0'")
+                            byConflictResolution("between versions 1.5 and 1.0")
                         }
                     }
                 }
@@ -1441,11 +1564,19 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
                 module("org:a:1.0") {
                     edge('proto:java:1.0', "nebula:java:2.0")
                     module('proto:java-util:1.0') {
+                        byConstraint("belongs to platform aligned-group:proto:1.0")
                         edge('proto:java:1.0', "nebula:java:2.0")
                     }
                 }
-                module('align:first:2.0')
-                module('nebula:java:2.0')
+                module('align:first:2.0') {
+                    byConstraint("belongs to platform aligned-group:align:2.0")
+                    byConflictResolution("between versions 2.0 and 1.0")
+                }
+                module('nebula:java:2.0') {
+                    byConstraint("belongs to platform aligned-group:nebula:2.0")
+                    selectedByRule("proto:java replaced with nebula:java")
+                    byConflictResolution("between versions 2.0 and 1.1")
+                }
                 module('org:b:1.0') {
                     module('org:c:1.0') {
                         module('org:d:1.0') {
@@ -1453,7 +1584,11 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
                                 edge('nebula:java:1.1', 'nebula:java:2.0')
                             }
                             edge('align:second:1.0', 'align:second:2.0') {
-                                module('align:third:2.0')
+                                byConstraint("belongs to platform aligned-group:align:2.0")
+                                byConflictResolution("between versions 2.0 and 1.0")
+                                module('align:third:2.0') {
+                                    byConstraint("belongs to platform aligned-group:align:2.0")
+                                }
                                 edge('align:first:1.0', 'align:first:2.0')
                                 module('org:f:1.0') {
                                     edge('proto:java:0.5', 'nebula:java:2.0')

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingPlatformAlignmentTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingPlatformAlignmentTest.groovy
@@ -89,13 +89,20 @@ abstract class ForcingPlatformAlignmentTest extends AbstractAlignmentSpec {
             root(":", ":test:") {
                 edge("org:core:2.9.4", "org:core:2.7.9") {
                     forced()
+                    byConstraint("belongs to platform org:platform:2.7.9")
                 }
                 module("org:databind:2.7.9") {
-                    module('org:annotations:2.7.9')
+                    forced()
+                    byConstraint("belongs to platform org:platform:2.7.9")
+                    module('org:annotations:2.7.9') {
+                        forced()
+                        byConstraint("belongs to platform org:platform:2.7.9")
+                    }
                     module('org:core:2.7.9')
                 }
                 edge("org:kotlin:2.9.4.1", "org:kotlin:2.7.9") {
                     forced()
+                    byConstraint("belongs to platform org:platform:2.7.9")
                     module('org:core:2.7.9')
                     module('org:annotations:2.7.9')
                 }
@@ -145,13 +152,21 @@ abstract class ForcingPlatformAlignmentTest extends AbstractAlignmentSpec {
             root(":", ":test:") {
                 edge("org:core:2.9.4", "org:core:2.7.9") {
                     forced()
+                    byConstraint("belongs to platform org:platform:2.7.9")
                 }
                 module("org:databind:2.7.9") {
-                    module('org:annotations:2.7.9')
+                    selectedByRule()
+                    forced()
+                    byConstraint("belongs to platform org:platform:2.7.9")
+                    module('org:annotations:2.7.9') {
+                        forced()
+                        byConstraint("belongs to platform org:platform:2.7.9")
+                    }
                     module('org:core:2.7.9')
                 }
                 edge("org:kotlin:2.9.4.1", "org:kotlin:2.7.9") {
                     forced()
+                    byConstraint("belongs to platform org:platform:2.7.9")
                     module('org:core:2.7.9')
                     module('org:annotations:2.7.9')
                 }
@@ -398,21 +413,26 @@ abstract class ForcingPlatformAlignmentTest extends AbstractAlignmentSpec {
             root(":", ":test:") {
                 module("bom:bom:1.0") {
                     configuration = 'platform-runtime'
-                    constraint("org:xml:2.0", "org:xml:1.0")
+                    constraint("org:xml:2.0", "org:xml:1.0") {
+                        forced()
+                        byConstraint()
+                        byConstraint("belongs to platform org:platform:1.0")
+                    }
                     noArtifacts()
                 }
                 module("root:root:1.0") {
                     module('org:webapp:1.0') {
+                        forced()
+                        byConstraint("belongs to platform org:platform:1.0")
                         module('org:xml:1.0')
                     }
                     module('org:other:1.0') {
                         forced()
+                        byConstraint("belongs to platform org:platform:1.0")
                     }
                 }
             }
         }
-
-
     }
 
     def "can force a virtual platform version by forcing the platform itself via a dependency"() {
@@ -444,13 +464,20 @@ abstract class ForcingPlatformAlignmentTest extends AbstractAlignmentSpec {
             root(":", ":test:") {
                 edge("org:core:2.9.4", "org:core:2.7.9") {
                     forced()
+                    byConstraint("belongs to platform org:platform:2.7.9")
                 }
                 edge("org:databind:2.9.4", "org:databind:2.7.9") {
-                    module('org:annotations:2.7.9')
+                    forced()
+                    byConstraint("belongs to platform org:platform:2.7.9")
+                    module('org:annotations:2.7.9') {
+                        forced()
+                        byConstraint("belongs to platform org:platform:2.7.9")
+                    }
                     module('org:core:2.7.9')
                 }
                 edge("org:kotlin:2.9.4.1", "org:kotlin:2.7.9") {
                     forced()
+                    byConstraint("belongs to platform org:platform:2.7.9")
                     module('org:core:2.7.9')
                     module('org:annotations:2.7.9')
                 }
@@ -495,13 +522,20 @@ abstract class ForcingPlatformAlignmentTest extends AbstractAlignmentSpec {
             root(":", ":test:") {
                 edge("org:core:2.9.4", "org:core:2.7.9") {
                     forced()
+                    byConstraint("belongs to platform org:platform:2.7.9")
                 }
                 module("org:databind:2.7.9") {
-                    module('org:annotations:2.7.9')
+                    forced()
+                    byConstraint("belongs to platform org:platform:2.7.9")
+                    module('org:annotations:2.7.9') {
+                        forced()
+                        byConstraint("belongs to platform org:platform:2.7.9")
+                    }
                     module('org:core:2.7.9')
                 }
                 edge("org:kotlin:2.9.4.1", "org:kotlin:2.7.9") {
                     forced()
+                    byConstraint("belongs to platform org:platform:2.7.9")
                     module('org:core:2.7.9')
                     module('org:annotations:2.7.9')
                 }
@@ -547,13 +581,20 @@ abstract class ForcingPlatformAlignmentTest extends AbstractAlignmentSpec {
             root(":", ":test:") {
                 edge("org:core:2.9.4", "org:core:2.7.9") {
                     forced()
+                    byConstraint("belongs to platform org:platform:2.7.9")
                 }
                 module("org:databind:2.7.9") {
-                    module('org:annotations:2.7.9')
+                    forced()
+                    byConstraint("belongs to platform org:platform:2.7.9")
+                    module('org:annotations:2.7.9') {
+                        forced()
+                        byConstraint("belongs to platform org:platform:2.7.9")
+                    }
                     module('org:core:2.7.9')
                 }
                 edge("org:kotlin:2.9.4.1", "org:kotlin:2.7.9") {
                     forced()
+                    byConstraint("belongs to platform org:platform:2.7.9")
                     module('org:core:2.7.9')
                     module('org:annotations:2.7.9')
                 }
@@ -594,12 +635,22 @@ abstract class ForcingPlatformAlignmentTest extends AbstractAlignmentSpec {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:core:2.7.9", "org:core:2.9.4.1")
+                edge("org:core:2.7.9", "org:core:2.9.4.1") {
+                    byConstraint("belongs to platform org:platform:2.9.4.1")
+                    maybeByConflictResolution()
+                }
                 edge("org:databind:2.7.9", "org:databind:2.9.4.1") {
-                    module('org:annotations:2.9.4.1')
+                    byConstraint("belongs to platform org:platform:2.9.4.1")
+                    byConflictResolution("between versions 2.9.4.1 and 2.7.9")
+                    module('org:annotations:2.9.4.1') {
+                        byConstraint("belongs to platform org:platform:2.9.4.1")
+                        maybeByConflictResolution()
+                    }
                     module('org:core:2.9.4.1')
                 }
                 edge("org:kotlin:2.9.4", "org:kotlin:2.9.4.1") {
+                    byConstraint("belongs to platform org:platform:2.9.4.1")
+                    byConflictResolution("between versions 2.9.4.1 and 2.9.4")
                     module('org:core:2.9.4.1')
                     module('org:annotations:2.9.4.1')
                 }
@@ -651,10 +702,15 @@ abstract class ForcingPlatformAlignmentTest extends AbstractAlignmentSpec {
         resolve.expectGraph {
             root(":", ":test:") {
                 edge("org:core:2.9.4", "org:core:2.7.9") {
+                    byConstraint()
                     forced()
                 }
                 module("org:databind:2.7.9") {
+                    byConstraint()
+                    forced()
                     module('org:annotations:2.7.9') {
+                        byConstraint()
+                        forced()
                         module("org:platform:2.7.9")
                     }
                     module('org:core:2.7.9') {
@@ -663,6 +719,7 @@ abstract class ForcingPlatformAlignmentTest extends AbstractAlignmentSpec {
                     module("org:platform:2.7.9")
                 }
                 edge("org:kotlin:2.9.4.1", "org:kotlin:2.7.9") {
+                    byConstraint()
                     forced()
                     module('org:core:2.7.9')
                     module('org:annotations:2.7.9')
@@ -670,6 +727,7 @@ abstract class ForcingPlatformAlignmentTest extends AbstractAlignmentSpec {
                 }
                 String expectedVariant = GradleMetadataResolveRunner.isGradleMetadataPublished() ? 'enforcedRuntimeElements' : 'enforced-platform-runtime'
                 edge("org:platform:{strictly 2.7.9}", "org:platform:2.7.9") {
+                    byAncestor()
                     configuration(expectedVariant)
                     constraint('org:core:2.7.9')
                     constraint('org:databind:2.7.9')
@@ -765,10 +823,24 @@ abstract class ForcingPlatformAlignmentTest extends AbstractAlignmentSpec {
             root(":", ":test:") {
                 module("com.amazonaws:aws-java-sdk-core:1.11.438") {
                     edge("org:cbor:2.6.7", "org:cbor:2.8.10") {
-                        module("org:core:2.8.10")
+                        byConstraint("belongs to platform org:platform:2.8.11.1")
+                        maybeByConflictResolution()
+                        forced()
+                        module("org:core:2.8.10") {
+                            byConstraint("belongs to platform org:platform:2.8.11.1")
+                            maybeByConflictResolution()
+                            forced()
+                        }
                     }
                     edge("org:databind:2.6.7.1", "org:databind:2.8.11.1") {
-                        edge("org:annotations:2.8.0", "org:annotations:2.8.10")
+                        byConstraint("belongs to platform org:platform:2.8.11.1")
+                        maybeByConflictResolution()
+                        forced()
+                        edge("org:annotations:2.8.0", "org:annotations:2.8.10") {
+                            byConstraint("belongs to platform org:platform:2.8.11.1")
+                            byConflictResolution("between versions 2.8.10 and 2.8.0")
+                            forced()
+                        }
                         module("org:core:2.8.10")
                     }
                 }
@@ -820,10 +892,21 @@ abstract class ForcingPlatformAlignmentTest extends AbstractAlignmentSpec {
             root(":", ":test:") {
                 module("com.amazonaws:aws-java-sdk-core:1.11.438") {
                     module("org:cbor:2.6.7") {
-                        module("org:core:2.6.7")
+                        byConstraint("belongs to platform org:platform:2.6.7.1")
+                        forced()
+                        module("org:core:2.6.7") {
+                            byConstraint("belongs to platform org:platform:2.6.7.1")
+                            forced()
+                        }
                     }
                     edge("org:databind:2.8.0", "org:databind:2.6.7.1") {
-                        edge("org:annotations:2.6.0", "org:annotations:2.6.7")
+                        byConstraint("belongs to platform org:platform:2.6.7.1")
+                        forced()
+                        edge("org:annotations:2.6.0", "org:annotations:2.6.7") {
+                            byConstraint("belongs to platform org:platform:2.6.7.1")
+                            byConflictResolution("between versions 2.6.7 and 2.6.0")
+                            forced()
+                        }
                         module("org:core:2.6.7")
                     }
                 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingUsingStrictlyPlatformAlignmentTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingUsingStrictlyPlatformAlignmentTest.groovy
@@ -67,12 +67,22 @@ class ForcingUsingStrictlyPlatformAlignmentTest extends AbstractAlignmentSpec {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:core:2.9.4", "org:core:2.7.9")
+                edge("org:core:2.9.4", "org:core:2.7.9") {
+                    byConstraint('belongs to platform org:platform:2.7.9')
+                    forced()
+                }
                 edge("org:databind:{strictly 2.7.9}", "org:databind:2.7.9") {
-                    module('org:annotations:2.7.9')
+                    byConstraint('belongs to platform org:platform:2.7.9')
+                    forced()
+                    module('org:annotations:2.7.9') {
+                        byConstraint('belongs to platform org:platform:2.7.9')
+                        forced()
+                    }
                     module('org:core:2.7.9')
                 }
                 edge("org:kotlin:2.9.4.1", "org:kotlin:2.7.9") {
+                    byConstraint('belongs to platform org:platform:2.7.9')
+                    forced()
                     module('org:core:2.7.9')
                     module('org:annotations:2.7.9')
                 }
@@ -305,10 +315,24 @@ include 'other'
             root(":", ":test:") {
                 module("com.amazonaws:aws-java-sdk-core:1.11.438") {
                     edge("org:cbor:2.6.7", "org:cbor:2.8.10") {
-                        module("org:core:2.8.10")
+                        byConstraint("belongs to platform org:platform:2.8.11.1")
+                        byConflictResolution("between versions 2.8.10 and 2.6.7")
+                        forced()
+                        module("org:core:2.8.10") {
+                            byConstraint("belongs to platform org:platform:2.8.11.1")
+                            byConflictResolution("between versions 2.8.10 and 2.6.7")
+                            forced()
+                        }
                     }
                     edge("org:databind:2.6.7.1", "org:databind:2.8.11.1") {
-                        edge("org:annotations:2.8.0", "org:annotations:2.8.10")
+                        byConstraint("belongs to platform org:platform:2.8.11.1")
+                        byAncestor()
+                        forced()
+                        edge("org:annotations:2.8.0", "org:annotations:2.8.10") {
+                            byConstraint("belongs to platform org:platform:2.8.11.1")
+                            byConflictResolution("between versions 2.8.10 and 2.8.0")
+                            forced()
+                        }
                         module("org:core:2.8.10")
                     }
                 }
@@ -350,10 +374,22 @@ include 'other'
             root(":", ":test:") {
                 module("com.amazonaws:aws-java-sdk-core:1.11.438") {
                     module("org:cbor:2.6.7") {
-                        module("org:core:2.6.7")
+                        byConstraint("belongs to platform org:platform:2.6.7.1")
+                        forced()
+                        module("org:core:2.6.7") {
+                            byConstraint("belongs to platform org:platform:2.6.7.1")
+                            forced()
+                        }
                     }
                     edge("org:databind:2.8.0", "org:databind:2.6.7.1") {
-                        edge("org:annotations:2.6.0", "org:annotations:2.6.7")
+                        byConstraint("belongs to platform org:platform:2.6.7.1")
+                        byAncestor()
+                        forced()
+                        edge("org:annotations:2.6.0", "org:annotations:2.6.7") {
+                            byConstraint("belongs to platform org:platform:2.6.7.1")
+                            byConflictResolution("between versions 2.6.7 and 2.6.0")
+                            forced()
+                        }
                         module("org:core:2.6.7")
                     }
                 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationDefaultsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationDefaultsIntegrationTest.groovy
@@ -233,6 +233,7 @@ include 'consumer', 'producer'
         resolve.expectGraph {
             root(":", ":test:") {
                 edge("org.test:producer:1.0", ":producer", "org.test:producer:1.0") {
+                    compositeSubstitute()
                     module("org:default-dependency:1.0")
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationMutationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationMutationIntegrationTest.groovy
@@ -328,6 +328,7 @@ include 'consumer', 'producer'
         resolve.expectGraph {
             root(":", "org.test:root:1.1") {
                 edge("org.test:producer:1.0", ":producer", "org.test:producer:1.0") {
+                    compositeSubstitute()
                     module("org:explicit-dependency:3.4")
                     module("org:added-dependency:3.4")
                 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRolesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRolesIntegrationTest.groovy
@@ -38,8 +38,9 @@ class ConfigurationRolesIntegrationTest extends AbstractIntegrationSpec {
         }
 
         task checkState {
+            def files = configurations.internal
             doLast {
-                configurations.internal.resolve()
+                files.files
             }
         }
 
@@ -139,7 +140,8 @@ class ConfigurationRolesIntegrationTest extends AbstractIntegrationSpec {
             }
 
             task check {
-                doLast { configurations.compile.resolve() }
+                def files = configurations.compile
+                doLast { files.files }
             }
         }
         project(':b') {
@@ -178,7 +180,8 @@ class ConfigurationRolesIntegrationTest extends AbstractIntegrationSpec {
             }
 
             task check {
-                doLast { configurations.compile.resolve() }
+                def files = configurations.compile
+                doLast { files.files }
             }
         }
         project(':b') {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/ComponentAttributesDynamicVersionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/ComponentAttributesDynamicVersionIntegrationTest.groovy
@@ -128,7 +128,10 @@ class ComponentAttributesDynamicVersionIntegrationTest extends AbstractModuleDep
         run ':checkDeps'
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org.test:module:${requested}", 'org.test:module:1.1')
+                edge("org.test:module:${requested}", 'org.test:module:1.1') {
+                    byReason("rejection: version 1.3:   - Attribute 'quality' didn't match. Requested 'qa', was: 'rc'")
+                    byReason("rejection: version 1.2:   - Attribute 'quality' didn't match. Requested 'qa', was: 'rc'")
+                }
             }
         }
 
@@ -197,7 +200,10 @@ class ComponentAttributesDynamicVersionIntegrationTest extends AbstractModuleDep
         run ':checkDeps'
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org.test:module:${requested}", 'org.test:module:1.1')
+                edge("org.test:module:${requested}", 'org.test:module:1.1') {
+                    byReason("rejection: version 1.3:   - Attribute 'quality' didn't match. Requested 'qa', was: 'rc'")
+                    byReason("rejection: version 1.2:   - Attribute 'quality' didn't match. Requested 'qa', was: 'rc'")
+                }
             }
         }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/DependenciesAttributesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/DependenciesAttributesIntegrationTest.groovy
@@ -96,7 +96,9 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge('org:test', 'org:test:1.0')
+                edge('org:test', 'org:test:1.0') {
+                    byConstraint()
+                }
                 constraint('org:test:1.0', 'org:test:1.0')
             }
         }
@@ -486,6 +488,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
         resolve.expectGraph {
             root(":", ":test:") {
                 edge('org:test', 'org:test:1.0') {
+                    byConstraint()
                     configuration = expectedVariant
                     variant(expectedVariant, expectedAttributes)
                 }
@@ -546,6 +549,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
             root(":", ":test:") {
                 module('org:test:1.0') {
                     configuration = expectedVariant
+                    byConstraint()
                     variant(expectedVariant, expectedAttributes)
                 }
                 constraint('org:test', 'org:test:1.0') {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/MultipleVariantSelectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/MultipleVariantSelectionIntegrationTest.groovy
@@ -260,10 +260,9 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
         } else {
             resolve.expectGraph {
                 root(":", ":test:") {
-                    edge('org:test:1.0', 'org:test:1.0') {
-                        variant('runtime', ['org.gradle.status': MultipleVariantSelectionIntegrationTest.defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: 'c2'])
-                    }
+                    edge('org:test:1.0', 'org:test:1.0')
                     module('org:test:1.0') {
+                        maybeByConflictResolution()
                         variant('runtime', ['org.gradle.status': MultipleVariantSelectionIntegrationTest.defaultStatus(), 'org.gradle.usage': 'java-runtime', 'org.gradle.libraryelements': 'jar', 'org.gradle.category': 'library', custom: 'c2'])
                     }
                 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesRulesIntegrationTest.groovy
@@ -514,7 +514,11 @@ dependencies {
         resolve.expectGraph {
             root(":", ":test:") {
                 edge('jakarta:xml', 'jakarta:xml:1.0') {
-                    module('jakarta:activation:1.0')
+                    byConflictResolution()
+                    selectedByRule()
+                    module('jakarta:activation:1.0') {
+                        byConflictResolution()
+                    }
                 }
                 module('hadoop:yarn:1.0') {
                     edge('javax:jaxb:1.0', 'jakarta:xml:1.0')

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesUseCasesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesUseCasesIntegrationTest.groovy
@@ -207,7 +207,9 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
                 root(":", ":test:") {
                     module('org:a:1.0') {
                         edge('org.apache:groovy:1.0', 'org.apache:groovy-all:1.0')
-                        edge('org.apache:groovy-json:1.0', 'org.apache:groovy-all:1.0')
+                        edge('org.apache:groovy-json:1.0', 'org.apache:groovy-all:1.0') {
+                            selectedByRule()
+                        }
                     }
                     module('org:b:1.0') {
                         edge('org.apache:groovy-all:1.0', 'org.apache:groovy-all:1.0')
@@ -325,7 +327,9 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
                 root(":", ":test:") {
                     module('org:a:1.0') {
                         edge('org.apache:groovy:1.0', 'org.apache:groovy:1.0')
-                        edge('org.apache:groovy-json:1.0', 'org.apache:groovy-json:1.0')
+                        edge('org.apache:groovy-json:1.0', 'org.apache:groovy-json:1.0') {
+                            selectedByRule()
+                        }
                     }
                     module('org:b:1.0') {
                         // this is not quite right, as we should replace with 2 edges

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/VersionCatalogExtensionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/VersionCatalogExtensionIntegrationTest.groovy
@@ -314,9 +314,12 @@ class VersionCatalogExtensionIntegrationTest extends AbstractVersionCatalogInteg
                 constraint("org.gradle.test:lib-core:{strictly [1.0,1.1)}", "org.gradle.test:lib-core:1.0")
                 constraint("org.gradle.test:lib-ext:{strictly [1.0,1.1)}", "org.gradle.test:lib-ext:1.0")
                 edge("org.gradle.test:lib-core:1.+", "org.gradle.test:lib-core:1.0") {
+                    notRequested()
                     byReasons(["rejected version 1.1", "constraint"])
                 }
-                edge("org.gradle.test:lib-ext", "org.gradle.test:lib-ext:1.0")
+                edge("org.gradle.test:lib-ext", "org.gradle.test:lib-ext:1.0") {
+                    byConstraint()
+                }
             }
         }
     }
@@ -377,9 +380,12 @@ class VersionCatalogExtensionIntegrationTest extends AbstractVersionCatalogInteg
                 constraint("org.gradle.test:lib-core:{strictly [1.0,1.1)}", "org.gradle.test:lib-core:1.0")
                 constraint("org.gradle.test:lib-ext:{strictly [1.0,1.1)}", "org.gradle.test:lib-ext:1.0")
                 edge("org.gradle.test:lib-core:1.+", "org.gradle.test:lib-core:1.0") {
+                    notRequested()
                     byReasons(["rejected version 1.1", "constraint"])
                 }
-                edge("org.gradle.test:lib-ext", "org.gradle.test:lib-ext:1.0")
+                edge("org.gradle.test:lib-ext", "org.gradle.test:lib-ext:1.0") {
+                    byConstraint()
+                }
             }
         }
     }
@@ -463,7 +469,9 @@ class VersionCatalogExtensionIntegrationTest extends AbstractVersionCatalogInteg
         resolve.expectGraph {
             root(":", ":test:") {
                 constraint('org.gradle.test:lib:1.1')
-                edge('org.gradle.test:lib', 'org.gradle.test:lib:1.1')
+                edge('org.gradle.test:lib', 'org.gradle.test:lib:1.1') {
+                    byConstraint()
+                }
             }
         }
     }
@@ -2219,8 +2227,12 @@ Second: 1.1"""
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org.gradle.test:lib:3.0.6", "org.gradle.test:lib:3.0.5")
-                edge("org.gradle.test:lib2:3.0.6", "org.gradle.test:lib2:3.0.5")
+                edge("org.gradle.test:lib:3.0.6", "org.gradle.test:lib:3.0.5") {
+                    forced()
+                }
+                edge("org.gradle.test:lib2:3.0.6", "org.gradle.test:lib2:3.0.5") {
+                    forced()
+                }
             }
         }
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/consistency/ProjectLocalDependencyResolutionConsistencyIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/consistency/ProjectLocalDependencyResolutionConsistencyIntegrationTest.groovy
@@ -57,6 +57,7 @@ class ProjectLocalDependencyResolutionConsistencyIntegrationTest extends Abstrac
             root(':', ':test:') {
                 edge('org:foo:1.0', 'org:foo:1.1') {
                     byConsistentResolution('other')
+                    byConflictResolution('between versions 1.1 and 1.0')
                 }
                 constraint("org:foo:{strictly 1.1}", "org:foo:1.1")
             }
@@ -203,8 +204,12 @@ class ProjectLocalDependencyResolutionConsistencyIntegrationTest extends Abstrac
                     byConsistentResolution('compileClasspath')
                     module('org:fooA:1.0') {
                         byConsistentResolution('compileClasspath')
+                        byAncestor()
+                        notRequested()
                         module("org:transitive:1.0") {
                             byConsistentResolution('compileClasspath')
+                            byAncestor()
+                            notRequested()
                         }
                     }
                 }
@@ -289,6 +294,7 @@ class ProjectLocalDependencyResolutionConsistencyIntegrationTest extends Abstrac
             root(':', ':test:') {
                 edge('org:foo:1.1', 'org:foo:1.2') {
                     selectedByRule()
+                    byConsistentResolution('other')
                 }
                 constraint("org:foo:{strictly 1.0}", "org:foo:1.2")
             }
@@ -327,6 +333,7 @@ class ProjectLocalDependencyResolutionConsistencyIntegrationTest extends Abstrac
             root(':', ':test:') {
                 edge('org:foo:1.0', 'org:foo:1.1') {
                     byConsistentResolution('other')
+                    byConflictResolution('between versions 1.1 and 1.0')
                 }
                 constraint("org:foo:{strictly 1.1}", "org:foo:1.1")
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/DependencyConstraintsAndResolutionStrategiesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/DependencyConstraintsAndResolutionStrategiesIntegrationTest.groovy
@@ -66,7 +66,10 @@ class DependencyConstraintsAndResolutionStrategiesIntegrationTest extends Abstra
             root(":", ":test:") {
                 constraint("org:foo:1.1","org:foo:1.0")
                 module("org:bar:1.0") {
-                    edge("org:foo:1.0","org:foo:1.0")
+                    edge("org:foo:1.0","org:foo:1.0") {
+                        forced()
+                        byConstraint()
+                    }
                 }
             }
         }
@@ -118,7 +121,10 @@ class DependencyConstraintsAndResolutionStrategiesIntegrationTest extends Abstra
             root(":", ":test:") {
                 constraint("org:foo:1.1","org:foo:1.0")
                 module("org:bar:1.0") {
-                    edge("org:foo:1.0","org:foo:1.0")
+                    edge("org:foo:1.0","org:foo:1.0") {
+                        selectedByRule()
+                        byConstraint()
+                    }
                 }
             }
         }
@@ -150,7 +156,11 @@ class DependencyConstraintsAndResolutionStrategiesIntegrationTest extends Abstra
             root(":", ":test:") {
                 constraint("org:foo:1.1","org:foo:1.0")
                 module("org:bar:1.0") {
-                    edge("org:foo:1.0","org:foo:1.0")
+                    selectedByRule()
+                    edge("org:foo:1.0","org:foo:1.0") {
+                        selectedByRule()
+                        byConstraint()
+                    }
                 }
             }
         }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/DependencyConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/DependencyConstraintsIntegrationTest.groovy
@@ -89,7 +89,9 @@ class DependencyConstraintsIntegrationTest extends AbstractPolyglotIntegrationSp
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:foo", "org:foo:1.1")
+                edge("org:foo", "org:foo:1.1") {
+                    byConstraint()
+                }
                 constraint("org:foo:1.1", "org:foo:1.1")
             }
         }
@@ -148,7 +150,10 @@ class DependencyConstraintsIntegrationTest extends AbstractPolyglotIntegrationSp
         resolve.expectGraph {
             root(":", ":test:") {
                 module("org:bar:1.0") {
-                    edge("org:foo:1.0", "org:foo:1.1").byConflictResolution("between versions 1.1 and 1.0")
+                    edge("org:foo:1.0", "org:foo:1.1") {
+                        byConstraint()
+                        byConflictResolution("between versions 1.1 and 1.0")
+                    }
                 }
                 constraint("org:foo:1.1", "org:foo:1.1")
             }
@@ -332,7 +337,10 @@ class DependencyConstraintsIntegrationTest extends AbstractPolyglotIntegrationSp
         resolve.expectGraph {
             root(":", ":test:") {
                 constraint("org:bar:1.1", "org:foo:1.1").selectedByRule()
-                edge("org:foo:1.0", "org:foo:1.1").byConflictResolution("between versions 1.1 and 1.0")
+                edge("org:foo:1.0", "org:foo:1.1") {
+                    byConstraint()
+                    byConflictResolution("between versions 1.1 and 1.0")
+                }
             }
         }
     }
@@ -366,7 +374,10 @@ class DependencyConstraintsIntegrationTest extends AbstractPolyglotIntegrationSp
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:foo:1.0", "org:foo:1.1").byConflictResolution("between versions 1.1 and 1.0")
+                edge("org:foo:1.0", "org:foo:1.1") {
+                    byConstraint()
+                    byConflictResolution("between versions 1.1 and 1.0")
+                }
                 constraint("org:foo:1.1", "org:foo:1.1")
             }
         }
@@ -459,6 +470,7 @@ class DependencyConstraintsIntegrationTest extends AbstractPolyglotIntegrationSp
             root(":", ":test:") {
                 edge("org:foo:1.0", "org:foo:1.1") {
                     configuration("runtime")
+                    byConstraint()
                     byConflictResolution("between versions 1.1 and 1.0")
                 }
                 edge("org:included:1.0", ":includeBuild", "org:included:1.0") {
@@ -498,7 +510,9 @@ class DependencyConstraintsIntegrationTest extends AbstractPolyglotIntegrationSp
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:foo", "org:foo:1.0")
+                edge("org:foo", "org:foo:1.0") {
+                    byConstraint()
+                }
                 constraint("org:foo:1.0")
             }
         }
@@ -525,10 +539,12 @@ class DependencyConstraintsIntegrationTest extends AbstractPolyglotIntegrationSp
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:foo:1.0", "org:foo:1.1")
-                constraint("org:foo:1.1", "org:foo:1.1") {
+                edge("org:foo:1.0", "org:foo:1.1") {
+                    byConstraint()
+                    byConflictResolution("between versions 1.1 and 1.0")
                     artifact(classifier: 'shaded')
                 }
+                constraint("org:foo:1.1", "org:foo:1.1")
             }
         }
     }
@@ -556,11 +572,13 @@ class DependencyConstraintsIntegrationTest extends AbstractPolyglotIntegrationSp
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                constraint("org:foo:1.1", "org:foo:1.1") {
-                    artifact(classifier: 'shaded')
-                }
+                constraint("org:foo:1.1", "org:foo:1.1")
                 module("org:bar:1.0") {
-                    edge("org:foo:1.0", "org:foo:1.1")
+                    edge("org:foo:1.0", "org:foo:1.1") {
+                        byConstraint()
+                        byConflictResolution("between versions 1.1 and 1.0")
+                        artifact(classifier: 'shaded')
+                    }
                 }
             }
         }
@@ -588,10 +606,12 @@ class DependencyConstraintsIntegrationTest extends AbstractPolyglotIntegrationSp
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                constraint("org:bar:1.1", "org:bar:1.1") {
+                constraint("org:bar:1.1", "org:bar:1.1")
+                edge('org:bar:1.0', 'org:bar:1.1') {
+                    byConstraint()
+                    byConflictResolution("between versions 1.1 and 1.0")
                     edge('org:foo:1.0', 'org:foo:1.0')
                 }
-                edge('org:bar:1.0', 'org:bar:1.1')
             }
         }
     }
@@ -618,10 +638,11 @@ class DependencyConstraintsIntegrationTest extends AbstractPolyglotIntegrationSp
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                constraint("org:bar:1.1", "org:bar:1.1") {
+                constraint("org:bar:1.1", "org:bar:1.1")
+                edge('org:bar', 'org:bar:1.1') {
+                    byConstraint()
                     edge('org:foo:1.0', 'org:foo:1.0')
                 }
-                edge('org:bar', 'org:bar:1.1')
             }
         }
     }
@@ -716,7 +737,11 @@ class DependencyConstraintsIntegrationTest extends AbstractPolyglotIntegrationSp
                 }
                 module("org:indirect:1.0") {
                     edge("org:user:1.0", "org:user:1.1") {
-                        edge("org:constrained:1.0", "org:constrained:1.1")
+                        byConflictResolution("between versions 1.1 and 1.0")
+                        edge("org:constrained:1.0", "org:constrained:1.1") {
+                            byConstraint()
+                            byConflictResolution("between versions 1.1 and 1.0")
+                        }
                     }
                     module("org:otherUser:1.0") {
                         module("org:user:1.1")
@@ -835,6 +860,8 @@ class DependencyConstraintsIntegrationTest extends AbstractPolyglotIntegrationSp
             root(':', ':test:') {
                 edge("org:foo:1.0", ":foo", "org:foo:1.1") {
                     configuration = 'default'
+                    byConstraint()
+                    byConflictResolution("between versions 1.1 and 1.0")
                     noArtifacts()
                     project(":bar", "org:bar:1.1") {
                         configuration = 'default'

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/PublishedDependencyConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/PublishedDependencyConstraintsIntegrationTest.groovy
@@ -220,7 +220,10 @@ class PublishedDependencyConstraintsIntegrationTest extends AbstractModuleDepend
                 }
                 module("org:first-level2:1.0") {
                     if (available) {
-                        edge("org:foo:1.0","org:foo:1.1").byConflictResolution("between versions 1.1 and 1.0")
+                        edge("org:foo:1.0","org:foo:1.1") {
+                            byConstraint()
+                            byConflictResolution("between versions 1.1 and 1.0")
+                        }
                     } else {
                         module("org:foo:1.0")
                     }
@@ -285,7 +288,9 @@ class PublishedDependencyConstraintsIntegrationTest extends AbstractModuleDepend
             root(":", ":test:") {
                 module("org:bar:1.0") {
                     if (available) {
-                        edge("org:foo:[1.1,1.2]", "org:foo:1.1")
+                        edge("org:foo:[1.1,1.2]", "org:foo:1.1") {
+                            byConstraint("didn't match version 1.2")
+                        }
                     } else {
                         edge("org:foo:[1.1,1.2]", "org:foo:1.2")
                     }
@@ -393,8 +398,12 @@ class PublishedDependencyConstraintsIntegrationTest extends AbstractModuleDepend
             root(":", ":test:") {
                 module("org:first-level:1.0") {
                     if (available) {
-                        constraint("org:bar:1.1", "org:foo:1.1").selectedByRule()
-                        edge("org:foo:1.0", "org:foo:1.1").byConflictResolution("between versions 1.1 and 1.0")
+                        constraint("org:bar:1.1", "org:foo:1.1")
+                        edge("org:foo:1.0", "org:foo:1.1") {
+                            selectedByRule()
+                            byConstraint()
+                            byConflictResolution("between versions 1.1 and 1.0")
+                        }
                     } else {
                         module("org:foo:1.0")
                     }
@@ -453,7 +462,9 @@ dependencies {
         then:
         resolve.expectGraph {
             root(':', ':test:') {
-                edge('org:weird:1.0', 'org:weird:1.1')
+                edge('org:weird:1.0', 'org:weird:1.1') {
+                    byConflictResolution("between versions 1.1 and 1.0")
+                }
                 module('org:other:1.0') {
                     module('org:bar:1.0')
                     module('org:weird:1.1')
@@ -532,7 +543,9 @@ dependencies {
                     noArtifacts()
                     configuration(platformConfiguration)
                 }
-                edge('org:first:1.0', 'org:first:2.0')
+                edge('org:first:1.0', 'org:first:2.0') {
+                    byConflictResolution("between versions 2.0 and 1.0")
+                }
                 module('org:second:1.0') {
                     module('org:intermediate:1.0') {
                         module('org:first:2.0')

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/ComponentSelectionRulesDependencyResolveIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/ComponentSelectionRulesDependencyResolveIntegTest.groovy
@@ -57,7 +57,10 @@ class ComponentSelectionRulesDependencyResolveIntegTest extends AbstractComponen
         checkDependencies {
             resolve.expectGraph {
                 root(":", ":test:") {
-                    edge("org.utils:api:${selector}", "org.utils:${chosenModule}:${chosenVersion}").byReasons(reasons)
+                    edge("org.utils:api:${selector}", "org.utils:${chosenModule}:${chosenVersion}") {
+                        byReasons(reasons)
+                        maybeRequested()
+                    }
                 }
             }
         }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDynamicRevisionMultiRepoResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDynamicRevisionMultiRepoResolveIntegrationTest.groovy
@@ -58,7 +58,10 @@ class IvyDynamicRevisionMultiRepoResolveIntegrationTest extends AbstractDependen
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org.test:projectA:latest.milestone", "org.test:projectA:1.1").byReason("didn't match version 1.2")
+                edge("org.test:projectA:latest.milestone", "org.test:projectA:1.1") {
+                    notRequested()
+                    byReason("didn't match version 1.2")
+                }
             }
         }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDynamicRevisionRemoteResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDynamicRevisionRemoteResolveIntegrationTest.groovy
@@ -570,7 +570,10 @@ dependencies {
         succeeds "checkDeps"
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org.test:projectA:1.+", "org.test:projectA:1.2").byReason("didn't match version 2.1")
+                edge("org.test:projectA:1.+", "org.test:projectA:1.2") {
+                    notRequested()
+                    byReason("didn't match version 2.1")
+                }
             }
         }
 
@@ -590,8 +593,11 @@ dependencies {
         succeeds "checkDeps"
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org.test:projectA:1.+", "org.test:projectA:2.1").byConflictResolution("between versions 1.2 and 2.1")
-                edge("org.test:projectA:2.+", "org.test:projectA:2.1").byConflictResolution("between versions 1.2 and 2.1")
+                edge("org.test:projectA:1.+", "org.test:projectA:2.1") {
+                    byConflictResolution("between versions 1.2 and 2.1")
+                    byReason("didn't match version 2.1")
+                }
+                edge("org.test:projectA:2.+", "org.test:projectA:2.1")
             }
         }
 
@@ -613,9 +619,15 @@ dependencies {
         succeeds "checkDeps"
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org.test:projectA:1.+", "org.test:projectA:3.0").byConflictResolution("between versions 3.0, 1.2 and 2.1")
-                edge("org.test:projectA:2.+", "org.test:projectA:3.0").byConflictResolution("between versions 3.0, 1.2 and 2.1")
-                edge("org.test:projectA:3.+", "org.test:projectA:3.0").byConflictResolution("between versions 3.0, 1.2 and 2.1")
+                edge("org.test:projectA:1.+", "org.test:projectA:3.0") {
+                    notRequested()
+                    byConflictResolution("between versions 3.0, 1.2 and 2.1")
+                    byReason("didn't match versions 2.1, 1.2, 1.1")
+                    byReason("didn't match versions 3.0, 2.1")
+                    byReason("didn't match version 3.0")
+                }
+                edge("org.test:projectA:2.+", "org.test:projectA:3.0")
+                edge("org.test:projectA:3.+", "org.test:projectA:3.0")
             }
         }
     }
@@ -1280,7 +1292,7 @@ dependencies {
             root(":", ":test:") {
                 edges.each { from, to ->
                     if (to instanceof List) {
-                        edge(from, to[0]).byReason(to[1])
+                        edge(from, to[0]).byReason(to[1]).notRequested()
                     } else {
                         edge(from, to)
                     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDynamicRevisionResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDynamicRevisionResolveIntegrationTest.groovy
@@ -187,7 +187,10 @@ Searched in the following locations:
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org.test:projectA:latest.milestone", "org.test:projectA:1.1").byReason("didn't match version 1.3")
+                edge("org.test:projectA:latest.milestone", "org.test:projectA:1.1") {
+                    notRequested()
+                    byReason("didn't match version 1.3")
+                }
             }
         }
 
@@ -217,7 +220,10 @@ Searched in the following locations:
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org.test:projectA:latest.milestone", "org.test:projectA:1.2").byReason("didn't match version 1.3")
+                edge("org.test:projectA:latest.milestone", "org.test:projectA:1.2") {
+                    notRequested()
+                    byReason("didn't match version 1.3")
+                }
             }
         }
 
@@ -248,7 +254,10 @@ Searched in the following locations:
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org.test:projectA:latest.milestone", "org.test:projectA:1.2").byReason("didn't match version 1.3")
+                edge("org.test:projectA:latest.milestone", "org.test:projectA:1.2") {
+                    notRequested()
+                    byReason("didn't match version 1.3")
+                }
             }
         }
     }
@@ -341,7 +350,10 @@ Searched in the following locations:
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org.test:projectA:latest.release", "org.test:projectA:1.1").byReason("didn't match versions 1.3, 1.2")
+                edge("org.test:projectA:latest.release", "org.test:projectA:1.1") {
+                    notRequested()
+                    byReason("didn't match versions 1.3, 1.2")
+                }
             }
         }
 
@@ -382,7 +394,10 @@ Searched in the following locations:
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org.test:projectA:latest.release", "org.test:projectA:1.1").byReason("didn't match versions 1.3, 1.2, 1.1.1")
+                edge("org.test:projectA:latest.release", "org.test:projectA:1.1") {
+                    notRequested()
+                    byReason("didn't match versions 1.3, 1.2, 1.1.1")
+                }
             }
         }
     }
@@ -431,7 +446,10 @@ Searched in the following locations:
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org.test:projectA:1.2+", "org.test:projectA:1.2.1").byReason("didn't match version 2.0")
+                edge("org.test:projectA:1.2+", "org.test:projectA:1.2.1") {
+                    notRequested()
+                    byReason("didn't match version 2.0")
+                }
             }
         }
 
@@ -454,7 +472,10 @@ Searched in the following locations:
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org.test:projectA:1.2+", "org.test:projectA:1.2.9").byReason("didn't match version 2.0")
+                edge("org.test:projectA:1.2+", "org.test:projectA:1.2.9") {
+                    notRequested()
+                    byReason("didn't match version 2.0")
+                }
             }
         }
 
@@ -477,7 +498,10 @@ Searched in the following locations:
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org.test:projectA:1.2+", "org.test:projectA:1.2.10").byReason("didn't match version 2.0")
+                edge("org.test:projectA:1.2+", "org.test:projectA:1.2.10") {
+                    notRequested()
+                    byReason("didn't match version 2.0")
+                }
             }
         }
     }
@@ -527,7 +551,10 @@ Searched in the following locations:
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org.test:projectA:[1.2,2.0]", "org.test:projectA:1.2.1").byReason("didn't match version 2.1")
+                edge("org.test:projectA:[1.2,2.0]", "org.test:projectA:1.2.1") {
+                    notRequested()
+                    byReason("didn't match version 2.1")
+                }
             }
         }
 
@@ -550,7 +577,10 @@ Searched in the following locations:
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org.test:projectA:[1.2,2.0]", "org.test:projectA:1.3").byReason("didn't match version 2.1")
+                edge("org.test:projectA:[1.2,2.0]", "org.test:projectA:1.3") {
+                    notRequested()
+                    byReason("didn't match version 2.1")
+                }
             }
         }
     }
@@ -602,7 +632,10 @@ Searched in the following locations:
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org.test:projectA:[1.2,2.0)", "org.test:projectA:1.2.1:default").byReason("didn't match version 2.0")
+                edge("org.test:projectA:[1.2,2.0)", "org.test:projectA:1.2.1:default") {
+                    notRequested()
+                    byReason("didn't match version 2.0")
+                }
             }
         }
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyResolveIntegrationTest.groovy
@@ -58,6 +58,7 @@ dependencies {
         resolve.expectGraph {
             root(":", "org.gradle:test:1.0") {
                 module("org.gradle:test:1.45") {
+                    byConflictResolution("between versions 1.45 and 1.0")
                     artifact()
                     artifact(classifier: "classifier")
                     artifact(name: "test-extra")
@@ -378,6 +379,7 @@ dependencies {
                     configuration('alice')
                     byConstraint()
                     module('org:bar:1.0') {
+                        notRequested()
                         byAncestor()
                         byConstraint()
                         configuration('extra')

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingLenientModeIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingLenientModeIntegrationTest.groovy
@@ -53,7 +53,7 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLockfile('lockedConf',['org:foo:1.0'], unique)
+        lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0'], unique)
 
         when:
         succeeds 'checkDeps'
@@ -62,11 +62,12 @@ dependencies {
         resolve.expectDefaultConfiguration('runtime')
         resolve.expectGraph {
             root(":", ":depLock:") {
-                edge("org:foo:1.+", "org:foo:1.1")
-                edge("org:foo:{strictly 1.1}", "org:foo:1.1")
-                constraint("org:foo:1.0", "org:foo:1.1"){
+                edge("org:foo:1.+", "org:foo:1.1") {
+                    byConflictResolution("between versions 1.0 and 1.1")
                     byConstraint("dependency was locked to version '1.0' (update/lenient mode)")
                 }
+                edge("org:foo:{strictly 1.1}", "org:foo:1.1")
+                constraint("org:foo:1.0", "org:foo:1.1")
             }
         }
 
@@ -101,7 +102,7 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLockfile('lockedConf',['org:foo:1.0'], unique)
+        lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0'], unique)
 
         when:
         succeeds 'checkDeps'
@@ -110,11 +111,12 @@ dependencies {
         resolve.expectDefaultConfiguration('runtime')
         resolve.expectGraph {
             root(":", ":depLock:") {
-                edge("org:foo:1.+", "org:foo:1.1")
-                module("org:foo:1.1")
-                constraint("org:foo:1.0", "org:foo:1.1"){
+                edge("org:foo:1.+", "org:foo:1.1") {
                     byConstraint("dependency was locked to version '1.0' (update/lenient mode)")
+                    byConflictResolution("between versions 1.0 and 1.1")
                 }
+                module("org:foo:1.1")
+                constraint("org:foo:1.0", "org:foo:1.1")
             }
         }
 
@@ -149,7 +151,7 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLockfile('lockedConf',['org:bar:1.0', 'org:foo:1.0', 'org:baz:1.0'], unique)
+        lockfileFixture.createLockfile('lockedConf', ['org:bar:1.0', 'org:foo:1.0', 'org:baz:1.0'], unique)
 
         when:
         succeeds 'checkDeps'
@@ -159,7 +161,7 @@ dependencies {
         resolve.expectGraph {
             root(":", ":depLock:") {
                 edge("org:foo:1.+", "org:foo:1.0")
-                constraint("org:foo:1.0", "org:foo:1.0"){
+                constraint("org:foo:1.0", "org:foo:1.0") {
                     byConstraint("dependency was locked to version '1.0' (update/lenient mode)")
                 }
             }
@@ -196,7 +198,7 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLockfile('lockedConf',['org:foo:1.0'], unique)
+        lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0'], unique)
 
         when:
         succeeds 'checkDeps'
@@ -207,7 +209,7 @@ dependencies {
             root(":", ":depLock:") {
                 edge("org:foo:1.+", "org:foo:1.0")
                 edge("org:bar:1.+", "org:bar:1.0")
-                constraint("org:foo:1.0", "org:foo:1.0"){
+                constraint("org:foo:1.0", "org:foo:1.0") {
                     byConstraint("dependency was locked to version '1.0' (update/lenient mode)")
                 }
             }
@@ -282,7 +284,7 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLockfile('lockedConf',['org:foo:1.0'])
+        lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0'])
 
         when:
         run 'dependencies'
@@ -323,7 +325,7 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLockfile('lockedConf',['org:bar:1.0', 'org:foo:1.0'])
+        lockfileFixture.createLockfile('lockedConf', ['org:bar:1.0', 'org:foo:1.0'])
 
         when:
         run 'dependencies'

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBomResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBomResolveIntegrationTest.groovy
@@ -64,7 +64,9 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
                     constraint("group:moduleA:2.0", "group:moduleA:2.0")
                     noArtifacts()
                 }
-                edge("group:moduleA", "group:moduleA:2.0")
+                edge("group:moduleA", "group:moduleA:2.0") {
+                    byConstraint()
+                }
             }
         }
     }
@@ -92,7 +94,9 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
                     constraint("group:moduleA:2.0", "group:moduleA:2.0")
                     noArtifacts()
                 }
-                edge("group:moduleA", "group:moduleA:2.0")
+                edge("group:moduleA", "group:moduleA:2.0") {
+                    byConstraint()
+                }
             }
         }
     }
@@ -132,7 +136,9 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
                     constraint("group:moduleA:2.0", "group:moduleA:2.0")
                     noArtifacts()
                 }
-                edge("group:moduleA", "group:moduleA:2.0")
+                edge("group:moduleA", "group:moduleA:2.0") {
+                    byConstraint()
+                }
             }
         }
     }
@@ -178,7 +184,9 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
                     module("group:moduleC:1.0")
                     noArtifacts()
                 }
-                edge("group:moduleA", "group:moduleA:2.0")
+                edge("group:moduleA", "group:moduleA:2.0") {
+                    byConstraint()
+                }
             }
         }
     }
@@ -298,7 +306,9 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
                     constraint("group:moduleA:2.0", "group:moduleA:2.0")
                     noArtifacts()
                 }
-                edge("group:moduleA", "group:moduleA:2.0")
+                edge("group:moduleA", "group:moduleA:2.0") {
+                    byConstraint()
+                }
             }
         }
     }
@@ -327,7 +337,9 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
                     constraint("group:moduleA:2.0", "group:moduleA:2.0")
                     noArtifacts()
                 }
-                edge("group:moduleA", "group:moduleA:2.0")
+                edge("group:moduleA", "group:moduleA:2.0") {
+                    byConstraint()
+                }
             }
         }
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenVersionRangeResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenVersionRangeResolveIntegrationTest.groovy
@@ -143,7 +143,9 @@ dependencies {
             root(":", ":test:") {
                 edge("org.test:child:1.0", "org.test:child:1.0") {
                     edge("org.test:imported:[2.0,3.0)", "org.test:imported:2.1") {
-                        artifact(type: 'pom').byReason("didn't match version 3.0")
+                        notRequested()
+                        byReason("didn't match version 3.0")
+                        artifact(type: 'pom')
                         edge("org.test:dep:2.1", "org.test:dep:2.1")
                     }
                 }
@@ -221,6 +223,7 @@ dependencies {
         resolve.expectGraph {
             root(":", ":testrange:") {
                 edge("org.test:dep:[1.0, 2.0[", "org.test:dep:1.5") {
+                    notRequested()
                     byReason("didn't match versions 3.0, 2.1, 2.0, 2.0-final, 2.0-dev1")
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/override/ComponentOverrideMetadataResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/override/ComponentOverrideMetadataResolveIntegrationTest.groovy
@@ -65,6 +65,7 @@ class ComponentOverrideMetadataResolveIntegrationTest extends AbstractModuleDepe
         resolve.expectGraph {
             root(":", ":test:") {
                 edge('org:foo', 'org:foo:1.0') {
+                    byConstraint()
                     artifact(type: 'distribution-tgz')
                 }
                 constraint('org:foo:1.0')
@@ -114,6 +115,7 @@ class ComponentOverrideMetadataResolveIntegrationTest extends AbstractModuleDepe
         resolve.expectGraph {
             root(":", ":test:") {
                 edge('org:foo', 'org:foo:1.0') {
+                    byConstraint()
                     artifact(name: artifactName, type: 'distribution-tgz')
                     artifact(name: artifactName, type: 'zip')
                 }
@@ -164,7 +166,11 @@ class ComponentOverrideMetadataResolveIntegrationTest extends AbstractModuleDepe
         def notSelectedModule = "org:foo:$otherVersion"
         resolve.expectGraph {
             root(":", ":test:") {
-                module('org:foo:1.0')
+                module('org:foo:1.0') {
+                    if (notSelectedModule != 'org:foo:1.0') {
+                        byConflictResolution('between versions 1.0 and 0.9')
+                    }
+                }
                 if (notSelectedModule != 'org:foo:1.0') {
                     edge(notSelectedModule, 'org:foo:1.0')
                 }
@@ -214,6 +220,7 @@ class ComponentOverrideMetadataResolveIntegrationTest extends AbstractModuleDepe
         resolve.expectGraph {
             root(":", ":test:") {
                 module('org:foo:1.1') {
+                    byConflictResolution('between versions 1.1 and 1.0')
                     module('org:bar:1.0')
                 }
                 edge('org:foo:[1.0,1.1]', 'org:foo:1.1')

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/EnforcedPlatformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/EnforcedPlatformIntegrationTest.groovy
@@ -63,7 +63,10 @@ class EnforcedPlatformIntegrationTest extends AbstractHttpDependencyResolutionTe
                     noArtifacts()
                     constraint('com.fasterxml.jackson.core:jackson-core:2.12.3', ':jackson-core', 'com.fasterxml.jackson.core:jackson-core:2.12.3-local-patch')
                 }
-                edge('com.fasterxml.jackson.core:jackson-core', ':jackson-core', 'com.fasterxml.jackson.core:jackson-core:2.12.3-local-patch')
+                edge('com.fasterxml.jackson.core:jackson-core', ':jackson-core', 'com.fasterxml.jackson.core:jackson-core:2.12.3-local-patch') {
+                    compositeSubstitute()
+                    byConstraint()
+                }
             }
         }
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/JavaPlatformResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/JavaPlatformResolveIntegrationTest.groovy
@@ -196,6 +196,7 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
                     noArtifacts()
                 }
                 edge('org:foo:1.2', 'org:foo:1.1') {
+                    forced()
                     byConstraint()
                 }
             }
@@ -246,6 +247,7 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
                     noArtifacts()
                 }
                 edge('org:foo:1.1', 'org:foo:1.0') {
+                    forced()
                     configuration = 'api'
                 }
             }
@@ -563,6 +565,7 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
                     configuration = 'runtime'
                     module('org:foo:1.0') {
                         configuration = 'runtime'
+                        byConstraint()
                         module('org:foobar:1.0') {
                             configuration = 'runtime'
                         }
@@ -620,7 +623,9 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
         then:
         resolve.expectGraph {
             root(":", "org.test:test:1.9") {
-                edge("org.test:depA", "org.test:depA:1.0")
+                edge("org.test:depA", "org.test:depA:1.0") {
+                    byConstraint()
+                }
                 module("org.test:depB:1.0") {
                     module("org.test:depC:1.0") {
                         module('org.test:platform:1.0') {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/NativeAlignmentWithJavaPlatformResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/NativeAlignmentWithJavaPlatformResolveIntegrationTest.groovy
@@ -196,6 +196,7 @@ class NativeAlignmentWithJavaPlatformResolveIntegrationTest extends AbstractModu
             root(":", ":consumer:") {
                 edge('com.acme.foo:core:1.0', 'com.acme.foo:core:1.1') {
                     byConstraint("platform alignment")
+                    byConflictResolution("between versions 1.1 and 1.0")
                     variant "apiElements", [
                         'org.gradle.category':'library',
                         'org.gradle.dependency.bundling':'external',
@@ -211,6 +212,7 @@ class NativeAlignmentWithJavaPlatformResolveIntegrationTest extends AbstractModu
                             'org.gradle.usage': 'java-api']
                         constraint('com.acme.foo:core:1.1')
                         constraint('com.acme.foo:lib:1.1')
+                        byConflictResolution("between versions 1.1 and 1.0")
                         noArtifacts()
                     }
                     module('com.acme.foo:lib:1.1') {
@@ -222,6 +224,7 @@ class NativeAlignmentWithJavaPlatformResolveIntegrationTest extends AbstractModu
                             'org.gradle.usage': 'java-api',
                             'org.gradle.libraryelements': 'jar',
                         ]
+                        byConflictResolution("between versions 1.1 and 1.0")
                         byConstraint("platform alignment")
                     }
                 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentAttributesRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentAttributesRulesIntegrationTest.groovy
@@ -220,7 +220,9 @@ class ComponentAttributesRulesIntegrationTest extends AbstractModuleDependencyRe
         run ':checkDeps'
         resolve.expectGraph {
             root(":", ":test:") {
-                edge('org.test:module:[1.0,2.0)', 'org.test:module:1.1')
+                edge('org.test:module:[1.0,2.0)', 'org.test:module:1.1') {
+                    byReason("rejection: version 1.2:   - Attribute 'quality' didn't match. Requested 'qa', was: 'low'")
+                }
             }
         }
 
@@ -444,7 +446,15 @@ class ComponentAttributesRulesIntegrationTest extends AbstractModuleDependencyRe
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge('org:test:[1,)', "org:test:$selected")
+                edge('org:test:[1,)', "org:test:$selected") {
+                    if (status == 'release') {
+                        byReason("rejection: version 5:   - Attribute 'org.gradle.status' didn't match. Requested 'release', was: 'integration'")
+                    } else if (status == 'milestone') {
+                        byReason("rejection: version 5:   - Attribute 'org.gradle.status' didn't match. Requested 'milestone', was: 'integration'")
+                        byReason("rejection: version 4:   - Attribute 'org.gradle.status' didn't match. Requested 'milestone', was: 'release'")
+                        byReason("rejection: version 3:   - Attribute 'org.gradle.status' didn't match. Requested 'milestone', was: 'integration'")
+                    }
+                }
             }
         }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/DependencyMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/DependencyMetadataRulesIntegrationTest.groovy
@@ -93,7 +93,9 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
         def expectedVariant = variantToTest
         resolve.expectGraph {
             root(':', ':test:') {
-                edge('org.test:moduleB', 'org.test:moduleB:1.0')
+                edge('org.test:moduleB', 'org.test:moduleB:1.0') {
+                    maybeByConstraint()
+                }
                 module("org.test:moduleA:1.0:$expectedVariant") {
                     if (thing == "dependencies") {
                         edge('org.test:moduleB:1.0', 'org.test:moduleB:1.0')
@@ -155,7 +157,9 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
         def expectedVariant = variantToTest
         resolve.expectGraph {
             root(':', ':test:') {
-                edge('org.test:moduleB', 'org.test:moduleB:1.0')
+                edge('org.test:moduleB', 'org.test:moduleB:1.0') {
+                    maybeByConstraint()
+                }
                 module("org.test:moduleA:1.0:$expectedVariant")
                 module("org.test:moduleA:1.0:new") {
                     if (thing == "dependencies") {
@@ -211,7 +215,9 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
         def expectedVariant = variantToTest
         resolve.expectGraph {
             root(':', ':test:') {
-                edge('org.test:moduleB', 'org.test:moduleB:1.0')
+                edge('org.test:moduleB', 'org.test:moduleB:1.0') {
+                    maybeByConstraint()
+                }
                 module("org.test:moduleA:1.0:$expectedVariant") {
                     if (thing == "dependencies") {
                         edge('org.test:moduleB:{strictly 1.0}', 'org.test:moduleB:1.0')
@@ -494,7 +500,9 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
         def expectedVariant = variantToTest
         resolve.expectGraph {
             root(':', ':test:') {
-                edge('org.test:moduleB', 'org.test:moduleB:1.0')
+                edge('org.test:moduleB', 'org.test:moduleB:1.0') {
+                    byConstraint(null)
+                }
                 module("org.test:moduleA:1.0:$expectedVariant") {
                     constraint('org.test:moduleB:1.0', 'org.test:moduleB:1.0')
                 }
@@ -634,7 +642,9 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
         def expectedVariant = variantToTest
         resolve.expectGraph {
             root(':', ':test:') {
-                edge('org.test:moduleC', 'org.test:moduleC:1.0')
+                edge('org.test:moduleC', 'org.test:moduleC:1.0') {
+                    maybeByConstraint()
+                }
                 module("org.test:moduleA:1.0:$expectedVariant") {
                     module("org.test:moduleB:1.0") {
                         if (thing == "dependencies") {
@@ -971,7 +981,10 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
         resolve.expectGraph {
             root(':', ':test:') {
                 module("org.test:moduleA:1.0:$expectedVariant") {
-                    module("org.test:moduleB:1.0").byReason('can set a custom reason in a rule')
+                    module("org.test:moduleB:1.0") {
+                        notRequested()
+                        byReason('can set a custom reason in a rule')
+                    }
                 }
             }
         }
@@ -1052,10 +1065,10 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
                 root(':', ':test:') {
                     module("org.test:moduleA:1.0:$expectedVariant") {
                         module("org.test:moduleB:1.0") {
-                            module("org.test:moduleC:1.0")
+                            notRequested()
                             byReason('can set a custom reason in a rule')
+                            module("org.test:moduleC:1.0")
                         }
-
                     }
                 }
             }
@@ -1064,10 +1077,15 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
                 root(':', ':test:') {
                     module("org.test:moduleA:1.0:$expectedVariant") {
                         module("org.test:moduleB:1.0") {
-                            edge("org.test:moduleC:1.0", "org.test:moduleC:1.1")
+                            notRequested()
                             byReason('can set a custom reason in a rule')
+                            edge("org.test:moduleC:1.0", "org.test:moduleC:1.1") {
+                                notRequested()
+                                byAncestor()
+                                byConstraint("1.0 is buggy")
+                            }
                         }
-                        constraint("org.test:moduleC:{strictly 1.1}", "org.test:moduleC:1.1").byAncestor()
+                        constraint("org.test:moduleC:{strictly 1.1}", "org.test:moduleC:1.1")
                     }
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/DependencyResolveRulesDisableGlobalDependencySubstitutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/DependencyResolveRulesDisableGlobalDependencySubstitutionIntegrationTest.groovy
@@ -97,10 +97,12 @@ class DependencyResolveRulesDisableGlobalDependencySubstitutionIntegrationTest e
         resolve.expectGraph {
             root(":m1", "org.test:m1:0.9") {
                 edge("org.test:m2:1.0", ":m2", "org.test:m2:0.9") {
+                    compositeSubstitute()
+                    noArtifacts()
                     edge("org.test:m3:1.0", ":m3", "org.test:m3:0.9") {
+                        compositeSubstitute()
                         noArtifacts()
                     }
-                    noArtifacts()
                 }
             }
         }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/DependencyResolveRulesPreferProjectModulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/DependencyResolveRulesPreferProjectModulesIntegrationTest.groovy
@@ -82,7 +82,9 @@ class DependencyResolveRulesPreferProjectModulesIntegrationTest extends Abstract
             root(":Subproject_with_preferProjectModules", "test:Subproject_with_preferProjectModules:") {
                 module("myorg:ModuleB:1.0") {
                     // Prefers project, regardless of version
-                    edge("myorg:ModuleC:2.0", ":ModuleC", "myorg:ModuleC:1.0")
+                    edge("myorg:ModuleC:2.0", ":ModuleC", "myorg:ModuleC:1.0") {
+                        byConflictResolution("between versions 1.0 and 2.0")
+                    }
                 }
                 project(":ModuleC", "myorg:ModuleC:1.0") {
                     noArtifacts()
@@ -99,7 +101,9 @@ class DependencyResolveRulesPreferProjectModulesIntegrationTest extends Abstract
                 project(":Subproject_with_preferProjectModules", "test:Subproject_with_preferProjectModules:") {
                     noArtifacts()
                     module("myorg:ModuleB:1.0") {
-                        module("myorg:ModuleC:2.0")
+                        module("myorg:ModuleC:2.0") {
+                            byConflictResolution("between versions 1.0 and 2.0")
+                        }
                     }
                     // 'Subproject_with_preferProjectModules' config DOES NOT influence this dependency
                     // and hence the higher version is picked from repo
@@ -156,7 +160,9 @@ class DependencyResolveRulesPreferProjectModulesIntegrationTest extends Abstract
         resolve.expectGraph {
             root(":ProjectA", "test:ProjectA:") {
                 module("myorg:ModuleB:1.0") {
-                    module("myorg:ModuleC:2.0")
+                    module("myorg:ModuleC:2.0") {
+                        byConflictResolution("between versions 1.0 and 2.0")
+                    }
                 }
                 // 'preferProjectModules()' is not inherited from 'baseConf'
                 // and hence the higher version is picked from repo
@@ -172,7 +178,9 @@ class DependencyResolveRulesPreferProjectModulesIntegrationTest extends Abstract
         resolve.expectGraph {
             root(":ProjectA", "test:ProjectA:") {
                 module("myorg:ModuleB:1.0") {
-                    edge("myorg:ModuleC:2.0", ":ModuleC", "myorg:ModuleC:1.0")
+                    edge("myorg:ModuleC:2.0", ":ModuleC", "myorg:ModuleC:1.0") {
+                        byConflictResolution("between versions 1.0 and 2.0")
+                    }
                 }
                 project("project :ModuleC", "myorg:ModuleC:1.0") {
                     noArtifacts()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/EndorseStrictVersionsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/EndorseStrictVersionsIntegrationTest.groovy
@@ -22,10 +22,6 @@ import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
 class EndorseStrictVersionsIntegrationTest extends AbstractModuleDependencyResolveTest {
 
-    def setup() {
-        resolve.withStrictReasonsCheck()
-    }
-
     void "can downgrade version through platform"() {
         given:
         repository {
@@ -71,11 +67,15 @@ class EndorseStrictVersionsIntegrationTest extends AbstractModuleDependencyResol
             root(':', ':test:') {
                 module('org:platform:1.0') {
                     constraint('org:bar:1.0').byConstraint()
-                    constraint('org:foo:{strictly 1.0}', 'org:foo:1.0').byConstraint()
+                    constraint('org:foo:{strictly 1.0}', 'org:foo:1.0')
                 }
                 edge('org:bar', 'org:bar:1.0') {
-                    edge('org:foo:2.0', 'org:foo:1.0').byAncestor()
-                }.byRequest()
+                    edge('org:foo:2.0', 'org:foo:1.0') {
+                        notRequested()
+                        byConstraint()
+                        byAncestor()
+                    }
+                }
             }
         }
     }
@@ -132,13 +132,19 @@ class EndorseStrictVersionsIntegrationTest extends AbstractModuleDependencyResol
         resolve.expectGraph {
             root(':', ':test:') {
                 edge('org:platform:1.0', 'org:platform:2.0') {
-                    constraint('org:bar:1.0').byConstraint()
-                    constraint('org:foo:1.0', 'org:foo:2.0').byConstraint().byConflictResolution("between versions 2.0 and 1.0")
-                }.byConflictResolution("between versions 2.0 and 1.0")
+                    byConflictResolution("between versions 2.0 and 1.0")
+                    constraint('org:bar:1.0')
+                    constraint('org:foo:1.0', 'org:foo:2.0') {
+                        notRequested()
+                        byConstraint()
+                        byConflictResolution("between versions 2.0 and 1.0")
+                    }
+                }
                 edge('org:bar', 'org:bar:1.0') {
+                    byConstraint()
                     module('org:foo:2.0')
-                    module('org:platform:2.0').byRequest()
-                }.byRequest()
+                    module('org:platform:2.0')
+                }
             }
         }
     }
@@ -244,11 +250,15 @@ class EndorseStrictVersionsIntegrationTest extends AbstractModuleDependencyResol
         resolve.expectGraph {
             root(':', ':test:') {
                 module('org:platform:1.0') {
-                    constraint('org:foo:{strictly 1.0}', 'org:foo:1.0').byConstraint()
+                    constraint('org:foo:{strictly 1.0}', 'org:foo:1.0')
                 }
                 module('org:baz:1.0') {
                     module('org:bar:1.0') {
-                        edge('org:foo:2.0', 'org:foo:1.0').byAncestor()
+                        edge('org:foo:2.0', 'org:foo:1.0') {
+                            notRequested()
+                            byConstraint()
+                            byAncestor()
+                        }
                     }
                 }
             }
@@ -306,11 +316,14 @@ class EndorseStrictVersionsIntegrationTest extends AbstractModuleDependencyResol
                 module('org:baz:1.0') {
                     module('org:platform:1.0') {
                         constraint('org:bar:1.0').byConstraint()
-                        constraint('org:foo:{strictly 1.0}', 'org:foo:1.0').byConstraint()
+                        constraint('org:foo:{strictly 1.0}', 'org:foo:1.0')
                     }
                     edge('org:bar', 'org:bar:1.0') {
-                        byRequest()
-                        edge('org:foo:2.0', 'org:foo:1.0').byAncestor()
+                        edge('org:foo:2.0', 'org:foo:1.0') {
+                            notRequested()
+                            byConstraint()
+                            byAncestor()
+                        }
                     }
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionConstraintsFeatureInteractionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionConstraintsFeatureInteractionIntegrationTest.groovy
@@ -20,11 +20,6 @@ import org.gradle.integtests.fixtures.RequiredFeature
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 
 class StrictVersionConstraintsFeatureInteractionIntegrationTest extends AbstractModuleDependencyResolveTest {
-
-    def setup() {
-        resolve.withStrictReasonsCheck()
-    }
-
     def "can turn constraint into strict constraint by using a component metadata rule"() {
         given:
         repository {
@@ -77,7 +72,7 @@ class StrictVersionConstraintsFeatureInteractionIntegrationTest extends Abstract
         resolve.expectGraph {
             root(':', ':test:') {
                 module('org:bar:1.0') {
-                    edge('org:baz:{strictly 1.0}', 'org:baz:1.0').byRequest()
+                    edge('org:baz:{strictly 1.0}', 'org:baz:1.0')
                     edge('org:foo:{strictly 1.0}', 'org:foo:1.0') {
                         edge('org:baz:2.0', 'org:baz:1.0').byAncestor()
                     }
@@ -144,7 +139,7 @@ class StrictVersionConstraintsFeatureInteractionIntegrationTest extends Abstract
                 module('org:bar:1.0') {
                     edge('org:baz:1.0', 'org:baz:2.0').byConflictResolution('between versions 2.0 and 1.0')
                     module('org:foo:1.0') {
-                        module('org:baz:2.0').byRequest()
+                        module('org:baz:2.0')
                     }
                 }
             }
@@ -189,9 +184,13 @@ class StrictVersionConstraintsFeatureInteractionIntegrationTest extends Abstract
         then:
         resolve.expectGraph {
             root(':', ':test:') {
-                constraint('org:foo:{strictly 1.0}', 'org:foo:1.0').byConstraint()
+                constraint('org:foo:{strictly 1.0}', 'org:foo:1.0')
                 module('org:bar:1.0') {
-                    edge('org:foo:2.0', 'org:foo:1.0').byAncestor()
+                    edge('org:foo:2.0', 'org:foo:1.0') {
+                        notRequested()
+                        byAncestor()
+                        byConstraint()
+                    }
                 }
             }
         }
@@ -279,7 +278,7 @@ class StrictVersionConstraintsFeatureInteractionIntegrationTest extends Abstract
                 constraint('org:bar:{strictly 1.0}', 'org:bar:2.0').byConstraint().forced()
                 project(':foo', 'test:foo:') {
                     configuration = 'conf'
-                    module('org:bar:2.0').byRequest()
+                    module('org:bar:2.0')
                 }
             }
         }
@@ -324,7 +323,7 @@ class StrictVersionConstraintsFeatureInteractionIntegrationTest extends Abstract
         then:
         resolve.expectGraph {
             root(':', ':test:') {
-                edge('org:foo:{strictly 1.0}', 'org:foo:1.0').byRequest()
+                edge('org:foo:{strictly 1.0}', 'org:foo:1.0')
                 module('org:bar:1.0') {
                     edge('org:old:2.0', 'org:foo:1.0').selectedByRule("better foo than old").byAncestor()
                 }
@@ -389,9 +388,14 @@ class StrictVersionConstraintsFeatureInteractionIntegrationTest extends Abstract
         then:
         resolve.expectGraph {
             root(':', ':test:') {
-                constraint('org:foo:{strictly 1.0}', 'org:foo:1.0').byConstraint()
+                constraint('org:foo:{strictly 1.0}', 'org:foo:1.0')
                 module('org:bar:1.0') {
-                    edge("org:foo:2.2", 'org:foo:1.0').selectedByRule("bad version").byAncestor()
+                    edge("org:foo:2.2", 'org:foo:1.0') {
+                        selectedByRule("bad version")
+                        byAncestor()
+                        byConstraint()
+                        notRequested()
+                    }
                 }
             }
         }
@@ -442,7 +446,7 @@ class StrictVersionConstraintsFeatureInteractionIntegrationTest extends Abstract
             root(':', ':test:') {
                 constraint('org:foo:{strictly 1.0}', 'org:foo:0.11').byConstraint()
                 module('org:bar:1.0') {
-                    edge('org:foo:2.0', 'org:foo:0.11').byRequest().selectedByRule('because I can')
+                    edge('org:foo:2.0', 'org:foo:0.11').selectedByRule('because I can')
                 }
             }
         }
@@ -493,7 +497,7 @@ class StrictVersionConstraintsFeatureInteractionIntegrationTest extends Abstract
         then:
         resolve.expectGraph {
             root(':', ':test:') {
-                edge('org:foo:{strictly 1.0}', 'org:new:1.0').byRequest().selectedByRule()
+                edge('org:foo:{strictly 1.0}', 'org:new:1.0').selectedByRule()
                 module('org:bar:1.0') {
                     module('org:foo:2.0')
                 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionConstraintsIntegrationTest.groovy
@@ -20,11 +20,6 @@ import org.gradle.integtests.fixtures.RequiredFeature
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 
 class StrictVersionConstraintsIntegrationTest extends AbstractModuleDependencyResolveTest {
-
-    def setup() {
-        resolve.withStrictReasonsCheck()
-    }
-
     def "can downgrade version"() {
         given:
         repository {
@@ -60,7 +55,7 @@ class StrictVersionConstraintsIntegrationTest extends AbstractModuleDependencyRe
         then:
         resolve.expectGraph {
             root(':', ':test:') {
-                edge('org:foo:{strictly 1.0}', 'org:foo:1.0').byRequest()
+                edge('org:foo:{strictly 1.0}', 'org:foo:1.0')
                 module('org:bar:1.0') {
                     edge('org:foo:2.0', 'org:foo:1.0').byAncestor()
                 }
@@ -105,9 +100,13 @@ class StrictVersionConstraintsIntegrationTest extends AbstractModuleDependencyRe
         then:
         resolve.expectGraph {
             root(':', ':test:') {
-                constraint('org:foo:{strictly 1.0}', 'org:foo:1.0').byConstraint()
+                constraint('org:foo:{strictly 1.0}', 'org:foo:1.0') {
+                    notRequested()
+                    byConstraint()
+                    byAncestor()
+                }
                 module('org:bar:1.0') {
-                    edge('org:foo:2.0', 'org:foo:1.0').byAncestor()
+                    edge('org:foo:2.0', 'org:foo:1.0')
                 }
             }
         }
@@ -161,13 +160,17 @@ class StrictVersionConstraintsIntegrationTest extends AbstractModuleDependencyRe
             root(':', ':test:') {
                 module('org:a:1.0') {
                     module('org:b:1.0') {
-                        edge('org:c:3.0', 'org:c:1.0').byAncestor()
+                        edge('org:c:3.0', 'org:c:1.0') {
+                            notRequested()
+                            byAncestor()
+                            byConstraint()
+                        }
                     }
                     if (publishedConstraintsSupported) {
                         constraint('org:c:{strictly 2.0}', 'org:c:1.0')
                     }
                 }
-                constraint('org:c:{strictly 1.0}', 'org:c:1.0').byConstraint()
+                constraint('org:c:{strictly 1.0}', 'org:c:1.0')
             }
         }
     }
@@ -219,13 +222,17 @@ class StrictVersionConstraintsIntegrationTest extends AbstractModuleDependencyRe
             root(':', ':test:') {
                 module('org:a:1.0') {
                     module('org:b:1.0') {
-                        edge('org:c:2.0', 'org:c:1.0').byAncestor()
+                        edge('org:c:2.0', 'org:c:1.0') {
+                            notRequested()
+                            byAncestor()
+                            byConstraint()
+                        }
                     }
                     if (publishedConstraintsSupported) {
                         constraint('org:c:{strictly 1.0}', 'org:c:1.0')
                     }
                 }
-                constraint('org:c:{strictly 1.0}', 'org:c:1.0').byConstraint()
+                constraint('org:c:{strictly 1.0}', 'org:c:1.0')
             }
         }
     }
@@ -343,13 +350,13 @@ class StrictVersionConstraintsIntegrationTest extends AbstractModuleDependencyRe
             root(':', ':test:') {
                 edge('org:a:1.0', 'org:a:2.0') {
                     module('org:b:1.0') {
-                        module('org:c:2.0').byRequest()
+                        module('org:c:2.0')
                     }
                     edge('org:c:1.0', 'org:c:2.0').byConflictResolution("between versions 2.0 and 1.0")
                 }.byConflictResolution("between versions 2.0 and 1.0")
                 module('org:x:1.0') {
                     module('org:y:1.0') {
-                        module('org:a:2.0').byRequest()
+                        module('org:a:2.0')
                     }
                 }
             }
@@ -395,9 +402,13 @@ class StrictVersionConstraintsIntegrationTest extends AbstractModuleDependencyRe
         then:
         resolve.expectGraph {
             root(':', ':test:') {
-                constraint('org:foo:{strictly 1.0}', 'org:foo:1.0').byConstraint()
+                constraint('org:foo:{strictly 1.0}', 'org:foo:1.0') {
+                    notRequested()
+                    byConstraint()
+                    byAncestor()
+                }
                 module('org:bar:1.0') {
-                    edge("org:foo:$publishedFooDependencyVersion", 'org:foo:1.0').byAncestor()
+                    edge("org:foo:$publishedFooDependencyVersion", 'org:foo:1.0')
                 }
             }
         }
@@ -441,9 +452,13 @@ class StrictVersionConstraintsIntegrationTest extends AbstractModuleDependencyRe
         then:
         resolve.expectGraph {
             root(':', ':test:') {
-                constraint('org:foo:{strictly 1.0}', 'org:foo:1.0').byConstraint()
+                constraint('org:foo:{strictly 1.0}', 'org:foo:1.0') {
+                    notRequested()
+                    byConstraint()
+                    byAncestor()
+                }
                 module('org:bar:1.0') {
-                    edge("org:foo:[2.0,3.0)", 'org:foo:1.0').byAncestor()
+                    edge("org:foo:[2.0,3.0)", 'org:foo:1.0')
                 }
             }
         }
@@ -495,7 +510,7 @@ class StrictVersionConstraintsIntegrationTest extends AbstractModuleDependencyRe
                 project(':foo', 'org:foo:1.0') {
                     configuration = 'default'
                     noArtifacts()
-                }.byRequest()
+                }
             }
         }
     }
@@ -631,14 +646,18 @@ class StrictVersionConstraintsIntegrationTest extends AbstractModuleDependencyRe
             root(':', ':test:') {
                 module('org:x1:1.0') {
                     module('org:bar:1.0') {
-                        edge('org:foo:2.0', 'org:foo:1.0').byAncestor()
+                        edge('org:foo:2.0', 'org:foo:1.0') {
+                            notRequested()
+                            byConstraint()
+                            byAncestor()
+                        }
                     }
-                    constraint('org:foo:{strictly 1.0}', 'org:foo:1.0').byConstraint()
+                    constraint('org:foo:{strictly 1.0}', 'org:foo:1.0')
                 }
                 module('org:x2:1.0') {
                     module('org:bar:1.0')
                 }
-                constraint('org:foo:{strictly 1.0}', 'org:foo:1.0').byConstraint()
+                constraint('org:foo:{strictly 1.0}', 'org:foo:1.0')
             }
         }
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionsInPlatformCentricDevelopmentIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionsInPlatformCentricDevelopmentIntegrationTest.groovy
@@ -39,10 +39,6 @@ class StrictVersionsInPlatformCentricDevelopmentIntegrationTest extends Abstract
         MODULE             // constraints in module are published with strict constraints, consumer uses normal dependencies with 'endorseStrictVersions()'
     }
 
-    def setup() {
-        resolve.withStrictReasonsCheck()
-    }
-
     String platformDependency(platformType, String dependency) {
         //noinspection GroovyFallthrough
         switch (platformType) {
@@ -178,7 +174,6 @@ class StrictVersionsInPlatformCentricDevelopmentIntegrationTest extends Abstract
         resolve.expectGraph {
             root(':', ':test:') {
                 edge(platformType == ENFORCED_PLATFORM ? "org:platform:${expectStrictVersion(platformType, '1.+')}" : 'org:platform:1.+', 'org:platform:1.0') {
-                    byRequest()
                     if (platformType != MODULE) {
                         configuration(platformType == ENFORCED_PLATFORM ? 'enforcedApiElements' : 'apiElements')
                         noArtifacts()
@@ -191,15 +186,14 @@ class StrictVersionsInPlatformCentricDevelopmentIntegrationTest extends Abstract
                     constraint("org:foo:${expectStrictVersion(platformType, '3.0', '3.1 & 3.2')}", 'org:foo:3.0').byConstraint()
                 }
                 edge('org:bar', 'org:bar:2.0') {
-                    byRequest()
                     if (platformType == ENFORCED_PLATFORM) {
                         forced()
                     }
                     edge('org:foo:3.1', 'org:foo:3.0') {
                         if (platformType != ENFORCED_PLATFORM) {
+                            notRequested()
                             byAncestor()
                         } else {
-                            byRequest()
                             forced()
                         }
                     }
@@ -241,7 +235,6 @@ class StrictVersionsInPlatformCentricDevelopmentIntegrationTest extends Abstract
         resolve.expectGraph {
             root(':', ':test:') {
                 edge(platformType == ENFORCED_PLATFORM ? "org:platform:${expectStrictVersion(platformType, '1.+')}" : 'org:platform:1.+', 'org:platform:1.1') {
-                    byRequest()
                     if (platformType != MODULE) {
                         configuration(platformType == ENFORCED_PLATFORM ? 'enforcedApiElements' : 'apiElements')
                         noArtifacts()
@@ -254,15 +247,14 @@ class StrictVersionsInPlatformCentricDevelopmentIntegrationTest extends Abstract
                     constraint("org:foo:${expectStrictVersion(platformType, '3.1.1', '3.1 & 3.2')}", 'org:foo:3.1.1').byConstraint()
                 }
                 edge('org:bar', 'org:bar:2.0') {
-                    byRequest()
                     if (platformType == ENFORCED_PLATFORM) {
                         forced()
                     }
                     edge('org:foo:3.1', 'org:foo:3.1.1') {
                         if (platformType != ENFORCED_PLATFORM) {
+                            notRequested()
                             byAncestor()
                         } else {
-                            byRequest()
                             forced()
                         }
                     }
@@ -388,7 +380,6 @@ class StrictVersionsInPlatformCentricDevelopmentIntegrationTest extends Abstract
                 root(':', ':test:') {
                     constraint('org:foo:{strictly 3.2}', "org:foo:$expectedFooVersion").byConstraint()
                     edge('org:platform:1.+', 'org:platform:1.1') {
-                        byRequest()
                         if (platformType != MODULE) {
                             configuration(platformType == ENFORCED_PLATFORM ? 'enforcedApiElements' : 'apiElements')
                             noArtifacts()
@@ -397,8 +388,13 @@ class StrictVersionsInPlatformCentricDevelopmentIntegrationTest extends Abstract
                         constraint("org:foo:${expectStrictVersion(platformType, '3.1.1', '3.1 & 3.2')}", "org:foo:$expectedFooVersion").byConstraint()
                     }
                     edge('org:bar', 'org:bar:2.0') {
-                        edge('org:foo:3.1', "org:foo:$expectedFooVersion").byAncestor()
-                    }.byRequest()
+                        edge('org:foo:3.1', "org:foo:$expectedFooVersion") {
+                            if (platformType != ENFORCED_PLATFORM) {
+                                notRequested()
+                            }
+                            byAncestor()
+                        }
+                    }
                 }
             }
         }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/DynamicRevisionRemoteResolveWithMetadataSupplierIntegrationTest.groovy
@@ -1345,7 +1345,7 @@ group:projectB:2.2;release
             root(":", ":test:") {
                 edges.each { from, to ->
                     if (to instanceof List) {
-                        edge(from, to[0]).byReason(to[1])
+                        edge(from, to[0]).byReason(to[1]).maybeRequested()
                     } else {
                         edge(from, to)
                     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/DisambiguateArtifactTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/DisambiguateArtifactTransformIntegrationTest.groovy
@@ -305,7 +305,6 @@ task resolveReleaseClasses {
     }
 }
 
-
 task resolveTestClasses {
     def artifacts = configurations.compile.incoming.artifactView {
         attributes {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
@@ -17,10 +17,10 @@
 package org.gradle.api.internal.artifacts.ivyservice;
 
 import com.google.common.collect.ImmutableList;
-import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.artifacts.UnresolvedDependency;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
+import org.gradle.api.artifacts.component.ProjectComponentSelector;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.internal.artifacts.ArtifactDependencyResolver;
 import org.gradle.api.internal.artifacts.ComponentSelectorConverter;
@@ -67,7 +67,6 @@ import org.gradle.api.specs.Specs;
 import org.gradle.cache.internal.BinaryStore;
 import org.gradle.cache.internal.Store;
 import org.gradle.internal.Cast;
-import org.gradle.internal.component.local.model.DslOriginDependencyMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.locking.DependencyLockingArtifactVisitor;
 import org.gradle.internal.operations.BuildOperationExecutor;
@@ -78,7 +77,7 @@ import java.util.List;
 import java.util.Set;
 
 public class DefaultConfigurationResolver implements ConfigurationResolver {
-    private static final Spec<DependencyMetadata> IS_LOCAL_EDGE = element -> element instanceof DslOriginDependencyMetadata && ((DslOriginDependencyMetadata) element).getSource() instanceof ProjectDependency;
+    private static final Spec<DependencyMetadata> IS_LOCAL_EDGE = element -> element.getSelector() instanceof ProjectComponentSelector;
     private final ArtifactDependencyResolver resolver;
     private final RepositoriesSupplier repositoriesSupplier;
     private final GlobalDependencyResolutionRules metadataHandler;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/type/DefaultArtifactTypeRegistry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/type/DefaultArtifactTypeRegistry.java
@@ -68,7 +68,7 @@ public class DefaultArtifactTypeRegistry implements ArtifactTypeRegistry {
             String format = sourceAttributes.getAttribute(ARTIFACT_TYPE_ATTRIBUTE);
             if (format != null && seen.add(format)) {
                 // Some artifact type that has not already been visited
-                ImmutableAttributes attributes = sourceAttributes.asImmutable();
+                ImmutableAttributes attributes = attributesFactory.of(ARTIFACT_TYPE_ATTRIBUTE, format);
                 action.accept(attributes);
             }
         }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/integtests/resolve/consistency/JavaProjectResolutionConsistencyIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/integtests/resolve/consistency/JavaProjectResolutionConsistencyIntegrationTest.groovy
@@ -72,12 +72,15 @@ class JavaProjectResolutionConsistencyIntegrationTest extends AbstractHttpDepend
         resolve.expectGraph {
             root(':', ':test:') {
                 module('org:foo:1.0') {
-                    module("org:transitive:1.0")
+                    byConsistentResolution('compileClasspath')
+                    module("org:transitive:1.0") {
+                        notRequested()
+                        byConsistentResolution('compileClasspath')
+                        byAncestor()
+                    }
                 }
                 module('org:bar:1.0') {
-                    edge("org:transitive:1.1", "org:transitive:1.0") {
-                        byConsistentResolution('compileClasspath')
-                    }
+                    edge("org:transitive:1.1", "org:transitive:1.0")
                 }
                 constraint("org:foo:{strictly 1.0}", "org:foo:1.0")
                 constraint("org:transitive:{strictly 1.0}", "org:transitive:1.0")
@@ -94,14 +97,18 @@ class JavaProjectResolutionConsistencyIntegrationTest extends AbstractHttpDepend
         resolve.expectGraph {
             root(':', ':test:') {
                 module('org:foo:1.0') {
+                    byConsistentResolution('testCompileClasspath')
                     module("org:transitive:1.0")
                 }
                 module('org:bar:1.0') {
                     edge("org:transitive:1.1", "org:transitive:1.0") {
+                        notRequested()
                         byConsistentResolution('testCompileClasspath')
+                        byAncestor()
                     }
                 }
                 module('org:baz:1.0') {
+                    byConsistentResolution('testCompileClasspath')
                     edge("org:transitive:1.2", "org:transitive:1.0") {
                         byConsistentResolution('testCompileClasspath')
                     }
@@ -146,7 +153,10 @@ class JavaProjectResolutionConsistencyIntegrationTest extends AbstractHttpDepend
         resolve.expectGraph {
             root(':', ':test:') {
                 module('org:foo:1.0') {
+                    byConsistentResolution('runtimeClasspath')
                     edge("org:transitive:1.0", "org:transitive:1.1") {
+                        notRequested()
+                        byAncestor()
                         byConsistentResolution('runtimeClasspath')
                     }
                 }
@@ -191,12 +201,15 @@ class JavaProjectResolutionConsistencyIntegrationTest extends AbstractHttpDepend
         resolve.expectGraph {
             root(':', ':test:') {
                 module('org:foo:1.0') {
-                    module("org:transitive:1.0")
+                    byConsistentResolution('customCompileClasspath')
+                    module("org:transitive:1.0") {
+                        notRequested()
+                        byConsistentResolution('customCompileClasspath')
+                        byAncestor()
+                    }
                 }
                 module('org:bar:1.0') {
-                    edge("org:transitive:1.1", "org:transitive:1.0") {
-                        byConsistentResolution('customCompileClasspath')
-                    }
+                    edge("org:transitive:1.1", "org:transitive:1.0")
                 }
                 constraint("org:foo:{strictly 1.0}", "org:foo:1.0")
                 constraint("org:transitive:{strictly 1.0}", "org:transitive:1.0")
@@ -249,7 +262,9 @@ class JavaProjectResolutionConsistencyIntegrationTest extends AbstractHttpDepend
         then:
         resolve.expectGraph {
             root(':', ':test:') {
-                module('org:foo:1.0')
+                module('org:foo:1.0') {
+                    byConsistentResolution("runtimeClasspath")
+                }
                 constraint("org:foo:{strictly 1.0}", "org:foo:1.0")
             }
         }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryPublishedTargetJvmEnvironmentIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryPublishedTargetJvmEnvironmentIntegrationTest.groovy
@@ -168,6 +168,7 @@ class JavaLibraryPublishedTargetJvmEnvironmentIntegrationTest extends AbstractHt
                         'org.gradle.dependency.bundling': 'external',
                         'org.gradle.status': 'release'
                     ])
+                    byConstraint()
                     artifact(classifier: 'jre')
                 }
             }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BomSupportPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BomSupportPluginsSmokeTest.groovy
@@ -67,7 +67,7 @@ class BomSupportPluginsSmokeTest extends AbstractSmokeTest {
             module("org.hamcrest:hamcrest-core:1.3").byReason(reason3)
         }
         def springCoreDeps = {
-            module("org.springframework:spring-jcl:${springVersion}")
+            module("org.springframework:spring-jcl:${springVersion}").byReason(reason3)
         }
         def springExpressionDeps = {
             module("org.springframework:spring-core:${springVersion}")
@@ -130,6 +130,13 @@ class BomSupportPluginsSmokeTest extends AbstractSmokeTest {
                 edge("org.springframework.boot:spring-boot", "org.springframework.boot:spring-boot:$bomVersion", springBootDeps).byReason(reason2)
                 edge("org.springframework:spring-test", "org.springframework:spring-test:${springVersion}", springTestDeps).byReason(reason2)
                 edge("junit:junit", "junit:junit:4.12", junitDeps).byReason(reason2)
+            }
+            nodes.each {
+                if (directBomDependency) {
+                    it.maybeByConstraint()
+                } else if (reason1 == "requested") {
+                    it.maybeSelectedByRule()
+                }
             }
         }
 


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context

Fix transform selection when serializing a file collection dependency to the cache.

Also fixes a number of tests to be compatible with configuration cache and make `ResolveTestFixture` stricter in checking the selection reason for a node in the graph.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
