### PR TITLE
Run all performance tests with Java 17 by default

### DIFF
--- a/.teamcity/src/main/kotlin/common/Os.kt
+++ b/.teamcity/src/main/kotlin/common/Os.kt
@@ -68,7 +68,7 @@ enum class Os(
     val perfTestWorkingDir: String = "%teamcity.build.checkoutDir%",
     val perfTestJavaVendor: JvmVendor = JvmVendor.openjdk,
     val buildJavaVersion: JvmVersion = JvmVersion.java11,
-    val perfTestJavaVersion: JvmVersion = JvmVersion.java11,
+    val perfTestJavaVersion: JvmVersion = JvmVersion.java17,
     val defaultArch: Arch = Arch.AMD64
 ) {
     LINUX(

--- a/.teamcity/src/main/kotlin/util/AdHocPerformanceScenario.kt
+++ b/.teamcity/src/main/kotlin/util/AdHocPerformanceScenario.kt
@@ -50,7 +50,7 @@ abstract class AdHocPerformanceScenario(os: Os, arch: Arch = Arch.AMD64) : Build
             allowEmpty = false,
             description = "Which performance test to run. Should be the fully qualified class name dot (unrolled) method name. E.g. org.gradle.performance.regression.java.JavaUpToDatePerformanceTest.up-to-date assemble (parallel true)"
         )
-        text("testJavaVersion", "8", display = ParameterDisplay.PROMPT, allowEmpty = false, description = "The java version to run the performance tests, e.g. 8/11/17")
+        text("testJavaVersion", "17", display = ParameterDisplay.PROMPT, allowEmpty = false, description = "The java version to run the performance tests, e.g. 8/11/17")
         select(
             "testJavaVendor",
             JvmVendor.openjdk.name,

--- a/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
+++ b/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
@@ -89,7 +89,7 @@ class PerformanceTestBuildTypeTest {
 
         val expectedRunnerParams = listOf(
             "-PperformanceBaselines=%performance.baselines%",
-            "-PtestJavaVersion=11",
+            "-PtestJavaVersion=17",
             "-PtestJavaVendor=openjdk",
             "-PautoDownloadAndroidStudio=true",
             "-PrunAndroidStudioInHeadlessMode=true",

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/FileContentGenerator.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/FileContentGenerator.groovy
@@ -68,7 +68,7 @@ abstract class FileContentGenerator {
 
         dependencies{
         ${
-            language == Language.GROOVY ? directDependencyDeclaration('implementation', 'org.codehaus.groovy:groovy:2.5.8') : ""
+            language == Language.GROOVY ? directDependencyDeclaration('implementation', 'org.codehaus.groovy:groovy:2.5.22') : ""
         }
         }
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaConfigurationCachePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaConfigurationCachePerformanceTest.groovy
@@ -52,6 +52,11 @@ class JavaConfigurationCachePerformanceTest extends AbstractCrossVersionPerforma
         // use the deprecated property so it works with previous versions
         runner.args = ["-D${ConfigurationCacheOption.DEPRECATED_PROPERTY_NAME}=true"]
 
+        // Workaround to make that test work on Java 17
+        // Unable to make field private final java.lang.Object[] java.lang.invoke.SerializedLambda.capturedArgs accessible
+        // module java.base does not "opens java.lang.invoke" to unnamed module
+        runner.gradleOpts += ["--add-opens=java.base/java.lang.invoke=ALL-UNNAMED"]
+
         and:
         runner.useDaemon = daemon == hot
         runner.addBuildMutator { configurationCacheInvocationListenerFor(it, action, stateDirectory) }


### PR DESCRIPTION
Java 17 is the latest LTS and it is known to be faster and better at memory management.

While Gradle supports being run with Java 8 we should recommend using the latest LTS.
Running our performance tests against older Java versions doesn't make much sense and would make us potentially optimise for the wrong target.

----


The default changed from Java 8 to Java 11 in
* https://github.com/gradle/gradle/pull/23718
