### PR TITLE
Introducing Work-Stealing for TestClassProcessor

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/DefaultWorkerProcessBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/DefaultWorkerProcessBuilder.java
@@ -255,6 +255,11 @@ public class DefaultWorkerProcessBuilder implements WorkerProcessBuilder {
         }
 
         @Override
+        public String toString() {
+            return String.format("MemoryRequesting %s", delegate);
+        }
+
+        @Override
         public WorkerProcess start() {
             memoryResourceManager.requestFreeMemory(memoryAmount);
             return delegate.start();

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/RemoteTestClassStealer.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/RemoteTestClassStealer.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.testing;
+
+import org.gradle.api.NonNullApi;
+
+import javax.annotation.Nullable;
+
+/**
+ * interface for delegating work stealing
+ */
+@NonNullApi
+public interface RemoteTestClassStealer {
+    /**
+     * true, if testClass not alsways startet or handed over<br>
+     * remove async testClass from central {@link TestClassStealer}
+     *
+     * @param testClass class that should start
+     * @return true, if class can be startet
+     */
+    boolean canStart(TestClassRunInfo testClass);
+
+    /**
+     * Call central TestClassStealer to find next test-class
+     *
+     * @return found next successful "stolen" test-class or null, if nothing left
+     */
+    @Nullable
+    TestClassRunInfo trySteal();
+
+    /**
+     * test if the testClass has been startet, send result to {@link TestClassStealer#handOverTestClass}
+     *
+     * @param testClass class that should start
+     */
+    void handOver(TestClassRunInfo testClass);
+}

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestClassStealer.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestClassStealer.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.testing;
+
+import org.gradle.api.NonNullApi;
+import org.gradle.api.internal.tasks.testing.worker.ForkingTestClassProcessor;
+
+import javax.annotation.Nullable;
+
+/**
+ * Interface to implement stealing of {@link TestClassRunInfo} in parallel execution environment
+ */
+
+@NonNullApi
+public interface TestClassStealer {
+    /**
+     * add new stealable testClass to planned classes, wich can be "stolen"
+     *
+     * @param testClass added class
+     * @param processor processor, from which testClass can be stolen
+     */
+    void add(TestClassRunInfo testClass, ForkingTestClassProcessor processor);
+
+    /**
+     * remove testClass from planned classes when startet
+     *
+     * @param testClass startet test class
+     */
+    void remove(TestClassRunInfo testClass);
+
+    /**
+     * remove all references to this processor, because he stopped
+     * @param processor stopped processor, for which cleanup should be done
+     */
+    void stopped(ForkingTestClassProcessor processor);
+
+    /**
+     * looking for next test-class, that have been successful {@link ForkingTestClassProcessor#handOver hand over}
+     *
+     * @return next {@link ForkingTestClassProcessor#handOver hand over} test-class or null, if nothing left
+     */
+    @Nullable
+    TestClassRunInfo trySteal();
+
+    /**
+     * result of {@link ForkingTestClassProcessor#handOver} request
+     *
+     * @param forkingTestClassProcessor processor, which should hand over the testClass
+     * @param testClass requested test class
+     * @param success success of hand over, false means, class was startet since request was initiated
+     */
+    void handOverTestClass(ForkingTestClassProcessor forkingTestClassProcessor, TestClassRunInfo testClass, boolean success);
+}

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/WorkerTestClassProcessorFactory.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/WorkerTestClassProcessorFactory.java
@@ -16,8 +16,27 @@
 
 package org.gradle.api.internal.tasks.testing;
 
+import org.gradle.api.tasks.Internal;
 import org.gradle.internal.service.ServiceRegistry;
 
 public interface WorkerTestClassProcessorFactory {
     TestClassProcessor create(ServiceRegistry serviceRegistry);
+
+    /**
+     * defines test-class stealing strategy:
+     * <ul>
+     *     <li>UNSUPPORTED: discard stealer (return null)</li>
+     *     <li>TESTWORKER: just return stealer<br>
+     *          stealing will be handled by {@link org.gradle.api.internal.tasks.testing.worker.TestWorker TestWorker}<br<
+     *          {@link TestClassProcessor#processTestClass} called by {@link org.gradle.api.internal.tasks.testing.worker.TestWorker TestWorker} must be run synchron</li>
+     *     <li>DElEGATED: return null, but store stealer to be used at the appropriate point </li>
+     * </ul>
+     *
+     * will be called before create, but only if stealer is not null
+     *
+     * @return TestClassStealer to be used by {@link org.gradle.api.internal.tasks.testing.worker.TestWorker TestWorker}
+     */
+    @Internal
+    RemoteTestClassStealer buildWorkerStealer(RemoteTestClassStealer stealer);
+
 }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/RemoteStealer.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/RemoteStealer.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.testing.worker;
+
+import org.gradle.api.NonNullApi;
+import org.gradle.api.internal.tasks.testing.TestClassRunInfo;
+import org.gradle.api.internal.tasks.testing.TestClassStealer;
+
+import javax.annotation.Nullable;
+import java.io.Serializable;
+
+/**
+ * interface for remote calling {@link TestClassStealer}, calls don't block
+ */
+@NonNullApi
+public interface RemoteStealer extends Serializable {
+    /**
+     * removes asynchron testClass from plannedClasses
+     */
+    void remove(TestClassRunInfo testClass);
+
+    /**
+     * looking for next test-class, that have been successful {@link ForkingTestClassProcessor#handOver hand over}<br>
+     */
+    void tryStealing();
+
+    /**
+     * result of hand over of giving test-class
+     */
+    void handOver(HandOverResult result);
+
+    @NonNullApi
+    class HandOverResult implements Serializable {
+        @Nullable
+        private final TestClassRunInfo testClass;
+        private final boolean success;
+
+        public HandOverResult(@Nullable TestClassRunInfo testClass, boolean success) {
+            this.testClass = testClass;
+            this.success = success;
+        }
+
+        @Nullable
+        public TestClassRunInfo getTestClass() {
+            return testClass;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("HandOverResult %s %s", testClass == null ? "null" : testClass.getTestClassName(), success);
+        }
+
+        public boolean isSuccess() {
+            return success;
+        }
+
+    }
+}

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/RemoteTestClassProcessor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/RemoteTestClassProcessor.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.tasks.testing.worker;
 
 import org.gradle.api.internal.tasks.testing.TestClassRunInfo;
+import org.gradle.api.internal.tasks.testing.TestClassStealer;
 
 /**
  * @see org.gradle.api.internal.tasks.testing.TestClassProcessor
@@ -36,4 +37,12 @@ public interface RemoteTestClassProcessor {
      * Does not block.
      */
     void stop();
+
+    /** Does not block; test, if testClass is not startet, and send result back to {@link TestClassStealer#handOverTestClass}  */
+    void handOverTestClass(TestClassRunInfo testClass);
+
+    /**
+     * @param result founded stolen test-class as {@link RemoteStealer.HandOverResult#getTestClass()} and is null, if no more left
+     */
+    void handedOver(RemoteStealer.HandOverResult result);
 }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/TestEventSerializer.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/TestEventSerializer.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.tasks.testing.worker;
 
