### PR TITLE
Let `:generateExternalPluginSpecBuilders` be UP-TO-DATE when a `compileOnly` dependency changes

### DIFF
--- a/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/DefaultPrecompiledScriptPluginsSupport.kt
+++ b/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/DefaultPrecompiledScriptPluginsSupport.kt
@@ -182,6 +182,8 @@ fun Project.enableScriptCompilationOf(
 
     val compileClasspath: FileCollection = sourceSets["main"].compileClasspath
 
+    val runtimeClasspath: FileCollection = configurations["runtimeClasspath"]
+
     tasks {
 
         val extractPrecompiledScriptPluginPlugins by registering(ExtractPrecompiledScriptPluginPlugins::class) {
@@ -195,7 +197,7 @@ fun Project.enableScriptCompilationOf(
                 "generateExternalPluginSpecBuilders",
                 kotlinSourceDirectorySet
             ) {
-                classPathFiles.from(compileClasspath)
+                classPathFiles.from(runtimeClasspath)
                 sourceCodeOutputDir.set(it)
                 metadataOutputDir.set(pluginSpecBuildersMetadata)
             }
@@ -223,7 +225,7 @@ fun Project.enableScriptCompilationOf(
             ) {
                 dependsOn(compilePluginsBlocks)
                 classPathFiles.from(compileClasspath)
-                runtimeClassPathFiles.from(configurations["runtimeClasspath"])
+                runtimeClassPathFiles.from(runtimeClasspath)
                 sourceCodeOutputDir.set(it)
                 metadataOutputDir.set(accessorsMetadata)
                 compiledPluginsBlocksDir.set(compiledPluginsBlocks)


### PR DESCRIPTION
by using the runtimeClasspath instead of the compileClasspath
