### PR TITLE
docs: Make the configuration avoidance API table more readable

### DIFF
--- a/subprojects/docs/src/docs/userguide/extending-gradle/task_configuration_avoidance.adoc
+++ b/subprojects/docs/src/docs/userguide/extending-gradle/task_configuration_avoidance.adoc
@@ -371,7 +371,7 @@ The second method is to use Java reflection to cope with the fact that the APIs 
 It is highly recommended to have cross-version test coverage using <<test_kit.adoc#sub:gradle-runner-gradle-version, TestKit>> and multiple versions of Gradle.
 
 [[sec:old_vs_new_configuration_api_overview]]
-== Existing vs New API overview
+== Old vs New API overview
 
 [NOTE]
 ====
@@ -383,111 +383,111 @@ It is highly recommended to have cross-version test coverage using <<test_kit.ad
 
 [cols="a,a", options="header"]
 |===
-| Old vs New API
-| Description
+| Old API
+| New API
 
-| Instead of: `task myTask(type: MyTask) {}`
-.2+| There is not a shorthand Groovy DSL for using the new API.
-| Use: `tasks.register("myTask", MyTask) {}`
+| `task myTask(type: MyTask) {}`
+| `tasks.register("myTask", MyTask) {}`
+2+| There is not a shorthand Groovy DSL for using the new API.
 
-| Instead of: link:{javadocPath}/org/gradle/api/tasks/TaskContainer.html#create-java.util.Map-[TaskContainer.create(java.util.Map)]
-.2+| Use one of the alternatives below.
-| Use: No direct equivalent.
+| link:{javadocPath}/org/gradle/api/tasks/TaskContainer.html#create-java.util.Map-[TaskContainer.create(java.util.Map)]
+| No direct equivalent.
+2+| Use one of the alternatives below.
 
-| Instead of: link:{javadocPath}/org/gradle/api/tasks/TaskContainer.html#create-java.util.Map-groovy.lang.Closure-[TaskContainer.create(java.util.Map, groovy.lang.Closure)]
-.2+| Use one of the alternatives below.
-| Use: No direct equivalent.
+| link:{javadocPath}/org/gradle/api/tasks/TaskContainer.html#create-java.util.Map-groovy.lang.Closure-[TaskContainer.create(java.util.Map, groovy.lang.Closure)]
+| No direct equivalent.
+2+| Use one of the alternatives below.
 
-| Instead of: link:{javadocPath}/org/gradle/api/tasks/TaskContainer.html#create-java.lang.String-[TaskContainer.create(java.lang.String)]
-.2+| This returns a `TaskProvider` instead of a `Task`.
-| Use: link:{javadocPath}/org/gradle/api/tasks/TaskContainer.html#register-java.lang.String-[TaskContainer.register(java.lang.String)]
+| link:{javadocPath}/org/gradle/api/tasks/TaskContainer.html#create-java.lang.String-[TaskContainer.create(java.lang.String)]
+| link:{javadocPath}/org/gradle/api/tasks/TaskContainer.html#register-java.lang.String-[TaskContainer.register(java.lang.String)]
+2+| This returns a `TaskProvider` instead of a `Task`.
 
-| Instead of: link:{javadocPath}/org/gradle/api/tasks/TaskContainer.html#create-java.lang.String-groovy.lang.Closure-[TaskContainer.create(java.lang.String, groovy.lang.Closure)]
-.2+| This returns a `TaskProvider` instead of a `Task`.
-| Use: link:{javadocPath}/org/gradle/api/tasks/TaskContainer.html#register-java.lang.String-org.gradle.api.Action-[TaskContainer.register(java.lang.String, org.gradle.api.Action)]
+| link:{javadocPath}/org/gradle/api/tasks/TaskContainer.html#create-java.lang.String-groovy.lang.Closure-[TaskContainer.create(java.lang.String, groovy.lang.Closure)]
+| link:{javadocPath}/org/gradle/api/tasks/TaskContainer.html#register-java.lang.String-org.gradle.api.Action-[TaskContainer.register(java.lang.String, org.gradle.api.Action)]
+2+| This returns a `TaskProvider` instead of a `Task`.
 
