### PR TITLE
Update ProfileFile link to ProjectLayout class in working_with_files.adoc

### DIFF
--- a/subprojects/docs/src/docs/userguide/authoring-builds/working_with_files.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/working_with_files.adoc
@@ -35,7 +35,7 @@ include::sample[dir="snippets/files/copy/kotlin",files="build.gradle.kts[tags=co
 include::sample[dir="snippets/files/copy/groovy",files="build.gradle[tags=copy-single-file-example]"]
 ====
 
-The link:{groovyDslPath}/org.gradle.api.Project.html#org.gradle.api.Project:file(java.lang.Object)[Project.file(java.lang.Object)] method is used to create a file or directory path relative to the current project and is a common way to make build scripts work regardless of the project path. The file and directory paths are then used to specify what file to copy using link:{groovyDslPath}/org.gradle.api.tasks.Copy.html#org.gradle.api.tasks.Copy:from(java.lang.Object++[]++)[Copy.from(java.lang.Object...)] and which directory to copy it to using link:{groovyDslPath}/org.gradle.api.tasks.Copy.html#org.gradle.api.tasks.Copy:into(java.lang.Object)[Copy.into(java.lang.Object)].
+The link:{javadocPath}/org/gradle/api/file/ProjectLayout.html[ProjectLayout] class is used to find a file or directory path relative to the current project. This is a common way to make build scripts work regardless of the project path. The file and directory paths are then used to specify what file to copy using link:{groovyDslPath}/org.gradle.api.tasks.Copy.html#org.gradle.api.tasks.Copy:from(java.lang.Object++[]++)[Copy.from(java.lang.Object...)] and which directory to copy it to using link:{groovyDslPath}/org.gradle.api.tasks.Copy.html#org.gradle.api.tasks.Copy:into(java.lang.Object)[Copy.into(java.lang.Object)].
 
 You can even use the path directly without the `file()` method, as explained early in the section <<#sec:copying_files,File copying in depth>>:
 


### PR DESCRIPTION
Fixes wrong link in Gradle user manual: The [copying_single_file_example](https://docs.gradle.org/current/userguide/working_with_files.html#sec:copying_single_file_example) should not link to [Project.file](https://docs.gradle.org/current/dsl/org.gradle.api.Project.html#org.gradle.api.Project:file(java.lang.Object)) as it is not used in the example

This is a Documentation change ONLY.

Context
This has been requested as per issue: https://github.com/gradle/gradle/issues/24500