### PR TITLE
Warn if copying configurations without resolvable usage allowed

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
@@ -527,6 +527,13 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
      * (without contributions from superconfigurations).  The new configuration will be in the
      * UNRESOLVED state, but will retain all other attributes of this configuration except superconfigurations.
      * {@link #getHierarchy()} for the copy will not include any superconfigurations.
+     * <p>
+     * This method is only intended for use for specific situations involving resolvable configuration, it is
+     * <strong>NOT</strong> intended as a general-purpose copying mechanism.
+     *
+     * @implSpec Usage: This method should only be called on resolvable configurations and will emit a deprecation warning if
+     * called on a configuration that does not permit this usage, or has allowed this usage but marked it as deprecated.
+     *
      * @return copy of this configuration
      */
     Configuration copy();
@@ -536,6 +543,13 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
      * and those derived from superconfigurations.  The new configuration will be in the
      * UNRESOLVED state, but will retain all other attributes of this configuration except superconfigurations.
      * {@link #getHierarchy()} for the copy will not include any superconfigurations.
+     * <p>
+     * This method is only intended for use for specific situations involving resolvable configuration, it is
+     * <strong>NOT</strong> intended as a general-purpose copying mechanism.
+     *
+     * @implSpec Usage: This method should only be called on resolvable configurations and will emit a deprecation warning if
+     * called on a configuration that does not permit this usage, or has allowed this usage but marked it as deprecated.
+     *
      * @return copy of this configuration
      */
     Configuration copyRecursive();
@@ -543,6 +557,12 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
     /**
      * Creates a copy of this configuration ignoring superconfigurations (see {@link #copy()} but filtering
      * the dependencies using the specified dependency spec.
+     * <p>
+     * This method is only intended for use for specific situations involving resolvable configuration, it is
+     * <strong>NOT</strong> intended as a general-purpose copying mechanism.
+     *
+     * @implSpec Usage: This method should only be called on resolvable configurations and will emit a deprecation warning if
+     * called on a configuration that does not permit this usage, or has allowed this usage but marked it as deprecated.
      *
      * @param dependencySpec filtering requirements
      * @return copy of this configuration
@@ -552,6 +572,12 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
     /**
      * Creates a copy of this configuration with dependencies from superconfigurations (see {@link #copyRecursive()})
      * but filtering the dependencies using the dependencySpec.
+     * <p>
+     * This method is only intended for use for specific situations involving resolvable configuration, it is
+     * <strong>NOT</strong> intended as a general-purpose copying mechanism.
+     *
+     * @implSpec Usage: This method should only be called on resolvable configurations and will emit a deprecation warning if
+     * called on a configuration that does not permit this usage, or has allowed this usage but marked it as deprecated.
      *
      * @param dependencySpec filtering requirements
      * @return copy of this configuration
@@ -560,6 +586,12 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
 
     /**
      * Takes a closure which gets coerced into a {@link Spec}. Behaves otherwise in the same way as {@link #copy(org.gradle.api.specs.Spec)}
+     *  <p>
+     * This method is only intended for use for specific situations involving resolvable configuration, it is
+     * <strong>NOT</strong> intended as a general-purpose copying mechanism.
+     *
+     * @implSpec Usage: This method should only be called on resolvable configurations and will emit a deprecation warning if
+     * called on a configuration that does not permit this usage, or has allowed this usage but marked it as deprecated.
      *
      * @param dependencySpec filtering requirements
      * @return copy of this configuration
@@ -568,6 +600,12 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
 
     /**
      * Takes a closure which gets coerced into a {@link Spec}. Behaves otherwise in the same way as {@link #copyRecursive(org.gradle.api.specs.Spec)}
+     * <p>
+     * This method is only intended for use for specific situations involving resolvable configuration, it is
+     * <strong>NOT</strong> intended as a general-purpose copying mechanism.
+     *
+     * @implSpec Usage: This method should only be called on resolvable configurations and will emit a deprecation warning if
+     * called on a configuration that does not permit this usage, or has allowed this usage but marked it as deprecated.
      *
      * @param dependencySpec filtering requirements
      * @return copy of this configuration

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/DeprecatedConfigurationUsageIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/DeprecatedConfigurationUsageIntegrationTest.groovy
@@ -75,6 +75,15 @@ class DeprecatedConfigurationUsageIntegrationTest extends AbstractIntegrationSpe
         'shouldResolveConsistentlyWith(Configuration)'  | 'bucket'      | 'shouldResolveConsistentlyWith(null)'                                 || [ProperMethodUsage.RESOLVABLE]
         'disableConsistentResolution()'                 | 'consumable'  | 'disableConsistentResolution()'                                       || [ProperMethodUsage.RESOLVABLE]
         'disableConsistentResolution()'                 | 'bucket'      | 'disableConsistentResolution()'                                       || [ProperMethodUsage.RESOLVABLE]
+        'copy()'                                        | 'consumable'  | 'copy()'                                                              || [ProperMethodUsage.RESOLVABLE]
+        'copy()'                                        | 'bucket'      | 'copy()'                                                              || [ProperMethodUsage.RESOLVABLE]
+        'copyRecursive()'                               | 'consumable'  | 'copyRecursive()'                                                     || [ProperMethodUsage.RESOLVABLE]
+        'copyRecursive()'                               | 'bucket'      | 'copyRecursive()'                                                     || [ProperMethodUsage.RESOLVABLE]
+        'copy(Spec)'                                    | 'consumable'  | 'copy { } as Spec'                                                    || [ProperMethodUsage.RESOLVABLE]
+        'copy(Spec)'                                    | 'bucket'      | 'copy { } as Spec'                                                    || [ProperMethodUsage.RESOLVABLE]
+        'copyRecursive(Spec)'                           | 'consumable'  | 'copyRecursive { } as Spec'                                           || [ProperMethodUsage.RESOLVABLE]
+        'copyRecursive(Spec)'                           | 'bucket'      | 'copyRecursive { } as Spec'                                           || [ProperMethodUsage.RESOLVABLE]
+
     }
 
     def "calling an invalid internal API method #methodName for role #role produces a deprecation warning"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/JavaPlatformEcosystemIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/JavaPlatformEcosystemIntegrationTest.groovy
@@ -75,6 +75,36 @@ class JavaPlatformEcosystemIntegrationTest extends AbstractHttpDependencyResolut
         }
     }
 
+    def "Configuration.copy() should when configuration contains project dependency constraints"() {
+        setup:
+        buildFile << """
+            configurations {
+                custom {
+                    canBeResolved = true
+                }
+            }
+
+            dependencies {
+                constraints {
+                    custom(project(":lib")) { because "platform alignment" }
+                }
+            }
+
+            configurations.custom.copy()
+        """
+        settingsFile << "include 'lib'"
+
+        expect:
+        succeeds ":help"
+    }
+
+    /**
+     * I think the test above: {@link JavaPlatformEcosystemIntegrationTest#"Configuration.copy() should when configuration contains project dependency constraints"}
+     * should be sufficient to cover this case, which seems to apply to any configurations that has a project dependency constraint
+     * and is independent of the involvement of the Java Platform plugin.  But I'll leave this test here just in case for now.
+     *
+     * Once the deprecation becomes an error, this test should be removed.
+     */
     @Issue("https://github.com/gradle/gradle/issues/17179")
     def "Configuration.copy() should work when platform declares project dependency constraints"() {
         setup:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/JavaPlatformEcosystemIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/JavaPlatformEcosystemIntegrationTest.groovy
@@ -94,6 +94,9 @@ class JavaPlatformEcosystemIntegrationTest extends AbstractHttpDependencyResolut
         settingsFile << "include 'lib'"
 
         expect:
+        executer.expectDocumentedDeprecationWarning("Calling configuration method 'copy()' is deprecated for configuration 'api', which has permitted usage(s):\n" +
+                "\tDeclarable Against - this configuration can have dependencies added to it\n" +
+                "This method is only meant to be called on configurations which allow the (non-deprecated) usage(s): 'Resolvable'. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_configuration_usage")
         succeeds ":help"
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -1291,21 +1291,25 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
 
     @Override
     public ConfigurationInternal copy() {
+        warnOnDeprecatedUsage("copy()", ProperMethodUsage.RESOLVABLE);
         return createCopy(getDependencies(), getDependencyConstraints());
     }
 
     @Override
     public Configuration copyRecursive() {
+        warnOnDeprecatedUsage("copyRecursive()", ProperMethodUsage.RESOLVABLE);
         return createCopy(getAllDependencies(), getAllDependencyConstraints());
     }
 
     @Override
     public Configuration copy(Spec<? super Dependency> dependencySpec) {
+        warnOnDeprecatedUsage("copy(Spec)", ProperMethodUsage.RESOLVABLE);
         return createCopy(CollectionUtils.filter(getDependencies(), dependencySpec), getDependencyConstraints());
     }
 
     @Override
     public Configuration copyRecursive(Spec<? super Dependency> dependencySpec) {
+        warnOnDeprecatedUsage("copyRecursive(Spec)", ProperMethodUsage.RESOLVABLE);
         return createCopy(CollectionUtils.filter(getAllDependencies(), dependencySpec), getAllDependencyConstraints());
     }
 

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
@@ -75,6 +75,7 @@ Currently, the following methods should only be called with these listed allowed
 - `shouldResolveConsistentlyWith(Configuration)` - RESOLVABLE configurations only
 - `disableConsistentResolution()` - RESOLVABLE configurations only
 - `getDependencyConstraints()` - DECLARABLE configurations only
+- `copy()`, `copy(Spec)`, `copy(Closure)`, `copyRecursive()`, `copyRecursive(Spec)`, `copyRecursive(Closure)` - RESOLVABLE configurations only
 
 Intended usage is noted in the `Configuration` interface's Javadoc.
 This list is likely to grow in future releases.


### PR DESCRIPTION
Replaces #24397.  After consideration, we decided to not deprecate copy, but to restrict it to resolvable configurations only.