### PR TITLE
Let `JsonModelWriter` encode empty strings correctly

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/JsonModelWriter.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/JsonModelWriter.kt
@@ -246,8 +246,12 @@ class JsonModelWriter(val writer: Writer) {
 
     private
     fun jsonString(value: String) {
-        buffer.addJsonEscapedString(value)
-        write(buffer.toStringAndRecycle())
+        if (value.isEmpty()) {
+            write("\"\"")
+        } else {
+            buffer.addJsonEscapedString(value)
+            write(buffer.toStringAndRecycle())
+        }
     }
 
     private

--- a/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/problems/JsonModelWriterTest.kt
+++ b/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/problems/JsonModelWriterTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache.problems
+
+import groovy.json.JsonSlurper
+import org.gradle.configurationcache.extensions.uncheckedCast
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.hasEntry
+import org.junit.Test
+import java.io.StringWriter
+
+
+class JsonModelWriterTest {
+
+    @Test
+    fun `encodes model with empty strings correctly`() {
+        assertThat(
+            jsonModelFor {
+                beginModel()
+                writeDiagnostic(
+                    DiagnosticKind.INPUT,
+                    PropertyProblem(
+                        PropertyTrace.Unknown,
+                        StructuredMessage.build { reference("") }
+                    )
+                )
+                endModel("", "", 0)
+            },
+            hasEntry(
+                "diagnostics",
+                listOf(
+                    mapOf(
+                        "trace" to listOf(mapOf("kind" to "Unknown")),
+                        "input" to listOf(mapOf("name" to ""))
+                    )
+                )
+            )
+        )
+    }
+
+    private
+    fun jsonModelFor(builder: JsonModelWriter.() -> Unit): Map<String, Any> =
+        JsonSlurper().parseText(
+            StringWriter().also {
+                JsonModelWriter(it).apply(builder)
+            }.toString()
+        ).uncheckedCast()
+}


### PR DESCRIPTION
Before this change, configuration cache problems or configuration inputs containing empty strings would make the report crash, for instance, the following build script would produce an invalid report:

```
System.getenv("") // configuration input with an empty string
```