### PR TITLE
Fix transform build operation test for two consumer projects

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformBuildOperationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformBuildOperationIntegrationTest.groovy
@@ -833,22 +833,17 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         )
 
         List<BuildOperationRecord> executeTransformationOps = getExecuteTransformOperations(2)
-
-        with(executeTransformationOps[0].details) {
-            verifyTransformationIdentity(plannedTransformStepIdentity, expectedTransformId1)
-            transformActionClass == "MakeGreen"
-
-            transformerName == "MakeGreen"
-            subjectName == "producer.jar (project :producer)"
-        }
-
-        with(executeTransformationOps[0].details) {
-            verifyTransformationIdentity(plannedTransformStepIdentity, expectedTransformId1)
-            transformActionClass == "MakeGreen"
-
-            transformerName == "MakeGreen"
-            subjectName == "producer.jar (project :producer)"
-        }
+        // Order of scheduling/execution is not guaranteed between the consumer projects
+        checkExecuteTransformOperation(executeTransformationOps, expectedTransformId1, [
+            transformActionClass: "MakeGreen",
+            transformerName: "MakeGreen",
+            subjectName: "producer.jar (project :producer)",
+        ])
+        checkExecuteTransformOperation(executeTransformationOps, expectedTransformId2, [
+            transformActionClass: "MakeGreen",
+            transformerName: "MakeGreen",
+            subjectName: "producer.jar (project :producer)",
+        ])
     }
 
     def "failing transform"() {


### PR DESCRIPTION
The test did not check for the build operations of the second transform step identity, and also ordering of those is not guaranteed between the consumer projects.