### PR TITLE
Fix worker daemon reuse on Mac OS

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/jvm/Jvm.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/jvm/Jvm.java
@@ -63,7 +63,7 @@ public class Jvm implements JavaInfo {
     @VisibleForTesting
     static JvmImplementation createCurrent() {
         String vendor = System.getProperty("java.vm.vendor");
-        if (vendor.toLowerCase().startsWith("apple inc.")) {
+        if (vendor.toLowerCase().startsWith("apple inc.") || OperatingSystem.current().isMacOsX()) {
             return new AppleJvm(OperatingSystem.current());
         }
         if (vendor.toLowerCase().startsWith("ibm corporation")) {
@@ -359,7 +359,8 @@ public class Jvm implements JavaInfo {
     }
 
     public boolean isIbmJvm() {
-        return false;
+        String vendor = System.getProperty("java.vm.vendor");
+        return vendor.toLowerCase().startsWith("ibm corporation");
     }
 
     /**

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultJavaForkOptionsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultJavaForkOptionsTest.groovy
@@ -593,6 +593,21 @@ class DefaultJavaForkOptionsTest extends Specification {
         options.isCompatibleWith(other)
     }
 
+    def "is compatible with JAVA_MAIN_CLASS when running on Apple JVMs"() {
+        given:
+        def oldOsName = System.properties['os.name']
+        System.properties['os.name'] = 'Mac OS X'
+
+        when:
+        def other = new DefaultJavaForkOptions(resolver, fileCollectionFactory, new DefaultJavaDebugOptions())
+
+        then:
+        other.getEnvironment().findAll { it.key.startsWith("JAVA_MAIN_CLASS") }.size() == 0
+
+        cleanup:
+        System.properties['os.name'] = oldOsName
+    }
+
     def "is not compatible with super set of environment variables"() {
         def other = new DefaultJavaForkOptions(resolver, fileCollectionFactory, new DefaultJavaDebugOptions())
 
@@ -853,5 +868,3 @@ class DefaultJavaForkOptionsTest extends Specification {
         }
     }
 }
-
-


### PR DESCRIPTION
This fixes the Apple JVM detection logic to take into account the `os.name` system property as well. The old os.vendor property isn't relevant anymore.

This in turns removes JAVA_MAIN_CLASS_* synthetic environment variables from the logic that detects if worker daemons are compatible with each other and therefore leads to re-using them.

Fixes #25029

I provide this as a draft since I think there are a few things that need to be discussed

### Context
<!--- Why do you believe many users will benefit from this change? -->
#25029

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
