### PR TITLE
Add sample for build service from work action

### DIFF
--- a/subprojects/docs/src/docs/userguide/extending-gradle/build_services.adoc
+++ b/subprojects/docs/src/docs/userguide/extending-gradle/build_services.adoc
@@ -136,10 +136,21 @@ them at configuration time. However, sometimes it can make sense to use the serv
 
 == Other ways of using a build service
 
-In addition to using a build service from a task, you can use a build service from a worker API action, an artifact transform or another build service.
+In addition to using a build service from a task, you can use a build service from a <<worker_api.adoc#converting_to_worker_api,worker API action>>, an <<artifact_transforms.adoc#sec:implementing-artifact-transforms,artifact transform>> or another build service.
 To do this, pass the build service `Provider` as a parameter of the consuming action or service, in the same way you pass other parameters to the action or service.
+
 For example, to pass a `MyServiceType` service to worker API action, you might add a property of type `Property<MyServiceType>` to the action's parameters object and
 then connect the `Provider<MyServiceType>` that you receive when registering the service to this property.
+
+.Build service usage from worker action
+====
+[source.multi-language-sample,java]
+.Download.java
+----
+include::{snippetsPath}/plugins/buildServiceFromWorkAction/groovy/buildSrc/src/main/java/Download.java[]
+----
+====
+
 
 Currently, it is not possible to use a build service with a worker API action that uses ClassLoader or process isolation modes.
 

--- a/subprojects/docs/src/docs/userguide/extending-gradle/worker_api.adoc
+++ b/subprojects/docs/src/docs/userguide/extending-gradle/worker_api.adoc
@@ -90,6 +90,7 @@ include::{snippetsPath}/workerApi/md5CustomTask/tests/md5Task.out[]
 In the `build/md5` directory, you should now see corresponding files with an `md5` extension containing MD5 hashes of the files from the `src` directory.
 Notice that the task takes at least 9 seconds to run because it hashes each file one at a time (i.e. 3 files at ~3 seconds a piece).
 
+[[converting_to_worker_api]]
 == Converting to the Worker API
 
 Although this task processes each file in sequence, the processing of each file is independent of any other file.

--- a/subprojects/docs/src/snippets/plugins/buildServiceFromWorkAction/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/plugins/buildServiceFromWorkAction/groovy/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'org.gradle.sample.download'
+}

--- a/subprojects/docs/src/snippets/plugins/buildServiceFromWorkAction/groovy/buildSrc/build.gradle
+++ b/subprojects/docs/src/snippets/plugins/buildServiceFromWorkAction/groovy/buildSrc/build.gradle
@@ -1,0 +1,16 @@
+plugins {
+    id('java-gradle-plugin')
+}
+
+repositories {
+    mavenCentral()
+}
+
+gradlePlugin {
+    plugins {
+        download {
+            id = 'org.gradle.sample.download'
+            implementationClass = 'DownloadPlugin'
+        }
+    }
+}

--- a/subprojects/docs/src/snippets/plugins/buildServiceFromWorkAction/groovy/buildSrc/src/main/java/Download.java
+++ b/subprojects/docs/src/snippets/plugins/buildServiceFromWorkAction/groovy/buildSrc/src/main/java/Download.java
@@ -1,0 +1,44 @@
+import org.gradle.api.DefaultTask;
+import org.gradle.api.provider.Property;
+import org.gradle.api.services.ServiceReference;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.workers.WorkAction;
+import org.gradle.workers.WorkParameters;
+import org.gradle.workers.WorkQueue;
+import org.gradle.workers.WorkerExecutor;
+
+import javax.inject.Inject;
+import java.net.URI;
+
+public abstract class Download extends DefaultTask {
+
+    public static abstract class DownloadWorkAction implements WorkAction<DownloadWorkAction.Parameters> {
+        interface Parameters extends WorkParameters {
+            // This property provides access to the service instance from the work action
+            abstract Property<WebServer> getServer();
+        }
+
+        @Override
+        public void execute() {
+            // Use the server to download a file
+            WebServer server = getParameters().getServer().get();
+            URI uri = server.getUri().resolve("somefile.zip");
+            System.out.println(String.format("Downloading %s", uri));
+        }
+    }
+
+    @Inject
+    abstract public WorkerExecutor getWorkerExecutor();
+
+    // This property provides access to the service instance from the task
+    @ServiceReference("web")
+    abstract Property<WebServer> getServer();
+
+    @TaskAction
+    public void download() {
+        WorkQueue workQueue = getWorkerExecutor().noIsolation();
+        workQueue.submit(DownloadWorkAction.class, parameter -> {
+            parameter.getServer().set(getServer());
+        });
+    }
+}

