### PR TITLE
Modernize test project generation

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/GroovyDslFileContentGenerator.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/GroovyDslFileContentGenerator.groovy
@@ -95,8 +95,8 @@ class GroovyDslFileContentGenerator extends FileContentGenerator {
 
 
     @Override
-    protected String directDependencyDeclaration(String configuration, String notation) {
-        notation.endsWith('()') ? "$configuration $notation" : "$configuration '$notation'"
+    protected String versionCatalogDependencyDeclaration(String configuration, String alias) {
+        "$configuration libs.$alias"
     }
 
     @Override

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/KotlinDslFileContentGenerator.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/KotlinDslFileContentGenerator.groovy
@@ -86,8 +86,8 @@ class KotlinDslFileContentGenerator extends FileContentGenerator {
 
 
     @Override
-    protected String directDependencyDeclaration(String configuration, String notation) {
-        notation.endsWith('()') ? "\"$configuration\"($notation)" : "\"$configuration\"(\"$notation\")"
+    protected String versionCatalogDependencyDeclaration(String configuration, String alias) {
+        "\"$configuration\"(libs.$alias)"
     }
 
     @Override

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/TestProjectGenerator.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/TestProjectGenerator.groovy
@@ -73,6 +73,8 @@ class TestProjectGenerator {
         if (isRoot) {
             file projectDir, "WORKSPACE", bazelContentGenerator.generateWorkspace()
             file projectDir, "junit.bzl", bazelContentGenerator.generateJunitHelper()
+        }
+        if (isRoot || config.compositeBuild) {
             file projectDir, "gradle/libs.versions.toml", fileContentGenerator.generateVersionCatalog()
         }
         file projectDir, "performance.scenarios", fileContentGenerator.generatePerformanceScenarios(isRoot)

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/TestProjectGenerator.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/TestProjectGenerator.groovy
@@ -73,6 +73,7 @@ class TestProjectGenerator {
         if (isRoot) {
             file projectDir, "WORKSPACE", bazelContentGenerator.generateWorkspace()
             file projectDir, "junit.bzl", bazelContentGenerator.generateJunitHelper()
+            file projectDir, "gradle/libs.versions.toml", fileContentGenerator.generateVersionCatalog()
         }
         file projectDir, "performance.scenarios", fileContentGenerator.generatePerformanceScenarios(isRoot)
 

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/TestProjectGeneratorConfiguration.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/generator/TestProjectGeneratorConfiguration.groovy
@@ -34,8 +34,8 @@ class TestProjectGeneratorConfiguration {
 
     String[] plugins
     String[] repositories
-    String[] externalApiDependencies
-    String[] externalImplementationDependencies
+    Map<String, String> externalApiDependencies
+    Map<String, String> externalImplementationDependencies
 
     boolean buildSrc
 
@@ -122,9 +122,15 @@ class TestProjectGeneratorConfigurationBuilder {
 
         config.plugins = this.language == Language.GROOVY ? ['groovy', 'java', 'eclipse', 'idea'] : ['java', 'eclipse', 'idea']
         config.repositories = [mavenCentralRepositoryDefinition(this.dsl)]
-        config.externalApiDependencies = ['commons-lang:commons-lang:2.5', 'commons-httpclient:commons-httpclient:3.0',
-                                          'commons-codec:commons-codec:1.2', 'org.slf4j:jcl-over-slf4j:1.7.10']
-        config.externalImplementationDependencies = ['com.googlecode:reflectasm:1.01']
+        config.externalApiDependencies = [
+            commonsLang: 'commons-lang:commons-lang:2.5',
+            commonsHttpClient: 'commons-httpclient:commons-httpclient:3.0',
+            commonsCodec: 'commons-codec:commons-codec:1.2',
+            jclOverSlf4j: 'org.slf4j:jcl-over-slf4j:1.7.10',
+        ]
+        config.externalImplementationDependencies = [
+            reflectasm: 'com.googlecode:reflectasm:1.01',
+        ]
 
         config.subProjects = this.subProjects
         config.sourceFiles = this.sourceFiles


### PR DESCRIPTION
The only opportunity I saw to modernize here was using version catalogs. Unfortunately test suites are not yet stable and have planned changes in the future, so I don't want to use them for fear of introducing incompatibilities with cross-version testing. There is still some risk of this with version catalogs, but they've been around longer and are stable so I don't expect major issues.