### PR TITLE
Reduce the number of `ConfigurationMetadata` instances retained in heap

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultComponentSelectorConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultComponentSelectorConverter.java
@@ -22,19 +22,16 @@ import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.LibraryComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
-import org.gradle.api.artifacts.component.ProjectComponentSelector;
-import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.LocalComponentRegistry;
+import org.gradle.internal.component.local.model.DefaultProjectComponentSelector;
 import org.gradle.internal.component.local.model.LocalComponentGraphResolveState;
 import org.gradle.util.internal.GUtil;
 
 public class DefaultComponentSelectorConverter implements ComponentSelectorConverter {
     private static final ModuleVersionSelector UNKNOWN_MODULE_VERSION_SELECTOR = DefaultModuleVersionSelector.newSelector(DefaultModuleIdentifier.newId("", "unknown"), "");
-    private final ComponentIdentifierFactory componentIdentifierFactory;
     private final LocalComponentRegistry localComponentRegistry;
 
-    public DefaultComponentSelectorConverter(ComponentIdentifierFactory componentIdentifierFactory, LocalComponentRegistry localComponentRegistry) {
-        this.componentIdentifierFactory = componentIdentifierFactory;
+    public DefaultComponentSelectorConverter(LocalComponentRegistry localComponentRegistry) {
         this.localComponentRegistry = localComponentRegistry;
     }
 
@@ -53,9 +50,9 @@ public class DefaultComponentSelectorConverter implements ComponentSelectorConve
         if (selector instanceof ModuleComponentSelector) {
             return DefaultModuleVersionSelector.newSelector((ModuleComponentSelector) selector);
         }
-        if (selector instanceof ProjectComponentSelector) {
-            ProjectComponentSelector projectSelector = (ProjectComponentSelector) selector;
-            ProjectComponentIdentifier projectId = componentIdentifierFactory.createProjectComponentIdentifier(projectSelector);
+        if (selector instanceof DefaultProjectComponentSelector) {
+            DefaultProjectComponentSelector projectSelector = (DefaultProjectComponentSelector) selector;
+            ProjectComponentIdentifier projectId = projectSelector.toIdentifier();
             LocalComponentGraphResolveState projectComponent = localComponentRegistry.getComponent(projectId);
             if (projectComponent != null) {
                 ModuleVersionIdentifier moduleVersionId = projectComponent.getModuleVersionId();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -199,7 +199,6 @@ public class DefaultDependencyManagementServices implements DependencyManagement
         void configure(ServiceRegistration registration) {
             registration.add(DefaultTransformedVariantFactory.class);
             registration.add(DefaultRootComponentMetadataBuilder.Factory.class);
-            registration.add(ProjectDependencyResolver.class);
         }
 
         AttributesSchemaInternal createConfigurationAttributesSchema(InstantiatorFactory instantiatorFactory, IsolatableFactory isolatableFactory, PlatformSupport platformSupport) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -77,7 +77,7 @@ import org.gradle.api.internal.artifacts.ivyservice.modulecache.dynamicversions.
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.DependencyMetadataFactory;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.DefaultProjectLocalComponentProvider;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.DefaultProjectPublicationRegistry;
-import org.gradle.api.internal.artifacts.ivyservice.projectmodule.LocalComponentRegistry;
+import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyResolver;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.DefaultArtifactDependencyResolver;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariantCache;
@@ -222,6 +222,8 @@ class DependencyManagementBuildScopeServices {
         registration.add(DefaultProjectLocalComponentProvider.class);
         registration.add(DefaultProjectPublicationRegistry.class);
         registration.add(FileResourceConnector.class);
+        registration.add(DefaultComponentSelectorConverter.class);
+        registration.add(ProjectDependencyResolver.class);
     }
 
     DependencyResolutionManagementInternal createSharedDependencyResolutionServices(Instantiator instantiator,
@@ -564,10 +566,6 @@ class DependencyManagementBuildScopeServices {
             instantiatorFactory,
             componentSelectionDescriptorFactory,
             calculatedValueContainerFactory, resolvedVariantCache);
-    }
-
-    ComponentSelectorConverter createModuleVersionSelectorFactory(ComponentIdentifierFactory componentIdentifierFactory, LocalComponentRegistry localComponentRegistry) {
-        return new DefaultComponentSelectorConverter(componentIdentifierFactory, localComponentRegistry);
     }
 
     VersionSelectorScheme createVersionSelectorScheme(VersionComparator versionComparator, VersionParser versionParser) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/component/ComponentIdentifierFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/component/ComponentIdentifierFactory.java
@@ -17,14 +17,14 @@
 package org.gradle.api.internal.artifacts.component;
 
 import org.gradle.api.artifacts.component.ComponentIdentifier;
-import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentSelector;
 import org.gradle.api.internal.artifacts.Module;
+import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.ServiceScope;
 
+@ServiceScope(Scopes.Build.class)
 public interface ComponentIdentifierFactory {
     ComponentIdentifier createComponentIdentifier(Module module);
 
     ProjectComponentSelector createProjectComponentSelector(String projectPath);
-
-    ProjectComponentIdentifier createProjectComponentIdentifier(ProjectComponentSelector selector);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/component/DefaultComponentIdentifierFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/component/DefaultComponentIdentifierFactory.java
@@ -48,9 +48,4 @@ public class DefaultComponentIdentifierFactory implements ComponentIdentifierFac
     public ProjectComponentSelector createProjectComponentSelector(String projectPath) {
         return DefaultProjectComponentSelector.newSelector(currentBuild.getProjects().getProject(Path.path(projectPath)).getComponentIdentifier());
     }
-
-    @Override
-    public ProjectComponentIdentifier createProjectComponentIdentifier(ProjectComponentSelector selector) {
-        return ((DefaultProjectComponentSelector) selector).toIdentifier();
-    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/BaseModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/BaseModuleComponentRepository.java
@@ -22,18 +22,18 @@ import org.gradle.internal.action.InstantiatingAction;
 
 import java.util.Map;
 
-public class BaseModuleComponentRepository implements ModuleComponentRepository {
-    protected final ModuleComponentRepository delegate;
-    private final ModuleComponentRepositoryAccess localAccess;
-    private final ModuleComponentRepositoryAccess remoteAccess;
+public class BaseModuleComponentRepository<T> implements ModuleComponentRepository<T> {
+    protected final ModuleComponentRepository<T> delegate;
+    private final ModuleComponentRepositoryAccess<T> localAccess;
+    private final ModuleComponentRepositoryAccess<T> remoteAccess;
 
-    public BaseModuleComponentRepository(ModuleComponentRepository delegate, ModuleComponentRepositoryAccess localAccess, ModuleComponentRepositoryAccess remoteAccess) {
+    public BaseModuleComponentRepository(ModuleComponentRepository<T> delegate, ModuleComponentRepositoryAccess<T> localAccess, ModuleComponentRepositoryAccess<T> remoteAccess) {
         this.delegate = delegate;
         this.localAccess = localAccess;
         this.remoteAccess = remoteAccess;
     }
 
-    public BaseModuleComponentRepository(ModuleComponentRepository delegate) {
+    public BaseModuleComponentRepository(ModuleComponentRepository<T> delegate) {
         this.delegate = delegate;
         this.localAccess = delegate.getLocalAccess();
         this.remoteAccess = delegate.getRemoteAccess();
@@ -55,12 +55,12 @@ public class BaseModuleComponentRepository implements ModuleComponentRepository 
     }
 
     @Override
-    public ModuleComponentRepositoryAccess getLocalAccess() {
+    public ModuleComponentRepositoryAccess<T> getLocalAccess() {
         return localAccess;
     }
 
     @Override
-    public ModuleComponentRepositoryAccess getRemoteAccess() {
+    public ModuleComponentRepositoryAccess<T> getRemoteAccess() {
         return remoteAccess;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/BaseModuleComponentRepositoryAccess.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/BaseModuleComponentRepositoryAccess.java
@@ -28,14 +28,14 @@ import org.gradle.internal.resolve.result.BuildableArtifactSetResolveResult;
 import org.gradle.internal.resolve.result.BuildableModuleComponentMetaDataResolveResult;
 import org.gradle.internal.resolve.result.BuildableModuleVersionListingResolveResult;
 
-public class BaseModuleComponentRepositoryAccess implements ModuleComponentRepositoryAccess {
-    private final ModuleComponentRepositoryAccess delegate;
+public class BaseModuleComponentRepositoryAccess<T> implements ModuleComponentRepositoryAccess<T> {
+    private final ModuleComponentRepositoryAccess<T> delegate;
 
-    public BaseModuleComponentRepositoryAccess(ModuleComponentRepositoryAccess delegate) {
+    public BaseModuleComponentRepositoryAccess(ModuleComponentRepositoryAccess<T> delegate) {
         this.delegate = delegate;
     }
 
-    public ModuleComponentRepositoryAccess getDelegate() {
+    public ModuleComponentRepositoryAccess<T> getDelegate() {
         return delegate;
     }
 
@@ -45,7 +45,7 @@ public class BaseModuleComponentRepositoryAccess implements ModuleComponentRepos
     }
 
     @Override
-    public void resolveComponentMetaData(ModuleComponentIdentifier moduleComponentIdentifier, ComponentOverrideMetadata requestMetaData, BuildableModuleComponentMetaDataResolveResult result) {
+    public void resolveComponentMetaData(ModuleComponentIdentifier moduleComponentIdentifier, ComponentOverrideMetadata requestMetaData, BuildableModuleComponentMetaDataResolveResult<T> result) {
         delegate.resolveComponentMetaData(moduleComponentIdentifier, requestMetaData, result);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachedMetadataProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachedMetadataProvider.java
@@ -20,20 +20,21 @@ import org.gradle.api.artifacts.ComponentMetadata;
 import org.gradle.api.artifacts.ivy.IvyModuleDescriptor;
 import org.gradle.api.internal.artifacts.ivyservice.DefaultIvyModuleDescriptor;
 import org.gradle.api.internal.artifacts.repositories.resolver.ComponentMetadataAdapter;
+import org.gradle.internal.component.external.model.ModuleComponentGraphResolveState;
 import org.gradle.internal.component.external.model.ivy.IvyModuleResolveMetadata;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 import org.gradle.internal.resolve.result.BuildableModuleComponentMetaDataResolveResult;
 
 class CachedMetadataProvider implements MetadataProvider {
-    private final BuildableModuleComponentMetaDataResolveResult cachedResult;
+    private final BuildableModuleComponentMetaDataResolveResult<ModuleComponentGraphResolveState> cachedResult;
     private final ComponentMetadata cachedComponentMetadata;
     private final boolean usable;
 
-    CachedMetadataProvider(BuildableModuleComponentMetaDataResolveResult result) {
+    CachedMetadataProvider(BuildableModuleComponentMetaDataResolveResult<ModuleComponentGraphResolveState> result) {
         cachedResult = result;
         usable = cachedResult.getState() == BuildableModuleComponentMetaDataResolveResult.State.Resolved;
         if (usable) {
-            cachedComponentMetadata = new ComponentMetadataAdapter(cachedResult.getMetaData());
+            cachedComponentMetadata = new ComponentMetadataAdapter(cachedResult.getMetaData().getModuleResolveMetadata());
         } else {
             cachedComponentMetadata = null;
         }
@@ -46,7 +47,7 @@ class CachedMetadataProvider implements MetadataProvider {
 
     @Override
     public IvyModuleDescriptor getIvyModuleDescriptor() {
-        ModuleComponentResolveMetadata metaData = cachedResult.getMetaData();
+        ModuleComponentResolveMetadata metaData = cachedResult.getMetaData().getModuleResolveMetadata();
         if (metaData instanceof IvyModuleResolveMetadata) {
             IvyModuleResolveMetadata ivyMetadata = (IvyModuleResolveMetadata) metaData;
             return new DefaultIvyModuleDescriptor(ivyMetadata.getExtraAttributes(), ivyMetadata.getBranch(), ivyMetadata.getStatus());

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepository.java
@@ -411,6 +411,7 @@ public class CachingModuleComponentRepository implements ModuleComponentReposito
                     }
                     DefaultModuleComponentGraphResolveState state = new DefaultModuleComponentGraphResolveState(processedMetadata);
                     cachedMetadata.putProcessedMetadata(metadataProcessor.getRulesHash(), state);
+                    localResult.applyTo(result);
                     result.resolved(state);
                     break;
                 case Failed:

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepository.java
@@ -454,10 +454,6 @@ public class CachingModuleComponentRepository implements ModuleComponentReposito
         }
     }
 
-    private ModuleDescriptorHashModuleSource findCachingModuleSource(ComponentResolveMetadata component) {
-        return findCachingModuleSource(component.getSources());
-    }
-
     private String cacheKey(ArtifactType artifactType) {
         return "artifacts:" + artifactType.name();
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ComponentMetaDataResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ComponentMetaDataResolveState.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.internal.component.external.model.ModuleComponentGraphResolveState;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.resolve.RejectedByRuleVersion;
 import org.gradle.internal.resolve.result.BuildableModuleComponentMetaDataResolveResult;
@@ -24,25 +25,25 @@ import org.gradle.internal.resolve.result.DefaultBuildableModuleComponentMetaDat
 import org.gradle.internal.resolve.result.ResourceAwareResolveResult;
 
 class ComponentMetaDataResolveState {
-    private final DefaultBuildableModuleComponentMetaDataResolveResult resolveResult;
+    private final DefaultBuildableModuleComponentMetaDataResolveResult<ModuleComponentGraphResolveState> resolveResult;
     private final VersionedComponentChooser versionedComponentChooser;
     private final ComponentOverrideMetadata componentOverrideMetadata;
     private final ModuleComponentIdentifier componentIdentifier;
 
-    final ModuleComponentRepository repository;
+    final ModuleComponentRepository<ModuleComponentGraphResolveState> repository;
 
     private boolean searchedLocally;
     private boolean searchedRemotely;
 
-    public ComponentMetaDataResolveState(ModuleComponentIdentifier componentIdentifier, ComponentOverrideMetadata componentOverrideMetadata, ModuleComponentRepository repository, VersionedComponentChooser versionedComponentChooser) {
+    public ComponentMetaDataResolveState(ModuleComponentIdentifier componentIdentifier, ComponentOverrideMetadata componentOverrideMetadata, ModuleComponentRepository<ModuleComponentGraphResolveState> repository, VersionedComponentChooser versionedComponentChooser) {
         this.componentOverrideMetadata = componentOverrideMetadata;
         this.componentIdentifier = componentIdentifier;
         this.repository = repository;
         this.versionedComponentChooser = versionedComponentChooser;
-        this.resolveResult = new DefaultBuildableModuleComponentMetaDataResolveResult();
+        this.resolveResult = new DefaultBuildableModuleComponentMetaDataResolveResult<>();
     }
 
-    BuildableModuleComponentMetaDataResolveResult resolve() {
+    BuildableModuleComponentMetaDataResolveResult<ModuleComponentGraphResolveState> resolve() {
         if (!searchedLocally) {
             searchedLocally = true;
             process(repository.getLocalAccess());
@@ -65,7 +66,7 @@ class ComponentMetaDataResolveState {
         throw new IllegalStateException();
     }
 
-    protected void process(ModuleComponentRepositoryAccess moduleAccess) {
+    protected void process(ModuleComponentRepositoryAccess<ModuleComponentGraphResolveState> moduleAccess) {
         moduleAccess.resolveComponentMetaData(componentIdentifier, componentOverrideMetadata, resolveResult);
         if (resolveResult.getState() == BuildableModuleComponentMetaDataResolveResult.State.Resolved) {
             RejectedByRuleVersion rejectedComponent = versionedComponentChooser.isRejectedComponent(componentIdentifier, new CachedMetadataProvider(resolveResult));

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ConfiguredModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ConfiguredModuleComponentRepository.java
@@ -16,12 +16,13 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
+import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 import org.gradle.internal.reflect.Instantiator;
 
 /**
  * A ModuleComponentRepository providing some user-configuration values.
  */
-public interface ConfiguredModuleComponentRepository extends ModuleComponentRepository {
+public interface ConfiguredModuleComponentRepository extends ModuleComponentRepository<ModuleComponentResolveMetadata> {
 
     /**
      * Should the 'dynamic resolve mode' be used for this (Ivy) repository, where the 'revConstraint'

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultMetadataProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultMetadataProvider.java
@@ -39,6 +39,7 @@ import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.internal.action.InstantiatingAction;
+import org.gradle.internal.component.external.model.ModuleComponentGraphResolveState;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 import org.gradle.internal.component.external.model.ivy.IvyModuleResolveMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
@@ -52,7 +53,7 @@ import java.util.List;
 class DefaultMetadataProvider implements MetadataProvider {
     private final static Transformer<ComponentMetadata, BuildableComponentMetadataSupplierDetails> TO_COMPONENT_METADATA = BuildableComponentMetadataSupplierDetails::getExecutionResult;
     private final ModuleComponentResolveState resolveState;
-    private BuildableModuleComponentMetaDataResolveResult cachedResult;
+    private BuildableModuleComponentMetaDataResolveResult<ModuleComponentGraphResolveState> cachedResult;
     private ComponentMetadata cachedComponentMetadata;
     private boolean computedMetadata;
 
@@ -81,7 +82,7 @@ class DefaultMetadataProvider implements MetadataProvider {
         if (metadata != null) {
             metadata = transformThroughComponentMetadataRules(componentMetadataSupplier, metadata);
         } else if (resolve()) {
-            metadata = new ComponentMetadataAdapter(cachedResult.getMetaData());
+            metadata = new ComponentMetadataAdapter(cachedResult.getMetaData().getModuleResolveMetadata());
         }
         return metadata;
     }
@@ -105,7 +106,7 @@ class DefaultMetadataProvider implements MetadataProvider {
     @Override
     public IvyModuleDescriptor getIvyModuleDescriptor() {
         if (resolve()) {
-            ModuleComponentResolveMetadata metaData = cachedResult.getMetaData();
+            ModuleComponentResolveMetadata metaData = cachedResult.getMetaData().getModuleResolveMetadata();
             if (metaData instanceof IvyModuleResolveMetadata) {
                 IvyModuleResolveMetadata ivyMetadata = (IvyModuleResolveMetadata) metaData;
                 return new DefaultIvyModuleDescriptor(ivyMetadata.getExtraAttributes(), ivyMetadata.getBranch(), ivyMetadata.getStatus());
@@ -126,7 +127,7 @@ class DefaultMetadataProvider implements MetadataProvider {
         return cachedResult == null || cachedResult.getState() == BuildableModuleComponentMetaDataResolveResult.State.Resolved;
     }
 
-    public BuildableModuleComponentMetaDataResolveResult getResult() {
+    public BuildableModuleComponentMetaDataResolveResult<?> getResult() {
         return cachedResult;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultVersionedComponentChooser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultVersionedComponentChooser.java
@@ -32,7 +32,7 @@ import org.gradle.api.internal.artifacts.repositories.ArtifactResolutionDetails;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
-import org.gradle.internal.component.model.ComponentResolveMetadata;
+import org.gradle.internal.component.model.ComponentGraphResolveMetadata;
 import org.gradle.internal.resolve.RejectedByAttributesVersion;
 import org.gradle.internal.resolve.RejectedByRuleVersion;
 import org.gradle.internal.resolve.result.BuildableModuleComponentMetaDataResolveResult;
@@ -60,7 +60,7 @@ class DefaultVersionedComponentChooser implements VersionedComponentChooser {
     }
 
     @Override
-    public ComponentResolveMetadata selectNewestComponent(@Nullable ComponentResolveMetadata one, @Nullable ComponentResolveMetadata two) {
+    public ComponentGraphResolveMetadata selectNewestComponent(@Nullable ComponentGraphResolveMetadata one, @Nullable ComponentGraphResolveMetadata two) {
         if (one == null || two == null) {
             return two == null ? one : two;
         }
@@ -77,8 +77,8 @@ class DefaultVersionedComponentChooser implements VersionedComponentChooser {
         return comparison < 0 ? two : one;
     }
 
-    private boolean isMissingModuleDescriptor(ComponentResolveMetadata componentResolveMetadata) {
-        return componentResolveMetadata.isMissing();
+    private boolean isMissingModuleDescriptor(ComponentGraphResolveMetadata metadata) {
+        return metadata.isMissing();
     }
 
     @Override
@@ -178,7 +178,7 @@ class DefaultVersionedComponentChooser implements VersionedComponentChooser {
     }
 
     private static void applyTo(DefaultMetadataProvider provider, ComponentSelectionContext result) {
-        BuildableModuleComponentMetaDataResolveResult metaDataResult = provider.getResult();
+        BuildableModuleComponentMetaDataResolveResult<?> metaDataResult = provider.getResult();
         switch (metaDataResult.getState()) {
             case Unknown:
             case Missing:

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DynamicVersionResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DynamicVersionResolver.java
@@ -36,8 +36,8 @@ import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.action.InstantiatingAction;
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
+import org.gradle.internal.component.external.model.ModuleComponentGraphResolveState;
 import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
-import org.gradle.internal.component.model.DefaultComponentGraphResolveState;
 import org.gradle.internal.component.model.DefaultComponentOverrideMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
@@ -74,7 +74,7 @@ import static org.gradle.internal.resolve.result.BuildableModuleComponentMetaDat
 public class DynamicVersionResolver {
     private static final Logger LOGGER = LoggerFactory.getLogger(DynamicVersionResolver.class);
 
-    private final List<ModuleComponentRepository> repositories = new ArrayList<>();
+    private final List<ModuleComponentRepository<ModuleComponentGraphResolveState>> repositories = new ArrayList<>();
     private final List<String> repositoryNames = new ArrayList<>();
     private final VersionedComponentChooser versionedComponentChooser;
     private final VersionParser versionParser;
@@ -96,7 +96,7 @@ public class DynamicVersionResolver {
         this.cachePolicy = cachePolicy;
     }
 
-    public void add(ModuleComponentRepository repository) {
+    public void add(ModuleComponentRepository<ModuleComponentGraphResolveState> repository) {
         repositories.add(repository);
         repositoryNames.add(repository.getName());
     }
@@ -107,13 +107,13 @@ public class DynamicVersionResolver {
         List<Throwable> errors = new ArrayList<>();
 
         List<RepositoryResolveState> resolveStates = Lists.newArrayListWithCapacity(repositories.size());
-        for (ModuleComponentRepository repository : repositories) {
+        for (ModuleComponentRepository<ModuleComponentGraphResolveState> repository : repositories) {
             resolveStates.add(new RepositoryResolveState(versionedComponentChooser, dependency, repository, versionSelector, rejectedVersionSelector, versionParser, consumerAttributes, attributesFactory, componentMetadataProcessor, componentMetadataSupplierRuleExecutor, cachePolicy));
         }
 
         final RepositoryChainModuleResolution latestResolved = findLatestModule(resolveStates, errors);
         if (latestResolved != null) {
-            LOGGER.debug("Using {} from {}", latestResolved.module.getModuleVersionId(), latestResolved.repository);
+            LOGGER.debug("Using {} from {}", latestResolved.component.getId(), latestResolved.repository);
             for (Throwable error : errors) {
                 LOGGER.debug("Discarding resolve failure.", error);
             }
@@ -132,7 +132,7 @@ public class DynamicVersionResolver {
         for (RepositoryResolveState resolveState : resolveStates) {
             resolveState.registerAttempts(result);
         }
-        result.resolved(DefaultComponentGraphResolveState.of(latestResolved.module));
+        result.resolved(latestResolved.component);
     }
 
     private void notFound(BuildableComponentIdResolveResult result, ModuleComponentSelector requested, List<RepositoryResolveState> resolveStates) {
@@ -215,7 +215,7 @@ public class DynamicVersionResolver {
         if (one == null || two == null) {
             return two == null ? one : two;
         }
-        return versionedComponentChooser.selectNewestComponent(one.module, two.module) == one.module ? one : two;
+        return versionedComponentChooser.selectNewestComponent(one.component.getMetadata(), two.component.getMetadata()) == one.component.getMetadata() ? one : two;
     }
 
     private static class AttemptCollector implements Action<ResourceAwareResolveResult> {
@@ -242,12 +242,12 @@ public class DynamicVersionResolver {
      */
     private static class RepositoryResolveState implements ComponentSelectionContext {
         private final VersionedComponentChooser versionedComponentChooser;
-        private final BuildableModuleComponentMetaDataResolveResult resolvedVersionMetadata = new DefaultBuildableModuleComponentMetaDataResolveResult();
+        private final BuildableModuleComponentMetaDataResolveResult<ModuleComponentGraphResolveState> resolvedVersionMetadata = new DefaultBuildableModuleComponentMetaDataResolveResult<>();
         private final Map<String, CandidateResult> candidateComponents = new LinkedHashMap<>();
         private final Set<String> unmatchedVersions = Sets.newLinkedHashSet();
         private final Set<RejectedVersion> rejectedVersions = Sets.newLinkedHashSet();
         private final VersionListResult versionListingResult;
-        private final ModuleComponentRepository repository;
+        private final ModuleComponentRepository<ModuleComponentGraphResolveState> repository;
         private final AttemptCollector attemptCollector;
         private final ModuleDependencyMetadata dependency;
         private final VersionSelector versionSelector;
@@ -261,7 +261,7 @@ public class DynamicVersionResolver {
         private ModuleComponentIdentifier firstRejected = null;
 
 
-        public RepositoryResolveState(VersionedComponentChooser versionedComponentChooser, ModuleDependencyMetadata dependency, ModuleComponentRepository repository, VersionSelector versionSelector, VersionSelector rejectedVersionSelector, VersionParser versionParser, AttributeContainer consumerAttributes, ImmutableAttributesFactory attributesFactory, ComponentMetadataProcessorFactory componentMetadataProcessorFactory, ComponentMetadataSupplierRuleExecutor metadataSupplierRuleExecutor, CachePolicy cachePolicy) {
+        public RepositoryResolveState(VersionedComponentChooser versionedComponentChooser, ModuleDependencyMetadata dependency, ModuleComponentRepository<ModuleComponentGraphResolveState> repository, VersionSelector versionSelector, VersionSelector rejectedVersionSelector, VersionParser versionParser, AttributeContainer consumerAttributes, ImmutableAttributesFactory attributesFactory, ComponentMetadataProcessorFactory componentMetadataProcessorFactory, ComponentMetadataSupplierRuleExecutor metadataSupplierRuleExecutor, CachePolicy cachePolicy) {
             this.versionedComponentChooser = versionedComponentChooser;
             this.dependency = dependency;
             this.versionSelector = versionSelector;
@@ -400,7 +400,7 @@ public class DynamicVersionResolver {
 
     private static class CandidateResult implements ModuleComponentResolveState {
         private final ModuleComponentIdentifier identifier;
-        private final ModuleComponentRepository repository;
+        private final ModuleComponentRepository<ModuleComponentGraphResolveState> repository;
         private final AttemptCollector attemptCollector;
         private final ModuleDependencyMetadata dependencyMetadata;
         private final Version version;
@@ -409,10 +409,10 @@ public class DynamicVersionResolver {
         private final ComponentMetadataSupplierRuleExecutor supplierRuleExecutor;
         private boolean searchedLocally;
         private boolean searchedRemotely;
-        private final DefaultBuildableModuleComponentMetaDataResolveResult result = new DefaultBuildableModuleComponentMetaDataResolveResult();
+        private final DefaultBuildableModuleComponentMetaDataResolveResult<ModuleComponentGraphResolveState> result = new DefaultBuildableModuleComponentMetaDataResolveResult<>();
         private final CachePolicy cachePolicy;
 
-        public CandidateResult(ModuleDependencyMetadata dependencyMetadata, String version, ModuleComponentRepository repository, AttemptCollector attemptCollector, VersionParser versionParser, ComponentMetadataProcessorFactory componentMetadataProcessorFactory, ImmutableAttributesFactory attributesFactory, ComponentMetadataSupplierRuleExecutor supplierRuleExecutor, CachePolicy cachePolicy) {
+        public CandidateResult(ModuleDependencyMetadata dependencyMetadata, String version, ModuleComponentRepository<ModuleComponentGraphResolveState> repository, AttemptCollector attemptCollector, VersionParser versionParser, ComponentMetadataProcessorFactory componentMetadataProcessorFactory, ImmutableAttributesFactory attributesFactory, ComponentMetadataSupplierRuleExecutor supplierRuleExecutor, CachePolicy cachePolicy) {
             this.dependencyMetadata = dependencyMetadata;
             this.componentMetadataProcessorFactory = componentMetadataProcessorFactory;
             this.attributesFactory = attributesFactory;
@@ -436,7 +436,7 @@ public class DynamicVersionResolver {
         }
 
         @Override
-        public BuildableModuleComponentMetaDataResolveResult resolve() {
+        public BuildableModuleComponentMetaDataResolveResult<ModuleComponentGraphResolveState> resolve() {
             if (!searchedLocally) {
                 searchedLocally = true;
                 process(repository.getLocalAccess(), result);
@@ -480,7 +480,7 @@ public class DynamicVersionResolver {
             return cachePolicy;
         }
 
-        private void process(ModuleComponentRepositoryAccess access, DefaultBuildableModuleComponentMetaDataResolveResult result) {
+        private void process(ModuleComponentRepositoryAccess<ModuleComponentGraphResolveState> access, DefaultBuildableModuleComponentMetaDataResolveResult<ModuleComponentGraphResolveState> result) {
             DependencyMetadata dependency = dependencyMetadata.withRequestedVersion(new DefaultImmutableVersionConstraint(version.getSource()));
             IvyArtifactName firstArtifact = dependency.getArtifacts().isEmpty() ? null : dependency.getArtifacts().get(0);
             access.resolveComponentMetaData(identifier, DefaultComponentOverrideMetadata.forDependency(dependency.isChanging(), firstArtifact, DefaultComponentOverrideMetadata.extractClientModule(dependency)), result);
@@ -493,8 +493,8 @@ public class DynamicVersionResolver {
          *
          * @param target where to put metadata
          */
-        private void tryResolveMetadata(BuildableModuleComponentMetaDataResolveResult target) {
-            BuildableModuleComponentMetaDataResolveResult result = resolve();
+        private void tryResolveMetadata(BuildableModuleComponentMetaDataResolveResult<ModuleComponentGraphResolveState> target) {
+            BuildableModuleComponentMetaDataResolveResult<ModuleComponentGraphResolveState> result = resolve();
             switch (result.getState()) {
                 case Resolved:
                     target.resolved(result.getMetaData());
@@ -516,13 +516,13 @@ public class DynamicVersionResolver {
 
     private static class VersionListResult {
         private final DefaultBuildableModuleVersionListingResolveResult result = new DefaultBuildableModuleVersionListingResolveResult();
-        private final ModuleComponentRepository repository;
+        private final ModuleComponentRepository<?> repository;
         private final ModuleDependencyMetadata dependency;
 
         private boolean searchedLocally;
         private boolean searchedRemotely;
 
-        public VersionListResult(ModuleDependencyMetadata dependency, ModuleComponentRepository repository) {
+        public VersionListResult(ModuleDependencyMetadata dependency, ModuleComponentRepository<?> repository) {
             this.dependency = dependency;
             this.repository = repository;
         }
@@ -556,7 +556,7 @@ public class DynamicVersionResolver {
             result.applyTo(target);
         }
 
-        private void process(ModuleDependencyMetadata dynamicVersionDependency, ModuleComponentRepositoryAccess moduleAccess) {
+        private void process(ModuleDependencyMetadata dynamicVersionDependency, ModuleComponentRepositoryAccess<?> moduleAccess) {
             moduleAccess.listModuleVersions(dynamicVersionDependency, result);
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DynamicVersionResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DynamicVersionResolver.java
@@ -19,7 +19,6 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.gradle.api.Action;
-import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.ComponentMetadataSupplierDetails;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
@@ -37,7 +36,6 @@ import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.action.InstantiatingAction;
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
-import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
 import org.gradle.internal.component.model.DefaultComponentGraphResolveState;
 import org.gradle.internal.component.model.DefaultComponentOverrideMetadata;
@@ -80,20 +78,18 @@ public class DynamicVersionResolver {
     private final List<String> repositoryNames = new ArrayList<>();
     private final VersionedComponentChooser versionedComponentChooser;
     private final VersionParser versionParser;
-    private final Transformer<ModuleComponentResolveMetadata, RepositoryChainModuleResolution> metaDataFactory;
     private final ImmutableAttributesFactory attributesFactory;
     private final ComponentMetadataProcessorFactory componentMetadataProcessor;
     private final ComponentMetadataSupplierRuleExecutor componentMetadataSupplierRuleExecutor;
     private final CachePolicy cachePolicy;
 
     public DynamicVersionResolver(
-        VersionedComponentChooser versionedComponentChooser, VersionParser versionParser, Transformer<ModuleComponentResolveMetadata, RepositoryChainModuleResolution> metaDataFactory,
+        VersionedComponentChooser versionedComponentChooser, VersionParser versionParser,
         ImmutableAttributesFactory attributesFactory, ComponentMetadataProcessorFactory componentMetadataProcessor,
         ComponentMetadataSupplierRuleExecutor componentMetadataSupplierRuleExecutor, CachePolicy cachePolicy
     ) {
         this.versionedComponentChooser = versionedComponentChooser;
         this.versionParser = versionParser;
-        this.metaDataFactory = metaDataFactory;
         this.attributesFactory = attributesFactory;
         this.componentMetadataProcessor = componentMetadataProcessor;
         this.componentMetadataSupplierRuleExecutor = componentMetadataSupplierRuleExecutor;
@@ -136,7 +132,7 @@ public class DynamicVersionResolver {
         for (RepositoryResolveState resolveState : resolveStates) {
             resolveState.registerAttempts(result);
         }
-        result.resolved(DefaultComponentGraphResolveState.of(metaDataFactory.transform(latestResolved)));
+        result.resolved(DefaultComponentGraphResolveState.of(latestResolved.module));
     }
 
     private void notFound(BuildableComponentIdResolveResult result, ModuleComponentSelector requested, List<RepositoryResolveState> resolveStates) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingArtifactResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingArtifactResolver.java
@@ -15,11 +15,9 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
-import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.internal.component.ArtifactType;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
-import org.gradle.internal.component.model.ComponentResolveMetadata;
-import org.gradle.internal.component.model.ModuleSources;
+import org.gradle.internal.component.model.ComponentArtifactResolveMetadata;
 import org.gradle.internal.resolve.ArtifactResolveException;
 import org.gradle.internal.resolve.resolver.ArtifactResolver;
 import org.gradle.internal.resolve.result.BuildableArtifactResolveResult;
@@ -33,7 +31,7 @@ public class ErrorHandlingArtifactResolver implements ArtifactResolver {
     }
 
     @Override
-    public void resolveArtifactsWithType(ComponentResolveMetadata component, ArtifactType artifactType, BuildableArtifactSetResolveResult result) {
+    public void resolveArtifactsWithType(ComponentArtifactResolveMetadata component, ArtifactType artifactType, BuildableArtifactSetResolveResult result) {
         try {
             resolver.resolveArtifactsWithType(component, artifactType, result);
         } catch (Exception t) {
@@ -42,9 +40,9 @@ public class ErrorHandlingArtifactResolver implements ArtifactResolver {
     }
 
     @Override
-    public void resolveArtifact(ModuleVersionIdentifier ownerId, ComponentArtifactMetadata artifact, ModuleSources moduleSources, BuildableArtifactResolveResult result) {
+    public void resolveArtifact(ComponentArtifactResolveMetadata component, ComponentArtifactMetadata artifact, BuildableArtifactResolveResult result) {
         try {
-            resolver.resolveArtifact(ownerId, artifact, moduleSources, result);
+            resolver.resolveArtifact(component, artifact, result);
         } catch (Exception t) {
             result.failed(new ArtifactResolveException(artifact.getId(), t));
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/LocalModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/LocalModuleComponentRepository.java
@@ -36,28 +36,28 @@ import org.gradle.internal.resolve.result.BuildableModuleVersionListingResolveRe
  * This is used to wrap a file-backed ExternalResourceRepository instance, so that both 'local' and 'remote' operations will
  * be considered local.
  */
-public class LocalModuleComponentRepository extends BaseModuleComponentRepository {
+public class LocalModuleComponentRepository<T> extends BaseModuleComponentRepository<T> {
     private final LocalAccess localAccess = new LocalAccess();
-    private final RemoteAccess remoteAccess = new RemoteAccess();
+    private final RemoteAccess<T> remoteAccess = new RemoteAccess<>();
 
-    public LocalModuleComponentRepository(ModuleComponentRepository delegate) {
+    public LocalModuleComponentRepository(ModuleComponentRepository<T> delegate) {
         super(delegate);
     }
 
     @Override
-    public ModuleComponentRepositoryAccess getLocalAccess() {
+    public ModuleComponentRepositoryAccess<T> getLocalAccess() {
         return localAccess;
     }
 
     @Override
-    public ModuleComponentRepositoryAccess getRemoteAccess() {
+    public ModuleComponentRepositoryAccess<T> getRemoteAccess() {
         return remoteAccess;
     }
 
-    private class LocalAccess implements ModuleComponentRepositoryAccess {
+    private class LocalAccess implements ModuleComponentRepositoryAccess<T> {
         @Override
         public String toString() {
-            return "local adapter > " + delegate.toString();
+            return "local adapter > " + delegate;
         }
 
         @Override
@@ -69,7 +69,7 @@ public class LocalModuleComponentRepository extends BaseModuleComponentRepositor
         }
 
         @Override
-        public void resolveComponentMetaData(ModuleComponentIdentifier moduleComponentIdentifier, ComponentOverrideMetadata requestMetaData, BuildableModuleComponentMetaDataResolveResult result) {
+        public void resolveComponentMetaData(ModuleComponentIdentifier moduleComponentIdentifier, ComponentOverrideMetadata requestMetaData, BuildableModuleComponentMetaDataResolveResult<T> result) {
             delegate.getLocalAccess().resolveComponentMetaData(moduleComponentIdentifier, requestMetaData, result);
             if (!result.hasResult()) {
                 delegate.getRemoteAccess().resolveComponentMetaData(moduleComponentIdentifier, requestMetaData, result);
@@ -98,7 +98,7 @@ public class LocalModuleComponentRepository extends BaseModuleComponentRepositor
         }
     }
 
-    private static class RemoteAccess implements ModuleComponentRepositoryAccess {
+    private static class RemoteAccess<T> implements ModuleComponentRepositoryAccess<T> {
         @Override
         public String toString() {
             return "empty";
@@ -109,7 +109,7 @@ public class LocalModuleComponentRepository extends BaseModuleComponentRepositor
         }
 
         @Override
-        public void resolveComponentMetaData(ModuleComponentIdentifier moduleComponentIdentifier, ComponentOverrideMetadata requestMetaData, BuildableModuleComponentMetaDataResolveResult result) {
+        public void resolveComponentMetaData(ModuleComponentIdentifier moduleComponentIdentifier, ComponentOverrideMetadata requestMetaData, BuildableModuleComponentMetaDataResolveResult<T> result) {
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ModuleComponentRepository.java
@@ -26,8 +26,10 @@ import java.util.Map;
 
 /**
  * A repository of module components.
+ *
+ * @param <T> the component resolution result type
  */
-public interface ModuleComponentRepository {
+public interface ModuleComponentRepository<T> {
     /**
      * A unique identifier for this repository, based on it's type and attributes.
      * Two repositories with the same configuration in different projects will share the same id.
@@ -42,13 +44,13 @@ public interface ModuleComponentRepository {
     /**
      * Accessor that attempts to locate module components without expensive network operations.
      */
-    ModuleComponentRepositoryAccess getLocalAccess();
+    ModuleComponentRepositoryAccess<T> getLocalAccess();
 
     /**
      * Accessor that attempts to locate module components remotely, allowing expensive network operations.
      * This access will be disabled when Gradle is executed with `--offline`.
      */
-    ModuleComponentRepositoryAccess getRemoteAccess();
+    ModuleComponentRepositoryAccess<T> getRemoteAccess();
 
     // TODO - put this somewhere else
     Map<ComponentArtifactIdentifier, ResolvableArtifact> getArtifactCache();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ModuleComponentRepositoryAccess.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ModuleComponentRepositoryAccess.java
@@ -31,11 +31,6 @@ import org.gradle.internal.resolve.result.BuildableModuleVersionListingResolveRe
 
 /**
  * Provides access to a repository of components that are identified by a ModuleComponentIdentifier.
- *
- * The plan is to eventually sync this with
- * {@link org.gradle.internal.resolve.resolver.DependencyToComponentIdResolver},
- * {@link org.gradle.internal.resolve.resolver.ComponentMetaDataResolver} and
- * {@link org.gradle.internal.resolve.resolver.ArtifactResolver}.
  */
 public interface ModuleComponentRepositoryAccess {
     /**

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ModuleComponentRepositoryAccess.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ModuleComponentRepositoryAccess.java
@@ -31,8 +31,10 @@ import org.gradle.internal.resolve.result.BuildableModuleVersionListingResolveRe
 
 /**
  * Provides access to a repository of components that are identified by a ModuleComponentIdentifier.
+ *
+ * @param <T> the component resolution result type
  */
-public interface ModuleComponentRepositoryAccess {
+public interface ModuleComponentRepositoryAccess<T> {
     /**
      * Resolves the given dependency to a list of module versions.
      */
@@ -41,7 +43,7 @@ public interface ModuleComponentRepositoryAccess {
     /**
      * Resolves the metadata for a module component.
      */
-    void resolveComponentMetaData(ModuleComponentIdentifier moduleComponentIdentifier, ComponentOverrideMetadata requestMetaData, BuildableModuleComponentMetaDataResolveResult result);
+    void resolveComponentMetaData(ModuleComponentIdentifier moduleComponentIdentifier, ComponentOverrideMetadata requestMetaData, BuildableModuleComponentMetaDataResolveResult<T> result);
 
     /**
      * Resolves a set of artifacts belonging to the given component, with the type specified. Any failures are packaged up in the result.

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ModuleComponentResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ModuleComponentResolveState.java
@@ -22,6 +22,7 @@ import org.gradle.api.internal.artifacts.ComponentMetadataProcessorFactory;
 import org.gradle.api.internal.artifacts.configurations.dynamicversion.CachePolicy;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.action.InstantiatingAction;
+import org.gradle.internal.component.external.model.ModuleComponentGraphResolveState;
 import org.gradle.internal.resolve.caching.ComponentMetadataSupplierRuleExecutor;
 import org.gradle.internal.resolve.result.BuildableModuleComponentMetaDataResolveResult;
 
@@ -30,7 +31,7 @@ import javax.annotation.Nullable;
 public interface ModuleComponentResolveState extends Versioned {
     ModuleComponentIdentifier getId();
 
-    BuildableModuleComponentMetaDataResolveResult resolve();
+    BuildableModuleComponentMetaDataResolveResult<ModuleComponentGraphResolveState> resolve();
 
     ComponentMetadataProcessorFactory getComponentMetadataProcessorFactory();
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/NoRepositoriesResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/NoRepositoriesResolver.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
 import com.google.common.collect.ImmutableList;
-import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactSet;
@@ -26,11 +25,10 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.component.ArtifactType;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
+import org.gradle.internal.component.model.ComponentArtifactResolveMetadata;
 import org.gradle.internal.component.model.ComponentArtifactResolveVariantState;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
-import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
-import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.internal.resolve.ModuleVersionNotFoundException;
 import org.gradle.internal.resolve.resolver.ArtifactResolver;
 import org.gradle.internal.resolve.resolver.ComponentMetaDataResolver;
@@ -85,17 +83,17 @@ public class NoRepositoriesResolver implements ComponentResolvers, DependencyToC
 
     @Nullable
     @Override
-    public ArtifactSet resolveArtifacts(ComponentResolveMetadata component, ComponentArtifactResolveVariantState allVariants, Set<ResolvedVariant> legacyVariants, ExcludeSpec exclusions, ImmutableAttributes overriddenAttributes) {
+    public ArtifactSet resolveArtifacts(ComponentArtifactResolveMetadata component, ComponentArtifactResolveVariantState allVariants, Set<ResolvedVariant> legacyVariants, ExcludeSpec exclusions, ImmutableAttributes overriddenAttributes) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void resolveArtifactsWithType(ComponentResolveMetadata component, ArtifactType artifactType, BuildableArtifactSetResolveResult result) {
+    public void resolveArtifactsWithType(ComponentArtifactResolveMetadata component, ArtifactType artifactType, BuildableArtifactSetResolveResult result) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void resolveArtifact(ModuleVersionIdentifier ownerId, ComponentArtifactMetadata artifact, ModuleSources moduleSources, BuildableArtifactResolveResult result) {
+    public void resolveArtifact(ComponentArtifactResolveMetadata component, ComponentArtifactMetadata artifact, BuildableArtifactResolveResult result) {
         throw new UnsupportedOperationException();
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainComponentMetaDataResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainComponentMetaDataResolver.java
@@ -129,6 +129,7 @@ public class RepositoryChainComponentMetaDataResolver implements ComponentMetaDa
         return findBestMatch(queue, failures, missing);
     }
 
+    @Nullable
     private RepositoryChainModuleResolution findBestMatch(LinkedList<ComponentMetaDataResolveState> queue, Collection<Throwable> failures, Collection<ComponentMetaDataResolveState> missing) {
         RepositoryChainModuleResolution best = null;
         while (!queue.isEmpty()) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainComponentMetaDataResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainComponentMetaDataResolver.java
@@ -19,8 +19,8 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.repositories.resolver.MetadataFetchingCost;
+import org.gradle.internal.component.external.model.ModuleComponentGraphResolveState;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
-import org.gradle.internal.component.model.DefaultComponentGraphResolveState;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 import org.gradle.internal.resolve.resolver.ComponentMetaDataResolver;
 import org.gradle.internal.resolve.result.BuildableComponentResolveResult;
@@ -40,7 +40,7 @@ import static org.gradle.internal.resolve.ResolveExceptionAnalyzer.isCriticalFai
 public class RepositoryChainComponentMetaDataResolver implements ComponentMetaDataResolver {
     private static final Logger LOGGER = LoggerFactory.getLogger(RepositoryChainComponentMetaDataResolver.class);
 
-    private final List<ModuleComponentRepository> repositories = new ArrayList<>();
+    private final List<ModuleComponentRepository<ModuleComponentGraphResolveState>> repositories = new ArrayList<>();
     private final List<String> repositoryNames = new ArrayList<>();
     private final VersionedComponentChooser versionedComponentChooser;
 
@@ -48,7 +48,7 @@ public class RepositoryChainComponentMetaDataResolver implements ComponentMetaDa
         this.versionedComponentChooser = componentChooser;
     }
 
-    public void add(ModuleComponentRepository repository) {
+    public void add(ModuleComponentRepository<ModuleComponentGraphResolveState> repository) {
         repositories.add(repository);
         repositoryNames.add(repository.getName());
     }
@@ -65,8 +65,8 @@ public class RepositoryChainComponentMetaDataResolver implements ComponentMetaDa
     @Override
     public boolean isFetchingMetadataCheap(ComponentIdentifier identifier) {
         if (identifier instanceof ModuleComponentIdentifier) {
-            for (ModuleComponentRepository repository : repositories) {
-                ModuleComponentRepositoryAccess localAccess = repository.getLocalAccess();
+            for (ModuleComponentRepository<ModuleComponentGraphResolveState> repository : repositories) {
+                ModuleComponentRepositoryAccess<ModuleComponentGraphResolveState> localAccess = repository.getLocalAccess();
                 MetadataFetchingCost fetchingCost = localAccess.estimateMetadataFetchingCost((ModuleComponentIdentifier) identifier);
                 if (fetchingCost.isFast()) {
                     return true;
@@ -84,18 +84,18 @@ public class RepositoryChainComponentMetaDataResolver implements ComponentMetaDa
         List<Throwable> errors = new ArrayList<>();
 
         List<ComponentMetaDataResolveState> resolveStates = new ArrayList<>();
-        for (ModuleComponentRepository repository : repositories) {
+        for (ModuleComponentRepository<ModuleComponentGraphResolveState> repository : repositories) {
             resolveStates.add(new ComponentMetaDataResolveState(identifier, componentOverrideMetadata, repository, versionedComponentChooser));
         }
 
         final RepositoryChainModuleResolution latestResolved = findBestMatch(resolveStates, errors);
         if (latestResolved != null) {
-            LOGGER.debug("Using {} from {}", latestResolved.module.getModuleVersionId(), latestResolved.repository);
+            LOGGER.debug("Using {} from {}", latestResolved.component.getId(), latestResolved.repository);
             for (Throwable error : errors) {
                 LOGGER.debug("Discarding resolve failure.", error);
             }
 
-            result.resolved(DefaultComponentGraphResolveState.of(latestResolved.module));
+            result.resolved(latestResolved.component);
             return;
         }
         if (!errors.isEmpty()) {
@@ -134,7 +134,7 @@ public class RepositoryChainComponentMetaDataResolver implements ComponentMetaDa
         RepositoryChainModuleResolution best = null;
         while (!queue.isEmpty()) {
             ComponentMetaDataResolveState request = queue.removeFirst();
-            BuildableModuleComponentMetaDataResolveResult metaDataResolveResult;
+            BuildableModuleComponentMetaDataResolveResult<ModuleComponentGraphResolveState> metaDataResolveResult;
             metaDataResolveResult = request.resolve();
             switch (metaDataResolveResult.getState()) {
                 case Failed:
@@ -151,7 +151,7 @@ public class RepositoryChainComponentMetaDataResolver implements ComponentMetaDa
                     break;
                 case Resolved:
                     RepositoryChainModuleResolution moduleResolution = new RepositoryChainModuleResolution(request.repository, metaDataResolveResult.getMetaData());
-                    if (!metaDataResolveResult.getMetaData().isMissing()) {
+                    if (!metaDataResolveResult.getMetaData().getMetadata().isMissing()) {
                         return moduleResolution;
                     }
                     best = best != null ? best : moduleResolution;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainComponentMetaDataResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainComponentMetaDataResolver.java
@@ -30,6 +30,7 @@ import org.gradle.internal.resolve.result.BuildableModuleComponentMetaDataResolv
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
@@ -111,6 +112,7 @@ public class RepositoryChainComponentMetaDataResolver implements ComponentMetaDa
         }
     }
 
+    @Nullable
     private RepositoryChainModuleResolution findBestMatch(List<ComponentMetaDataResolveState> resolveStates, Collection<Throwable> failures) {
         LinkedList<ComponentMetaDataResolveState> queue = new LinkedList<>(resolveStates);
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainComponentMetaDataResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainComponentMetaDataResolver.java
@@ -16,11 +16,9 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
-import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.repositories.resolver.MetadataFetchingCost;
-import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.DefaultComponentGraphResolveState;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
@@ -45,11 +43,9 @@ public class RepositoryChainComponentMetaDataResolver implements ComponentMetaDa
     private final List<ModuleComponentRepository> repositories = new ArrayList<>();
     private final List<String> repositoryNames = new ArrayList<>();
     private final VersionedComponentChooser versionedComponentChooser;
-    private final Transformer<ModuleComponentResolveMetadata, RepositoryChainModuleResolution> metaDataFactory;
 
-    public RepositoryChainComponentMetaDataResolver(VersionedComponentChooser componentChooser, Transformer<ModuleComponentResolveMetadata, RepositoryChainModuleResolution> metaDataFactory) {
+    public RepositoryChainComponentMetaDataResolver(VersionedComponentChooser componentChooser) {
         this.versionedComponentChooser = componentChooser;
-        this.metaDataFactory = metaDataFactory;
     }
 
     public void add(ModuleComponentRepository repository) {
@@ -99,7 +95,7 @@ public class RepositoryChainComponentMetaDataResolver implements ComponentMetaDa
                 LOGGER.debug("Discarding resolve failure.", error);
             }
 
-            result.resolved(DefaultComponentGraphResolveState.of(metaDataFactory.transform(latestResolved)));
+            result.resolved(DefaultComponentGraphResolveState.of(latestResolved.module));
             return;
         }
         if (!errors.isEmpty()) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainDependencyToComponentIdResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainDependencyToComponentIdResolver.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
-import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentSelector;
@@ -30,7 +29,6 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionP
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
-import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
 import org.gradle.internal.component.external.model.ModuleDependencyMetadataWrapper;
 import org.gradle.internal.component.model.DependencyMetadata;
@@ -44,8 +42,8 @@ public class RepositoryChainDependencyToComponentIdResolver implements Dependenc
     private final DynamicVersionResolver dynamicRevisionResolver;
     private final AttributeContainer consumerAttributes;
 
-    public RepositoryChainDependencyToComponentIdResolver(VersionedComponentChooser componentChooser, Transformer<ModuleComponentResolveMetadata, RepositoryChainModuleResolution> metaDataFactory, VersionParser versionParser, AttributeContainer consumerAttributes, ImmutableAttributesFactory attributesFactory, ComponentMetadataProcessorFactory componentMetadataProcessorFactory, ComponentMetadataSupplierRuleExecutor componentMetadataSupplierRuleExecutor, CachePolicy cachePolicy) {
-        this.dynamicRevisionResolver = new DynamicVersionResolver(componentChooser, versionParser, metaDataFactory, attributesFactory, componentMetadataProcessorFactory, componentMetadataSupplierRuleExecutor, cachePolicy);
+    public RepositoryChainDependencyToComponentIdResolver(VersionedComponentChooser componentChooser, VersionParser versionParser, AttributeContainer consumerAttributes, ImmutableAttributesFactory attributesFactory, ComponentMetadataProcessorFactory componentMetadataProcessorFactory, ComponentMetadataSupplierRuleExecutor componentMetadataSupplierRuleExecutor, CachePolicy cachePolicy) {
+        this.dynamicRevisionResolver = new DynamicVersionResolver(componentChooser, versionParser, attributesFactory, componentMetadataProcessorFactory, componentMetadataSupplierRuleExecutor, cachePolicy);
         this.consumerAttributes = consumerAttributes;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainDependencyToComponentIdResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainDependencyToComponentIdResolver.java
@@ -29,6 +29,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionP
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
+import org.gradle.internal.component.external.model.ModuleComponentGraphResolveState;
 import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
 import org.gradle.internal.component.external.model.ModuleDependencyMetadataWrapper;
 import org.gradle.internal.component.model.DependencyMetadata;
@@ -47,7 +48,7 @@ public class RepositoryChainDependencyToComponentIdResolver implements Dependenc
         this.consumerAttributes = consumerAttributes;
     }
 
-    public void add(ModuleComponentRepository repository) {
+    public void add(ModuleComponentRepository<ModuleComponentGraphResolveState> repository) {
         dynamicRevisionResolver.add(repository);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainModuleResolution.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainModuleResolution.java
@@ -15,19 +15,19 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
-import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
+import org.gradle.internal.component.external.model.ModuleComponentGraphResolveState;
 
 class RepositoryChainModuleResolution implements StringVersioned {
-    public final ModuleComponentRepository repository;
-    public final ModuleComponentResolveMetadata module;
+    public final ModuleComponentRepository<?> repository;
+    public final ModuleComponentGraphResolveState component;
 
-    public RepositoryChainModuleResolution(ModuleComponentRepository repository, ModuleComponentResolveMetadata module) {
+    public RepositoryChainModuleResolution(ModuleComponentRepository<?> repository, ModuleComponentGraphResolveState component) {
         this.repository = repository;
-        this.module = module;
+        this.component = component;
     }
 
     @Override
     public String getVersion() {
-        return module.getModuleVersionId().getVersion();
+        return component.getId().getVersion();
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainModuleSource.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainModuleSource.java
@@ -21,7 +21,7 @@ public class RepositoryChainModuleSource implements ModuleSource {
     private final String repositoryId;
     private final String repositoryName;
 
-    public RepositoryChainModuleSource(ModuleComponentRepository repository) {
+    public RepositoryChainModuleSource(ModuleComponentRepository<?> repository) {
         this.repositoryId = repository.getId();
         this.repositoryName = repository.getName();
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactory.java
@@ -16,7 +16,6 @@
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
 import org.gradle.api.Action;
-import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.result.ArtifactResult;
 import org.gradle.api.attributes.AttributeContainer;
@@ -41,10 +40,9 @@ import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.component.ArtifactType;
 import org.gradle.internal.Actions;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
+import org.gradle.internal.component.model.ComponentArtifactResolveMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
-import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
-import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.internal.model.CalculatedValueContainerFactory;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resolve.caching.ComponentMetadataSupplierRuleExecutor;
@@ -74,16 +72,18 @@ public class ResolveIvyFactory {
     private final DependencyVerificationOverride dependencyVerificationOverride;
     private final ChangingValueDependencyResolutionListener listener;
 
-    public ResolveIvyFactory(ModuleRepositoryCacheProvider cacheProvider,
-                             StartParameterResolutionOverride startParameterResolutionOverride,
-                             DependencyVerificationOverride dependencyVerificationOverride,
-                             BuildCommencedTimeProvider timeProvider,
-                             VersionComparator versionComparator,
-                             ImmutableModuleIdentifierFactory moduleIdentifierFactory,
-                             RepositoryDisabler repositoryBlacklister,
-                             VersionParser versionParser,
-                             ChangingValueDependencyResolutionListener listener,
-                             CalculatedValueContainerFactory calculatedValueContainerFactory) {
+    public ResolveIvyFactory(
+        ModuleRepositoryCacheProvider cacheProvider,
+        StartParameterResolutionOverride startParameterResolutionOverride,
+        DependencyVerificationOverride dependencyVerificationOverride,
+        BuildCommencedTimeProvider timeProvider,
+        VersionComparator versionComparator,
+        ImmutableModuleIdentifierFactory moduleIdentifierFactory,
+        RepositoryDisabler repositoryBlacklister,
+        VersionParser versionParser,
+        ChangingValueDependencyResolutionListener listener,
+        CalculatedValueContainerFactory calculatedValueContainerFactory
+    ) {
         this.cacheProvider = cacheProvider;
         this.startParameterResolutionOverride = startParameterResolutionOverride;
         this.timeProvider = timeProvider;
@@ -96,14 +96,16 @@ public class ResolveIvyFactory {
         this.calculatedValueContainerFactory = calculatedValueContainerFactory;
     }
 
-    public ComponentResolvers create(String resolveContextName,
-                                     ResolutionStrategyInternal resolutionStrategy,
-                                     Collection<? extends ResolutionAwareRepository> repositories,
-                                     ComponentMetadataProcessorFactory metadataProcessor,
-                                     AttributeContainer consumerAttributes,
-                                     AttributesSchema attributesSchema,
-                                     ImmutableAttributesFactory attributesFactory,
-                                     ComponentMetadataSupplierRuleExecutor componentMetadataSupplierRuleExecutor) {
+    public ComponentResolvers create(
+        String resolveContextName,
+        ResolutionStrategyInternal resolutionStrategy,
+        Collection<? extends ResolutionAwareRepository> repositories,
+        ComponentMetadataProcessorFactory metadataProcessor,
+        AttributeContainer consumerAttributes,
+        AttributesSchema attributesSchema,
+        ImmutableAttributesFactory attributesFactory,
+        ComponentMetadataSupplierRuleExecutor componentMetadataSupplierRuleExecutor
+    ) {
         if (repositories.isEmpty()) {
             return new NoRepositoriesResolver();
         }
@@ -164,16 +166,17 @@ public class ResolveIvyFactory {
     private static class ParentModuleLookupResolver implements ComponentResolvers, DependencyToComponentIdResolver, ComponentMetaDataResolver, ArtifactResolver {
         private final UserResolverChain delegate;
 
-        public ParentModuleLookupResolver(VersionComparator versionComparator,
-                                          ImmutableModuleIdentifierFactory moduleIdentifierFactory,
-                                          VersionParser versionParser,
-                                          AttributeContainer consumerAttributes,
-                                          AttributesSchema attributesSchema,
-                                          ImmutableAttributesFactory attributesFactory,
-                                          ComponentMetadataProcessorFactory componentMetadataProcessorFactory,
-                                          ComponentMetadataSupplierRuleExecutor componentMetadataSupplierRuleExecutor,
-                                          CalculatedValueContainerFactory calculatedValueContainerFactory,
-                                          CachePolicy cachePolicy
+        public ParentModuleLookupResolver(
+            VersionComparator versionComparator,
+            ImmutableModuleIdentifierFactory moduleIdentifierFactory,
+            VersionParser versionParser,
+            AttributeContainer consumerAttributes,
+            AttributesSchema attributesSchema,
+            ImmutableAttributesFactory attributesFactory,
+            ComponentMetadataProcessorFactory componentMetadataProcessorFactory,
+            ComponentMetadataSupplierRuleExecutor componentMetadataSupplierRuleExecutor,
+            CalculatedValueContainerFactory calculatedValueContainerFactory,
+            CachePolicy cachePolicy
         ) {
             this.delegate = new UserResolverChain(versionComparator, new DefaultComponentSelectionRules(moduleIdentifierFactory), versionParser, consumerAttributes, attributesSchema, attributesFactory, componentMetadataProcessorFactory, componentMetadataSupplierRuleExecutor, calculatedValueContainerFactory, cachePolicy);
         }
@@ -218,13 +221,13 @@ public class ResolveIvyFactory {
         }
 
         @Override
-        public void resolveArtifactsWithType(final ComponentResolveMetadata component, final ArtifactType artifactType, final BuildableArtifactSetResolveResult result) {
+        public void resolveArtifactsWithType(ComponentArtifactResolveMetadata component, ArtifactType artifactType, BuildableArtifactSetResolveResult result) {
             delegate.getArtifactResolver().resolveArtifactsWithType(component, artifactType, result);
         }
 
         @Override
-        public void resolveArtifact(ModuleVersionIdentifier ownerId, final ComponentArtifactMetadata artifact, final ModuleSources moduleSources, final BuildableArtifactResolveResult result) {
-            delegate.getArtifactResolver().resolveArtifact(ownerId, artifact, moduleSources, result);
+        public void resolveArtifact(ComponentArtifactResolveMetadata component, ComponentArtifactMetadata artifact, BuildableArtifactResolveResult result) {
+            delegate.getArtifactResolver().resolveArtifact(component, artifact, result);
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/StartParameterResolutionOverride.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/StartParameterResolutionOverride.java
@@ -37,6 +37,8 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.resources.ResourceException;
 import org.gradle.internal.Factory;
+import org.gradle.internal.component.external.model.ModuleComponentGraphResolveState;
+import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
@@ -65,7 +67,6 @@ import org.gradle.util.internal.BuildCommencedTimeProvider;
 
 import javax.annotation.Nullable;
 import java.io.File;
-import java.io.IOException;
 import java.util.List;
 
 @ServiceScope(Scopes.BuildTree.class)
@@ -91,7 +92,7 @@ public class StartParameterResolutionOverride {
         }
     }
 
-    public ModuleComponentRepository overrideModuleVersionRepository(ModuleComponentRepository original) {
+    public ModuleComponentRepository<ModuleComponentResolveMetadata> overrideModuleVersionRepository(ModuleComponentRepository<ModuleComponentResolveMetadata> original) {
         if (startParameter.isOffline()) {
             return new OfflineModuleComponentRepository(original);
         }
@@ -138,25 +139,25 @@ public class StartParameterResolutionOverride {
         // There's currently no good way to figure that out.
         File buildDir = new File(gradleDir.getParentFile(), "build");
         File reportsDirectory = new File(buildDir, "reports");
-        File verifReportsDirectory = new File(reportsDirectory, "dependency-verification");
-        return new File(verifReportsDirectory, "at-" + timeProvider.getCurrentTime());
+        File verifyReportsDirectory = new File(reportsDirectory, "dependency-verification");
+        return new File(verifyReportsDirectory, "at-" + timeProvider.getCurrentTime());
     }
 
-    private static class OfflineModuleComponentRepository extends BaseModuleComponentRepository {
+    private static class OfflineModuleComponentRepository extends BaseModuleComponentRepository<ModuleComponentResolveMetadata> {
 
         private final FailedRemoteAccess failedRemoteAccess = new FailedRemoteAccess();
 
-        public OfflineModuleComponentRepository(ModuleComponentRepository original) {
+        public OfflineModuleComponentRepository(ModuleComponentRepository<ModuleComponentResolveMetadata> original) {
             super(original);
         }
 
         @Override
-        public ModuleComponentRepositoryAccess getRemoteAccess() {
+        public ModuleComponentRepositoryAccess<ModuleComponentResolveMetadata> getRemoteAccess() {
             return failedRemoteAccess;
         }
     }
 
-    private static class FailedRemoteAccess implements ModuleComponentRepositoryAccess {
+    private static class FailedRemoteAccess implements ModuleComponentRepositoryAccess<ModuleComponentResolveMetadata> {
         @Override
         public String toString() {
             return "offline remote";
@@ -168,7 +169,7 @@ public class StartParameterResolutionOverride {
         }
 
         @Override
-        public void resolveComponentMetaData(ModuleComponentIdentifier moduleComponentIdentifier, ComponentOverrideMetadata requestMetaData, BuildableModuleComponentMetaDataResolveResult result) {
+        public void resolveComponentMetaData(ModuleComponentIdentifier moduleComponentIdentifier, ComponentOverrideMetadata requestMetaData, BuildableModuleComponentMetaDataResolveResult<ModuleComponentResolveMetadata> result) {
             result.failed(new ModuleVersionResolveException(moduleComponentIdentifier, () -> String.format("No cached version of %s available for offline mode.", moduleComponentIdentifier.getDisplayName())));
         }
 
@@ -222,7 +223,7 @@ public class StartParameterResolutionOverride {
         }
 
         @Override
-        public void upload(ReadableContent resource, ExternalResourceName destination) throws IOException {
+        public void upload(ReadableContent resource, ExternalResourceName destination) {
             throw new ResourceException(destination.getUri(), String.format("Cannot upload to '%s' in offline mode.", destination.getUri()));
         }
 
@@ -239,7 +240,7 @@ public class StartParameterResolutionOverride {
         }
 
         @Override
-        public ModuleComponentRepository overrideDependencyVerification(ModuleComponentRepository original, String resolveContextName, ResolutionStrategyInternal resolutionStrategy) {
+        public ModuleComponentRepository<ModuleComponentGraphResolveState> overrideDependencyVerification(ModuleComponentRepository<ModuleComponentGraphResolveState> original, String resolveContextName, ResolutionStrategyInternal resolutionStrategy) {
             throw new DependencyVerificationException("Dependency verification cannot be performed", error);
         }
     }
@@ -258,7 +259,7 @@ public class StartParameterResolutionOverride {
         }
 
         @Override
-        public ModuleComponentRepository overrideDependencyVerification(ModuleComponentRepository original, String resolveContextName, ResolutionStrategyInternal resolutionStrategy) {
+        public ModuleComponentRepository<ModuleComponentGraphResolveState> overrideDependencyVerification(ModuleComponentRepository<ModuleComponentGraphResolveState> original, String resolveContextName, ResolutionStrategyInternal resolutionStrategy) {
             if (resolutionStrategy.isDependencyVerificationEnabled()) {
                 return delegate.overrideDependencyVerification(original, resolveContextName, resolutionStrategy);
             } else {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/UserResolverChain.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/UserResolverChain.java
@@ -24,6 +24,7 @@ import org.gradle.api.internal.artifacts.configurations.dynamicversion.CachePoli
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionComparator;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.internal.component.external.model.ModuleComponentGraphResolveState;
 import org.gradle.internal.model.CalculatedValueContainerFactory;
 import org.gradle.internal.resolve.caching.ComponentMetadataSupplierRuleExecutor;
 import org.gradle.internal.resolve.resolver.ArtifactResolver;
@@ -79,7 +80,7 @@ public class UserResolverChain implements ComponentResolvers {
         return componentSelectionRules;
     }
 
-    public void add(ModuleComponentRepository repository) {
+    public void add(ModuleComponentRepository<ModuleComponentGraphResolveState> repository) {
         componentIdResolver.add(repository);
         componentResolver.add(repository);
         artifactResolver.add(repository);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/UserResolverChain.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/UserResolverChain.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
-import org.gradle.api.Transformer;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.AttributesSchema;
 import org.gradle.api.internal.artifacts.ComponentMetadataProcessorFactory;
@@ -25,9 +24,6 @@ import org.gradle.api.internal.artifacts.configurations.dynamicversion.CachePoli
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionComparator;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
-import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
-import org.gradle.internal.component.model.ImmutableModuleSources;
-import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.internal.model.CalculatedValueContainerFactory;
 import org.gradle.internal.resolve.caching.ComponentMetadataSupplierRuleExecutor;
 import org.gradle.internal.resolve.resolver.ArtifactResolver;
@@ -54,9 +50,8 @@ public class UserResolverChain implements ComponentResolvers {
     ) {
         this.componentSelectionRules = componentSelectionRules;
         VersionedComponentChooser componentChooser = new DefaultVersionedComponentChooser(versionComparator, versionParser, componentSelectionRules, attributesSchema);
-        ModuleTransformer metaDataFactory = new ModuleTransformer();
-        componentIdResolver = new RepositoryChainDependencyToComponentIdResolver(componentChooser, metaDataFactory, versionParser, consumerAttributes, attributesFactory, componentMetadataProcessor, componentMetadataSupplierRuleExecutor, cachePolicy);
-        componentResolver = new RepositoryChainComponentMetaDataResolver(componentChooser, metaDataFactory);
+        componentIdResolver = new RepositoryChainDependencyToComponentIdResolver(componentChooser, versionParser, consumerAttributes, attributesFactory, componentMetadataProcessor, componentMetadataSupplierRuleExecutor, cachePolicy);
+        componentResolver = new RepositoryChainComponentMetaDataResolver(componentChooser);
         artifactResolver = new RepositoryChainArtifactResolver(calculatedValueContainerFactory);
     }
 
@@ -88,15 +83,5 @@ public class UserResolverChain implements ComponentResolvers {
         componentIdResolver.add(repository);
         componentResolver.add(repository);
         artifactResolver.add(repository);
-    }
-
-    private static class ModuleTransformer implements Transformer<ModuleComponentResolveMetadata, RepositoryChainModuleResolution> {
-        @Override
-        public ModuleComponentResolveMetadata transform(RepositoryChainModuleResolution original) {
-            RepositoryChainModuleSource moduleSource = new RepositoryChainModuleSource(original.repository);
-            ModuleSources originSources = original.module.getSources();
-            ImmutableModuleSources mutated = ImmutableModuleSources.of(originSources, moduleSource);
-            return original.module.withSources(mutated);
-        }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/VersionedComponentChooser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/VersionedComponentChooser.java
@@ -18,7 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
-import org.gradle.internal.component.model.ComponentResolveMetadata;
+import org.gradle.internal.component.model.ComponentGraphResolveMetadata;
 import org.gradle.internal.resolve.RejectedByRuleVersion;
 import org.gradle.internal.resolve.result.ComponentSelectionContext;
 
@@ -27,7 +27,7 @@ import java.util.Collection;
 
 public interface VersionedComponentChooser {
     @Nullable
-    ComponentResolveMetadata selectNewestComponent(ComponentResolveMetadata one, ComponentResolveMetadata two);
+    ComponentGraphResolveMetadata selectNewestComponent(ComponentGraphResolveMetadata one, ComponentGraphResolveMetadata two);
 
     void selectNewestMatchingComponent(Collection<? extends ModuleComponentResolveState> versions, ComponentSelectionContext result, VersionSelector versionSelector, VersionSelector rejectedVersionSelector, ImmutableAttributes consumerAttributes);
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/ChecksumAndSignatureVerificationOverride.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/ChecksumAndSignatureVerificationOverride.java
@@ -42,6 +42,7 @@ import org.gradle.api.logging.Logging;
 import org.gradle.internal.Factory;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
+import org.gradle.internal.component.external.model.ModuleComponentGraphResolveState;
 import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.hash.ChecksumService;
 import org.gradle.internal.logging.ConsoleRenderer;
@@ -163,7 +164,7 @@ public class ChecksumAndSignatureVerificationOverride implements DependencyVerif
     }
 
     @Override
-    public ModuleComponentRepository overrideDependencyVerification(ModuleComponentRepository original, String resolveContextName, ResolutionStrategyInternal resolutionStrategy) {
+    public ModuleComponentRepository<ModuleComponentGraphResolveState> overrideDependencyVerification(ModuleComponentRepository<ModuleComponentGraphResolveState> original, String resolveContextName, ResolutionStrategyInternal resolutionStrategy) {
         return new DependencyVerifyingModuleComponentRepository(original, this, verifier.getConfiguration().isVerifySignatures());
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/DependencyVerificationOverride.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/DependencyVerificationOverride.java
@@ -19,6 +19,7 @@ import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ModuleComponentRepository;
+import org.gradle.internal.component.external.model.ModuleComponentGraphResolveState;
 
 import java.io.File;
 
@@ -36,7 +37,7 @@ public interface DependencyVerificationOverride {
         return new File(gradleDir, VERIFICATION_KEYRING_GPG);
     }
 
-    ModuleComponentRepository overrideDependencyVerification(ModuleComponentRepository original, String resolveContextName, ResolutionStrategyInternal resolutionStrategy);
+    ModuleComponentRepository<ModuleComponentGraphResolveState> overrideDependencyVerification(ModuleComponentRepository<ModuleComponentGraphResolveState> original, String resolveContextName, ResolutionStrategyInternal resolutionStrategy);
 
     default void buildFinished(GradleInternal model) {
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFile.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFile.java
@@ -53,6 +53,7 @@ import org.gradle.api.logging.Logging;
 import org.gradle.internal.Factory;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
+import org.gradle.internal.component.external.model.ModuleComponentGraphResolveState;
 import org.gradle.internal.deprecation.DeprecatableConfiguration;
 import org.gradle.internal.hash.ChecksumService;
 import org.gradle.internal.operations.BuildOperationContext;
@@ -172,7 +173,7 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
     }
 
     @Override
-    public ModuleComponentRepository overrideDependencyVerification(ModuleComponentRepository original, String resolveContextName, ResolutionStrategyInternal resolutionStrategy) {
+    public ModuleComponentRepository<ModuleComponentGraphResolveState> overrideDependencyVerification(ModuleComponentRepository<ModuleComponentGraphResolveState> original, String resolveContextName, ResolutionStrategyInternal resolutionStrategy) {
         return new DependencyVerifyingModuleComponentRepository(original, this, generatePgpInfo);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/AbstractModuleMetadataCache.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/AbstractModuleMetadataCache.java
@@ -31,13 +31,13 @@ public abstract class AbstractModuleMetadataCache implements ModuleMetadataCache
     }
 
     @Override
-    public CachedMetadata getCachedModuleDescriptor(ModuleComponentRepository repository, ModuleComponentIdentifier id) {
+    public CachedMetadata getCachedModuleDescriptor(ModuleComponentRepository<?> repository, ModuleComponentIdentifier id) {
         final ModuleComponentAtRepositoryKey key = createKey(repository, id);
         return get(key);
     }
 
     @Override
-    public CachedMetadata cacheMissing(ModuleComponentRepository repository, ModuleComponentIdentifier id) {
+    public CachedMetadata cacheMissing(ModuleComponentRepository<?> repository, ModuleComponentIdentifier id) {
         LOGGER.debug("Recording absence of module descriptor in cache: {} [changing = {}]", id, false);
         ModuleComponentAtRepositoryKey key = createKey(repository, id);
         ModuleMetadataCacheEntry entry = ModuleMetadataCacheEntry.forMissingModule(timeProvider.getCurrentTime());
@@ -47,7 +47,7 @@ public abstract class AbstractModuleMetadataCache implements ModuleMetadataCache
     }
 
     @Override
-    public CachedMetadata cacheMetaData(ModuleComponentRepository repository, ModuleComponentIdentifier id, final ModuleComponentResolveMetadata metadata) {
+    public CachedMetadata cacheMetaData(ModuleComponentRepository<?> repository, ModuleComponentIdentifier id, ModuleComponentResolveMetadata metadata) {
         LOGGER.debug("Recording module descriptor in cache: {} [changing = {}]", metadata.getId(), metadata.isChanging());
         final ModuleComponentAtRepositoryKey key = createKey(repository, id);
         ModuleMetadataCacheEntry entry = createEntry(metadata);
@@ -55,7 +55,7 @@ public abstract class AbstractModuleMetadataCache implements ModuleMetadataCache
         return store(key, entry, cachedMetaData);
     }
 
-    protected ModuleComponentAtRepositoryKey createKey(ModuleComponentRepository repository, ModuleComponentIdentifier id) {
+    protected ModuleComponentAtRepositoryKey createKey(ModuleComponentRepository<?> repository, ModuleComponentIdentifier id) {
         return new ModuleComponentAtRepositoryKey(repository.getId(), id);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/DefaultCachedMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/DefaultCachedMetadata.java
@@ -17,6 +17,7 @@ package org.gradle.api.internal.artifacts.ivyservice.modulecache;
 
 import org.gradle.api.artifacts.ResolvedModuleVersion;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.dynamicversions.DefaultResolvedModuleVersion;
+import org.gradle.internal.component.external.model.ModuleComponentGraphResolveState;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
 import org.gradle.internal.component.model.ModuleSources;
@@ -32,7 +33,7 @@ class DefaultCachedMetadata implements ModuleMetadataCache.CachedMetadata {
     private final long ageMillis;
     private final ModuleComponentResolveMetadata metadata;
 
-    private volatile Map<Integer, ModuleComponentResolveMetadata> processedMetadataByRules;
+    private volatile Map<Integer, ModuleComponentGraphResolveState> processedMetadataByRules;
 
     DefaultCachedMetadata(ModuleMetadataCacheEntry entry, ModuleComponentResolveMetadata metadata, BuildCommencedTimeProvider timeProvider) {
         this(timeProvider.getCurrentTime() - entry.createTimestamp, metadata);
@@ -70,7 +71,7 @@ class DefaultCachedMetadata implements ModuleMetadataCache.CachedMetadata {
 
     @Nullable
     @Override
-    public ModuleComponentResolveMetadata getProcessedMetadata(int key) {
+    public ModuleComponentGraphResolveState getProcessedMetadata(int key) {
         if (processedMetadataByRules != null) {
             return processedMetadataByRules.get(key);
         }
@@ -78,7 +79,7 @@ class DefaultCachedMetadata implements ModuleMetadataCache.CachedMetadata {
     }
 
     @Override
-    public synchronized void putProcessedMetadata(int hash, ModuleComponentResolveMetadata processed) {
+    public synchronized void putProcessedMetadata(int hash, ModuleComponentGraphResolveState processed) {
         if (processedMetadataByRules == null) {
             processedMetadataByRules = Collections.singletonMap(hash, processed);
             return;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataCache.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataCache.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.modulecache;
 import org.gradle.api.artifacts.ResolvedModuleVersion;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ModuleComponentRepository;
+import org.gradle.internal.component.external.model.ModuleComponentGraphResolveState;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 import org.gradle.internal.component.model.ModuleSources;
 
@@ -49,12 +50,12 @@ public interface ModuleMetadataCache {
          * @param key the hash of the rules
          */
         @Nullable
-        ModuleComponentResolveMetadata getProcessedMetadata(int key);
+        ModuleComponentGraphResolveState getProcessedMetadata(int key);
 
         /**
          * Set the processed metadata to be cached in-memory only.
          */
-        void putProcessedMetadata(int key, ModuleComponentResolveMetadata processedMetadata);
+        void putProcessedMetadata(int key, ModuleComponentGraphResolveState state);
 
         /**
          * Returns a copy of this cached metadata where the module metadata is safe to store

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataCache.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataCache.java
@@ -25,11 +25,11 @@ import javax.annotation.Nullable;
 import java.time.Duration;
 
 public interface ModuleMetadataCache {
-    CachedMetadata cacheMissing(ModuleComponentRepository repository, ModuleComponentIdentifier id);
+    CachedMetadata cacheMissing(ModuleComponentRepository<?> repository, ModuleComponentIdentifier id);
 
-    CachedMetadata cacheMetaData(ModuleComponentRepository repository, ModuleComponentIdentifier id, ModuleComponentResolveMetadata metaData);
+    CachedMetadata cacheMetaData(ModuleComponentRepository<?> repository, ModuleComponentIdentifier id, ModuleComponentResolveMetadata metaData);
 
-    CachedMetadata getCachedModuleDescriptor(ModuleComponentRepository repository, ModuleComponentIdentifier id);
+    CachedMetadata getCachedModuleDescriptor(ModuleComponentRepository<?> repository, ModuleComponentIdentifier id);
 
     interface CachedMetadata {
         ResolvedModuleVersion getModuleVersion();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ReadOnlyModuleMetadataCache.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ReadOnlyModuleMetadataCache.java
@@ -40,12 +40,12 @@ public class ReadOnlyModuleMetadataCache extends PersistentModuleMetadataCache {
     }
 
     @Override
-    public CachedMetadata cacheMissing(ModuleComponentRepository repository, ModuleComponentIdentifier id) {
+    public CachedMetadata cacheMissing(ModuleComponentRepository<?> repository, ModuleComponentIdentifier id) {
         return operationShouldNotHaveBeenCalled();
     }
 
     @Override
-    public CachedMetadata cacheMetaData(ModuleComponentRepository repository, ModuleComponentIdentifier id, ModuleComponentResolveMetadata metadata) {
+    public CachedMetadata cacheMetaData(ModuleComponentRepository<?> repository, ModuleComponentIdentifier id, ModuleComponentResolveMetadata metadata) {
         return operationShouldNotHaveBeenCalled();
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ResolvedArtifactCaches.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ResolvedArtifactCaches.java
@@ -24,6 +24,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ModuleComponentRe
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
+import org.gradle.internal.component.external.model.ModuleComponentGraphResolveState;
 import org.gradle.internal.concurrent.Stoppable;
 
 import java.util.Map;
@@ -42,12 +43,12 @@ public class ResolvedArtifactCaches implements Stoppable {
      * For a remote repository, the only thing required is a resolved artifact cache.
      * The rest of the in-memory caching is handled by the CachingModuleComponentRepository.
      */
-    public ModuleComponentRepository provideResolvedArtifactCache(ModuleComponentRepository input, boolean withVerification) {
+    public ModuleComponentRepository<ModuleComponentGraphResolveState> provideResolvedArtifactCache(ModuleComponentRepository<ModuleComponentGraphResolveState> input, boolean withVerification) {
         Map<ComponentArtifactIdentifier, ResolvableArtifact> caches = getResolvedArtifactCache(withVerification ? cachePerRepoWithVerification : cachePerRepo, input);
         return new ResolvedArtifactCacheProvidingModuleComponentRepository(caches, input);
     }
 
-    private Map<ComponentArtifactIdentifier, ResolvableArtifact> getResolvedArtifactCache(Map<String, Map<ComponentArtifactIdentifier, ResolvableArtifact>> cache, ModuleComponentRepository input) {
+    private Map<ComponentArtifactIdentifier, ResolvableArtifact> getResolvedArtifactCache(Map<String, Map<ComponentArtifactIdentifier, ResolvableArtifact>> cache, ModuleComponentRepository<ModuleComponentGraphResolveState> input) {
         Map<ComponentArtifactIdentifier, ResolvableArtifact> resolvedArtifactCache = cache.get(input.getId());
         if (resolvedArtifactCache == null) {
             LOG.debug("Creating new in-memory cache for repo '{}' [{}].", input.getName(), input.getId());
@@ -65,11 +66,11 @@ public class ResolvedArtifactCaches implements Stoppable {
         cachePerRepoWithVerification.clear();
     }
 
-    private static class ResolvedArtifactCacheProvidingModuleComponentRepository extends BaseModuleComponentRepository {
+    private static class ResolvedArtifactCacheProvidingModuleComponentRepository extends BaseModuleComponentRepository<ModuleComponentGraphResolveState> {
 
         private final Map<ComponentArtifactIdentifier, ResolvableArtifact> resolvedArtifactCache;
 
-        public ResolvedArtifactCacheProvidingModuleComponentRepository(Map<ComponentArtifactIdentifier, ResolvableArtifact> resolvedArtifactsCache, ModuleComponentRepository delegate) {
+        public ResolvedArtifactCacheProvidingModuleComponentRepository(Map<ComponentArtifactIdentifier, ResolvableArtifact> resolvedArtifactsCache, ModuleComponentRepository<ModuleComponentGraphResolveState> delegate) {
             super(delegate);
             this.resolvedArtifactCache = resolvedArtifactsCache;
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/AbstractArtifactsCache.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/AbstractArtifactsCache.java
@@ -34,7 +34,7 @@ public abstract class AbstractArtifactsCache implements ModuleArtifactsCache {
     }
 
     @Override
-    public CachedArtifacts cacheArtifacts(ModuleComponentRepository repository, ComponentIdentifier componentId, String context, HashCode descriptorHash, Collection<? extends ComponentArtifactMetadata> artifacts) {
+    public CachedArtifacts cacheArtifacts(ModuleComponentRepository<?> repository, ComponentIdentifier componentId, String context, HashCode descriptorHash, Collection<? extends ComponentArtifactMetadata> artifacts) {
         ArtifactsAtRepositoryKey key = new ArtifactsAtRepositoryKey(repository.getId(), componentId, context);
         ModuleArtifactsCacheEntry entry = new ModuleArtifactsCacheEntry(ImmutableSet.copyOf(artifacts), timeProvider.getCurrentTime(), descriptorHash);
         store(key, entry);
@@ -44,7 +44,7 @@ public abstract class AbstractArtifactsCache implements ModuleArtifactsCache {
     protected abstract void store(ArtifactsAtRepositoryKey key, ModuleArtifactsCacheEntry entry);
 
     @Override
-    public CachedArtifacts getCachedArtifacts(ModuleComponentRepository repository, ComponentIdentifier componentId, String context) {
+    public CachedArtifacts getCachedArtifacts(ModuleComponentRepository<?> repository, ComponentIdentifier componentId, String context) {
         ArtifactsAtRepositoryKey key = new ArtifactsAtRepositoryKey(repository.getId(), componentId, context);
         ModuleArtifactsCacheEntry entry = get(key);
         return entry == null ? null : createCacheArtifacts(entry);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/ModuleArtifactsCache.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/ModuleArtifactsCache.java
@@ -23,8 +23,8 @@ import org.gradle.internal.hash.HashCode;
 import java.util.Collection;
 
 public interface ModuleArtifactsCache {
-    CachedArtifacts cacheArtifacts(ModuleComponentRepository repository, ComponentIdentifier componentId, String context, HashCode descriptorHash, Collection<? extends ComponentArtifactMetadata> artifacts);
+    CachedArtifacts cacheArtifacts(ModuleComponentRepository<?> repository, ComponentIdentifier componentId, String context, HashCode descriptorHash, Collection<? extends ComponentArtifactMetadata> artifacts);
 
-    CachedArtifacts getCachedArtifacts(ModuleComponentRepository delegate, ComponentIdentifier componentId, String context);
+    CachedArtifacts getCachedArtifacts(ModuleComponentRepository<?> delegate, ComponentIdentifier componentId, String context);
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/ReadOnlyModuleArtifactsCache.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/ReadOnlyModuleArtifactsCache.java
@@ -35,7 +35,7 @@ public class ReadOnlyModuleArtifactsCache extends DefaultModuleArtifactsCache {
     }
 
     @Override
-    public CachedArtifacts cacheArtifacts(ModuleComponentRepository repository, ComponentIdentifier componentId, String context, HashCode descriptorHash, Collection<? extends ComponentArtifactMetadata> artifacts) {
+    public CachedArtifacts cacheArtifacts(ModuleComponentRepository<?> repository, ComponentIdentifier componentId, String context, HashCode descriptorHash, Collection<? extends ComponentArtifactMetadata> artifacts) {
         return operationShouldNotHaveBeenCalled();
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/dynamicversions/AbstractModuleVersionsCache.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/dynamicversions/AbstractModuleVersionsCache.java
@@ -32,7 +32,7 @@ public abstract class AbstractModuleVersionsCache implements ModuleVersionsCache
     }
 
     @Override
-    public void cacheModuleVersionList(ModuleComponentRepository repository, ModuleIdentifier moduleId, Set<String> listedVersions) {
+    public void cacheModuleVersionList(ModuleComponentRepository<?> repository, ModuleIdentifier moduleId, Set<String> listedVersions) {
         LOGGER.debug("Caching version list in module versions cache: Using '{}' for '{}'", listedVersions, moduleId);
         ModuleAtRepositoryKey key = createKey(repository, moduleId);
         ModuleVersionsCacheEntry entry = createEntry(listedVersions);
@@ -40,7 +40,7 @@ public abstract class AbstractModuleVersionsCache implements ModuleVersionsCache
     }
 
     @Override
-    public CachedModuleVersionList getCachedModuleResolution(ModuleComponentRepository repository, ModuleIdentifier moduleId) {
+    public CachedModuleVersionList getCachedModuleResolution(ModuleComponentRepository<?> repository, ModuleIdentifier moduleId) {
         ModuleAtRepositoryKey key = createKey(repository, moduleId);
         ModuleVersionsCacheEntry entry = get(key);
         return entry == null ? null : versionList(entry);
@@ -53,7 +53,7 @@ public abstract class AbstractModuleVersionsCache implements ModuleVersionsCache
         );
     }
 
-    private ModuleAtRepositoryKey createKey(ModuleComponentRepository repository, ModuleIdentifier moduleId) {
+    private ModuleAtRepositoryKey createKey(ModuleComponentRepository<?> repository, ModuleIdentifier moduleId) {
         return new ModuleAtRepositoryKey(repository.getId(), moduleId);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/dynamicversions/ModuleVersionsCache.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/dynamicversions/ModuleVersionsCache.java
@@ -23,9 +23,9 @@ import java.util.Set;
 
 public interface ModuleVersionsCache {
 
-    void cacheModuleVersionList(ModuleComponentRepository repository, ModuleIdentifier moduleId, Set<String> listedVersions);
+    void cacheModuleVersionList(ModuleComponentRepository<?> repository, ModuleIdentifier moduleId, Set<String> listedVersions);
 
-    CachedModuleVersionList getCachedModuleResolution(ModuleComponentRepository repository, ModuleIdentifier moduleId);
+    CachedModuleVersionList getCachedModuleResolution(ModuleComponentRepository<?> repository, ModuleIdentifier moduleId);
 
     interface CachedModuleVersionList {
         Set<String> getModuleVersions();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/dynamicversions/ReadOnlyModuleVersionsCache.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/dynamicversions/ReadOnlyModuleVersionsCache.java
@@ -35,7 +35,7 @@ public class ReadOnlyModuleVersionsCache extends DefaultModuleVersionsCache {
     }
 
     @Override
-    public void cacheModuleVersionList(ModuleComponentRepository repository, ModuleIdentifier moduleId, Set<String> listedVersions) {
+    public void cacheModuleVersionList(ModuleComponentRepository<?> repository, ModuleIdentifier moduleId, Set<String> listedVersions) {
         throw operationShouldNotHaveBeenCalled();
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectArtifactResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectArtifactResolver.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.artifacts.ivyservice.projectmodule;
 
 import com.google.common.collect.Maps;
-import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.internal.artifacts.DefaultResolvableArtifact;
@@ -31,8 +30,7 @@ import org.gradle.api.internal.tasks.NodeExecutionContext;
 import org.gradle.internal.Describables;
 import org.gradle.internal.component.local.model.LocalComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
-import org.gradle.internal.component.model.ComponentResolveMetadata;
-import org.gradle.internal.component.model.ModuleSources;
+import org.gradle.internal.component.model.ComponentArtifactResolveMetadata;
 import org.gradle.internal.model.CalculatedValue;
 import org.gradle.internal.model.CalculatedValueContainerFactory;
 import org.gradle.internal.model.ValueCalculator;
@@ -57,12 +55,12 @@ public class ProjectArtifactResolver implements ArtifactResolver, HoldsProjectSt
     }
 
     @Override
-    public void resolveArtifactsWithType(ComponentResolveMetadata component, ArtifactType artifactType, BuildableArtifactSetResolveResult result) {
+    public void resolveArtifactsWithType(ComponentArtifactResolveMetadata component, ArtifactType artifactType, BuildableArtifactSetResolveResult result) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void resolveArtifact(ModuleVersionIdentifier ownerId, ComponentArtifactMetadata artifact, ModuleSources moduleSources, BuildableArtifactResolveResult result) {
+    public void resolveArtifact(ComponentArtifactResolveMetadata component, ComponentArtifactMetadata artifact, BuildableArtifactResolveResult result) {
         // NOTE: This isn't thread-safe because we're not locking around allResolvedArtifacts to ensure we're not inserting multiple resolvableArtifacts for
         // the same artifact id.
         //
@@ -76,7 +74,7 @@ public class ProjectArtifactResolver implements ArtifactResolver, HoldsProjectSt
             File localArtifactFile = projectStateRegistry.stateFor(projectId).fromMutableState(p -> projectArtifact.getFile());
             if (localArtifactFile != null) {
                 CalculatedValue<File> artifactSource = calculatedValueContainerFactory.create(Describables.of(artifact.getId()), resolveArtifactLater(artifact));
-                resolvableArtifact = new DefaultResolvableArtifact(ownerId, artifact.getName(), artifact.getId(), context -> context.add(artifact.getBuildDependencies()), artifactSource, calculatedValueContainerFactory);
+                resolvableArtifact = new DefaultResolvableArtifact(component.getModuleVersionId(), artifact.getName(), artifact.getId(), context -> context.add(artifact.getBuildDependencies()), artifactSource, calculatedValueContainerFactory);
                 allResolvedArtifacts.put(artifact.getId(), resolvableArtifact);
             }
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyResolver.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.projectmodule;
 
-import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentSelector;
@@ -31,11 +30,10 @@ import org.gradle.api.internal.component.ArtifactType;
 import org.gradle.internal.component.local.model.DefaultProjectComponentSelector;
 import org.gradle.internal.component.local.model.LocalComponentGraphResolveState;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
+import org.gradle.internal.component.model.ComponentArtifactResolveMetadata;
 import org.gradle.internal.component.model.ComponentArtifactResolveVariantState;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
-import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
-import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 import org.gradle.internal.resolve.resolver.ArtifactResolver;
 import org.gradle.internal.resolve.resolver.ComponentMetaDataResolver;
@@ -123,7 +121,7 @@ public class ProjectDependencyResolver implements ComponentMetaDataResolver, Dep
     }
 
     @Override
-    public void resolveArtifactsWithType(ComponentResolveMetadata component, ArtifactType artifactType, BuildableArtifactSetResolveResult result) {
+    public void resolveArtifactsWithType(ComponentArtifactResolveMetadata component, ArtifactType artifactType, BuildableArtifactSetResolveResult result) {
         if (isProjectModule(component.getId())) {
             throw new UnsupportedOperationException("Resolving artifacts by type is not yet supported for project modules");
         }
@@ -131,7 +129,7 @@ public class ProjectDependencyResolver implements ComponentMetaDataResolver, Dep
 
     @Nullable
     @Override
-    public ArtifactSet resolveArtifacts(final ComponentResolveMetadata component, ComponentArtifactResolveVariantState allVariants, Set<ResolvedVariant> legacyVariants, final ExcludeSpec exclusions, final ImmutableAttributes overriddenAttributes) {
+    public ArtifactSet resolveArtifacts(ComponentArtifactResolveMetadata component, ComponentArtifactResolveVariantState allVariants, Set<ResolvedVariant> legacyVariants, final ExcludeSpec exclusions, final ImmutableAttributes overriddenAttributes) {
         if (isProjectModule(component.getId())) {
             return ArtifactSetFactory.createFromVariantMetadata(component.getId(), allVariants, legacyVariants, component.getAttributesSchema(), overriddenAttributes);
         } else {
@@ -140,9 +138,9 @@ public class ProjectDependencyResolver implements ComponentMetaDataResolver, Dep
     }
 
     @Override
-    public void resolveArtifact(ModuleVersionIdentifier ownerId, ComponentArtifactMetadata artifact, ModuleSources moduleSources, final BuildableArtifactResolveResult result) {
+    public void resolveArtifact(ComponentArtifactResolveMetadata component, ComponentArtifactMetadata artifact, BuildableArtifactResolveResult result) {
         if (isProjectModule(artifact.getComponentId())) {
-            artifactResolver.resolveArtifact(ownerId, artifact, moduleSources, result);
+            artifactResolver.resolveArtifact(component, artifact, result);
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyResolver.java
@@ -17,8 +17,6 @@ package org.gradle.api.internal.artifacts.ivyservice.projectmodule;
 
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
-import org.gradle.api.artifacts.component.ProjectComponentSelector;
-import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ComponentResolvers;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactSet;
@@ -49,18 +47,13 @@ import org.gradle.internal.service.scopes.ServiceScope;
 import javax.annotation.Nullable;
 import java.util.Set;
 
-@ServiceScope(Scopes.Project.class)
+@ServiceScope(Scopes.Build.class)
 public class ProjectDependencyResolver implements ComponentMetaDataResolver, DependencyToComponentIdResolver, ArtifactResolver, OriginArtifactSelector, ComponentResolvers {
     private final LocalComponentRegistry localComponentRegistry;
-    private final ComponentIdentifierFactory componentIdentifierFactory;
     private final ProjectArtifactResolver artifactResolver;
 
-    public ProjectDependencyResolver(LocalComponentRegistry localComponentRegistry,
-                                     ComponentIdentifierFactory componentIdentifierFactory,
-                                     ProjectArtifactResolver artifactResolver
-    ) {
+    public ProjectDependencyResolver(LocalComponentRegistry localComponentRegistry, ProjectArtifactResolver artifactResolver) {
         this.localComponentRegistry = localComponentRegistry;
-        this.componentIdentifierFactory = componentIdentifierFactory;
         this.artifactResolver = artifactResolver;
     }
 
@@ -86,9 +79,9 @@ public class ProjectDependencyResolver implements ComponentMetaDataResolver, Dep
 
     @Override
     public void resolve(DependencyMetadata dependency, VersionSelector acceptor, @Nullable VersionSelector rejector, BuildableComponentIdResolveResult result) {
-        if (dependency.getSelector() instanceof ProjectComponentSelector) {
-            ProjectComponentSelector selector = (ProjectComponentSelector) dependency.getSelector();
-            ProjectComponentIdentifier projectId = componentIdentifierFactory.createProjectComponentIdentifier(selector);
+        if (dependency.getSelector() instanceof DefaultProjectComponentSelector) {
+            DefaultProjectComponentSelector selector = (DefaultProjectComponentSelector) dependency.getSelector();
+            ProjectComponentIdentifier projectId = selector.toIdentifier();
             LocalComponentGraphResolveState component = localComponentRegistry.getComponent(projectId);
             if (component == null) {
                 result.failed(new ModuleVersionResolveException(selector, () -> projectId + " not found."));

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ComponentResolversChain.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ComponentResolversChain.java
@@ -163,5 +163,4 @@ public class ComponentResolversChain {
             }
         }
     }
-
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ComponentResolversChain.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ComponentResolversChain.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine;
 
-import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ComponentResolvers;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ErrorHandlingArtifactResolver;
@@ -24,10 +23,9 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.Resol
 import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry;
 import org.gradle.api.internal.component.ArtifactType;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
+import org.gradle.internal.component.model.ComponentArtifactResolveMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
-import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
-import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.internal.model.CalculatedValueContainerFactory;
 import org.gradle.internal.resolve.resolver.ArtifactResolver;
 import org.gradle.internal.resolve.resolver.ArtifactSelector;
@@ -126,17 +124,17 @@ public class ComponentResolversChain {
         }
 
         @Override
-        public void resolveArtifact(ModuleVersionIdentifier ownerId, ComponentArtifactMetadata artifact, ModuleSources moduleSources, BuildableArtifactResolveResult result) {
+        public void resolveArtifact(ComponentArtifactResolveMetadata component, ComponentArtifactMetadata artifact, BuildableArtifactResolveResult result) {
             for (ArtifactResolver resolver : resolvers) {
                 if (result.hasResult()) {
                     return;
                 }
-                resolver.resolveArtifact(ownerId, artifact, moduleSources, result);
+                resolver.resolveArtifact(component, artifact, result);
             }
         }
 
         @Override
-        public void resolveArtifactsWithType(ComponentResolveMetadata component, ArtifactType artifactType, BuildableArtifactSetResolveResult result) {
+        public void resolveArtifactsWithType(ComponentArtifactResolveMetadata component, ArtifactType artifactType, BuildableArtifactSetResolveResult result) {
             for (ArtifactResolver resolver : resolvers) {
                 if (result.hasResult()) {
                     return;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformResolveMetadata.java
@@ -37,6 +37,7 @@ import org.gradle.internal.component.external.model.RealisedConfigurationMetadat
 import org.gradle.internal.component.external.model.VariantDerivationStrategy;
 import org.gradle.internal.component.external.model.VariantMetadataRules;
 import org.gradle.internal.component.external.model.VirtualComponentIdentifier;
+import org.gradle.internal.component.model.ImmutableModuleSources;
 import org.gradle.internal.component.model.ModuleConfigurationMetadata;
 import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.internal.component.model.VariantGraphResolveMetadata;
@@ -74,7 +75,7 @@ class LenientPlatformResolveMetadata implements ModuleComponentResolveMetadata {
 
     @Override
     public ModuleSources getSources() {
-        return null;
+        return ImmutableModuleSources.of();
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQuery.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQuery.java
@@ -192,7 +192,7 @@ public class DefaultArtifactResolutionQuery implements ArtifactResolutionQuery {
 
         for (ComponentArtifactMetadata artifactMetaData : artifactSetResolveResult.getResult()) {
             BuildableArtifactResolveResult resolveResult = new DefaultBuildableArtifactResolveResult();
-            artifactResolver.resolveArtifact(owner, artifactMetaData, componentState.getSources(), resolveResult);
+            artifactResolver.resolveArtifact(componentState.getResolveMetadata(), artifactMetaData, resolveResult);
             try {
                 artifacts.addArtifact(ivyFactory.verifiedArtifact(new DefaultResolvedArtifactResult(artifactMetaData.getId(), ImmutableAttributes.EMPTY, Collections.emptyList(), Describables.of(componentState.getId().getDisplayName()), type, resolveResult.getResult().getFile())));
             } catch (Exception e) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
@@ -57,6 +57,7 @@ import org.gradle.internal.Cast;
 import org.gradle.internal.action.InstantiatingAction;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
+import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
 import org.gradle.internal.component.external.model.maven.MutableMavenModuleResolveMetadata;
@@ -99,7 +100,7 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
     private final ChecksumService checksumService;
     private final MavenMetadataSources metadataSources = new MavenMetadataSources();
     private final InstantiatorFactory instantiatorFactory;
-    private VersionParser versionParser;
+    private final VersionParser versionParser;
 
     public DefaultMavenArtifactRepository(FileResolver fileResolver,
                                           RepositoryTransportFactory transportFactory,
@@ -462,7 +463,7 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
         }
 
         @Override
-        public MutableModuleComponentResolveMetadata create(String repositoryName, ComponentResolvers componentResolvers, ModuleComponentIdentifier moduleComponentIdentifier, ComponentOverrideMetadata prescribedMetaData, ExternalResourceArtifactResolver artifactResolver, BuildableModuleComponentMetaDataResolveResult result) {
+        public MutableModuleComponentResolveMetadata create(String repositoryName, ComponentResolvers componentResolvers, ModuleComponentIdentifier moduleComponentIdentifier, ComponentOverrideMetadata prescribedMetaData, ExternalResourceArtifactResolver artifactResolver, BuildableModuleComponentMetaDataResolveResult<ModuleComponentResolveMetadata> result) {
             MutableModuleComponentResolveMetadata metadata = delegate.create(repositoryName, componentResolvers, moduleComponentIdentifier, prescribedMetaData, artifactResolver, result);
             if (metadata != null) {
                 return MavenResolver.processMetaData((MutableMavenModuleResolveMetadata) metadata);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/AbstractRepositoryMetadataSource.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/AbstractRepositoryMetadataSource.java
@@ -27,6 +27,7 @@ import org.gradle.api.internal.artifacts.repositories.resolver.ExternalResourceR
 import org.gradle.api.internal.artifacts.repositories.resolver.ExternalResourceResolverDescriptorParseContext;
 import org.gradle.internal.SystemProperties;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
+import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.DefaultModuleDescriptorArtifactMetadata;
@@ -64,7 +65,7 @@ abstract class AbstractRepositoryMetadataSource<S extends MutableModuleComponent
     }
 
     @Override
-    public S create(String repositoryName, ComponentResolvers componentResolvers, ModuleComponentIdentifier moduleVersionIdentifier, ComponentOverrideMetadata prescribedMetaData, ExternalResourceArtifactResolver artifactResolver, BuildableModuleComponentMetaDataResolveResult result) {
+    public S create(String repositoryName, ComponentResolvers componentResolvers, ModuleComponentIdentifier moduleVersionIdentifier, ComponentOverrideMetadata prescribedMetaData, ExternalResourceArtifactResolver artifactResolver, BuildableModuleComponentMetaDataResolveResult<ModuleComponentResolveMetadata> result) {
         S parsedMetadataFromRepository = parseMetaDataFromArtifact(repositoryName, componentResolvers, moduleVersionIdentifier, artifactResolver, result);
         if (parsedMetadataFromRepository != null) {
             LOGGER.debug("Metadata file found for module '{}' in repository '{}'.", moduleVersionIdentifier, repositoryName);
@@ -82,7 +83,7 @@ abstract class AbstractRepositoryMetadataSource<S extends MutableModuleComponent
             if (parseResult != null) {
                 if (parseResult.hasGradleMetadataRedirectionMarker()) {
                     if (result instanceof BuildableModuleComponentMetaDataResolveResult) {
-                        ((BuildableModuleComponentMetaDataResolveResult) result).redirectToGradleMetadata();
+                        ((BuildableModuleComponentMetaDataResolveResult<?>) result).redirectToGradleMetadata();
                     } else {
                         throw new IllegalStateException("Unexpected Gradle metadata redirection answer");
                     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultArtifactMetadataSource.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultArtifactMetadataSource.java
@@ -24,6 +24,7 @@ import org.gradle.api.internal.artifacts.repositories.resolver.ExternalResourceR
 import org.gradle.api.internal.artifacts.repositories.resolver.ResourcePattern;
 import org.gradle.api.internal.artifacts.repositories.resolver.VersionLister;
 import org.gradle.internal.component.external.model.DefaultModuleComponentArtifactMetadata;
+import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
@@ -51,7 +52,7 @@ public class DefaultArtifactMetadataSource extends AbstractMetadataSource<Mutabl
     }
 
     @Override
-    public MutableModuleComponentResolveMetadata create(String repositoryName, ComponentResolvers componentResolvers, ModuleComponentIdentifier moduleComponentIdentifier, ComponentOverrideMetadata prescribedMetaData, ExternalResourceArtifactResolver artifactResolver, BuildableModuleComponentMetaDataResolveResult result) {
+    public MutableModuleComponentResolveMetadata create(String repositoryName, ComponentResolvers componentResolvers, ModuleComponentIdentifier moduleComponentIdentifier, ComponentOverrideMetadata prescribedMetaData, ExternalResourceArtifactResolver artifactResolver, BuildableModuleComponentMetaDataResolveResult<ModuleComponentResolveMetadata> result) {
         IvyArtifactName artifact = getArtifactName(moduleComponentIdentifier, prescribedMetaData);
         if (!artifactResolver.artifactExists(new DefaultModuleComponentArtifactMetadata(moduleComponentIdentifier, artifact), result)) {
             return null;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultGradleModuleMetadataSource.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultGradleModuleMetadataSource.java
@@ -25,6 +25,7 @@ import org.gradle.api.internal.artifacts.repositories.resolver.ExternalResourceA
 import org.gradle.api.internal.artifacts.repositories.resolver.ResourcePattern;
 import org.gradle.api.internal.artifacts.repositories.resolver.VersionLister;
 import org.gradle.internal.component.external.model.DefaultModuleComponentArtifactMetadata;
+import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
 import org.gradle.internal.component.external.model.MutableComponentVariant;
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
@@ -64,7 +65,7 @@ public class DefaultGradleModuleMetadataSource extends AbstractMetadataSource<Mu
     }
 
     @Override
-    public MutableModuleComponentResolveMetadata create(String repositoryName, ComponentResolvers componentResolvers, ModuleComponentIdentifier moduleComponentIdentifier, ComponentOverrideMetadata prescribedMetaData, ExternalResourceArtifactResolver artifactResolver, BuildableModuleComponentMetaDataResolveResult result) {
+    public MutableModuleComponentResolveMetadata create(String repositoryName, ComponentResolvers componentResolvers, ModuleComponentIdentifier moduleComponentIdentifier, ComponentOverrideMetadata prescribedMetaData, ExternalResourceArtifactResolver artifactResolver, BuildableModuleComponentMetaDataResolveResult<ModuleComponentResolveMetadata> result) {
         DefaultIvyArtifactName moduleMetadataArtifact = new DefaultIvyArtifactName(moduleComponentIdentifier.getModule(), "module", "module");
         DefaultModuleComponentArtifactMetadata artifactId = new DefaultModuleComponentArtifactMetadata(moduleComponentIdentifier, moduleMetadataArtifact);
         LocallyAvailableExternalResource gradleMetadataArtifact = artifactResolver.resolveArtifact(artifactId, result);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/MetadataSource.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/MetadataSource.java
@@ -21,6 +21,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ComponentResolver
 import org.gradle.api.internal.artifacts.repositories.resolver.ExternalResourceArtifactResolver;
 import org.gradle.api.internal.artifacts.repositories.resolver.ResourcePattern;
 import org.gradle.api.internal.artifacts.repositories.resolver.VersionLister;
+import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
@@ -43,7 +44,7 @@ public interface MetadataSource<S extends MutableModuleComponentResolveMetadata>
              ModuleComponentIdentifier moduleComponentIdentifier,
              ComponentOverrideMetadata prescribedMetaData,
              ExternalResourceArtifactResolver artifactResolver, // Required for MavenLocal to verify the presence of the artifact
-             BuildableModuleComponentMetaDataResolveResult result);
+             BuildableModuleComponentMetaDataResolveResult<ModuleComponentResolveMetadata> result);
 
     /**
      * Use the supplied patterns and version lister to list available versions for the supplied dependency/module.

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/RedirectingGradleMetadataModuleMetadataSource.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/RedirectingGradleMetadataModuleMetadataSource.java
@@ -21,6 +21,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ComponentResolver
 import org.gradle.api.internal.artifacts.repositories.resolver.ExternalResourceArtifactResolver;
 import org.gradle.api.internal.artifacts.repositories.resolver.ResourcePattern;
 import org.gradle.api.internal.artifacts.repositories.resolver.VersionLister;
+import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
@@ -47,7 +48,7 @@ public class RedirectingGradleMetadataModuleMetadataSource extends AbstractMetad
     }
 
     @Override
-    public MutableModuleComponentResolveMetadata create(String repositoryName, ComponentResolvers componentResolvers, ModuleComponentIdentifier moduleComponentIdentifier, ComponentOverrideMetadata prescribedMetaData, ExternalResourceArtifactResolver artifactResolver, BuildableModuleComponentMetaDataResolveResult result) {
+    public MutableModuleComponentResolveMetadata create(String repositoryName, ComponentResolvers componentResolvers, ModuleComponentIdentifier moduleComponentIdentifier, ComponentOverrideMetadata prescribedMetaData, ExternalResourceArtifactResolver artifactResolver, BuildableModuleComponentMetaDataResolveResult<ModuleComponentResolveMetadata> result) {
         MutableModuleComponentResolveMetadata metadata = delegate.create(repositoryName, componentResolvers, moduleComponentIdentifier, prescribedMetaData, artifactResolver, result);
         if (result.shouldUseGradleMetatada()) {
             MutableModuleComponentResolveMetadata resolveMetadata = gradleModuleMetadataSource.create(repositoryName, componentResolvers, moduleComponentIdentifier, prescribedMetaData, artifactResolver, result);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolver.java
@@ -229,11 +229,11 @@ public abstract class ExternalResourceResolver<T extends ModuleComponentResolveM
         return CollectionUtils.filter(ivyPatterns, element -> element.isComplete(module));
     }
 
-    protected void doResolveComponentMetaData(ModuleComponentIdentifier moduleComponentIdentifier, ComponentOverrideMetadata prescribedMetaData, BuildableModuleComponentMetaDataResolveResult result) {
+    protected void doResolveComponentMetaData(ModuleComponentIdentifier moduleComponentIdentifier, ComponentOverrideMetadata prescribedMetaData, BuildableModuleComponentMetaDataResolveResult<ModuleComponentResolveMetadata> result) {
         resolveStaticDependency(moduleComponentIdentifier, prescribedMetaData, result, createArtifactResolver());
     }
 
-    protected final void resolveStaticDependency(ModuleComponentIdentifier moduleVersionIdentifier, ComponentOverrideMetadata prescribedMetaData, BuildableModuleComponentMetaDataResolveResult result, ExternalResourceArtifactResolver artifactResolver) {
+    protected final void resolveStaticDependency(ModuleComponentIdentifier moduleVersionIdentifier, ComponentOverrideMetadata prescribedMetaData, BuildableModuleComponentMetaDataResolveResult<ModuleComponentResolveMetadata> result, ExternalResourceArtifactResolver artifactResolver) {
         for (MetadataSource<?> source : metadataSources.sources()) {
             MutableModuleComponentResolveMetadata value = source.create(name, componentResolvers, moduleVersionIdentifier, prescribedMetaData, artifactResolver, result);
             if (value != null) {
@@ -379,7 +379,7 @@ public abstract class ExternalResourceResolver<T extends ModuleComponentResolveM
         CollectionUtils.addAll(artifactPatterns, patterns);
     }
 
-    protected abstract class AbstractRepositoryAccess implements ModuleComponentRepositoryAccess {
+    protected abstract class AbstractRepositoryAccess implements ModuleComponentRepositoryAccess<ModuleComponentResolveMetadata> {
         @Override
         public void resolveArtifactsWithType(ComponentResolveMetadata component, ArtifactType artifactType, BuildableArtifactSetResolveResult result) {
             T moduleMetaData = getSupportedMetadataType().cast(component);
@@ -402,7 +402,7 @@ public abstract class ExternalResourceResolver<T extends ModuleComponentResolveM
     protected abstract class LocalRepositoryAccess extends AbstractRepositoryAccess {
         @Override
         public String toString() {
-            return "local > " + ExternalResourceResolver.this.toString();
+            return "local > " + ExternalResourceResolver.this;
         }
 
         @Override
@@ -410,7 +410,7 @@ public abstract class ExternalResourceResolver<T extends ModuleComponentResolveM
         }
 
         @Override
-        public final void resolveComponentMetaData(ModuleComponentIdentifier moduleComponentIdentifier, ComponentOverrideMetadata requestMetaData, BuildableModuleComponentMetaDataResolveResult result) {
+        public final void resolveComponentMetaData(ModuleComponentIdentifier moduleComponentIdentifier, ComponentOverrideMetadata requestMetaData, BuildableModuleComponentMetaDataResolveResult<ModuleComponentResolveMetadata> result) {
         }
 
         @Override
@@ -442,7 +442,7 @@ public abstract class ExternalResourceResolver<T extends ModuleComponentResolveM
         }
 
         @Override
-        public final void resolveComponentMetaData(ModuleComponentIdentifier moduleComponentIdentifier, ComponentOverrideMetadata requestMetaData, BuildableModuleComponentMetaDataResolveResult result) {
+        public final void resolveComponentMetaData(ModuleComponentIdentifier moduleComponentIdentifier, ComponentOverrideMetadata requestMetaData, BuildableModuleComponentMetaDataResolveResult<ModuleComponentResolveMetadata> result) {
             doResolveComponentMetaData(moduleComponentIdentifier, requestMetaData, result);
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolverDescriptorParseContext.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolverDescriptorParseContext.java
@@ -84,7 +84,7 @@ public class ExternalResourceResolverDescriptorParseContext implements Descripto
 
         BuildableArtifactResolveResult artifactResolveResult = new DefaultBuildableArtifactResolveResult();
         ComponentArtifactMetadata artifactMetaData = moduleArtifactsResolveResult.getResult().iterator().next();
-        artifactResolver.resolveArtifact(moduleVersionResolveResult.getModuleVersionId(), artifactMetaData, moduleVersionResolveResult.getState().getSources(), artifactResolveResult);
+        artifactResolver.resolveArtifact(artifactResolveState.getResolveMetadata(), artifactMetaData, artifactResolveResult);
         File file = artifactResolveResult.getResult().getFile();
         LocallyAvailableExternalResource resource = fileResourceRepository.resource(file);
         ComponentArtifactIdentifier id = artifactMetaData.getId();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/IvyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/IvyResolver.java
@@ -25,6 +25,7 @@ import org.gradle.api.internal.component.ArtifactType;
 import org.gradle.internal.action.InstantiatingAction;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
+import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 import org.gradle.internal.component.external.model.ivy.IvyModuleResolveMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.hash.ChecksumService;
@@ -124,12 +125,12 @@ public class IvyResolver extends ExternalResourceResolver<IvyModuleResolveMetada
     }
 
     @Override
-    public ModuleComponentRepositoryAccess getLocalAccess() {
+    public ModuleComponentRepositoryAccess<ModuleComponentResolveMetadata> getLocalAccess() {
         return localRepositoryAccess;
     }
 
     @Override
-    public ModuleComponentRepositoryAccess getRemoteAccess() {
+    public ModuleComponentRepositoryAccess<ModuleComponentResolveMetadata> getRemoteAccess() {
         return remoteRepositoryAccess;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/MavenResolver.java
@@ -29,6 +29,7 @@ import org.gradle.api.resources.MissingResourceException;
 import org.gradle.internal.action.InstantiatingAction;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
+import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 import org.gradle.internal.component.external.model.maven.MavenModuleResolveMetadata;
 import org.gradle.internal.component.external.model.maven.MutableMavenModuleResolveMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
@@ -103,7 +104,7 @@ public class MavenResolver extends ExternalResourceResolver<MavenModuleResolveMe
     }
 
     @Override
-    protected void doResolveComponentMetaData(ModuleComponentIdentifier moduleComponentIdentifier, ComponentOverrideMetadata prescribedMetaData, BuildableModuleComponentMetaDataResolveResult result) {
+    protected void doResolveComponentMetaData(ModuleComponentIdentifier moduleComponentIdentifier, ComponentOverrideMetadata prescribedMetaData, BuildableModuleComponentMetaDataResolveResult<ModuleComponentResolveMetadata> result) {
         MavenUniqueSnapshotModuleSource uniqueSnapshotVersion = isNonUniqueSnapshot(moduleComponentIdentifier)
             ? findUniqueSnapshotVersion(moduleComponentIdentifier, result)
             : composeUniqueSnapshotVersion(moduleComponentIdentifier);
@@ -121,7 +122,7 @@ public class MavenResolver extends ExternalResourceResolver<MavenModuleResolveMe
         return artifactType == ArtifactType.MAVEN_POM;
     }
 
-    private void resolveUniqueSnapshotDependency(MavenUniqueSnapshotComponentIdentifier module, ComponentOverrideMetadata prescribedMetaData, BuildableModuleComponentMetaDataResolveResult result, MavenUniqueSnapshotModuleSource snapshotSource) {
+    private void resolveUniqueSnapshotDependency(MavenUniqueSnapshotComponentIdentifier module, ComponentOverrideMetadata prescribedMetaData, BuildableModuleComponentMetaDataResolveResult<ModuleComponentResolveMetadata> result, MavenUniqueSnapshotModuleSource snapshotSource) {
         resolveStaticDependency(module, prescribedMetaData, result, createArtifactResolver(MutableModuleSources.of(snapshotSource)));
     }
 
@@ -193,12 +194,12 @@ public class MavenResolver extends ExternalResourceResolver<MavenModuleResolveMe
     }
 
     @Override
-    public ModuleComponentRepositoryAccess getLocalAccess() {
+    public ModuleComponentRepositoryAccess<ModuleComponentResolveMetadata> getLocalAccess() {
         return localAccess;
     }
 
     @Override
-    public ModuleComponentRepositoryAccess getRemoteAccess() {
+    public ModuleComponentRepositoryAccess<ModuleComponentResolveMetadata> getRemoteAccess() {
         return remoteAccess;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentGraphResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentGraphResolveState.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.component.external.model;
+
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.internal.component.model.ComponentGraphResolveMetadata;
+import org.gradle.internal.component.model.DefaultComponentGraphResolveState;
+
+public class DefaultModuleComponentGraphResolveState extends DefaultComponentGraphResolveState<ComponentGraphResolveMetadata, ModuleComponentResolveMetadata> implements ModuleComponentGraphResolveState {
+    public DefaultModuleComponentGraphResolveState(ModuleComponentResolveMetadata metadata) {
+        super(metadata, metadata);
+    }
+
+    @Override
+    public ModuleComponentIdentifier getId() {
+        return getArtifactMetadata().getId();
+    }
+
+    @Override
+    public ModuleComponentResolveMetadata getModuleResolveMetadata() {
+        return getArtifactMetadata();
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleComponentGraphResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleComponentGraphResolveState.java
@@ -19,6 +19,9 @@ package org.gradle.internal.component.external.model;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.internal.component.model.ComponentGraphResolveState;
 
+/**
+ * <p>Instances of this type are cached and reused for multiple graph resolutions, possibly in parallel. This means that the implementation must be thread-safe.
+ */
 public interface ModuleComponentGraphResolveState extends ComponentGraphResolveState {
     @Override
     ModuleComponentIdentifier getId();

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleComponentGraphResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleComponentGraphResolveState.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.component.external.model;
+
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.internal.component.model.ComponentGraphResolveState;
+
+public interface ModuleComponentGraphResolveState extends ComponentGraphResolveState {
+    @Override
+    ModuleComponentIdentifier getId();
+
+    // Try to avoid using this, this is here to allow migration away from ModuleComponentResolveMetadata
+    ModuleComponentResolveMetadata getModuleResolveMetadata();
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentGraphResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentGraphResolveState.java
@@ -36,7 +36,6 @@ import org.gradle.internal.component.model.VariantGraphResolveMetadata;
 import org.gradle.internal.component.model.VariantResolveMetadata;
 import org.gradle.internal.resolve.resolver.ArtifactSelector;
 
-import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -143,7 +142,6 @@ public class DefaultLocalComponentGraphResolveState extends AbstractComponentGra
             return metadata.getModuleVersionId();
         }
 
-        @Nullable
         @Override
         public ModuleSources getSources() {
             return metadata.getSources();

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentGraphResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentGraphResolveState.java
@@ -22,22 +22,32 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.ExcludeSpec;
+import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.model.AbstractComponentGraphResolveState;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
+import org.gradle.internal.component.model.ComponentArtifactResolveMetadata;
+import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
+import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.internal.component.model.VariantArtifactGraphResolveMetadata;
 import org.gradle.internal.component.model.VariantArtifactResolveState;
 import org.gradle.internal.component.model.VariantGraphResolveMetadata;
 import org.gradle.internal.component.model.VariantResolveMetadata;
 import org.gradle.internal.resolve.resolver.ArtifactSelector;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
 
+/**
+ * Holds the resolution state for a local component. The state is calculated as required, and an instance can be used for multiple resolutions across a build tree.
+ *
+ * <p>The aim is to create only a single instance of this type per project and reuse that for all resolution that happens in a build tree. This isn't quite the case yet.
+ */
 public class DefaultLocalComponentGraphResolveState extends AbstractComponentGraphResolveState<LocalComponentMetadata, LocalComponentMetadata> implements LocalComponentGraphResolveState {
     private final ConcurrentMap<LocalConfigurationGraphResolveMetadata, DefaultLocalVariantArtifactResolveState> variants = new ConcurrentHashMap<>();
 
@@ -53,6 +63,11 @@ public class DefaultLocalComponentGraphResolveState extends AbstractComponentGra
 
     public DefaultLocalComponentGraphResolveState(LocalComponentMetadata metadata) {
         super(metadata, metadata);
+    }
+
+    @Override
+    public ComponentArtifactResolveMetadata getResolveMetadata() {
+        return new LocalComponentArtifactResolveMetadata(getMetadata());
     }
 
     @Override
@@ -93,7 +108,7 @@ public class DefaultLocalComponentGraphResolveState extends AbstractComponentGra
             LocalConfigurationMetadata configuration = graphSelectedVariant.prepareToResolveArtifacts();
             Set<? extends VariantResolveMetadata> fallbackVariants = configuration.getVariants();
             Optional<List<? extends VariantGraphResolveMetadata>> variantsForGraphTraversal = component.getVariantsForGraphTraversal();
-            return artifactSelector.resolveArtifacts(component, () -> buildAllVariants(fallbackVariants, variantsForGraphTraversal), fallbackVariants, exclusions, overriddenAttributes);
+            return artifactSelector.resolveArtifacts(new LocalComponentArtifactResolveMetadata(component), () -> buildAllVariants(fallbackVariants, variantsForGraphTraversal), fallbackVariants, exclusions, overriddenAttributes);
         }
 
         private static Set<? extends VariantResolveMetadata> buildAllVariants(Set<? extends VariantResolveMetadata> fallbackVariants, Optional<List<? extends VariantGraphResolveMetadata>> variantsForGraphTraversal) {
@@ -108,6 +123,45 @@ public class DefaultLocalComponentGraphResolveState extends AbstractComponentGra
                 allVariants = fallbackVariants;
             }
             return allVariants;
+        }
+    }
+
+    private static class LocalComponentArtifactResolveMetadata implements ComponentArtifactResolveMetadata {
+        private final LocalComponentMetadata metadata;
+
+        public LocalComponentArtifactResolveMetadata(LocalComponentMetadata metadata) {
+            this.metadata = metadata;
+        }
+
+        @Override
+        public ComponentIdentifier getId() {
+            return metadata.getId();
+        }
+
+        @Override
+        public ModuleVersionIdentifier getModuleVersionId() {
+            return metadata.getModuleVersionId();
+        }
+
+        @Nullable
+        @Override
+        public ModuleSources getSources() {
+            return metadata.getSources();
+        }
+
+        @Override
+        public ImmutableAttributes getAttributes() {
+            return metadata.getAttributes();
+        }
+
+        @Override
+        public AttributesSchemaInternal getAttributesSchema() {
+            return metadata.getAttributesSchema();
+        }
+
+        @Override
+        public ComponentResolveMetadata getMetadata() {
+            return metadata;
         }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/AbstractComponentGraphResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/AbstractComponentGraphResolveState.java
@@ -70,11 +70,11 @@ public abstract class AbstractComponentGraphResolveState<T extends ComponentGrap
     }
 
     public void resolveArtifactsWithType(ArtifactResolver artifactResolver, ArtifactType artifactType, BuildableArtifactSetResolveResult result) {
-        artifactResolver.resolveArtifactsWithType(artifactMetadata, artifactType, result);
+        artifactResolver.resolveArtifactsWithType(getResolveMetadata(), artifactType, result);
     }
 
     @Override
     public ArtifactSet prepareForArtifactResolution(ArtifactSelector artifactSelector, Collection<? extends ComponentArtifactMetadata> artifacts, ImmutableAttributes overriddenAttributes) {
-        return artifactSelector.resolveArtifacts(artifactMetadata, artifacts, overriddenAttributes);
+        return artifactSelector.resolveArtifacts(getResolveMetadata(), artifacts, overriddenAttributes);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentArtifactResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentArtifactResolveMetadata.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.component.model;
+
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.internal.attributes.AttributesSchemaInternal;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+
+import javax.annotation.Nullable;
+
+/**
+ * Metadata used to resolve artifacts of a component.
+ */
+public interface ComponentArtifactResolveMetadata {
+    ComponentIdentifier getId();
+
+    ModuleVersionIdentifier getModuleVersionId();
+
+    @Nullable
+    ModuleSources getSources();
+
+    ImmutableAttributes getAttributes();
+
+    AttributesSchemaInternal getAttributesSchema();
+
+    // Try to avoid using this, it's here to transition away from using ComponentResolveMetadata everywhere
+    ComponentResolveMetadata getMetadata();
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentArtifactResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentArtifactResolveState.java
@@ -40,13 +40,15 @@ import java.util.Collection;
  *
  * <p>This interface says nothing about thread safety, however some subtypes may be required to be thread safe.</p>
  *
- * <p>Instances of this type are located using {@link ComponentGraphResolveState#prepareForArtifactResolution()}.</p>
+ * <p>Instances of this type are created using {@link ComponentGraphResolveState#prepareForArtifactResolution()}.</p>
  */
 public interface ComponentArtifactResolveState {
     ComponentIdentifier getId();
 
     @Nullable
     ModuleSources getSources();
+
+    ComponentArtifactResolveMetadata getResolveMetadata();
 
     /**
      * Returns the state required to resolve artifacts, given a variant that was selected during graph resolution.

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentGraphResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentGraphResolveMetadata.java
@@ -64,4 +64,6 @@ public interface ComponentGraphResolveMetadata {
 
     @Nullable
     String getStatus();
+
+    boolean isMissing();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentGraphResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentGraphResolveState.java
@@ -27,7 +27,7 @@ import javax.annotation.Nullable;
  *
  * <p>Resolution happens in multiple steps. The first step is to calculate the dependency graph, which involves selecting component instances and one or more variants of each instance.
  * This type exposes only the information and operations required to do this. In particular, it does not expose any information about artifacts unless this is actually required for graph resolution,
- * which is only required in certain specific cases (and something we should deprecate).</p>
+ * which only happens in certain specific cases (and something we should deprecate).</p>
  *
  * <p>The subsequent resolution steps, to select artifacts, are performed using the instance returned by {@link #prepareForArtifactResolution()}.</p>
  *

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentResolveMetadata.java
@@ -61,7 +61,6 @@ public interface ComponentResolveMetadata extends HasAttributes {
     /**
      * @return the sources information for this component.
      */
-    @Nullable
     ModuleSources getSources();
 
     /**

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultComponentGraphResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultComponentGraphResolveState.java
@@ -26,7 +26,6 @@ import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 import org.gradle.internal.resolve.resolver.ArtifactSelector;
 
-import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -110,7 +109,6 @@ public class DefaultComponentGraphResolveState<T extends ComponentGraphResolveMe
             return metadata.getModuleVersionId();
         }
 
-        @Nullable
         @Override
         public ModuleSources getSources() {
             return metadata.getSources();

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/ArtifactResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/ArtifactResolver.java
@@ -15,11 +15,9 @@
  */
 package org.gradle.internal.resolve.resolver;
 
-import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.internal.component.ArtifactType;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
-import org.gradle.internal.component.model.ComponentResolveMetadata;
-import org.gradle.internal.component.model.ModuleSources;
+import org.gradle.internal.component.model.ComponentArtifactResolveMetadata;
 import org.gradle.internal.resolve.result.BuildableArtifactResolveResult;
 import org.gradle.internal.resolve.result.BuildableArtifactSetResolveResult;
 
@@ -27,11 +25,10 @@ public interface ArtifactResolver {
     /**
      * Discovers the set of artifacts belonging to the given component, with the type specified. Does not download the artifacts. Any failures are packaged up in the result.
      */
-    void resolveArtifactsWithType(ComponentResolveMetadata component, ArtifactType artifactType, BuildableArtifactSetResolveResult result);
+    void resolveArtifactsWithType(ComponentArtifactResolveMetadata component, ArtifactType artifactType, BuildableArtifactSetResolveResult result);
 
     /**
      * Resolves the given artifact. Any failures are packaged up in the result.
      */
-    void resolveArtifact(ModuleVersionIdentifier ownerId, ComponentArtifactMetadata artifact, ModuleSources moduleSources, BuildableArtifactResolveResult result);
-
+    void resolveArtifact(ComponentArtifactResolveMetadata component, ComponentArtifactMetadata artifact, BuildableArtifactResolveResult result);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/ArtifactSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/ArtifactSelector.java
@@ -21,7 +21,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.local.model.LocalFileDependencyMetadata;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
-import org.gradle.internal.component.model.ComponentResolveMetadata;
+import org.gradle.internal.component.model.ComponentArtifactResolveMetadata;
 import org.gradle.internal.component.model.VariantResolveMetadata;
 
 import java.util.Collection;
@@ -32,12 +32,12 @@ public interface ArtifactSelector {
     /**
      * Creates a set that will resolve the artifacts of the given configuration, minus those artifacts that are excluded.
      */
-    ArtifactSet resolveArtifacts(ComponentResolveMetadata component, Supplier<Set<? extends VariantResolveMetadata>> allVariants, Set<? extends VariantResolveMetadata> legacyVariants, ExcludeSpec exclusions, ImmutableAttributes overriddenAttributes);
+    ArtifactSet resolveArtifacts(ComponentArtifactResolveMetadata component, Supplier<Set<? extends VariantResolveMetadata>> allVariants, Set<? extends VariantResolveMetadata> legacyVariants, ExcludeSpec exclusions, ImmutableAttributes overriddenAttributes);
 
     /**
      * Creates a set that will resolve the given artifacts of the given component.
      */
-    ArtifactSet resolveArtifacts(ComponentResolveMetadata component, Collection<? extends ComponentArtifactMetadata> artifacts, ImmutableAttributes overriddenAttributes);
+    ArtifactSet resolveArtifacts(ComponentArtifactResolveMetadata component, Collection<? extends ComponentArtifactMetadata> artifacts, ImmutableAttributes overriddenAttributes);
 
     /**
      * Creates a set that will resolve the artifacts of the file dependency.

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/ComponentMetaDataResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/ComponentMetaDataResolver.java
@@ -20,9 +20,12 @@ import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.resolve.result.BuildableComponentResolveResult;
 
+/**
+ * Responsible for resolving a {@link ComponentIdentifier} to a {@link org.gradle.internal.component.model.ComponentGraphResolveState} instance for that component.
+ */
 public interface ComponentMetaDataResolver {
     /**
-     * Resolves the metadata for a component instance. Failures should be attached to the returned result.
+     * Resolves the resolution state for a component instance. Failures should be attached to the returned result.
      */
     void resolve(ComponentIdentifier identifier, ComponentOverrideMetadata componentOverrideMetadata, BuildableComponentResolveResult result);
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/DefaultArtifactSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/DefaultArtifactSelector.java
@@ -33,9 +33,8 @@ import org.gradle.internal.component.external.model.DefaultImmutableCapability;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.component.local.model.LocalFileDependencyMetadata;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
+import org.gradle.internal.component.model.ComponentArtifactResolveMetadata;
 import org.gradle.internal.component.model.ComponentArtifactResolveVariantState;
-import org.gradle.internal.component.model.ComponentResolveMetadata;
-import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.internal.component.model.VariantResolveMetadata;
 import org.gradle.internal.component.model.VariantWithOverloadAttributes;
 import org.gradle.internal.model.CalculatedValueContainerFactory;
@@ -68,12 +67,9 @@ public class DefaultArtifactSelector implements ArtifactSelector {
     }
 
     @Override
-    public ArtifactSet resolveArtifacts(ComponentResolveMetadata component, Supplier<Set<? extends VariantResolveMetadata>> allVariants, Set<? extends VariantResolveMetadata> legacyVariants, ExcludeSpec exclusions, ImmutableAttributes overriddenAttributes) {
-        ModuleVersionIdentifier moduleVersionId = component.getModuleVersionId();
-        ModuleSources sources = component.getSources();
-
-        ImmutableSet<ResolvedVariant> legacyResolvedVariants = buildResolvedVariants(moduleVersionId, sources, legacyVariants, exclusions);
-        ComponentArtifactResolveVariantState allResolvedVariants = () -> buildResolvedVariants(moduleVersionId, sources, allVariants.get(), exclusions);
+    public ArtifactSet resolveArtifacts(ComponentArtifactResolveMetadata component, Supplier<Set<? extends VariantResolveMetadata>> allVariants, Set<? extends VariantResolveMetadata> legacyVariants, ExcludeSpec exclusions, ImmutableAttributes overriddenAttributes) {
+        ImmutableSet<ResolvedVariant> legacyResolvedVariants = buildResolvedVariants(component, legacyVariants, exclusions);
+        ComponentArtifactResolveVariantState allResolvedVariants = () -> buildResolvedVariants(component, allVariants.get(), exclusions);
 
         for (OriginArtifactSelector selector : selectors) {
             ArtifactSet artifacts = selector.resolveArtifacts(component, allResolvedVariants, legacyResolvedVariants, exclusions, overriddenAttributes);
@@ -84,28 +80,29 @@ public class DefaultArtifactSelector implements ArtifactSelector {
         throw new IllegalStateException("No artifacts selected.");
     }
 
-    private ImmutableSet<ResolvedVariant> buildResolvedVariants(ModuleVersionIdentifier moduleVersionId, ModuleSources sources, Set<? extends VariantResolveMetadata> allVariants, ExcludeSpec exclusions) {
+    private ImmutableSet<ResolvedVariant> buildResolvedVariants(ComponentArtifactResolveMetadata component, Set<? extends VariantResolveMetadata> allVariants, ExcludeSpec exclusions) {
         ImmutableSet.Builder<ResolvedVariant> resolvedVariantBuilder = ImmutableSet.builder();
         for (VariantResolveMetadata variant : allVariants) {
-            ResolvedVariant resolvedVariant = toResolvedVariant(variant.getIdentifier(), variant.asDescribable(), variant.getAttributes(), variant.getArtifacts(), withImplicitCapability(variant.getCapabilities(), moduleVersionId), exclusions, moduleVersionId, sources, resolvedVariantCache, variant.isEligibleForCaching());
+            ResolvedVariant resolvedVariant = toResolvedVariant(variant.getIdentifier(), variant.asDescribable(), variant.getAttributes(), variant.getArtifacts(), withImplicitCapability(variant.getCapabilities(), component.getModuleVersionId()), exclusions, component, resolvedVariantCache, variant.isEligibleForCaching());
             resolvedVariantBuilder.add(resolvedVariant);
         }
         return resolvedVariantBuilder.build();
     }
 
-    private ResolvedVariant toResolvedVariant(VariantResolveMetadata.Identifier identifier,
-                                              DisplayName displayName,
-                                              ImmutableAttributes variantAttributes,
-                                              ImmutableList<? extends ComponentArtifactMetadata> artifacts,
-                                              ImmutableCapabilities capabilities,
-                                              ExcludeSpec exclusions,
-                                              ModuleVersionIdentifier ownerId,
-                                              ModuleSources moduleSources,
-                                              ResolvedVariantCache resolvedVariantCache,
-                                              boolean eligibleForCaching) {
+    private ResolvedVariant toResolvedVariant(
+        VariantResolveMetadata.Identifier identifier,
+        DisplayName displayName,
+        ImmutableAttributes variantAttributes,
+        ImmutableList<? extends ComponentArtifactMetadata> artifacts,
+        ImmutableCapabilities capabilities,
+        ExcludeSpec exclusions,
+        ComponentArtifactResolveMetadata component,
+        ResolvedVariantCache resolvedVariantCache,
+        boolean eligibleForCaching
+    ) {
         // artifactsToResolve are those not excluded by their owning module
         List<? extends ComponentArtifactMetadata> artifactsToResolve = CollectionUtils.filter(artifacts,
-                artifact -> !exclusions.excludesArtifact(ownerId.getModule(), artifact.getName())
+            artifact -> !exclusions.excludesArtifact(component.getModuleVersionId().getModule(), artifact.getName())
         );
 
         boolean hasExcludedArtifact = artifactsToResolve.size() < artifacts.size();
@@ -113,9 +110,9 @@ public class DefaultArtifactSelector implements ArtifactSelector {
 
         if (hasExcludedArtifact) {
             // An ad hoc variant, has no identifier
-            return ArtifactSetFactory.toResolvedVariant(null, displayName, attributes, artifactsToResolve, capabilities, ownerId, moduleSources, artifactResolver);
+            return ArtifactSetFactory.toResolvedVariant(null, displayName, attributes, artifactsToResolve, capabilities, component, artifactResolver);
         } else if (!eligibleForCaching) {
-            return ArtifactSetFactory.toResolvedVariant(identifier, displayName, attributes, artifactsToResolve, capabilities, ownerId, moduleSources, artifactResolver);
+            return ArtifactSetFactory.toResolvedVariant(identifier, displayName, attributes, artifactsToResolve, capabilities, component, artifactResolver);
         } else {
             // This is a bit of a hack because we allow the artifactType registry to be different in every resolution scope.
             // This means it's not safe to assume a variant resolved in one consumer can be reused in another consumer with the same key.
@@ -123,7 +120,7 @@ public class DefaultArtifactSelector implements ArtifactSelector {
             // It might be better to tighten this up by either requiring a single artifactType registry for the entire build or eliminating this feature
             // entirely.
             VariantWithOverloadAttributes key = new VariantWithOverloadAttributes(identifier, attributes);
-            return resolvedVariantCache.computeIfAbsent(key, id -> ArtifactSetFactory.toResolvedVariant(identifier, displayName, attributes, artifactsToResolve, capabilities, ownerId, moduleSources, artifactResolver));
+            return resolvedVariantCache.computeIfAbsent(key, id -> ArtifactSetFactory.toResolvedVariant(identifier, displayName, attributes, artifactsToResolve, capabilities, component, artifactResolver));
         }
     }
 
@@ -139,8 +136,8 @@ public class DefaultArtifactSelector implements ArtifactSelector {
     }
 
     @Override
-    public ArtifactSet resolveArtifacts(ComponentResolveMetadata component, Collection<? extends ComponentArtifactMetadata> artifacts, ImmutableAttributes overriddenAttributes) {
+    public ArtifactSet resolveArtifacts(ComponentArtifactResolveMetadata component, Collection<? extends ComponentArtifactMetadata> artifacts, ImmutableAttributes overriddenAttributes) {
         ImmutableAttributes attributes = artifactTypeRegistry.mapAttributesFor(component.getAttributes(), artifacts);
-        return ArtifactSetFactory.adHocVariant(component.getId(), component.getModuleVersionId(), artifacts, component.getSources(), component.getAttributesSchema(), artifactResolver, attributes, overriddenAttributes);
+        return ArtifactSetFactory.adHocVariant(component, artifacts, component.getAttributesSchema(), artifactResolver, attributes, overriddenAttributes);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/DependencyToComponentIdResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/DependencyToComponentIdResolver.java
@@ -22,6 +22,12 @@ import org.gradle.internal.resolve.result.BuildableComponentIdResolveResult;
 
 import javax.annotation.Nullable;
 
+/**
+ * Responsible for taking a dependency declaration and locating the matching component. The component can be returned either the resolution state for the component, if this state is cheaply available
+ * to this resolver, or an id for the component if not.
+ *
+ * <p>At some point in the future, this should resolve to a set of candidates rather than a single instance.
+ */
 public interface DependencyToComponentIdResolver {
     /**
      * Resolves the given dependency to a component instance. Failures should be attached to the result.

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/OriginArtifactSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/OriginArtifactSelector.java
@@ -20,8 +20,8 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.Artif
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.ExcludeSpec;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.internal.component.model.ComponentArtifactResolveMetadata;
 import org.gradle.internal.component.model.ComponentArtifactResolveVariantState;
-import org.gradle.internal.component.model.ComponentResolveMetadata;
 
 import javax.annotation.Nullable;
 import java.util.Set;
@@ -31,5 +31,5 @@ public interface OriginArtifactSelector {
      * Creates a set that will resolve the artifacts of the given configuration, minus those artifacts that are excluded.
      */
     @Nullable
-    ArtifactSet resolveArtifacts(ComponentResolveMetadata component, ComponentArtifactResolveVariantState allVariants, Set<ResolvedVariant> legacyVariants, ExcludeSpec exclusions, ImmutableAttributes overriddenAttributes);
+    ArtifactSet resolveArtifacts(ComponentArtifactResolveMetadata component, ComponentArtifactResolveVariantState allVariants, Set<ResolvedVariant> legacyVariants, ExcludeSpec exclusions, ImmutableAttributes overriddenAttributes);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/BuildableModuleComponentMetaDataResolveResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/BuildableModuleComponentMetaDataResolveResult.java
@@ -16,15 +16,16 @@
 
 package org.gradle.internal.resolve.result;
 
-import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 
 import javax.annotation.Nullable;
 
 /**
  * The result of attempting to resolve a component id to the meta-data for the component.
+ *
+ * @param <T> the resolution result type
  */
-public interface BuildableModuleComponentMetaDataResolveResult extends ResourceAwareResolveResult, ErroringResolveResult<ModuleVersionResolveException> {
+public interface BuildableModuleComponentMetaDataResolveResult<T> extends ResourceAwareResolveResult, ErroringResolveResult<ModuleVersionResolveException> {
     enum State {
         Resolved, Missing, Failed, Unknown, Redirect
     }
@@ -39,7 +40,7 @@ public interface BuildableModuleComponentMetaDataResolveResult extends ResourceA
      *
      * @throws ModuleVersionResolveException If the resolution was not successful.
      */
-    ModuleComponentResolveMetadata getMetaData() throws ModuleVersionResolveException;
+    T getMetaData() throws ModuleVersionResolveException;
 
     @Override
     @Nullable
@@ -48,12 +49,12 @@ public interface BuildableModuleComponentMetaDataResolveResult extends ResourceA
     /**
      * Marks the module version as resolved, with the given meta-data.
      */
-    void resolved(ModuleComponentResolveMetadata metaData);
+    void resolved(T metaData);
 
     /**
      * Replaces the meta-data for this result. Must be resolved.
      */
-    void setMetadata(ModuleComponentResolveMetadata metaData);
+    void setMetadata(T metaData);
 
     /**
      * Marks the resolve as failed with the given exception.

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachedMetadataProviderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachedMetadataProviderTest.groovy
@@ -16,24 +16,24 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve
 
+import org.gradle.internal.component.external.model.ModuleComponentGraphResolveState
 import org.gradle.internal.component.external.model.ivy.IvyModuleResolveMetadata
-import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata
 import org.gradle.internal.resolve.result.BuildableModuleComponentMetaDataResolveResult
 import spock.lang.Specification
 import spock.lang.Subject
 
 class CachedMetadataProviderTest extends Specification {
 
-    BuildableModuleComponentMetaDataResolveResult cachedResult = Mock()
+    def cachedResult = Stub(BuildableModuleComponentMetaDataResolveResult)
+    def componentState = Stub(ModuleComponentGraphResolveState)
     @Subject
     CachedMetadataProvider provider
-
 
     def 'verifies that metadata was provided when state is Resolved'() {
         given:
         cachedResult.state >> BuildableModuleComponentMetaDataResolveResult.State.Resolved
+        cachedResult.metaData >> componentState
         provider = new CachedMetadataProvider(cachedResult)
-
 
         expect:
         provider.usable
@@ -56,9 +56,9 @@ class CachedMetadataProviderTest extends Specification {
     def 'returns IvyModuleDescriptor when available'() {
         given:
         cachedResult.state >> BuildableModuleComponentMetaDataResolveResult.State.Resolved
-        cachedResult.metaData >> Mock(IvyModuleResolveMetadata)
+        cachedResult.metaData >> componentState
+        componentState.moduleResolveMetadata >> Mock(IvyModuleResolveMetadata)
         provider = new CachedMetadataProvider(cachedResult)
-
 
         expect:
         provider.ivyModuleDescriptor
@@ -67,9 +67,8 @@ class CachedMetadataProviderTest extends Specification {
     def 'returns null for IvyModuleDescriptor when not available'() {
         given:
         cachedResult.state >> BuildableModuleComponentMetaDataResolveResult.State.Resolved
-        cachedResult.metaData >> Mock(ModuleComponentResolveMetadata)
+        cachedResult.metaData >> componentState
         provider = new CachedMetadataProvider(cachedResult)
-
 
         expect:
         !provider.ivyModuleDescriptor

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepositoryTest.groovy
@@ -31,6 +31,7 @@ import org.gradle.api.internal.artifacts.repositories.resolver.MetadataFetchingC
 import org.gradle.api.internal.component.ArtifactType
 import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata
+import org.gradle.internal.component.external.model.ModuleComponentGraphResolveState
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata
 import org.gradle.internal.component.external.model.ModuleDependencyMetadata
 import org.gradle.internal.component.model.ComponentArtifactMetadata
@@ -191,8 +192,10 @@ class CachingModuleComponentRepositoryTest extends Specification {
             isMustCheck() >> mustRefreshChangingModule
         }
         moduleDescriptorCache.getCachedModuleDescriptor(_, module) >> Stub(ModuleMetadataCache.CachedMetadata) {
-            getProcessedMetadata(_) >> Stub(ModuleComponentResolveMetadata) {
-                isChanging() >> true
+            getProcessedMetadata(_) >> Stub(ModuleComponentGraphResolveState) {
+                getMetadata() >> Stub(ModuleComponentResolveMetadata) {
+                    isChanging() >> true
+                }
             }
             getAge() >> Duration.ofMillis(100)
         }
@@ -221,7 +224,7 @@ class CachingModuleComponentRepositoryTest extends Specification {
             isMustCheck() >> mustRefreshModule
         }
         moduleDescriptorCache.getCachedModuleDescriptor(_, module) >> Stub(ModuleMetadataCache.CachedMetadata) {
-            getProcessedMetadata(_) >> Stub(ModuleComponentResolveMetadata)
+            getProcessedMetadata(_) >> Stub(ModuleComponentGraphResolveState)
             getAge() >> Duration.ofMillis(100)
         }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/CachingModuleComponentRepositoryTest.groovy
@@ -119,8 +119,8 @@ class CachingModuleComponentRepositoryTest extends Specification {
         repo.localAccess.resolveComponentMetaData(componentId, prescribedMetaData, result)
 
         then:
-        realLocalAccess.resolveComponentMetaData(componentId, prescribedMetaData, result) >> {
-            result.resolved(Mock(ModuleComponentResolveMetadata))
+        1 * realLocalAccess.resolveComponentMetaData(componentId, prescribedMetaData, _) >> { id, m, r ->
+            r.resolved(Mock(ModuleComponentResolveMetadata))
         }
         0 * _
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultMetadataProviderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultMetadataProviderTest.groovy
@@ -32,6 +32,7 @@ import org.gradle.cache.scopes.GlobalScopedCacheBuilderFactory
 import org.gradle.internal.action.DefaultConfigurableRule
 import org.gradle.internal.action.DefaultConfigurableRules
 import org.gradle.internal.action.InstantiatingAction
+import org.gradle.internal.component.external.model.ModuleComponentGraphResolveState
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata
 import org.gradle.internal.component.external.model.ivy.IvyModuleResolveMetadata
 import org.gradle.internal.resolve.caching.ComponentMetadataSupplierRuleExecutor
@@ -52,6 +53,9 @@ class DefaultMetadataProviderTest extends Specification {
         getVersion() >> "1.2"
     }
     def metaData = Stub(ModuleComponentResolveMetadata)
+    def componentState = Stub(ModuleComponentGraphResolveState) {
+        getModuleResolveMetadata() >> metaData
+    }
     def resolveState = Mock(ModuleComponentResolveState)
     def metadataProvider = new DefaultMetadataProvider(resolveState)
     def cachePolicy = new DefaultCachePolicy()
@@ -71,7 +75,7 @@ class DefaultMetadataProviderTest extends Specification {
         then:
         1 * resolveState.resolve() >> {
             def result = new DefaultBuildableModuleComponentMetaDataResolveResult()
-            result.resolved(metaData)
+            result.resolved(componentState)
             return result
         }
         0 * resolveState.resolve()
@@ -81,7 +85,7 @@ class DefaultMetadataProviderTest extends Specification {
         given:
         resolveState.resolve() >> {
             def result = new DefaultBuildableModuleComponentMetaDataResolveResult()
-            result.resolved(metaData)
+            result.resolved(componentState)
             return result
         }
 
@@ -108,7 +112,7 @@ class DefaultMetadataProviderTest extends Specification {
         resolveState.id >> Stub(ModuleComponentIdentifier)
         resolveState.resolve() >> {
             def result = new DefaultBuildableModuleComponentMetaDataResolveResult()
-            result.resolved(metaData)
+            result.resolved(componentState)
             return result
         }
 
@@ -129,9 +133,12 @@ class DefaultMetadataProviderTest extends Specification {
         metaData.branch >> "branchValue"
         metaData.extraAttributes >> ImmutableMap.copyOf(extraInfo)
 
+        def componentState = Stub(ModuleComponentGraphResolveState)
+        componentState.moduleResolveMetadata >> metaData
+
         resolveState.resolve() >> {
             def result = new DefaultBuildableModuleComponentMetaDataResolveResult()
-            result.resolved(metaData)
+            result.resolved(componentState)
             return result
         }
 
@@ -148,7 +155,7 @@ class DefaultMetadataProviderTest extends Specification {
         given:
         resolveState.resolve() >> {
             def result = new DefaultBuildableModuleComponentMetaDataResolveResult()
-            result.resolved(metaData)
+            result.resolved(componentState)
             return result
         }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultVersionedComponentChooserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultVersionedComponentChooserTest.groovy
@@ -28,9 +28,10 @@ import org.gradle.api.internal.attributes.DefaultAttributesSchema
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.specs.Specs
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
+import org.gradle.internal.component.external.model.ModuleComponentGraphResolveState
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata
 import org.gradle.internal.component.model.AttributeMatcher
-import org.gradle.internal.component.model.ComponentResolveMetadata
+import org.gradle.internal.component.model.ComponentGraphResolveMetadata
 import org.gradle.internal.resolve.ModuleVersionResolveException
 import org.gradle.internal.resolve.caching.ComponentMetadataSupplierRuleExecutor
 import org.gradle.internal.resolve.result.ComponentSelectionContext
@@ -54,13 +55,13 @@ class DefaultVersionedComponentChooserTest extends Specification {
     def chooser = new DefaultVersionedComponentChooser(versionComparator, versionParser, componentSelectionRules, attributesSchema)
 
     def "chooses latest version for component meta data"() {
-        def one = Stub(ComponentResolveMetadata) {
+        def one = Stub(ComponentGraphResolveMetadata) {
             getModuleVersionId() >> DefaultModuleVersionIdentifier.newId("group", "name", "1.0")
         }
-        def two = Stub(ComponentResolveMetadata) {
+        def two = Stub(ComponentGraphResolveMetadata) {
             getModuleVersionId() >> DefaultModuleVersionIdentifier.newId("group", "name", "1.1")
         }
-        def three = Stub(ComponentResolveMetadata) {
+        def three = Stub(ComponentGraphResolveMetadata) {
             getModuleVersionId() >> DefaultModuleVersionIdentifier.newId("group", "name", "1.2")
         }
 
@@ -78,10 +79,10 @@ class DefaultVersionedComponentChooserTest extends Specification {
     }
 
     def "chooses non-generated descriptor over generated"() {
-        def one = Mock(ComponentResolveMetadata) {
+        def one = Mock(ComponentGraphResolveMetadata) {
             getModuleVersionId() >> DefaultModuleVersionIdentifier.newId("group", "name", "1.0")
         }
-        def two = Mock(ComponentResolveMetadata) {
+        def two = Mock(ComponentGraphResolveMetadata) {
             getModuleVersionId() >> DefaultModuleVersionIdentifier.newId("group", "name", "1.0")
         }
 
@@ -364,8 +365,11 @@ class DefaultVersionedComponentChooserTest extends Specification {
             getStatus() >> status
             getAttributes() >> AttributeTestUtil.attributes(attributes)
         }
+        def state = Stub(ModuleComponentGraphResolveState) {
+            getModuleResolveMetadata() >> meta
+        }
         def result = new DefaultBuildableModuleComponentMetaDataResolveResult()
-        result.resolved(meta)
+        result.resolved(state)
         return result
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingArtifactResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingArtifactResolverTest.groovy
@@ -18,12 +18,9 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve
 
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier
 import org.gradle.api.artifacts.component.ComponentIdentifier
-import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.component.ArtifactType
 import org.gradle.internal.component.model.ComponentArtifactMetadata
-import org.gradle.internal.component.model.ComponentResolveMetadata
-import org.gradle.internal.component.model.ImmutableModuleSources
-import org.gradle.internal.component.model.ModuleSource
+import org.gradle.internal.component.model.ComponentArtifactResolveMetadata
 import org.gradle.internal.resolve.ArtifactResolveException
 import org.gradle.internal.resolve.resolver.ArtifactResolver
 import org.gradle.internal.resolve.result.BuildableArtifactResolveResult
@@ -35,22 +32,21 @@ class ErrorHandlingArtifactResolverTest extends Specification {
     def artifactResolver = new ErrorHandlingArtifactResolver(delegate)
 
     def "wraps resolveArtifact exception as failure"() {
-        def moduleVersionId = DefaultModuleVersionIdentifier.newId("org", "name", "1.0")
         def componentArtifactId = Stub(ComponentArtifactIdentifier) {
             getDisplayName() >> "<component-artifact>"
         }
         def componentArtifact = Stub(ComponentArtifactMetadata) {
             getId() >> componentArtifactId
         }
-        def moduleSources = ImmutableModuleSources.of(Mock(ModuleSource))
+        def component = Stub(ComponentArtifactResolveMetadata)
         def artifactResolveResult = Mock(BuildableArtifactResolveResult)
         def failure = new RuntimeException("foo")
 
         when:
-        delegate.resolveArtifact(moduleVersionId, componentArtifact, moduleSources, artifactResolveResult) >> { throw failure }
+        delegate.resolveArtifact(component, componentArtifact, artifactResolveResult) >> { throw failure }
 
         and:
-        artifactResolver.resolveArtifact(moduleVersionId, componentArtifact, moduleSources, artifactResolveResult)
+        artifactResolver.resolveArtifact(component, componentArtifact, artifactResolveResult)
 
         then:
         1 * artifactResolveResult.failed(_ as ArtifactResolveException) >> { ArtifactResolveException e ->
@@ -63,7 +59,7 @@ class ErrorHandlingArtifactResolverTest extends Specification {
         def componentId = Stub(ComponentIdentifier) {
             getDisplayName() >> "<component>"
         }
-        def component = Stub(ComponentResolveMetadata) {
+        def component = Stub(ComponentArtifactResolveMetadata) {
             getId() >> componentId
         }
         def result = Mock(BuildableArtifactSetResolveResult)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainArtifactResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainArtifactResolverTest.groovy
@@ -20,6 +20,7 @@ import com.google.common.collect.Maps
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.internal.component.external.model.DefaultModuleComponentArtifactMetadata
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
+import org.gradle.internal.component.model.ComponentArtifactResolveMetadata
 import org.gradle.internal.component.model.DefaultIvyArtifactName
 import org.gradle.internal.component.model.ImmutableModuleSources
 import org.gradle.internal.model.CalculatedValueContainerFactory
@@ -52,6 +53,9 @@ class RepositoryChainArtifactResolverTest extends Specification {
     final repo2Source = new RepositoryChainModuleSource(repo2)
 
     final moduleSources = ImmutableModuleSources.of(repo2Source)
+    final component = Stub(ComponentArtifactResolveMetadata) {
+        getSources() >> moduleSources
+    }
 
     final resolver = new RepositoryChainArtifactResolver(calculatedValueContainerFactory)
 
@@ -62,7 +66,7 @@ class RepositoryChainArtifactResolverTest extends Specification {
 
     def "locates artifact with local access in repository defined by module source"() {
         when:
-        resolver.resolveArtifact(moduleVersionId, artifact, moduleSources, result)
+        resolver.resolveArtifact(component, artifact, result)
         then:
         result.hasResult()
         cache.size() == 1
@@ -81,7 +85,7 @@ class RepositoryChainArtifactResolverTest extends Specification {
         result.result.file == artifactFile
 
         when:
-        resolver.resolveArtifact(moduleVersionId, artifact, moduleSources, result)
+        resolver.resolveArtifact(component, artifact, result)
         then:
         result.hasResult()
         result.result.file == artifactFile
@@ -91,7 +95,7 @@ class RepositoryChainArtifactResolverTest extends Specification {
 
     def "locates artifact with remote access in repository defined by module source"() {
         when:
-        resolver.resolveArtifact(moduleVersionId, artifact, moduleSources, result)
+        resolver.resolveArtifact(component, artifact, result)
         then:
         result.hasResult()
         cache.size() == 1
@@ -113,7 +117,7 @@ class RepositoryChainArtifactResolverTest extends Specification {
         result.result.file == artifactFile
 
         when:
-        resolver.resolveArtifact(moduleVersionId, artifact, moduleSources, result)
+        resolver.resolveArtifact(component, artifact, result)
         then:
         result.hasResult()
         result.result.file == artifactFile

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainComponentMetaDataResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainComponentMetaDataResolverTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.artifacts.ModuleVersionSelector
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
+import org.gradle.internal.component.external.model.ModuleComponentGraphResolveState
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata
 import org.gradle.internal.component.model.ComponentGraphResolveState
 import org.gradle.internal.component.model.ComponentOverrideMetadata
@@ -28,9 +29,12 @@ import org.gradle.internal.resolve.ModuleVersionResolveException
 import org.gradle.internal.resolve.result.BuildableComponentResolveResult
 import spock.lang.Specification
 
-class ResolverProviderComponentMetaDataResolverTest extends Specification {
+class RepositoryChainComponentMetaDataResolverTest extends Specification {
     final org.gradle.internal.Factory<String> broken = { "broken" }
     final metaData = metaData("1.2")
+    final componentState = Stub(ModuleComponentGraphResolveState) {
+        getModuleResolveMetadata() >> metaData
+    }
     final moduleComponentId = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "project"), "1.0")
     final componentRequestMetaData = Mock(ComponentOverrideMetadata)
 
@@ -70,10 +74,10 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
 
         then:
         1 * localAccess.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _) >> { id, meta, result ->
-            result.resolved(metaData)
+            result.resolved(componentState)
         }
         1 * result.resolved(_) >> { ComponentGraphResolveState state ->
-            assert state.metadata == this.metaData
+            assert state == componentState
         }
 
         and:
@@ -92,10 +96,10 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
         then:
         1 * localAccess.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _)
         1 * remoteAccess.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _) >> { id, meta, result ->
-            result.resolved(metaData)
+            result.resolved(componentState)
         }
         1 * result.resolved(_) >> { ComponentGraphResolveState state ->
-            assert state.metadata == this.metaData
+            assert state == componentState
         }
 
         and:
@@ -117,10 +121,10 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
             result.authoritative = false
         }
         1 * remoteAccess.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _) >> { id, meta, result ->
-            result.resolved(metaData)
+            result.resolved(componentState)
         }
         1 * result.resolved(_) >> { ComponentGraphResolveState state ->
-            assert state.metadata == this.metaData
+            assert state == componentState
         }
 
         and:
@@ -186,10 +190,10 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
 
         then:
         1 * localAccess.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _) >> { id, meta, result ->
-            result.resolved(metaData)
+            result.resolved(componentState)
         }
         1 * result.resolved(_) >> { ComponentGraphResolveState state ->
-            assert state.metadata == this.metaData
+            assert state == componentState
         }
 
         and:
@@ -213,10 +217,10 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
             result.missing()
         }
         1 * localAccess2.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _) >> { id, meta, result ->
-            result.resolved(metaData)
+            result.resolved(componentState)
         }
         1 * result.resolved(_) >> { ComponentGraphResolveState state ->
-            assert state.metadata == this.metaData
+            assert state == componentState
         }
 
         and:
@@ -241,10 +245,10 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
             result.authoritative = false
         }
         1 * localAccess2.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _) >> { id, meta, result ->
-            result.resolved(metaData)
+            result.resolved(componentState)
         }
         1 * result.resolved(_) >> { ComponentGraphResolveState state ->
-            assert state.metadata == this.metaData
+            assert state == componentState
         }
 
         and:
@@ -270,10 +274,10 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
         }
         1 * localAccess2.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _)
         1 * remoteAccess2.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _) >> { id, meta, result ->
-            result.resolved(metaData)
+            result.resolved(componentState)
         }
         1 * result.resolved(_) >> { ComponentGraphResolveState state ->
-            assert state.metadata == this.metaData
+            assert state == componentState
         }
 
         and:
@@ -305,10 +309,10 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
             result.missing()
         }
         1 * remoteAccess2.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _) >> { id, meta, result ->
-            result.resolved(metaData)
+            result.resolved(componentState)
         }
         1 * result.resolved(_) >> { ComponentGraphResolveState state ->
-            assert state.metadata == this.metaData
+            assert state == componentState
         }
 
         and:
@@ -336,10 +340,10 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
             result.authoritative = false
         }
         1 * remoteAccess2.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _) >> { id, meta, result ->
-            result.resolved(metaData)
+            result.resolved(componentState)
         }
         1 * result.resolved(_) >> { ComponentGraphResolveState state ->
-            assert state.metadata == this.metaData
+            assert state == componentState
         }
 
         and:
@@ -368,10 +372,10 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
             result.missing()
         }
         1 * remoteAccess.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _) >> { id, meta, result ->
-            result.resolved(metaData)
+            result.resolved(componentState)
         }
         1 * result.resolved(_) >> { ComponentGraphResolveState state ->
-            assert state.metadata == this.metaData
+            assert state == componentState
         }
 
         and:
@@ -395,10 +399,10 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
             result.failed(new ModuleVersionResolveException(id, broken))
         }
         1 * localAccess2.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _) >> { id, meta, result ->
-            result.resolved(metaData)
+            result.resolved(componentState)
         }
         1 * result.resolved(_) >> { ComponentGraphResolveState state ->
-            assert state.metadata == this.metaData
+            assert state == componentState
         }
 
         and:
@@ -424,10 +428,10 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
         }
         1 * localAccess2.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _)
         1 * remoteAccess2.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _) >> { id, meta, result ->
-            result.resolved(metaData)
+            result.resolved(componentState)
         }
         1 * result.resolved(_) >> { ComponentGraphResolveState state ->
-            assert state.metadata == this.metaData
+            assert state == componentState
         }
 
         and:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolverProviderComponentMetaDataResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolverProviderComponentMetaDataResolverTest.groovy
@@ -16,13 +16,10 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve
 
-import org.apache.ivy.core.module.descriptor.ModuleDescriptor
-import org.gradle.api.Transformer
-import org.gradle.api.artifacts.ModuleVersionIdentifier
+
 import org.gradle.api.artifacts.ModuleVersionSelector
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
-import org.gradle.api.internal.artifacts.ivyservice.IvyUtil
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata
 import org.gradle.internal.component.model.ComponentGraphResolveState
@@ -37,7 +34,6 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
     final moduleComponentId = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "project"), "1.0")
     final componentRequestMetaData = Mock(ComponentOverrideMetadata)
 
-    final Transformer<ModuleComponentResolveMetadata, RepositoryChainModuleResolution> transformer = Mock(Transformer)
     final result = Mock(BuildableComponentResolveResult)
     def localAccess = Mock(ModuleComponentRepositoryAccess)
     def remoteAccess = Mock(ModuleComponentRepositoryAccess)
@@ -45,12 +41,7 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
     def remoteAccess2 = Mock(ModuleComponentRepositoryAccess)
 
     final VersionedComponentChooser componentSelectionStrategy = Mock(VersionedComponentChooser)
-    final RepositoryChainComponentMetaDataResolver resolver = new RepositoryChainComponentMetaDataResolver(componentSelectionStrategy, transformer)
-
-    ModuleVersionIdentifier moduleVersionIdentifier(ModuleDescriptor moduleDescriptor) {
-        def moduleRevId = moduleDescriptor.moduleRevisionId
-        DefaultModuleVersionIdentifier.newId(DefaultModuleIdentifier.newId(moduleRevId.organisation, moduleRevId.name), moduleRevId.revision)
-    }
+    final RepositoryChainComponentMetaDataResolver resolver = new RepositoryChainComponentMetaDataResolver(componentSelectionStrategy)
 
     def addRepo1() {
         addModuleComponentRepository("repo1", localAccess, remoteAccess)
@@ -81,11 +72,6 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
         1 * localAccess.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _) >> { id, meta, result ->
             result.resolved(metaData)
         }
-        1 * transformer.transform(_) >> { RepositoryChainModuleResolution it ->
-            assert it.module == metaData
-            assert it.repository == repo
-            metaData
-        }
         1 * result.resolved(_) >> { ComponentGraphResolveState state ->
             assert state.metadata == this.metaData
         }
@@ -107,11 +93,6 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
         1 * localAccess.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _)
         1 * remoteAccess.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _) >> { id, meta, result ->
             result.resolved(metaData)
-        }
-        1 * transformer.transform(_) >> { RepositoryChainModuleResolution it ->
-            assert it.module == metaData
-            assert it.repository == repo
-            metaData
         }
         1 * result.resolved(_) >> { ComponentGraphResolveState state ->
             assert state.metadata == this.metaData
@@ -137,11 +118,6 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
         }
         1 * remoteAccess.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _) >> { id, meta, result ->
             result.resolved(metaData)
-        }
-        1 * transformer.transform(_) >> { RepositoryChainModuleResolution it ->
-            assert it.module == metaData
-            assert it.repository == repo
-            metaData
         }
         1 * result.resolved(_) >> { ComponentGraphResolveState state ->
             assert state.metadata == this.metaData
@@ -212,11 +188,6 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
         1 * localAccess.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _) >> { id, meta, result ->
             result.resolved(metaData)
         }
-        1 * transformer.transform(_) >> { RepositoryChainModuleResolution it ->
-            assert it.module == metaData
-            assert it.repository == repo1
-            metaData
-        }
         1 * result.resolved(_) >> { ComponentGraphResolveState state ->
             assert state.metadata == this.metaData
         }
@@ -243,11 +214,6 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
         }
         1 * localAccess2.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _) >> { id, meta, result ->
             result.resolved(metaData)
-        }
-        1 * transformer.transform(_) >> { RepositoryChainModuleResolution it ->
-            assert it.module == metaData
-            assert it.repository == repo2
-            metaData
         }
         1 * result.resolved(_) >> { ComponentGraphResolveState state ->
             assert state.metadata == this.metaData
@@ -277,11 +243,6 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
         1 * localAccess2.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _) >> { id, meta, result ->
             result.resolved(metaData)
         }
-        1 * transformer.transform(_) >> { RepositoryChainModuleResolution it ->
-            assert it.module == metaData
-            assert it.repository == repo2
-            metaData
-        }
         1 * result.resolved(_) >> { ComponentGraphResolveState state ->
             assert state.metadata == this.metaData
         }
@@ -310,11 +271,6 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
         1 * localAccess2.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _)
         1 * remoteAccess2.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _) >> { id, meta, result ->
             result.resolved(metaData)
-        }
-        1 * transformer.transform(_) >> { RepositoryChainModuleResolution it ->
-            assert it.module == metaData
-            assert it.repository == repo2
-            metaData
         }
         1 * result.resolved(_) >> { ComponentGraphResolveState state ->
             assert state.metadata == this.metaData
@@ -351,11 +307,6 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
         1 * remoteAccess2.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _) >> { id, meta, result ->
             result.resolved(metaData)
         }
-        1 * transformer.transform(_) >> { RepositoryChainModuleResolution it ->
-            assert it.module == metaData
-            assert it.repository == repo2
-            metaData
-        }
         1 * result.resolved(_) >> { ComponentGraphResolveState state ->
             assert state.metadata == this.metaData
         }
@@ -386,11 +337,6 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
         }
         1 * remoteAccess2.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _) >> { id, meta, result ->
             result.resolved(metaData)
-        }
-        1 * transformer.transform(_) >> { RepositoryChainModuleResolution it ->
-            assert it.module == metaData
-            assert it.repository == repo2
-            metaData
         }
         1 * result.resolved(_) >> { ComponentGraphResolveState state ->
             assert state.metadata == this.metaData
@@ -424,11 +370,6 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
         1 * remoteAccess.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _) >> { id, meta, result ->
             result.resolved(metaData)
         }
-        1 * transformer.transform(_) >> { RepositoryChainModuleResolution it ->
-            assert it.module == metaData
-            assert it.repository == repo1
-            metaData
-        }
         1 * result.resolved(_) >> { ComponentGraphResolveState state ->
             assert state.metadata == this.metaData
         }
@@ -455,11 +396,6 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
         }
         1 * localAccess2.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _) >> { id, meta, result ->
             result.resolved(metaData)
-        }
-        1 * transformer.transform(_) >> { RepositoryChainModuleResolution it ->
-            assert it.module == metaData
-            assert it.repository == repo2
-            metaData
         }
         1 * result.resolved(_) >> { ComponentGraphResolveState state ->
             assert state.metadata == this.metaData
@@ -489,11 +425,6 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
         1 * localAccess2.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _)
         1 * remoteAccess2.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _) >> { id, meta, result ->
             result.resolved(metaData)
-        }
-        1 * transformer.transform(_) >> { RepositoryChainModuleResolution it ->
-            assert it.module == metaData
-            assert it.repository == repo2
-            metaData
         }
         1 * result.resolved(_) >> { ComponentGraphResolveState state ->
             assert state.metadata == this.metaData
@@ -562,17 +493,10 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
         0 * result._
     }
 
-    def descriptor(String version) {
-        def descriptor = Stub(ModuleDescriptor)
-        descriptor.resolvedModuleRevisionId >> IvyUtil.createModuleRevisionId("org", "module", version)
-        return descriptor
-    }
-
     def metaData(String version) {
         return Stub(ModuleComponentResolveMetadata) {
             toString() >> version
             getId() >> DefaultModuleVersionIdentifier.newId("org", "module", version)
-            getDescriptor() >> descriptor(version)
         }
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyResolverTest.groovy
@@ -39,7 +39,7 @@ class ProjectDependencyResolverTest extends Specification {
     final ComponentIdentifierFactory componentIdentifierFactory = Mock()
     final ProjectStateRegistry projectRegistry = Stub()
     final ProjectArtifactResolver projectArtifactResolver = Stub()
-    final ProjectDependencyResolver resolver = new ProjectDependencyResolver(registry, componentIdentifierFactory, projectArtifactResolver)
+    final ProjectDependencyResolver resolver = new ProjectDependencyResolver(registry, projectArtifactResolver)
 
     def setup() {
         def projectState = Stub(ProjectState)
@@ -61,7 +61,6 @@ class ProjectDependencyResolverTest extends Specification {
         resolver.resolve(dependencyMetaData, null, null, result)
 
         then:
-        1 * componentIdentifierFactory.createProjectComponentIdentifier(selector) >> id
         1 * registry.getComponent(id) >> componentState
         1 * result.resolved(componentState)
         0 * result._

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSetTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSetTest.groovy
@@ -26,10 +26,11 @@ import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry
 import org.gradle.api.internal.attributes.AttributesSchemaInternal
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.internal.Describables
+import org.gradle.internal.component.external.model.DefaultImmutableCapability
 import org.gradle.internal.component.external.model.DefaultModuleComponentArtifactIdentifier
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.external.model.ImmutableCapabilities
-import org.gradle.internal.component.external.model.DefaultImmutableCapability
+import org.gradle.internal.component.model.ComponentArtifactResolveMetadata
 import org.gradle.internal.component.model.DefaultIvyArtifactName
 import spock.lang.Specification
 
@@ -37,6 +38,7 @@ class DefaultArtifactSetTest extends Specification {
     def componentId = Stub(ComponentIdentifier)
     def schema = Stub(AttributesSchemaInternal)
     def artifactTypeRegistry = Stub(ArtifactTypeRegistry)
+    def component = Stub(ComponentArtifactResolveMetadata)
 
     def setup() {
         artifactTypeRegistry.mapAttributesFor(_) >> ImmutableAttributes.EMPTY
@@ -50,7 +52,7 @@ class DefaultArtifactSetTest extends Specification {
         given:
         def artifacts1 = ArtifactSetFactory.createFromVariantMetadata(componentId, () -> ([variant1, variant2] as Set), [variant1, variant2] as Set, schema, ImmutableAttributes.EMPTY)
         def artifacts2 = ArtifactSetFactory.createFromVariantMetadata(componentId, () -> ([variant1] as Set), [variant1] as Set, schema, ImmutableAttributes.EMPTY)
-        def artifacts3 = ArtifactSetFactory.adHocVariant(componentId, ownerId, [] as Set, null, schema, null, ImmutableAttributes.EMPTY, ImmutableAttributes.EMPTY)
+        def artifacts3 = ArtifactSetFactory.adHocVariant(component, [] as Set, schema, null, ImmutableAttributes.EMPTY, ImmutableAttributes.EMPTY)
 
         ownerId.group >> "group"
         ownerId.name >> "name"
@@ -107,7 +109,7 @@ class DefaultArtifactSetTest extends Specification {
         given:
         def artifacts1 = ArtifactSetFactory.createFromVariantMetadata(componentId, () -> ([variant1, variant2] as Set), [variant1, variant2] as Set, schema, ImmutableAttributes.EMPTY)
         def artifacts2 = ArtifactSetFactory.createFromVariantMetadata(componentId, () -> ([variant1] as Set), [variant1] as Set, schema, ImmutableAttributes.EMPTY)
-        def artifacts3 = ArtifactSetFactory.adHocVariant(componentId, ownerId, [] as Set, null, schema, null, ImmutableAttributes.EMPTY, ImmutableAttributes.EMPTY)
+        def artifacts3 = ArtifactSetFactory.adHocVariant(component, [] as Set, schema, null, ImmutableAttributes.EMPTY, ImmutableAttributes.EMPTY)
 
         selector.select(_, _) >> resolvedVariant1
         ownerId.group >> "group"

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/TestResolver.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/TestResolver.java
@@ -55,7 +55,7 @@ public class TestResolver extends ExternalResourceResolver<ModuleComponentResolv
     }
 
     @Override
-    public ModuleComponentRepositoryAccess getLocalAccess() {
+    public ModuleComponentRepositoryAccess<ModuleComponentResolveMetadata> getLocalAccess() {
         throw new UnsupportedOperationException();
     }
 
@@ -65,7 +65,7 @@ public class TestResolver extends ExternalResourceResolver<ModuleComponentResolv
     }
 
     @Override
-    public ModuleComponentRepositoryAccess getRemoteAccess() {
+    public ModuleComponentRepositoryAccess<ModuleComponentResolveMetadata> getRemoteAccess() {
         return new RemoteRepositoryAccess() {
 
             @Override

--- a/subprojects/version-control/src/main/java/org/gradle/vcs/internal/resolver/VcsDependencyResolver.java
+++ b/subprojects/version-control/src/main/java/org/gradle/vcs/internal/resolver/VcsDependencyResolver.java
@@ -34,10 +34,9 @@ import org.gradle.internal.build.IncludedBuildState;
 import org.gradle.internal.build.PublicBuildPath;
 import org.gradle.internal.component.local.model.LocalComponentGraphResolveState;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
+import org.gradle.internal.component.model.ComponentArtifactResolveMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
-import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
-import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.internal.resolve.ModuleVersionNotFoundException;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 import org.gradle.internal.resolve.resolver.ArtifactResolver;
@@ -175,10 +174,10 @@ public class VcsDependencyResolver implements DependencyToComponentIdResolver, C
     }
 
     @Override
-    public void resolveArtifactsWithType(ComponentResolveMetadata component, ArtifactType artifactType, BuildableArtifactSetResolveResult result) {
+    public void resolveArtifactsWithType(ComponentArtifactResolveMetadata component, ArtifactType artifactType, BuildableArtifactSetResolveResult result) {
     }
 
     @Override
-    public void resolveArtifact(ModuleVersionIdentifier ownerId, ComponentArtifactMetadata artifact, ModuleSources moduleSources, BuildableArtifactResolveResult result) {
+    public void resolveArtifact(ComponentArtifactResolveMetadata component, ComponentArtifactMetadata artifact, BuildableArtifactResolveResult result) {
     }
 }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context

This PR reduces the amount of heap required by dependency resolution, by reusing the set of candidate variants for artifact selection for a given variant of an external module selected during graph resolution. Previously a new set was created each time the variant was selected in a graph.

A `ComponentGraphResolveState` instance for each external component is now cached in memory, instead of caching the `ComponentResolveMetadata`. This allows calculated values (for example, the candidate variants) to be calculated once per external component. Later PRs will make use of this to cache and deduplicate more calculated state.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