+import org.gradle.api.NonNullApi;
 import org.gradle.api.internal.tasks.testing.DefaultNestedTestSuiteDescriptor;
 import org.gradle.api.internal.tasks.testing.DefaultTestClassDescriptor;
 import org.gradle.api.internal.tasks.testing.DefaultTestClassRunInfo;
@@ -58,6 +59,7 @@ public class TestEventSerializer {
         registry.register(TestStartEvent.class, new TestStartEventSerializer());
         registry.register(TestCompleteEvent.class, new TestCompleteEventSerializer());
         registry.register(DefaultTestOutputEvent.class, new DefaultTestOutputEventSerializer());
+        registry.register(RemoteStealer.HandOverResult.class, new HandOverResultEventSerializer());
         Serializer<Throwable> throwableSerializer = factory.getSerializerFor(Throwable.class);
         registry.register(Throwable.class, throwableSerializer);
         registry.register(DefaultTestFailure.class, new DefaultTestFailureSerializer(throwableSerializer));
@@ -110,6 +112,22 @@ public class TestEventSerializer {
         @Override
         public void write(Encoder encoder, DefaultTestClassRunInfo value) throws Exception {
             encoder.writeString(value.getTestClassName());
+        }
+    }
+
+    @NonNullApi
+    private static class HandOverResultEventSerializer implements Serializer<RemoteStealer.HandOverResult> {
+
+        @Override
+        public RemoteStealer.HandOverResult read(Decoder decoder) throws Exception {
+            String className = decoder.readNullableString();
+            return new RemoteStealer.HandOverResult(className == null ? null: new DefaultTestClassRunInfo(className), decoder.readBoolean());
+        }
+
+        @Override
+        public void write(Encoder encoder, RemoteStealer.HandOverResult value) throws Exception {
+            encoder.writeNullableString(value.getTestClass() == null ? null:value.getTestClass().getTestClassName());
+            encoder.writeBoolean(value.isSuccess());
         }
     }
 

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/TestWorker.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/TestWorker.java
@@ -17,6 +17,8 @@
 package org.gradle.api.internal.tasks.testing.worker;
 
 import org.gradle.api.Action;
+import org.gradle.api.NonNullApi;
+import org.gradle.api.internal.tasks.testing.RemoteTestClassStealer;
 import org.gradle.api.internal.tasks.testing.TestClassProcessor;
 import org.gradle.api.internal.tasks.testing.TestClassRunInfo;
 import org.gradle.api.internal.tasks.testing.TestResultProcessor;
@@ -40,8 +42,12 @@ import org.gradle.process.internal.worker.WorkerProcessContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.security.AccessControlException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 
@@ -58,27 +64,41 @@ import java.util.concurrent.BlockingQueue;
  * main thread in order of arrival.
  */
 public class TestWorker implements Action<WorkerProcessContext>, RemoteTestClassProcessor, Serializable, Stoppable {
-    private enum State { INITIALIZING, STARTED, STOPPED }
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(TestWorker.class);
     public static final String WORKER_ID_SYS_PROPERTY = "org.gradle.test.worker";
     public static final String WORKER_TMPDIR_SYS_PROPERTY = "org.gradle.internal.worker.tmpdir";
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestWorker.class);
     private static final String WORK_THREAD_NAME = "Test worker";
-
     private final WorkerTestClassProcessorFactory factory;
-    private final BlockingQueue<Runnable> runQueue = new ArrayBlockingQueue<Runnable>(1);
+    private final BlockingQueue<Runnable> runQueue = new ArrayBlockingQueue<Runnable>(2);
+    private final RemoteStealer testClassStealer;
+    /**
+     * only on remote-site, before delegated
+     */
+    private transient TestWorker.WorkerTestClassStealer remoteStealer = null;
+    @Nullable
+    private transient RemoteTestClassStealer workerTestClassStealer = null;
     private TestClassProcessor processor;
     private TestResultProcessor resultProcessor;
-
     /**
-     * Note that the state object is not synchronized and not thread-safe.  Any modifications to the
+     * Note that the state object is not synchronized and not thread-safe.  Any modifications to
      * the state should ONLY be made inside the main thread or inside a command passed to the run queue
      * (which will execute on the main thread).
      */
     private volatile State state = State.INITIALIZING;
 
-    public TestWorker(WorkerTestClassProcessorFactory factory) {
+    public TestWorker(WorkerTestClassProcessorFactory factory, RemoteStealer testClassStealer) {
         this.factory = factory;
+        this.testClassStealer = testClassStealer;
+    }
+
+    private static void executeAndMaintainThreadName(Runnable action) {
+        try {
+            action.run();
+        } finally {
+            // Reset the thread name if the action changes it (e.g. if a test sets the thread name without resetting it afterwards)
+            Thread.currentThread().setName(WORK_THREAD_NAME);
+        }
     }
 
     @Override
@@ -107,7 +127,7 @@ public class TestWorker implements Action<WorkerProcessContext>, RemoteTestClass
 
             // In the event that the main thread exits with an uncaught exception, stop processing
             // and clear out the run queue to unblock any running communication threads
-            synchronized(this) {
+            synchronized (this) {
                 state = State.STOPPED;
                 runQueue.clear();
             }
@@ -124,30 +144,29 @@ public class TestWorker implements Action<WorkerProcessContext>, RemoteTestClass
         }
     }
 
-    private static void executeAndMaintainThreadName(Runnable action) {
-        try {
-            action.run();
-        } finally {
-            // Reset the thread name if the action changes it (e.g. if a test sets the thread name without resetting it afterwards)
-            Thread.currentThread().setName(WORK_THREAD_NAME);
-        }
-    }
-
     private void startReceivingTests(WorkerProcessContext workerProcessContext, ServiceRegistry testServices) {
+        if (testClassStealer != null) {
+            remoteStealer = new WorkerTestClassStealer();
+            workerTestClassStealer = factory.buildWorkerStealer(remoteStealer);
+        }
         TestClassProcessor targetProcessor = factory.create(testServices);
         IdGenerator<Object> idGenerator = Cast.uncheckedNonnullCast(testServices.get(IdGenerator.class));
 
         targetProcessor = new WorkerTestClassProcessor(targetProcessor, idGenerator.generateId(),
-                workerProcessContext.getDisplayName(), testServices.get(Clock.class));
+            workerProcessContext.getDisplayName(), testServices.get(Clock.class));
         ContextClassLoaderProxy<TestClassProcessor> proxy = new ContextClassLoaderProxy<TestClassProcessor>(
-                TestClassProcessor.class, targetProcessor, workerProcessContext.getApplicationClassLoader());
+            TestClassProcessor.class, targetProcessor, workerProcessContext.getApplicationClassLoader());
         processor = proxy.getSource();
 
         ObjectConnection serverConnection = workerProcessContext.getServerConnection();
         serverConnection.useParameterSerializers(TestEventSerializer.create());
         this.resultProcessor = serverConnection.addOutgoing(TestResultProcessor.class);
