### PR TITLE
Allow opt-out for wrapper task validation of distribution url

### DIFF
--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/internal/WrapperPluginAutoApplyActionIntegTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/internal/WrapperPluginAutoApplyActionIntegTest.groovy
@@ -68,7 +68,7 @@ class WrapperPluginAutoApplyActionIntegTest extends AbstractIntegrationSpec {
                 gradleVersion = '12.34'
             }
     """
-        run 'wrapper', '--offline'
+        run 'wrapper', '--no-validate-url'
         then:
         wrapper.generated("12.34")
     }

--- a/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
+++ b/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
@@ -113,7 +113,6 @@ public abstract class Wrapper extends DefaultTask {
     private final DistributionLocator locator = new DistributionLocator();
     private final boolean isOffline;
     private boolean distributionUrlConfigured = false;
-    private final Property<Boolean> validateDistributionUrl = getProject().getObjects().property(Boolean.class);
 
     public Wrapper() {
         scriptFile = "gradlew";
@@ -121,7 +120,7 @@ public abstract class Wrapper extends DefaultTask {
         distributionPath = DEFAULT_DISTRIBUTION_PARENT_NAME;
         archivePath = DEFAULT_DISTRIBUTION_PARENT_NAME;
         isOffline = getProject().getGradle().getStartParameter().isOffline();
-        validateDistributionUrl.set(true);
+        getValidateDistributionUrl().convention(true);
     }
 
     @Inject
@@ -171,7 +170,7 @@ public abstract class Wrapper extends DefaultTask {
     private static final String DISTRIBUTION_URL_EXCEPTION_MESSAGE = "Test of distribution url %s failed. Please check the values set with --gradle-distribution-url and --gradle-version.";
 
     private void validateDistributionUrl() {
-        if (distributionUrlConfigured && validateDistributionUrl.get()) {
+        if (distributionUrlConfigured && getValidateDistributionUrl().get()) {
             String url = getDistributionUrl();
             URI uri = URI.create(url);
             if (uri.getScheme().equals("file")) {
@@ -214,6 +213,7 @@ public abstract class Wrapper extends DefaultTask {
         if (networkTimeout.isPresent()) {
             wrapperProperties.put(WrapperExecutor.NETWORK_TIMEOUT_PROPERTY, String.valueOf(networkTimeout.get()));
         }
+        wrapperProperties.put(WrapperExecutor.VALIDATE_DISTRIBUTION_URL, String.valueOf(getValidateDistributionUrl().get()));
         try {
             PropertiesUtils.store(wrapperProperties, propertiesFileDestination);
         } catch (IOException e) {
@@ -535,17 +535,6 @@ public abstract class Wrapper extends DefaultTask {
     }
 
     /**
-     * Sets if the task will validate the distribution url that has been configured.
-     *
-     * @since 8.2
-     */
-    @Incubating
-    @Option(option = "validate-url", description = "Sets task to validate the configured distribution url")
-    public void setValidateDistributionUrl(Boolean validateDistributionUrl) {
-        this.validateDistributionUrl.set(validateDistributionUrl);
-    }
-
-    /**
      * Indicates if this task will validate the distribution url that has been configured.
      *
      * @since 8.2
@@ -553,8 +542,6 @@ public abstract class Wrapper extends DefaultTask {
      */
     @Incubating
     @Input
-    @Optional
-    public Property<Boolean> getValidateDistributionUrl() {
-        return validateDistributionUrl;
-    }
+    @Option(option = "validate-url", description = "Sets task to validate the configured distribution url")
+    public abstract Property<Boolean> getValidateDistributionUrl();
 }

--- a/subprojects/build-init/src/test/groovy/org/gradle/api/tasks/wrapper/WrapperTest.groovy
+++ b/subprojects/build-init/src/test/groovy/org/gradle/api/tasks/wrapper/WrapperTest.groovy
@@ -56,7 +56,6 @@ class WrapperTest extends AbstractTaskTest {
         new File(getProject().getProjectDir(), TARGET_WRAPPER_FINAL).mkdirs()
         wrapper.setDistributionPath("somepath")
         wrapper.setDistributionSha256Sum("somehash")
-        wrapper.setValidateDistributionUrl(true)
     }
 
     Wrapper getTask() {
@@ -193,7 +192,6 @@ class WrapperTest extends AbstractTaskTest {
 
         then:
         properties.getProperty(WrapperExecutor.VALIDATE_DISTRIBUTION_URL) == "false"
-
     }
 
     def "check inputs"() {

--- a/subprojects/build-init/src/test/groovy/org/gradle/api/tasks/wrapper/WrapperTest.groovy
+++ b/subprojects/build-init/src/test/groovy/org/gradle/api/tasks/wrapper/WrapperTest.groovy
@@ -56,6 +56,7 @@ class WrapperTest extends AbstractTaskTest {
         new File(getProject().getProjectDir(), TARGET_WRAPPER_FINAL).mkdirs()
         wrapper.setDistributionPath("somepath")
         wrapper.setDistributionSha256Sum("somehash")
+        wrapper.setValidateDistributionUrl(true)
     }
 
     Wrapper getTask() {
@@ -78,6 +79,7 @@ class WrapperTest extends AbstractTaskTest {
         wrapper.getDistributionUrl() != null
         wrapper.getDistributionSha256Sum() == null
         !wrapper.getNetworkTimeout().isPresent()
+        wrapper.getValidateDistributionUrl()
     }
 
     def "determines Windows script path from unix script path with #inName"() {
@@ -144,6 +146,14 @@ class WrapperTest extends AbstractTaskTest {
         5000 == wrapper.getNetworkTimeout().get()
     }
 
+    def "uses defined validateDistributionUrl value"() {
+        when:
+        wrapper.setValidateDistributionUrl(false)
+
+        then:
+        !wrapper.getValidateDistributionUrl().get()
+    }
+
     def "execute with non extant wrapper jar parent directory"() {
         when:
         def unjarDir = temporaryFolder.createDir("unjar")
@@ -173,11 +183,24 @@ class WrapperTest extends AbstractTaskTest {
         properties.getProperty(WrapperExecutor.NETWORK_TIMEOUT_PROPERTY) == "6000"
     }
 
+    def "execute with validateDistributionUrl set"() {
+        given:
+        wrapper.setValidateDistributionUrl(false)
+
+        when:
+        execute(wrapper)
+        def properties = GUtil.loadProperties(expectedTargetWrapperProperties)
+
+        then:
+        properties.getProperty(WrapperExecutor.VALIDATE_DISTRIBUTION_URL) == "false"
+
+    }
+
     def "check inputs"() {
         expect:
         TaskPropertyTestUtils.getProperties(wrapper).keySet() == WrapUtil.toSet(
             "distributionBase", "distributionPath", "distributionUrl", "distributionSha256Sum",
-            "distributionType", "archiveBase", "archivePath", "gradleVersion", "networkTimeout")
+            "distributionType", "archiveBase", "archivePath", "gradleVersion", "networkTimeout", "validateDistributionUrl")
     }
 
     def "execute with extant wrapper jar parent directory and extant wrapper jar"() {

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.wrapper.Wrapper.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.wrapper.Wrapper.xml
@@ -56,6 +56,10 @@
                 <td>networkTimeout</td>
                 <td><literal>10000</literal>ms</td>
             </tr>
+            <tr>
+                <td>validateDistributionUrl</td>
+                <td><literal>true</literal></td>
+            </tr>
         </table>
     </section>
     <section>

--- a/subprojects/docs/src/docs/userguide/reference/gradle_wrapper.adoc
+++ b/subprojects/docs/src/docs/userguide/reference/gradle_wrapper.adoc
@@ -64,6 +64,7 @@ The generated Wrapper properties file, `gradle/wrapper/gradle-wrapper.properties
 * The type of Gradle distribution. By default that’s the `-bin` distribution containing only the runtime but no sample code and documentation.
 * The Gradle version used for executing the build. By default the `wrapper` task picks the exact same Gradle version that was used to generate the Wrapper files.
 * Optionally, a timeout in ms used when downloading the gradle distribution.
+* Optionally, a boolean to set the validation of the distribution url.
 
 
 .Example: The generated distribution URL
@@ -102,6 +103,12 @@ The SHA256 hash sum used for <<#sec:verification,verifying the downloaded Gradle
 
 `--network-timeout`::
 The network timeout to use when downloading the gradle distribution, in ms. The default value is `10000`.
+
+`--no-validate-url`::
+Disables the validation of the configured distribution url.
+
+`--validate-url`::
+Enables the validation of the configured distribution url. Enabled by default.
 
 If the distribution url is configured with `--gradle-version` or `--gradle-distribution-url`, the url is validated by sending a HEAD request in the case of the `https` scheme or by checking the existence of the file in the case of the `file` scheme.
 

--- a/subprojects/wrapper-shared/src/main/java/org/gradle/wrapper/WrapperConfiguration.java
+++ b/subprojects/wrapper-shared/src/main/java/org/gradle/wrapper/WrapperConfiguration.java
@@ -25,6 +25,7 @@ public class WrapperConfiguration {
     private String zipBase = PathAssembler.GRADLE_USER_HOME_STRING;
     private String zipPath = Install.DEFAULT_DISTRIBUTION_PATH;
     private int networkTimeout = Download.DEFAULT_NETWORK_TIMEOUT_MILLISECONDS;
+    private boolean validateDistributionUrl = true;
 
     public URI getDistribution() {
         return distribution;
@@ -80,5 +81,13 @@ public class WrapperConfiguration {
 
     public void setNetworkTimeout(int networkTimeout) {
         this.networkTimeout = networkTimeout;
+    }
+
+    public boolean getValidateDistributionUrl() {
+        return validateDistributionUrl;
+    }
+
+    public void setValidateDistributionUrl(boolean validateDistributionUrl) {
+        this.validateDistributionUrl = validateDistributionUrl;
     }
 }

--- a/subprojects/wrapper-shared/src/main/java/org/gradle/wrapper/WrapperExecutor.java
+++ b/subprojects/wrapper-shared/src/main/java/org/gradle/wrapper/WrapperExecutor.java
@@ -31,6 +31,7 @@ public class WrapperExecutor {
     public static final String ZIP_STORE_BASE_PROPERTY = "zipStoreBase";
     public static final String ZIP_STORE_PATH_PROPERTY = "zipStorePath";
     public static final String NETWORK_TIMEOUT_PROPERTY = "networkTimeout";
+    public static final String VALIDATE_DISTRIBUTION_URL = "validateDistributionUrl";
     private final Properties properties;
     private final File propertiesFile;
     private final WrapperConfiguration config = new WrapperConfiguration();
@@ -59,6 +60,7 @@ public class WrapperExecutor {
                 config.setZipBase(getProperty(ZIP_STORE_BASE_PROPERTY, config.getZipBase()));
                 config.setZipPath(getProperty(ZIP_STORE_PATH_PROPERTY, config.getZipPath()));
                 config.setNetworkTimeout(getProperty(NETWORK_TIMEOUT_PROPERTY, config.getNetworkTimeout()));
+                config.setValidateDistributionUrl(getProperty(VALIDATE_DISTRIBUTION_URL, config.getValidateDistributionUrl()));
             } catch (Exception e) {
                 throw new RuntimeException(String.format("Could not load wrapper properties from '%s'.", propertiesFile), e);
             }
@@ -120,6 +122,10 @@ public class WrapperExecutor {
 
     private int getProperty(String propertyName, int defaultValue) {
         return Integer.parseInt(getProperty(propertyName, String.valueOf(defaultValue)));
+    }
+
+    private boolean getProperty(String propertyName, boolean defaultValue) {
+        return Boolean.parseBoolean(getProperty(propertyName, String.valueOf(defaultValue)));
     }
 
     private String getProperty(String propertyName, String defaultValue, boolean required) {

--- a/subprojects/wrapper-shared/src/test/groovy/org/gradle/wrapper/WrapperExecutorTest.groovy
+++ b/subprojects/wrapper-shared/src/test/groovy/org/gradle/wrapper/WrapperExecutorTest.groovy
@@ -40,6 +40,7 @@ class WrapperExecutorTest extends Specification {
         properties.zipStorePath = 'testZipPath'
         properties.distributionSha256Sum = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
         properties.networkTimeout = '11000'
+        properties.validateDistributionUrl = 'true'
         propertiesFile.parentFile.mkdirs()
         propertiesFile.withOutputStream { properties.store(it, 'header') }
     }
@@ -56,6 +57,7 @@ class WrapperExecutorTest extends Specification {
         wrapper.configuration.zipPath == 'testZipPath'
         wrapper.configuration.distributionSha256Sum == 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
         wrapper.configuration.networkTimeout == 11000
+        wrapper.configuration.validateDistributionUrl
     }
 
     def "loads wrapper meta data from specified project directory"() {
@@ -70,6 +72,7 @@ class WrapperExecutorTest extends Specification {
         wrapper.configuration.zipPath == 'testZipPath'
         wrapper.configuration.distributionSha256Sum == 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
         wrapper.configuration.networkTimeout == 11000
+        wrapper.configuration.validateDistributionUrl
     }
 
     def "uses default meta data when properties file does not exist in project directory"() {
@@ -84,6 +87,7 @@ class WrapperExecutorTest extends Specification {
         wrapper.configuration.zipPath == Install.DEFAULT_DISTRIBUTION_PATH
         wrapper.configuration.distributionSha256Sum == null
         wrapper.configuration.networkTimeout == Download.DEFAULT_NETWORK_TIMEOUT_MILLISECONDS
+        wrapper.configuration.validateDistributionUrl
     }
 
     def "properties file need contain only the distribution URL"() {
@@ -102,6 +106,7 @@ class WrapperExecutorTest extends Specification {
         wrapper.configuration.zipBase == PathAssembler.GRADLE_USER_HOME_STRING
         wrapper.configuration.zipPath == Install.DEFAULT_DISTRIBUTION_PATH
         wrapper.configuration.networkTimeout == Download.DEFAULT_NETWORK_TIMEOUT_MILLISECONDS
+        wrapper.configuration.validateDistributionUrl
     }
 
     def "execute installs distribution and launches application"() {

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
@@ -39,7 +39,7 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when:
-        run "wrapper", "--offline"
+        run "wrapper", "--no-validate-url"
 
         then:
         file("gradlew").text.split(TextUtil.unixLineSeparator).length > 1
@@ -55,7 +55,7 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when:
-        run "wrapper", "--offline"
+        run "wrapper", "--no-validate-url"
 
         then:
         // wrapper needs to be small. Let's check it's smaller than some arbitrary 'small' limit
@@ -64,7 +64,7 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
 
     def "generated wrapper scripts for given version from command-line"() {
         when:
-        run "wrapper", "--gradle-version", "2.2.1", "--offline"
+        run "wrapper", "--gradle-version", "2.2.1", "--no-validate-url"
 
         then:
         file("gradle/wrapper/gradle-wrapper.properties").text.contains("distributionUrl=https\\://services.gradle.org/distributions/gradle-2.2.1-bin.zip")
@@ -88,7 +88,7 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
     def "generated wrapper does not change unnecessarily"() {
         def wrapperJar = file("gradle/wrapper/gradle-wrapper.jar")
         def wrapperProperties = file("gradle/wrapper/gradle-wrapper.properties")
-        run "wrapper", "--gradle-version", "2.2.1", "--offline"
+        run "wrapper", "--gradle-version", "2.2.1", "--no-validate-url"
         def testFile = file("modtime").touch()
         def originalTime = testFile.lastModified()
         when:
@@ -97,7 +97,7 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
             testFile.touch()
             assert (testFile.lastModified() - originalTime) >= 2000L
         }
-        run "wrapper", "--gradle-version", "2.2.1", "--rerun-tasks", "--offline"
+        run "wrapper", "--gradle-version", "2.2.1", "--rerun-tasks", "--no-validate-url"
 
         then:
         result.assertTasksExecuted(":wrapper")
@@ -107,7 +107,7 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
 
     def "generated wrapper scripts for valid distribution types from command-line"() {
         when:
-        run "wrapper", "--gradle-version", "2.13", "--distribution-type", distributionType, "--offline"
+        run "wrapper", "--gradle-version", "2.13", "--distribution-type", distributionType, "--no-validate-url"
 
         then:
         file("gradle/wrapper/gradle-wrapper.properties").text.contains("distributionUrl=https\\://services.gradle.org/distributions/gradle-2.13-${distributionType}.zip")
@@ -118,7 +118,7 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
 
     def "no generated wrapper scripts for invalid distribution type from command-line"() {
         when:
-        fails "wrapper", "--gradle-version", "2.13", "--distribution-type", "invalid-distribution-type", "--offline"
+        fails "wrapper", "--gradle-version", "2.13", "--distribution-type", "invalid-distribution-type", "--no-validate-url"
 
         then:
         failure.assertHasCause("Cannot convert string value 'invalid-distribution-type' to an enum value of type 'org.gradle.api.tasks.wrapper.Wrapper\$DistributionType' (valid case insensitive values: BIN, ALL)")
@@ -126,7 +126,7 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
 
     def "generated wrapper scripts for given distribution URL from command-line"() {
         when:
-        run "wrapper", "--gradle-distribution-url", "http://localhost:8080/gradlew/dist", "--offline"
+        run "wrapper", "--gradle-distribution-url", "http://localhost:8080/gradlew/dist", "--no-validate-url"
 
         then:
         file("gradle/wrapper/gradle-wrapper.properties").text.contains("distributionUrl=http\\://localhost\\:8080/gradlew/dist")
@@ -234,6 +234,29 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
         def url = "${httpServer.uri}" + path
         when:
         run("wrapper", "--gradle-distribution-url", "${url}", "--offline")
+
+        then:
+        succeeds()
+    }
+
+    def "wrapper task with distribution url from command-line respects --no-validate-url"() {
+        httpServer.start()
+        def path = "/distributions/8.0-RC-5"
+        def url = "${httpServer.uri}" + path
+        when:
+        run("wrapper", "--gradle-distribution-url", "${url}", "--no-validate-url")
+
+        then:
+        succeeds()
+    }
+
+    def "wrapper task with distribution url from command-line respects --validate-url"() {
+        given:
+        def target = file("/distributions/8.0-rc-5") << "some content"
+        def url = target.toURI().toString()
+
+        when:
+        run( "wrapper", "--gradle-distribution-url", url, "--validate-url")
 
         then:
         succeeds()

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
@@ -76,7 +76,7 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
         executer.inDirectory(file("second")).withTasks("wrapper").run()
 
         then: "the checksum should be constant (unless there are code changes)"
-        Hashing.sha256().hashFile(file("first/gradle/wrapper/gradle-wrapper.jar")) == HashCode.fromString("d6e9cf246766412ce1f6ba205230ec404d0eaa6be2ce297f305ba718e951a266")
+        Hashing.sha256().hashFile(file("first/gradle/wrapper/gradle-wrapper.jar")) == HashCode.fromString("55e949185c26ba3ddcd2c6a4217d043bfa0ce3cc002bbbb52b709a181a513e81")
 
         and:
         file("first/gradle/wrapper/gradle-wrapper.jar").md5Hash == file("second/gradle/wrapper/gradle-wrapper.jar").md5Hash


### PR DESCRIPTION
Fixes #24741

### Context
Starting with #24010, the wrapper task validates the configured distribution url by default. However, there are scenarios where this is expected to fail so an opt-out is required. This change introduces the task options `--validate-url` and (the auto-generated) `--no-validate-url` to enable/disable validation. The default is set to true.

FYI: The auto-generation of opposite task options was introduced with #24664.