-| Instead of: link:{javadocPath}/org/gradle/api/tasks/TaskContainer.html#create-java.lang.String-java.lang.Class-[TaskContainer.create(java.lang.String, java.lang.Class)]
-.2+| This returns a `TaskProvider` instead of a `Task`.
-| Use: link:{javadocPath}/org/gradle/api/tasks/TaskContainer.html#register-java.lang.String-java.lang.Class-[TaskContainer.register(java.lang.String, java.lang.Class)]
+| link:{javadocPath}/org/gradle/api/tasks/TaskContainer.html#create-java.lang.String-java.lang.Class-[TaskContainer.create(java.lang.String, java.lang.Class)]
+| link:{javadocPath}/org/gradle/api/tasks/TaskContainer.html#register-java.lang.String-java.lang.Class-[TaskContainer.register(java.lang.String, java.lang.Class)]
+2+| This returns a `TaskProvider` instead of a `Task`.
 
-| Instead of: link:{javadocPath}/org/gradle/api/tasks/TaskContainer.html#create-java.lang.String-java.lang.Class-org.gradle.api.Action-[TaskContainer.create(java.lang.String, java.lang.Class, org.gradle.api.Action)]
-.2+| This returns a `TaskProvider` instead of a `Task`.
-| Use: link:{javadocPath}/org/gradle/api/tasks/TaskContainer.html#register-java.lang.String-java.lang.Class-org.gradle.api.Action-[TaskContainer.register(java.lang.String, java.lang.Class, org.gradle.api.Action)]
+| link:{javadocPath}/org/gradle/api/tasks/TaskContainer.html#create-java.lang.String-java.lang.Class-org.gradle.api.Action-[TaskContainer.create(java.lang.String, java.lang.Class, org.gradle.api.Action)]
+| link:{javadocPath}/org/gradle/api/tasks/TaskContainer.html#register-java.lang.String-java.lang.Class-org.gradle.api.Action-[TaskContainer.register(java.lang.String, java.lang.Class, org.gradle.api.Action)]
+2+| This returns a `TaskProvider` instead of a `Task`.
 
-| Instead of: link:{javadocPath}/org/gradle/api/tasks/TaskContainer.html#create-java.lang.String-java.lang.Class-java.lang.Object++...++-[TaskContainer.create(java.lang.String, java.lang.Class, java.lang.Object...)]
-.2+| This returns a `TaskProvider` instead of a `Task`.
-| Use: link:{javadocPath}/org/gradle/api/tasks/TaskContainer.html#register-java.lang.String-java.lang.Class-java.lang.Object++...++-[TaskContainer.register(java.lang.String, java.lang.Class, java.lang.Object...)]
+| link:{javadocPath}/org/gradle/api/tasks/TaskContainer.html#create-java.lang.String-java.lang.Class-java.lang.Object++...++-[TaskContainer.create(java.lang.String, java.lang.Class, java.lang.Object...)]
+| link:{javadocPath}/org/gradle/api/tasks/TaskContainer.html#register-java.lang.String-java.lang.Class-java.lang.Object++...++-[TaskContainer.register(java.lang.String, java.lang.Class, java.lang.Object...)]
+2+| This returns a `TaskProvider` instead of a `Task`.
 
-| Instead of: link:{javadocPath}/org/gradle/api/tasks/TaskCollection.html#getByName-java.lang.String-[TaskCollection.getByName(java.lang.String)]
-.2+| This returns a `TaskProvider` instead of a `Task`.
-| Use: link:{javadocPath}/org/gradle/api/tasks/TaskCollection.html#named-java.lang.String-[TaskCollection.named(java.lang.String)]
+| link:{javadocPath}/org/gradle/api/tasks/TaskCollection.html#getByName-java.lang.String-[TaskCollection.getByName(java.lang.String)]
+| link:{javadocPath}/org/gradle/api/tasks/TaskCollection.html#named-java.lang.String-[TaskCollection.named(java.lang.String)]
+2+| This returns a `TaskProvider` instead of a `Task`.
 
