### PR TITLE
Do not emit deprecation warning for BuildIdentifier.{name,isCurrentBuild}

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildPathAssignmentIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildPathAssignmentIntegrationTest.groovy
@@ -40,7 +40,6 @@ class CompositeBuildBuildPathAssignmentIntegrationTest extends AbstractComposite
         def includingBuild = builds.find { it.rootProjectName == 'includingBuild' }
 
         when:
-        executer.expectDocumentedDeprecationWarning("The BuildIdentifier.getName() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use getBuildPath() to get a unique identifier for the build. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation")
         succeeds(includingBuild, "help")
         then:
         assignedBuildPaths ==~ [
@@ -79,7 +78,6 @@ class CompositeBuildBuildPathAssignmentIntegrationTest extends AbstractComposite
         def includingBuild = builds.find { it.rootProjectName == 'includingBuild' }
 
         when:
-        executer.expectDocumentedDeprecationWarning("The BuildIdentifier.getName() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use getBuildPath() to get a unique identifier for the build. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation")
         succeeds(includingBuild, 'help')
         then:
         assignedBuildPaths ==~ [
@@ -125,7 +123,6 @@ class CompositeBuildBuildPathAssignmentIntegrationTest extends AbstractComposite
         }
 
         when:
-        executer.expectDocumentedDeprecationWarning("The BuildIdentifier.getName() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use getBuildPath() to get a unique identifier for the build. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation")
         succeeds(includingBuild, 'help')
         then:
         assignedBuildPaths ==~ [
@@ -163,7 +160,6 @@ class CompositeBuildBuildPathAssignmentIntegrationTest extends AbstractComposite
         new BuildTestFixture(includedBuildBNested).multiProjectBuild('includedBuildB-nested', ['project1', 'project2'])
 
         when:
-        executer.expectDocumentedDeprecationWarning("The BuildIdentifier.getName() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use getBuildPath() to get a unique identifier for the build. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation")
         succeeds(includingBuild, 'help')
         then:
         assignedBuildPaths ==~ [':', ':includedBuildB', ':includedBuildA', ':nested', ':includedBuildB:nested']

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcIdentityIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcIdentityIntegrationTest.groovy
@@ -170,10 +170,6 @@ Required by:
             }
         """
 
-        2.times {
-            executer.expectDocumentedDeprecationWarning("The BuildIdentifier.getName() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use getBuildPath() to get a unique identifier for the build. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation")
-            executer.expectDocumentedDeprecationWarning("The BuildIdentifier.isCurrentBuild() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use getBuildPath() to get a unique identifier for the build. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation")
-        }
         executer.expectDocumentedDeprecationWarning("The ProjectComponentSelector.getBuildName() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use getBuildPath() to get a unique identifier for the build. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation")
 
         expect:

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildIdentityIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildIdentityIntegrationTest.groovy
@@ -178,10 +178,6 @@ Required by:
             }
         """
 
-        3.times {
-            executer.expectDocumentedDeprecationWarning("The BuildIdentifier.getName() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use getBuildPath() to get a unique identifier for the build. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation")
-            executer.expectDocumentedDeprecationWarning("The BuildIdentifier.isCurrentBuild() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use getBuildPath() to get a unique identifier for the build. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation")
-        }
         executer.expectDocumentedDeprecationWarning("The ProjectComponentSelector.getBuildName() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use getBuildPath() to get a unique identifier for the build. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation")
 
         expect:
@@ -251,8 +247,6 @@ Required by:
                 assert self == rootComponent
             }
         """
-
-        8.times { executer.expectDocumentedDeprecationWarning("The BuildIdentifier.isCurrentBuild() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use getBuildPath() to get a unique identifier for the build. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation") }
 
         expect:
         execute(buildA, ":buildC:assemble", ":buildB:assemble", ":assemble")

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcIdentityIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcIdentityIntegrationTest.groovy
@@ -186,10 +186,6 @@ Required by:
             }
         """
 
-        2.times {
-            executer.expectDocumentedDeprecationWarning("The BuildIdentifier.getName() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use getBuildPath() to get a unique identifier for the build. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation")
-            executer.expectDocumentedDeprecationWarning("The BuildIdentifier.isCurrentBuild() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use getBuildPath() to get a unique identifier for the build. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation")
-        }
         executer.expectDocumentedDeprecationWarning("The ProjectComponentSelector.getBuildName() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use getBuildPath() to get a unique identifier for the build. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation")
 
         expect:

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/DefaultBuildIdentifier.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/DefaultBuildIdentifier.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.artifacts;
 
 import com.google.common.base.Objects;
 import org.gradle.api.artifacts.component.BuildIdentifier;
