### PR TITLE
Don't warn when kotlin projects redundantly set the allowed usage on the test fixtures runtime configuration

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -1957,7 +1957,7 @@ since users cannot create non-legacy configurations and there is no current publ
      */
     @SuppressWarnings("JavadocReference")
     private boolean isPermittedConfigurationForRedundantActivation() {
-        return name.equals("runtimeClasspath") || name.endsWith("testRuntimeClasspath") || name.endsWith("TestRuntimeClasspath");
+        return name.equals("runtimeClasspath") || name.equals("testFixturesRuntimeClasspath") || name.endsWith("testRuntimeClasspath") || name.endsWith("TestRuntimeClasspath");
     }
 
     @Override

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/fixtures/AbstractJavaProjectTestFixturesIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/fixtures/AbstractJavaProjectTestFixturesIntegrationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,14 @@
 
 package org.gradle.java.fixtures
 
-
-import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import org.gradle.test.fixtures.GradleModuleMetadata
-import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.maven.MavenPom
 
-abstract class AbstractJavaTestFixturesIntegrationTest extends AbstractIntegrationSpec {
+/**
+ * Base class for integration tests for the `java-test-fixtures` plugin that involve `java` or `java-library` projects.
+ */
+abstract class AbstractJavaProjectTestFixturesIntegrationTest extends AbstractTestFixturesIntegrationTest {
     abstract String getPluginName()
 
     abstract List getSkippedJars(boolean compileClasspathPackaging)
@@ -71,10 +71,10 @@ abstract class AbstractJavaTestFixturesIntegrationTest extends AbstractIntegrati
         def skippedJars = getSkippedJars(compileClasspathPackaging)
         def producedJars = [':jar', ':testFixturesJar'] - skippedJars
         executedAndNotSkipped(
-            ":compileJava",
-            ":compileTestFixturesJava",
-            ":compileTestJava",
-            *producedJars
+                ":compileJava",
+                ":compileTestFixturesJava",
+                ":compileTestJava",
+                *producedJars
         )
         notExecuted(*skippedJars)
         outputContains """Test compile classpath
@@ -128,10 +128,10 @@ hamcrest-core-1.3.jar
         def skippedJars = getSkippedJars(compileClasspathPackaging)
         def producedJars = [':jar', ':testFixturesJar'] - skippedJars
         executedAndNotSkipped(
-            ":compileJava",
-            ":compileTestFixturesJava",
-            ":compileTestJava",
-            *producedJars
+                ":compileJava",
+                ":compileTestFixturesJava",
+                ":compileTestJava",
+                *producedJars
         )
         notExecuted(*skippedJars)
 
@@ -220,7 +220,7 @@ hamcrest-core-1.3.jar
 
         then:
         executedAndNotSkipped(
-            ":sub:compileTestFixturesJava"
+                ":sub:compileTestFixturesJava"
         )
     }
 
@@ -249,7 +249,7 @@ hamcrest-core-1.3.jar
 
         then:
         executedAndNotSkipped(
-            ":sub:compileTestFixturesJava"
+                ":sub:compileTestFixturesJava"
         )
     }
 
@@ -292,7 +292,7 @@ hamcrest-core-1.3.jar
         MavenPom pom = new MavenPom(file("build/repo/com/acme/root/1.3/root-1.3.pom"))
         pom.scope("runtime") {
             assertOptionalDependencies(
-                "org.apache.commons:commons-lang3:3.9"
+                    "org.apache.commons:commons-lang3:3.9"
             )
         }
 
@@ -360,19 +360,19 @@ hamcrest-core-1.3.jar
 
     def "can consume test fixtures of an external module"() {
         mavenRepo.module("com.acme", "external-module", "1.3")
-            .variant("testFixturesApiElements", ['org.gradle.usage': 'java-api', 'org.gradle.libraryelements': 'jar']) {
-                capability('com.acme', 'external-module-test-fixtures', '1.3')
-                dependsOn("com.acme:external-module:1.3")
-                artifact("external-module-1.3-test-fixtures.jar")
-            }
-            .variant("testFixturesRuntimeElements", ['org.gradle.usage': 'java-runtime', 'org.gradle.libraryelements': 'jar']) {
-                capability('com.acme', 'external-module-test-fixtures', '1.3')
-                dependsOn("com.acme:external-module:1.3")
-                dependsOn("org.apache.commons:commons-lang3:3.9")
-                artifact("external-module-1.3-test-fixtures.jar")
-            }
-            .withModuleMetadata()
-            .publish()
+                .variant("testFixturesApiElements", ['org.gradle.usage': 'java-api', 'org.gradle.libraryelements': 'jar']) {
+                    capability('com.acme', 'external-module-test-fixtures', '1.3')
+                    dependsOn("com.acme:external-module:1.3")
+                    artifact("external-module-1.3-test-fixtures.jar")
+                }
+                .variant("testFixturesRuntimeElements", ['org.gradle.usage': 'java-runtime', 'org.gradle.libraryelements': 'jar']) {
+                    capability('com.acme', 'external-module-test-fixtures', '1.3')
+                    dependsOn("com.acme:external-module:1.3")
+                    dependsOn("org.apache.commons:commons-lang3:3.9")
+                    artifact("external-module-1.3-test-fixtures.jar")
+                }
+                .withModuleMetadata()
+                .publish()
         buildFile << """
             dependencies {
                 testImplementation(testFixtures('com.acme:external-module:1.3'))
@@ -397,7 +397,7 @@ hamcrest-core-1.3.jar
                 }
                 module('com.acme:external-module:1.3') {
                     variant("testFixturesApiElements", [
-                        'org.gradle.status': 'release', 'org.gradle.usage': 'java-api', 'org.gradle.libraryelements': 'jar'
+                            'org.gradle.status': 'release', 'org.gradle.usage': 'java-api', 'org.gradle.libraryelements': 'jar'
                     ])
                     firstLevelConfigurations = ['testFixturesApiElements']
                     module('com.acme:external-module:1.3') {
@@ -423,7 +423,7 @@ hamcrest-core-1.3.jar
                 }
                 module('com.acme:external-module:1.3') {
                     variant("testFixturesRuntimeElements", [
-                        'org.gradle.status': 'release', 'org.gradle.usage': 'java-runtime', 'org.gradle.libraryelements': 'jar'
+                            'org.gradle.status': 'release', 'org.gradle.usage': 'java-runtime', 'org.gradle.libraryelements': 'jar'
                     ])
                     firstLevelConfigurations = ['testFixturesRuntimeElements']
                     module('com.acme:external-module:1.3') {
@@ -437,104 +437,5 @@ hamcrest-core-1.3.jar
                 }
             }
         }
-    }
-
-    protected TestFile addPersonTestUsingTestFixtures(String subproject = "") {
-        file("${subproject ? "${subproject}/" : ""}src/test/java/org/PersonTest.java") << """
-            import org.PersonFixture;
-            import org.Person;
-            import org.junit.Test;
-            import static org.junit.Assert.*;
-
-            public class PersonTest {
-                @Test
-                public void testAny() {
-                    Person anyone = PersonFixture.anyone();
-                    assertEquals("John", anyone.getFirstName());
-                    assertEquals("Doe", anyone.getLastName());
-                }
-            }
-        """
-    }
-
-    protected TestFile addPersonDomainClass(String subproject = "", String lang = 'java') {
-        file("${subproject ? "${subproject}/" : ""}src/main/$lang/org/Person.$lang") << """
-            package org;
-
-            public class Person {
-                private final String firstName;
-                private final String lastName;
-
-                public Person(String first, String last) {
-                    this.firstName = first;
-                    this.lastName = last;
-                }
-
-                public String getFirstName() {
-                    return firstName;
-                }
-
-                public String getLastName() {
-                    return lastName;
-                }
-            }
-        """
-    }
-
-    protected TestFile addPersonTestFixture(String subproject = "", String lang = "java") {
-        file("${subproject ? "${subproject}/" : ""}src/testFixtures/$lang/org/PersonFixture.$lang") << """
-            package org;
-
-            public class PersonFixture {
-                public static Person anyone() {
-                    return new Person("John", "Doe");
-                }
-            }
-        """
-    }
-
-    protected TestFile addPersonTestFixtureUsingApacheCommons(String subproject = "") {
-        file("${subproject ? "${subproject}/" : ""}src/testFixtures/java/org/PersonFixture.java") << """
-            package org;
-            import org.apache.commons.lang3.StringUtils;
-
-            public class PersonFixture {
-                public static Person anyone() {
-                    return new Person(StringUtils.capitalize("john"), StringUtils.capitalize("doe"));
-                }
-            }
-        """
-    }
-
-    protected void dumpCompileAndRuntimeTestClasspath() {
-        buildFile << """
-            class Utils {
-                static void printClasspathFile(File it) {
-                    if (it.absolutePath.contains('intTestHomeDir')) {
-                        println it.name
-                    } else {
-                        println it.absolutePath.substring(it.absolutePath.lastIndexOf('build') + 6).replace(File.separatorChar, (char) '/')
-                    }
-                }
-            }
-
-            compileTestJava {
-               doFirst {
-                   println "Test compile classpath"
-                   println "---"
-                   classpath.each { Utils.printClasspathFile(it) }
-                   println "---"
-               }
-            }
-
-            test {
-               doFirst {
-                  println "Test runtime classpath"
-                  println "---"
-                  classpath.each { Utils.printClasspathFile(it) }
-                  println "---"
-               }
-            }
-"""
     }
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/fixtures/AbstractTestFixturesIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/fixtures/AbstractTestFixturesIntegrationTest.groovy
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.java.fixtures
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.test.fixtures.file.TestFile
+
+/**
+ * Base class for integration tests of the Java test fixtures plugin that supplies some utility methods
+ * for creating classes to test, tests for the them, and fixtures using them.
+ */
+abstract class AbstractTestFixturesIntegrationTest extends AbstractIntegrationSpec {
+    protected TestFile addPersonTestUsingTestFixtures(String subproject = "") {
+        file("${subproject ? "${subproject}/" : ""}src/test/java/org/PersonTest.java") << """
+            import org.PersonFixture;
+            import org.Person;
+            import org.junit.Test;
+            import static org.junit.Assert.*;
+
+            public class PersonTest {
+                @Test
+                public void testAny() {
+                    Person anyone = PersonFixture.anyone();
+                    assertEquals("John", anyone.getFirstName());
+                    assertEquals("Doe", anyone.getLastName());
+                }
+            }
+        """
+    }
+
+    protected TestFile addPersonDomainClass(String subproject = "", String lang = 'java') {
+        file("${subproject ? "${subproject}/" : ""}src/main/$lang/org/Person.$lang") << """
+            package org;
+
+            public class Person {
+                private final String firstName;
+                private final String lastName;
+
+                public Person(String first, String last) {
+                    this.firstName = first;
+                    this.lastName = last;
+                }
+
+                public String getFirstName() {
+                    return firstName;
+                }
+
+                public String getLastName() {
+                    return lastName;
+                }
+            }
+        """
+    }
+
+    protected TestFile addPersonTestFixture(String subproject = "", String lang = "java") {
+        file("${subproject ? "${subproject}/" : ""}src/testFixtures/$lang/org/PersonFixture.$lang") << """
+            package org;
+
+            public class PersonFixture {
+                public static Person anyone() {
+                    return new Person("John", "Doe");
+                }
+            }
+        """
+    }
+
+    protected TestFile addPersonTestFixtureUsingApacheCommons(String subproject = "") {
+        file("${subproject ? "${subproject}/" : ""}src/testFixtures/java/org/PersonFixture.java") << """
+            package org;
+            import org.apache.commons.lang3.StringUtils;
+
+            public class PersonFixture {
+                public static Person anyone() {
+                    return new Person(StringUtils.capitalize("john"), StringUtils.capitalize("doe"));
+                }
+            }
+        """
+    }
+
+    protected void dumpCompileAndRuntimeTestClasspath() {
+        buildFile << """
+            class Utils {
+                static void printClasspathFile(File it) {
+                    if (it.absolutePath.contains('intTestHomeDir')) {
+                        println it.name
+                    } else {
+                        println it.absolutePath.substring(it.absolutePath.lastIndexOf('build') + 6).replace(File.separatorChar, (char) '/')
+                    }
+                }
+            }
+
+            compileTestJava {
+               doFirst {
+                   println "Test compile classpath"
+                   println "---"
+                   classpath.each { Utils.printClasspathFile(it) }
+                   println "---"
+               }
+            }
+
+            test {
+               doFirst {
+                  println "Test runtime classpath"
+                  println "---"
+                  classpath.each { Utils.printClasspathFile(it) }
+                  println "---"
+               }
+            }
+"""
+    }
+}

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/fixtures/JavaLibraryTestFixturesIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/fixtures/JavaLibraryTestFixturesIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.java.fixtures
 
-class JavaLibraryTestFixturesIntegrationTest extends AbstractJavaTestFixturesIntegrationTest {
+class JavaLibraryTestFixturesIntegrationTest extends AbstractJavaProjectTestFixturesIntegrationTest {
     @Override
     String getPluginName() {
         'java-library'
@@ -34,7 +34,7 @@ class JavaLibraryTestFixturesIntegrationTest extends AbstractJavaTestFixturesInt
         file("sub/build.gradle") << """
             apply plugin: 'java-test-fixtures'
             apply plugin: 'groovy'
-            
+
             dependencies {
                api(localGroovy())
                testFixturesApi(localGroovy())
@@ -43,7 +43,7 @@ class JavaLibraryTestFixturesIntegrationTest extends AbstractJavaTestFixturesInt
         buildFile << """
             dependencies {
                 testImplementation(testFixtures(project(":sub")))
-            }           
+            }
         """
         addPersonDomainClass("sub", "groovy")
         addPersonTestFixture("sub", "groovy")

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/fixtures/JavaTestFixturesIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/fixtures/JavaTestFixturesIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.java.fixtures
 
-class JavaTestFixturesIntegrationTest extends AbstractJavaTestFixturesIntegrationTest {
+class JavaTestFixturesIntegrationTest extends AbstractJavaProjectTestFixturesIntegrationTest {
     @Override
     String getPluginName() {
         'java'

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/fixtures/KotlinTestFixturesIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/fixtures/KotlinTestFixturesIntegrationTest.groovy
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.java.fixtures
+
+import spock.lang.Issue
+
+/**
+ * Integration tests for the `java-test-fixtures` plugin that involve `kotlin` projects.
+ */
+class KotlinTestFixturesIntegrationTest extends AbstractTestFixturesIntegrationTest {
+    /**
+     * Ensure we make an exception for test fixtures when checking for redundant
+     * configuration usage activation - this combination of plugins should not warn.
+     */
+    @Issue("https://github.com/gradle/gradle/pull/24271")
+    def "test kotlin + java-test-fixtures"() {
+        given:
+        settingsFile << """
+            include 'sub'
+        """
+
+        file("sub/build.gradle") << """
+            plugins {
+                id 'java-library'
+                id 'java-test-fixtures'
+            }
+        """
+
+        addPersonDomainClass("sub", "java")
+        addPersonTestFixture("sub", "java")
+
+        buildFile.text = """
+            plugins {
+                id("org.gradle.java-test-fixtures")
+                id("org.jetbrains.kotlin.jvm") version "1.8.20"
+            }
+
+            ${mavenCentralRepository()}
+
+            dependencies {
+                testImplementation('junit:junit:4.13')
+                testImplementation(testFixtures(project(":sub")))
+            }
+        """
+
+        // the test will live in the current project, instead of "sub"
+        // which demonstrates that the test fixtures are exposed
+        addPersonTestUsingTestFixtures()
+
+        when:
+        succeeds ':build'
+
+        then:
+        executedAndNotSkipped ':test', ':sub:compileTestFixturesJava'
+    }
+}

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/fixtures/KotlinTestFixturesIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/fixtures/KotlinTestFixturesIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.java.fixtures
 
+import org.gradle.integtests.fixtures.versions.KotlinGradlePluginVersions
 import spock.lang.Issue
 
 /**
@@ -46,7 +47,7 @@ class KotlinTestFixturesIntegrationTest extends AbstractTestFixturesIntegrationT
         buildFile.text = """
             plugins {
                 id("org.gradle.java-test-fixtures")
-                id("org.jetbrains.kotlin.jvm") version "1.8.20"
+                id("org.jetbrains.kotlin.jvm").version("${new KotlinGradlePluginVersions().latest}")
             }
 
             ${mavenCentralRepository()}


### PR DESCRIPTION
The user can't do anything about these warnings, so suppress them.  This was a case missed during the original work on this feature.

Fixes the issue reported here: https://github.com/gradle/gradle/pull/24271#issuecomment-1546706115