### PR TITLE
Update archives and default configuration documentation

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
@@ -195,8 +195,9 @@ import java.util.Map;
  * <p>The notation <code>project(':project-a')</code> is similar to the syntax you use
  * when configuring a projectA in a multi-module gradle project.
  *
- * <p>By default, when you declare dependency to projectA, you actually declare dependency to the 'default' configuration of the projectA.
- * If you need to depend on a specific configuration of projectA, use map notation for projects:
+ * <p>Project dependencies are resolved by treating each consumable configuration in the target
+ * project as a variant and performing variant-aware attribute matching against them.
+ * However, in order to override this process, an explicit target configuration can be specified:
  * <p><code><i>configurationName</i> project(path: ':project-a', configuration: 'someOtherConfiguration')</code>
  *
  * <p>Project dependencies are represented using a {@link org.gradle.api.artifacts.ProjectDependency}.

--- a/subprojects/docs/src/docs/userguide/core-plugins/base_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/core-plugins/base_plugin.adoc
@@ -45,7 +45,7 @@ _Depends on_: `check`, `assemble`
 Intended to build everything, including running all tests, producing the production artifacts and generating documentation. You will probably rarely attach concrete tasks directly to `build` as `assemble` and `check` are typically more appropriate.
 
 `build__Configuration__` — task rule::
-Assembles those artifacts attached to the named configuration. For example, `buildArchives` will execute any task that is required to create any artifact attached to the `archives` configuration.
+Assembles those artifacts attached to the named configuration. For example, `buildRuntimeElements` will execute any task that is required to create any artifact attached to the `runtimeElements` configuration.
 
 `clean__Task__` — task rule::
 Removes the <<incremental_build.adoc#sec:task_inputs_outputs,defined outputs>> of a task, e.g. `cleanJar` will delete the JAR file produced by the `jar` task of the Java Plugin.
@@ -59,12 +59,15 @@ The Base Plugin adds no <<declaring_dependencies.adoc#sec:what-are-dependency-co
 `default`::
 A fallback configuration used by consumer projects. Let's say you have project B with a <<declaring_dependencies.adoc#sub:project_dependencies,project dependency>> on project A. Gradle uses some internal logic to determine which of project A's artifacts and dependencies are added to the specified configuration of project B. If no other factors apply — you don't need to worry what these are — then Gradle falls back to using everything in project A's `default` configuration.
 +
-*New builds and plugins should not be using the `default` configuration!* It remains for the reason of backwards compatibility.
+*New builds and plugins should not be using the `default` configuration!*
+It remains solely for backwards compatibility.
 
 `archives`::
-A standard configuration for the production artifacts of a project.
-
-Note that the `assemble` task generates all artifacts that are attached to the `archives` configuration.
+All artifacts defined on the `archives` configuration are automatically built by the `assemble` task.
++
+*New builds and plugins should not be using the `archives` configuration!*
+It remains solely for backwards compatibility.
+Instead, task dependencies should be declared directly on the `assemble` task.
 
 [[sec:base_plugin_extension]]
 == Contributed extensions

--- a/subprojects/docs/src/docs/userguide/core-plugins/base_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/core-plugins/base_plugin.adoc
@@ -57,10 +57,11 @@ Removes the <<incremental_build.adoc#sec:task_inputs_outputs,defined outputs>> o
 The Base Plugin adds no <<declaring_dependencies.adoc#sec:what-are-dependency-configurations,configurations for dependencies>>, but it does add the following configurations:
 
 `default`::
-A fallback configuration used by consumer projects. Let's say you have project B with a <<declaring_dependencies.adoc#sub:project_dependencies,project dependency>> on project A. Gradle uses some internal logic to determine which of project A's artifacts and dependencies are added to the specified configuration of project B. If no other factors apply — you don't need to worry what these are — then Gradle falls back to using everything in project A's `default` configuration.
+A fallback configuration used when dependency resolution is performed without request attributes.
 +
 *New builds and plugins should not be using the `default` configuration!*
 It remains solely for backwards compatibility.
+Dependency resolution should be performed with request attributes.
 
 `archives`::
 All artifacts defined on the `archives` configuration are automatically built by the `assemble` task.

