### PR TITLE
Disable embedded testing jetty server stop timeout

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/HttpServerFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/HttpServerFixture.groovy
@@ -133,6 +133,7 @@ trait HttpServerFixture {
             handlers.addHandler(securityHandlerWrapper)
             handlers.addHandler(getCustomHandler())
             server.setHandler(handlers)
+            server.setStopTimeout(0)
             configured = true
         }
 


### PR DESCRIPTION
Currently, the embedded jetty server used in integration tests uses the default 30s stop timeout. Jetty waits for half the stop timeout time before shutting down when a stop request is sent. This causes test cases which use this test fixture to take at least 15 seconds to execute. As a result, some tests take much longer than necessary, reducing testing turn-around time, for example when running all tests in a given subproject, even if only one of those tests use the fixture. `DependencyUnresolvedModuleIntegrationTest` is a prime example of this, and is often the last test to remain executing when running all dependency-management tests.

This PR massively speeds up `DependencyUnresolvedModuleIntegrationTest`. However, both `DependencyUnresolvedModuleIntegrationTest` and `KotlinDslVersionCatalogExtensionIntegrationTest` remain very slow, leading to running all dependency-management embedded integ tests not completing noticeably faster. 

This PR also updates the embedded jetty server version to the latest 9.x version available
