### PR TITLE
Fix test failures on master

### DIFF
--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaCrossCompilationIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaCrossCompilationIntegrationTest.groovy
@@ -106,7 +106,7 @@ class JavaCrossCompilationIntegrationTest extends AbstractIntegrationSpec {
             public class ThingTest {
                 @Test
                 public void verify() {
-                    assert System.getProperty("java.version").startsWith("${version}.");
+                    assert System.getProperty("java.version").startsWith("${version}");
                 }
             }
         """

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestingIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestingIntegrationTest.groovy
@@ -216,7 +216,7 @@ class TestingIntegrationTest extends JUnitMultiVersionIntegrationSpec implements
     @Issue("https://issues.gradle.org/browse/GRADLE-2527")
     def "test class detection works for custom test tasks"() {
         given:
-        ignoreWhenJupiter()
+        ignoreWhenJUnitPlatform()
         buildFile << """
                 apply plugin:'java'
                 ${mavenCentralRepository()}
@@ -247,7 +247,7 @@ class TestingIntegrationTest extends JUnitMultiVersionIntegrationSpec implements
             """
 
         file("src/othertests/java/TestCaseExtendsAbstractClass.java") << """
-                import junit.framework.Assert;
+                import org.junit.Assert;
                 public class TestCaseExtendsAbstractClass extends AbstractTestClass{
                     public void testTrue() {
                         Assert.assertTrue(true);


### PR DESCRIPTION
1. Make sure we only run the test with junit since we call useJUnit
2. On JDK 16, java.version returns "16" with nothing after. Remove the check for the following period

Fixes https://github.com/gradle/gradle-private/issues/3823
Fixes https://github.com/gradle/gradle-private/issues/3825