-| Instead of: link:{javadocPath}/org/gradle/api/tasks/TaskCollection.html#getByName-java.lang.String-groovy.lang.Closure-[TaskCollection.getByName(java.lang.String, groovy.lang.Closure)]
-.2+| This returns a `TaskProvider` instead of a `Task`.
-| Use: `named(java.lang.String, Action)`
+| link:{javadocPath}/org/gradle/api/tasks/TaskCollection.html#getByName-java.lang.String-groovy.lang.Closure-[TaskCollection.getByName(java.lang.String, groovy.lang.Closure)]
+| `named(java.lang.String, Action)`
+2+| This returns a `TaskProvider` instead of a `Task`.
 
-| Instead of: link:{javadocPath}/org/gradle/api/tasks/TaskContainer.html#getByPath-java.lang.String-[TaskContainer.getByPath(java.lang.String)]
-.2+| Accessing tasks from another project requires a specific ordering of project evaluation.
-| Use: No direct equivalent.
+| link:{javadocPath}/org/gradle/api/tasks/TaskContainer.html#getByPath-java.lang.String-[TaskContainer.getByPath(java.lang.String)]
+| No direct equivalent.
+2+| Accessing tasks from another project requires a specific ordering of project evaluation.
 
-| Instead of: link:{javadocPath}/org/gradle/api/NamedDomainObjectCollection.html#findByName-java.lang.String-[NamedDomainObjectCollection.findByName(java.lang.String)]
-.2+| `named(String)` is the closest equivalent, but will fail if the task does not exist. Using `findByName(String)` will cause tasks registered with the new API to be created/configured.
-| Use: No direct equivalent.
+| link:{javadocPath}/org/gradle/api/NamedDomainObjectCollection.html#findByName-java.lang.String-[NamedDomainObjectCollection.findByName(java.lang.String)]
+| No direct equivalent.
+2+| `named(String)` is the closest equivalent, but will fail if the task does not exist. Using `findByName(String)` will cause tasks registered with the new API to be created/configured.
 
-| Instead of: link:{javadocPath}/org/gradle/api/tasks/TaskContainer.html#findByPath-java.lang.String-[TaskContainer.findByPath(java.lang.String)]
-.2+| See `getByPath(String)` above.
-| Use: No direct equivalent.
+| link:{javadocPath}/org/gradle/api/tasks/TaskContainer.html#findByPath-java.lang.String-[TaskContainer.findByPath(java.lang.String)]
+| No direct equivalent.
+2+| See `getByPath(String)` above.
 
-| Instead of: link:{javadocPath}/org/gradle/api/tasks/TaskCollection.html#withType-java.lang.Class-[TaskCollection.withType(java.lang.Class)]
-.2+| This is OK to use because it does not require tasks to be created immediately.
-| Use: _OK_
+| link:{javadocPath}/org/gradle/api/tasks/TaskCollection.html#withType-java.lang.Class-[TaskCollection.withType(java.lang.Class)]
+| _OK_
+2+| This is OK to use because it does not require tasks to be created immediately.
 
-| Instead of: `withType(java.lang.Class).getByName(java.lang.String)`
-.2+| This returns a `TaskProvider` instead of a `Task`.
-| Use: `named(java.lang.String, java.lang.Class)`
+| `withType(java.lang.Class).getByName(java.lang.String)`
+| `named(java.lang.String, java.lang.Class)`
+2+| This returns a `TaskProvider` instead of a `Task`.
 
