### PR TITLE
Fix language-java tests for CC/load-after-store

### DIFF
--- a/subprojects/language-java/build.gradle.kts
+++ b/subprojects/language-java/build.gradle.kts
@@ -92,7 +92,3 @@ packageCycles {
 
 integTest.usesJavadocCodeSnippets = true
 
-// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
-tasks.configCacheIntegTest {
-    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
-}

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
@@ -429,7 +429,10 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
         def kotlinVersionNumber = VersionNumber.parse(kotlinPluginVersion)
         def isKotlin1dot6 = kotlinVersionNumber.baseVersion < VersionNumber.parse("1.7.0")
         def isKotlin1dot8 = kotlinVersionNumber.baseVersion >= VersionNumber.parse("1.8.0")
-
+        println("kotlinVersionNumber.baseVersion = ${kotlinVersionNumber.baseVersion}")
+        println("kotlinVersionNumber = ${kotlinVersionNumber}")
+        println("isKotlin1dot6 = $isKotlin1dot6")
+        println("isKotlin1dot8 = $isKotlin1dot8")
         when:
         if (isKotlin1dot6) {
             def wrapUtilWarning = "The org.gradle.util.WrapUtil type has been deprecated. " +

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileCompatibilityIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileCompatibilityIntegrationTest.groovy
@@ -500,9 +500,11 @@ class JavaCompileCompatibilityIntegrationTest extends AbstractIntegrationSpec im
                 }
             }
 
+            def compileJavaSourceCompatibility = compileJava.sourceCompatibility
+            def compileJavaOptionsRelease = compileJava.options.release
             compileJava.doFirst {
-                logger.lifecycle("Source is set to '\${compileJava.sourceCompatibility}'")
-                logger.lifecycle("Release is set to '\${compileJava.options.release.getOrNull()}'")
+                logger.lifecycle("Source is set to '\${compileJavaSourceCompatibility}'")
+                logger.lifecycle("Release is set to '\${compileJavaOptionsRelease.getOrNull()}'")
             }
         """
 
@@ -534,9 +536,12 @@ class JavaCompileCompatibilityIntegrationTest extends AbstractIntegrationSpec im
                 }
             }
 
+            def compileJavaSourceCompatibility = compileJava.sourceCompatibility
+            def compileJavaOptionsRelease = compileJava.options.release
+
             compileJava.doFirst {
-                logger.lifecycle("Source is set to '\${compileJava.sourceCompatibility}'")
-                logger.lifecycle("Release is set to '\${compileJava.options.release.getOrNull()}'")
+                logger.lifecycle("Source is set to '\${compileJavaSourceCompatibility}'")
+                logger.lifecycle("Release is set to '\${compileJavaOptionsRelease.getOrNull()}'")
             }
         """
 

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileTaskOperationResultIntegTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileTaskOperationResultIntegTest.groovy
@@ -68,6 +68,8 @@ class JavaCompileTaskOperationResultIntegTest extends AbstractIntegrationSpec {
 
                 void apply(Project project) {
                     def listener = project.gradle.sharedServices.registerIfAbsent("listener", JavaCompileListener) { }
+                    // capture plugin field to make it available to task action
+                    def registry = this.registry
                     project.tasks.withType(JavaCompile) { task ->
                         task.doFirst {
                             registry.onTaskCompletion(listener)

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/jpms/execution/JavaModuleExecutionIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/jpms/execution/JavaModuleExecutionIntegrationTest.groovy
@@ -173,9 +173,11 @@ class JavaModuleExecutionIntegrationTest extends AbstractJavaModuleCompileIntegr
             task run {
                 dependsOn jar
                 def execOperations = project.objects.newInstance(Services).exec
+                def jarFiles = files(jar)
+                def runtimeClasspathConfiguration = configurations.runtimeClasspath
                 doLast {
                     execOperations.javaexec { action ->
-                        action.classpath = files(jar) + configurations.runtimeClasspath
+                        action.classpath = jarFiles + runtimeClasspathConfiguration
                         action.mainModule.set('consumer')
                     }
                 }
@@ -206,9 +208,11 @@ class JavaModuleExecutionIntegrationTest extends AbstractJavaModuleCompileIntegr
             task run {
                 dependsOn jar
                 def execOperations = project.objects.newInstance(Services).exec
+                def jarFiles = files(jar)
+                def runtimeClasspathConfiguration = configurations.runtimeClasspath
                 doLast {
                     execOperations.javaexec { action ->
-                        action.classpath = files(jar) + configurations.runtimeClasspath
+                        action.classpath = jarFiles + runtimeClasspathConfiguration
                         action.mainModule.set('consumer')
                         action.mainClass.set('consumer.MainModule')
                     }


### PR DESCRIPTION
Towards fixing language-java tests under configCacheIntegTest with load-after-store enabled.
