### PR TITLE
Canonicalize "." and ".." segments in RelativePaths

### DIFF
--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
@@ -670,6 +670,32 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
         !file('dest/dir1/extra2.txt').exists()
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/5748")
+    def "works correctly when . is a path segment"() {
+        given:
+        defaultSourceFileTree()
+        file('dest').create {
+            file 'extra.txt'
+        }
+
+        buildScript '''
+            task sync(type: Sync) {
+                into 'dest'
+                into ('.') {
+                    from 'source/dir1'
+                }
+            }
+        '''.stripIndent()
+
+        when:
+        run 'sync'
+
+        then:
+        file('dest').assertHasDescendants(
+            'file1.txt'
+        )
+    }
+
     def defaultSourceFileTree() {
         file('source').create {
             dir1 { file 'file1.txt' }


### PR DESCRIPTION
Fixes #5748

### Context
As documented in #5748, Sync and Copy tasks can have buggy behaviors (such as deleting copied files) when RelativePath objects refer to the same path but consist of a different list of segments. This can happen in particular when "." and ".." are used in path segments.

Avoid this situation by canonicalizing RelativePaths as they are created, so that "." is not used and ".." only appears at the beginning of a path.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
