### PR TITLE
Update nomenclature + general ascii doc cleanup of variant_model.adoc file

### DIFF
--- a/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/variant_model.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/variant_model.adoc
@@ -24,12 +24,13 @@ Gradle's dependency management engine is _variant aware_.
 
 In addition to a component, Gradle has the concept of _variants_ of a component.
 Variants correspond to the different ways a component can be used, such as for Java compilation or native linking or documentation.
-Artifacts are attached to a _variant_ and each variant can have a different set of dependencies:
+Artifacts are attached to a _variant_ and each variant can have a different set of dependencies.
 
 How does Gradle know which variant to choose when there's more than one?
 Variants are matched by use of <<variant_attributes.adoc#variant_attributes,attributes>>, which provide semantics to the variants and help the engine to produce a _consistent_ resolution result.
 
 Gradle differentiates between two kind of components:
+
 - local components (like projects), built from sources
 - external components, published to repositories
 
@@ -88,16 +89,17 @@ Let's consider an example where a consumer is trying to use a library for compil
 
 First, the consumer needs to explain how it's going to use the result of dependency resolution. This is done by setting _attributes_ on the resolvable configuration of the consumer.
 
-The consumer wants to resolve a variant that matches:
-- `org.gradle.usage=JAVA_API`
+The consumer wants to resolve a variant that matches: `org.gradle.usage=JAVA_API`
 
 Second, the producer needs to expose the different variants of the component.
 
 The producer component exposes 2 variants:
+
 - its API (named `apiElements`) with attribute `org.gradle.usage=JAVA_API`
 - its runtime (named `runtimeElements`) with attribute `org.gradle.usage=JAVA_RUNTIME`
 
 Finally, Gradle selects the appropriate variant by looking at the variant attributes:
+
 - the consumer wants a variant with attributes `org.gradle.usage=JAVA_API`
 - the producer has a matching variant (`apiElements`)
 - the producer has a non-matching variant (`runtimeElements`)
@@ -108,7 +110,7 @@ Gradle provides the artifacts and dependencies from the `apiElements` variant to
 
 In the real world, consumers and producers have more than one attribute.
 
-A Java Library project in Gradle will involve several different attributes
+A Java Library project in Gradle will involve several different attributes:
 
 - `org.gradle.usage` that describes how the variant is used
 - `org.gradle.dependency.bundling` that describes how the variant handles dependencies (shadow jar vs fat jar vs regular jar)
@@ -121,18 +123,21 @@ Let's consider an example where the consumer wants to run tests with a library o
 First, the consumer needs to explain which version of the Java it needs.
 
 The consumer wants to resolve a variant that:
+
 - can be used at runtime (has `org.gradle.usage=JAVA_RUNTIME`)
 - can be run on _at least_ Java 8 (`org.gradle.jvm.version=8`)
 
 Second, the producer needs to expose the different variants of the component.
 
 Like in the simple example, there is both a API (compilation) and runtime variant. These exist for both the Java 8 and Java 11 version of the component.
+
 - its API for Java 8 consumers (named `apiJava8Elements`) with attribute `org.gradle.usage=JAVA_API` and `org.gradle.jvm.version=8`
 - its runtime for Java 8 consumers (named `runtime8Elements`) with attribute `org.gradle.usage=JAVA_RUNTIME` and `org.gradle.jvm.version=8`
 - its API for Java 11 consumers (named `apiJava11Elements`) with attribute `org.gradle.usage=JAVA_API` and `org.gradle.jvm.version=11`
 - its runtime for Java 11 consumers (named `runtime11Elements`) with attribute `org.gradle.usage=JAVA_RUNTIME` and `org.gradle.jvm.version=11`
 
 Finally, Gradle selects the best matching variant by looking at all of the attributes:
+
 - the consumer wants a variant with compatible attributes to `org.gradle.usage=JAVA_RUNTIME` and `org.gradle.jvm.version=8`
 - the variants `runtime8Elements` and `runtime11Elements` have `org.gradle.usage=JAVA_RUNTIME`
 - the variants `apiJava8Elements` and `apiJava11Elements` are incompatible
@@ -156,6 +161,7 @@ If the consumer requested `org.gradle.jvm.version=15`, then Gradle knows either 
 == Variant selection errors
 
 When selecting the most compatible variant of a component, resolution may fail:
+
 * when more than one variant from the producer matches the consumer attributes (ambiguity error)
 * when no variants from the producer match the consumer attributes (incompatibility error)
 
@@ -232,7 +238,7 @@ A no matching variant error looks like the following:
 All _compatible_ candidate variants are displayed with their attributes.
 
 * Incompatible attributes are presented first, as they usually are the key in understanding why a variant could not be selected.
-* Other attributes are presented second, this includes _required_ and _compatible_ ones as well as all extra _producer_ attributes that are not requested by the consumer.
+* Other attributes are presented second, this includes _requested_ and _compatible_ ones as well as all extra _producer_ attributes that are not requested by the consumer.
 
 Similar to the ambiguous variant error, the goal is to understand which variant should be selected. In some cases, there may not be any compatible variants from the producer (e.g., trying to run on Java 8 with a library built for Java 11).
 
@@ -536,13 +542,14 @@ See the {metadata-file-spec}[Gradle Module Metadata specification] for more info
 Modules published on a Maven repository are automatically converted into variant-aware modules.
 
 There is no way for Gradle to know which kind of component was published:
+
 - a BOM that represents a Gradle platform
 - a BOM used as a super-POM
 - a POM that is both a platform _and_ a library
 
 The default strategy used by Java projects in Gradle is to derive 8 different variants:
 
-* 2 "library" variants (attribute `org.gradle.category` = `library`)
+* two "library" variants (attribute `org.gradle.category` = `library`)
 ** the `compile` variant maps the `<scope>compile</scope>` dependencies.
 This variant is equivalent to the `apiElements` variant of the <<java_library_plugin.adoc#java_library_plugin,Java Library plugin>>.
 All dependencies of this scope are considered _API dependencies_.
@@ -552,7 +559,7 @@ All dependencies of those scopes are considered _runtime dependencies_.
 - in both cases, the `<dependencyManagement>` dependencies are _not converted to constraints_
 * a "sources" variant that represents the sources jar for the component
 * a "javadoc" variant that represents the javadoc jar for the component
-* 4 "platform" variants derived from the `<dependencyManagement>` block (attribute `org.gradle.category` = `platform`):
+* four "platform" variants derived from the `<dependencyManagement>` block (attribute `org.gradle.category` = `platform`):
 ** the `platform-compile` variant maps the  `<scope>compile</scope>` dependency management dependencies as _dependency constraints_.
 ** the `platform-runtime` variant maps both the `<scope>compile</scope>` and `<scope>runtime</scope>` dependency management dependencies as _dependency constraints_.
 ** the `enforced-platform-compile` is similar to `platform-compile` but all the constraints are _forced_


### PR DESCRIPTION
Fixes nomenclature in [gradle/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/variant_model.adoc](https://github.com/gradle/gradle/blob/8d3589259a9fe039129044431bc7ae825e85657f/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/variant_model.adoc?plain=1#L235); line 235 and some ascii docs syntax update. 

This is a Documentation change ONLY.

Context
This has been requested as per issue: https://github.com/gradle/gradle/issues/23778