### PR TITLE
Let config cache support `ArrayDeque` serialization natively

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheSupportedTypesIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheSupportedTypesIntegrationTest.groovy
@@ -116,6 +116,7 @@ class ConfigurationCacheSupportedTypesIntegrationTest extends AbstractConfigurat
         "TreeMap<String, Integer>"           | treeMapWithComparator()                   | "[b:2, a:1]"
         "ConcurrentHashMap<String, Integer>" | "new ConcurrentHashMap([a: 1, b: 2])"     | "[a:1, b:2]"
         "EnumMap<SomeEnum, String>"          | enumMapToString()                         | "[One:one, Two:two]"
+        "ArrayDeque<String>"                 | "['a', 'b', 'c'] as ArrayDeque"           | "[a, b, c]"
         "byte[]"                             | "[Byte.MIN_VALUE, Byte.MAX_VALUE]"        | "[-128, 127]"
         "short[]"                            | "[Short.MIN_VALUE, Short.MAX_VALUE]"      | "[-32768, 32767]"
         "int[]"                              | integerArray()                            | "[-2147483648, 2147483647]"

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/Codecs.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/Codecs.kt
@@ -375,6 +375,9 @@ class Codecs(
         bind(CharArrayCodec)
         bind(NonPrimitiveArrayCodec)
 
+        // Only serialize certain Queue implementations
+        bind(arrayDequeCodec)
+
         bind(EnumCodec)
         bind(RegexpPatternCodec)
         bind(UrlCodec)

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/CollectionCodecs.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/CollectionCodecs.kt
@@ -26,6 +26,7 @@ import org.gradle.configurationcache.serialization.readList
 import org.gradle.configurationcache.serialization.readMapInto
 import org.gradle.configurationcache.serialization.writeCollection
 import org.gradle.configurationcache.serialization.writeMap
+import java.util.ArrayDeque
 import java.util.LinkedList
 import java.util.TreeMap
 import java.util.TreeSet
@@ -39,7 +40,11 @@ val arrayListCodec: Codec<ArrayList<Any?>> = collectionCodec { ArrayList(it) }
 
 
 internal
-val linkedListCodec: Codec<LinkedList<Any?>> = collectionCodec { LinkedList<Any?>() }
+val linkedListCodec: Codec<LinkedList<Any?>> = collectionCodec { LinkedList() }
+
+
+internal
+val arrayDequeCodec: Codec<ArrayDeque<Any?>> = collectionCodec { ArrayDeque(it) }
 
 
 internal


### PR DESCRIPTION
As to avoid reflection errors with later JDKs when using TestKit.

Fixes #24980