### PR TITLE
Reference issues/comment for smoke test deprecations

### DIFF
--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractAndroidSantaTrackerSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractAndroidSantaTrackerSmokeTest.groovy
@@ -154,7 +154,7 @@ class AbstractAndroidSantaTrackerSmokeTest extends AbstractSmokeTest {
                     "This is scheduled to be removed in Gradle 9.0. " +
                     "Use getBuildPath() to get a unique identifier for the build. " +
                     "Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation",
-                "TODO"
+                "https://issuetracker.google.com/issues/279306626"
             )
         }
 
@@ -164,7 +164,7 @@ class AbstractAndroidSantaTrackerSmokeTest extends AbstractSmokeTest {
                     "This is scheduled to be removed in Gradle 9.0. " +
                     "Use getBuildPath() to get a unique identifier for the build. " +
                     "Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation",
-                "TODO"
+                "Build Scan plugin 3.13.1"
             )
         }
     }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
@@ -108,7 +108,7 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
                     "This is scheduled to be removed in Gradle 9.0. " +
                     "Use getBuildPath() to get a unique identifier for the build. " +
                     "Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation",
-                "TODO"
+                "Build Scan plugin 3.13.1"
             ).build().output.contains("Build scan written to")
 
         where:
@@ -131,7 +131,7 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
                     "This is scheduled to be removed in Gradle 9.0. " +
                     "Use getBuildPath() to get a unique identifier for the build. " +
                     "Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation",
-                "TODO"
+                "Build Scan plugin 3.13.1"
             )
             .build().output.contains("Build scan written to")
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithAndroidDeprecations.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithAndroidDeprecations.groovy
@@ -82,7 +82,7 @@ trait WithAndroidDeprecations implements WithReportDeprecations {
                 "This is scheduled to be removed in Gradle 9.0. " +
                 "Use getBuildPath() to get a unique identifier for the build. " +
                 "Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation",
-            "TODO"
+            "https://issuetracker.google.com/issues/279306626"
         )
     }
 
@@ -92,7 +92,7 @@ trait WithAndroidDeprecations implements WithReportDeprecations {
                 "This is scheduled to be removed in Gradle 9.0. " +
                 "Use getBuildPath() to get a unique identifier for the build. " +
                 "Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation",
-            "TODO"
+            "https://issuetracker.google.com/issues/279306626"
         )
     }
 }


### PR DESCRIPTION
Follow up for https://github.com/gradle/gradle/pull/24648, now that all the issues have been created.