### PR TITLE
Support providing Jars with alternative Java compiler implementations

### DIFF
--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJavaCompilerFactory.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DefaultJavaCompilerFactory.java
@@ -54,16 +54,20 @@ public class DefaultJavaCompilerFactory implements JavaCompilerFactory {
         this.actionExecutionSpecFactory = actionExecutionSpecFactory;
     }
 
+    /**
+     * If the 'customCompilerClasspath' is empty, the compiler classpath will be enriched with the 'org.gradle.internal.compiler.java.IncrementalCompileTask' compiler plugin.
+     * The compiler plugin is only compatible with the standard Java compiler. It is an optimization and the incremental compilation also works without it.
+     *
+     * @param customCompilerClasspath classpath containing a custom implementation of {@link javax.tools.JavaCompiler} or an empty collection
+     */
     private Factory<JavaCompiler> getJavaHomeBasedJavaCompilerFactory(Collection<File> customCompilerClasspath) {
         List<File> compilerPluginsClasspath;
         if (customCompilerClasspath.isEmpty()) {
-            // The 'IncrementalCompileTask' on the 'JAVA-COMPILER-PLUGIN' classpath is only compatible with the standard Java compiler (no custom compiler classpath).
-            // It is an optimization - the incremental compilation also works without it.
             compilerPluginsClasspath = classPathRegistry.getClassPath("JAVA-COMPILER-PLUGIN").getAsFiles();
         } else {
             compilerPluginsClasspath = new ArrayList<>(customCompilerClasspath);
         }
-        if (javaHomeBasedJavaCompilerFactory == null || !javaHomeBasedJavaCompilerFactory.compilerPluginsClasspath.equals(compilerPluginsClasspath)) {
+        if (javaHomeBasedJavaCompilerFactory == null || !javaHomeBasedJavaCompilerFactory.getCompilerPluginsClasspath().equals(compilerPluginsClasspath)) {
             javaHomeBasedJavaCompilerFactory = new JavaHomeBasedJavaCompilerFactory(compilerPluginsClasspath);
         }
         return javaHomeBasedJavaCompilerFactory;

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaHomeBasedJavaCompilerFactory.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaHomeBasedJavaCompilerFactory.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class JavaHomeBasedJavaCompilerFactory implements Factory<JavaCompiler>, Serializable {
-    private final List<File> compilerPluginsClasspath;
+    final List<File> compilerPluginsClasspath;
     // We use a static cache here because we want to reuse classloaders in compiler workers as
     // it has a huge impact on performance. Previously there was a single, JdkTools.current()
     // instance, but we can have different "compiler plugins" classpath. For this reason we use
@@ -41,7 +41,7 @@ public class JavaHomeBasedJavaCompilerFactory implements Factory<JavaCompiler>, 
     @Override
     public JavaCompiler create() {
         JdkTools jdkTools = JavaHomeBasedJavaCompilerFactory.JDK_TOOLS.computeIfAbsent(compilerPluginsClasspath, JavaHomeBasedJavaCompilerFactory::createJdkTools);
-        return jdkTools.getSystemJavaCompiler();
+        return jdkTools.getSystemJavaCompiler(compilerPluginsClasspath);
     }
 
     private static JdkTools createJdkTools(List<File> compilerPluginsClasspath) {

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaHomeBasedJavaCompilerFactory.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaHomeBasedJavaCompilerFactory.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class JavaHomeBasedJavaCompilerFactory implements Factory<JavaCompiler>, Serializable {
-    final List<File> compilerPluginsClasspath;
+    private final List<File> compilerPluginsClasspath;
     // We use a static cache here because we want to reuse classloaders in compiler workers as
     // it has a huge impact on performance. Previously there was a single, JdkTools.current()
     // instance, but we can have different "compiler plugins" classpath. For this reason we use
@@ -36,6 +36,10 @@ public class JavaHomeBasedJavaCompilerFactory implements Factory<JavaCompiler>, 
 
     public JavaHomeBasedJavaCompilerFactory(List<File> compilerPluginsClasspath) {
         this.compilerPluginsClasspath = compilerPluginsClasspath;
+    }
+
+    protected List<File> getCompilerPluginsClasspath() {
+        return compilerPluginsClasspath;
     }
 
     @Override

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkTools.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkTools.java
@@ -95,7 +95,7 @@ public class JdkTools {
     }
 
     public JavaCompiler getSystemJavaCompiler(List<File> compilerPluginsClasspath) {
-        if (compilerPluginsClasspath.stream().anyMatch(f -> f.getName().startsWith("java-compiler-plugin"))) {
+        if (compilerPluginsClasspath.stream().anyMatch(f -> f.getName().startsWith("gradle-java-compiler-plugin"))) {
             return new DefaultIncrementalAwareCompiler(buildJavaCompiler());
         } else {
             return buildJavaCompiler();

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkTools.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkTools.java
@@ -115,7 +115,7 @@ public class JdkTools {
                     for (JavaCompiler compilerCandidate : ServiceLoader.load(JavaCompiler.class, isolatedToolsLoader)) {
                         if (!compilerCandidate.getClass().getName().equals(DEFAULT_COMPILER_IMPL_NAME)) {
                             // take the first compiler found on the custom compiler classpath that is not the JavacTool system compiler (if any)
-                            LOG.debug("Using Java compiler {}", compilerCandidate.getClass().getName());
+                            LOG.info("Using Java compiler {}", compilerCandidate.getClass().getName());
                             compiler = compilerCandidate;
                             break;
                         }

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkTools.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkTools.java
@@ -28,6 +28,8 @@ import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.classpath.DefaultClassPath;
 import org.gradle.internal.jvm.Jvm;
 import org.gradle.internal.reflect.DirectInstantiator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.lang.model.SourceVersion;
 import javax.tools.DiagnosticListener;
@@ -57,6 +59,7 @@ import static java.lang.ClassLoader.getSystemClassLoader;
  * Subset replacement for {@link javax.tools.ToolProvider} that avoids the application class loader.
  */
 public class JdkTools {
+    private static final Logger LOG = LoggerFactory.getLogger(JdkTools.class);
 
     // Copied from ToolProvider.defaultJavaCompilerName
     private static final String DEFAULT_COMPILER_IMPL_NAME = "com.sun.tools.javac.api.JavacTool";
@@ -112,6 +115,7 @@ public class JdkTools {
                     for (JavaCompiler compilerCandidate : ServiceLoader.load(JavaCompiler.class, isolatedToolsLoader)) {
                         if (!compilerCandidate.getClass().getName().equals(DEFAULT_COMPILER_IMPL_NAME)) {
                             // take the first compiler found on the custom compiler classpath that is not the JavacTool system compiler (if any)
+                            LOG.debug("Using Java compiler {}", compilerCandidate.getClass().getName());
                             compiler = compilerCandidate;
                             break;
                         }

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/reflect/GradleStandardJavaFileManager.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/reflect/GradleStandardJavaFileManager.java
@@ -18,18 +18,22 @@ package org.gradle.api.internal.tasks.compile.reflect;
 
 import org.gradle.internal.classpath.ClassPath;
 
+import javax.tools.FileObject;
 import javax.tools.ForwardingJavaFileManager;
 import javax.tools.JavaFileManager;
 import javax.tools.JavaFileObject;
 import javax.tools.StandardJavaFileManager;
 import javax.tools.StandardLocation;
+import java.io.File;
 import java.io.IOException;
 import java.net.URLClassLoader;
+import java.nio.file.Path;
+import java.util.Collection;
 import java.util.Set;
 
 import static org.gradle.api.internal.tasks.compile.filter.AnnotationProcessorFilter.getFilteredClassLoader;
 
-public class GradleStandardJavaFileManager extends ForwardingJavaFileManager<StandardJavaFileManager> {
+public class GradleStandardJavaFileManager extends ForwardingJavaFileManager<StandardJavaFileManager> implements StandardJavaFileManager {
     private final ClassPath annotationProcessorPath;
     private final boolean hasEmptySourcePaths;
 
@@ -91,5 +95,70 @@ public class GradleStandardJavaFileManager extends ForwardingJavaFileManager<Sta
         }
 
         return classLoader;
+    }
+
+    @Override
+    public Iterable<? extends JavaFileObject> getJavaFileObjectsFromFiles(Iterable<? extends File> files) {
+        return fileManager.getJavaFileObjectsFromFiles(files);
+    }
+
+    @Override
+    public Iterable<? extends JavaFileObject> getJavaFileObjects(File... files) {
+        return fileManager.getJavaFileObjects(files);
+    }
+
+    @Override
+    public Iterable<? extends JavaFileObject> getJavaFileObjectsFromStrings(Iterable<String> names) {
+        return fileManager.getJavaFileObjectsFromStrings(names);
+    }
+
+    @Override
+    public Iterable<? extends JavaFileObject> getJavaFileObjects(String... names) {
+        return fileManager.getJavaFileObjects(names);
+    }
+
+    @Override
+    public void setLocation(Location location, Iterable<? extends File> files) throws IOException {
+        fileManager.setLocation(location, files);
+    }
+
+    @Override
+    public Iterable<? extends File> getLocation(Location location) {
+        return fileManager.getLocation(location);
+    }
+
+    @Override
+    public Iterable<? extends JavaFileObject> getJavaFileObjectsFromPaths(Iterable<? extends Path> paths) {
+        return fileManager.getJavaFileObjectsFromPaths(paths);
+    }
+
+    @Override
+    public Iterable<? extends JavaFileObject> getJavaFileObjects(Path... paths) {
+        return fileManager.getJavaFileObjects(paths);
+    }
+
+    @Override
+    public void setLocationFromPaths(Location location, Collection<? extends Path> paths) throws IOException {
+        fileManager.setLocationFromPaths(location, paths);
+    }
+
+    @Override
+    public void setLocationForModule(Location location, String moduleName, Collection<? extends Path> paths) throws IOException {
+        fileManager.setLocationForModule(location, moduleName, paths);
+    }
+
+    @Override
+    public Iterable<? extends Path> getLocationAsPaths(Location location) {
+        return fileManager.getLocationAsPaths(location);
+    }
+
+    @Override
+    public Path asPath(FileObject file) {
+        return fileManager.asPath(file);
+    }
+
+    @Override
+    public void setPathFactory(PathFactory f) {
+        fileManager.setPathFactory(f);
     }
 }

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -348,7 +348,8 @@ public abstract class JavaCompile extends AbstractCompile implements HasCompileO
     }
 
     /**
-     * Register alternative Java compiler Jars, like the Eclipse Java Compiler.
+     * This property can be used to configure alternate Java compilers, like the Eclipse Java Compiler. If set, the jars on this classpath with be scanned for the
+     * first alternate implementation of {@link javax.tools.JavaCompiler} (not `com.sun.tools.javac.api.JavacTool`), and use the task will use that compiler instead.
      *
      * @since 8.3
      */

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -351,7 +351,7 @@ public abstract class JavaCompile extends AbstractCompile implements HasCompileO
      * This property can be used to configure alternate Java compilers, like the Eclipse Java Compiler. If set, the jars on this classpath with be scanned for the
      * first alternate implementation of {@link javax.tools.JavaCompiler} (not `com.sun.tools.javac.api.JavacTool`), and use the task will use that compiler instead.
      *
-     * @since 8.5
+     * @since 8.6
      */
     @Incubating
     @CompileClasspath

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -351,7 +351,7 @@ public abstract class JavaCompile extends AbstractCompile implements HasCompileO
      * This property can be used to configure alternate Java compilers, like the Eclipse Java Compiler. If set, the jars on this classpath with be scanned for the
      * first alternate implementation of {@link javax.tools.JavaCompiler} (not `com.sun.tools.javac.api.JavacTool`), and use the task will use that compiler instead.
      *
-     * @since 8.3
+     * @since 8.4
      */
     @Incubating
     @CompileClasspath

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -351,7 +351,7 @@ public abstract class JavaCompile extends AbstractCompile implements HasCompileO
      * This property can be used to configure alternate Java compilers, like the Eclipse Java Compiler. If set, the jars on this classpath with be scanned for the
      * first alternate implementation of {@link javax.tools.JavaCompiler} (not `com.sun.tools.javac.api.JavacTool`), and use the task will use that compiler instead.
      *
-     * @since 8.4
+     * @since 8.5
      */
     @Incubating
     @CompileClasspath

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -18,7 +18,9 @@ package org.gradle.api.tasks.compile;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import org.gradle.api.Incubating;
 import org.gradle.api.JavaVersion;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.file.ProjectLayout;
@@ -199,7 +201,7 @@ public abstract class JavaCompile extends AbstractCompile implements HasCompileO
     private <T extends CompileSpec> Compiler<T> createToolchainCompiler() {
         return spec -> {
             DefaultToolchainJavaCompiler compiler = (DefaultToolchainJavaCompiler) getJavaCompiler().get();
-            return compiler.execute(spec);
+            return compiler.execute(spec, getCustomCompilerClasspath().getFiles());
         };
     }
 
@@ -344,6 +346,15 @@ public abstract class JavaCompile extends AbstractCompile implements HasCompileO
     public FileCollection getClasspath() {
         return super.getClasspath();
     }
+
+    /**
+     * Register alternative Java compiler Jars, like the Eclipse Java Compiler.
+     *
+     * @since 8.3
+     */
+    @Incubating
+    @CompileClasspath
+    public abstract ConfigurableFileCollection getCustomCompilerClasspath();
 
     /**
      * The sources for incremental change detection.

--- a/platforms/jvm/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/DefaultJavaCompilerFactoryTest.groovy
+++ b/platforms/jvm/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/DefaultJavaCompilerFactoryTest.groovy
@@ -30,7 +30,7 @@ class DefaultJavaCompilerFactoryTest extends Specification {
 
     def "creates in-process compiler when JavaCompileSpec is provided"() {
         expect:
-        def compiler = factory.create(JavaCompileSpec.class)
+        def compiler = factory.create(JavaCompileSpec.class, [])
         compiler instanceof ModuleApplicationNameWritingCompiler
         compiler.delegate instanceof AnnotationProcessorDiscoveringCompiler
         compiler.delegate.delegate instanceof NormalizingJavaCompiler
@@ -39,7 +39,7 @@ class DefaultJavaCompilerFactoryTest extends Specification {
 
     def "creates command line compiler when CommandLineJavaCompileSpec is provided"() {
         expect:
-        def compiler = factory.create(TestCommandLineJavaSpec.class)
+        def compiler = factory.create(TestCommandLineJavaSpec.class, [])
         compiler instanceof ModuleApplicationNameWritingCompiler
         compiler.delegate instanceof AnnotationProcessorDiscoveringCompiler
         compiler.delegate.delegate instanceof NormalizingJavaCompiler
@@ -48,7 +48,7 @@ class DefaultJavaCompilerFactoryTest extends Specification {
 
     def "creates daemon compiler when ForkingJavaCompileSpec"() {
         expect:
-        def compiler = factory.create(TestForkingJavaCompileSpec)
+        def compiler = factory.create(TestForkingJavaCompileSpec, [])
         compiler instanceof ModuleApplicationNameWritingCompiler
         compiler.delegate instanceof AnnotationProcessorDiscoveringCompiler
         compiler.delegate.delegate instanceof NormalizingJavaCompiler

--- a/platforms/jvm/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/JdkToolsTest.groovy
+++ b/platforms/jvm/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/JdkToolsTest.groovy
@@ -30,11 +30,11 @@ class JdkToolsTest extends Specification {
     JdkTools current = new JdkTools(Jvm.current(), [])
 
     def "can get java compiler"() {
-        def compiler = current.systemJavaCompiler
+        def compiler = current.getSystemJavaCompiler([])
 
         expect:
         compiler instanceof JavaCompiler
-        compiler.class == current.systemJavaCompiler.class
+        compiler.class == current.getSystemJavaCompiler([]).class
     }
 
     def "throws when no tools"() {

--- a/platforms/jvm/toolchains-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultToolchainJavaCompiler.java
+++ b/platforms/jvm/toolchains-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultToolchainJavaCompiler.java
@@ -26,6 +26,9 @@ import org.gradle.language.base.internal.compile.CompileSpec;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
+import java.util.Collection;
+
 public class DefaultToolchainJavaCompiler implements JavaCompiler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultToolchainJavaCompiler.class);
@@ -51,9 +54,9 @@ public class DefaultToolchainJavaCompiler implements JavaCompiler {
     }
 
     @SuppressWarnings("unchecked")
-    public <T extends CompileSpec> WorkResult execute(T spec) {
+    public <T extends CompileSpec> WorkResult execute(T spec, Collection<File> customCompilerClasspath) {
         LOGGER.info("Compiling with toolchain '{}'.", javaToolchain.getDisplayName());
         final Class<T> specType = (Class<T>) spec.getClass();
-        return compilerFactory.create(specType).execute(spec);
+        return compilerFactory.create(specType, customCompilerClasspath).execute(spec);
     }
 }

--- a/platforms/jvm/toolchains-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaCompilerFactory.java
+++ b/platforms/jvm/toolchains-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaCompilerFactory.java
@@ -28,5 +28,5 @@ import java.util.Collection;
  */
 @ServiceScope(Scopes.Project.class)
 public interface JavaCompilerFactory {
-    <T extends CompileSpec> Compiler<T> create(Class<T> type, Collection<File> additions);
+    <T extends CompileSpec> Compiler<T> create(Class<T> type, Collection<File> customCompilerClasspath);
 }

--- a/platforms/jvm/toolchains-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaCompilerFactory.java
+++ b/platforms/jvm/toolchains-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaCompilerFactory.java
@@ -20,10 +20,13 @@ import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.language.base.internal.compile.CompileSpec;
 import org.gradle.language.base.internal.compile.Compiler;
 
+import java.io.File;
+import java.util.Collection;
+
 /**
  * Creates Java compilers based on the provided compile options.
  */
 @ServiceScope(Scopes.Project.class)
 public interface JavaCompilerFactory {
-    <T extends CompileSpec> Compiler<T> create(Class<T> type);
+    <T extends CompileSpec> Compiler<T> create(Class<T> type, Collection<File> additions);
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsOperationIntegrationTest.groovy
@@ -254,7 +254,7 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
         then:
         def result = snapshotResults(":a:compileJava")
         def aCompileJava = result.inputFileProperties
-        aCompileJava.size() == 5
+        aCompileJava.size() == 6
 
         // Not in just-values property
         aCompileJava.keySet().every { !result.inputValueHashes.containsKey(it) }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/customcompiler/EclipseCompilerIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/customcompiler/EclipseCompilerIntegrationTest.groovy
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.java.compile.customcompiler
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class EclipseCompilerIntegrationTest extends AbstractIntegrationSpec {
+
+    def setup() {
+        settingsFile << "rootProject.name = 'consumer'\n"
+        buildFile << """
+            plugins {
+                id 'java-library'
+            }
+            group = 'org'
+            version = '1.0-beta2'
+
+            ${mavenCentralRepository()}
+
+            configurations.create('ecj')
+            dependencies {
+                ecj('org.eclipse.jdt:ecj:3.33.0')
+            }
+            tasks.withType(JavaCompile).configureEach {
+                // customCompilerClasspath.from(configurations.ecj)
+                options.headerOutputDirectory.convention(null) // https://github.com/gradle/gradle/issues/12904
+            }
+        """
+    }
+
+    def "compiles code with specific generics handling"() {
+        given:
+        file("src/main/java/foo/AbstractClass.java") << """
+            package foo;
+            abstract class AbstractClass {}
+        """
+        file("src/main/java/foo/ConcreteClassTypeA.java") << """
+            package foo;
+            class ConcreteClassTypeA extends AbstractClass {}
+        """
+        file("src/main/java/foo/DoSomething.java") << """
+            package foo;
+            interface DoSomething<T extends AbstractClass> {
+               public void doThis(final T aClass);
+            }
+        """
+        file("src/main/java/foo/AbstractDoSomething.java") << """
+            package foo;
+            abstract class AbstractDoSomething<T extends AbstractClass> implements DoSomething<T> {
+               public void doThis(final AbstractClass aClass) {}
+            }
+        """
+        file("src/main/java/foo/ConcreteTypeADoSomethings.java") << """
+            package foo;
+            public class ConcreteTypeADoSomethings extends AbstractDoSomething<ConcreteClassTypeA> {
+               public void doThis(final ConcreteClassTypeA aClass) {}
+            }
+        """
+
+        when:
+        runAndFail ':compileJava'
+
+        then:
+        result.assertTaskExecuted(':compileJava')
+        result.getError().contains("error: name clash: class ConcreteTypeADoSomethings has two methods with the same erasure, yet neither overrides the other")
+
+        when:
+        buildFile << '''
+            tasks.withType(JavaCompile).configureEach {
+                customCompilerClasspath.from(configurations.ecj) // Use the ECJ Compiler, that compiles the example code without error
+            }
+        '''
+        run ':compileJava'
+
+        then:
+        result.assertTaskExecuted(':compileJava')
+    }
+}

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/customcompiler/EclipseCompilerIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/customcompiler/EclipseCompilerIntegrationTest.groovy
@@ -17,7 +17,10 @@
 package org.gradle.java.compile.customcompiler
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.UnitTestPreconditions
 
+@Requires(UnitTestPreconditions.Jdk11OrLater) // Eclipse compiler requires Java 11+ (loading a compiler via API is supported by Gradle from Java 9+)
 class EclipseCompilerIntegrationTest extends AbstractIntegrationSpec {
 
     def setup() {

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/customcompiler/EclipseCompilerIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/customcompiler/EclipseCompilerIntegrationTest.groovy
@@ -34,7 +34,6 @@ class EclipseCompilerIntegrationTest extends AbstractIntegrationSpec {
                 ecj('org.eclipse.jdt:ecj:3.33.0')
             }
             tasks.withType(JavaCompile).configureEach {
-                // customCompilerClasspath.from(configurations.ecj)
                 options.headerOutputDirectory.convention(null) // https://github.com/gradle/gradle/issues/12904
             }
         """

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/customcompiler/EclipseCompilerIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/customcompiler/EclipseCompilerIntegrationTest.groovy
@@ -73,7 +73,7 @@ class EclipseCompilerIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         result.assertTaskExecuted(':compileJava')
-        result.getError().contains("error: name clash: class ConcreteTypeADoSomethings has two methods with the same erasure, yet neither overrides the other")
+        result.getError().contains("error: name clash:")
 
         when:
         buildFile << '''


### PR DESCRIPTION
<!--- The issue this PR addresses -->

### Context
Proposal to provide a solution for: #15942

The proposal is to allow the definition of a `customCompilerClasspath` of the `JavaCompile` task. If the `customCompilerClasspath` contains an implementation of `javax.tools.JavaCompiler` that can be discovered through Java's `ServiceLoader` it is used in place of the default JDK compiler (JavacTool) – "on top" of the selected Java toolchain. 

This is how you would configure it to use the Eclipse Compiler (ECJ):

```kotlin
val ecj = configurations.create("ecj")
dependencies {
    "ecj"("org.eclipse.jdt:ecj:3.33.0")
}

tasks.withType(JavaCompile::class).configureEach {
    customCompilerClasspath.from(ecj)
    options.headerOutputDirectory.convention(null) // see #12904
}
```


### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