+        if (remoteStealer != null) {
+            remoteStealer.setRemoteTestClassStealer(serverConnection.addOutgoing(RemoteStealer.class));
+        }
         serverConnection.addIncoming(RemoteTestClassProcessor.class, this);
         serverConnection.connect();
+
     }
 
     @Override
@@ -172,12 +191,18 @@ public class TestWorker implements Action<WorkerProcessContext>, RemoteTestClass
                 if (state != State.STARTED) {
                     throw new IllegalStateException("Test classes cannot be processed until a command to start processing has been received");
                 }
+                //noinspection CaughtExceptionImmediatelyRethrown
                 try {
-                    processor.processTestClass(testClass);
+                    if (workerTestClassStealer == null || workerTestClassStealer.canStart(testClass)) {
+                        processor.processTestClass(testClass);
+                    } else {
+                        LOGGER.info("{} skip test: {}", Thread.currentThread().getName(), testClass);
+                    }
                 } catch (AccessControlException e) {
                     throw e;
                 } finally {
                     // Clean the interrupted status
+                    //noinspection ResultOfMethodCallIgnored
                     Thread.interrupted();
                 }
             }
@@ -190,15 +215,45 @@ public class TestWorker implements Action<WorkerProcessContext>, RemoteTestClass
             @Override
             public void run() {
                 try {
-                    processor.stop();
+                    TestClassRunInfo testClass = workerTestClassStealer != null ? workerTestClassStealer.trySteal() : null;
+                    if (testClass != null) {
+                        LOGGER.info("{} added test: {}", Thread.currentThread().getName(), testClass);
+                        processTestClass(testClass);
+                    } else {
+                        try {
+                            processor.stop();
+                        } finally {
+                            state = State.STOPPED;
+                            // Clean the interrupted status
+                            // because some test class processors do work here, e.g. JUnitPlatform
+                            //noinspection ResultOfMethodCallIgnored
+                            Thread.interrupted();
+                        }
+                    }
                 } finally {
-                    state = State.STOPPED;
-                    // Clean the interrupted status
-                    // because some test class processors do work here, e.g. JUnitPlatform
-                    Thread.interrupted();
+                    if (state != State.STOPPED) {
+                        stop();
+                    }
                 }
             }
         });