-import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.util.Path;
 
 public class DefaultBuildIdentifier implements BuildIdentifier {
@@ -41,19 +40,12 @@ public class DefaultBuildIdentifier implements BuildIdentifier {
     @SuppressWarnings("deprecation")
     @Override
     public String getName() {
-        DeprecationLogger.deprecateMethod(BuildIdentifier.class, "getName()")
-            .withAdvice("Use getBuildPath() to get a unique identifier for the build.")
-            .willBeRemovedInGradle9()
-            .withUpgradeGuideSection(8, "build_identifier_name_and_current_deprecation")
-            .nagUser();
-
         return buildPath.getName() == null ? ":" : buildPath.getName();
     }
 
     @SuppressWarnings("deprecation")
     @Override
     public boolean isCurrentBuild() {
-        nagAboutDeprecatedIsCurrentBuild();
         return true;
     }
 
@@ -77,13 +69,5 @@ public class DefaultBuildIdentifier implements BuildIdentifier {
     @Override
     public String toString() {
         return "build '" + buildPath + "'";
-    }
-
-    protected static void nagAboutDeprecatedIsCurrentBuild() {
-        DeprecationLogger.deprecateMethod(BuildIdentifier.class, "isCurrentBuild()")
-            .withAdvice("Use getBuildPath() to get a unique identifier for the build.")
-            .willBeRemovedInGradle9()
-            .withUpgradeGuideSection(8, "build_identifier_name_and_current_deprecation")
-            .nagUser();
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/ForeignBuildIdentifier.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/ForeignBuildIdentifier.java
@@ -29,7 +29,6 @@ public class ForeignBuildIdentifier extends DefaultBuildIdentifier {
 
     @Override
     public boolean isCurrentBuild() {
-        nagAboutDeprecatedIsCurrentBuild();
         return false;
     }
 }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractAndroidSantaTrackerSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractAndroidSantaTrackerSmokeTest.groovy
@@ -63,13 +63,11 @@ class AbstractAndroidSantaTrackerSmokeTest extends AbstractSmokeTest {
 
     protected BuildResult buildLocation(File projectDir, String agpVersion) {
         return runnerForLocation(projectDir, agpVersion, "assembleDebug").deprecations(SantaTrackerDeprecations) {
-            expectBuildIdentifierNameDeprecation()
             if (GradleContextualExecuter.notConfigCache) {
                 expectProjectConventionDeprecationWarning(agpVersion)
                 expectAndroidConventionTypeDeprecationWarning(agpVersion)
                 expectBasePluginConventionDeprecation(agpVersion)
                 expectConfigUtilDeprecationWarning(agpVersion)
-                expectBuildIdentifierIsCurrentBuildDeprecation(agpVersion)
             }
         }.build()
     }
@@ -81,17 +79,10 @@ class AbstractAndroidSantaTrackerSmokeTest extends AbstractSmokeTest {
                 expectAndroidConventionTypeDeprecationWarning(agpVersion)
                 expectBasePluginConventionDeprecation(agpVersion)
                 expectConfigUtilDeprecationWarning(agpVersion)
-                expectBuildIdentifierNameDeprecation()
-                expectBuildIdentifierIsCurrentBuildDeprecation(agpVersion)
             } else {
-                expectBuildIdentifierNameDeprecation()
                 // TODO - this is here because AGP 7.4.x reads build/generated/source/kapt/debug at configuration time
                 if (agpVersion.startsWith("7.4")){
                     expectConfigUtilDeprecationWarning(agpVersion)
-                }
-                // TODO - this is here because AGP > 7.3 reads build/generated/source/kapt/debug at configuration time
-                if (!agpVersion.startsWith("7.3")) {
-                    expectBuildIdentifierIsCurrentBuildDeprecation(agpVersion)
                 }
             }
         }.build()
@@ -105,8 +96,6 @@ class AbstractAndroidSantaTrackerSmokeTest extends AbstractSmokeTest {
                 expectAndroidConventionTypeDeprecationWarning(agpVersion)
                 expectBasePluginConventionDeprecation(agpVersion)
                 expectConfigUtilDeprecationWarning(agpVersion)
-                expectBuildIdentifierIsCurrentBuildDeprecation(agpVersion)
-                expectBuildIdentifierNameDeprecation()
             }.build()
     }
 
@@ -114,7 +103,6 @@ class AbstractAndroidSantaTrackerSmokeTest extends AbstractSmokeTest {
         return runnerForLocation(location, agpVersion,"assembleDebug")
             .deprecations(SantaTrackerDeprecations) {
                 expectAndroidWorkerExecutionSubmitDeprecationWarning(agpVersion)
-                expectBuildIdentifierNameDeprecation()
             }.build()
     }
 
@@ -125,11 +113,6 @@ class AbstractAndroidSantaTrackerSmokeTest extends AbstractSmokeTest {
                 // TODO - this is here because AGP 7.4.x reads build/generated/source/kapt/debug at configuration time
                 if (agpVersion.startsWith("7.4")){
                     expectConfigUtilDeprecationWarning(agpVersion)
-                }
-                expectBuildIdentifierNameDeprecation()
-                if (!agpVersion.startsWith("7.3")) {
-                    // TODO - this is here because AGP > 7.3 reads build/generated/source/kapt/debug at configuration time
-                    expectBuildIdentifierIsCurrentBuildDeprecation(agpVersion)
                 }
             }.build()
     }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
@@ -109,8 +109,6 @@ class AndroidPluginsSmokeTest extends AbstractPluginValidatingSmokeTest implemen
             expectProjectConventionDeprecationWarning(agpVersion)
             expectAndroidConventionTypeDeprecationWarning(agpVersion)
             expectBasePluginConventionDeprecation(agpVersion)
-            expectBuildIdentifierNameDeprecation()
-            expectBuildIdentifierIsCurrentBuildDeprecation(agpVersion)
         }.build()
 
         then:
@@ -132,7 +130,6 @@ class AndroidPluginsSmokeTest extends AbstractPluginValidatingSmokeTest implemen
                 expectProjectConventionDeprecationWarning(agpVersion)
                 expectAndroidConventionTypeDeprecationWarning(agpVersion)
                 expectBasePluginConventionDeprecation(agpVersion)
-                expectBuildIdentifierIsCurrentBuildDeprecation(agpVersion)
             }
         }.build()
 
