### PR TITLE
Default to file.encdoing=UTF-8 on s390x arch

### DIFF
--- a/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+++ b/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
@@ -137,11 +137,13 @@ cygwin=false
 msys=false
 darwin=false
 nonstop=false
+s390x=false
 case "\$( uname )" in                #(
   CYGWIN* )         cygwin=true  ;; #(
   Darwin* )         darwin=true  ;; #(
   MSYS* | MINGW* )  msys=true    ;; #(
-  NONSTOP* )        nonstop=true ;;
+  NONSTOP* )        nonstop=true ;; #(
+  OS/390 )          s390x=true   ;;
 esac
 
 CLASSPATH=$classpath
@@ -191,6 +193,12 @@ if ! "\$cygwin" && ! "\$darwin" && ! "\$nonstop" ; then
         ulimit -n "\$MAX_FD" ||
             warn "Could not set maximum file descriptor limit to \$MAX_FD"
     esac
+fi
+
+# When running on s390x the JVM must run in UTF-8 instead of IBM-1047 (platform default)
+# This is added to the DEFAULT_JVM_OPTS to allow overrides with JAVA_OPTS and/or GRADLE_OPTS
+if "$s390x" ; then
+  DEFAULT_JVM_OPTS=$DEFAULT_JVM_OPTS' "-Dfile.encoding=UTF-8"'
 fi
 
 # Collect all arguments for the java command, stacking in reverse order:


### PR DESCRIPTION
On an IBM Mainframe (s390x architecture) the default file.encoding of the JVM is IBM-1048 (EBCDIC). Gradle expects the JVM to run in UTF-8. Issues appear if either the client or the daemon JVM run in EBCDIC.

Instead of changing the code it makes most sense to make sure the JVM is started in UTF-8 on s390x as well.

<!--- The issue this PR addresses -->
Fixes #24498

### Context
As described in #24498 this is needed to be able to start Gradle on an IBM Mainframe (s390x architecture). The JVM by default runs in EBCDIC (IBM-1047). Gradle expects to run the JVM in UTF-8 because some of the communication between client and daemon relies on it.

This change allows to run Gradle on s390x without any manual modifications or knowledge about setting the JVM option which will ease usage and (hopefully) contribute a wider usage in general.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
