### PR TITLE
Avoid creating dependency locking handler eagerly in script handlers

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
@@ -54,7 +54,7 @@ public class DefaultScriptHandler implements ScriptHandler, ScriptHandlerInterna
     private final ClassLoaderScope classLoaderScope;
     private final ScriptClassPathResolver scriptClassPathResolver;
     private final DependencyResolutionServices dependencyResolutionServices;
-    private final DependencyLockingHandler dependencyLockingHandler;
+
     // The following values are relatively expensive to create, so defer creation until required
     private ClassPath resolvedClasspath;
     private RepositoryHandler repositoryHandler;
@@ -68,7 +68,6 @@ public class DefaultScriptHandler implements ScriptHandler, ScriptHandlerInterna
         this.scriptResource = scriptSource.getResource().getLocation();
         this.classLoaderScope = classLoaderScope;
         this.scriptClassPathResolver = scriptClassPathResolver;
-        this.dependencyLockingHandler = dependencyResolutionServices.getDependencyLockingHandler();
         JavaEcosystemSupport.configureSchema(dependencyResolutionServices.getAttributesSchema(), dependencyResolutionServices.getObjectFactory());
     }
 
@@ -90,6 +89,9 @@ public class DefaultScriptHandler implements ScriptHandler, ScriptHandlerInterna
     @Override
     public ClassPath getInstrumentedScriptClassPath() {
         if (resolvedClasspath == null) {
+            // There's a side effect of creating a dependency locking handler that's needed for writing verification metadata
+            getDependencyLocking();
+
             resolvedClasspath = scriptClassPathResolver.resolveClassPath(classpathConfiguration);
             if (!System.getProperty(DISABLE_RESET_CONFIGURATION_SYSTEM_PROPERTY, "false").equals("true") && classpathConfiguration != null) {
                 ((ResettableConfiguration) classpathConfiguration).resetResolutionState();
@@ -145,7 +147,7 @@ public class DefaultScriptHandler implements ScriptHandler, ScriptHandlerInterna
 
     @Override
     public DependencyLockingHandler getDependencyLocking() {
-        return dependencyLockingHandler;
+        return dependencyResolutionServices.getDependencyLockingHandler();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
@@ -175,4 +175,9 @@ public class DefaultScriptHandler implements ScriptHandler, ScriptHandlerInterna
         }
         return dynamicObject;
     }
+
+    @Override
+    public String toString() {
+        return (resolvedClasspath == null ? "unresolved" : "resolved") + " script handler for " + getSourceFile();
+    }
 }


### PR DESCRIPTION
We have special code to avoid the creation of ConfigurationContainers,
but creating a dependency locking handler implicitly creates a configuration
container.

This may have a small performance improvement with many scripts.