### PR TITLE
Create ArtifactViews using "live" attributes from creating configuration

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/ArtifactViewAttributesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/ArtifactViewAttributesIntegrationTest.groovy
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.attributes
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Ignore
+
+/**
+ * Tests for [org.gradle.api.artifacts.ArtifactView ArtifactView] that ensure it uses the "live" attributes
+ * of the configuration that created it to select files and artifacts.
+ *
+ * These tests assume a situation where a consumer should resolve the secondary "classes" variant of a producer
+ * and obtain the "main" directory as the only file.  As the necessary attributes are not present on the
+ * consumer's compileClasspath configuration until the beforeLocking callback method is called, the previous
+ * incorrect behavior of the ArtifactView was to select the standard jar file variant instead of the "classes"
+ * variant.
+ */
+class ArtifactViewAttributesIntegrationTest extends AbstractIntegrationSpec {
+    private static declareIncomingFiles = "def incomingFiles = configurations.compileClasspath.incoming.files\n"
+    private static declareIncomingArtifacts = "def incomingArtifacts = configurations.compileClasspath.incoming.artifacts\n"
+    private static declareArtifactViewFiles = "def artifactViewFiles = configurations.compileClasspath.incoming.artifactView { }.files\n"
+    private static declareArtifactViewArtifacts = "def artifactViewArtifacts = configurations.compileClasspath.incoming.artifactView { }.artifacts\n"
+    private static iterateIncomingFiles = """logger.warn 'Incoming Files:'
+incomingFiles.each {
+    logger.warn 'Name: ' + it.name
+}
+logger.warn ''
+"""
+    private static iterateIncomingArtifacts = """logger.warn 'Incoming Artifacts:'
+incomingArtifacts.each {
+    logger.warn 'Name: ' + it.id.name + ', File: ' + it.id.file.name
+}
+logger.warn ''
+"""
+    private static iterateArtifactViewFiles = """logger.warn 'Artifact View Files:'
+artifactViewFiles.each {
+    logger.warn 'Name: ' + it.name
+}
+logger.warn ''
+"""
+    private static iterateArtifactViewArtifacts = """logger.warn 'Artifact View Artifacts:'
+artifactViewArtifacts.each {
+    logger.warn 'Name: ' + it.id.name + ', File: ' + it.id.file.name
+}
+logger.warn ''
+"""
+
+    private static filesComparison = "assert incomingFiles*.name == artifactViewFiles*.name"
+    private static artifactComparison = "assert incomingArtifacts*.id.file.name == artifactViewArtifacts*.id.file.name"
+
+    def setup() {
+        settingsFile << """
+            rootProject.name = "consumer"
+            include "producer"
+        """
+
+        file("producer/build.gradle").text = """
+            plugins {
+                id 'java-library'
+            }
+        """
+
+        buildFile << """
+            plugins {
+                id 'java-library'
+            }
+
+            dependencies {
+                api project(':producer')
+            }
+        """
+    }
+
+    def "incoming declarations first during configuration phase"() {
+        buildFile << """
+            def incomingFiles = configurations.compileClasspath.incoming.files
+            def incomingArtifacts = configurations.compileClasspath.incoming.artifacts
+            def artifactViewFiles = configurations.compileClasspath.incoming.artifactView { }.files
+            def artifactViewArtifacts = configurations.compileClasspath.incoming.artifactView { }.artifacts
+
+            assert incomingFiles*.name == artifactViewFiles*.name
+            assert incomingArtifacts*.id.file.name == artifactViewArtifacts*.id.file.name
+        """
+
+        expect:
+        run ':help'
+    }
+
+    def "incoming declarations first during configuration phase, iteration during execution phase"() {
+        buildFile << """
+            tasks.register('verifySameFilesAndArtifacts') {
+                def incomingFiles = configurations.compileClasspath.incoming.files
+                def incomingArtifacts = configurations.compileClasspath.incoming.artifacts
+                def artifactViewFiles = configurations.compileClasspath.incoming.artifactView { }.files
+                def artifactViewArtifacts = configurations.compileClasspath.incoming.artifactView { }.artifacts
+
+                doLast {
+                    assert incomingFiles*.name == artifactViewFiles*.name
+                    assert incomingArtifacts*.id.file.name == artifactViewArtifacts*.id.file.name
+                }
+            }
+        """
+
+        expect:
+        run ':verifySameFilesAndArtifacts'
+    }
+
+    def "incoming declarations first during execution phase"() {
+        buildFile << """
+            tasks.register('verifySameFilesAndArtifacts') {
+                doLast {
+                    def incomingFiles = configurations.compileClasspath.incoming.files
+                    def incomingArtifacts = configurations.compileClasspath.incoming.artifacts
+                    def artifactViewFiles = configurations.compileClasspath.incoming.artifactView { }.files
+                    def artifactViewArtifacts = configurations.compileClasspath.incoming.artifactView { }.artifacts
+
+                    assert incomingFiles*.name == artifactViewFiles*.name
+                    assert incomingArtifacts*.id.file.name == artifactViewArtifacts*.id.file.name
+                }
+            }
+        """
+
+        expect:
+        run ':verifySameFilesAndArtifacts'
+    }
+
+    def "artifact view declarations first"() {
+        buildFile << """
+            def artifactViewFiles = configurations.compileClasspath.incoming.artifactView { }.files
+            def artifactViewArtifacts = configurations.compileClasspath.incoming.artifactView { }.artifacts
+            def incomingFiles = configurations.compileClasspath.incoming.files
+            def incomingArtifacts = configurations.compileClasspath.incoming.artifacts
+
+            assert incomingFiles*.name == artifactViewFiles*.name
+            assert incomingArtifacts*.id.file.name == artifactViewArtifacts*.id.file.name
+        """
+
+        expect:
+        run ':help'
+    }
+
+    def "incoming declarations first, then iteration to force resolution"() {
+        buildFile << """
+            def incomingFiles = configurations.compileClasspath.incoming.files
+            def incomingArtifacts = configurations.compileClasspath.incoming.artifacts
+
+            incomingFiles.size()
+            incomingArtifacts.size()
+
+            def artifactViewFiles = configurations.compileClasspath.incoming.artifactView { }.files
+            def artifactViewArtifacts = configurations.compileClasspath.incoming.artifactView { }.artifacts
+
+            assert incomingFiles*.name == artifactViewFiles*.name
+            assert incomingArtifacts*.id.file.name == artifactViewArtifacts*.id.file.name
+        """
+
+        expect:
+        run ':help'
+    }
+
+    def "incoming artifacts first"() {
+        buildFile << """
+            $declareIncomingArtifacts
+            $iterateIncomingArtifacts
+
+            $declareArtifactViewArtifacts
+            $iterateArtifactViewArtifacts
+
+            $artifactComparison
+        """
+
+        expect:
+        run ':help'
+    }
+
+    def "artifactView artifacts first"() {
+        buildFile << """
+            $declareArtifactViewArtifacts
+            $iterateArtifactViewArtifacts
+
+            $declareIncomingArtifacts
+            $iterateIncomingArtifacts
+
+            $artifactComparison
+        """
+
+        expect:
+        run ':help'
+    }
+
+    @Ignore
+    def "mixer"() {
+        buildFile << """
+            logger.warn '******************'
+            logger.warn '***** Script *****'
+            logger.warn '******************'
+            logger.warn ''
+            logger.warn '''$codeBlock'''
+            logger.warn ''
+
+            logger.warn '******************'
+            logger.warn '***** Output *****'
+            logger.warn '******************'
+            logger.warn ''
+            $codeBlock
+
+            assert incomingFiles*.name == artifactViewFiles*.name
+            assert incomingArtifacts*.id.file.name == artifactViewArtifacts*.id.file.name
+        """
+
+        expect:
+        run ':help'
+
+        where:
+        codeBlock << [
+            declareIncomingFiles,
+            declareIncomingArtifacts,
+            declareArtifactViewFiles,
+            declareArtifactViewArtifacts,
+            iterateIncomingFiles,
+            iterateIncomingArtifacts,
+            iterateArtifactViewFiles,
+            iterateArtifactViewArtifacts
+        ].permutations().findAll { isValid(it) }.collect { it.join('\n') }
+    }
+
+    private boolean isValid(List<String> code) {
+        return code.indexOf(declareIncomingFiles) < code.indexOf(iterateIncomingFiles) &&
+            code.indexOf(declareIncomingArtifacts) < code.indexOf(iterateIncomingArtifacts) &&
+            code.indexOf(declareArtifactViewFiles) < code.indexOf(iterateArtifactViewFiles) &&
+            code.indexOf(declareArtifactViewArtifacts) < code.indexOf(iterateArtifactViewArtifacts);
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -2193,7 +2193,7 @@ since users cannot create non-legacy configurations and there is no current publ
         }
 
         private ArtifactView createArtifactView(ArtifactViewConfiguration config) {
-            ImmutableAttributes viewAttributes = config.lockViewAttributes();
+            AttributeContainerInternal viewAttributes = config.configurationAttributes;
             // This is a little coincidental: if view attributes have not been accessed, don't allow no matching variants
             boolean allowNoMatchingVariants = config.attributesUsed;
             ArtifactView view;
@@ -2216,13 +2216,13 @@ since users cannot create non-legacy configurations and there is no current publ
         }
 
         private class ConfigurationArtifactView implements ArtifactView {
-            private final ImmutableAttributes viewAttributes;
+            private final AttributeContainerInternal viewAttributes;
             private final Spec<? super ComponentIdentifier> componentFilter;
             private final boolean lenient;
             private final boolean allowNoMatchingVariants;
             private final boolean selectFromAllVariants;
 
-            ConfigurationArtifactView(ImmutableAttributes viewAttributes, Spec<? super ComponentIdentifier> componentFilter, boolean lenient, boolean allowNoMatchingVariants, boolean selectFromAllVariants) {
+            ConfigurationArtifactView(AttributeContainerInternal viewAttributes, Spec<? super ComponentIdentifier> componentFilter, boolean lenient, boolean allowNoMatchingVariants, boolean selectFromAllVariants) {
                 this.viewAttributes = viewAttributes;
                 this.componentFilter = componentFilter;
                 this.lenient = lenient;
@@ -2436,15 +2436,6 @@ since users cannot create non-legacy configurations and there is no current publ
                 componentFilter = Specs.satisfyAll();
             }
             return componentFilter;
-        }
-
-        private ImmutableAttributes lockViewAttributes() {
-            if (viewAttributes == null) {
-                viewAttributes = configurationAttributes.asImmutable();
-            } else {
-                viewAttributes = viewAttributes.asImmutable();
-            }
-            return viewAttributes.asImmutable();
         }
     }
 


### PR DESCRIPTION
Certain attributes are adding to Java configurations by the beforeLocking callback by the JavaBasePlugin and DefaultJvmPluginServices classes.  Previously, if an ArtifactView was created prior to these callbacks being triggered, the attributes they added were not present in the AV's collection when the AttributeMatchingVariantSelector selected a variant to obtain files from the ArtifactView.

Depending on the order files were accessed, this could cause AV's with no additional configuration to return a different set of files than the configurations that created them.

Instead of copying an immutable collection of attributes, just use the existing collection of attributes, as we defensively copy the attributes of the VA if they are requested to be configured.
