### PR TITLE
Add support for non-present providers in attribute containers

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/JavaEcosystemSupport.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/JavaEcosystemSupport.java
@@ -27,14 +27,12 @@ import org.gradle.api.attributes.AttributesSchema;
 import org.gradle.api.attributes.Bundling;
 import org.gradle.api.attributes.Category;
 import org.gradle.api.attributes.CompatibilityCheckDetails;
-import org.gradle.api.attributes.HasAttributes;
 import org.gradle.api.attributes.LibraryElements;
 import org.gradle.api.attributes.MultipleCandidatesDetails;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.attributes.java.TargetJvmEnvironment;
 import org.gradle.api.attributes.java.TargetJvmVersion;
 import org.gradle.api.internal.ReusableAction;
-import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.DescribableAttributesSchema;
 import org.gradle.api.model.ObjectFactory;
 
@@ -107,14 +105,6 @@ public abstract class JavaEcosystemSupport {
 
     private static void configureConsumerDescriptors(DescribableAttributesSchema attributesSchema) {
         attributesSchema.addConsumerDescriber(new JavaEcosystemAttributesDescriber());
-    }
-
-    public static void configureDefaultTargetPlatform(HasAttributes configuration, int majorVersion) {
-        AttributeContainerInternal attributes = (AttributeContainerInternal) configuration.getAttributes();
-        // If nobody said anything about this variant's target platform, use whatever the convention says
-        if (!attributes.contains(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE)) {
-            attributes.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, majorVersion);
-        }
     }
 
     private static void configureTargetPlatform(AttributesSchema attributesSchema) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
@@ -64,7 +64,11 @@ public interface ConfigurationInternal extends ResolveContext, DeprecatableConfi
 
     /**
      * Registers an action to execute before locking for further mutation.
+     *
+     * @deprecated This method is used in the gradle/gradle build. We should remove that
+     * usage and then remove this method.
      */
+    @Deprecated
     void beforeLocking(Action<? super ConfigurationInternal> action);
 
     boolean isCanBeMutated();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -1131,6 +1131,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     }
 
     @Override
