### PR TITLE
Re-enable flaky tests with explicit timeout

### DIFF
--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r40/ArtifactDownloadProgressCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r40/ArtifactDownloadProgressCrossVersionSpec.groovy
@@ -19,12 +19,15 @@ package org.gradle.integtests.tooling.r40
 import org.gradle.integtests.tooling.fixture.AbstractHttpCrossVersionSpec
 import org.gradle.integtests.tooling.fixture.ProgressEvents
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
-import org.gradle.test.fixtures.Flaky
 import org.gradle.tooling.ProjectConnection
 import org.gradle.util.GradleVersion
+import spock.lang.Timeout
+
+import java.util.concurrent.TimeUnit
 
 class ArtifactDownloadProgressCrossVersionSpec extends AbstractHttpCrossVersionSpec {
-    @Flaky(because = "https://github.com/gradle/gradle-private/issues/3638")
+
+    @Timeout(value = 10, unit = TimeUnit.MINUTES)
     @TargetGradleVersion(">=5.7")
     def "generates events for downloading artifacts"() {
         given:

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r40/ProjectConfigurationChildrenProgressCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r40/ProjectConfigurationChildrenProgressCrossVersionSpec.groovy
@@ -20,12 +20,14 @@ import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.integtests.tooling.fixture.ProgressEvents
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.TextUtil
-import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.maven.MavenFileRepository
 import org.gradle.test.fixtures.server.http.MavenHttpRepository
 import org.gradle.test.fixtures.server.http.RepositoryHttpServer
 import org.gradle.tooling.ProjectConnection
 import org.gradle.util.GradleVersion
+import spock.lang.Timeout
+
+import java.util.concurrent.TimeUnit
 
 @IntegrationTestTimeout(300)
 @TargetGradleVersion('>=4.0')
@@ -224,7 +226,7 @@ class ProjectConfigurationChildrenProgressCrossVersionSpec extends AbstractProgr
         }
     }
 
-    @Flaky(because = "https://github.com/gradle/gradle-private/issues/3638")
+    @Timeout(value = 10, unit = TimeUnit.MINUTES)
     def "generates events for downloading artifacts"() {
         given:
         toolingApi.requireIsolatedUserHome()

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r47/BuildProgressCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r47/BuildProgressCrossVersionSpec.groovy
@@ -19,12 +19,14 @@ package org.gradle.integtests.tooling.r47
 import org.gradle.integtests.tooling.fixture.ProgressEvents
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
-import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.maven.MavenFileRepository
 import org.gradle.test.fixtures.server.http.MavenHttpRepository
 import org.gradle.test.fixtures.server.http.RepositoryHttpServer
 import org.gradle.tooling.ProjectConnection
 import org.gradle.util.GradleVersion
+import spock.lang.Timeout
+
+import java.util.concurrent.TimeUnit
 
 @TargetGradleVersion(">=4.7")
 class BuildProgressCrossVersionSpec extends ToolingApiSpecification {
@@ -40,7 +42,7 @@ class BuildProgressCrossVersionSpec extends ToolingApiSpecification {
         server.after()
     }
 
-    @Flaky(because = "https://github.com/gradle/gradle-private/issues/3638")
+    @Timeout(value = 10, unit = TimeUnit.MINUTES)
     def "generates download events during maven publish"() {
         given:
         toolingApi.requireIsolatedUserHome()

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r51/ProjectConfigurationProgressEventCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r51/ProjectConfigurationProgressEventCrossVersionSpec.groovy
@@ -21,7 +21,6 @@ import org.gradle.integtests.tooling.fixture.ProgressEvents
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.integtests.tooling.fixture.ToolingApiVersion
-import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.gradle.tooling.BuildException
@@ -32,8 +31,10 @@ import org.gradle.tooling.events.ScriptPluginIdentifier
 import org.gradle.tooling.events.configuration.ProjectConfigurationOperationResult
 import org.gradle.util.GradleVersion
 import org.junit.Rule
+import spock.lang.Timeout
 
 import java.time.Duration
+import java.util.concurrent.TimeUnit
 
 import static org.gradle.integtests.tooling.fixture.TextUtil.escapeString
 
@@ -262,7 +263,7 @@ class ProjectConfigurationProgressEventCrossVersionSpec extends ToolingApiSpecif
         }
     }
 
-    @Flaky(because = "https://github.com/gradle/gradle-private/issues/3638")
+    @Timeout(value = 10, unit = TimeUnit.MINUTES)
     def "reports plugin configuration results for remote script plugins"() {
         given:
         toolingApi.requireIsolatedUserHome() // So that the script is not cached

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r73/DependencyArtifactDownloadProgressEventCrossVersionTest.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r73/DependencyArtifactDownloadProgressEventCrossVersionTest.groovy
@@ -20,16 +20,18 @@ import org.gradle.integtests.tooling.fixture.AbstractHttpCrossVersionSpec
 import org.gradle.integtests.tooling.fixture.ProgressEvents
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiVersion
-import org.gradle.test.fixtures.Flaky
 import org.gradle.tooling.BuildException
 import org.gradle.tooling.ProjectConnection
 import org.gradle.tooling.events.OperationType
+import spock.lang.Timeout
+
+import java.util.concurrent.TimeUnit
 
 @ToolingApiVersion(">=7.3")
 @TargetGradleVersion(">=7.3")
-@Flaky(because = "https://github.com/gradle/gradle-private/issues/3765")
+@Timeout(value = 10, unit = TimeUnit.MINUTES)
 class DependencyArtifactDownloadProgressEventCrossVersionTest extends AbstractHttpCrossVersionSpec {
-    @Flaky(because = "https://github.com/gradle/gradle-private/issues/3638")
+
     def "generates typed events for downloads during dependency resolution"() {
         def modules = setupBuildWithArtifactDownloadDuringConfiguration()
         modules.useLargeJars()
@@ -106,7 +108,6 @@ class DependencyArtifactDownloadProgressEventCrossVersionTest extends AbstractHt
         events.operation("Download ${projectF2.artifact.uri}").assertIsDownload(projectF2.artifact)
     }
 
-    @Flaky(because = "https://github.com/gradle/gradle-private/issues/3638")
     def "generates typed events for failed downloads during dependency resolution"() {
         def modules = setupBuildWithFailedArtifactDownloadDuringTaskExecution()
 


### PR DESCRIPTION
The Tooling API cross-version tests verifying download progress events were flaky on CI. Sometimes the execution hung and the build failed with a timeout. Consequently, the tests were marked as @Flaky.

The problem is not reproducible locally with the data available. On top of that, the existing reports don't have enough details about the failing execution: the timeout generates a thread dump from the build agent and not from the test execution process.

The tests were marked as @Flaky quite a while ago, so there's also a chance that the problem no longer exists. Test execution data from GE seems to confirm that.

This PR tentatively re-enable the flaky tests and defines an explicit timeout on them. After merging, if we don't see flaky tests then removing the @Flaky annotation was indeed correct. If the failures re-appear, we'll then get stacktraces from the test worker and can continue with the investigation.
