### PR TITLE
Remove limitation of using the Kotlin DSL together with Configure-on-Demand

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ProjectConfigurationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ProjectConfigurationIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Issue
 
 class ProjectConfigurationIntegrationTest extends AbstractIntegrationSpec {
 
@@ -99,5 +100,17 @@ class ProjectConfigurationIntegrationTest extends AbstractIntegrationSpec {
         def result = fails()
         result.assertHasDescription("A problem occurred evaluating root project 'root'.")
         failure.assertHasCause("Cannot run Project.afterEvaluate(Action) when the project is already evaluated.")
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/4823")
+    def "evaluationDependsOn deep project forces evaluation of parents"() {
+        given:
+        settingsFile << "include(':a', ':b:c')"
+        file("a/build.gradle") << "evaluationDependsOn(':b:c')"
+        file("b/build.gradle") << "plugins { id('org.gradle.hello-world') version '0.2' apply false }"
+        file("b/c/build.gradle") << "import org.gradle.plugin.HelloWorldTask"
+
+        expect:
+        succeeds 'help'
     }
 }

--- a/subprojects/docs/src/docs/userguide/api/kotlin_dsl.adoc
+++ b/subprojects/docs/src/docs/userguide/api/kotlin_dsl.adoc
@@ -1011,6 +1011,5 @@ The main reason for this is the slower script compilation for Kotlin DSL.
 * Kotlin DSL script compilation avoidance has known issues.
   If you encounter problems, it can be disabled by <<build_environment#sec:gradle_system_properties, setting>> the `org.gradle.kotlin.dsl.scriptCompilationAvoidance` system property to `false`.
 * The Kotlin DSL will not support the `model {}` block, which is part of the link:https://blog.gradle.org/state-and-future-of-the-gradle-software-model[discontinued Gradle Software Model].
-* We recommend against enabling the incubating <<multi_project_configuration_and_execution#sec:configuration_on_demand,configuration on demand>> feature as it can lead to very hard-to-diagnose problems.
 
 If you run into trouble or discover a suspected bug, please report the issue in the link:{gradle-issues}[Gradle issue tracker].


### PR DESCRIPTION
* See https://github.com/gradle/gradle/issues/4823#issuecomment-1488817800

----

This PR also adds a regression test for the reproducer mentioned in the comment linked above.