### PR TITLE
Include opposite task options in documentation

### DIFF
--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/tasks/InitBuild.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/tasks/InitBuild.java
@@ -84,7 +84,8 @@ public abstract class InitBuild extends DefaultTask {
     /**
      * Should the build be split into multiple subprojects?
      *
-     * This property can be set via command-line option '--split-project'.
+     * This property can be set via the command-line options '--split-project'
+     * and '--no-split-project'.
      *
      * @since 6.7
      */

--- a/subprojects/docs/src/docs/userguide/core-plugins/build_init_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/core-plugins/build_init_plugin.adoc
@@ -78,7 +78,7 @@ You can change the name of the generated project using the `--project-name` opti
 
 You can change the package used for generated source files using the `--package` option. It defaults to the project name.
 
-If the `--incubating` option is provided, Gradle will generate build scripts which may use the latest versions of APIs, which are marked `@Incubating` and remain <<feature_lifecycle.adoc#feature_lifecycle,subject to change>>.
+If the `--incubating` option is provided, Gradle will generate build scripts which may use the latest versions of APIs, which are marked `@Incubating` and remain <<feature_lifecycle.adoc#feature_lifecycle,subject to change>>. To disable this behavior, use `--no-incubating`.
 
 All build types also setup the Gradle wrapper.
 

--- a/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/variant_model.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/variant_model.adoc
@@ -254,7 +254,7 @@ This task is similar to the `dependencyInsight` <<viewing_debugging_dependencies
 
 By default, `outgoingVariants` prints information about all variants.
 It offers the optional parameter `--variant <variantName>` to select a single variant to display.
-It also accepts the `--all` flag to include information about legacy and deprecated configurations.
+It also accepts the `--all` flag to include information about legacy and deprecated configurations, or `--no-all` to exclude this information.
 
 Here is the output of the `outgoingVariants` task on a freshly generated `java-library` project:
 
@@ -397,8 +397,9 @@ By default, `resolvableConfigurations` prints information about all purely resol
 These are configurations that are marked resolvable but *not* marked consumable.
 Though some resolvable configurations are also marked consumable, these are legacy configurations that should *not* have dependencies added in build scripts.
 This report offers the optional parameter `--configuration <configurationName>` to select a single configuration to display.
-It also accepts the `--all` flag to include information about legacy and deprecated configurations.
+It also accepts the `--all` flag to include information about legacy and deprecated configurations, or `--no-all` to exclude this information.
 Finally, it accepts the `--recursive` flag to list in the extended configurations section those configurations which are extended _transitively_ rather than directly.
+Alternatively, `--no-recursive` can be used to exclude this information.
 
 Here is the output of the `resolvableConfigurations` task on a freshly generated `java-library` project:
 

--- a/subprojects/docs/src/docs/userguide/jvm/java_testing.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/java_testing.adoc
@@ -88,7 +88,7 @@ If this property is `true`, Gradle will continue with the project's build once t
 `failFast` —  (since Gradle 4.6) default: false::
 Set this to `true` if you want the build to fail and finish as soon as one of your tests fails. This can save a lot of time when you have a long-running test suite and is particularly useful when running the build on continuous integration servers. When a build fails before all tests have run, the test reports only include the results of the tests that have completed, successfully or not.
 +
-You can also enable this behavior by using the `--fail-fast` command line option.
+You can also enable this behavior by using the `--fail-fast` command line option, or disable it respectively with `--no-fail-fast`.
 
 `testLogging` — default: _not set_::
 This property represents a set of options that control which test events are logged and at what level. You can also configure other logging behavior via this property. See link:{javadocPath}/org/gradle/api/tasks/testing/logging/TestLoggingContainer.html[TestLoggingContainer] for more detail.
@@ -641,7 +641,7 @@ Alternatively, if <<build_cache.adoc#sec:build_cache_enable,build caching>> is n
 [[sec:debugging_java_tests]]
 == Debugging when running tests
 
-On the few occasions that you want to debug your code while the tests are running, it can be helpful if you can attach a debugger at that point. You can either set the link:{groovyDslPath}/org.gradle.api.tasks.testing.Test.html#org.gradle.api.tasks.testing.Test:debug[Test.getDebug()] property to `true` or use the `--debug-jvm` command line option.
+On the few occasions that you want to debug your code while the tests are running, it can be helpful if you can attach a debugger at that point. You can either set the link:{groovyDslPath}/org.gradle.api.tasks.testing.Test.html#org.gradle.api.tasks.testing.Test:debug[Test.getDebug()] property to `true` or use the `--debug-jvm` command line option, or use `--no-debug-jvm` to set it to false.
 
 When debugging for tests is enabled, Gradle will start the test process suspended and listening on port 5005.
 

--- a/subprojects/docs/src/docs/userguide/native/native_software.adoc
+++ b/subprojects/docs/src/docs/userguide/native/native_software.adoc
@@ -284,6 +284,9 @@ Here is the corresponding report for the `operators` component, showing dependen
 include::{snippetsPath}/native-binaries/cunit/tests/buildDependentComponentsReport.out[]
 ----
 
+Furthermore, the `--non-binaries` option shows non-buildable binaries in the report, `--no-non-buildable` hides them.
+Similarly, the `--test-suites` option shows test suites and `--no-test-suites` hides them.
+The option `--no-all` hides both non-buildable binaries and test suites from the report.
 
 [[sec:assemble_dependents]]
 === Assembling dependents

--- a/subprojects/docs/src/docs/userguide/reference/command_line_interface.adoc
+++ b/subprojects/docs/src/docs/userguide/reference/command_line_interface.adoc
@@ -293,6 +293,8 @@ By default, this report shows only those tasks which have been assigned to a tas
 $ gradle tasks --all
 ----
 
+The option `--no-all` can be used to limit the report to tasks assigned to a task group.
+
 If you need to be more precise, you can display only the tasks from a specific group using the `--group` option.
 
 ----
@@ -311,6 +313,8 @@ include::{snippetsPath}/tutorial/projectReports/tests/taskHelp.out[]
 ----
 
 This information includes the full task path, the task type, possible <<sec:task_options,task-specific command line options>> and the description of the given task.
+
+Additionally, you can get detailed information about the task class types using the `--types` option, or use `--no-types` to hide this information.
 
 === Reporting dependencies
 


### PR DESCRIPTION
Fixes #24966

[Generated docs](https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_BuildDistributions/65635169?buildTab=artifacts#%2Fdistributions%2Fgradle-8.2-docs.zip!%2Fgradle-8.2-20230505074648%2B0000%2Fdocs%2Fuserguide)