### PR TITLE
Deprecate recognizing Boolean isFoo() as a property

### DIFF
--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
@@ -507,6 +507,20 @@ tasks.withType(HtmlDependencyReportTask) {
 =====
 ====
 
+[[groovy_boolean_properties]]
+==== Declaring boolean properties with `is`-prefix and `Boolean` types
+
+Gradle property names are derived by following the Java Bean specification with one exception.
+Gradle recognizes methods with a `Boolean` return type and a `is`-prefix as a boolean property. This is behavior inherited from Groovy originally.
+Groovy 4 more closely follows the Java Bean specification and link:https://issues.apache.org/jira/browse/GROOVY-10708[no longer supports this exception].
+
+Gradle will emit a deprecation warning when it detects that a boolean property is derived from a method with a `Boolean` return type and `is`-prefix.
+In Gradle 9.0, these methods will no longer be treated as defining a Gradle property. This may cause tasks to be considered up-to-date when a boolean property is an input.
+
+To fix this deprecation requires code changes:
+1. Introduce a new method or rename the existing method to start with `get` instead of `is`. This is preferred.
+2. Change the return type of the method to `boolean`.
+
 [[redundant_configuration_usage_activation]]
 ==== Redundant configuration usage activation
 

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/internal/extensibility/DeprecatedBooleanPropertyIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/internal/extensibility/DeprecatedBooleanPropertyIntegrationTest.groovy
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.extensibility
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class DeprecatedBooleanPropertyIntegrationTest extends AbstractIntegrationSpec {
+    def "does not emit deprecation warning when a decorated class exposes a Boolean getter"() {
+        buildFile << """
+            abstract class MyExtension {
+                Boolean getProperty() { return Boolean.TRUE }
+            }
+            def myext = extensions.create("myext", MyExtension)
+            task assertProperty {
+                doLast {
+                    assert myext.property
+                }
+            }
+        """
+        expect:
+        succeeds("assertProperty")
+    }
+
+    def "does not emit deprecation warning when a decorated class exposes a boolean is-getter"() {
+        buildFile << """
+            abstract class MyExtension {
+                boolean isProperty() { return Boolean.TRUE }
+            }
+            def myext = extensions.create("myext", MyExtension)
+            task assertProperty {
+                doLast {
+                    assert myext.property
+                }
+            }
+        """
+        expect:
+        succeeds("assertProperty")
+    }
+
+    def "emits deprecation warning when a decorated class exposes a Boolean is-getter"() {
+        buildFile << """
+            abstract class MyExtension {
+                Boolean isProperty() { return Boolean.TRUE }
+            }
+            def myext = extensions.create("myext", MyExtension)
+            task assertProperty {
+                doLast {
+                    assert myext.property
+                }
+            }
+        """
+        expect:
+        executer.expectDocumentedDeprecationWarning("'MyExtension' declares a property with a Boolean type. This behavior has been deprecated. This will change in Gradle 9.0. " +
+            "The combination of method name and return type is not consistent with Java Bean property rules and will become unsupported in future versions of Groovy. " +
+            "Change the return type of 'isProperty' to boolean or rename 'isProperty' to 'getProperty'. " +
+            "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#groovy_boolean_properties")
+        succeeds("assertProperty")
+    }
+}

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/internal/extensibility/DeprecatedBooleanPropertyIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/internal/extensibility/DeprecatedBooleanPropertyIntegrationTest.groovy
@@ -19,6 +19,22 @@ package org.gradle.internal.extensibility
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 
 class DeprecatedBooleanPropertyIntegrationTest extends AbstractIntegrationSpec {
+    def "does not emit deprecation warning when a decorated class exposes a Boolean property like a field"() {
+        buildFile << """
+            abstract class MyExtension {
+                Boolean property = Boolean.TRUE
+            }
+            def myext = extensions.create("myext", MyExtension)
+            task assertProperty {
+                doLast {
+                    assert myext.property
+                }
+            }
+        """
+        expect:
+        succeeds("assertProperty")
+    }
+
     def "does not emit deprecation warning when a decorated class exposes a Boolean getter"() {
         buildFile << """
             abstract class MyExtension {

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
@@ -299,6 +299,10 @@ abstract class AbstractClassGenerator implements ClassGenerator {
         }
 
         for (PropertyDetails property : classDetails.getProperties()) {
+            for (ClassValidator validator : validators) {
+                validator.validateProperty(property);
+            }
+
             PropertyMetadata propertyMetaData = classMetaData.property(property.getName());
             for (ClassGenerationHandler handler : generationHandlers) {
                 handler.visitProperty(propertyMetaData);
@@ -753,7 +757,28 @@ abstract class AbstractClassGenerator implements ClassGenerator {
     }
 
     private interface ClassValidator {
-        void validateMethod(Method method, PropertyAccessorType accessorType);
+        /**
+         * Validates the method is declared properly.
+         *
+         * Implementations might check things like the annotations declared on the method.
+         *
+         * @param method the method to check
+         * @param accessorType the type of property this method would represent
+         */
+        default void validateMethod(Method method, PropertyAccessorType accessorType) {
+
+        }
+
+        /**
+         * Validate the property is declared properly.
+         *
+         * Implementations might check things like the name or type of property.
+         *
+         * @param property the property to check
+         */
+        default void validateProperty(PropertyDetails property) {
+
+        }
     }
 
     private static class ClassGenerationHandler {
@@ -1507,21 +1532,42 @@ abstract class AbstractClassGenerator implements ClassGenerator {
     }
 
     /**
-     * Groovy no longer considers {@code Boolean isFoo()} a property {@code foo} of type {@code Boolean}.
+     * Groovy 4 no longer considers {@code Boolean isFoo()} a property {@code foo} of type {@code Boolean}.
      * <p>
      * To create a boolean property, you need to use {@code boolean isFoo()} or {@code Boolean getFoo()}.
      */
     @NonNullApi
     private static class BooleanPropertyDeprecatingValidator implements ClassValidator {
         @Override
-        public void validateMethod(Method method, PropertyAccessorType accessorType) {
-            if (accessorType == PropertyAccessorType.IS_GETTER && method.getReturnType().isAssignableFrom(Boolean.class)) {
-                DeprecationLogger.deprecateBehaviour(String.format("'%s' declares a property with a Boolean type.", method.getDeclaringClass().getCanonicalName()))
-                    .withAdvice(String.format("Change the return type of '%s' to boolean or rename '%1$s' to '%s'.", method.getName(), method.getName().replace("is", "get")))
-                    .withContext("The combination of method name and return type is not consistent with Java Bean property rules and will become unsupported in future versions of Groovy.")
-                    .willChangeInGradle9()
-                    .withUpgradeGuideSection(8, "groovy_boolean_properties")
-                    .nagUser();
+        public void validateProperty(PropertyDetails property) {
+            // If a property only has a single getter, we need to check if its getXXX or isXXX when it's a Boolean.
+            // In a future version of Groovy, the Groovy compiler will not consider a Boolean is-getter as defining a property.
+            //
+            // However, in Groovy 3, the compiler will still generate getters for a field-like declaration:
+            // class GroovyClass {
+            //      Boolean foo
+            // }
+            // This will generate a private field "foo", a getFoo() and a isFoo().
+            // We do not emit a deprecation if a property has both a get-getter and an is-getter.
+            //
+            // In Groovy 4, the same code will only generate the field and getFoo().
+            //
+            if (property.getGetters().size() == 1) {
+                Method method = property.getGetters().iterator().next();
+                PropertyAccessorType accessorType = PropertyAccessorType.of(method);
+                if (accessorType == PropertyAccessorType.IS_GETTER && method.getReturnType().isAssignableFrom(Boolean.class)) {
+                    // To remove this deprecation, we need to do a few things:
+                    // 1. We should no longer recognize isXXX for anything that is not explicitly boolean (primitive type)
+                    // 2. We should be able to remove this validator completely. We do not need to make this an error.
+                    //
+                    // If we do not upgrade to Groovy 4 in Gradle 9, we can still remove this deprecation and drop support for these types of properties.
+                    DeprecationLogger.deprecateBehaviour(String.format("'%s' declares a property with a Boolean type.", method.getDeclaringClass().getCanonicalName()))
+                        .withAdvice(String.format("Change the return type of '%s' to boolean or rename '%1$s' to '%s'.", method.getName(), method.getName().replace("is", "get")))
+                        .withContext("The combination of method name and return type is not consistent with Java Bean property rules and will become unsupported in future versions of Groovy.")
+                        .willChangeInGradle9()
+                        .withUpgradeGuideSection(8, "groovy_boolean_properties")
+                        .nagUser();
+                }
             }
         }
     }

--- a/subprojects/model-core/src/main/java/org/gradle/model/internal/manage/schema/extract/ModelPropertyExtractionContext.java
+++ b/subprojects/model-core/src/main/java/org/gradle/model/internal/manage/schema/extract/ModelPropertyExtractionContext.java
@@ -16,9 +16,7 @@
 
 package org.gradle.model.internal.manage.schema.extract;
 
-import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableSortedSet;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Ordering;
 import org.gradle.internal.reflect.PropertyAccessorType;
@@ -27,7 +25,6 @@ import org.gradle.model.internal.type.ModelType;
 import javax.annotation.Nullable;
 import java.lang.reflect.Method;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -74,13 +71,6 @@ public class ModelPropertyExtractionContext {
         return accessors.values();
     }
 
-    public void dropInvalidAccessor(PropertyAccessorType type, ImmutableCollection.Builder<Method> droppedMethods) {
-        PropertyAccessorExtractionContext removedAccessor = accessors.remove(type);
-        if (removedAccessor != null) {
-            droppedMethods.add(removedAccessor.getMostSpecificDeclaration());
-        }
-    }
-
     public Set<ModelType<?>> getDeclaredBy() {
         ImmutableSortedSet.Builder<ModelType<?>> declaredBy = new ImmutableSortedSet.Builder<ModelType<?>>(Ordering.usingToString());
         for (PropertyAccessorExtractionContext accessor : accessors.values()) {
@@ -91,15 +81,4 @@ public class ModelPropertyExtractionContext {
         return declaredBy.build();
     }
 
-    @Nullable
-    public PropertyAccessorExtractionContext mergeGetters() {
-        PropertyAccessorExtractionContext getGetter = getAccessor(PropertyAccessorType.GET_GETTER);
-        PropertyAccessorExtractionContext isGetter = getAccessor(PropertyAccessorType.IS_GETTER);
-        if (getGetter == null && isGetter == null) {
-            return null;
-        }
-        Iterable<Method> getMethods = getGetter != null ? getGetter.getDeclaringMethods() : Collections.<Method>emptyList();
-        Iterable<Method> isMethods = isGetter != null ? isGetter.getDeclaringMethods() : Collections.<Method>emptyList();
-        return new PropertyAccessorExtractionContext(PropertyAccessorType.GET_GETTER, Iterables.concat(getMethods, isMethods));
-    }
 }


### PR DESCRIPTION
Groovy 4 no longer recognizes these methods as properties.

You need to use either:
- boolean isFoo()
- Boolean getFoo()

fixes https://github.com/gradle/gradle/issues/22218