### PR TITLE
Mark GenerateSamplePageAsciidoc as CC-incompatible

### DIFF
--- a/build-logic/root-build/src/main/kotlin/gradlebuild.internal.cc-experiment.gradle.kts
+++ b/build-logic/root-build/src/main/kotlin/gradlebuild.internal.cc-experiment.gradle.kts
@@ -61,6 +61,7 @@ val unsupportedTasksPredicate: (Task) -> Boolean = { task: Task ->
             "NativeProjectWithDepsGeneratorTask",
             "CppMultiProjectGeneratorTask",
             "BuildBuilderGenerator",
+            "GenerateSamplePageAsciidoc",
         ) -> true
 
         // Third parties tasks


### PR DESCRIPTION
There's a mysterious use of getProject at execution time which isn't solved with load-after-store.
