### PR TITLE
Support ExtensiblePolymorphicDomainObjectContainer as a managed property

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/model/ObjectFactoryIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/model/ObjectFactoryIntegrationTest.groovy
@@ -836,4 +836,45 @@ class ObjectFactoryIntegrationTest extends AbstractIntegrationSpec {
         expect:
         succeeds()
     }
+
+    def "plugin can create instance of interface with nested ExtensiblePolymorphicDomainObjectContainer using named managed types"() {
+        given:
+        buildFile """
+            interface Element extends Named {
+            }
+            interface Thing extends Element {
+                Property<Integer> getValue()
+            }
+            interface AnotherThing extends Element {
+                Property<String> getValue()
+            }
+
+            interface Bag {
+                ExtensiblePolymorphicDomainObjectContainer<Element> getThings()
+            }
+
+            def bag = project.objects.newInstance(Bag)
+            bag.things.registerBinding(Thing, Thing)
+            bag.things.registerBinding(AnotherThing, AnotherThing)
+
+            bag.things {
+                a(Thing) {
+                    value = 1
+                }
+                b(AnotherThing) {
+                    value = "foo"
+                }
+            }
+
+            def container = bag.things
+            assert container.size() == 2
+            assert container[0].name == 'a'
+            assert container[0].value.get() == 1
+            assert container[1].name == 'b'
+            assert container[1].value.get() == "foo"
+        """
+
+        expect:
+        succeeds()
+    }
 }

--- a/subprojects/docs/src/docs/userguide/extending-gradle/custom_gradle_types.adoc
+++ b/subprojects/docs/src/docs/userguide/extending-gradle/custom_gradle_types.adoc
@@ -61,6 +61,7 @@ The property type must be one of the following:
 - `ConfigurableFileTree`
 - `DomainObjectSet<T>`
 - `NamedDomainObjectContainer<T>`
+- `ExtensiblePolymorphicDomainObjectContainer<T>`
 
 Gradle creates values for managed properties in the same way as link:{javadocPath}/org/gradle/api/model/ObjectFactory.html[ObjectFactory].
 

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
@@ -32,6 +32,7 @@ import groovy.lang.MetaClass;
 import org.gradle.api.Action;
 import org.gradle.api.Describable;
 import org.gradle.api.DomainObjectSet;
+import org.gradle.api.ExtensiblePolymorphicDomainObjectContainer;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.NonExtensible;
 import org.gradle.api.file.ConfigurableFileCollection;
@@ -102,6 +103,12 @@ import static java.util.Optional.ofNullable;
  * </ul>
  */
 abstract class AbstractClassGenerator implements ClassGenerator {
+    /**
+     * Types that are allowed to be instantiated directly by Gradle when exposed as a getter on a type.
+     *
+     * @implNote Keep in sync with subprojects/docs/src/docs/userguide/extending-gradle/custom_gradle_types.adoc
+     * @see ManagedObjectFactory#newInstance
+     */
     private static final ImmutableSet<Class<?>> MANAGED_PROPERTY_TYPES = ImmutableSet.of(
         ConfigurableFileCollection.class,
         ConfigurableFileTree.class,
@@ -112,6 +119,7 @@ abstract class AbstractClassGenerator implements ClassGenerator {
         DirectoryProperty.class,
         Property.class,
         NamedDomainObjectContainer.class,
+        ExtensiblePolymorphicDomainObjectContainer.class,
         DomainObjectSet.class
     );
     private static final Object[] NO_PARAMS = new Object[0];

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/ManagedObjectFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/ManagedObjectFactory.java
@@ -19,6 +19,7 @@ package org.gradle.internal.instantiation.generator;
 import org.apache.commons.lang.StringUtils;
 import org.gradle.api.Describable;
 import org.gradle.api.DomainObjectSet;
+import org.gradle.api.ExtensiblePolymorphicDomainObjectContainer;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.ConfigurableFileTree;
@@ -97,6 +98,9 @@ public class ManagedObjectFactory {
         }
         if (type.isAssignableFrom(DomainObjectSet.class)) {
             return attachOwner(getObjectFactory().domainObjectSet(paramType), owner, propertyName);
+        }
+        if (type.isAssignableFrom(ExtensiblePolymorphicDomainObjectContainer.class)) {
+            return attachOwner(getObjectFactory().polymorphicDomainObjectContainer(paramType), owner, propertyName);
         }
         throw new IllegalArgumentException("Don't know how to create an instance of type " + type.getName());
     }


### PR DESCRIPTION
This allows users to define interfaces like:
```
public interface Component extends Named {
    ExtensiblePolymorphicDomainObjectContainer<Feature> getFeatures();
}
```

Gradle will implement `getFeatures` automatically. 