### PR TITLE
Remove LenientResolutionResult

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheUnsupportedTypesIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheUnsupportedTypesIntegrationTest.groovy
@@ -58,7 +58,6 @@ import org.gradle.api.internal.artifacts.PreResolvedResolvableArtifact
 import org.gradle.api.internal.artifacts.configurations.DefaultConfiguration
 import org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.ConfigurationResolvableDependencies
 import org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.ConfigurationResolvableDependencies.ConfigurationArtifactView
-import org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.ConfigurationResolvableDependencies.LenientResolutionResult
 import org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer
 import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency
 import org.gradle.api.internal.artifacts.dsl.DefaultComponentMetadataHandler
@@ -66,6 +65,7 @@ import org.gradle.api.internal.artifacts.dsl.DefaultComponentModuleMetadataHandl
 import org.gradle.api.internal.artifacts.dsl.DefaultRepositoryHandler
 import org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyConstraintHandler
 import org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyHandler
+import org.gradle.api.internal.artifacts.ivyservice.ErrorHandlingConfigurationResolver.ErrorHandlingResolutionResult
 import org.gradle.api.internal.artifacts.ivyservice.ErrorHandlingConfigurationResolver.ErrorHandlingLenientConfiguration
 import org.gradle.api.internal.artifacts.ivyservice.ErrorHandlingConfigurationResolver.ErrorHandlingResolvedConfiguration
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultResolutionStrategy
@@ -100,7 +100,6 @@ import java.util.concurrent.Executor
 import java.util.concurrent.Executors.DefaultThreadFactory
 import java.util.concurrent.Executors.FinalizableDelegatedExecutorService
 import java.util.concurrent.ThreadFactory
-
 
 class ConfigurationCacheUnsupportedTypesIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
 
@@ -274,7 +273,7 @@ class ConfigurationCacheUnsupportedTypesIntegrationTest extends AbstractConfigur
         ErrorHandlingResolvedConfiguration    | ResolvedConfiguration          | "project.configurations.maybeCreate('some').resolvedConfiguration"
         ErrorHandlingLenientConfiguration     | LenientConfiguration           | "project.configurations.maybeCreate('some').resolvedConfiguration.lenientConfiguration"
         ConfigurationResolvableDependencies   | ResolvableDependencies         | "project.configurations.maybeCreate('some').incoming"
-        LenientResolutionResult               | ResolutionResult               | "project.configurations.maybeCreate('some').incoming.resolutionResult"
+        ErrorHandlingResolutionResult         | ResolutionResult               | "project.configurations.maybeCreate('some').incoming.resolutionResult"
         DefaultDependencyConstraintSet        | DependencyConstraintSet        | "project.configurations.maybeCreate('some').dependencyConstraints"
         DefaultRepositoryHandler              | RepositoryHandler              | "project.repositories"
         DefaultMavenArtifactRepository        | ArtifactRepository             | "project.repositories.mavenCentral()"

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultResolverResults.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultResolverResults.java
@@ -128,12 +128,8 @@ public class DefaultResolverResults implements ResolverResults {
     }
 
     @Override
-    public ResolveException consumeNonFatalFailure() {
-        try {
-            return nonFatalFailure;
-        } finally {
-            nonFatalFailure = null;
-        }
+    public ResolveException getNonFatalFailure() {
+        return nonFatalFailure;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolverResults.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolverResults.java
@@ -69,18 +69,14 @@ public interface ResolverResults {
     void artifactsResolved(ResolvedConfiguration resolvedConfiguration, VisitedArtifactSet visitedArtifacts);
 
     /**
-     * Consumes the failure, allowing to either throw or do something else with it. Consuming effectively
-     * removes the exception from the underlying resolver results, meaning that subsequent calls to consume
-     * will return null.
+     * Gets any non-fatal attached failure, or null if no non-fatal failure is attached.
      */
     @Nullable
-    ResolveException consumeNonFatalFailure();
+    ResolveException getNonFatalFailure();
 
     /**
      * Returns the failure, fatal or non fatal, or null if there's no failure. Used internally to
-     * set the failure on the resolution build operation result. In opposite to {@link #consumeNonFatalFailure()},
-     * this doesn't consume the error, so subsequent calls will return the same instance, unless the error was
-     * consumed in between.
+     * set the failure on the resolution build operation result.
      */
     @Nullable
     Throwable getFailure();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ErrorHandlingConfigurationResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ErrorHandlingConfigurationResolver.java
@@ -115,7 +115,7 @@ public class ErrorHandlingConfigurationResolver implements ConfigurationResolver
         return resolveException;
     }
 
-    private static class ErrorHandlingLenientConfiguration implements LenientConfiguration {
+    public static class ErrorHandlingLenientConfiguration implements LenientConfiguration {
         private final LenientConfiguration lenientConfiguration;
         private final ResolveContext resolveContext;
 
@@ -197,7 +197,7 @@ public class ErrorHandlingConfigurationResolver implements ConfigurationResolver
         }
     }
 
-    private static class ErrorHandlingResolutionResult implements ResolutionResult {
+    public static class ErrorHandlingResolutionResult implements ResolutionResult {
         private final ResolutionResult resolutionResult;
         private final ResolveContext resolveContext;
 
@@ -266,7 +266,7 @@ public class ErrorHandlingConfigurationResolver implements ConfigurationResolver
         }
     }
 
-    private static class ErrorHandlingResolvedConfiguration implements ResolvedConfiguration {
+    public static class ErrorHandlingResolvedConfiguration implements ResolvedConfiguration {
         private final ResolvedConfiguration resolvedConfiguration;
         private final ResolveContext resolveContext;
 


### PR DESCRIPTION
LenientResolutionResult was used to allow DependencyInsightReportTask to access non-fatal errors from a resolution, like dependency locking and version conflict failures, and format them separately in the task output. However, implementing an entire new ResolutionResult here was not necessary at all and could easily be accomplished without a new implementation.

This PR removes that implementation and simplifies the ResolutionResult codepath.
