### PR TITLE
Implement splitting source-sets in Kotlin DSL reference

### DIFF
--- a/build-logic/build-platform/build.gradle.kts
+++ b/build-logic/build-platform/build.gradle.kts
@@ -58,7 +58,7 @@ dependencies {
         api("org.spockframework:spock-junit4:$spockVersion")
         api("org.asciidoctor:asciidoctorj:2.4.3")
         api("org.asciidoctor:asciidoctorj-pdf:1.5.4")
-        api("dev.adamko.dokkatoo:dokkatoo-plugin:1.0.0")
+        api("dev.adamko.dokkatoo:dokkatoo-plugin:1.3.0")
         api("org.jetbrains.dokka:dokka-core:1.8.10")
         api("com.beust:jcommander:1.78")
         api("org.codehaus.groovy:$groovyVersion")

--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleBuildDocumentationPlugin.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleBuildDocumentationPlugin.java
@@ -109,15 +109,13 @@ public class GradleBuildDocumentationPlugin implements Plugin<Project> {
 
         extension.getClasspath().from(runtimeClasspath);
         extension.getDocumentedSource().from(sourcesPath.getIncoming().artifactView(v -> v.lenient(true)).getFiles().getAsFileTree().matching(f -> {
-            // Filter out any non-public APIs
             f.include(PublicApi.INSTANCE.getIncludes());
+            // Filter out any non-public APIs
             f.exclude(PublicApi.INSTANCE.getExcludes());
         }));
         extension.getKotlinDslSource().from(sourcesPath.getIncoming().artifactView(v -> v.lenient(true)).getFiles().getAsFileTree().matching(f -> {
-            // Filter out any non-public APIs
-            f.include(PublicApi.INSTANCE.getIncludes());
             f.include(PublicKotlinDslApi.INSTANCE.getIncludes());
-            f.exclude(PublicApi.INSTANCE.getExcludes());
+            // Filter out any non-public APIs
             f.exclude(PublicKotlinDslApi.INSTANCE.getExcludes());
         }));
     }

--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleKotlinDslReferencePlugin.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleKotlinDslReferencePlugin.java
@@ -28,7 +28,6 @@ import org.gradle.api.Task;
 import org.gradle.api.file.Directory;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskProvider;
-import org.jetbrains.dokka.Platform;
 
 public class GradleKotlinDslReferencePlugin implements Plugin<Project> {
 
@@ -73,14 +72,21 @@ public class GradleKotlinDslReferencePlugin implements Plugin<Project> {
                 task.getGeneratedClasses().set(project.getLayout().getBuildDirectory().dir("gradle-kotlin-dsl-extensions/classes"));
             });
 
-        NamedDomainObjectContainer<DokkaSourceSetSpec> sourceSets = getDokkatooExtension(project).getDokkatooSourceSets();
-        sourceSets.register("kotlin_dsl", spec -> {
+        NamedDomainObjectContainer<DokkaSourceSetSpec> kotlinSourceSet = getDokkatooExtension(project).getDokkatooSourceSets();
+        kotlinSourceSet.register("kotlin_dsl", spec -> {
             spec.getDisplayName().set("Kotlin DSL");
             spec.getSourceRoots().from(extension.getKotlinDslSource());
             spec.getSourceRoots().from(runtimeExtensions.flatMap(GradleKotlinDslRuntimeGeneratedSources::getGeneratedSources));
             spec.getClasspath().from(extension.getClasspath());
             spec.getClasspath().from(runtimeExtensions.flatMap(GradleKotlinDslRuntimeGeneratedSources::getGeneratedClasses));
-            spec.getAnalysisPlatform().set(Platform.jvm);
+            spec.getIncludes().from(extension.getSourceRoot().file("kotlin/Module.md"));
+        });
+
+        NamedDomainObjectContainer<DokkaSourceSetSpec> javaSourceSet = getDokkatooExtension(project).getDokkatooSourceSets();
+        javaSourceSet.register("java_api", spec -> {
+            spec.getDisplayName().set("Java API");
+            spec.getSourceRoots().from(extension.getDocumentedSource());
+            spec.getClasspath().from(extension.getClasspath());
             spec.getIncludes().from(extension.getSourceRoot().file("kotlin/Module.md"));
         });
     }

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -766,9 +766,9 @@
             </sha256>
          </artifact>
       </component>
-      <component group="dev.adamko.dokkatoo" name="dokkatoo-plugin" version="1.0.0">
-         <artifact name="dokkatoo-plugin-1.0.0.jar">
-            <sha256 value="4fcd9c32f6cfcd4257095daab40c885244862834da97710a73a26538ec92a0b7" origin="Verified" reason="Artifact is not signed"/>
+      <component group="dev.adamko.dokkatoo" name="dokkatoo-plugin" version="1.3.0">
+         <artifact name="dokkatoo-plugin-1.3.0.jar">
+            <sha256 value="70ba2b912d823dd511be2ed6a033e86b0e62faef9f17d09eb5c50d96542a4254" origin="Verified" reason="Artifact is not signed"/>
          </artifact>
       </component>
       <component group="flot" name="flot" version="0.8.1">

--- a/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/DocsDistributionIntegrationSpec.groovy
+++ b/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/DocsDistributionIntegrationSpec.groovy
@@ -32,7 +32,7 @@ class DocsDistributionIntegrationSpec extends DistributionIntegrationSpec {
 
     @Override
     int getMaxDistributionSizeBytes() {
-        return 58 * 1024 * 1024
+        return 59 * 1024 * 1024
     }
 
     @Override

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildExternalPluginsValidationSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildExternalPluginsValidationSmokeTest.groovy
@@ -70,6 +70,7 @@ class GradleBuildExternalPluginsValidationSmokeTest extends AbstractGradleceptio
                 'dev.adamko.dokkatoo.DokkatooBasePlugin$Inject',
                 'dev.adamko.dokkatoo.adapters.DokkatooJavaAdapter$Inject',
                 'dev.adamko.dokkatoo.adapters.DokkatooKotlinAdapter$Inject',
+                'dev.adamko.dokkatoo.adapters.DokkatooAndroidAdapter$Inject',
                 'dev.adamko.dokkatoo.formats.DokkatooHtmlPlugin$Inject',
             ]
         }


### PR DESCRIPTION
Fixes 
* #24661 
