### PR TITLE
Mark failing wrapper tests `@LocalOnly`

### DIFF
--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperChecksumVerificationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperChecksumVerificationTest.groovy
@@ -16,10 +16,10 @@
 
 package org.gradle.integtests
 
+import com.gradle.enterprise.testing.annotations.LocalOnly
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.executer.GradleDistribution
 import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext
-import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.gradle.wrapper.WrapperExecutor
 import org.junit.Rule
@@ -30,7 +30,7 @@ import static org.gradle.internal.hash.Hashing.sha256
 
 // wrapperExecuter requires a real distribution
 @IgnoreIf({ GradleContextualExecuter.embedded })
-@Flaky(because = "https://github.com/gradle/gradle-private/issues/3799")
+@LocalOnly(because = "https://github.com/gradle/gradle-private/issues/3799")
 class WrapperChecksumVerificationTest extends AbstractWrapperIntegrationSpec {
 
     private static final String WRAPPER_PROPERTIES_PATH = 'gradle/wrapper/gradle-wrapper.properties'

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperHttpsIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperHttpsIntegrationTest.groovy
@@ -16,10 +16,10 @@
 
 package org.gradle.integtests
 
+import com.gradle.enterprise.testing.annotations.LocalOnly
 import org.gradle.integtests.fixtures.TestResources
 import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
-import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.keystore.TestKeyStore
 import org.gradle.test.fixtures.server.http.BlockingHttpsServer
 import org.gradle.test.fixtures.server.http.TestProxyServer
@@ -35,7 +35,7 @@ import static org.hamcrest.MatcherAssert.assertThat
 
 // wrapperExecuter requires a real distribution
 @IgnoreIf({ GradleContextualExecuter.embedded })
-@Flaky(because = "https://github.com/gradle/gradle-private/issues/3799")
+@LocalOnly(because = "https://github.com/gradle/gradle-private/issues/3799")
 class WrapperHttpsIntegrationTest extends AbstractWrapperIntegrationSpec {
     private static final String DEFAULT_USER = "jdoe"
     private static final String DEFAULT_PASSWORD = "changeit"


### PR DESCRIPTION
See https://github.com/gradle/gradle-private/issues/3799

We have been seeing failing failures in
WrapperChecksumVerificationTest/WrapperHttpsIntegrationTest, which seem to happen only in TD remote executor.
Let's mark them as `@LocalOnly`.