### PR TITLE
Expand the timeout of the gitStream automation, so it doesn't fail

### DIFF
--- a/.github/workflows/gitstream.yml
+++ b/.github/workflows/gitstream.yml
@@ -32,7 +32,7 @@ on:
 
 jobs:
   gitStream:
-    timeout-minutes: 5
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     name: gitStream workflow automation
     steps:


### PR DESCRIPTION
I can see that many of our PRs cannot benefit from gitStream, as the automation pipeline fails.
Maybe the 5-minute timeout was a bit too conservative when it comes to a bigger repository like gradle/gradle?