### PR TITLE
Account for Gradle 7.6.2 metadata cache layout

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
@@ -72,7 +72,8 @@ public enum CacheLayout {
         .changedTo(96, "6.4-rc-1")
         .changedTo(97, "6.8-rc-1")
         .changedTo(99, "7.5-rc-1")
-        .changedTo(100, "8.0-milestone-5")
+        .changedTo(101, "7.6.2")
+        .changedToWithConflict(100, "8.0-milestone-5")
         .changedTo(105, "8.1-rc-2")
         .changedTo(106, "8.2-milestone-1")
     ),

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
@@ -64,6 +64,17 @@ class CacheLayoutTest extends Specification {
         cacheLayout.versionMapping.getVersionUsedBy(GradleVersion.version("1.9-rc-2")).get() == CacheVersion.of(2, 1)
     }
 
+    def "metadata store layout for 7.6.2 and before and after versions can be retrieved"() {
+        when:
+        CacheLayout cacheLayout = CacheLayout.META_DATA
+
+        then:
+        cacheLayout.versionMapping.getVersionUsedBy(GradleVersion.version("7.6.1")).get() == CacheVersion.parse("2.99")
+        cacheLayout.versionMapping.getVersionUsedBy(GradleVersion.version("7.6.2")).get() == CacheVersion.parse("2.101")
+        cacheLayout.versionMapping.getVersionUsedBy(GradleVersion.version("7.7")).get() == CacheVersion.parse("2.101")
+        cacheLayout.versionMapping.getVersionUsedBy(GradleVersion.version("8.0")).get() == CacheVersion.parse("2.100")
+    }
+
     def "use transforms layout"() {
         when:
         CacheLayout cacheLayout = CacheLayout.TRANSFORMS

--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/dependency_resolution.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/dependency_resolution.adoc
@@ -317,7 +317,8 @@ If multiple incompatible Gradle versions are in play, all should be used when se
 | `modules-2`           | `files-2.1`           | `metadata-2.96`           | Gradle 6.4 to Gradle 6.7
 
 | `modules-2`           | `files-2.1`           | `metadata-2.97`           | Gradle 6.8 to Gradle 7.4
-| `modules-2`           | `files-2.1`           | `metadata-2.99`           | Gradle 7.5 to Gradle 7.6
+| `modules-2`           | `files-2.1`           | `metadata-2.99`           | Gradle 7.5 to Gradle 7.6.1
+| `modules-2`           | `files-2.1`           | `metadata-2.101`          | Gradle 7.6.2
 | `modules-2`           | `files-2.1`           | `metadata-2.100`          | Gradle 8.0
 | `modules-2`           | `files-2.1`           | `metadata-2.105`          | Gradle 8.1
 | `modules-2`           | `files-2.1`           | `metadata-2.106`          | Gradle 8.2 and above

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CacheVersionMapping.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CacheVersionMapping.java
@@ -80,6 +80,17 @@ public class CacheVersionMapping {
             return this;
         }
 
+        /**
+         * You should not use this method. But Gradle 7.6.2 backport made it necessary.
+         * Only one set of argument is currently accepted
+         */
+        public Builder changedToWithConflict(int cacheVersion, String minGradleVersion) {
+            GradleVersion parsedGradleVersion = GradleVersion.version(minGradleVersion);
+            Preconditions.checkArgument(cacheVersion == 100 && minGradleVersion.equals("8.0-milestone-5"));
+            versions.put(parsedGradleVersion, cacheVersion);
+            return this;
+        }
+
         public CacheVersionMapping build() {
             return build(CacheVersion.empty());
         }


### PR DESCRIPTION
Because we lacked a gap between 7.5 and 8.0 and 7.6.2 requires a cache layout bump, we are forced to add this version with an exception.

This is related to #25060 and should only be merged if that other PR is merged and 7.6.2 release is confirmed.