--- a/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_customization.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_customization.adoc
@@ -102,7 +102,7 @@ In general, there are two options:
 - Add artifacts to a publication based on a component with metadata (not recommended, instead <<sec:adding-variants-to-existing-components,adjust a component>> or use a <<#sec:publishing-custom-components,adhoc component publication>> which will both also produce metadata fitting your artifacts)
 
 To create a publication based on artifacts, start by defining a custom artifact and attaching it to a Gradle <<dependency_management_terminology.adoc#sub:terminology_configuration,configuration>> of your choice.
-The following sample defines an RPM artifact that is produced by an `rpm` task (not shown) and attaches that artifact to the `archives` configuration:
+The following sample defines an RPM artifact that is produced by an `rpm` task (not shown) and attaches that artifact to the `conf` configuration:
 
 .Defining a custom artifact for a configuration
 ====

--- a/subprojects/docs/src/docs/userguide/dep-man/06-publishing/signing_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/06-publishing/signing_plugin.adoc
@@ -162,22 +162,22 @@ In addition, the above DSL allows to `sign` multiple comma-separated publication
 [[sec:signing_configurations]]
 === Signing Configurations
 
-It is common to want to sign the artifacts of a configuration. For example, the <<java_plugin.adoc#java_plugin,Java plugin>> configures a jar to build and this jar artifact is added to the `archives` configuration. Using the Signing DSL, you can specify that all of the artifacts of this configuration should be signed.
+It is common to want to sign the artifacts of a configuration. For example, the <<java_plugin.adoc#java_plugin,Java plugin>> configures a jar to build and this jar artifact is added to the `runtimeElements` configuration. Using the Signing DSL, you can specify that all of the artifacts of this configuration should be signed.
 
 .Signing a configuration
 ====
-include::sample[dir="snippets/signing/configurations/kotlin",files="build.gradle.kts[tags=sign-archives]"]
-include::sample[dir="snippets/signing/configurations/groovy",files="build.gradle[tags=sign-archives]"]
+include::sample[dir="snippets/signing/configurations/kotlin",files="build.gradle.kts[tags=sign-runtime-elements]"]
+include::sample[dir="snippets/signing/configurations/groovy",files="build.gradle[tags=sign-runtime-elements]"]
 ====
 
-This will create a task (of type link:{groovyDslPath}/org.gradle.plugins.signing.Sign.html[Sign]) in your project named `signArchives`, that will build any `archives` artifacts (if needed) and then generate signatures for them. The signature files will be placed alongside the artifacts being signed.
+This will create a task (of type link:{groovyDslPath}/org.gradle.plugins.signing.Sign.html[Sign]) in your project named `signRuntimeElements`, that will build any `runtimeElements` artifacts (if needed) and then generate signatures for them. The signature files will be placed alongside the artifacts being signed.
 
 === Example: Signing a configuration output
 
-.Output of **`gradle signArchives`**
+.Output of **`gradle signRuntimeElements`**
 ----
-> gradle signArchives
-include::{snippetsPath}/signing/configurations/tests/signingArchivesOutput.out[]
+> gradle signRuntimeElements
+include::{snippetsPath}/signing/configurations/tests/signingRuntimeElementsOutput.out[]
 ----
 
 [[sec:signing_tasks]]
@@ -239,4 +239,4 @@ include::sample[dir="snippets/signing/conditional/groovy",files="build.gradle[ta
 When signing <<#sec:signing_publications,publications>>, the resultant signature artifacts are automatically added to the corresponding publication.
 Thus, when publishing to a repository, e.g. by executing the `publish` task, your signatures will be distributed along with the other artifacts without any additional configuration.
 
-When signing <<#sec:signing_configurations,configurations>> and <<#sec:signing_tasks,tasks>>, the resultant signature artifacts are automatically added to the `signatures` and `archives` dependency configurations.
+When signing <<#sec:signing_configurations,configurations>> and <<#sec:signing_tasks,tasks>>, the resultant signature artifacts are automatically added to the `signatures` dependency configuration.

--- a/subprojects/docs/src/docs/userguide/jvm/building_java_projects.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/building_java_projects.adoc
@@ -66,7 +66,7 @@ The project version is also used in archive names by default.
 
 The Java Library Plugin also integrates the above tasks into the standard <<base_plugin.adoc#sec:base_tasks,Base Plugin lifecycle tasks>>:
 
- * `jar` is attached to `assemble` footnote:[In fact, any artifact added to the `archives` configuration will be built by `assemble`]
+ * `jar` is attached to `assemble`
  * `test` is attached to `check`
 
 The rest of the chapter explains the different avenues for customizing the build to your requirements. You will also see later how to adjust the build for libraries, applications, web apps and enterprise apps.

--- a/subprojects/docs/src/docs/userguide/jvm/java_library_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/java_library_plugin.adoc
@@ -200,7 +200,7 @@ The role of each configuration is described in the following tables:
 | For compiling against this library
 | yes
 | no
-| This configuration is meant to be used by consumers, to retrieve all the elements necessary to compile against this library. Unlike the `default` configuration, this doesn't leak implementation or runtime dependencies.
+| This configuration is meant to be used by consumers, to retrieve all the elements necessary to compile against this library.
 
 | `runtimeElements`
 | For executing this library

--- a/subprojects/docs/src/docs/userguide/jvm/java_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/java_plugin.adoc
@@ -113,7 +113,7 @@ Prepares the given source set's classes and resources for packaging and executio
 The Java plugin attaches some of its tasks to the lifecycle tasks defined by the <<base_plugin.adoc#sec:base_tasks,Base Plugin>> — which the Java Plugin applies automatically — and it also adds a few other lifecycle tasks:
 
 `assemble`::
-_Depends on_: `jar`, and all other tasks that create artifacts attached to the `archives` configuration
+_Depends on_: `jar`
 +
 Aggregate task that assembles all the archives in the project. This task is added by the Base Plugin.
 
@@ -294,7 +294,12 @@ Tasks such as `compileJava` and `test` then use one or more of those configurati
 [NOTE]
 ====
 
-To find information on the `api` configuration, please consult the <<java_library_plugin.adoc#sec:java_library_separation, Java Library Plugin>> reference documentation and <<dependency_management_for_java_projects.adoc#dependency_management_for_java_projects, Dependency Management for Java Projects>>.
+For information on the `default` and `archives` configurations, please consult the
+<<base_plugin.adoc#sec:base_plugin_configurations,Base Plugin>> reference documentation.
+
+For information on the `api` or `compileOnlyApi` configurations, please consult the
+<<java_library_plugin.adoc#sec:java_library_separation, Java Library Plugin>> reference documentation and
+<<dependency_management_for_java_projects.adoc#dependency_management_for_java_projects, Dependency Management for Java Projects>>.
 
 ====
 
@@ -331,15 +336,8 @@ Runtime only dependencies for running tests.
 `testRuntimeClasspath` extends `testRuntimeOnly, testImplementation`::
 Runtime classpath for running tests. Used by task `test`.
 
-`archives`::
-Artifacts (e.g. jars) produced by this project. Used by Gradle to determine "default" tasks to execute when building.
-
-`default` extends `runtimeElements`::
-The default configuration used by a project dependency on this project. Contains the artifacts and dependencies required by this project at runtime.
-
 The following diagrams show the dependency configurations for the _main_ and _test_ source sets respectively. You can use this legend to interpret the colors:
 
- * Gray text — the configuration is _deprecated_.
  * Green background — you can declare dependencies against the configuration.
  * Blue-gray background — the configuration is for consumption by tasks, not for you to declare dependencies.
  * Light blue background with monospace text — a task.

--- a/subprojects/docs/src/snippets/ear/earCustomized/groovy/ear/build.gradle
+++ b/subprojects/docs/src/snippets/ear/earCustomized/groovy/ear/build.gradle
@@ -8,7 +8,7 @@ repositories { mavenCentral() }
 dependencies {
     // The following dependencies will be the ear modules and
     // will be placed in the ear root
-    deploy project(path: ':war', configuration: 'archives')
+    deploy project(path: ':war', configuration: 'war')
 
     // The following dependencies will become ear libs and will
     // be placed in a dir configured via the libDirName property

--- a/subprojects/docs/src/snippets/ear/earCustomized/groovy/war/build.gradle
+++ b/subprojects/docs/src/snippets/ear/earCustomized/groovy/war/build.gradle
@@ -6,6 +6,15 @@ repositories {
     mavenCentral()
 }
 
+configurations {
+    war {
+        canBeResolved = false
+        outgoing {
+            artifact(tasks.war)
+        }
+    }
+}
+
 dependencies {
     implementation group: 'log4j', name: 'log4j', version: '1.2.15', ext: 'jar'
 }

--- a/subprojects/docs/src/snippets/ear/earCustomized/kotlin/ear/build.gradle.kts
+++ b/subprojects/docs/src/snippets/ear/earCustomized/kotlin/ear/build.gradle.kts
@@ -8,7 +8,7 @@ repositories { mavenCentral() }
 dependencies {
     // The following dependencies will be the ear modules and
     // will be placed in the ear root
-    deploy(project(path = ":war", configuration = "archives"))
+    deploy(project(path = ":war", configuration = "war"))
 
     // The following dependencies will become ear libs and will
     // be placed in a dir configured via the libDirName property

--- a/subprojects/docs/src/snippets/ear/earCustomized/kotlin/war/build.gradle.kts
+++ b/subprojects/docs/src/snippets/ear/earCustomized/kotlin/war/build.gradle.kts
@@ -6,6 +6,15 @@ repositories {
     mavenCentral()
 }
 
+configurations {
+    create("war") {
+        isCanBeResolved = false
+        outgoing {
+            artifact(tasks["war"])
+        }
+    }
+}
+
 dependencies {
     implementation(group = "log4j", name = "log4j", version = "1.2.15", ext = "jar")
 }

--- a/subprojects/docs/src/snippets/ear/earWithWar/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/ear/earWithWar/groovy/build.gradle
@@ -9,7 +9,7 @@ repositories {
 }
 
 dependencies {
-    deploy project(path: ':war', configuration: 'archives')
+    deploy project(path: ':war', configuration: 'war')
 
     earlib group: 'log4j', name: 'log4j', version: '1.2.15', ext: 'jar'
 }

--- a/subprojects/docs/src/snippets/ear/earWithWar/groovy/war/build.gradle
+++ b/subprojects/docs/src/snippets/ear/earWithWar/groovy/war/build.gradle
@@ -6,6 +6,15 @@ repositories {
     mavenCentral()
 }
 
+configurations {
+    war {
+        canBeResolved = false
+        outgoing {
+            artifact(tasks.war)
+        }
+    }
+}
+
 dependencies {
     implementation group: 'log4j', name: 'log4j', version: '1.2.15', ext: 'jar'
 }

--- a/subprojects/docs/src/snippets/ear/earWithWar/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/ear/earWithWar/kotlin/build.gradle.kts
@@ -9,7 +9,7 @@ repositories {
 }
 
 dependencies {
-    deploy(project(path = ":war", configuration = "archives"))
+    deploy(project(path = ":war", configuration = "war"))
 
     earlib(group = "log4j", name = "log4j", version = "1.2.15", ext = "jar")
 }

--- a/subprojects/docs/src/snippets/ear/earWithWar/kotlin/war/build.gradle.kts
+++ b/subprojects/docs/src/snippets/ear/earWithWar/kotlin/war/build.gradle.kts
@@ -6,6 +6,15 @@ repositories {
     mavenCentral()
 }
 
+configurations {
+    create("war") {
+        isCanBeResolved = false
+        outgoing {
+            artifact(tasks["war"])
+        }
+    }
+}
+
 dependencies {
     implementation(group = "log4j", name = "log4j", version = "1.2.15", ext = "jar")
 }

--- a/subprojects/docs/src/snippets/ivy-publish/publish-artifact/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/ivy-publish/publish-artifact/groovy/build.gradle
@@ -7,8 +7,11 @@ group = "org.gradle.sample"
 version = "1.0"
 
 // tag::custom-artifact[]
+configurations {
+    conf
+}
 def rpmFile = layout.buildDirectory.file("rpms/my-package.rpm")
-def rpmArtifact = artifacts.add("archives", rpmFile.get().asFile) {
+def rpmArtifact = artifacts.add("conf", rpmFile.get().asFile) {
     type "rpm"
     builtBy "rpm"
 }

--- a/subprojects/docs/src/snippets/maven-publish/publish-artifact/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/maven-publish/publish-artifact/groovy/build.gradle
@@ -7,8 +7,11 @@ group = 'org.gradle.sample'
 version = '1.0'
 
 // tag::custom-artifact[]
+configurations {
+    conf
+}
 def rpmFile = layout.buildDirectory.file('rpms/my-package.rpm')
-def rpmArtifact = artifacts.add('archives', rpmFile.get().asFile) {
+def rpmArtifact = artifacts.add('conf', rpmFile.get().asFile) {
     type 'rpm'
     builtBy 'rpm'
 }

--- a/subprojects/docs/src/snippets/maven-publish/publish-artifact/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/maven-publish/publish-artifact/kotlin/build.gradle.kts
@@ -7,8 +7,11 @@ group = "org.gradle.sample"
 version = "1.0"
 
 // tag::custom-artifact[]
+configurations {
+    create("conf")
+}
 val rpmFile = layout.buildDirectory.file("rpms/my-package.rpm")
-val rpmArtifact = artifacts.add("archives", rpmFile.get().asFile) {
+val rpmArtifact = artifacts.add("conf", rpmFile.get().asFile) {
     type = "rpm"
     builtBy("rpm")
 }

--- a/subprojects/docs/src/snippets/signing/configurations/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/signing/configurations/groovy/build.gradle
@@ -16,8 +16,8 @@ project['signing.keyId'] = "24875D73"
 project['signing.password'] = "gradle"
 project['signing.secretKeyRingFile'] = file("secKeyRingFile.gpg").absolutePath
 
-// tag::sign-archives[]
+// tag::sign-runtime-elements[]
 signing {
-    sign configurations.archives
+    sign configurations.runtimeElements
 }
-// end::sign-archives[]
+// end::sign-runtime-elements[]

--- a/subprojects/docs/src/snippets/signing/configurations/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/signing/configurations/kotlin/build.gradle.kts
@@ -16,8 +16,8 @@ extra["signing.keyId"] = "24875D73"
 extra["signing.password"] = "gradle"
 extra["signing.secretKeyRingFile"] = file("secKeyRingFile.gpg").absolutePath
 
-// tag::sign-archives[]
+// tag::sign-runtime-elements[]
 signing {
-    sign(configurations.archives.get())
+    sign(configurations.runtimeElements.get())
 }
-// end::sign-archives[]
+// end::sign-runtime-elements[]

--- a/subprojects/docs/src/snippets/signing/configurations/tests/signingRuntimeElementsOutput.out
+++ b/subprojects/docs/src/snippets/signing/configurations/tests/signingRuntimeElementsOutput.out
@@ -2,7 +2,7 @@
 > Task :processResources
 > Task :classes
 > Task :jar
-> Task :signArchives
+> Task :signRuntimeElements
 
 BUILD SUCCESSFUL in 0s
 4 actionable tasks: 4 executed

--- a/subprojects/docs/src/snippets/signing/configurations/tests/signingRuntimeElementsOutput.sample.conf
+++ b/subprojects/docs/src/snippets/signing/configurations/tests/signingRuntimeElementsOutput.sample.conf
@@ -2,7 +2,7 @@
 # gradle signArchives
 # end::cli[]
 executable: gradle
-args: signArchives
+args: signRuntimeElements
 # Do not fail for deprecation warnings: deprecated Maven plugin
 flags: "--warning-mode=none"
-expected-output-file: signingArchivesOutput.out
+expected-output-file: signingRuntimeElementsOutput.out

--- a/subprojects/docs/src/snippets/signing/gnupg-signatory/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/signing/gnupg-signatory/groovy/build.gradle
@@ -9,6 +9,6 @@ version = '1.0'
 // tag::configure-signatory[]
 signing {
     useGpgCmd()
-    sign configurations.archives
+    sign configurations.runtimeElements
 }
 // end::configure-signatory[]

--- a/subprojects/docs/src/snippets/signing/gnupg-signatory/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/signing/gnupg-signatory/kotlin/build.gradle.kts
@@ -9,6 +9,6 @@ version = "1.0"
 // tag::configure-signatory[]
 signing {
     useGpgCmd()
-    sign(configurations.archives.get())
+    sign(configurations.runtimeElements.get())
 }
 // end::configure-signatory[]

--- a/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningSamplesSpec.groovy
+++ b/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningSamplesSpec.groovy
@@ -61,7 +61,7 @@ class SigningSamplesSpec extends AbstractSampleIntegrationTest {
         inDirectory(projectDir)
 
         and:
-        run "signArchives"
+        run "signRuntimeElements"
 
         then:
         projectDir.file("build/libs/gnupg-signatory-1.0.jar.asc").assertExists()

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/SigningExtension.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/SigningExtension.java
@@ -324,7 +324,7 @@ public abstract class SigningExtension {
     /**
      * Creates signing tasks that sign {@link Configuration#getAllArtifacts() all artifacts} of the given configurations.
      *
-     * <p>The created tasks will be named "sign<i>&lt;configuration name capitalized&gt;</i>". That is, given a configuration with the name "archives" the created task will be named "signArchives".
+     * <p>The created tasks will be named "sign<i>&lt;configuration name capitalized&gt;</i>". That is, given a configuration with the name "conf" the created task will be named "signConf".
      *
      * The signature artifacts for the created tasks are added to the {@link #getConfiguration() configuration} for this settings object.
      *


### PR DESCRIPTION
Fixes: #17006 

* Update base plugin to add warning not to use archives configuration but instead add task dependencies directly on assemble
* Update samples to not use archives configuration
* Remove documentation references to archives configuration other than in base plugin documentation
* Update `java` plugin doc to reference base plugin docs instead of re-documenting archives and default configurations

Future work: 
Refine [composite build limitations](https://docs.gradle.org/current/userguide/composite_builds.html#included_build_substitution_requirements) - It includes references to the `default` configuration which are likely no longer true. These limitations were [originally](https://github.com/gradle/gradle/commit/340421a4ca32dd1c7aa72f9c02ded86c4ced9f5d) written in gradle 3