### PR TITLE
Add a gradle property for --project-cache-dir

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheDirIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheDirIntegrationTest.groovy
@@ -60,7 +60,7 @@ class ConfigurationCacheDirIntegrationTest extends AbstractConfigurationCacheInt
         def configurationCache = newConfigurationCacheFixture()
 
         when:
-        configurationCacheRun 'help', '-Porg.gradle.projectcachedir', 'custom-cache-dir'
+        configurationCacheRun 'help', '-Dorg.gradle.projectcachedir=custom-cache-dir'
 
         then:
         !file('.gradle/configuration-cache').exists()
@@ -72,7 +72,7 @@ class ConfigurationCacheDirIntegrationTest extends AbstractConfigurationCacheInt
         configurationCache.assertStateStored()
 
         when:
-        configurationCacheRun 'help', '-Porg.gradle.projectcachedir', 'custom-cache-dir'
+        configurationCacheRun 'help', '-Dorg.gradle.projectcachedir=custom-cache-dir'
 
         then:
         configurationCache.assertStateLoaded()

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheDirIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheDirIntegrationTest.groovy
@@ -54,4 +54,27 @@ class ConfigurationCacheDirIntegrationTest extends AbstractConfigurationCacheInt
         then:
         configurationCache.assertStateLoaded()
     }
+
+    def "configuration cache honours org.gradle.projectcachedir"() {
+        given:
+        def configurationCache = newConfigurationCacheFixture()
+
+        when:
+        configurationCacheRun 'help', '-Porg.gradle.projectcachedir', 'custom-cache-dir'
+
+        then:
+        !file('.gradle/configuration-cache').exists()
+
+        and:
+        file('custom-cache-dir/configuration-cache').isDirectory()
+
+        and:
+        configurationCache.assertStateStored()
+
+        when:
+        configurationCacheRun 'help', '-Porg.gradle.projectcachedir', 'custom-cache-dir'
+
+        then:
+        configurationCache.assertStateLoaded()
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
@@ -89,8 +89,10 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
     }
 
     public static class ProjectCacheDirOption extends StringBuildOption<StartParameterInternal> {
+        public static final String PROPERTY_NAME = "org.gradle.projectcachedir";
+        
         public ProjectCacheDirOption() {
-            super(null, CommandLineOptionConfiguration.create("project-cache-dir", "Specify the project-specific cache directory. Defaults to .gradle in the root project directory."));
+            super(PROPERTY_NAME, CommandLineOptionConfiguration.create("project-cache-dir", "Specify the project-specific cache directory. Defaults to .gradle in the root project directory."));
         }
 
         @Override


### PR DESCRIPTION
### Context
It is currently impossible to set --project-cache-dir to be used in IDE by default. Adding a property allows a way to do that consistently between CLI and IDE.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
