### PR TITLE
Set the target JDK for older PMD tests

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginVersionIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginVersionIntegrationTest.groovy
@@ -41,6 +41,8 @@ class PmdPluginVersionIntegrationTest extends AbstractPmdPluginVersionIntegratio
 
             pmd {
                 toolVersion = '$version'
+                // Set target JDK for PMD <5.x tests, so the test code is accepted
+                targetJdk = TargetJdk.VERSION_1_7
                 ${supportIncrementalAnalysis() ? "" : "incrementalAnalysis = false"}
             }
 


### PR DESCRIPTION
This allows our test code to work on older PMD versions, instead of failing due to old Java restrictions

Fixes https://github.com/gradle/gradle-private/issues/3830