### PR TITLE
Introduce test task option to fail when there is no test

### DIFF
--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/GroovyApplicationInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/GroovyApplicationInitIntegrationTest.groovy
@@ -178,6 +178,9 @@ class GroovyApplicationInitIntegrationTest extends AbstractJvmLibraryInitIntegra
                 package org.acme;
 
                 class SampleMainTest {
+
+                    @org.junit.jupiter.api.Test
+                    public void sampleTest() { }
                 }
         """
         when:

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/GroovyLibraryInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/GroovyLibraryInitIntegrationTest.groovy
@@ -139,6 +139,9 @@ class GroovyLibraryInitIntegrationTest extends AbstractJvmLibraryInitIntegration
                     package org.acme;
 
                     class SampleMainTest {
+
+                        @org.junit.jupiter.api.Test
+                        public void sampleTest() { }
                     }
             """
         when:

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaApplicationInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaApplicationInitIntegrationTest.groovy
@@ -241,6 +241,9 @@ class JavaApplicationInitIntegrationTest extends AbstractJvmLibraryInitIntegrati
                 package org.acme;
 
                 public class SampleMainTest {
+
+                    @org.junit.jupiter.api.Test
+                    public void sampleTest() { }
                 }
         """
         when:

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaLibraryInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaLibraryInitIntegrationTest.groovy
@@ -285,6 +285,9 @@ class JavaLibraryInitIntegrationTest extends AbstractJvmLibraryInitIntegrationSp
                 package org.acme;
 
                 public class SampleMainTest {
+
+                    @org.junit.jupiter.api.Test
+                    public void sampleTest() { }
                 }
         """
         when:

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/KotlinApplicationInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/KotlinApplicationInitIntegrationTest.groovy
@@ -157,6 +157,9 @@ class KotlinApplicationInitIntegrationTest extends AbstractJvmLibraryInitIntegra
                 package org.acme
 
                 class SampleMainTest {
+
+                    @org.junit.jupiter.api.Test
+                    fun sampleTest() { }
                 }
         """
         when:

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/KotlinLibraryInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/KotlinLibraryInitIntegrationTest.groovy
@@ -132,6 +132,9 @@ class KotlinLibraryInitIntegrationTest extends AbstractJvmLibraryInitIntegration
                     package org.acme
 
                     class SampleMainTest {
+
+                        @org.junit.jupiter.api.Test
+                        fun sampleTest() { }
                     }
             """
         when:

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/ScalaApplicationInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/ScalaApplicationInitIntegrationTest.groovy
@@ -155,6 +155,9 @@ class ScalaApplicationInitIntegrationTest extends AbstractJvmLibraryInitIntegrat
                 package org.acme;
 
                 class SampleMainSuite {
+
+                    @org.junit.Test
+                    def sampleTest : Unit = { }
                 }
         """
         when:

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/ScalaLibraryInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/ScalaLibraryInitIntegrationTest.groovy
@@ -116,6 +116,9 @@ class ScalaLibraryInitIntegrationTest extends AbstractJvmLibraryInitIntegrationS
                     package org.acme;
 
                     class SampleMainTest{
+
+                        @org.junit.Test
+                        def sampleTest : Unit = { }
                     }
             """
 

--- a/subprojects/docs/src/docs/userguide/jvm/java_testing.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/java_testing.adoc
@@ -90,6 +90,11 @@ Set this to `true` if you want the build to fail and finish as soon as one of yo
 +
 You can also enable this behavior by using the `--fail-fast` command line option.
 
+`failOnNoTest` —  (since Gradle 8.3) default: false::
+Set this to `true` if you want the build to fail when there is no test to run. This can reveal configuration issues in testing, for example after migrating to a new test framework.
++
+You can also use the command line option `--fail-on-no-test` to enable and `--no-fail-on-no-test` to disable the behaviour respectively.
+
 `testLogging` — default: _not set_::
 This property represents a set of options that control which test events are logged and at what level. You can also configure other logging behavior via this property. See link:{javadocPath}/org/gradle/api/tasks/testing/logging/TestLoggingContainer.html[TestLoggingContainer] for more detail.
 

