### PR TITLE
Enable compileAll build to be triggered for all commits with next-gen build cache

### DIFF
--- a/.teamcity/src/main/kotlin/model/CIBuildModel.kt
+++ b/.teamcity/src/main/kotlin/model/CIBuildModel.kt
@@ -185,7 +185,7 @@ data class CIBuildModel(
         ),
         Stage(
             StageName.EXPERIMENTAL_BUILD_CACHE_NG,
-            trigger = Trigger.never,
+            trigger = Trigger.eachCommit,
             runsIndependent = true,
             specificBuilds = listOf(SpecificBuild.CompileAllBuildCacheNG),
         )


### PR DESCRIPTION
This populates the dogfooding build cache node.