@@ -155,7 +152,6 @@ class AndroidPluginsSmokeTest extends AbstractPluginValidatingSmokeTest implemen
                 expectProjectConventionDeprecationWarning(agpVersion)
                 expectAndroidConventionTypeDeprecationWarning(agpVersion)
                 expectBasePluginConventionDeprecation(agpVersion)
-                expectBuildIdentifierIsCurrentBuildDeprecation(agpVersion)
             }
         }.build()
 
@@ -178,13 +174,11 @@ class AndroidPluginsSmokeTest extends AbstractPluginValidatingSmokeTest implemen
         SantaTrackerConfigurationCacheWorkaround.beforeBuild(runner.projectDir, IntegrationTestBuildContext.INSTANCE.gradleUserHomeDir)
         result = runner.deprecations(AndroidDeprecations) {
             expectAndroidWorkerExecutionSubmitDeprecationWarning(agpVersion)
-            expectBuildIdentifierNameDeprecation()
             if (!GradleContextualExecuter.isConfigCache()) {
                 expectReportDestinationPropertyDeprecation(agpVersion)
                 expectProjectConventionDeprecationWarning(agpVersion)
                 expectAndroidConventionTypeDeprecationWarning(agpVersion)
                 expectBasePluginConventionDeprecation(agpVersion)
-                expectBuildIdentifierIsCurrentBuildDeprecation(agpVersion)
             }
         }.build()
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerSmokeTest.groovy
@@ -118,10 +118,6 @@ class AndroidSantaTrackerLintSmokeTest extends AndroidSantaTrackerSmokeTest {
             expectProjectConventionDeprecationWarning(agpVersion)
             expectAndroidConventionTypeDeprecationWarning(agpVersion)
             expectBasePluginConventionDeprecation(agpVersion)
-            expectBuildIdentifierIsCurrentBuildDeprecation()
-            if (agpVersion.startsWith('7.')) {
-                expectBuildIdentifierNameDeprecation()
-            }
         }
         def result = runner.buildAndFail()
 
@@ -141,7 +137,6 @@ class AndroidSantaTrackerLintSmokeTest extends AndroidSantaTrackerSmokeTest {
                 expectProjectConventionDeprecationWarning(agpVersion)
                 expectAndroidConventionTypeDeprecationWarning(agpVersion)
                 expectBasePluginConventionDeprecation(agpVersion)
-                expectBuildIdentifierIsCurrentBuildDeprecation(agpVersion)
             }
         }
         result = runner.buildAndFail()

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.smoketests
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.internal.enterprise.core.GradleEnterprisePluginManager
 import org.gradle.testkit.runner.BuildResult