--- a/subprojects/docs/src/snippets/plugins/buildServiceFromWorkAction/groovy/buildSrc/src/main/java/DownloadPlugin.java
+++ b/subprojects/docs/src/snippets/plugins/buildServiceFromWorkAction/groovy/buildSrc/src/main/java/DownloadPlugin.java
@@ -1,0 +1,15 @@
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.provider.Provider;
+
+public class DownloadPlugin implements Plugin<Project> {
+    public void apply(Project project) {
+        // Register the service
+        project.getGradle().getSharedServices().registerIfAbsent("web", WebServer.class, spec -> {
+            // Provide some parameters
+            spec.getParameters().getPort().set(5005);
+        });
+
+        project.getTasks().register("download", Download.class, task -> {});
+    }
+}

--- a/subprojects/docs/src/snippets/plugins/buildServiceFromWorkAction/groovy/buildSrc/src/main/java/WebServer.java
+++ b/subprojects/docs/src/snippets/plugins/buildServiceFromWorkAction/groovy/buildSrc/src/main/java/WebServer.java
@@ -1,0 +1,39 @@
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.services.BuildService;
+import org.gradle.api.services.BuildServiceParameters;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public abstract class WebServer implements BuildService<WebServer.Params>, AutoCloseable {
+
+    // Some parameters for the web server
+    interface Params extends BuildServiceParameters {
+        Property<Integer> getPort();
+
+        DirectoryProperty getResources();
+    }
+
+    private final URI uri;
+
+    public WebServer() throws URISyntaxException {
+        // Use the parameters
+        int port = getParameters().getPort().get();
+        uri = new URI(String.format("https://localhost:%d/", port));
+
+        // Start the server ...
+
+        System.out.println(String.format("Server is running at %s", uri));
+    }
+
+    // A public method for tasks to use
+    public URI getUri() {
+        return uri;
+    }
+
+    @Override
+    public void close() {
+        // Stop the server ...
+    }
+}

--- a/subprojects/docs/src/snippets/plugins/buildServiceFromWorkAction/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/plugins/buildServiceFromWorkAction/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'build-services'

--- a/subprojects/docs/src/snippets/plugins/buildServiceFromWorkAction/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/plugins/buildServiceFromWorkAction/kotlin/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    id("org.gradle.sample.download")
+}

--- a/subprojects/docs/src/snippets/plugins/buildServiceFromWorkAction/kotlin/buildSrc/build.gradle
+++ b/subprojects/docs/src/snippets/plugins/buildServiceFromWorkAction/kotlin/buildSrc/build.gradle
@@ -1,0 +1,16 @@
+plugins {
+    id('java-gradle-plugin')
+}
+
+repositories {
+    mavenCentral()
+}
+
+gradlePlugin {
+    plugins {
+        download {
+            id = 'org.gradle.sample.download'
+            implementationClass = 'DownloadPlugin'
+        }
+    }
+}