+    }
+
+    @Override
+    public void handOverTestClass(final TestClassRunInfo testClass) {
+        if (remoteStealer == null) {
+            throw new IllegalStateException();
+        }
+        remoteStealer.handOver(testClass);
+    }
+
+    @Override
+    public void handedOver(final RemoteStealer.HandOverResult result) {
+        if (remoteStealer == null) {
+            throw new IllegalStateException("");
+        }
+        LOGGER.debug("TestWorker: handedOver (trySteal result) {}", result);
+        remoteStealer.handedOver(result);
     }
 
     private synchronized void submitToRun(Runnable command) {
@@ -211,6 +266,8 @@ public class TestWorker implements Action<WorkerProcessContext>, RemoteTestClass
         }
     }
 
+    private enum State {INITIALIZING, STARTED, STOPPED}
+
     private static class TestFrameworkServiceRegistry extends DefaultServiceRegistry {
         private final WorkerProcessContext workerProcessContext;
 
@@ -218,20 +275,85 @@ public class TestWorker implements Action<WorkerProcessContext>, RemoteTestClass
             this.workerProcessContext = workerProcessContext;
         }
 
+        @SuppressWarnings("unused")
         protected Clock createClock() {
             return workerProcessContext.getServiceRegistry().get(Clock.class);
         }
 
+        @SuppressWarnings("unused")
         protected IdGenerator<Object> createIdGenerator() {
             return new CompositeIdGenerator(workerProcessContext.getWorkerId(), new LongIdGenerator());
         }
 
+        @SuppressWarnings({"MethodMayBeStatic", "unused"})
         protected ExecutorFactory createExecutorFactory() {
             return new DefaultExecutorFactory();
         }
 
+        @SuppressWarnings({"MethodMayBeStatic", "unused"})
         protected ActorFactory createActorFactory(ExecutorFactory executorFactory) {
             return new DefaultActorFactory(executorFactory);
+        }
+    }
+
+    @NonNullApi
+    private static class WorkerTestClassStealer implements RemoteTestClassStealer {
+        private final Set<TestClassRunInfo> working = Collections.synchronizedSet(new HashSet<TestClassRunInfo>());
+        private final BlockingQueue<RemoteStealer.HandOverResult> stolenRunInfo = new ArrayBlockingQueue<RemoteStealer.HandOverResult>(1);
+        @Nullable
+        private RemoteStealer remoteRemoteStealer;
+
+        public void setRemoteTestClassStealer(@Nullable RemoteStealer testClassStealer) {
+            remoteRemoteStealer = testClassStealer;
+        }
+
+        /**
+         * {@link org.gradle.api.internal.tasks.testing.worker.TestWorker} will answer with false, if testClass always handed over
+         *
+         * @param testClass class that will be startet
+         * @return true, if class can be startet
+         */
+        @Override
+        public boolean canStart(TestClassRunInfo testClass) {
+            final boolean started = working.add(testClass);
+            if (started && remoteRemoteStealer != null) {
+                remoteRemoteStealer.remove(testClass);
+            }
+            return started;
+        }
+
+        /**
+         * {@link TestWorker} will answer with false, if testClass always started
+         *
+         * @param testClass class that will be startet on other process
+         */
+        public void handOver(TestClassRunInfo testClass) {
+            if (remoteRemoteStealer == null) {
+                throw new IllegalStateException();
+            }
+            final boolean newAdded = working.add(testClass);
+            remoteRemoteStealer.handOver(new RemoteStealer.HandOverResult(testClass, newAdded));
+        }
+
+
+        @Override
+        @Nullable
+        public TestClassRunInfo trySteal() {
+            if (remoteRemoteStealer == null) {
+                return null;
+            }
+            remoteRemoteStealer.tryStealing();
+            try {
+                return stolenRunInfo.take().getTestClass();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                // possible problem of not running stolen class?
+                return null;
+            }
+        }
+
+        public void handedOver(RemoteStealer.HandOverResult result) {
+            stolenRunInfo.add(result);
         }
     }
 }

