### PR TITLE
Support java.util.Properties in Java 8

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/Codecs.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/Codecs.kt
@@ -363,6 +363,8 @@ class Codecs(
         bind(treeMapCodec)
         bind(concurrentHashMapCodec)
         bind(ImmutableMapCodec)
+        bind(propertiesCodec)
+        bind(hashtableCodec)
 
         // Arrays
         bind(BYTE_ARRAY_SERIALIZER)

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/CollectionCodecs.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/CollectionCodecs.kt
@@ -26,7 +26,9 @@ import org.gradle.configurationcache.serialization.readList
 import org.gradle.configurationcache.serialization.readMapInto
 import org.gradle.configurationcache.serialization.writeCollection
 import org.gradle.configurationcache.serialization.writeMap
+import java.util.Hashtable
 import java.util.LinkedList
+import java.util.Properties
 import java.util.TreeMap
 import java.util.TreeSet
 import java.util.concurrent.ConcurrentHashMap
@@ -176,6 +178,21 @@ val linkedHashMapCodec: Codec<LinkedHashMap<Any?, Any?>> = mapCodec { LinkedHash
 
 internal
 val concurrentHashMapCodec: Codec<ConcurrentHashMap<Any?, Any?>> = mapCodec { ConcurrentHashMap<Any?, Any?>(it) }
+
+
+/*
+ * Cannot rely on Java serialization as
+ * Hashtable's readObject() calls unsupported ObjectInputStream#readFields().
+ */
+internal
+val hashtableCodec: Codec<Hashtable<Any?, Any?>> = mapCodec { Hashtable(it) }
+
+
+/*
+ * Decodes Properties as Properties instead of Hashtable.
+ */
+internal
+val propertiesCodec: Codec<Properties> = mapCodec { Properties() }
 
 
 internal

--- a/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/serialization/codecs/BaseTypeCodecTest.kt
+++ b/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/serialization/codecs/BaseTypeCodecTest.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache.serialization.codecs
+
+import org.hamcrest.CoreMatchers
+import org.hamcrest.MatcherAssert
+import org.junit.Test
+import java.util.Properties
+
+
+class BaseTypeCodecTest : AbstractUserTypeCodecTest() {
+
+    @Test
+    fun `can handle Properties`() {
+        val properties = Properties()
+        properties.put("prop1", "value1")
+        properties.put("prop2", "value2")
+        configurationCacheRoundtripOf(properties).run {
+            MatcherAssert.assertThat(properties, CoreMatchers.equalTo(this))
+        }
+    }
+}

--- a/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/serialization/codecs/BaseTypeCodecTest.kt
+++ b/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/serialization/codecs/BaseTypeCodecTest.kt
@@ -16,9 +16,10 @@
 
 package org.gradle.configurationcache.serialization.codecs
 
-import org.hamcrest.CoreMatchers
-import org.hamcrest.MatcherAssert
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
+import java.util.Hashtable
 import java.util.Properties
 
 
@@ -27,10 +28,21 @@ class BaseTypeCodecTest : AbstractUserTypeCodecTest() {
     @Test
     fun `can handle Properties`() {
         val properties = Properties()
-        properties.put("prop1", "value1")
-        properties.put("prop2", "value2")
+        properties.setProperty("prop1", "value1")
+        properties.setProperty("prop2", "value2")
         configurationCacheRoundtripOf(properties).run {
-            MatcherAssert.assertThat(properties, CoreMatchers.equalTo(this))
+            assertThat(properties, equalTo(this))
+        }
+    }
+
+    @Test
+    fun `can handle Hashtable`() {
+        val hashtable = Hashtable<String, Any>(100)
+        hashtable.put("key1", "value1")
+        hashtable.put("key2", true)
+        hashtable.put("key3", 42)
+        configurationCacheRoundtripOf(hashtable).run {
+            assertThat(hashtable, equalTo(this))
         }
     }
 }


### PR DESCRIPTION
Hashtable's readObject() uses unsupported ObjectInputStream#readFields(), and so did Properties up to Java 8.

Issue: #24765
