### PR TITLE
Update GE plugin version

### DIFF
--- a/subprojects/docs/src/docs/userguide/reference/ci-systems/github-actions.adoc
+++ b/subprojects/docs/src/docs/userguide/reference/ci-systems/github-actions.adoc
@@ -65,7 +65,7 @@ In order to publish Build Scans from GitHub Actions, you'll need to pre-approve 
 To do so, add the following content to the top of your `settings.gradle[.kts]` file. The "CI" environment variable is set by GitHub Actions:
 ```
 plugins {
-    id("com.gradle.enterprise") version("3.12.6")
+    id("com.gradle.enterprise") version("3.13")
 }
 
 gradleEnterprise {

--- a/subprojects/docs/src/docs/userguide/reference/ci-systems/github-actions.adoc
+++ b/subprojects/docs/src/docs/userguide/reference/ci-systems/github-actions.adoc
@@ -65,7 +65,7 @@ In order to publish Build Scans from GitHub Actions, you'll need to pre-approve 
 To do so, add the following content to the top of your `settings.gradle[.kts]` file. The "CI" environment variable is set by GitHub Actions:
 ```
 plugins {
-    id("com.gradle.enterprise") version("3.9")
+    id("com.gradle.enterprise") version("3.12.6")
 }
 
 gradleEnterprise {
@@ -129,7 +129,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout project sources
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
     - name: Run build with Gradle Wrapper


### PR DESCRIPTION
This updates the Gradle Enterprise Gradle plugin version as well as the Github checkout action versions.

### Context
Keeping latest versions up to date

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