+    @Deprecated
     public void beforeLocking(Action<? super ConfigurationInternal> action) {
         if (canBeMutated) {
             if (beforeLocking != null) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -1517,19 +1517,6 @@ class DefaultConfigurationSpec extends Specification implements InspectableConfi
         conf.attributes.getAttribute(buildType).name == 'release'
     }
 
-    def "cannot define two attributes with the same name but different types"() {
-        def conf = conf()
-        def flavor = Attribute.of('flavor', Flavor)
-
-        when:
-        conf.getAttributes().attribute(flavor, new FlavorImpl(name: 'free'))
-        conf.getAttributes().attribute(Attribute.of('flavor', String.class), 'paid')
-
-        then:
-        def e = thrown(IllegalArgumentException)
-        e.message == 'Cannot have two attributes with the same name but different types. This container already has an attribute named \'flavor\' of type \'org.gradle.api.internal.artifacts.configurations.DefaultConfigurationSpec$Flavor\' and you are trying to store another one of type \'java.lang.String\''
-    }
-
     def "can overwrite a configuration attribute"() {
         def conf = conf()
         def flavor = Attribute.of(Flavor)

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProvider.java
@@ -42,14 +42,14 @@ public class DefaultProvider<T> extends AbstractMinimalProvider<T> {
     public Class<T> getType() {
         // guard against https://youtrack.jetbrains.com/issue/KT-36297
         try {
-            return inferTypeFromCallableGenericArgument();
+            return inferTypeFromCallableGenericArgument(value);
         } catch (NoClassDefFoundError e) {
             return null;
         }
     }
 
     @Nullable
-    private Class<T> inferTypeFromCallableGenericArgument() {
+    static <E> Class<E> inferTypeFromCallableGenericArgument(Callable<? extends E> value) {
         // We could do a better job of figuring this out
         // Extract the type for common case that is quick to calculate
         for (Type superType : value.getClass().getGenericInterfaces()) {

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProviderWithValue.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProviderWithValue.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider;
+
+import org.gradle.internal.UncheckedException;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.concurrent.Callable;
+
+/**
+ * A provider whose value is computed by a {@link Callable}. This provider is very similar to {@link DefaultProvider},
+ * except it guarantees that the value is always present. This way, we can avoid eagerly calculating the value
+ * when calling {@link #isPresent()}.
+ *
+ * <h3>Configuration Cache Behavior</h3>
+ * <b>Eager</b>. The value is computed at store time and loaded from the cache.
+ */
+public class DefaultProviderWithValue<T> extends AbstractProviderWithValue<T> {
+    private final Callable<? extends T> value;
+
+    public DefaultProviderWithValue(Callable<? extends T> value) {
+        this.value = value;
+    }
+
+    @Override
+    protected Value<? extends T> calculateOwnValue(ValueConsumer consumer) {
+        try {
+            T result = value.call();
+            if (result == null) {
+                throw new IllegalArgumentException("Callable must never return null.");
+            }
+            return Value.of(result);
+        } catch (Exception e) {
+            throw UncheckedException.throwAsUncheckedException(e);
+        }
+    }
+
+    @Nullable
+    @Override
+    public Class<T> getType() {
+        // guard against https://youtrack.jetbrains.com/issue/KT-36297
+        try {
+            return DefaultProvider.inferTypeFromCallableGenericArgument(value);
+        } catch (NoClassDefFoundError e) {
+            return null;
+        }
+    }
+}

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainQueryService.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainQueryService.java
@@ -19,7 +19,7 @@ package org.gradle.jvm.toolchain.internal;
 import com.google.common.annotations.VisibleForTesting;
 import org.gradle.api.GradleException;
 import org.gradle.api.internal.file.FileFactory;
-import org.gradle.api.internal.provider.DefaultProvider;
+import org.gradle.api.internal.provider.DefaultProviderWithValue;
 import org.gradle.api.internal.provider.ProviderInternal;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.internal.deprecation.DeprecationLogger;
@@ -100,7 +100,7 @@ public class JavaToolchainQueryService {
 
     public ProviderInternal<JavaToolchain> findMatchingToolchain(JavaToolchainSpec filter) {
         JavaToolchainSpecInternal filterInternal = (JavaToolchainSpecInternal) Objects.requireNonNull(filter);
-        return new DefaultProvider<>(() -> resolveToolchain(filterInternal));
+        return new DefaultProviderWithValue<>(() -> resolveToolchain(filterInternal));
     }
 
     private JavaToolchain resolveToolchain(JavaToolchainSpecInternal requestedSpec) throws Exception {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -32,6 +32,7 @@ import org.gradle.api.internal.artifacts.configurations.ConfigurationRoles;
 import org.gradle.api.internal.artifacts.configurations.RoleBasedConfigurationContainerInternal;
 import org.gradle.api.internal.file.FileTreeInternal;
 import org.gradle.api.internal.plugins.DslObject;
+import org.gradle.api.internal.provider.DefaultProviderWithValue;
 import org.gradle.api.internal.tasks.DefaultSourceSetOutput;
 import org.gradle.api.internal.tasks.JvmConstants;
 import org.gradle.api.internal.tasks.compile.CompilationSourceDirs;
@@ -189,7 +190,11 @@ public abstract class JavaBasePlugin implements Plugin<Project> {
             })
             .map(value -> objectFactory.named(LibraryElements.class, value));
 
-        compileClasspath.getAttributes().attributeProvider(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, libraryElements);
+        compileClasspath.getAttributes().attributeProvider(
+            LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
+            // TODO: This breaks the provider chain.
+            new DefaultProviderWithValue<>(libraryElements::get)
+        );
     }
 
     private void configureTargetPlatform(TaskProvider<JavaCompile> compileTask, SourceSet sourceSet, ConfigurationContainer configurations) {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmPluginServices.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmPluginServices.java
@@ -30,6 +30,7 @@ import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.artifacts.publish.AbstractPublishArtifact;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.provider.DefaultProviderWithValue;
 import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.internal.tasks.DefaultSourceSetOutput;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
@@ -236,7 +237,7 @@ public class DefaultJvmPluginServices implements JvmPluginServices {
     }
 
     private <COMPILE extends AbstractCompile & HasCompileOptions> Provider<Integer> getMajorVersion(COMPILE compileTask) {
-        return compileTask.getOptions().getRelease().orElse(providerFactory.provider(() -> {
+        return compileTask.getOptions().getRelease().orElse(new DefaultProviderWithValue<>(() -> {
             List<String> compilerArgs = compileTask.getOptions().getCompilerArgs();
             int flagIndex = compilerArgs.indexOf("--release");
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmPluginServices.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmPluginServices.java
@@ -226,6 +226,7 @@ public class DefaultJvmPluginServices implements JvmPluginServices {
             return Providers.notDefined();
         }
 
+        // TODO: This breaks the provider chain.
         return new DefaultProviderWithValue<>(() ->
             compileTasks.stream()
                 .map(task -> getMajorVersion(task.get()))

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/jvm/internal/DefaultJvmPluginServicesTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/jvm/internal/DefaultJvmPluginServicesTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.api.plugins.jvm.internal
 
-import org.gradle.api.Action
+
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ConfigurationPublications
@@ -61,10 +61,8 @@ class DefaultJvmPluginServicesTest extends AbstractJvmPluginServicesTest {
     def "configures compileClasspath"() {
         def mutable = AttributeTestUtil.attributesFactory().mutable()
         def attrs = Mock(HasConfigurableAttributes)
-        Action[] action = new Action[1]
         def config
         config = Stub(ConfigurationInternal) {
-            beforeLocking(_) >> { args -> action[0] = args[0] }
             getAttributes() >> mutable
         }
         def javaCompileProvider = Stub(TaskProvider) {
@@ -87,7 +85,6 @@ class DefaultJvmPluginServicesTest extends AbstractJvmPluginServicesTest {
 
         when:
         services.useDefaultTargetPlatformInference(config, javaCompileProvider)
-        action[0].execute(config)
 
         then:
         mutable.asMap() == [


### PR DESCRIPTION
Attribute containers currently do not support providers which have no value. This limits us from leveraging laziness in some places where we conditionally want to add attributes to a container. With this change, we are able to get rid of the internal beforeLocking method on configurations by updating those methods to add attribute providers to the configuration's container.

We cannot remove the beforeLocking method entirely, since the gradle/gradle build uses that method, but once we update the wrapper this should be possible.

When implementing this feature, I chose to make it so non-present attribute providers are not visible when querying the attribute container. So, querying keySet, contains, etc will act as if the attribute was never set on the container. I chose this approach since I believe it is a common use-case to first check if an attribute is present on the container with a keySet or contains check, and then if so, call getAttribute and assume the return-value is non-null.
