### PR TITLE
Deprecate archives configuration for deletion

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ConfigurationOnDemandIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ConfigurationOnDemandIntegrationTest.groovy
@@ -143,7 +143,7 @@ class ConfigurationOnDemandIntegrationTest extends AbstractIntegrationSpec {
         buildFile << """
 allprojects { apply plugin: 'java-library' }
 project(':impl') {
-    dependencies { implementation project(path: ':api', configuration: 'archives') }
+    dependencies { implementation project(path: ':api') }
 }
 project(':api') {
     dependencies { runtimeOnly project(':impl') }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationRolesForMigration.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationRolesForMigration.java
@@ -54,6 +54,16 @@ public final class ConfigurationRolesForMigration {
     public static final ConfigurationRole RESOLVABLE_BUCKET_TO_BUCKET = difference(ConfigurationRoles.RESOLVABLE_BUCKET, ConfigurationRoles.BUCKET);
 
     /**
+     * A configuration which cannot do anything. Intended solely to create {@code X_TO_DELETED} roles.
+     */
+    private static final ConfigurationRole DELETED = new DefaultConfigurationRole("Deleted", false, false, false, false, false, false);
+
+    /**
+     * A consumable configuration which will be deleted in the next major version.
+     */
+    public static final ConfigurationRole CONSUMABLE_TO_DELETED = difference(ConfigurationRoles.CONSUMABLE, DELETED);
+
+    /**
      * Computes the difference between two roles, such that any usage that is allowed in the
      * initial role but not allowed in the eventual role will be deprecated in the returned role.
      */

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -1516,6 +1516,20 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     }
 
     private void preventIllegalMutation(MutationType type) {
+        if (type == MutationType.ARTIFACTS) {
+            if (!canBeConsumed) {
+                DeprecationLogger.deprecate("Adding artifacts to non-consumable configurations")
+                    .willBecomeAnErrorInGradle9()
+                    .withUpgradeGuideSection(8, "adding_artifacts_to_consumable_configurations")
+                    .nagUser();
+            } else if (isDeprecatedForConsumption()) {
+                DeprecationLogger.deprecateConfiguration(name).forArtifactDeclaration()
+                    .willBecomeAnErrorInGradle9()
+                    .withUpgradeGuideSection(8, "deprecated_configuration_usage")
+                    .nagUser();
+            }
+        }
+
         // TODO: Deprecate and eventually prevent these mutations when already resolved
         if (type == MutationType.DEPENDENCY_ATTRIBUTES) {
             assertIsDeclarable();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -1317,7 +1317,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         copiedConfiguration.declarationAlternatives = declarationAlternatives;
         copiedConfiguration.resolutionAlternatives = resolutionAlternatives;
 
-        copiedConfiguration.getArtifacts().addAll(getAllArtifacts());
+        DeprecationLogger.whileDisabled(() -> copiedConfiguration.getArtifacts().addAll(getAllArtifacts()));
 
         if (!configurationAttributes.isEmpty()) {
             for (Attribute<?> attribute : configurationAttributes.keySet()) {
@@ -1524,6 +1524,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
                     .nagUser();
             }
             // TODO: Enable this once KMP stops adding artifacts to non-consumable configurations
+            // See: https://github.com/JetBrains/kotlin/blob/37402336d5afbbdeae8d4921549abfc7b8d6e639/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/AbstractKotlinTarget.kt#L213-L216
 //            else if (!canBeConsumed) {
 //                DeprecationLogger.deprecate("Adding artifacts to non-consumable configurations")
 //                    .willBecomeAnErrorInGradle9()

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -1517,17 +1517,19 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
 
     private void preventIllegalMutation(MutationType type) {
         if (type == MutationType.ARTIFACTS) {
-            if (!canBeConsumed) {
-                DeprecationLogger.deprecate("Adding artifacts to non-consumable configurations")
-                    .willBecomeAnErrorInGradle9()
-                    .withUpgradeGuideSection(8, "adding_artifacts_to_consumable_configurations")
-                    .nagUser();
-            } else if (isDeprecatedForConsumption()) {
+            if (isDeprecatedForConsumption()) {
                 DeprecationLogger.deprecateConfiguration(name).forArtifactDeclaration()
                     .willBecomeAnErrorInGradle9()
                     .withUpgradeGuideSection(8, "deprecated_configuration_usage")
                     .nagUser();
             }
+            // TODO: Enable this once KMP stops adding artifacts to non-consumable configurations
+//            else if (!canBeConsumed) {
+//                DeprecationLogger.deprecate("Adding artifacts to non-consumable configurations")
+//                    .willBecomeAnErrorInGradle9()
+//                    .withUpgradeGuideSection(8, "adding_artifacts_to_consumable_configurations")
+//                    .nagUser();
+//            }
         }
 
         // TODO: Deprecate and eventually prevent these mutations when already resolved

--- a/subprojects/ear/src/main/java/org/gradle/plugins/ear/EarPlugin.java
+++ b/subprojects/ear/src/main/java/org/gradle/plugins/ear/EarPlugin.java
@@ -130,7 +130,7 @@ public abstract class EarPlugin implements Plugin<Project> {
                 deploymentDescriptor.setDescription(project.getDescription());
             }
         }
-        project.getExtensions().getByType(DefaultArtifactPublicationSet.class).addCandidate(new LazyPublishArtifact(ear, ((ProjectInternal) project).getFileResolver(), taskDependencyFactory));
+        project.getExtensions().getByType(DefaultArtifactPublicationSet.class).addCandidateInternal(new LazyPublishArtifact(ear, ((ProjectInternal) project).getFileResolver(), taskDependencyFactory));
     }
 
     private void wireEarTaskConventions(Project project, final EarPluginConvention earConvention) {

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpEarAndWebAndEjbProjectIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpEarAndWebAndEjbProjectIntegrationTest.groovy
@@ -37,7 +37,7 @@ project(':ear') {
 
     dependencies {
         deploy project(':java')
-        deploy project(path: ':web', configuration: 'archives')
+        deploy project(path: ':web', configuration: 'war')
     }
 }
 project(':web') {
@@ -46,6 +46,14 @@ project(':web') {
     dependencies {
         providedCompile 'javax.servlet:javax.servlet-api:3.1.0'
         testImplementation "junit:junit:4.13"
+    }
+
+    configurations {
+        war {
+            outgoing {
+                artifact(tasks.war)
+            }
+        }
     }
 }
 project(':java') {

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
@@ -144,9 +144,14 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
                 archiveBaseName = "publishTest-extra"
             }
 
+            configurations {
+                conf {
+                    canBeResolved = false
+                }
+            }
+
             artifacts {
-                implementation extraJar
-                archives extraJar
+                conf extraJar
                 it."default" extraJar
             }
 

--- a/subprojects/platform-base/src/main/java/org/gradle/api/internal/plugins/DefaultArtifactPublicationSet.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/api/internal/plugins/DefaultArtifactPublicationSet.java
@@ -23,6 +23,7 @@ import org.gradle.api.internal.provider.AbstractMinimalProvider;
 import org.gradle.api.internal.provider.ChangingValue;
 import org.gradle.api.internal.provider.ChangingValueHandler;
 import org.gradle.api.internal.provider.CollectionProviderInternal;
+import org.gradle.internal.deprecation.DeprecationLogger;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -41,9 +42,22 @@ public abstract class DefaultArtifactPublicationSet {
     }
 
     public void addCandidate(PublishArtifact artifact) {
+        DeprecationLogger.deprecate("DefaultArtifactPublicationSet")
+            .withAdvice("This class is internal and is not meant for public usage. To build artifacts during the assemble lifecycle phase, use task dependencies.")
+            .willBeRemovedInGradle9()
+            .withUpgradeGuideSection(8, "archives_configuration_deprecation")
+            .nagUser();
+
+        addCandidateInternal(artifact);
+    }
+
+    public void addCandidateInternal(PublishArtifact artifact) {
+        // TODO: In 9.0 when we remove this class, calls to this method should be replaced with calls to
+        // projects.tasks.assemble.dependsOn(artifact)
+
         if (defaultArtifactProvider == null) {
             defaultArtifactProvider = new DefaultArtifactProvider();
-            artifactContainer.addAllLater(defaultArtifactProvider);
+            DeprecationLogger.whileDisabled(() -> artifactContainer.addAllLater(defaultArtifactProvider));
         }
         defaultArtifactProvider.addArtifact(artifact);
     }

--- a/subprojects/platform-base/src/main/java/org/gradle/api/internal/plugins/DefaultArtifactPublicationSet.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/api/internal/plugins/DefaultArtifactPublicationSet.java
@@ -42,6 +42,7 @@ public abstract class DefaultArtifactPublicationSet {
     }
 
     public void addCandidate(PublishArtifact artifact) {
+        // We add a deprecation warning here even though it is internal since it's used by KMP and some other plugins.
         DeprecationLogger.deprecate("DefaultArtifactPublicationSet")
             .withAdvice("This class is internal and is not meant for public usage. To build artifacts during the assemble lifecycle phase, use task dependencies.")
             .willBeRemovedInGradle9()

--- a/subprojects/platform-base/src/main/java/org/gradle/api/plugins/BasePlugin.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/api/plugins/BasePlugin.java
@@ -21,6 +21,7 @@ import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationRoles;
+import org.gradle.api.internal.artifacts.configurations.ConfigurationRolesForMigration;
 import org.gradle.api.internal.artifacts.configurations.RoleBasedConfigurationContainerInternal;
 import org.gradle.api.internal.plugins.BuildConfigurationRule;
 import org.gradle.api.internal.plugins.DefaultArtifactPublicationSet;
@@ -89,7 +90,7 @@ public abstract class BasePlugin implements Plugin<Project> {
         RoleBasedConfigurationContainerInternal configurations = (RoleBasedConfigurationContainerInternal) project.getConfigurations();
         ((ProjectInternal) project).getInternalStatus().convention("integration");
 
-        final Configuration archivesConfiguration = configurations.maybeCreateWithRole(Dependency.ARCHIVES_CONFIGURATION, ConfigurationRoles.CONSUMABLE, false, false).
+        final Configuration archivesConfiguration = configurations.maybeCreateWithRole(Dependency.ARCHIVES_CONFIGURATION, ConfigurationRolesForMigration.CONSUMABLE_TO_DELETED, false, false).
             setDescription("Configuration for archive artifacts.");
 
         final Configuration defaultConfiguration = configurations.maybeCreateWithRole(Dependency.DEFAULT_CONFIGURATION, ConfigurationRoles.CONSUMABLE, false, false).

--- a/subprojects/platform-base/src/main/java/org/gradle/api/plugins/BasePlugin.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/api/plugins/BasePlugin.java
@@ -104,7 +104,7 @@ public abstract class BasePlugin implements Plugin<Project> {
             if (!configuration.equals(archivesConfiguration)) {
                 configuration.getArtifacts().configureEach(artifact -> {
                     if (configuration.isVisible()) {
-                        defaultArtifacts.addCandidate(artifact);
+                        defaultArtifacts.addCandidateInternal(artifact);
                     }
                 });
             }

--- a/subprojects/plugins/src/main/java/org/gradle/api/distribution/plugins/DistributionPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/distribution/plugins/DistributionPlugin.java
@@ -130,7 +130,7 @@ public abstract class DistributionPlugin implements Plugin<Project> {
         });
 
         PublishArtifact archiveArtifact = new LazyPublishArtifact(archiveTask, ((ProjectInternal) project).getFileResolver(), ((ProjectInternal) project).getTaskDependencyFactory());
-        project.getExtensions().getByType(DefaultArtifactPublicationSet.class).addCandidate(archiveArtifact);
+        project.getExtensions().getByType(DefaultArtifactPublicationSet.class).addCandidateInternal(archiveArtifact);
     }
 
     private void addInstallTask(final Project project, final String taskName, final Distribution distribution) {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/WarPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/WarPlugin.java
@@ -97,7 +97,7 @@ public abstract class WarPlugin implements Plugin<Project> {
         });
 
         PublishArtifact warArtifact = new LazyPublishArtifact(war, ((ProjectInternal) project).getFileResolver(), ((ProjectInternal) project).getTaskDependencyFactory());
-        project.getExtensions().getByType(DefaultArtifactPublicationSet.class).addCandidate(warArtifact);
+        project.getExtensions().getByType(DefaultArtifactPublicationSet.class).addCandidateInternal(warArtifact);
         configureConfigurations(((ProjectInternal) project).getConfigurations(), mainFeature);
         configureComponent(project, warArtifact);
     }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultAdhocSoftwareComponent.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultAdhocSoftwareComponent.java
@@ -51,12 +51,14 @@ public class DefaultAdhocSoftwareComponent implements AdhocComponentWithVariants
 
     @Override
     public void addVariantsFromConfiguration(Configuration outgoingConfiguration, Action<? super ConfigurationVariantDetails> spec) {
+        // TODO: Verify outgoingConfiguration is consumable
         checkNotFinalized();
         variants.put(outgoingConfiguration, new ConfigurationVariantMapping((ConfigurationInternal) outgoingConfiguration, spec, instantiator));
     }
 
     @Override
     public void withVariantsFromConfiguration(Configuration outgoingConfiguration, Action<? super ConfigurationVariantDetails> action) {
+        // TODO: Verify outgoingConfiguration is consumable
         checkNotFinalized();
         if (!variants.containsKey(outgoingConfiguration)) {
             throw new InvalidUserDataException("Variant for configuration " + outgoingConfiguration.getName() + " does not exist in component " + componentName);

--- a/subprojects/plugins/src/main/java/org/gradle/jvm/component/internal/DefaultJvmSoftwareComponent.java
+++ b/subprojects/plugins/src/main/java/org/gradle/jvm/component/internal/DefaultJvmSoftwareComponent.java
@@ -92,7 +92,7 @@ public class DefaultJvmSoftwareComponent extends DefaultAdhocSoftwareComponent i
 
         // Build the main jar when running `assemble`.
         extensions.getByType(DefaultArtifactPublicationSet.class)
-            .addCandidate(mainFeature.getRuntimeElementsConfiguration().getArtifacts().iterator().next());
+            .addCandidateInternal(mainFeature.getRuntimeElementsConfiguration().getArtifacts().iterator().next());
 
         configurePublishing(plugins, extensions, sourceSet);
 


### PR DESCRIPTION
Fixes: #22339
Fixes: #15639

TODO:
- [ ] Add integration tests to verify all operations made on archives configuration emit deprecation warnings
- [ ] File issue with Kotlin to stop using archives configuration
- [ ] File issue with Kotlin to stop using DefaultArtifactPublicationSet
- [ ] File issue with Kotlin to [stop adding artifacts to non-consumable configurations](- [ ] File issue with Kotlin to stop using DefaultArtifactPublicationSet)