### PR TITLE
Fix wrong filter condition for small regressions

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/IndexPageGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/IndexPageGenerator.java
@@ -47,7 +47,7 @@ public class IndexPageGenerator extends AbstractTablePageGenerator {
         long successCount = executionDataProvider.getReportScenarios().stream().filter(PerformanceReportScenario::isSuccessful).count();
         long smallRegressions = executionDataProvider.getReportScenarios().stream()
             .filter(PerformanceReportScenario::isRegressed)
-            .filter(this::failsBuild)
+            .filter(scenario -> !failsBuild(scenario))
             .count();
         long failureCount = executionDataProvider.getReportScenarios().size() - successCount - smallRegressions;
 


### PR DESCRIPTION
Previously when counting failed performance test scenarios, the intention was to filter out the small regressions, but actually the big regressions were filtered out.