### PR TITLE
Deprecate running test task successfully when no test executed

### DIFF
--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/GroovyApplicationInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/GroovyApplicationInitIntegrationTest.groovy
@@ -178,6 +178,9 @@ class GroovyApplicationInitIntegrationTest extends AbstractJvmLibraryInitIntegra
                 package org.acme;
 
                 class SampleMainTest {
+
+                    @org.junit.jupiter.api.Test
+                    public void sampleTest() { }
                 }
         """
         when:

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/GroovyLibraryInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/GroovyLibraryInitIntegrationTest.groovy
@@ -139,6 +139,9 @@ class GroovyLibraryInitIntegrationTest extends AbstractJvmLibraryInitIntegration
                     package org.acme;
 
                     class SampleMainTest {
+
+                        @org.junit.jupiter.api.Test
+                        public void sampleTest() { }
                     }
             """
         when:

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaApplicationInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaApplicationInitIntegrationTest.groovy
@@ -241,6 +241,9 @@ class JavaApplicationInitIntegrationTest extends AbstractJvmLibraryInitIntegrati
                 package org.acme;
 
                 public class SampleMainTest {
+
+                    @org.junit.jupiter.api.Test
+                    public void sampleTest() { }
                 }
         """
         when:

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaLibraryInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaLibraryInitIntegrationTest.groovy
@@ -285,6 +285,9 @@ class JavaLibraryInitIntegrationTest extends AbstractJvmLibraryInitIntegrationSp
                 package org.acme;
 
                 public class SampleMainTest {
+
+                    @org.junit.jupiter.api.Test
+                    public void sampleTest() { }
                 }
         """
         when:

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/KotlinApplicationInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/KotlinApplicationInitIntegrationTest.groovy
@@ -157,6 +157,9 @@ class KotlinApplicationInitIntegrationTest extends AbstractJvmLibraryInitIntegra
                 package org.acme
 
                 class SampleMainTest {
+
+                    @org.junit.jupiter.api.Test
+                    fun sampleTest() { }
                 }
         """
         when:

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/KotlinLibraryInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/KotlinLibraryInitIntegrationTest.groovy
@@ -132,6 +132,9 @@ class KotlinLibraryInitIntegrationTest extends AbstractJvmLibraryInitIntegration
                     package org.acme
 
                     class SampleMainTest {
+
+                        @org.junit.jupiter.api.Test
+                        fun sampleTest() { }
                     }
             """
         when:

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/ScalaApplicationInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/ScalaApplicationInitIntegrationTest.groovy
@@ -155,6 +155,9 @@ class ScalaApplicationInitIntegrationTest extends AbstractJvmLibraryInitIntegrat
                 package org.acme;
 
                 class SampleMainSuite {
+
+                    @org.junit.Test
+                    def sampleTest : Unit = { }
                 }
         """
         when:

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/ScalaLibraryInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/ScalaLibraryInitIntegrationTest.groovy
@@ -116,6 +116,9 @@ class ScalaLibraryInitIntegrationTest extends AbstractJvmLibraryInitIntegrationS
                     package org.acme;
 
                     class SampleMainTest{
+
+                        @org.junit.Test
+                        def sampleTest : Unit = { }
                     }
             """
 

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginVersionIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginVersionIntegrationTest.groovy
@@ -483,9 +483,9 @@ class CheckstylePluginVersionIntegrationTest extends MultiVersionIntegrationSpec
 
     private goodCode() {
         file('src/main/java/org/gradle/Class1.java') << 'package org.gradle; class Class1 { }'
-        file('src/test/java/org/gradle/TestClass1.java') << 'package org.gradle; class TestClass1 { }'
+        file('src/test/java/org/gradle/TestClass1.java') << 'package org.gradle; public class TestClass1 { @org.junit.Test public void test1() { } }'
         file('src/main/groovy/org/gradle/Class2.java') << 'package org.gradle; class Class2 { }'
-        file('src/test/groovy/org/gradle/TestClass2.java') << 'package org.gradle; class TestClass2 { }'
+        file('src/test/groovy/org/gradle/TestClass2.java') << 'package org.gradle; public class TestClass2 { @org.junit.Test public void test2() { } }'
     }
 
     private badCode() {

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/codenarc/CodeNarcTestFixture.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/codenarc/CodeNarcTestFixture.groovy
@@ -22,7 +22,7 @@ import org.gradle.test.fixtures.file.TestFile
 trait CodeNarcTestFixture {
     def goodCode() {
         file("src/main/groovy/org/gradle/class1.java") << "package org.gradle; class class1 { }"
-        file("src/test/groovy/org/gradle/testclass1.java") << "package org.gradle; class testclass1 { }"
+        file("src/test/groovy/org/gradle/testclass1.java") << "package org.gradle; public class testclass1 { @org.junit.Test public void test1() { } }"
         file("src/main/groovy/org/gradle/Class2.groovy") << "package org.gradle; class Class2 { }"
         file("src/test/groovy/org/gradle/TestClass2.groovy") << "package org.gradle; class TestClass2 { }"
     }
@@ -30,7 +30,7 @@ trait CodeNarcTestFixture {
     def badCode() {
         file("src/main/groovy/org/gradle/class1.java") << "package org.gradle; class class1 { }"
         file("src/main/groovy/org/gradle/Class2.groovy") << "package org.gradle; class Class2 { }"
-        file("src/test/groovy/org/gradle/TestClass1.java") << "package org.gradle; class TestClass1 { }"
+        file("src/test/groovy/org/gradle/TestClass1.java") << "package org.gradle; public class TestClass1 { @org.junit.Test public void test1() { } }"
         file("src/test/groovy/org/gradle/testclass2.groovy") << "package org.gradle; class testclass2 { }"
     }
 

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginDependenciesIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginDependenciesIntegrationTest.groovy
@@ -100,6 +100,22 @@ class PmdPluginDependenciesIntegrationTest extends AbstractIntegrationSpec {
         // PMD Lvl 2 Warning BooleanInstantiation
         // PMD Lvl 3 Warning OverrideBothEqualsAndHashcode
         file("src/test/java/org/gradle/Class1Test.java") <<
-            "package org.gradle; class Class1Test<T> { public boolean equals(Object arg) { return java.lang.Boolean.valueOf(true); } }"
+            """
+            package org.gradle;
+
+            import static org.junit.Assert.assertTrue;
+
+            import org.junit.Test;
+
+            public class Class1Test<T> {
+                @Test
+                public void testFoo() {
+                    Class1 c = new Class1();
+                    assertTrue(c.isFoo("foo"));
+                }
+
+                public boolean equals(Object arg) { return java.lang.Boolean.valueOf(true); }
+            }
+            """
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/caching/configuration/internal/BuildCacheCompositeConfigurationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/caching/configuration/internal/BuildCacheCompositeConfigurationIntegrationTest.groovy
@@ -168,9 +168,27 @@ class BuildCacheCompositeConfigurationIntegrationTest extends AbstractIntegratio
                 tasks.build.dependsOn(subprojects.tasks.build)
                 tasks.clean.dependsOn(subprojects.tasks.clean)
             """
-            file("src/test/java/Test.java") << """class Test {}"""
-            file("first/src/test/java/Test.java") << """class TestFirst {}"""
-            file("second/src/test/java/Test.java") << """class TestSecond {}"""
+            file("src/test/java/Test.java") <<
+                """
+                class Test {
+                    @org.junit.jupiter.api.Test
+                    public void test() {}
+                }
+                """
+            file("first/src/test/java/TestFirst.java") <<
+                """
+                class TestFirst {
+                    @org.junit.jupiter.api.Test
+                    public void test() {}
+                }
+                """
+            file("second/src/test/java/TestSecond.java") <<
+                """
+                class TestSecond {
+                    @org.junit.jupiter.api.Test
+                    public void test() {}
+                }
+                """
         }
 
         settingsFile << localCache.localCacheConfiguration() << """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationDependenciesBuildOperationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationDependenciesBuildOperationIntegrationTest.groovy
@@ -661,7 +661,13 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
             }
         """
         file("fixtures/src/testFixtures/java/SomeClass.java") << "class SomeClass {}"
-        file("src/test/java/SomeTest.java") << "class SomeClass {}"
+        file("src/test/java/SomeTest.java") <<
+            """
+            public class SomeTest {
+                @org.junit.Test
+                public void test() { }
+            }
+            """
 
         when:
         succeeds ':test'

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
@@ -1142,6 +1142,11 @@ Calling link:{javadocPath}/org/gradle/api/Task.html#getConvention--[Task.getConv
 
 See the <<configuration_cache#config_cache:requirements:disallowed_types,configuration cache chapter>> for details on how to migrate these usages to APIs that are supported by the configuration cache.
 
+[[test_task_fail_on_no_test_executed]]
+==== Deprecated running test task successfully when no test executed
+Running the `Test` task successfully when no test was executed is now deprecated and will become an error in Gradle 9.
+This is done to avoid accidental successful test runs due to erroneous configuration.
+
 === Changes in the IDE integration
 
 [[kotlin_dsl_plugins_catalogs_workaround]]

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
@@ -1145,7 +1145,8 @@ See the <<configuration_cache#config_cache:requirements:disallowed_types,configu
 [[test_task_fail_on_no_test_executed]]
 ==== Deprecated running test task successfully when no test executed
 Running the `Test` task successfully when no test was executed is now deprecated and will become an error in Gradle 9.
-This is done to avoid accidental successful test runs due to erroneous configuration.
+Note that it is not an error when no test sources are present, in this case the `test` task is simply skipped. It is only an error when test sources are present, but no test was selected for execution.
+This is changed to avoid accidental successful test runs due to erroneous configuration.
 
 === Changes in the IDE integration
 

--- a/subprojects/docs/src/snippets/kotlinDsl/accessors/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/kotlinDsl/accessors/kotlin/build.gradle.kts
@@ -29,6 +29,7 @@ java {                                      // <4>
 tasks {
     test {                                  // <5>
         testLogging.showExceptions = true
+        useJUnit()
     }
 }
 // end::accessors[]

--- a/subprojects/docs/src/snippets/kotlinDsl/accessors/kotlin/src/test/java/TestSource.java
+++ b/subprojects/docs/src/snippets/kotlinDsl/accessors/kotlin/src/test/java/TestSource.java
@@ -1,2 +1,4 @@
 public class TestSource {
+    @org.junit.Test
+    public void test() { }
 }

--- a/subprojects/docs/src/snippets/testing/patch-module/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/testing/patch-module/groovy/build.gradle
@@ -5,6 +5,10 @@ repositories {
     mavenCentral()
 }
 
+tasks.named('test') {
+    useJUnitPlatform()
+}
+
 // tag::patchArgs[]
 def moduleName = "org.gradle.sample"
 def patchArgs = ["--patch-module", "$moduleName=${tasks.compileJava.destinationDirectory.asFile.get().path}"]

--- a/subprojects/docs/src/snippets/testing/patch-module/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/testing/patch-module/kotlin/build.gradle.kts
@@ -5,6 +5,10 @@ repositories {
     mavenCentral()
 }
 
+tasks.test {
+    useJUnitPlatform()
+}
+
 // tag::patchArgs[]
 val moduleName = "org.gradle.sample"
 val patchArgs = listOf("--patch-module", "$moduleName=${tasks.compileJava.get().destinationDirectory.asFile.get().path}")

--- a/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/test/TestTaskPropertiesServiceIntegrationTest.groovy
+++ b/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/test/TestTaskPropertiesServiceIntegrationTest.groovy
@@ -193,7 +193,10 @@ class TestTaskPropertiesServiceIntegrationTest extends AbstractIntegrationSpec {
         """
         file('src/test/java/org/example/TestClass.java') << """
             package org.example;
-            public class TestClass {}
+            public class TestClass {
+                @org.junit.Test
+                public void test() {}
+            }
         """
 
         when:

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/JavaProjectIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/JavaProjectIntegrationTest.groovy
@@ -65,6 +65,9 @@ class JavaProjectIntegrationTest extends AbstractIntegrationTest {
         """
 
         expect:
+        executer.expectDocumentedDeprecationWarning("No test executed. This behavior has been deprecated. " +
+            "This will fail with an error in Gradle 9.0. There are test sources present but no test was executed. Please check your test configuration. " +
+            "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#test_task_fail_on_no_test_executed")
         executer.withTasks("build").run()
     }
 
@@ -105,7 +108,12 @@ class JavaProjectIntegrationTest extends AbstractIntegrationTest {
         testFile("src/main/resources/prod.resource") << ""
         testFile("src/main/java/Main.java") << "class Main {}"
         testFile("src/test/resources/test.resource") << "test resource"
-        testFile("src/test/java/TestFoo.java") << "class TestFoo {}"
+        testFile("src/test/java/TestFoo.java") << """
+        public class TestFoo {
+            @org.junit.Test
+            public void test() {}
+        }
+        """
 
         when:
         executer.withTasks("build").run()

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ProjectLayoutIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ProjectLayoutIntegrationTest.groovy
@@ -76,17 +76,17 @@ sourceSets.each {
         file('src/resources/org/gradle/main/resource2.txt') << 'some text'
         file('src/resources/org/gradle/test/resource2.txt') << 'some text'
         file('src/org/gradle/main/JavaClass.java') << 'package org.gradle; public class JavaClass { }'
-        file('src/org/gradle/test/JavaClassTest.java') << 'package org.gradle; class JavaClassTest { JavaClass c = new JavaClass(); }'
+        file('src/org/gradle/test/JavaClassTest.java') << 'package org.gradle; class JavaClassTest { JavaClass c = new JavaClass(); @org.junit.jupiter.api.Test public void test() { } }'
         file('src/java/org/gradle/main/JavaClass2.java') << 'package org.gradle; class JavaClass2 { }'
-        file('src/java/org/gradle/test/JavaClassTest2.java') << 'package org.gradle; class JavaClassTest2 { JavaClass c = new JavaClass(); }'
+        file('src/java/org/gradle/test/JavaClassTest2.java') << 'package org.gradle; class JavaClassTest2 { JavaClass c = new JavaClass(); @org.junit.jupiter.api.Test public void test() { } }'
         file('src/org/gradle/main/GroovyClass.groovy') << 'package org.gradle; class GroovyClass { }'
-        file('src/org/gradle/test/GroovyClassTest.groovy') << 'package org.gradle; class GroovyClassTest { GroovyClass c = new GroovyClass() }'
+        file('src/org/gradle/test/GroovyClassTest.groovy') << 'package org.gradle; class GroovyClassTest { GroovyClass c = new GroovyClass(); @org.junit.jupiter.api.Test void test() { } }'
         file('src/groovy/org/gradle/main/GroovyClass2.groovy') << 'package org.gradle; class GroovyClass2 { }'
-        file('src/groovy/org/gradle/test/GroovyClassTest2.groovy') << 'package org.gradle; class GroovyClassTest2 { GroovyClass c = new GroovyClass() }'
+        file('src/groovy/org/gradle/test/GroovyClassTest2.groovy') << 'package org.gradle; class GroovyClassTest2 { GroovyClass c = new GroovyClass(); @org.junit.jupiter.api.Test public void test() { } }'
         file('src/org/gradle/main/ScalaClass.scala') << 'package org.gradle; class ScalaClass { }'
-        file('src/org/gradle/test/ScalaClassTest.scala') << 'package org.gradle; class ScalaClassTest { val c: ScalaClass = new ScalaClass() }'
+        file('src/org/gradle/test/ScalaClassTest.scala') << 'package org.gradle; class ScalaClassTest { val c: ScalaClass = new ScalaClass(); @org.junit.jupiter.api.Test def test { } }'
         file('src/scala/org/gradle/main/ScalaClass2.scala') << 'package org.gradle; class ScalaClass2 { }'
-        file('src/scala/org/gradle/test/ScalaClassTest2.scala') << 'package org.gradle; class ScalaClassTest2 { val c: ScalaClass = new ScalaClass() }'
+        file('src/scala/org/gradle/test/ScalaClassTest2.scala') << 'package org.gradle; class ScalaClassTest2 { val c: ScalaClass = new ScalaClass(); @org.junit.jupiter.api.Test def test { } }'
 
         executer.withTasks('build').run()
 

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/SwiftXCTestWithDepAndCustomXCTestSuite.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/app/SwiftXCTestWithDepAndCustomXCTestSuite.groovy
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.nativeplatform.fixtures.app
+
+class SwiftXCTestWithDepAndCustomXCTestSuite extends SwiftXCTest {
+    String testSuiteName
+    String methodName
+    String assertion
+    String[] imports
+    String[] importsTestable
+
+    SwiftXCTestWithDepAndCustomXCTestSuite(
+        String projectName,
+        String classToTest,
+        String assertion,
+        String[] imports,
+        String[] importsTestable
+    ) {
+        super(projectName)
+        this.testSuiteName = classToTest + "Test"
+        this.methodName = "test" + classToTest
+        this.assertion = assertion
+        this.imports = imports
+        this.importsTestable = importsTestable
+    }
+
+    @Override
+    List<XCTestSourceFileElement> getTestSuites() {
+        def xcTestSourceFileElement = new XCTestSourceFileElement(testSuiteName) {
+            @Override
+            List<XCTestCaseElement> getTestCases() {
+                return [testCase(methodName, assertion)]
+            }
+        }
+        imports.each { item ->
+            xcTestSourceFileElement.withImport(item)
+        }
+        importsTestable.each { item ->
+            xcTestSourceFileElement.withTestableImport(item)
+        }
+        return [xcTestSourceFileElement]
+    }
+}

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/GroovyCompilerIntegrationSpec/gradle3235/build.gradle
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/GroovyCompilerIntegrationSpec/gradle3235/build.gradle
@@ -10,5 +10,5 @@ dependencies {
 }
 
 testing.suites.test {
-    useJUnit()
+    useJUnitJupiter()
 }

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/GroovyCompilerIntegrationSpec/gradle3235/src/test/groovy/DummyFileForCompilation.groovy
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/GroovyCompilerIntegrationSpec/gradle3235/src/test/groovy/DummyFileForCompilation.groovy
@@ -16,7 +16,11 @@
 
 import groovy.transform.Canonical
 import groovy.transform.CompileStatic
+import org.junit.jupiter.api.Test
 
 @Canonical
 @CompileStatic
-class DummyFileForCompilation {}
+class DummyFileForCompilation {
+    @Test
+    void dummyTest() {}
+}

--- a/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
@@ -483,10 +483,11 @@ public abstract class AbstractTestTask extends ConventionTask implements Verific
         if (testCountLogger.hadFailures()) {
             handleTestFailures();
         } else if (testCountLogger.getTotalTests() == 0) {
-            if (shouldFailOnNoMatchingTests()) {
+            if (!hasFilter()) {
+                emitDeprecationMessage();
+            } else if (shouldFailOnNoMatchingTests()) {
                 throw new TestExecutionException(createNoMatchingTestErrorMessage());
             }
-            emitDeprecationMessage();
         }
     }
 
@@ -499,9 +500,13 @@ public abstract class AbstractTestTask extends ConventionTask implements Verific
     }
 
     private boolean shouldFailOnNoMatchingTests() {
-        return filter.isFailOnNoMatchingTests() && (!filter.getIncludePatterns().isEmpty()
+        return filter.isFailOnNoMatchingTests() && hasFilter();
+    }
+
+    private boolean hasFilter() {
+        return !filter.getIncludePatterns().isEmpty()
             || !filter.getCommandLineIncludePatterns().isEmpty()
-            || !filter.getExcludePatterns().isEmpty());
+            || !filter.getExcludePatterns().isEmpty();
     }
 
     private String createNoMatchingTestErrorMessage() {

--- a/subprojects/testing-base/src/testFixtures/groovy/org/gradle/testing/AbstractTestFrameworkIntegrationTest.groovy
+++ b/subprojects/testing-base/src/testFixtures/groovy/org/gradle/testing/AbstractTestFrameworkIntegrationTest.groovy
@@ -161,6 +161,9 @@ abstract class AbstractTestFrameworkIntegrationTest extends AbstractIntegrationS
         createEmptyProject()
 
         when:
+        executer.expectDocumentedDeprecationWarning("No test executed. This behavior has been deprecated. " +
+            "This will fail with an error in Gradle 9.0. There are test sources present but no test was executed. Please check your test configuration. " +
+            "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#test_task_fail_on_no_test_executed")
         succeeds "check"
 
         then:

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskFailOnNoTestIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskFailOnNoTestIntegrationTest.groovy
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+import static org.gradle.testing.fixture.JUnitCoverage.getLATEST_JUPITER_VERSION
+
+class TestTaskFailOnNoTestIntegrationTest extends AbstractIntegrationSpec {
+
+    def "test succeeds if a test was executed"() {
+        createBuildFileWithJUnitJupiter()
+
+        file("src/test/java/SomeTest.java") << """
+            public class SomeTest {
+                @org.junit.jupiter.api.Test
+                public void foo() { }
+            }
+        """
+
+        expect:
+        succeeds("test")
+    }
+
+    def "test succeeds with warning if no test was executed"() {
+        createBuildFileWithJUnitJupiter()
+
+        file("src/test/java/NotATest.java") << """
+            public class NotATest {}
+        """
+
+        executer.expectDocumentedDeprecationWarning("No test executed. This behavior has been deprecated. " +
+            "This will fail with an error in Gradle 9.0. There are test sources present but no test was executed. Please check your test configuration. " +
+            "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#test_task_fail_on_no_test_executed")
+
+        expect:
+        succeeds("test")
+    }
+
+    def "test is skipped if no test source detected"() {
+        buildFile << "apply plugin: 'java'"
+
+        file("src/test/java/not_a_test.txt")
+
+        when:
+        succeeds("test")
+
+        then:
+        skipped(":test")
+    }
+
+    def createBuildFileWithJUnitJupiter() {
+        buildFile << """
+            plugins {
+                id 'java'
+                id 'jvm-test-suite'
+            }
+            ${mavenCentralRepository()}
+            dependencies {
+                testImplementation 'org.junit.jupiter:junit-jupiter:${LATEST_JUPITER_VERSION}'
+            }
+            testing.suites.test {
+                useJUnitJupiter()
+            }
+        """.stripIndent()
+    }
+}

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/AbstractJUnitCategoriesOrTagsCoverageIntegrationSpec.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/AbstractJUnitCategoriesOrTagsCoverageIntegrationSpec.groovy
@@ -236,6 +236,9 @@ abstract class AbstractJUnitCategoriesOrTagsCoverageIntegrationSpec extends Abst
         """
 
         when:
+        executer.expectDocumentedDeprecationWarning("No test executed. This behavior has been deprecated. " +
+            "This will fail with an error in Gradle 9.0. There are test sources present but no test was executed. Please check your test configuration. " +
+            "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#test_task_fail_on_no_test_executed")
         run('test')
 
         then:

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/junit4/JUnit4CategoriesOrTagsCoverageIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/junit4/JUnit4CategoriesOrTagsCoverageIntegrationTest.groovy
@@ -182,8 +182,8 @@ class JUnit4CategoriesOrTagsCoverageIntegrationTest extends AbstractJUnit4Catego
         testSources.with {
             ['test', 'integTest'].each { sourceSet ->
                 testClass('SomeTestClass', sourceSet).with {
-                    testMethod('ok1')
-                    testMethod('ok2')
+                    testMethod('ok1').withCategoryOrTag('CategoryA')
+                    testMethod('ok2').withCategoryOrTag('CategoryB')
                 }
                 testCategory('CategoryA', sourceSet)
                 testCategory('CategoryB', sourceSet)
@@ -256,8 +256,8 @@ class JUnit4CategoriesOrTagsCoverageIntegrationTest extends AbstractJUnit4Catego
         given:
         testSources.with {
             testClass('SomeTestClass').with {
-                testMethod('ok1')
-                testMethod('ok2')
+                testMethod('ok1').withCategoryOrTag('CategoryA')
+                testMethod('ok2').withCategoryOrTag('CategoryB')
             }
             testCategory('CategoryA')
             testCategory('CategoryB')

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/junit4/JUnit4JUnitIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/junit4/JUnit4JUnitIntegrationTest.groovy
@@ -37,6 +37,8 @@ class JUnit4JUnitIntegrationTest extends AbstractJUnit4JUnitIntegrationTest impl
         and:
         file("src/test/java/SomeTest.java") << """
             public class SomeTest extends org.junit.runner.Result {
+                @org.junit.Test
+                public void test() { }
             }
         """.stripIndent()
         then:

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/platform/JUnitPlatformIntegrationSpec.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/platform/JUnitPlatformIntegrationSpec.groovy
@@ -55,4 +55,23 @@ class JUnitPlatformIntegrationSpec extends AbstractIntegrationSpec {
             }
             '''
     }
+
+    void createSimpleJupiterTests() {
+        file('src/test/java/org/gradle/JUnitJupiterTest.java') << '''
+            package org.gradle;
+
+            import org.junit.jupiter.api.Tag;
+            import org.junit.jupiter.api.Test;
+
+            public class JUnitJupiterTest {
+                @Test
+                @Tag("good")
+                public void good() { }
+
+                @Test
+                @Tag("bad")
+                public void bad() { }
+            }
+            '''
+    }
 }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/platform/JUnitPlatformIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/platform/JUnitPlatformIntegrationTest.groovy
@@ -260,7 +260,7 @@ public class StaticInnerTest {
                 }
             }
         """)
-        createSimpleJupiterTest()
+        createSimpleJupiterTests()
 
         when:
         succeeds ':test'
@@ -283,10 +283,10 @@ public class StaticInnerTest {
 
         where:
         key              | value
-        'includeTags'    | '"ok"'
-        'excludeTags'    | '"ok"'
+        'includeTags'    | '"good"'
+        'excludeTags'    | '"bad"'
         'includeEngines' | '"junit-jupiter"'
-        'excludeEngines' | '"junit-jupiter"'
+        'excludeEngines' | '"junit-vintage-engine"'
     }
 
     @Timeout(60)

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/platform/JUnitPlatformLauncherSessionListenerIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/platform/JUnitPlatformLauncherSessionListenerIntegrationTest.groovy
@@ -69,6 +69,7 @@ class JUnitPlatformLauncherSessionListenerIntegrationTest extends JUnitPlatformI
 
             dependencies {
                 testImplementation project(':other')
+                testCompileOnly 'org.junit.jupiter:junit-jupiter:5.9.1'
                 testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.1'
             }
 
@@ -77,7 +78,14 @@ class JUnitPlatformLauncherSessionListenerIntegrationTest extends JUnitPlatformI
                 testLogging.showStandardStreams = true
             }
         """
-        file("src/test/java/com/example/MyTest.java") << "package com.example; public class MyTest {} "
+        file("src/test/java/com/example/MyTest.java") << """
+            package com.example;
+
+            public class MyTest {
+                @org.junit.jupiter.api.Test
+                public void myTest() { }
+            }
+        """
 
         when:
         executer.expectDocumentedDeprecationWarning("The automatic loading of test framework implementation dependencies has been deprecated. This is scheduled to be removed in Gradle 9.0. Declare the desired test framework directly on the test suite or explicitly declare the test framework implementation dependencies on the test's runtime classpath. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#test_framework_implementation_dependencies")

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFailOnNoTestIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFailOnNoTestIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.testing.testng
 
-import static org.gradle.testing.fixture.JUnitCoverage.getLATEST_PLATFORM_VERSION
+import static org.gradle.testing.fixture.JUnitCoverage.LATEST_JUPITER_VERSION
 import static org.gradle.testing.fixture.TestNGCoverage.NEWEST
 
 class TestNGFailOnNoTestIntegrationTest extends TestNGTestFrameworkIntegrationTest {
@@ -55,7 +55,8 @@ class TestNGFailOnNoTestIntegrationTest extends TestNGTestFrameworkIntegrationTe
             apply plugin:'java-library'
             ${mavenCentralRepository()}
             dependencies {
-                testRuntimeOnly 'org.junit.platform:junit-platform-suite-engine:${LATEST_PLATFORM_VERSION}'
+                testImplementation 'org.junit.jupiter:junit-jupiter:${LATEST_JUPITER_VERSION}'
+                testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
             }
             test {
                 useJUnitPlatform()

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFailOnNoTestIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFailOnNoTestIntegrationTest.groovy
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing.testng
+
+import static org.gradle.testing.fixture.JUnitCoverage.getLATEST_PLATFORM_VERSION
+import static org.gradle.testing.fixture.TestNGCoverage.NEWEST
+
+class TestNGFailOnNoTestIntegrationTest extends TestNGTestFrameworkIntegrationTest {
+
+    static final String LATEST_TESTNG_VERSION = NEWEST
+
+    def "test source and test task use same test framework"() {
+        given:
+        buildFile << """
+            apply plugin:'java-library'
+            ${mavenCentralRepository()}
+            dependencies {
+                testImplementation 'org.testng:testng:$LATEST_TESTNG_VERSION'
+            }
+            test {
+                useTestNG()
+            }
+        """
+
+        file("src/test/java/NotATest.java") << """
+            // missing @org.testng.annotations.Test
+            public class NotATest {}
+        """
+
+        executer.expectDocumentedDeprecationWarning("No test executed. This behavior has been deprecated. " +
+            "This will fail with an error in Gradle 9.0. There are test sources present but no test was executed. Please check your test configuration. " +
+            "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#test_task_fail_on_no_test_executed")
+
+        expect:
+        succeeds('test')
+    }
+
+    def "test source and test task use different test frameworks"() {
+        given:
+        buildFile << """
+            apply plugin:'java-library'
+            ${mavenCentralRepository()}
+            dependencies {
+                testRuntimeOnly 'org.junit.platform:junit-platform-suite-engine:${LATEST_PLATFORM_VERSION}'
+            }
+            test {
+                useJUnitPlatform()
+            }
+        """
+
+        createPassingFailingTest()
+
+        executer.expectDocumentedDeprecationWarning("No test executed. This behavior has been deprecated. " +
+            "This will fail with an error in Gradle 9.0. There are test sources present but no test was executed. Please check your test configuration. " +
+            "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#test_task_fail_on_no_test_executed")
+
+        expect:
+        succeeds('test')
+    }
+}

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGIntegrationTest.groovy
@@ -370,6 +370,8 @@ class TestNGIntegrationTest extends MultiVersionIntegrationSpec {
         and:
         file("src/test/java/SomeTest.java") << """
             public class SomeTest extends org.testng.Converter {
+                @org.testng.annotations.Test
+                public void test() {}
             }
         """
         then:

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGTestFrameworkIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGTestFrameworkIntegrationTest.groovy
@@ -88,6 +88,9 @@ class TestNGTestFrameworkIntegrationTest extends AbstractTestFrameworkIntegratio
         """
 
         when:
+        executer.expectDocumentedDeprecationWarning("No test executed. This behavior has been deprecated. " +
+            "This will fail with an error in Gradle 9.0. There are test sources present but no test was executed. Please check your test configuration. " +
+            "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#test_task_fail_on_no_test_executed")
         succeeds "test"
 
         then:
@@ -108,6 +111,9 @@ class TestNGTestFrameworkIntegrationTest extends AbstractTestFrameworkIntegratio
         """
 
         when:
+        executer.expectDocumentedDeprecationWarning("No test executed. This behavior has been deprecated. " +
+            "This will fail with an error in Gradle 9.0. There are test sources present but no test was executed. Please check your test configuration. " +
+            "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#test_task_fail_on_no_test_executed")
         succeeds "test"
 
         then:

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGUpToDateCheckIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGUpToDateCheckIntegrationTest.groovy
@@ -26,7 +26,7 @@ class TestNGUpToDateCheckIntegrationTest extends AbstractIntegrationSpec {
         executer.noExtraLogging()
         file('src/test/java/SomeTest.java') << '''
             public class SomeTest {
-                @org.testng.annotations.Test
+                @org.testng.annotations.Test(groups = {"group to include"})
                 public void pass() {}
             }
         '''.stripIndent()
@@ -173,8 +173,8 @@ class TestNGUpToDateCheckIntegrationTest extends AbstractIntegrationSpec {
 
         where:
         property              | modification
-        'excludeGroups'       | '= ["some group"]'
-        'includeGroups'       | '= ["some group"]'
+        'excludeGroups'       | '= ["group to exclude"]'
+        'includeGroups'       | '= ["group to include"]'
         'outputDirectory'     | '= file("$buildDir/my-out")'
         'suiteXmlFiles'       | '= [file("suite.xml")]'
         'suiteXmlBuilder()'   | '''

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/SwiftXCTestIntegrationTest.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/SwiftXCTestIntegrationTest.groovy
@@ -35,6 +35,7 @@ import org.gradle.nativeplatform.fixtures.app.SwiftLibTest
 import org.gradle.nativeplatform.fixtures.app.SwiftLibWithXCTest
 import org.gradle.nativeplatform.fixtures.app.SwiftSingleFileApp
 import org.gradle.nativeplatform.fixtures.app.SwiftSingleFileLibWithSingleXCTestSuite
+import org.gradle.nativeplatform.fixtures.app.SwiftXCTestWithDepAndCustomXCTestSuite
 import org.gradle.nativeplatform.fixtures.app.XCTestCaseElement
 import org.gradle.nativeplatform.fixtures.app.XCTestSourceElement
 import org.gradle.nativeplatform.fixtures.app.XCTestSourceFileElement
@@ -429,7 +430,7 @@ apply plugin: 'swift-library'
     }
 
     @ToBeFixedForConfigurationCache
-    def 'can build xctest bundle which transitively dependencies on other Swift libraries'() {
+    def 'can build xctest bundle which transitively depends on other Swift libraries'() {
         given:
         def app = new SwiftAppWithLibraries()
         settingsFile << """
@@ -456,16 +457,9 @@ apply plugin: 'swift-library'
         app.greeter.writeToProject(file('hello'))
         app.logger.writeToProject(file('log'))
 
-        file('src/test/swift/MainTest.swift') << """
-            import XCTest
-            import App
+        def test = new SwiftXCTestWithDepAndCustomXCTestSuite('bundle', 'Main','XCTAssert(main() == 0)', ['App'] as String[], [] as String[])
+        test.writeToProject(testDirectory)
 
-            public class MainTest : XCTestCase {
-                public func testMain() {
-                    XCTAssert(main() == 0)
-                }
-            }
-        """
         when:
         succeeds 'test'
 
@@ -516,16 +510,9 @@ apply plugin: 'swift-library'
         app.greeter.writeToProject(file('Sources/Hello'))
         app.logger.writeToProject(file('Sources/Log'))
 
-        file('Tests/AppTests/UtilTest.swift') << """
-            import XCTest
-            import App
+        def test = new SwiftXCTestWithDepAndCustomXCTestSuite('testing', 'Main', 'XCTAssert(main() == 0)', ['App'] as String[], [] as String[])
+        test.writeToProject(testDirectory)
 
-            public class MainTest : XCTestCase {
-                public func testMain() {
-                    XCTAssert(main() == 0)
-                }
-            }
-        """
         when:
         succeeds 'test'
 

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/XCTestWithApplicationDependenciesIntegrationTest.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/XCTestWithApplicationDependenciesIntegrationTest.groovy
@@ -34,7 +34,7 @@ class XCTestWithApplicationDependenciesIntegrationTest extends AbstractNativeUni
 """
         file("src/main/swift/App.swift") << """
             import Lib
-            
+
             class App {
                 var util = Util()
             }
@@ -42,9 +42,13 @@ class XCTestWithApplicationDependenciesIntegrationTest extends AbstractNativeUni
         file("src/test/swift/Test.swift") << """
             @testable import Root
             import XCTest
-                        
-            class Test {
+
+            class Test : XCTestCase {
                 var app = App()
+
+                func test() {
+                    XCTAssertNotNil(app.util)
+                }
             }
 """
         file("lib/src/main/swift/Util.swift") << """

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/XCTestWithApplicationDependenciesIntegrationTest.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/XCTestWithApplicationDependenciesIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.language.AbstractNativeUnitTestComponentDependenciesIntegratio
 import org.gradle.language.swift.SwiftTaskNames
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
+import org.gradle.nativeplatform.fixtures.app.SwiftXCTestWithDepAndCustomXCTestSuite
 
 @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC)
 class XCTestWithApplicationDependenciesIntegrationTest extends AbstractNativeUnitTestComponentDependenciesIntegrationTest implements SwiftTaskNames {
@@ -39,18 +40,9 @@ class XCTestWithApplicationDependenciesIntegrationTest extends AbstractNativeUni
                 var util = Util()
             }
 """
-        file("src/test/swift/Test.swift") << """
-            @testable import Root
-            import XCTest
+        def testSource = new SwiftXCTestWithDepAndCustomXCTestSuite("app", "App", "XCTAssertNotNil(App().util)", [] as String[], ["Root"] as String[])
+        testSource.writeToProject(testDirectory)
 
-            class Test : XCTestCase {
-                var app = App()
-
-                func test() {
-                    XCTAssertNotNil(app.util)
-                }
-            }
-"""
         file("lib/src/main/swift/Util.swift") << """
             public class Util {
                 public init() { }


### PR DESCRIPTION
The `test` task currently succeeds when no test was executed, this is to be deprecated. Running the test task with no test to execute is typically caused by some misconfiguration, which is likely missed if `test` succeeds.

Note that "no test to execute" is different to "no test present". The former means there are test sources present, but they are not run (for example because of a missing test annotation or a different test framework.) The latter means there are no test sources present, in which case the `test` task is skipped.

`TestFilter::isFailOnNoMatchingTests` is not affected by this change. If `isFailOnNoMatchingTests == true`, `test` will fail and if `isFailOnNoMatchingTests == false`, `test` will run without a deprecation warning.

Most changes in this PR are updates of existing tests where tests were not run due to a missing test annotation or test method.

Relates to #7452