### PR TITLE
Standardize 'Gradle User Home' across Gradle documentation

### DIFF
--- a/subprojects/docs/src/docs/userguide/authoring-builds/test_kit.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/test_kit.adoc
@@ -133,7 +133,7 @@ include::sample[dir="snippets/testKit/automaticClasspathInjectionCustomTestSourc
 [[sec:controlling_the_build_environment]]
 == Controlling the build environment
 
-The runner executes the test builds in an isolated environment by specifying a dedicated "working directory" in a directory inside the JVM's temp directory (i.e. the location specified by the `java.io.tmpdir` system property, typically `/tmp`). Any configuration in the default Gradle user home directory (e.g. `~/.gradle/gradle.properties`) is not used for test execution. The TestKit does not expose a mechanism for fine grained control of all aspects of the environment (e.g., JDK). Future versions of the TestKit will provide improved configuration options.
+The runner executes the test builds in an isolated environment by specifying a dedicated "working directory" in a directory inside the JVM's temp directory (i.e. the location specified by the `java.io.tmpdir` system property, typically `/tmp`). Any configuration in the default Gradle User Home (e.g. `~/.gradle/gradle.properties`) is not used for test execution. The TestKit does not expose a mechanism for fine grained control of all aspects of the environment (e.g., JDK). Future versions of the TestKit will provide improved configuration options.
 
 The TestKit uses dedicated daemon processes that are automatically shut down after test execution.
 
@@ -227,7 +227,7 @@ To enable the <<build_cache.adoc#build_cache,Build Cache>> in your tests, you ca
 include::{snippetsPath}/testKit/testKitFunctionalTestSpockBuildCache/groovy/src/test/groovy/org/gradle/sample/BuildLogicFunctionalTest.groovy[tag=functional-test-build-cache]
 ----
 
-Note that TestKit re-uses a Gradle user home between tests (see link:{javadocPath}/org/gradle/testkit/runner/GradleRunner.html#withTestKitDir-java.io.File-[GradleRunner.withTestKitDir(java.io.File)]) which contains the default location for the local build cache.
+Note that TestKit re-uses a Gradle User Home between tests (see link:{javadocPath}/org/gradle/testkit/runner/GradleRunner.html#withTestKitDir-java.io.File-[GradleRunner.withTestKitDir(java.io.File)]) which contains the default location for the local build cache.
 For testing with the build cache, the build cache directory should be cleaned between tests.
 The easiest way to accomplish this is to configure the local build cache to use a temporary directory.
 

--- a/subprojects/docs/src/docs/userguide/build-cache/build_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/build-cache/build_cache.adoc
@@ -43,7 +43,7 @@ Gradle will use the build cache for this build only.
 Put `org.gradle.caching=true` in your `gradle.properties`::
 Gradle will try to reuse outputs from previous builds for all builds, unless explicitly disabled with `--no-build-cache`.
 
-When the build cache is enabled, it will store build outputs in the Gradle user home.
+When the build cache is enabled, it will store build outputs in the Gradle User Home.
 For configuring this directory or different kinds of build caches see <<#sec:build_cache_configure,Configure the Build Cache>>.
 
 [[sec:task_output_caching]]
@@ -277,7 +277,7 @@ The remote build cache can be configured by specifying the type of build cache t
 === Built-in local build cache
 
 The built-in local build cache, link:{groovyDslPath}/org.gradle.caching.local.DirectoryBuildCache.html[DirectoryBuildCache], uses a directory to store build cache artifacts.
-By default, this directory resides in the Gradle user home directory, but its location is configurable.
+By default, this directory resides in the Gradle User Home, but its location is configurable.
 
 Gradle will periodically clean-up the local cache directory by removing entries that have not been used recently to conserve disk space.
 How often Gradle will perform this clean-up is configurable as shown in the example below.
@@ -396,7 +396,7 @@ include::sample[dir="snippets/buildCache/developer-ci-setup/kotlin",files="setti
 include::sample[dir="snippets/buildCache/developer-ci-setup/groovy",files="settings.gradle[tags=developer-ci-setup]"]
 ====
 
-It is also possible to configure the build cache from an <<init_scripts.adoc#sec:using_an_init_script,init script>>, which can be used from the command line, added to your Gradle user home or be a part of your custom Gradle distribution.
+It is also possible to configure the build cache from an <<init_scripts.adoc#sec:using_an_init_script,init script>>, which can be used from the command line, added to your Gradle User Home or be a part of your custom Gradle distribution.
 
 .Init script to configure the build cache
 ====

--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/dependency_resolution.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/dependency_resolution.adoc
@@ -328,7 +328,7 @@ Instead of <<sub:cache_copy,copying the dependency cache into each container>>, 
 This cache, unlike the classical dependency cache, is accessed without locking, making it possible for multiple builds to read from the cache concurrently. It's important that the read-only cache
 is not written to when other builds may be reading from it.
 
-When using the shared read-only cache, Gradle looks for dependencies (artifacts or metadata) in both the writable cache in the local Gradle user home directory and the shared read-only cache.
+When using the shared read-only cache, Gradle looks for dependencies (artifacts or metadata) in both the writable cache in the local Gradle User Home directory and the shared read-only cache.
 If a dependency is present in the read-only cache, it will not be downloaded.
 If a dependency is missing from the read-only cache, it will be downloaded and added to the writable cache.
 In practice, this means that the writable cache will only contain dependencies that are unavailable in the read-only cache.

--- a/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
@@ -216,7 +216,7 @@ In order to disable auto-detection, you can use the `org.gradle.java.installatio
 == Auto-provisioning
 
 If Gradle can't find a locally available toolchain that matches the requirements of the build, it can automatically download one (as long as a toolchain download repository has been configured; for detail, see <<#sub:download_repositories,relevant section>>).
-Gradle installs the downloaded JDKs in the <<directory_layout.adoc#dir:gradle_user_home,Gradle User Home directory>>.
+Gradle installs the downloaded JDKs in the <<directory_layout.adoc#dir:gradle_user_home,Gradle User Home>>.
 
 [NOTE]
 ====
@@ -224,7 +224,7 @@ Gradle only downloads JDK versions for GA releases.
 There is no support for downloading early access versions.
 ====
 
-Once installed in the <<directory_layout.adoc#dir:gradle_user_home,Gradle User Home directory>>, a provisioned JDK becomes one of the JDKs visible to <<#sec:auto_detection,auto-detection>> and can be used by any subsequent builds, just like any other JDK installed on the system.
+Once installed in the <<directory_layout.adoc#dir:gradle_user_home,Gradle User Home>>, a provisioned JDK becomes one of the JDKs visible to <<#sec:auto_detection,auto-detection>> and can be used by any subsequent builds, just like any other JDK installed on the system.
 
 Since auto-provisioning only kicks in when auto-detection fails to find a matching JDK, auto-provisioning can only download new JDKs and is in no way involved in updating any of the already installed ones.
 None of the auto-provisioned JDKs will ever be revisited and automatically updated by auto-provisioning, even if there is a newer minor version available for them.

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
@@ -161,7 +161,7 @@ Obtain the set of all configurations from the project's `configurations` contain
 === CACHEDIR.TAG files are created in global cache directories
 Gradle now emits a `CACHEDIR.TAG` file in some global cache directories, as specified in <<directory_layout#dir:gradle_user_home:cache_marking>>.
 
-This may cause these directories to no longer be searched or backed up by some tools. To disable it, use the following code in an <<init_scripts#sec:using_an_init_script,init script>> in the Gradle user home directory:
+This may cause these directories to no longer be searched or backed up by some tools. To disable it, use the following code in an <<init_scripts#sec:using_an_init_script,init script>> in the Gradle User Home:
 
 ====
 [.multi-language-sample]
@@ -517,7 +517,7 @@ Please use standard locations for settings and build files:
 [[disabling_user_home_cache_cleanup]]
 ==== Deprecated org.gradle.cache.cleanup property
 
-The `org.gradle.cache.cleanup` property in `gradle.properties` under Gradle user home has been deprecated.  Please use the <<directory_layout#dir:gradle_user_home:configure_cache_cleanup,cache cleanup DSL>> instead to disable or modify the cleanup configuration.
+The `org.gradle.cache.cleanup` property in `gradle.properties` under Gradle User Home has been deprecated.  Please use the <<directory_layout#dir:gradle_user_home:configure_cache_cleanup,cache cleanup DSL>> instead to disable or modify the cleanup configuration.
 
 Since the `org.gradle.cache.cleanup` property may still be needed for older versions of Gradle, this property may still be present and no deprecation warnings will be printed as long as it is also configured via the DSL.
 The DSL value will always take preference over the `org.gradle.cache.cleanup` property.

--- a/subprojects/docs/src/docs/userguide/reference/command_line_interface.adoc
+++ b/subprojects/docs/src/docs/userguide/reference/command_line_interface.adoc
@@ -621,7 +621,7 @@ Specifies the build file. For example: `gradle --build-file=foo.gradle`. The def
 Specifies the settings file. For example: `gradle --settings-file=somewhere/else/settings.gradle`
 
 `-g`, `--gradle-user-home`::
-Specifies the Gradle user home directory. The default is the `.gradle` directory in the user's home directory.
+Specifies the Gradle User Home directory. The default is the `.gradle` directory in the user's home directory.
 
 `-p`, `--project-dir`::
 Specifies the start directory for Gradle. Defaults to current directory.

--- a/subprojects/docs/src/docs/userguide/reference/directory_layout.adoc
+++ b/subprojects/docs/src/docs/userguide/reference/directory_layout.adoc
@@ -20,9 +20,9 @@ The following two sections describe what is stored in each of them and how trans
 
 
 [[dir:gradle_user_home]]
-== Gradle user home directory
+== Gradle User Home directory
 
-The Gradle user home directory (`<home directory of the current user>/.gradle` by default) is used to store global configuration properties and initialization scripts as well as caches and log files.
+The Gradle User Home (`<home directory of the current user>/.gradle` by default) is used to store global configuration properties and initialization scripts as well as caches and log files.
 It is roughly structured as follows:
 
 [listing]
@@ -94,7 +94,7 @@ include::sample[dir="snippets/initScripts/cacheRetention/kotlin",files="gradleUs
 The frequency at which cache cleanup is invoked is also configurable.  There are three possible settings:
 
 - *DEFAULT:* Cleanup is performed periodically in the background (currently once every 24 hours).
-- *DISABLED:* Never cleanup Gradle user home.  This is useful in cases where Gradle user home is ephemeral or it's desirable to delay cleanup until an explicit point in the future.
+- *DISABLED:* Never cleanup Gradle User Home.  This is useful in cases where Gradle User Home is ephemeral or it's desirable to delay cleanup until an explicit point in the future.
 - *ALWAYS:* Cleanup is performed at the end of each build session.  This is useful in cases where it's desirable to ensure that cleanup has actually occurred before proceeding.  However, this does perform cache cleanup during the build (rather than in the background) which can be an expensive operation, so this option should only be used when absolutely necessary.
 
 .Disabling cache cleanup
@@ -103,22 +103,22 @@ include::sample[dir="snippets/initScripts/disableCacheCleanup/groovy",files="gra
 include::sample[dir="snippets/initScripts/disableCacheCleanup/kotlin",files="gradleUserHome/init.d/cache-settings.gradle.kts"]
 ====
 
-Note that cache cleanup settings can only be configured via init scripts and should be placed under the `init.d` directory in Gradle user home.  This effectively couples the configuration of cache cleanup to the Gradle user home directory those settings apply to and limits the possibility of different conflicting settings from different projects being applied to the same directory.
+Note that cache cleanup settings can only be configured via init scripts and should be placed under the `init.d` directory in Gradle User Home.  This effectively couples the configuration of cache cleanup to the Gradle User Home those settings apply to and limits the possibility of different conflicting settings from different projects being applied to the same directory.
 
 [[dir:gradle_user_home:multi_version_cache_cleanup]]
-==== Sharing a Gradle user home directory between multiple versions of Gradle
+==== Sharing a Gradle User Home between multiple versions of Gradle
 
-It is common to share a single Gradle user home directory between multiple versions of Gradle.
-As stated above, there are caches in Gradle user home that are version-specific.
+It is common to share a single Gradle User Home between multiple versions of Gradle.
+As stated above, there are caches in Gradle User Home that are version-specific.
 In general, different versions of Gradle will perform maintenance on only the version-specific caches associated with each version.
 On the other hand, there are other caches that are shared between versions (e.g. the dependency artifact cache or the artifact transform cache).
 Beginning with Gradle version 8.0, the cache cleanup settings can be configured to custom retention periods.  However, older versions have retention periods that are fixed (7 or 30 days depending on the cache) and so the shared caches could be accessed by versions of Gradle with different settings for the retention of cache artifacts.  This means that:
 
-- If the retention period is _not_ customized, all versions that perform cleanup will have the same retention periods and there will be no effect due to sharing a Gradle user home directory with multiple versions.
+- If the retention period is _not_ customized, all versions that perform cleanup will have the same retention periods and there will be no effect due to sharing a Gradle User Home with multiple versions.
 - If the retention period is customized for Gradle versions greater than or equal to version 8.0 to use retention periods _shorter_ than the previously fixed periods, there will also be no effect.  The versions of Gradle aware of these settings will cleanup artifacts earlier than the previously fixed retention periods and older versions will effectively not participate in the cleanup of shared caches.
-- If the retention period is customized for Gradle versions greater than or equal to version 8.0 to use retention periods _longer_ than the previously fixed periods, the older versions of Gradle may clean the shared caches earlier than what is configured.  In this case, if it is desirable to maintain these shared cache entries for newer versions for the longer retention periods, they will not be able to share a Gradle user home directory with older versions and will need to use a separate directory.
+- If the retention period is customized for Gradle versions greater than or equal to version 8.0 to use retention periods _longer_ than the previously fixed periods, the older versions of Gradle may clean the shared caches earlier than what is configured.  In this case, if it is desirable to maintain these shared cache entries for newer versions for the longer retention periods, they will not be able to share a Gradle User Home with older versions and will need to use a separate directory.
 
-Another consideration when sharing the Gradle user home directory with versions of Gradle before version 8.0 is that the DSL elements to configure the cache retention settings are not available in earlier versions, so this must be accounted for in any init script that is shared between versions.
+Another consideration when sharing the Gradle User Home with versions of Gradle before version 8.0 is that the DSL elements to configure the cache retention settings are not available in earlier versions, so this must be accounted for in any init script that is shared between versions.
 This can easily be handled by conditionally applying a version-compliant script.
 Note that the version-compliant script should reside somewhere other than the `init.d` directory (such as a sub-directory) so that it is not automatically applied.
 
@@ -138,12 +138,12 @@ include::sample[dir="snippets/initScripts/multiVersionCacheRetention/kotlin",fil
 Beginning with Gradle version 8.1, Gradle supports marking caches with a `CACHEDIR.TAG` file.
 It follows the format described in https://bford.info/cachedir/[the Cache Directory Tagging Specification].
 The purpose of this file is to allow tools to identify the directories that do not need to be searched or backed up.
-By default, the directories `caches`, `wrapper/dists`, `daemon`, and `jdks` in the Gradle user home directory are marked with this file.
+By default, the directories `caches`, `wrapper/dists`, `daemon`, and `jdks` in the Gradle User Home are marked with this file.
 
 [[dir:gradle_user_home:configure_cache_marking]]
 ==== Configuring cache marking
 
-The cache marking feature can be configured via an init script in the Gradle user home directory:
+The cache marking feature can be configured via an init script in the Gradle User Home:
 
 .Configuring cache marking
 ====
@@ -151,7 +151,7 @@ include::sample[dir="snippets/initScripts/cacheMarking/groovy",files="gradleUser
 include::sample[dir="snippets/initScripts/cacheMarking/kotlin",files="gradleUserHome/init.d/cache-settings.gradle.kts"]
 ====
 
-Note that cache marking settings can only be configured via init scripts and should be placed under the `init.d` directory in Gradle user home. This effectively couples the configuration of cache marking to the Gradle user home directory those settings apply to and limits the possibility of different conflicting settings from different projects being applied to the same directory.
+Note that cache marking settings can only be configured via init scripts and should be placed under the `init.d` directory in Gradle User Home. This effectively couples the configuration of cache marking to the Gradle User Home those settings apply to and limits the possibility of different conflicting settings from different projects being applied to the same directory.
 
 [[dir:project_root]]
 == Project root directory

--- a/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
@@ -41,7 +41,7 @@ The final configuration taken into account by Gradle is a combination of all Gra
 * `gradle.properties` in the project's directory, then its parent project's directory up to the build's root directory.
 * `gradle.properties` in Gradle installation directory.
 
-Note that the location of the Gradle user home may have been changed beforehand via the `-Dgradle.user.home` system property passed on the command line.
+Note that the location of the Gradle User Home may have been changed beforehand via the `-Dgradle.user.home` system property passed on the command line.
 
 The following properties can be used to configure the Gradle build environment:
 
@@ -213,7 +213,7 @@ Specify user name to download Gradle distributions from servers using HTTP Basic
 `gradle.wrapperPassword=(mypassword)`::
 Specify password for downloading a Gradle distribution using the Gradle wrapper.
 `gradle.user.home=(path to directory)`::
-Specify the Gradle user home directory.
+Specify the Gradle User Home directory.
 `https.protocols`::
 Specify the supported TLS versions in a comma separated format. For example: `TLSv1.2,TLSv1.3`.
 
@@ -254,7 +254,7 @@ The following environment variables are available for the `gradle` command. Note
 Specifies JVM arguments to use when starting the Gradle client VM. The client VM only handles command line input/output, so it is rare that one would need to change its VM options.
 The actual build is run by the Gradle daemon, which is not affected by this environment variable.
 `<<directory_layout.adoc#dir:gradle_user_home,GRADLE_USER_HOME>>`::
-Specifies the Gradle user home directory (which defaults to `<home directory of the current user>/.gradle` if not set).
+Specifies the Gradle User Home directory (which defaults to `<home directory of the current user>/.gradle` if not set).
 `JAVA_HOME`::
 Specifies the JDK installation directory to use for the client VM. This VM is also used for the daemon, unless a different one is specified in a Gradle properties file with `org.gradle.java.home`.
 

--- a/subprojects/docs/src/docs/userguide/running-builds/file_system_watching.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/file_system_watching.adoc
@@ -88,7 +88,7 @@ $ gradle <task> -Dorg.gradle.vfs.verbose=true
 ----
 ====
 
-Or configure the property in the `gradle.properties` file in the project root or your Gradle user home:
+Or configure the property in the `gradle.properties` file in the project root or your Gradle User Home:
 
 ====
 .gradle.properties

--- a/subprojects/docs/src/docs/userguide/running-builds/gradle_daemon.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/gradle_daemon.adoc
@@ -74,7 +74,7 @@ $ gradle <task> --daemon
 This flag overrides any settings that disable the Daemon in your project or user `gradle.properties` files.
 
 To enable the Daemon by default in older Gradle versions, add the following setting to the
-`gradle.properties` file in the project root or your Gradle user home:
+`gradle.properties` file in the project root or your Gradle User Home:
 
 ====
 .gradle.properties


### PR DESCRIPTION
Fixes naming convention issues in Gradle documentation for "Gradle User Home".

**This is a Documentation change ONLY.**

### Context
This has been requested as per issue 24308: https://github.com/gradle/gradle/issues/24308
