### PR TITLE
Update tested AGP versions

### DIFF
--- a/build-logic/build-update-utils/src/main/kotlin/gradlebuild.update-versions.gradle.kts
+++ b/build-logic/build-update-utils/src/main/kotlin/gradlebuild.update-versions.gradle.kts
@@ -34,12 +34,14 @@ tasks.register<UpdateAgpVersions>("updateAgpVersions") {
     minimumSupportedMinor = "7.3"
     fetchNightly = false
     propertiesFile = layout.projectDirectory.file("gradle/dependency-management/agp-versions.properties")
+    compatibilityDocFile = layout.projectDirectory.file("subprojects/docs/src/docs/userguide/compatibility.adoc")
 }
 
 tasks.register<UpdateKotlinVersions>("updateKotlinVersions") {
     comment = " Generated - Update by running `./gradlew updateKotlinVersions`"
     minimumSupported = "1.6.10"
     propertiesFile = layout.projectDirectory.file("gradle/dependency-management/kotlin-versions.properties")
+    compatibilityDocFile = layout.projectDirectory.file("subprojects/docs/src/docs/userguide/compatibility.adoc")
 }
 
 data class VersionBuildTimeInfo(val version: String, val buildTime: String)

--- a/gradle/dependency-management/agp-versions.properties
+++ b/gradle/dependency-management/agp-versions.properties
@@ -1,2 +1,2 @@
 # Generated - Update by running `./gradlew updateAgpVersions`
-latests=7.3.1,7.4.2,8.0.0-rc01,8.1.0-alpha11
+latests=7.3.1,7.4.2,8.0.0,8.1.0-beta01

--- a/subprojects/docs/src/docs/userguide/compatibility.adoc
+++ b/subprojects/docs/src/docs/userguide/compatibility.adoc
@@ -84,5 +84,5 @@ Gradle is tested with Groovy 1.5.8 through 4.0.0.
 Gradle plugins written in Groovy must use Groovy 3.x for compatibility with Gradle and Groovy DSL build scripts.
 
 == Android
-Gradle is tested with Android Gradle Plugin 7.3, 7.4 and 8.0.
+Gradle is tested with Android Gradle Plugin 7.3 through 8.0.
 Alpha and beta versions may or may not work.

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidCommunityPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidCommunityPluginsSmokeTest.groovy
@@ -116,6 +116,7 @@ class AndroidCommunityPluginsSmokeTest extends AbstractPluginValidatingSmokeTest
         """
         buildFile << """
                 android {
+                    namespace = "org.gradle.smoke.test"
                     compileSdkVersion 24
                     buildToolsVersion '${TestedVersions.androidTools}'
                     defaultConfig {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
@@ -374,6 +374,7 @@ class KotlinPluginSmokeTest extends AbstractPluginValidatingSmokeTest implements
             if (isAndroidKotlinPlugin(testedPluginId)) {
                 buildFile << """
                     android {
+                        namespace = "org.gradle.smoke.test"
                         compileSdkVersion 24
                         buildToolsVersion '${TestedVersions.androidTools}'
                     }


### PR DESCRIPTION
from 8.0.0-rc01 to 8.0.0
from 8.1.0-alpha11 to 8.1.0-beta01

Also let `:updateAgpVersions` and `:updateKotlinVersions` tasks update the compatibility matrix documentation to make next updates easier.