### PR TITLE
Expand validation of nested map key type to Enum and Integer

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/NestedInputIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/NestedInputIntegrationTest.groovy
@@ -784,14 +784,20 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
 
     @Issue("https://github.com/gradle/gradle/issues/24594")
     @ValidationTestFor(ValidationProblemId.NESTED_MAP_UNSUPPORTED_KEY_TYPE)
-    def "nested map with non-string key works with deprecation warning"() {
+    def "nested map with #type key is validated"() {
         buildFile << """
             abstract class CustomTask extends DefaultTask {
                 @Nested
-                abstract MapProperty<Integer, Object> getLazyMap()
+                abstract MapProperty<$type, Object> getLazyMap()
 
                 @Nested
-                Map<Integer, Object> eagerMap = [:]
+                Map<$type, Object> eagerMap = [:]
+
+                @Nested
+                abstract MapProperty<Boolean, Object> getUnsupportedLazyMap()
+
+                @Nested
+                Map<Boolean, Object> unsupportedEagerMap = [:]
 
                 @OutputFile
                 abstract RegularFileProperty getOutputFile()
@@ -800,27 +806,39 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
                 void execute() {
                     outputFile.getAsFile().get() << lazyMap.get()
                     outputFile.getAsFile().get() << eagerMap
+                    outputFile.getAsFile().get() << unsupportedLazyMap.get()
+                    outputFile.getAsFile().get() << unsupportedEagerMap
                 }
             }
 
             tasks.register("customTask", CustomTask) {
-                lazyMap.put(100, "example")
-                eagerMap.put(100, "example")
+                lazyMap.put($value, "example")
+                eagerMap.put($value, "example")
+                unsupportedLazyMap.put(true, "example")
+                unsupportedEagerMap.put(false, "example")
                 outputFile = file("output.txt")
             }
+
+            enum Letter { A, B, C }
         """
 
         when:
         expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer,
-            "Type 'CustomTask' property 'eagerMap' where key of nested map is of type 'java.lang.Integer'. " +
-                "Reason: Key of nested map must be of type 'String'.",
+            "Type 'CustomTask' property 'unsupportedEagerMap' where key of nested map is of type 'java.lang.Boolean'. " +
+                "Reason: Key of nested map must be of type 'String', 'Integer', or 'Enum'.",
             'validation_problems',
             'unsupported_key_type_of_nested_map')
         run("customTask")
 
         then:
         executedAndNotSkipped(":customTask")
-        file("output.txt").text == "[100:example][100:example]"
+        file("output.txt").text == "[$expectedValue:example][$expectedValue:example][true:example][false:example]"
+
+        where:
+        type      | value      | expectedValue
+        'Integer' | 100        | 100
+        'String'  | '"foo"'    | 'foo'
+        'Enum'    | 'Letter.A' | 'A'
     }
 
     private static String namedBeanClass() {

--- a/subprojects/docs/src/docs/userguide/troubleshooting/validation_problems.adoc
+++ b/subprojects/docs/src/docs/userguide/troubleshooting/validation_problems.adoc
@@ -395,6 +395,6 @@ Please find below the list of unsupported value type and links to respective sec
 
 This error indicates that a nested map declares a key of an unsupported type.
 Gradle uses the key to generate a name for the (sub)property.
-Only allowing keys of type String, Integer, and Enum guarantees that these names are unique and well-formed, and is preferable to relying on `toString()` for producing such names.
+Only allowing keys of type `Enum`, `Integer`, and `String` guarantees that these names are unique and well-formed, and is preferable to relying on `toString()` for producing such names.
 
-To fix this problem, change the type of the key to String, Integer, or Enum.
+To fix this problem, change the type of the key to `Enum`, `Integer`, or `String`.

--- a/subprojects/docs/src/docs/userguide/troubleshooting/validation_problems.adoc
+++ b/subprojects/docs/src/docs/userguide/troubleshooting/validation_problems.adoc
@@ -391,10 +391,10 @@ Please find below the list of unsupported value type and links to respective sec
 `ResolvedArtifactResult`:: <<incremental_build#sec:task_input_using_dependency_resolution_results, Using dependency resolution results as task inputs>>
 
 [[unsupported_key_type_of_nested_map]]
-== Key of nested map must be of type String
+== Unsupported key type of nested map
 
 This error indicates that a nested map declares a key of an unsupported type.
 Gradle uses the key to generate a name for the (sub)property.
-Only allowing keys of type String guarantees that these names are unique and well-formed, and is preferable to relying on `toString()` for producing such names.
+Only allowing keys of type String, Integer, and Enum guarantees that these names are unique and well-formed, and is preferable to relying on `toString()` for producing such names.
 
-To fix this problem, change the type of the key to String.
+To fix this problem, change the type of the key to String, Integer, or Enum.

--- a/subprojects/model-core/src/main/java/org/gradle/internal/properties/annotations/NestedBeanAnnotationHandler.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/properties/annotations/NestedBeanAnnotationHandler.java
@@ -26,12 +26,8 @@ import org.gradle.internal.reflect.problems.ValidationProblemId;
 import org.gradle.internal.reflect.validation.TypeValidationContext;
 
 import java.lang.annotation.Annotation;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Comparator;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.gradle.internal.reflect.validation.Severity.WARNING;
@@ -59,10 +55,10 @@ public class NestedBeanAnnotationHandler extends AbstractPropertyAnnotationHandl
     public void visitPropertyValue(String propertyName, PropertyValue value, PropertyMetadata propertyMetadata, PropertyVisitor visitor) {
     }
 
-    private static final Set<Class<?>> SUPPORTED_KEY_TYPES = new HashSet<>(Arrays.asList(String.class, Integer.class, Enum.class));
+    private static final ImmutableSet<Class<?>> SUPPORTED_KEY_TYPES = ImmutableSet.of(Enum.class, Integer.class, String.class);
 
     private static String getSupportedKeyTypes() {
-        return SUPPORTED_KEY_TYPES.stream().sorted(Comparator.comparing(Class::toString)).map(cls -> "'" + cls.getSimpleName() + "'").collect(Collectors.joining(", "));
+        return SUPPORTED_KEY_TYPES.stream().map(cls -> "'" + cls.getSimpleName() + "'").collect(Collectors.joining(", "));
     }
 
     private static void validateKeyType(PropertyMetadata propertyMetadata, TypeValidationContext validationContext, Class<?> keyType) {

--- a/subprojects/model-core/src/main/java/org/gradle/internal/properties/annotations/NestedBeanAnnotationHandler.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/properties/annotations/NestedBeanAnnotationHandler.java
@@ -28,9 +28,11 @@ import org.gradle.internal.reflect.validation.TypeValidationContext;
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.gradle.internal.reflect.validation.Severity.WARNING;
 
@@ -59,6 +61,10 @@ public class NestedBeanAnnotationHandler extends AbstractPropertyAnnotationHandl
 
     private static final Set<Class<?>> SUPPORTED_KEY_TYPES = new HashSet<>(Arrays.asList(String.class, Integer.class, Enum.class));
 
+    private static String getSupportedKeyTypes() {
+        return SUPPORTED_KEY_TYPES.stream().sorted(Comparator.comparing(Class::toString)).map(cls -> "'" + cls.getSimpleName() + "'").collect(Collectors.joining(", "));
+    }
+
     private static void validateKeyType(PropertyMetadata propertyMetadata, TypeValidationContext validationContext, Class<?> keyType) {
         if (!SUPPORTED_KEY_TYPES.contains(keyType)) {
             validationContext.visitPropertyProblem(problem ->
@@ -66,8 +72,8 @@ public class NestedBeanAnnotationHandler extends AbstractPropertyAnnotationHandl
                     .reportAs(WARNING)
                     .forProperty(propertyMetadata.getPropertyName())
                     .withDescription(() -> "where key of nested map is of type '" + keyType.getName() + "'")
-                    .happensBecause("Key of nested map must be of type 'String', 'Integer', or 'Enum'")
-                    .addPossibleSolution("Change type of key to 'String', 'Integer', or 'Enum'")
+                    .happensBecause("Key of nested map must be one of the following types: " + getSupportedKeyTypes())
+                    .addPossibleSolution("Change type of key to one of the following types: " + getSupportedKeyTypes())
                     .documentedAt("validation_problems", "unsupported_key_type_of_nested_map")
             );
         }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/properties/annotations/NestedBeanAnnotationHandler.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/properties/annotations/NestedBeanAnnotationHandler.java
@@ -26,8 +26,11 @@ import org.gradle.internal.reflect.problems.ValidationProblemId;
 import org.gradle.internal.reflect.validation.TypeValidationContext;
 
 import java.lang.annotation.Annotation;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import static org.gradle.internal.reflect.validation.Severity.WARNING;
 
@@ -54,15 +57,17 @@ public class NestedBeanAnnotationHandler extends AbstractPropertyAnnotationHandl
     public void visitPropertyValue(String propertyName, PropertyValue value, PropertyMetadata propertyMetadata, PropertyVisitor visitor) {
     }
 
+    private static final Set<Class<?>> SUPPORTED_KEY_TYPES = new HashSet<>(Arrays.asList(String.class, Integer.class, Enum.class));
+
     private static void validateKeyType(PropertyMetadata propertyMetadata, TypeValidationContext validationContext, Class<?> keyType) {
-        if (!keyType.equals(String.class)) {
+        if (!SUPPORTED_KEY_TYPES.contains(keyType)) {
             validationContext.visitPropertyProblem(problem ->
                 problem.withId(ValidationProblemId.NESTED_MAP_UNSUPPORTED_KEY_TYPE)
                     .reportAs(WARNING)
                     .forProperty(propertyMetadata.getPropertyName())
                     .withDescription(() -> "where key of nested map is of type '" + keyType.getName() + "'")
-                    .happensBecause("Key of nested map must be of type 'String'")
-                    .addPossibleSolution("Change type of key to 'String'")
+                    .happensBecause("Key of nested map must be of type 'String', 'Integer', or 'Enum'")
+                    .addPossibleSolution("Change type of key to 'String', 'Integer', or 'Enum'")
                     .documentedAt("validation_problems", "unsupported_key_type_of_nested_map")
             );
         }

--- a/subprojects/model-core/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageChecker.groovy
+++ b/subprojects/model-core/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageChecker.groovy
@@ -430,8 +430,8 @@ trait ValidationMessageChecker {
     String nestedMapUnsupportedKeyType(@DelegatesTo(value = NestedMapUnsupportedKeyType, strategy = Closure.DELEGATE_FIRST) Closure<?> spec) {
         def config = display(NestedMapUnsupportedKeyType, "unsupported_key_type_of_nested_map", spec)
         config.description("where key of nested map is of type '${config.keyType}'.")
-            .reason("Key of nested map must be of type 'String'.")
-            .solution("Change type of key to 'String'")
+            .reason("Key of nested map must be of type 'String', 'Integer', or 'Enum'.")
+            .solution("Change type of key to 'String', 'Integer', or 'Enum'")
             .render()
     }
 

--- a/subprojects/model-core/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageChecker.groovy
+++ b/subprojects/model-core/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageChecker.groovy
@@ -430,8 +430,8 @@ trait ValidationMessageChecker {
     String nestedMapUnsupportedKeyType(@DelegatesTo(value = NestedMapUnsupportedKeyType, strategy = Closure.DELEGATE_FIRST) Closure<?> spec) {
         def config = display(NestedMapUnsupportedKeyType, "unsupported_key_type_of_nested_map", spec)
         config.description("where key of nested map is of type '${config.keyType}'.")
-            .reason("Key of nested map must be of type 'String', 'Integer', or 'Enum'.")
-            .solution("Change type of key to 'String', 'Integer', or 'Enum'")
+            .reason("Key of nested map must be one of the following types: 'Enum', 'Integer', 'String'")
+            .solution("Change type of key to one of the following types: 'Enum', 'Integer', 'String'")
             .render()
     }
 


### PR DESCRIPTION
In addition to String, allow Enum and Integer as key type in a nested map.

Follow-up of #23045.