### PR TITLE
Fix ClassCastException in Groovy DSL plugins { ... } block syntax checker (#7897)

### DIFF
--- a/subprojects/base-services-groovy/src/main/java/org/gradle/groovy/scripts/internal/AstUtils.java
+++ b/subprojects/base-services-groovy/src/main/java/org/gradle/groovy/scripts/internal/AstUtils.java
@@ -220,13 +220,16 @@ public abstract class AstUtils {
 
     @Nullable
     public static ConstantExpression hasSingleConstantArgOfType(MethodCallExpression call, Class<?> type) {
-        ArgumentListExpression argumentList = (ArgumentListExpression) call.getArguments();
-        if (argumentList.getExpressions().size() == 1) {
-            Expression argumentExpression = argumentList.getExpressions().get(0);
-            if (argumentExpression instanceof ConstantExpression) {
-                ConstantExpression constantArgumentExpression = (ConstantExpression) argumentExpression;
-                if (isOfType(constantArgumentExpression, type)) {
-                    return constantArgumentExpression;
+        Expression arguments = call.getArguments();
+        if (arguments instanceof ArgumentListExpression) {
+            ArgumentListExpression argumentList = (ArgumentListExpression) arguments;
+            if (argumentList.getExpressions().size() == 1) {
+                Expression argumentExpression = argumentList.getExpressions().get(0);
+                if (argumentExpression instanceof ConstantExpression) {
+                    ConstantExpression constantArgumentExpression = (ConstantExpression) argumentExpression;
+                    if (isOfType(constantArgumentExpression, type)) {
+                        return constantArgumentExpression;
+                    }
                 }
             }
         }

--- a/subprojects/core/src/main/java/org/gradle/plugin/use/internal/PluginUseScriptBlockMetadataCompiler.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/use/internal/PluginUseScriptBlockMetadataCompiler.java
@@ -34,6 +34,7 @@ import org.gradle.groovy.scripts.internal.RestrictiveCodeVisitor;
 import org.gradle.groovy.scripts.internal.ScriptBlock;
 
 import static org.gradle.groovy.scripts.internal.AstUtils.hasSingleConstantArgOfType;
+import static org.gradle.groovy.scripts.internal.AstUtils.hasSingleConstantStringArg;
 import static org.gradle.groovy.scripts.internal.AstUtils.hasSinglePropertyExpressionArgument;
 import static org.gradle.groovy.scripts.internal.AstUtils.isOfType;
 
@@ -99,7 +100,7 @@ public class PluginUseScriptBlockMetadataCompiler {
                                 restrict(call, formatErrorMessage(DISALLOWED_ALIAS_NOTATION));
                                 return;
                             case "id":
-                                ConstantExpression argumentExpression = hasSingleConstantArgOfType(call, String.class);
+                                ConstantExpression argumentExpression = hasSingleConstantStringArg(call);
                                 if (argumentExpression == null) {
                                     restrict(call, formatErrorMessage(NEED_LITERAL_STRING));
                                     return;
@@ -170,7 +171,7 @@ public class PluginUseScriptBlockMetadataCompiler {
      * b) A GString expression containing only variable expressions
      */
     private static boolean hasSimpleInterpolatedStringType(MethodCallExpression call) {
-        if (hasSingleConstantArgOfType(call, String.class) != null) {
+        if (hasSingleConstantStringArg(call) != null) {
             return true;
         }
 

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/PluginUseDslIntegrationSpec.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/PluginUseDslIntegrationSpec.groovy
@@ -200,6 +200,7 @@ class PluginUseDslIntegrationSpec extends AbstractIntegrationSpec {
         2          | "apply false"                          | BASE_MESSAGE
         2          | "id 'foo' apply"                       | BASE_MESSAGE
         2          | "id 'foo' apply('foo')"                | NEED_SINGLE_BOOLEAN
+        2          | "apply plugin: 'java'"                 | NEED_SINGLE_BOOLEAN
         2          | "id null"                              | NEED_LITERAL_STRING
         2          | "id 'foo' version null"                | NEED_INTERPOLATED_STRING
         2          | "file('foo')" /* script api */         | BASE_MESSAGE


### PR DESCRIPTION
* Fixes #7897

### Context
The code unconditionally casted the arguments Expression of the MethodCallExpression
to ArgumentListExpression. But it could also have other types like for example
NamedArgumentListExpression when the arguments are given as map. This happens
if you have a legacy plugin apply within the plugins { ... } block and then
caused a cryptic Groovy compiler error instead of a clear message what is wrong.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificateof Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- n/a Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [x] Verify design and implementation
- [ ] Verify test coverage and CI build status
- [x] Verify documentation