### PR TITLE
Update wrapper and enable persistent javac daemons

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,6 +16,9 @@ kotlin.js.ir.output.granularity=whole-program
 # Temporarily force IDEs to produce build scans
 systemProp.org.gradle.internal.ide.scan=true
 
+# Enable persistent `javac` daemons
+systemProp.org.gradle.internal.java.compile.daemon.keepAlive=DAEMON
+
 # If you're experimenting with changes and don't want to update the verification file right away, please change the mode to "lenient" (not "off")
 org.gradle.dependency.verification=strict
 


### PR DESCRIPTION
In order to discover issues with doing this by default, the JVM team would like to enable persistent javac daemons for the GBT build. This may lead to increased memory pressure even when Gradle is not running. I would like an approval from @gradle/bt-developer-productivity before merging in order to ensure they are aware that this is occurring, and that OOM issues may appear.

If you are finding this is causing problems, locally override the value to `SESSION` instead of `DAEMON`.

Closes https://github.com/gradle/gradle-private/issues/3792. 