--- a/subprojects/docs/src/snippets/kotlinDsl/accessors/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/kotlinDsl/accessors/kotlin/build.gradle.kts
@@ -29,6 +29,7 @@ java {                                      // <4>
 tasks {
     test {                                  // <5>
         testLogging.showExceptions = true
+        useJUnit()
     }
 }
 // end::accessors[]

--- a/subprojects/docs/src/snippets/kotlinDsl/accessors/kotlin/src/test/java/TestSource.java
+++ b/subprojects/docs/src/snippets/kotlinDsl/accessors/kotlin/src/test/java/TestSource.java
@@ -1,2 +1,6 @@
+import org.junit.Test;
+
 public class TestSource {
+    @Test
+    public void testSomething() { }
 }

--- a/subprojects/docs/src/snippets/testing/patch-module/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/testing/patch-module/groovy/build.gradle
@@ -5,6 +5,10 @@ repositories {
     mavenCentral()
 }
 
+tasks.named('test') {
+    useJUnitPlatform()
+}
+
 // tag::patchArgs[]
 def moduleName = "org.gradle.sample"
 def patchArgs = ["--patch-module", "$moduleName=${tasks.compileJava.destinationDirectory.asFile.get().path}"]

--- a/subprojects/docs/src/snippets/testing/patch-module/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/testing/patch-module/kotlin/build.gradle.kts
@@ -5,6 +5,10 @@ repositories {
     mavenCentral()
 }
 
+tasks.test {
+    useJUnitPlatform()
+}
+
 // tag::patchArgs[]
 val moduleName = "org.gradle.sample"
 val patchArgs = listOf("--patch-module", "$moduleName=${tasks.compileJava.get().destinationDirectory.asFile.get().path}")

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/TestTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/TestTest.groovy
@@ -85,6 +85,7 @@ class TestTest extends AbstractConventionTaskTest {
         test.getExcludes().isEmpty()
         !test.getIgnoreFailures()
         !test.getFailFast()
+        !test.getFailOnNoTest().get()
     }
 
     def "test execute()"() {

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskFailOnNoTestIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskFailOnNoTestIntegrationTest.groovy
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class TestTaskFailOnNoTestIntegrationTest extends AbstractIntegrationSpec {
+
+    def "#task succeeds if there is a test"() {
+        buildFile << """
+            apply plugin: 'java'
+            ${mavenCentralRepository()}
+            dependencies { testImplementation 'org.testng:testng:6.3.1' }
+            test { useTestNG() }
+        """.stripIndent()
+
+        file("src/test/java/SomeTest.java") << """
+            public class SomeTest {
+                @org.testng.annotations.Test
+                public void foo() { }
+            }
+        """
+
+        when:
+        succeeds(task as String[])
+
+        then:
+        noExceptionThrown()
+
+        where:
+        task  << [["test"], ["test", "--no-fail-on-no-test"]]
+    }
+
+    def "test --fail-on-no-test fails if there is no test"() {
+        buildFile << """
+            apply plugin: 'java'
+            ${mavenCentralRepository()}
+            dependencies { testImplementation 'org.testng:testng:6.3.1' }
+            test { useTestNG() }
+        """.stripIndent()
+
+        file("src/test/java/NotATest.java") << """
+            public class NotATest {}
+        """
+
+        expect:
+        def failure = fails("test", "--fail-on-no-test")
+        failure.assertHasErrorOutput("No tests found for given includes: ")
+    }
+
+    def "test --no-fail-on-no-test succeeds if there is no test"() {
+        buildFile << """
+            apply plugin: 'java'
+            ${mavenCentralRepository()}
+            dependencies { testImplementation 'org.testng:testng:6.3.1' }
+            test { useTestNG() }
+        """.stripIndent()
+
+        file("src/test/java/NotATest.java") << """
+            public class NotATest {}
+        """
+
+        when:
+        succeeds("test", "--no-fail-on-no-test")
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "#task is skipped if there is no test file"() {
+        buildFile << "apply plugin: 'java'"
+
+        file("src/test/java/not_a_test.txt")
+
+        when:
+        succeeds(task as String[])
+
+        then:
+        skipped(":test")
+
+
+        where:
+        task  << [["test"], ["test", "--fail-on-no-test"], ["test", "--no-fail-on-no-test"]]
+    }
+}

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestingIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestingIntegrationTest.groovy
@@ -198,7 +198,11 @@ class TestingIntegrationTest extends JUnitMultiVersionIntegrationSpec implements
         """
         and:
         file("src/test/java/SomeTest.java") << """
+            import $annotation;
+
             public class SomeTest extends $superClass {
+                @Test
+                public void foo() { }
             }
         """
         then:
@@ -208,9 +212,9 @@ class TestingIntegrationTest extends JUnitMultiVersionIntegrationSpec implements
         file("build/tmp/test").exists() // ensure we extracted classes
 
         where:
-        framework   | dependency                | superClass
-        "useJUnit"  | "$testJunitCoordinates"   | "org.junit.runner.Result"
-        "useTestNG" | "org.testng:testng:6.3.1" | "org.testng.Converter"
+        framework   | dependency                | superClass                | annotation
+        "useJUnit"  | "$testJunitCoordinates"   | "org.junit.runner.Result" | "org.junit.Test"
+        "useTestNG" | "org.testng:testng:6.3.1" | "org.testng.Converter"    | "org.testng.annotations.Test"
     }
 
     @Issue("https://issues.gradle.org/browse/GRADLE-2527")

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformIntegrationSpec.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformIntegrationSpec.groovy
@@ -55,4 +55,23 @@ class JUnitPlatformIntegrationSpec extends AbstractIntegrationSpec {
             }
             '''
     }
+
+    void createSimpleJupiterTests() {
+        file('src/test/java/org/gradle/JUnitJupiterTest.java') << '''
+            package org.gradle;
+
+            import org.junit.jupiter.api.Tag;
+            import org.junit.jupiter.api.Test;
+
+            public class JUnitJupiterTest {
+                @Test
+                @Tag("good")
+                public void good() { }
+
+                @Test
+                @Tag("bad")
+                public void bad() { }
+            }
+            '''
+    }
 }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformIntegrationTest.groovy
@@ -260,7 +260,7 @@ public class StaticInnerTest {
                 }
             }
         """)
-        createSimpleJupiterTest()
+        createSimpleJupiterTests()
 
         when:
         succeeds ':test'
@@ -283,10 +283,10 @@ public class StaticInnerTest {
 
         where:
         key              | value
-        'includeTags'    | '"ok"'
-        'excludeTags'    | '"ok"'
+        'includeTags'    | '"good"'
+        'excludeTags'    | '"bad"'
         'includeEngines' | '"junit-jupiter"'
-        'excludeEngines' | '"junit-jupiter"'
+        'excludeEngines' | '"junit-vintage-engine"'
     }
 
     @Timeout(60)

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformLauncherSessionListenerIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformLauncherSessionListenerIntegrationTest.groovy
@@ -69,6 +69,7 @@ class JUnitPlatformLauncherSessionListenerIntegrationTest extends JUnitPlatformI
 
             dependencies {
                 testImplementation project(':other')
+                testCompileOnly 'org.junit.jupiter:junit-jupiter:5.9.1'
                 testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.1'
             }
 
@@ -77,7 +78,14 @@ class JUnitPlatformLauncherSessionListenerIntegrationTest extends JUnitPlatformI
                 testLogging.showStandardStreams = true
             }
         """
-        file("src/test/java/com/example/MyTest.java") << "package com.example; public class MyTest {} "
+        file("src/test/java/com/example/MyTest.java") << """
+            package com.example;
+
+            public class MyTest {
+                @org.junit.jupiter.api.Test
+                public void myTest() { }
+            }
+        """
 
         when:
         executer.expectDocumentedDeprecationWarning("The automatic loading of test framework implementation dependencies has been deprecated. This is scheduled to be removed in Gradle 9.0. Declare the desired test framework directly on the test suite or explicitly declare the test framework implementation dependencies on the test's runtime classpath. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#test_framework_implementation_dependencies")

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFailOnNoTestIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFailOnNoTestIntegrationTest.groovy
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing.testng
+
+import static org.gradle.testing.fixture.JUnitCoverage.getLATEST_JUPITER_VERSION
+
+class TestNGFailOnNoTestIntegrationTest extends TestNGTestFrameworkIntegrationTest {
+
+    def "test source and test task use same test framework"() {
+        given:
+        buildFile << """
+            apply plugin:'java-library'
+            ${mavenCentralRepository()}
+            dependencies {
+                testImplementation 'org.testng:testng:6.3.1'
+            }
+            test {
+                useTestNG()
+            }
+        """
+
+        file("src/test/java/NotATest.java") << """
+            @org.testng.annotations.Test
+            public class NotATest {}
+        """
+
+        when:
+        run('test')
+
+        then:
+        noExceptionThrown()
+
+        when:
+        run('test', '--no-fail-on-no-test')
+
+        then:
+        noExceptionThrown()
+
+        expect:
+        def failure = fails("test", "--fail-on-no-test")
+        failure.assertHasErrorOutput("No tests found for given includes: ")
+
+    }
+
+    def "test source and test task use different test frameworks"() {
+        given:
+        buildFile << """
+            apply plugin:'java-library'
+            ${mavenCentralRepository()}
+            dependencies {
+                testImplementation 'org.junit.jupiter:junit-jupiter:$LATEST_JUPITER_VERSION'
+                testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+            }
+            test {
+                useJUnitPlatform()
+            }
+        """
+
+        createPassingFailingTest()
+
+        when:
+        run("test")
+
+        then:
+        noExceptionThrown()
+
+        when:
+        run('test', '--no-fail-on-no-test')
+
+        then:
+        noExceptionThrown()
+
+        expect:
+        def failure = fails("test", "--fail-on-no-test")
+        failure.assertHasErrorOutput("No tests found for given includes: ")
+    }
+}

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGUpToDateCheckIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGUpToDateCheckIntegrationTest.groovy
@@ -26,7 +26,7 @@ class TestNGUpToDateCheckIntegrationTest extends AbstractIntegrationSpec {
         executer.noExtraLogging()
         file('src/test/java/SomeTest.java') << '''
             public class SomeTest {
-                @org.testng.annotations.Test
+                @org.testng.annotations.Test(groups = {"group to include"})
                 public void pass() {}
             }
         '''.stripIndent()
@@ -173,8 +173,8 @@ class TestNGUpToDateCheckIntegrationTest extends AbstractIntegrationSpec {
 
         where:
         property              | modification
-        'excludeGroups'       | '= ["some group"]'
-        'includeGroups'       | '= ["some group"]'
+        'excludeGroups'       | '= ["group to exclude"]'
+        'includeGroups'       | '= ["group to include"]'
         'outputDirectory'     | '= file("$buildDir/my-out")'
         'suiteXmlFiles'       | '= [file("suite.xml")]'
         'suiteXmlBuilder()'   | '''

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesIntegrationSpec/reExecutesWhenPropertyIsChanged/src/integTest/java/org/gradle/SomeTestClass.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesIntegrationSpec/reExecutesWhenPropertyIsChanged/src/integTest/java/org/gradle/SomeTestClass.java
@@ -17,13 +17,16 @@
 package org.gradle;
 
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 public class SomeTestClass {
+    @Category(CategoryA.class)
     @Test
     public void ok1() {
     }
 
     @Test
+    @Category(CategoryB.class)
     public void ok2() {
     }
 }

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesIntegrationSpec/reExecutesWhenPropertyIsChanged/src/test/java/org/gradle/SomeTestClass.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesIntegrationSpec/reExecutesWhenPropertyIsChanged/src/test/java/org/gradle/SomeTestClass.java
@@ -17,12 +17,15 @@
 package org.gradle;
 
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 public class SomeTestClass {
+    @Category(CategoryA.class)
     @Test
     public void ok1() {
     }
 
+    @Category(CategoryB.class)
     @Test
     public void ok2() {
     }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -55,6 +55,7 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SkipWhenEmpty;
@@ -490,7 +491,6 @@ public abstract class Test extends AbstractTestTask implements JavaForkOptions, 
         forkOptions.setDebug(enabled);
     }
 
-
     /**
      * {@inheritDoc}
      */
@@ -524,6 +524,30 @@ public abstract class Test extends AbstractTestTask implements JavaForkOptions, 
     @Override
     public boolean getFailFast() {
         return super.getFailFast();
+    }
+
+    /**
+     * Sets the task to fail when there is no test to run.
+     *
+     * @since 8.3
+     */
+    @Option(option = "fail-on-no-test", description = "Sets task to fail when there is no test to run.")
+    @Override
+    public void setFailOnNoTest(Boolean failOnNoTest) {
+        super.setFailOnNoTest(failOnNoTest);
+    }
+
+    /**
+     * Indicates if this task will fail when there is no test to run.
+     *
+     * @return whether this task will fail when there is no test to run
+     * @since 8.3
+     */
+    @Input
+    @Optional
+    @Override
+    public Property<Boolean> getFailOnNoTest() {
+        return super.getFailOnNoTest();
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/7452

### Context
Introduce an option on the test task to fail when there is no test to run, e.g. `test --fail-on-no-test`  and the opposite `test --no-fail-on-no-test`. 

The option behaves similarly to [TestFilter::isFailOnNoMatchingTests](https://github.com/gradle/gradle/blob/8db9012a4754bc236700be78b43b5172d9d2aa4e/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/TestFilter.java#L156) but is more generalized  as no filter configuration has to be provided.

A common use case is misconfiguration, for example after switching test frameworks where test sources accidentally use a different framework than what the build is configured with. In this case, the test task currently runs successfully, which can obfuscate that no tests were run (and that those tests might have failed.) 

This work started off with the plan to deprecate this behaviour and eventually make it a failure. However, multiple lifecycle tasks depend on the `test` task (`check`, `build`) and would now emit a deprecation warning, for example when run on a new project. This is quite disruptive so I opted against it. This being said, if a test task should fail when there are no tests to run is a general question - if there is agreement on the deprecation, it can certainly be done in a follow up.

Please note that most of the test changes address issues in test declarations that surfaced when I tested the deprecation and ran with `failOnNoTest = true`. They are unrelated to the source changes but included for due diligence.

FYI: The auto-generation of opposite task options was introduced with #24664.

<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