-import org.gradle.util.GradleVersion
 import org.gradle.util.internal.VersionNumber
 import org.junit.Assume
 import spock.lang.IgnoreIf
@@ -104,13 +103,7 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
         usePluginVersion version
 
         then:
-        scanRunner()
-            .expectLegacyDeprecationWarningIf(versionNumber < FIRST_VERSION_CALLING_BUILD_PATH,
-                "The BuildIdentifier.getName() method has been deprecated. " +
-                    "This is scheduled to be removed in Gradle 9.0. " +
-                    "Use getBuildPath() to get a unique identifier for the build. " +
-                    "Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation"
-            ).build().output.contains("Build scan written to")
+        scanRunner().build().output.contains("Build scan written to")
 
         where:
         version << SUPPORTED
@@ -126,14 +119,7 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
         usePluginVersion version
 
         then:
-        scanRunner()
-            .expectLegacyDeprecationWarningIf(versionNumber < FIRST_VERSION_CALLING_BUILD_PATH,
-                "The BuildIdentifier.getName() method has been deprecated. " +
-                    "This is scheduled to be removed in Gradle 9.0. " +
-                    "Use getBuildPath() to get a unique identifier for the build. " +
-                    "Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation"
-            )
-            .build().output.contains("Build scan written to")
+        scanRunner().build().output.contains("Build scan written to")
 
         where:
         version << SUPPORTED

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginAndroidGroovyDSLSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginAndroidGroovyDSLSmokeTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.smoketests
 
 import com.gradle.enterprise.testing.annotations.LocalOnly
 import org.gradle.integtests.fixtures.android.AndroidHome
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.util.internal.VersionNumber
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
@@ -49,9 +48,6 @@ class KotlinPluginAndroidGroovyDSLSmokeTest extends AbstractSmokeTest {
                 expectAndroidOrKotlinWorkerSubmitDeprecation(androidPluginVersion, workers, kotlinPluginVersion)
                 expectReportDestinationPropertyDeprecation(androidPluginVersion)
                 expectKotlinCompileDestinationDirPropertyDeprecation(kotlinPluginVersion)
-                if (GradleContextualExecuter.configCache || VersionNumber.parse(kotlinPluginVersion) >= VersionNumber.parse("1.8.0")) {
-                    expectBuildIdentifierIsCurrentBuildDeprecation(androidPluginVersion)
-                }
             }.build()
 
         then:

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginAndroidKotlinDSLSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginAndroidKotlinDSLSmokeTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.smoketests
 
 import com.gradle.enterprise.testing.annotations.LocalOnly
 import org.gradle.integtests.fixtures.android.AndroidHome
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.util.internal.VersionNumber
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
@@ -49,9 +48,6 @@ class KotlinPluginAndroidKotlinDSLSmokeTest extends AbstractSmokeTest {
                 expectAndroidOrKotlinWorkerSubmitDeprecation(androidPluginVersion, workers, kotlinPluginVersion)
                 expectReportDestinationPropertyDeprecation(androidPluginVersion)
                 expectKotlinCompileDestinationDirPropertyDeprecation(kotlinPluginVersion)
-                if (GradleContextualExecuter.isConfigCache() || VersionNumber.parse(kotlinPluginVersion) >= VersionNumber.parse("1.8.0")) {
-                    expectBuildIdentifierIsCurrentBuildDeprecation(androidPluginVersion)
-                }
             }.build()
 
         then:

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
@@ -20,7 +20,6 @@ import org.gradle.api.JavaVersion
 import org.gradle.api.internal.DocumentationRegistry
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.internal.reflect.validation.ValidationMessageChecker
-import org.gradle.util.GradleVersion
 import org.gradle.util.internal.VersionNumber
 import spock.lang.Issue
 
@@ -253,7 +252,6 @@ class KotlinPluginSmokeTest extends AbstractPluginValidatingSmokeTest implements
                 expectProjectConventionDeprecation(kotlinVersion)
                 expectConventionTypeDeprecation(kotlinVersion)
                 expectJavaPluginConventionDeprecation(kotlinVersion)
-                expectBuildIdentifierNameDeprecation(kotlinVersion)
             }
             .build()
 
