### PR TITLE
Support modular project dependency in eclipse plugin

### DIFF
--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseClasspathFixture.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseClasspathFixture.groovy
@@ -114,6 +114,10 @@ class EclipseClasspathFixture {
         String getName() {
             return entry.@path.substring(1)
         }
+
+        void assertModularDependency() {
+            assert entry.attributes.find { it.attribute[0].@name == 'module' && it.attribute[0].@value == 'true' }
+        }
     }
 
     class EclipseSourceDir extends EclipseClasspathEntry {

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseJavaProjectModulesIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseJavaProjectModulesIntegrationTest.groovy
@@ -44,14 +44,14 @@ class EclipseJavaProjectModulesIntegrationTest extends AbstractEclipseIntegratio
             }
         """
 
-        file("settings.gradle") << """
+        settingsFile << """
             rootProject.name = 'root'
             include 'api'
             include 'util'
 
         """
 
-        file("build.gradle") << """
+        buildFile << """
             allprojects {
                 apply plugin: 'java'
                 apply plugin: 'eclipse'

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseJavaProjectModulesIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseJavaProjectModulesIntegrationTest.groovy
@@ -16,14 +16,12 @@
 
 package org.gradle.plugins.ide.eclipse
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.util.Requires;
 import org.gradle.util.TestPrecondition
 
 @Requires(TestPrecondition.JDK9_OR_LATER)
 class EclipseJavaProjectModulesIntegrationTest extends AbstractEclipseIntegrationSpec {
 
-    @ToBeFixedForConfigurationCache
     def "depend on modular project"() {
         setup:
         /*

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseJavaProjectModulesIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseJavaProjectModulesIntegrationTest.groovy
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugins.ide.eclipse
+
+import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import org.gradle.util.Requires;
+import org.gradle.util.TestPrecondition
+
+@Requires(TestPrecondition.JDK9_OR_LATER)
+class EclipseJavaProjectModulesIntegrationTest extends AbstractEclipseIntegrationSpec {
+
+    @ToBeFixedForConfigurationCache
+    def "depend on modular project"() {
+        setup:
+        /*
+        This is the multi-module project structure the integration test works with:
+        -root
+          -api
+          -util
+        */
+        file("/api/src/main/java/module-info.java") << """
+            module api {
+                exports api
+            }
+        """
+
+        file("/util/src/main/java/module-info.java") << """
+            module util {
+                requires api
+            }
+        """
+
+        file("settings.gradle") << """
+            rootProject.name = 'root'
+            include 'api'
+            include 'util'
+
+        """
+
+        file("build.gradle") << """
+            allprojects {
+                apply plugin: 'java'
+                apply plugin: 'eclipse'
+            }
+
+            project(':util') {
+                dependencies {
+                    implementation project(':api')
+                }
+            }
+
+        """
+
+        when:
+        succeeds "eclipse"
+
+        then:
+        def projects = classpath("util").projects
+        assert projects.size() == 1
+        projects.get(0).assertModularDependency()
+    }
+}

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
@@ -21,20 +21,15 @@ import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
-import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.internal.file.FileTreeInternal;
 import org.gradle.api.internal.project.ProjectInternal;
-import org.gradle.api.internal.tasks.JvmConstants;
-import org.gradle.api.internal.tasks.compile.CompilationSourceDirs;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.SourceSet;
-import org.gradle.api.tasks.compile.JavaCompile;
-import org.gradle.internal.jvm.JavaModuleDetector;
 import org.gradle.internal.xml.XmlTransformer;
 import org.gradle.plugins.ide.api.XmlFileContentMerger;
 import org.gradle.plugins.ide.eclipse.model.internal.ClasspathFactory;
+import org.gradle.plugins.ide.eclipse.model.internal.EclipseClassPathUtil;
 import org.gradle.plugins.ide.eclipse.model.internal.FileReferenceFactory;
 import org.gradle.plugins.ide.internal.IdeArtifactRegistry;
 import org.gradle.plugins.ide.internal.resolver.DefaultGradleApiSourcesResolver;
@@ -362,21 +357,10 @@ public abstract class EclipseClasspath {
     public List<ClasspathEntry> resolveDependencies() {
         ProjectInternal projectInternal = (ProjectInternal) this.project;
         IdeArtifactRegistry ideArtifactRegistry = projectInternal.getServices().get(IdeArtifactRegistry.class);
-        ClasspathFactory classpathFactory = new ClasspathFactory(this, ideArtifactRegistry, new DefaultGradleApiSourcesResolver(projectInternal.newDetachedResolver()), isInferModulePath(this.project));
+        ClasspathFactory classpathFactory = new ClasspathFactory(this, ideArtifactRegistry, new DefaultGradleApiSourcesResolver(projectInternal.newDetachedResolver()), EclipseClassPathUtil.isInferModulePath(this.project));
         return classpathFactory.createEntries();
     }
 
-    public boolean isInferModulePath(org.gradle.api.Project project) {
-        Task javaCompileTask = project.getTasks().findByName(JvmConstants.COMPILE_JAVA_TASK_NAME);
-        if (javaCompileTask instanceof JavaCompile) {
-            JavaCompile javaCompile = (JavaCompile) javaCompileTask;
-            if (javaCompile.getModularity().getInferModulePath().get()) {
-                List<File> sourceRoots = CompilationSourceDirs.inferSourceRoots((FileTreeInternal) javaCompile.getSource());
-                return JavaModuleDetector.isModuleSource(true, sourceRoots);
-            }
-        }
-        return false;
-    }
 
     @SuppressWarnings("unchecked")
     public void mergeXmlClasspath(Classpath xmlClasspath) {

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
@@ -362,20 +362,21 @@ public abstract class EclipseClasspath {
     public List<ClasspathEntry> resolveDependencies() {
         ProjectInternal projectInternal = (ProjectInternal) this.project;
         IdeArtifactRegistry ideArtifactRegistry = projectInternal.getServices().get(IdeArtifactRegistry.class);
-        boolean inferModulePath = false;
-        Task javaCompileTask = project.getTasks().findByName(JvmConstants.COMPILE_JAVA_TASK_NAME);
-        if (javaCompileTask instanceof JavaCompile) {
-            JavaCompile javaCompile = (JavaCompile) javaCompileTask;
-            inferModulePath = javaCompile.getModularity().getInferModulePath().get();
-            if (inferModulePath) {
-                List<File> sourceRoots = CompilationSourceDirs.inferSourceRoots((FileTreeInternal) javaCompile.getSource());
-                inferModulePath = JavaModuleDetector.isModuleSource(true, sourceRoots);
-            }
-        }
-        ClasspathFactory classpathFactory = new ClasspathFactory(this, ideArtifactRegistry, new DefaultGradleApiSourcesResolver(projectInternal.newDetachedResolver()), inferModulePath);
+        ClasspathFactory classpathFactory = new ClasspathFactory(this, ideArtifactRegistry, new DefaultGradleApiSourcesResolver(projectInternal.newDetachedResolver()), isInferModulePath(this.project));
         return classpathFactory.createEntries();
     }
 
+    public boolean isInferModulePath(org.gradle.api.Project project) {
+        Task javaCompileTask = project.getTasks().findByName(JvmConstants.COMPILE_JAVA_TASK_NAME);
+        if (javaCompileTask instanceof JavaCompile) {
+            JavaCompile javaCompile = (JavaCompile) javaCompileTask;
+            if (javaCompile.getModularity().getInferModulePath().get()) {
+                List<File> sourceRoots = CompilationSourceDirs.inferSourceRoots((FileTreeInternal) javaCompile.getSource());
+                return JavaModuleDetector.isModuleSource(true, sourceRoots);
+            }
+        }
+        return false;
+    }
 
     @SuppressWarnings("unchecked")
     public void mergeXmlClasspath(Classpath xmlClasspath) {

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseClassPathUtil.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseClassPathUtil.java
@@ -16,6 +16,7 @@
 
 package org.gradle.plugins.ide.eclipse.model.internal;
 
+import org.gradle.api.NonNullApi;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.internal.file.FileTreeInternal;
@@ -27,6 +28,7 @@ import org.gradle.internal.jvm.JavaModuleDetector;
 import java.io.File;
 import java.util.List;
 
+@NonNullApi
 public class EclipseClassPathUtil {
 
     public static boolean isInferModulePath(Project project) {

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseClassPathUtil.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseClassPathUtil.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugins.ide.eclipse.model.internal;
+
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.internal.file.FileTreeInternal;
+import org.gradle.api.internal.tasks.JvmConstants;
+import org.gradle.api.internal.tasks.compile.CompilationSourceDirs;
+import org.gradle.api.tasks.compile.JavaCompile;
+import org.gradle.internal.jvm.JavaModuleDetector;
+
+import java.io.File;
+import java.util.List;
+
+public class EclipseClassPathUtil {
+
+    public static boolean isInferModulePath(Project project) {
+        Task javaCompileTask = project.getTasks().findByName(JvmConstants.COMPILE_JAVA_TASK_NAME);
+        if (javaCompileTask instanceof JavaCompile) {
+            JavaCompile javaCompile = (JavaCompile) javaCompileTask;
+            if (javaCompile.getModularity().getInferModulePath().get()) {
+                List<File> sourceRoots = CompilationSourceDirs.inferSourceRoots((FileTreeInternal) javaCompile.getSource());
+                return JavaModuleDetector.isModuleSource(true, sourceRoots);
+            }
+        }
+        return false;
+    }
+}

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
@@ -124,6 +124,12 @@ public class EclipseDependenciesCreator {
             if (artifactId instanceof ComponentArtifactMetadata) {
                 buildDependencies = ((ComponentArtifactMetadata) artifactId).getBuildDependencies();
             }
+            if (!asJavaModule) {
+                Project artifactProject = project.findProject(componentIdentifier.getProjectPath());
+                if (artifactProject != null) {
+                    asJavaModule = classpath.isInferModulePath(artifactProject);
+                }
+            }
             projects.add(projectDependencyBuilder.build(componentIdentifier, classpath.getFileReferenceFactory().fromFile(artifact.getFile()), buildDependencies, testDependency, asJavaModule));
         }
 

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
@@ -127,7 +127,7 @@ public class EclipseDependenciesCreator {
             if (!asJavaModule) {
                 Project artifactProject = project.findProject(componentIdentifier.getProjectPath());
                 if (artifactProject != null) {
-                    asJavaModule = classpath.isInferModulePath(artifactProject);
+                    asJavaModule = EclipseClassPathUtil.isInferModulePath(artifactProject);
                 }
             }
             projects.add(projectDependencyBuilder.build(componentIdentifier, classpath.getFileReferenceFactory().fromFile(artifact.getFile()), buildDependencies, testDependency, asJavaModule));


### PR DESCRIPTION
<!--- The issue this PR addresses -->
- Fixes #19827
https://github.com/eclipse/buildship/issues/1210

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

Currently the eclipse plugin can't resolve modular information between modular projects, making some multi-module projects can't be synchrozed well in eclipse and VS Code. 
- https://github.com/eclipse/buildship/issues/1210 
talks about the steps to reproduce this issue.

The root cause is that now we're using the artifact path to determine if the artifact is modular, see: https://github.com/gradle/gradle/blob/8dbd4eb1db138bfd600983b53776ab432b5190e4/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/IdeDependencySet.java#L229

Consider a new modular project without executing `build` task, the artifact file is not existing, so the result is always false. This PR intoduces a way to get the modular info from EclipseClasspath and then check it.

As for the tests, see new file `EclipseJavaProjectModulesIntegrationTest`

cc @donat 
### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