--- a/subprojects/docs/src/snippets/plugins/buildServiceFromWorkAction/kotlin/buildSrc/src/main/java/Download.java
+++ b/subprojects/docs/src/snippets/plugins/buildServiceFromWorkAction/kotlin/buildSrc/src/main/java/Download.java
@@ -1,0 +1,44 @@
+import org.gradle.api.DefaultTask;
+import org.gradle.api.provider.Property;
+import org.gradle.api.services.ServiceReference;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.workers.WorkAction;
+import org.gradle.workers.WorkParameters;
+import org.gradle.workers.WorkQueue;
+import org.gradle.workers.WorkerExecutor;
+
+import javax.inject.Inject;
+import java.net.URI;
+
+public abstract class Download extends DefaultTask {
+
+    public static abstract class DownloadWorkAction implements WorkAction<DownloadWorkAction.Parameters> {
+        interface Parameters extends WorkParameters {
+            // This property provides access to the service instance from the work action
+            abstract Property<WebServer> getServer();
+        }
+
+        @Override
+        public void execute() {
+            // Use the server to download a file
+            WebServer server = getParameters().getServer().get();
+            URI uri = server.getUri().resolve("somefile.zip");
+            System.out.println(String.format("Downloading %s", uri));
+        }
+    }
+
+    @Inject
+    abstract public WorkerExecutor getWorkerExecutor();
+
+    // This property provides access to the service instance from the task
+    @ServiceReference("web")
+    abstract Property<WebServer> getServer();
+
+    @TaskAction
+    public void download() {
+        WorkQueue workQueue = getWorkerExecutor().noIsolation();
+        workQueue.submit(DownloadWorkAction.class, parameter -> {
+            parameter.getServer().set(getServer());
+        });
+    }
+}

--- a/subprojects/docs/src/snippets/plugins/buildServiceFromWorkAction/kotlin/buildSrc/src/main/java/DownloadPlugin.java
+++ b/subprojects/docs/src/snippets/plugins/buildServiceFromWorkAction/kotlin/buildSrc/src/main/java/DownloadPlugin.java
@@ -1,0 +1,15 @@
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.provider.Provider;
+
+public class DownloadPlugin implements Plugin<Project> {
+    public void apply(Project project) {
+        // Register the service
+        project.getGradle().getSharedServices().registerIfAbsent("web", WebServer.class, spec -> {
+            // Provide some parameters
+            spec.getParameters().getPort().set(5005);
+        });
+
+        project.getTasks().register("download", Download.class, task -> {});
+    }
+}

--- a/subprojects/docs/src/snippets/plugins/buildServiceFromWorkAction/kotlin/buildSrc/src/main/java/WebServer.java
+++ b/subprojects/docs/src/snippets/plugins/buildServiceFromWorkAction/kotlin/buildSrc/src/main/java/WebServer.java
@@ -1,0 +1,39 @@
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.services.BuildService;
+import org.gradle.api.services.BuildServiceParameters;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public abstract class WebServer implements BuildService<WebServer.Params>, AutoCloseable {
+
+    // Some parameters for the web server
+    interface Params extends BuildServiceParameters {
+        Property<Integer> getPort();
+
+        DirectoryProperty getResources();
+    }
+
+    private final URI uri;
+
+    public WebServer() throws URISyntaxException {
+        // Use the parameters
+        int port = getParameters().getPort().get();
+        uri = new URI(String.format("https://localhost:%d/", port));
+
+        // Start the server ...
+
+        System.out.println(String.format("Server is running at %s", uri));
+    }
+
+    // A public method for tasks to use
+    public URI getUri() {
+        return uri;
+    }
+
+    @Override
+    public void close() {
+        // Stop the server ...
+    }
+}

--- a/subprojects/docs/src/snippets/plugins/buildServiceFromWorkAction/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/plugins/buildServiceFromWorkAction/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "build-services"

--- a/subprojects/docs/src/snippets/plugins/buildServiceFromWorkAction/tests/buildServiceFromWorkAction.out
+++ b/subprojects/docs/src/snippets/plugins/buildServiceFromWorkAction/tests/buildServiceFromWorkAction.out
@@ -1,0 +1,3 @@
+> Task :download
+Server is running at https://localhost:5005/
+Downloading https://localhost:5005/somefile.zip

--- a/subprojects/docs/src/snippets/plugins/buildServiceFromWorkAction/tests/buildServiceFromWorkAction.sample.conf
+++ b/subprojects/docs/src/snippets/plugins/buildServiceFromWorkAction/tests/buildServiceFromWorkAction.sample.conf
@@ -1,0 +1,4 @@
+executable: gradle
+args: "download"
+expected-output-file: buildServiceFromWorkAction.out
+allow-additional-output: true


### PR DESCRIPTION
Changes are mostly to add a sample snippet for the "build service from work action" use case - the prose itself was not modified, so this is more of a sample review (unless you see need to add new or modify existing prose). 

Notice I snuck in usage of service references at the task level, to make the code simpler, but the traditional consumption model would have worked as well.

Issue: #22559