@@ -320,7 +318,6 @@ class KotlinPluginSmokeTest extends AbstractPluginValidatingSmokeTest implements
                 expectJavaPluginConventionDeprecation(kotlinVersion)
             }
             expectConfigureUtilDeprecation(kotlinVersion)
-            expectBuildIdentifierNameDeprecation(kotlinVersion)
         }
 
         def result = testRunner.build()
@@ -563,17 +560,6 @@ class KotlinPluginSmokeTest extends AbstractPluginValidatingSmokeTest implements
                     "This is scheduled to be removed in Gradle 9.0. " +
                     "Consult the upgrading guide for further information: " +
                     DOC_REGISTRY.getDocumentationFor("upgrading_version_8", "org_gradle_util_reports_deprecations")
-            )
-        }
-
-        void expectBuildIdentifierNameDeprecation(String kotlinVersion) {
-            VersionNumber versionNumber = VersionNumber.parse(kotlinVersion)
-            runner.expectDeprecationWarningIf(versionNumber >= VersionNumber.parse("1.8.20"),
-                "The BuildIdentifier.getName() method has been deprecated. " +
-                    "This is scheduled to be removed in Gradle 9.0. " +
-                    "Use getBuildPath() to get a unique identifier for the build. " +
-                    "Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation",
-                "https://youtrack.jetbrains.com/issue/KT-58157"
             )
         }
     }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithAndroidDeprecations.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithAndroidDeprecations.groovy
@@ -64,35 +64,4 @@ trait WithAndroidDeprecations implements WithReportDeprecations {
                 "https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#org_gradle_util_reports_deprecations",
         )
     }
-
-    void expectBuildIdentifierIsCurrentBuildDeprecation(String agpVersion) {
-        VersionNumber agpVersionNumber = VersionNumber.parse(agpVersion)
-        runner.expectLegacyDeprecationWarningIf(
-            agpVersionNumber < VersionNumber.parse("8.0.0-rc01"),
-            "The BuildIdentifier.isCurrentBuild() method has been deprecated. " +
-                "This is scheduled to be removed in Gradle 9.0. " +
-                "Use getBuildPath() to get a unique identifier for the build. " +
-                "Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation"
-        )
-    }
-
-    void expectBuildIdentifierIsCurrentBuildDeprecation() {
-        runner.expectDeprecationWarning(
-            "The BuildIdentifier.isCurrentBuild() method has been deprecated. " +
-                "This is scheduled to be removed in Gradle 9.0. " +
-                "Use getBuildPath() to get a unique identifier for the build. " +
-                "Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation",
-            "https://issuetracker.google.com/issues/279306626"
-        )
-    }
-
-    void expectBuildIdentifierNameDeprecation() {
-        runner.expectDeprecationWarning(
-            "The BuildIdentifier.getName() method has been deprecated. " +
-                "This is scheduled to be removed in Gradle 9.0. " +
-                "Use getBuildPath() to get a unique identifier for the build. " +
-                "Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation",
-            "https://issuetracker.google.com/issues/279306626"
-        )
-    }
 }

--- a/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/NestedSourceDependencyIdentityIntegrationTest.groovy
+++ b/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/NestedSourceDependencyIdentityIntegrationTest.groovy
@@ -189,10 +189,6 @@ Required by:
             }
         """
 
-        4.times {
-            executer.expectDocumentedDeprecationWarning("The BuildIdentifier.getName() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use getBuildPath() to get a unique identifier for the build. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation")
-            executer.expectDocumentedDeprecationWarning("The BuildIdentifier.isCurrentBuild() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use getBuildPath() to get a unique identifier for the build. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation")
-        }
         executer.expectDocumentedDeprecationWarning("The ProjectComponentSelector.getBuildName() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use getBuildPath() to get a unique identifier for the build. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation")
 
         expect:

--- a/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyIdentityIntegrationTest.groovy
+++ b/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyIdentityIntegrationTest.groovy
@@ -156,10 +156,6 @@ Required by:
             }
         """
 
-        3.times {
-            executer.expectDocumentedDeprecationWarning("The BuildIdentifier.getName() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use getBuildPath() to get a unique identifier for the build. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation")
-            executer.expectDocumentedDeprecationWarning("The BuildIdentifier.isCurrentBuild() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use getBuildPath() to get a unique identifier for the build. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation")
-        }
         executer.expectDocumentedDeprecationWarning("The ProjectComponentSelector.getBuildName() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use getBuildPath() to get a unique identifier for the build. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation")
 
         expect:


### PR DESCRIPTION
To give Android and Kotlin some time to remove the usage.

Relates to #24648 and #24963.