--- a/subprojects/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestClassProcessorFactory.java
+++ b/subprojects/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestClassProcessorFactory.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.tasks.testing.junit;
 
+import org.gradle.api.internal.tasks.testing.RemoteTestClassStealer;
 import org.gradle.api.internal.tasks.testing.TestClassProcessor;
 import org.gradle.api.internal.tasks.testing.WorkerTestClassProcessorFactory;
 import org.gradle.internal.actor.ActorFactory;
@@ -39,5 +40,10 @@ class JUnitTestClassProcessorFactory implements WorkerTestClassProcessorFactory,
     @Override
     public TestClassProcessor create(ServiceRegistry serviceRegistry) {
         return new JUnitTestClassProcessor(spec, serviceRegistry.get(IdGenerator.class), serviceRegistry.get(ActorFactory.class), serviceRegistry.get(Clock.class));
+    }
+
+    @Override
+    public RemoteTestClassStealer buildWorkerStealer(RemoteTestClassStealer stealer) {
+        return stealer; // stealing handled by TestWorker
     }
 }

--- a/subprojects/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestClassProcessorFactory.java
+++ b/subprojects/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestClassProcessorFactory.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.tasks.testing.junitplatform;
 
+import org.gradle.api.internal.tasks.testing.RemoteTestClassStealer;
 import org.gradle.api.internal.tasks.testing.TestClassProcessor;
 import org.gradle.api.internal.tasks.testing.WorkerTestClassProcessorFactory;
 import org.gradle.internal.UncheckedException;
@@ -50,5 +51,10 @@ class JUnitPlatformTestClassProcessorFactory implements WorkerTestClassProcessor
         } catch (Exception e) {
             throw UncheckedException.throwAsUncheckedException(e);
         }
+    }
+
+    @Override
+    public RemoteTestClassStealer buildWorkerStealer(RemoteTestClassStealer stealer) {
+        return null; // currently not supported, planned to delegate
     }
 }

--- a/subprojects/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNgTestClassProcessorFactory.java
+++ b/subprojects/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNgTestClassProcessorFactory.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.tasks.testing.testng;
 
+import org.gradle.api.internal.tasks.testing.RemoteTestClassStealer;
 import org.gradle.api.internal.tasks.testing.TestClassProcessor;
 import org.gradle.api.internal.tasks.testing.WorkerTestClassProcessorFactory;
 import org.gradle.internal.actor.ActorFactory;
@@ -45,5 +46,10 @@ class TestNgTestClassProcessorFactory implements WorkerTestClassProcessorFactory
     @Override
     public TestClassProcessor create(ServiceRegistry serviceRegistry) {
         return new TestNGTestClassProcessor(testReportDir, options, suiteFiles, serviceRegistry.get(IdGenerator.class), serviceRegistry.get(Clock.class), serviceRegistry.get(ActorFactory.class));
+    }
+
+    @Override
+    public RemoteTestClassStealer buildWorkerStealer(RemoteTestClassStealer stealer) {
+        return null; // stealing not supported, planned to be delegated
     }
 }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/JvmTestClassStealer.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/JvmTestClassStealer.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.testing;