-| Instead of: link:{javadocPath}/org/gradle/api/DomainObjectCollection.html#withType-java.lang.Class-org.gradle.api.Action-[DomainObjectCollection.withType(java.lang.Class, org.gradle.api.Action)]
-.2+| This returns `void`, so it cannot be chained.
-| Use: `withType(java.lang.Class).configureEach(org.gradle.api.Action)`
+| link:{javadocPath}/org/gradle/api/DomainObjectCollection.html#withType-java.lang.Class-org.gradle.api.Action-[DomainObjectCollection.withType(java.lang.Class, org.gradle.api.Action)]
+| `withType(java.lang.Class).configureEach(org.gradle.api.Action)`
+2+| This returns `void`, so it cannot be chained.
 
-| Instead of: link:{javadocPath}/org/gradle/api/DomainObjectCollection.html#all-org.gradle.api.Action-[DomainObjectCollection.all(org.gradle.api.Action)]
-.2+| This returns `void`, so it cannot be chained.
-| Use: link:{javadocPath}/org/gradle/api/DomainObjectCollection.html#configureEach-org.gradle.api.Action-[DomainObjectCollection.configureEach(org.gradle.api.Action)]
+| link:{javadocPath}/org/gradle/api/DomainObjectCollection.html#all-org.gradle.api.Action-[DomainObjectCollection.all(org.gradle.api.Action)]
+| link:{javadocPath}/org/gradle/api/DomainObjectCollection.html#configureEach-org.gradle.api.Action-[DomainObjectCollection.configureEach(org.gradle.api.Action)]
+2+| This returns `void`, so it cannot be chained.
 
-| Instead of: link:{javadocPath}/org/gradle/api/tasks/TaskCollection.html#whenTaskAdded-org.gradle.api.Action-[TaskCollection.whenTaskAdded(org.gradle.api.Action)]
-.2+| This returns `void`, so it cannot be chained.
-| Use: link:{javadocPath}/org/gradle/api/DomainObjectCollection.html#configureEach-org.gradle.api.Action-[DomainObjectCollection.configureEach(org.gradle.api.Action)]
+| link:{javadocPath}/org/gradle/api/tasks/TaskCollection.html#whenTaskAdded-org.gradle.api.Action-[TaskCollection.whenTaskAdded(org.gradle.api.Action)]
+| link:{javadocPath}/org/gradle/api/DomainObjectCollection.html#configureEach-org.gradle.api.Action-[DomainObjectCollection.configureEach(org.gradle.api.Action)]
+2+| This returns `void`, so it cannot be chained.
 
-| Instead of: link:{javadocPath}/org/gradle/api/DomainObjectCollection.html#whenObjectAdded-org.gradle.api.Action-[DomainObjectCollection.whenObjectAdded(org.gradle.api.Action)]
-.2+| This returns `void`, so it cannot be chained.
-| Use: link:{javadocPath}/org/gradle/api/DomainObjectCollection.html#configureEach-org.gradle.api.Action-[DomainObjectCollection.configureEach(org.gradle.api.Action)]
+| link:{javadocPath}/org/gradle/api/DomainObjectCollection.html#whenObjectAdded-org.gradle.api.Action-[DomainObjectCollection.whenObjectAdded(org.gradle.api.Action)]
+| link:{javadocPath}/org/gradle/api/DomainObjectCollection.html#configureEach-org.gradle.api.Action-[DomainObjectCollection.configureEach(org.gradle.api.Action)]
+2+| This returns `void`, so it cannot be chained.
 
-| Instead of: link:{javadocPath}/org/gradle/api/NamedDomainObjectSet.html#findAll-groovy.lang.Closure-[NamedDomainObjectSet.findAll(groovy.lang.Closure)]
-.2+| Avoid calling this method. `matching(Spec)` and `configureEach(Action)` are more appropriate in most cases.
-| Use: _OK_, with issues.
+| link:{javadocPath}/org/gradle/api/NamedDomainObjectSet.html#findAll-groovy.lang.Closure-[NamedDomainObjectSet.findAll(groovy.lang.Closure)]
+| _OK_, with issues.
+2+| Avoid calling this method. `matching(Spec)` and `configureEach(Action)` are more appropriate in most cases.
 
