### PR TITLE
Increase max parallel fork to 8

### DIFF
--- a/.teamcity/src/main/kotlin/model/CIBuildModel.kt
+++ b/.teamcity/src/main/kotlin/model/CIBuildModel.kt
@@ -280,7 +280,7 @@ data class TestCoverage(
 
 enum class TestType(val unitTests: Boolean = true, val functionalTests: Boolean = true, val crossVersionTests: Boolean = false, val timeout: Int = 180, val maxParallelForks: Int = 4) {
     // Include cross version tests, these take care of selecting a very small set of versions to cover when run as part of this stage, including the current version
-    quick(true, true, true, 120, 2),
+    quick(true, true, true, 120, 8),
 
     // Include cross version tests, these take care of selecting a very small set of versions to cover when run as part of this stage, including the current version
     platform(true, true, true),


### PR DESCRIPTION
In the past when we were using shared agents, we decreased maxParallelForks to 2. But now, experiments show that it's more efficient to have maxParallelForks=8:

<img width="1641" alt="image" src="https://github.com/gradle/gradle/assets/12689835/76eadd7c-ab18-46b8-bf54-d6773fbefa7a">

