### PR TITLE
Add cross-process file locking around H2 build cache

### DIFF
--- a/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/NextGenBuildCacheHttpIntegrationTest.groovy
+++ b/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/NextGenBuildCacheHttpIntegrationTest.groovy
@@ -98,6 +98,8 @@ class NextGenBuildCacheHttpIntegrationTest extends AbstractIntegrationSpec imple
 
         when:
         httpBuildCacheServer.deleteCacheFiles()
+        def alternativeBuildCache = new TestBuildCache(temporaryFolder.file("cache-dir-ng").deleteDir().createDir())
+        settingsFile << alternativeBuildCache.localCacheConfiguration()
         runWithBuildCacheNG "clean", "testBuildCache"
 
         then:

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/internal/StatefulNextGenBuildCacheService.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/internal/StatefulNextGenBuildCacheService.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.caching.internal;
+
+import java.io.Closeable;
+
+public interface StatefulNextGenBuildCacheService extends NextGenBuildCacheService, Closeable {
+    void open();
+
+    @Override
+    void close();
+}

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/local/internal/LockOnDemandCrossProcessBuildCacheService.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/local/internal/LockOnDemandCrossProcessBuildCacheService.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.caching.local.internal;
+
+import org.gradle.api.Action;
+import org.gradle.cache.FileLock;
+import org.gradle.cache.FileLockManager;
+import org.gradle.cache.internal.AbstractCrossProcessCacheAccess;
+import org.gradle.cache.internal.LockOnDemandCrossProcessCacheAccess;
+import org.gradle.cache.internal.cacheops.CacheAccessOperationsStack;
+import org.gradle.cache.internal.filelock.LockOptionsBuilder;
+import org.gradle.caching.BuildCacheEntryReader;
+import org.gradle.caching.BuildCacheEntryWriter;
+import org.gradle.caching.BuildCacheException;
+import org.gradle.caching.BuildCacheKey;
+import org.gradle.caching.internal.NextGenBuildCacheService;
+import org.gradle.caching.internal.StatefulNextGenBuildCacheService;
+import org.gradle.internal.UncheckedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static org.gradle.cache.FileLockManager.LockMode.Exclusive;
+import static org.gradle.cache.internal.CacheInitializationAction.NO_INIT_REQUIRED;
+
+public class LockOnDemandCrossProcessBuildCacheService implements NextGenBuildCacheService {
+    private final static Logger LOG = LoggerFactory.getLogger(LockOnDemandCrossProcessBuildCacheService.class);
+
+    private final String cacheDisplayName;
+    private final StatefulNextGenBuildCacheService delegate;
+    private final AbstractCrossProcessCacheAccess crossProcessCacheAccess;
+    private final CacheAccessOperationsStack operations;
+
+    private final Lock stateLock = new ReentrantLock(); // protects the following state
+    private final Condition condition = stateLock.newCondition();
+
+    private Thread owner;
+    private FileLock fileLock;
+    private Runnable fileLockHeldByOwner;
+    private int cacheClosedCount;
+
+    public LockOnDemandCrossProcessBuildCacheService(
+        String cacheDisplayName,
+        File lockTarget,
+        FileLockManager lockManager,
+        StatefulNextGenBuildCacheService delegate
+    ) {
+        this.cacheDisplayName = cacheDisplayName;
+        this.delegate = delegate;
+        this.operations = new CacheAccessOperationsStack();
+
+        Action<FileLock> onFileLockAcquireAction = this::afterLockAcquire;
+        Action<FileLock> onFileLockReleaseAction = this::beforeLockRelease;
+
+        LockOptionsBuilder lockOptions = LockOptionsBuilder
+            .mode(Exclusive)
+            // TODO Is cross-version something we need?
+            .useCrossVersionImplementation();
+        this.crossProcessCacheAccess = new LockOnDemandCrossProcessCacheAccess(
+            cacheDisplayName,
+            lockTarget,
+            lockOptions,
+            lockManager,
+            stateLock,
+            NO_INIT_REQUIRED,
+            onFileLockAcquireAction,
+            onFileLockReleaseAction);
+
+        withOwnershipNow(() -> {
+            try {
+                crossProcessCacheAccess.open();
+            } catch (Throwable throwable) {
+                crossProcessCacheAccess.close();
+                throw UncheckedException.throwAsUncheckedException(throwable);
+            }
+        });
+    }
+
+    @Override
+    public boolean contains(BuildCacheKey key) {
+        return crossProcessCacheAccess.withFileLock(() -> delegate.contains(key));
+    }
+
+    @Override
+    public void store(BuildCacheKey key, BuildCacheEntryWriter legacyWriter) throws BuildCacheException {
+        crossProcessCacheAccess.withFileLock(() -> {
+            delegate.store(key, legacyWriter);
+            return null;
+        });
+    }
+
+    @Override
+    public void store(BuildCacheKey key, NextGenWriter writer) throws BuildCacheException {
+        crossProcessCacheAccess.withFileLock(() -> {
+            delegate.store(key, writer);
+            return null;
+        });
+    }
+
+    @Override
+    public boolean load(BuildCacheKey key, BuildCacheEntryReader reader) throws BuildCacheException {
+        return crossProcessCacheAccess.withFileLock(() -> delegate.load(key, reader));
+    }
+
+    @Override
+    public synchronized void close() {
+        withOwnershipNow(() -> {
+            try {
+                if (fileLockHeldByOwner != null) {
+                    fileLockHeldByOwner.run();
+                }
+                crossProcessCacheAccess.close();
+
+                if (cacheClosedCount != 1) {
+                    LOG.debug("Cache {} was closed {} times.", cacheDisplayName, cacheClosedCount);
+                }
+            } finally {
+                owner = null;
+                fileLockHeldByOwner = null;
+            }
+        });
+    }
+
+    private void withOwnershipNow(Runnable action) {
+        stateLock.lock();
+        try {
+            // Take ownership
+            takeOwnershipNow();
+            try {
+                action.run();
+            } finally {
+                releaseOwnership();
+            }
+        } finally {
+            stateLock.unlock();
+        }
+    }
+
+    /**
+     * Takes ownership of the cache, asserting that this can be done without waiting.
+     * Must be called while holding the lock.
+     */
+    private void takeOwnershipNow() {
+        if (owner != null && owner != Thread.currentThread()) {
+            throw new IllegalStateException(String.format("Cannot take ownership of %s as it is currently being used by another thread.", cacheDisplayName));
+        }
+        owner = Thread.currentThread();
+        operations.pushCacheAction();
+    }
+
+    /**
+     * Releases ownership of the cache.
+     * Must be called while holding the lock.
+     */
+    private void releaseOwnership() {
+        operations.popCacheAction();
+        if (!operations.isInCacheAction()) {
+            owner = null;
+            condition.signalAll();
+        }
+    }
+
+    /**
+     * Called just after the file lock has been acquired.
+     */
+    private void afterLockAcquire(FileLock fileLock) {
+        assert this.fileLock == null;
+        this.fileLock = fileLock;
+
+        withOwnershipNow(delegate::open);
+    }
+
+    /**
+     * Called just before the file lock is about to be released.
+     */
+    private void beforeLockRelease(FileLock fileLock) {
+        assert this.fileLock == fileLock;
+        try {
+            cacheClosedCount++;
+            withOwnershipNow(delegate::close);
+        } finally {
+            this.fileLock = null;
+        }
+    }
+}