-| Instead of: link:{javadocPath}/org/gradle/api/tasks/TaskCollection.html#matching-groovy.lang.Closure-[TaskCollection.matching(groovy.lang.Closure)]
-.2+| `matching(Spec)` requires all tasks to be created, so try to limit the impact by restricting the type of task, like `withType(java.lang.Class).matching(Spec)`.
-| Use: _OK_, with issues.
+| link:{javadocPath}/org/gradle/api/tasks/TaskCollection.html#matching-groovy.lang.Closure-[TaskCollection.matching(groovy.lang.Closure)]
+| _OK_, with issues.
+2+| `matching(Spec)` requires all tasks to be created, so try to limit the impact by restricting the type of task, like `withType(java.lang.Class).matching(Spec)`.
 
-| Instead of: link:{javadocPath}/org/gradle/api/tasks/TaskCollection.html#getAt-java.lang.String-[TaskCollection.getAt(java.lang.String)]
-.2+| Avoid calling this directly as it's a Groovy convenience method. The alternative returns a `TaskProvider` instead of a `Task`.
-| Use: link:{javadocPath}/org/gradle/api/tasks/TaskCollection.html#named-java.lang.String-[TaskCollection.named(java.lang.String)]
+| link:{javadocPath}/org/gradle/api/tasks/TaskCollection.html#getAt-java.lang.String-[TaskCollection.getAt(java.lang.String)]
+| link:{javadocPath}/org/gradle/api/tasks/TaskCollection.html#named-java.lang.String-[TaskCollection.named(java.lang.String)]
+2+| Avoid calling this directly as it's a Groovy convenience method. The alternative returns a `TaskProvider` instead of a `Task`.
 
-| Instead of: `iterator()` or implicit iteration over the `Task` collection
-.2+| Avoid doing this as it requires creating and configuring all tasks. See `findAll(Closure)` above.
-| Use: _OK_, with issues.
+| `iterator()` or implicit iteration over the `Task` collection
+| _OK_, with issues.
+2+| Avoid doing this as it requires creating and configuring all tasks. See `findAll(Closure)` above.
 
-| Instead of: `remove(org.gradle.api.Task)`
-.2+| Avoid calling this. The behavior of `remove` with the new API may change in the future.
-| Use: _OK_, with issues.
+| `remove(org.gradle.api.Task)`
+| _OK_, with issues.
+2+| Avoid calling this. The behavior of `remove` with the new API may change in the future.
 
-| Instead of: link:{javadocPath}/org/gradle/api/tasks/TaskContainer.html#replace-java.lang.String-[TaskContainer.replace(java.lang.String)]
-.2+| Avoid calling this. The behavior of `replace` with the new API may change in the future.
-| Use: _OK_, with issues.
+| link:{javadocPath}/org/gradle/api/tasks/TaskContainer.html#replace-java.lang.String-[TaskContainer.replace(java.lang.String)]
+| _OK_, with issues.
+2+| Avoid calling this. The behavior of `replace` with the new API may change in the future.
 
-| Instead of: link:{javadocPath}/org/gradle/api/tasks/TaskContainer.html#replace-java.lang.String-java.lang.Class-[TaskContainer.replace(java.lang.String, java.lang.Class)]
-.2+| Avoid calling this. The behavior of `replace` with the new API may change in the future.
-| Use: _OK_, with issues.
+| link:{javadocPath}/org/gradle/api/tasks/TaskContainer.html#replace-java.lang.String-java.lang.Class-[TaskContainer.replace(java.lang.String, java.lang.Class)]
+| _OK_, with issues.
+2+| Avoid calling this. The behavior of `replace` with the new API may change in the future.
 
 |===


### PR DESCRIPTION
### Context

The current table at https://docs.gradle.org/current/userguide/task_configuration_avoidance.html#sec:old_vs_new_configuration_api_overview is hard to read as old and new value are below each other instead of next to each other, and prefixed with distracting "Instead of:" and "Use:" terms.

### Contributor Checklist

- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist

- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