+
+import org.gradle.api.NonNullApi;
+import org.gradle.api.internal.tasks.testing.worker.ForkingTestClassProcessor;
+import org.gradle.api.tasks.testing.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Manages stealing test-classes not startet from busy processors.<br>
+ * <br>
+ * Collects planned {@link TestClassRunInfo} with assigned processors and removes it, when started.<br>
+ * To steal, it will repeat remove first entry until the other processor
+ * {@link ForkingTestClassProcessor#handOver hand it over} or no more entries left.<br>
+ * <br>
+ * incompatible with {@link Test#getForkEvery()} > 0 and senseless, if {@link Test#getMaxParallelForks()} == 1
+ *
+ * <ul>
+ *     <li>{@link #add} collects all {@link TestClassRunInfo} in incoming order with assigned processor</li>
+ *     <li>{@link #remove} removes started {@link TestClassRunInfo} from {@link #plannedClasses}</li>
+ *     <li>{@link #trySteal} manages stealing</li>
+ *     <li>{@link #handOverTestClass} hand over result received</li>
+ *     <li>{@link #stopped} signalling processor stopped, related entries cleaned up</li>
+ * </ul>
+ */
+@NonNullApi
+public class JvmTestClassStealer implements TestClassStealer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JvmTestClassStealer.class);
+    /**
+     * serialize Tasks depending on stealing actions to avoid locking
+     */
+    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    /**
+     * planned test-classes with assigned processors, could contain always startet Work
+     */
+    private final Map<TestClassRunInfo, ForkingTestClassProcessor> plannedClasses = new LinkedHashMap<TestClassRunInfo, ForkingTestClassProcessor>();
+
+    /**
+     * remember per target-processor which test-class is waiting for handover result, adding result, will release the trySteal waiting
+     */
+    private final Map<ForkingTestClassProcessor, Map<TestClassRunInfo, BlockingQueue<Boolean>>> tryStealingMap =
+        Collections.synchronizedMap(new HashMap<ForkingTestClassProcessor, Map<TestClassRunInfo, BlockingQueue<Boolean>>>());
+    private final Set<ForkingTestClassProcessor> stoppedProcessors = Collections.synchronizedSet(new HashSet<ForkingTestClassProcessor>());
+    private final CallNextPlanned callNextPlanned = new CallNextPlanned();
+
+    /**
+     * add entry with testClass and processor to {@link #plannedClasses}
+     *
+     * @param testClass new planned test-class
+     * @param processor processor planned to work on the testClass
+     */
+    @Override
+    public void add(final TestClassRunInfo testClass, final ForkingTestClassProcessor processor) {
+        executor.submit(new RunAdd(testClass, processor));
+    }
+
+    /**
+     * removes asynchron testClass from {@link #plannedClasses}
+     */
+    @Override
+    public void remove(final TestClassRunInfo testClass) {
+        executor.submit(new RunRemove(testClass));
+    }
+
+    @Override
+    public void stopped(final ForkingTestClassProcessor processor) {
+        if (stoppedProcessors.add(processor)) {
+            LOGGER.info("Stealer: clean process {}", processor);
+            executor.submit(new RunStopped(processor));
+        }
+    }
+
+    /**
+     * looking for next test-class, that have been successful {@link ForkingTestClassProcessor#handOver hand over}
+     *
+     * @return next {@link ForkingTestClassProcessor#handOver hand over} test-class or null, if nothing left
+     */
+    @Override
+    @Nullable
+    public TestClassRunInfo trySteal() {
+        try {
+            NextPlanned nextPlanned;
+            LOGGER.debug("Stealer: waiting for next...");
+            do { // looping over async wait ...
+                nextPlanned = executor.submit(callNextPlanned).get();
+            } while (nextPlanned != null && !nextPlanned.handOver(this));
+            LOGGER.info("Stealer: found {}", nextPlanned);
+            return nextPlanned == null ? null : nextPlanned.testClass;
+        } catch (InterruptedException e) {
+            // ignore and clean the interrupted state
+            //noinspection ResultOfMethodCallIgnored
+            Thread.interrupted();
+        } catch (Exception e) { // ExecutionException | ReflectiveOperationException only since java 1.7
+            // ignore
+        }
+        return null;
+    }
+
+    @Override
+    public void handOverTestClass(ForkingTestClassProcessor forkingTestClassProcessor, TestClassRunInfo testClass, boolean success) {
+        LOGGER.debug("Stealer: handOver {} {}", testClass.getTestClassName(), success);
+        synchronized (tryStealingMap) {
+            final Map<TestClassRunInfo, BlockingQueue<Boolean>> map = tryStealingMap.get(forkingTestClassProcessor);
+            if (map == null) {
+                return;
+            }
+            final BlockingQueue<Boolean> queue = map.get(testClass);
+            if (queue != null) {
+                queue.add(success);
+            }
+        }
+    }
+
+    @NonNullApi
+    private static class NextPlanned {
+        private final ForkingTestClassProcessor processor;
+        private final TestClassRunInfo testClass;
+        private final BlockingQueue<Boolean> queue;
+
+        public NextPlanned(Map.Entry<TestClassRunInfo, ForkingTestClassProcessor> entry, BlockingQueue<Boolean> queue) {
+            this.processor = entry.getValue();
+            this.testClass = entry.getKey();
+            this.queue = queue;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("%s from %s", testClass.getTestClassName(), processor);
+        }
+
+        private boolean handOver(JvmTestClassStealer stealer) {
+            try {
+                LOGGER.debug("Stealer: wait for handOver {} from {}", testClass.getTestClassName(), processor);
+                processor.handOver(testClass);
+                return queue.take(); // stop searching if found
+            } catch (Exception ignore) {
+                // if anything go wrong, take next
+                return true;
+            } finally {
+                synchronized (stealer.tryStealingMap) {
+                    final Map<TestClassRunInfo, BlockingQueue<Boolean>> map = stealer.tryStealingMap.get(processor);
+                    if (map != null) {
+                        map.remove(testClass);
+                        if (map.isEmpty()) {
+                            stealer.tryStealingMap.remove(processor);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @NonNullApi
+    private class RunAdd implements Runnable, Serializable {
+        private final TestClassRunInfo testClass;
+        private final ForkingTestClassProcessor processor;
+
+        public RunAdd(TestClassRunInfo testClass, ForkingTestClassProcessor processor) {
+            this.testClass = testClass;
+            this.processor = processor;
+        }
+
+        @Override
+        public void run() {
+            plannedClasses.put(testClass, processor);
+        }
+    }
+
+    @NonNullApi
+    private class RunRemove implements Runnable, Serializable {
+        private final TestClassRunInfo testClass;
+
+        public RunRemove(TestClassRunInfo testClass) {
+            this.testClass = testClass;
+        }
+
+        @Override
+        public void run() {
+            plannedClasses.remove(testClass);
+        }
+    }
+
+    @NonNullApi
+    private class CallNextPlanned implements Callable<NextPlanned>, Serializable {
+        public CallNextPlanned() {
+            // required to not produce subclass failing InternalNullabilityTest
+        }
+
+        @Override
+        @Nullable
+        public NextPlanned call() {
+            if (plannedClasses.isEmpty()) {
+                return null;
+            }
+            final Iterator<Map.Entry<TestClassRunInfo, ForkingTestClassProcessor>> iterator = plannedClasses.entrySet().iterator();
+            try {
+                final ArrayBlockingQueue<Boolean> queue;
+                final Map.Entry<TestClassRunInfo, ForkingTestClassProcessor> entry = iterator.next();
+                synchronized (tryStealingMap) {
+                    Map<TestClassRunInfo, BlockingQueue<Boolean>> remoteStealings = tryStealingMap.get(entry.getValue());
+                    if (remoteStealings == null) {
+                        remoteStealings = new HashMap<TestClassRunInfo, BlockingQueue<Boolean>>();
+                        tryStealingMap.put(entry.getValue(), remoteStealings);
+                    }
+                    queue = new ArrayBlockingQueue<Boolean>(1);
+                    remoteStealings.put(entry.getKey(), queue);
+                }
+                return new NextPlanned(entry, queue);
+            } finally {
+                iterator.remove();
+            }
+        }
+    }
+
+    @NonNullApi
+    private class RunStopped implements Runnable {
+        private final ForkingTestClassProcessor processor;
+
+        public RunStopped(ForkingTestClassProcessor processor) {
+            this.processor = processor;
+        }
+
+        @Override
+        public void run() {
+            if (!plannedClasses.isEmpty()) {
+                for (final Iterator<Map.Entry<TestClassRunInfo, ForkingTestClassProcessor>> iterator = plannedClasses.entrySet().iterator(); iterator.hasNext();) {
+                    final Map.Entry<TestClassRunInfo, ForkingTestClassProcessor> entry = iterator.next();
+                    if (entry.getValue() == processor) {
+                        iterator.remove();
+                    }
+                }
+            }
+            synchronized (tryStealingMap) {
+                final Map<TestClassRunInfo, BlockingQueue<Boolean>> waitingMap = tryStealingMap.get(processor);
+                if (waitingMap != null) {
+                    for (BlockingQueue<Boolean> queue : waitingMap.values()) {
+                        queue.add(false);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/JvmTestExecutionSpec.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/JvmTestExecutionSpec.java
@@ -40,8 +40,9 @@ public class JvmTestExecutionSpec implements TestExecutionSpec {
     private final int maxParallelForks;
     private final Set<String> previousFailedTestClasses;
     private final boolean testIsModule;
+    private final boolean allowTestClassStealing;
 
-    public JvmTestExecutionSpec(TestFramework testFramework, Iterable<? extends File> classpath, Iterable<? extends File>  modulePath, FileTree candidateClassFiles, boolean scanForTestClasses, FileCollection testClassesDirs, String path, Path identityPath, long forkEvery, JavaForkOptions javaForkOptions, int maxParallelForks, Set<String> previousFailedTestClasses, boolean testIsModule) {
+    public JvmTestExecutionSpec(TestFramework testFramework, Iterable<? extends File> classpath, Iterable<? extends File> modulePath, FileTree candidateClassFiles, boolean scanForTestClasses, FileCollection testClassesDirs, String path, Path identityPath, long forkEvery, JavaForkOptions javaForkOptions, int maxParallelForks, Set<String> previousFailedTestClasses, boolean testIsModule, boolean allowTestClassStealing) {
         this.testFramework = testFramework;
         this.classpath = classpath;
         this.modulePath = modulePath;
@@ -55,6 +56,7 @@ public class JvmTestExecutionSpec implements TestExecutionSpec {
         this.maxParallelForks = maxParallelForks;
         this.previousFailedTestClasses = previousFailedTestClasses;
         this.testIsModule = testIsModule;
+        this.allowTestClassStealing = allowTestClassStealing;
     }
 
     @SuppressWarnings("unused")
@@ -62,8 +64,8 @@ public class JvmTestExecutionSpec implements TestExecutionSpec {
     public JvmTestExecutionSpec copyWithTestFramework(TestFramework testFramework) {
         return new JvmTestExecutionSpec(testFramework, this.classpath, this.modulePath, this.candidateClassFiles,
             this.scanForTestClasses, this.testClassesDirs, this.path, this.identityPath, this.forkEvery,
-            this.javaForkOptions, this.maxParallelForks, this.previousFailedTestClasses, this.testIsModule
-        );
+            this.javaForkOptions, this.maxParallelForks, this.previousFailedTestClasses, this.testIsModule,
+            this.allowTestClassStealing);
     }
 
     public TestFramework getTestFramework() {
@@ -118,5 +120,9 @@ public class JvmTestExecutionSpec implements TestExecutionSpec {
 
     public boolean getTestIsModule() {
         return testIsModule;
+    }
+
+    public boolean isAllowTestClassStealing() {
+        return allowTestClassStealing;
     }
 }

--- a/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/JvmTestClassStealerTest.groovy
+++ b/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/JvmTestClassStealerTest.groovy
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.testing
+
+import org.gradle.api.internal.tasks.testing.worker.ForkingTestClassProcessor
+import spock.lang.Specification
+
+class JvmTestClassStealerTest extends Specification {
+    JvmTestClassStealer instant = new JvmTestClassStealer()
+    TestClassRunInfo findTest = Mock(TestClassRunInfo)
+    TestClassRunInfo workingTest = Mock(TestClassRunInfo)
+    TestClassRunInfo stolenTest = Mock(TestClassRunInfo)
+
+
+    def registerFindAndStealTest(){
+        given:
+        ForkingTestClassProcessor remote = Mock(ForkingTestClassProcessor) {
+            1 * handOver(workingTest) >> { args -> instant.handOverTestClass it, workingTest, false }
+            1 * handOver(stolenTest) >> { args -> instant.handOverTestClass it, stolenTest, true }
+        }
+
+        when:
+        instant.add findTest, remote
+        instant.add workingTest, remote
+        instant.add stolenTest, remote
+        instant.remove findTest
+
+        then:
+        instant.trySteal() === stolenTest
+        instant.trySteal() === null
+
+        0 * remote.handOver(findTest)
+    }
+
+    def registerAndStopWorker(){
+        given:
+        ForkingTestClassProcessor remote = Mock(ForkingTestClassProcessor)
+
+        when:
+        instant.add findTest, remote
+        instant.stopped remote
+
+        then:
+        instant.trySteal() === null
+    }
+
+    def registerAndStopWorkerWhileSteal(){
+        given:
+        ForkingTestClassProcessor remote = Mock(ForkingTestClassProcessor) {
+            handOver(findTest) >> { args ->  instant.stopped it}
+        }
+
+        when:
+        instant.add findTest, remote
+
+        then:
+        instant.trySteal() === null
+    }
+}

--- a/subprojects/testing-jvm/src/test/groovy/org/gradle/api/tasks/testing/TestTest.groovy
+++ b/subprojects/testing-jvm/src/test/groovy/org/gradle/api/tasks/testing/TestTest.groovy
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+//file:noinspection ConfigurationAvoidance
+
 package org.gradle.api.tasks.testing
 
 import org.gradle.api.InvalidUserDataException
@@ -23,6 +25,12 @@ import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 import org.gradle.util.TestUtil
 
 class TestTest extends AbstractProjectBuilderSpec {
+
+    def 'test default values'() {
+        def task = project.tasks.create("test", Test)
+        expect:
+        task.allowTestClassStealing.get() == Boolean.TRUE
+    }
 
     def 'fails if custom executable does not exist'() {
         def task = project.tasks.create("test", Test)


### PR DESCRIPTION
<!--- The issue this PR addresses -->
partially Fixes #2669 (for junit4 tests, as first step)

### Context
On the issue discussion page, a number of people have asked for an improvement in the parallel test scheduling, and even others who are not aware of it might be positively affected through shorter execution times.

The fix proposed here is to establish a work-stealing Feature, with primary focus on TestWorker. This works currently only for JUnit4-Tests. Other test-frameworks have to delegate the stealing process, which is out of scope for this PR.

This is only part one, to reach optimal performance. Next planned parts are:

 - delegate stealing for JUnit5
 - delegate stealing for JUnitNG
 - sorting test-classes based on external provided statistic-data and replace round-robin distribution to test-processors to minimize stealing
 
The solution focused on reducing interrupt of planned test executions and move synchronization overhead to the stealing process.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
  * existing tests will use the feature by default
  * Tests depending on timing in unpredictable environments are inherent instable, so no explicit integration tests added
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
  updated/added Javadoc, imho out of scope for User Guide and DSL Reference, please correct, if wrong
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