--- a/subprojects/build-cache/src/test/groovy/org/gradle/caching/local/internal/H2BuildCacheServiceTest.groovy
+++ b/subprojects/build-cache/src/test/groovy/org/gradle/caching/local/internal/H2BuildCacheServiceTest.groovy
@@ -18,7 +18,9 @@ package org.gradle.caching.local.internal
 
 import org.gradle.caching.BuildCacheEntryReader
 import org.gradle.caching.BuildCacheKey
+import org.gradle.caching.internal.DefaultBuildCacheKey
 import org.gradle.caching.internal.controller.service.StoreTarget
+import org.gradle.internal.hash.TestHashCodes
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
 import spock.lang.Specification
@@ -37,6 +39,22 @@ class H2BuildCacheServiceTest extends Specification {
 
     BuildCacheKey key = Mock(BuildCacheKey) {
         getHashCode() >> "1234abcd"
+    }
+
+    def "can open database cheaply"() {
+        def tmpFile = temporaryFolder.createFile("test")
+        tmpFile << "Hello world"
+
+        expect:
+        10000.times { index ->
+            if (index % 100 == 0) {
+                print "."
+            }
+            def service2 = new H2BuildCacheService(dbDir.toPath(), 20)
+            def key2 = new DefaultBuildCacheKey(TestHashCodes.hashCodeFrom(index))
+            service2.store(key2, new StoreTarget(tmpFile))
+            service2.close()
+        }
     }
 
     def "can write to h2"() {

--- a/subprojects/build-cache/src/test/groovy/org/gradle/caching/local/internal/H2BuildCacheServiceTest.groovy
+++ b/subprojects/build-cache/src/test/groovy/org/gradle/caching/local/internal/H2BuildCacheServiceTest.groovy
@@ -18,9 +18,7 @@ package org.gradle.caching.local.internal
 
 import org.gradle.caching.BuildCacheEntryReader
 import org.gradle.caching.BuildCacheKey
-import org.gradle.caching.internal.DefaultBuildCacheKey
 import org.gradle.caching.internal.controller.service.StoreTarget
-import org.gradle.internal.hash.TestHashCodes
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
 import spock.lang.Specification
@@ -31,7 +29,12 @@ class H2BuildCacheServiceTest extends Specification {
     TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
     def dbDir = temporaryFolder.createDir("h2db")
-    def service = new H2BuildCacheService(dbDir.toPath(), 20)
+    H2BuildCacheService service
+
+    def setup() {
+        service = new H2BuildCacheService(dbDir.toPath(), 20)
+        service.open()
+    }
 
     def cleanup() {
         service.close()
@@ -39,22 +42,6 @@ class H2BuildCacheServiceTest extends Specification {
 
     BuildCacheKey key = Mock(BuildCacheKey) {
         getHashCode() >> "1234abcd"
-    }
-
-    def "can open database cheaply"() {
-        def tmpFile = temporaryFolder.createFile("test")
-        tmpFile << "Hello world"
-
-        expect:
-        10000.times { index ->
-            if (index % 100 == 0) {
-                print "."
-            }
-            def service2 = new H2BuildCacheService(dbDir.toPath(), 20)
-            def key2 = new DefaultBuildCacheKey(TestHashCodes.hashCodeFrom(index))
-            service2.store(key2, new StoreTarget(tmpFile))
-            service2.close()
-        }
     }
 
     def "can write to h2"() {
@@ -92,6 +79,7 @@ class H2BuildCacheServiceTest extends Specification {
 
         expect:
         def newService = new H2BuildCacheService(dbDir.toPath(), 20)
+        newService.open()
         newService.load(key, new BuildCacheEntryReader() {
             @Override
             void readFrom(InputStream input) throws IOException {

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/FileLockManager.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/FileLockManager.java
@@ -63,7 +63,7 @@ public interface FileLockManager {
 
     enum LockMode {
         /**
-         * No synchronisation is done.
+         * Support processes asking for access.
          */
         OnDemand,
         /**
@@ -75,7 +75,7 @@ public interface FileLockManager {
          */
         Exclusive,
         /**
-         * No locking whatsoever
+         * No locking whatsoever.
          */
         None
     }

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CacheInitializationAction.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CacheInitializationAction.java
@@ -29,4 +29,15 @@ public interface CacheInitializationAction {
      * The lock is not released between calling {@link #requiresInitialization(FileLock)} and this method.
      */
     void initialize(FileLock fileLock);
+
+    CacheInitializationAction NO_INIT_REQUIRED = new CacheInitializationAction() {
+        @Override
+        public boolean requiresInitialization(FileLock fileLock) {
+            return false;
+        }
+
+        @Override
+        public void initialize(FileLock fileLock) {
+        }
+    };
 }

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultPersistentDirectoryStore.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultPersistentDirectoryStore.java
@@ -18,7 +18,6 @@ package org.gradle.cache.internal;
 import org.gradle.cache.CacheBuilder;
 import org.gradle.cache.CacheCleanupStrategy;
 import org.gradle.cache.CacheOpenException;
-import org.gradle.cache.FileLock;
 import org.gradle.cache.FileLockManager;
 import org.gradle.cache.IndexedCache;
 import org.gradle.cache.IndexedCacheParameters;
@@ -39,6 +38,8 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
+
+import static org.gradle.cache.internal.CacheInitializationAction.NO_INIT_REQUIRED;
 
 public class DefaultPersistentDirectoryStore implements ReferencablePersistentCache {
 
@@ -111,17 +112,7 @@ public class DefaultPersistentDirectoryStore implements ReferencablePersistentCa
     }
 
     protected CacheInitializationAction getInitAction() {
-        return new CacheInitializationAction() {
-            @Override
-            public boolean requiresInitialization(FileLock fileLock) {
-                return false;
-            }
-
-            @Override
-            public void initialize(FileLock fileLock) {
-                throw new UnsupportedOperationException();
-            }
-        };
+        return NO_INIT_REQUIRED;
     }
 
     protected CacheCleanupExecutor getCleanupExecutor() {

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/ExclusiveCacheAccessingWorker.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/ExclusiveCacheAccessingWorker.java
@@ -35,7 +35,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 
-class ExclusiveCacheAccessingWorker implements Runnable, Stoppable, AsyncCacheAccess {
+public class ExclusiveCacheAccessingWorker implements Runnable, Stoppable, AsyncCacheAccess {
     private final BlockingQueue<Runnable> workQueue;
     private final String displayName;
     private final ExclusiveCacheAccessCoordinator cacheAccess;
@@ -47,7 +47,7 @@ class ExclusiveCacheAccessingWorker implements Runnable, Stoppable, AsyncCacheAc
     private final CountDownLatch doneSignal = new CountDownLatch(1);
     private final ExecutorPolicy.CatchAndRecordFailures failureHandler = new ExecutorPolicy.CatchAndRecordFailures();
 
-    ExclusiveCacheAccessingWorker(String displayName, ExclusiveCacheAccessCoordinator cacheAccess) {
+    public ExclusiveCacheAccessingWorker(String displayName, ExclusiveCacheAccessCoordinator cacheAccess) {
         this.displayName = displayName;
         this.cacheAccess = cacheAccess;
         this.batchWindowMillis = 200;

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/LockOnDemandCrossProcessCacheAccess.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/LockOnDemandCrossProcessCacheAccess.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.util.concurrent.locks.Lock;
 
-class LockOnDemandCrossProcessCacheAccess extends AbstractCrossProcessCacheAccess {
+public class LockOnDemandCrossProcessCacheAccess extends AbstractCrossProcessCacheAccess {
     private static final Logger LOGGER = LoggerFactory.getLogger(LockOnDemandCrossProcessCacheAccess.class);
     private final String cacheDisplayName;
     private final File lockTarget;


### PR DESCRIPTION
Make sure multiple daemon processes can safely access the experimental H2-based local build cache.

----
/cc @gradle/bt-execution 