### PR TITLE
Revert "Ignore failing test in Gradleception build"

### DIFF
--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/test/fixtures/server/http/BlockingHttpServerTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/test/fixtures/server/http/BlockingHttpServerTest.groovy
@@ -21,9 +21,7 @@ import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.TestUtil
 import org.hamcrest.CoreMatchers
 import org.junit.Rule
-import spock.lang.Ignore
 
-@Ignore("SLG Ignore temporarily to re-enable Gradleception")
 class BlockingHttpServerTest extends ConcurrentSpec {
     @Rule
     TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())


### PR DESCRIPTION
This reverts commit 66947bca23c1f0390addbee9e2a08f86c4907335.
