### PR TITLE
Upgrade to HikariCP 4.0.3

### DIFF
--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -288,6 +288,7 @@
             <trusting group="^org[.]codehaus($|([.].*))" regex="true"/>
          </trusted-key>
          <trusted-key id="f3184bcd55f4d016e30d4c9bf42e87f9665015c9" group="org.jsoup" name="jsoup"/>
+         <trusted-key id="f3a90e6b10e809f851ab4fc54cc08e7f47c3ec76" group="com.zaxxer" name="HikariCP"/>
          <trusted-key id="f42b96b8648b5c4a1c43a62fbb2914c1fa0811c3" group="net.bytebuddy"/>
          <trusted-key id="fa77dcfef2ee6eb2debedd2c012579464d01c06a" group="org.codehaus.plexus"/>
          <trusted-key id="fa7929f83ad44c4590f6cc6815c71c0a4e0b8edd" group="net.java.dev.jna"/>
@@ -710,11 +711,6 @@
       <component group="com.yarnpkg" name="yarn" version="1.22.17">
          <artifact name="yarn-1.22.17.tar.gz">
             <pgp value="6d98490c6f1acddd448e45954f77679369475baa"/>
-         </artifact>
-      </component>
-      <component group="com.zaxxer" name="HikariCP" version="4.0.2">
-         <artifact name="HikariCP-4.0.2.jar">
-            <pgp value="f3a90e6b10e809f851ab4fc54cc08e7f47c3ec76"/>
          </artifact>
       </component>
       <component group="commons-codec" name="commons-codec" version="1.15">

--- a/subprojects/distributions-dependencies/build.gradle.kts
+++ b/subprojects/distributions-dependencies/build.gradle.kts
@@ -92,7 +92,7 @@ dependencies {
         api(libs.gson)                  { version { strictly("2.8.9") }}
         api(libs.h2Database)            { version { strictly("2.1.214") }}
         api(libs.hamcrest)              { version { strictly("1.3"); because("2.x changes the API") }}
-        api(libs.hikariCP)              { version { strictly("4.0.2") }}
+        api(libs.hikariCP)              { version { strictly("4.0.3"); because("5.x requires Java 11+") }}
         api(libs.httpcore)              { version { strictly("4.4.14") }}
         api(libs.inject)                { version { strictly("1") }}
         api(libs.ivy)                   { version { strictly("2.3.0"); because("2.4.0 contains a breaking change in DefaultModuleDescriptor.getExtraInfo(), cf. https://issues.apache.org/jira/browse/IVY-1457") }}


### PR DESCRIPTION
We can't upgrade to 5.x as it requires Java 11+.

See information about the CVEs reported against the (unshipped) dependencies of this library here: https://github.com/gradle/gradle/issues/24708.