### PR TITLE
Fix BuildCacheIntegrationTest

### DIFF
--- a/subprojects/soak/src/integTest/kotlin/org/gradle/kotlin/dsl/caching/BuildCacheIntegrationTest.kt
+++ b/subprojects/soak/src/integTest/kotlin/org/gradle/kotlin/dsl/caching/BuildCacheIntegrationTest.kt
@@ -49,6 +49,10 @@ class BuildCacheIntegrationTest : AbstractScriptCachingIntegrationTest() {
             """ + settingsFile.readText()
         )
 
+        executer.expectDocumentedDeprecationWarning("The BuildIdentifier.getName() method has been deprecated. " +
+            "This is scheduled to be removed in Gradle 9.0. " +
+            "Use getBuildPath() to get a unique identifier for the build. " +
+            "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation")
         build("--scan", "--build-cache", "-Dscan.dump").apply {
             assertThat(output, containsString("Build scan written to"))
         }


### PR DESCRIPTION
Was broken by the deprecation introduced in #24648.