### PR TITLE
Deprecate Configuration filtered File and FileCollection methods

### DIFF
--- a/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/tasks/ClasspathManifest.kt
+++ b/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/tasks/ClasspathManifest.kt
@@ -37,7 +37,7 @@ abstract class ClasspathManifest : DefaultTask() {
     abstract val optionalProjects: ListProperty<String>
 
     @get:Internal
-    abstract val runtimeClasspath: ConfigurableFileCollection
+    abstract val projectDependencies: ConfigurableFileCollection
 
     @Input
     val runtime = externalDependencies.elements.map { it.map { it.asFile.name }.sorted() }
@@ -46,7 +46,7 @@ abstract class ClasspathManifest : DefaultTask() {
     abstract val externalDependencies: ConfigurableFileCollection
 
     @Input
-    val projects = runtimeClasspath.elements.map { it.mapNotNull { it.toGradleModuleName() }.sorted() }
+    val projects = projectDependencies.elements.map { it.map { it.toGradleModuleName() }.sorted() }
 
     @get:OutputFile
     abstract val manifestFile: RegularFileProperty
@@ -66,9 +66,7 @@ abstract class ClasspathManifest : DefaultTask() {
     }
 
     private
-    fun FileSystemLocation.toGradleModuleName(): String? = asFile.name
-        .takeIf { it.startsWith("gradle-") || it.contains("-patched-for-gradle-") }
-        ?.run { substring(0, lastIndexOf('-')) }
+    fun FileSystemLocation.toGradleModuleName(): String = asFile.name.run { substring(0, lastIndexOf('-')) }
 
     private
     fun Iterable<String>.joinForProperties() = sorted().joinToString(",")

--- a/build-logic-commons/module-identity/src/main/kotlin/gradlebuild.module-jar.gradle.kts
+++ b/build-logic-commons/module-identity/src/main/kotlin/gradlebuild.module-jar.gradle.kts
@@ -29,10 +29,79 @@ fun configureJarTasks() {
 
 fun configureClasspathManifestGeneration() {
     val runtimeClasspath by configurations
+    val externalComponents by lazy {
+        runtimeClasspath.incoming.resolutionResult.rootComponent.map { rootComponent ->
+            val rootVariant = rootComponent.variants.find { it.displayName == runtimeClasspath.name }
+            rootVariant?.let { computeExternalDependenciesNotAccessibleFromProjectDependencies(rootComponent, it) } ?: emptySet()
+        }.get()
+    }
     val classpathManifest = tasks.register("classpathManifest", ClasspathManifest::class) {
-        this.runtimeClasspath.from(runtimeClasspath)
-        this.externalDependencies.from(runtimeClasspath.fileCollection { it is ExternalDependency })
+        this.projectDependencies.from(runtimeClasspath.incoming.artifactView {
+            componentFilter {
+                it is ProjectComponentIdentifier
+            }
+        }.files)
+        this.externalDependencies.from(runtimeClasspath.incoming.artifactView {
+            componentFilter {
+                externalComponents.contains(it)
+            }
+        }.files)
         this.manifestFile = moduleIdentity.baseName.map { layout.buildDirectory.file("generated-resources/$it-classpath/$it-classpath.properties").get() }
     }
     sourceSets["main"].output.dir(classpathManifest.map { it.manifestFile.get().asFile.parentFile })
+}
+
+/**
+ * Walk the resolved graph and discover all external dependencies that are not transitive dependencies
+ * of project dependencies. This optimizes module loading during runtime, as we will only load external
+ * modules that are not loaded transitively by other project modules.
+ *
+ * We perform this filtering, since if we simply include all external dependencies, regardless of whether
+ * they are already loaded transitively, there is a measurable performance impact during module-loading.
+ */
+fun computeExternalDependenciesNotAccessibleFromProjectDependencies(
+    rootComponent: ResolvedComponentResult,
+    rootVariant: ResolvedVariantResult
+): Set<ComponentIdentifier> {
+    val locallyAccessible = mutableSetOf<ComponentIdentifier>()
+    val externallyAccessible = mutableSetOf<ComponentIdentifier>()
+
+    val seen = mutableSetOf<ResolvedVariantResult>()
+    val queue = ArrayDeque<DependencyResult>()
+
+    val rootDependencies = rootComponent.getDependenciesForVariant(rootVariant)
+    seen.add(rootVariant)
+    queue.addAll(rootDependencies)
+
+    while (queue.isNotEmpty()) {
+        val dependency = when (val result = queue.removeFirst()) {
+            is ResolvedDependencyResult -> result
+            else -> throw IllegalArgumentException("Expected ResolvedDependencyResult")
+        }
+
+        if (dependency.isConstraint) {
+            continue
+        }
+
+        val to = dependency.resolvedVariant
+
+        when (val fromComponent = dependency.from.id) {
+            is ProjectComponentIdentifier -> if (fromComponent != rootComponent.id) {
+                // Only track accessible dependencies from _transitive_ local dependencies
+                // We should not include the root variant's dependencies in the locally accessible set
+                locallyAccessible.add(to.owner)
+            }
+            is ModuleComponentIdentifier -> externallyAccessible.add(to.owner)
+        }
+
+        if (seen.add(to)) {
+            dependency.selected.getDependenciesForVariant(to).forEach {
+                queue.add(it)
+            }
+        }
+    }
+
+    val rootModuleComponents = rootDependencies.map { (it as ResolvedDependencyResult).selected.id }
+    val candidateExternalComponents = (rootModuleComponents + externallyAccessible).filterIsInstance<ModuleComponentIdentifier>().toSet()
+    return candidateExternalComponents - locallyAccessible
 }

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/ConfigurationDeprecatedExtensions.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/ConfigurationDeprecatedExtensions.kt
@@ -241,6 +241,7 @@ fun <T : Configuration> NamedDomainObjectProvider<T>.resolve(): Set<File> =
 /**
  * See [Configuration.files].
  */
+@Suppress("DEPRECATION")
 @Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().files(dependencySpec)"), level = DeprecationLevel.HIDDEN)
 fun <T : Configuration> NamedDomainObjectProvider<T>.files(dependencySpec: Spec<Dependency>): Set<File> =
     get().files(dependencySpec)
@@ -249,6 +250,7 @@ fun <T : Configuration> NamedDomainObjectProvider<T>.files(dependencySpec: Spec<
 /**
  * See [Configuration.files].
  */
+@Suppress("DEPRECATION")
 @Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().files(dependencies)"), level = DeprecationLevel.HIDDEN)
 fun <T : Configuration> NamedDomainObjectProvider<T>.files(vararg dependencies: Dependency): Set<File> =
     get().files(*dependencies)
@@ -257,6 +259,7 @@ fun <T : Configuration> NamedDomainObjectProvider<T>.files(vararg dependencies: 
 /**
  * See [Configuration.fileCollection].
  */
+@Suppress("DEPRECATION")
 @Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().fileCollection(dependencySpec)"), level = DeprecationLevel.HIDDEN)
 fun <T : Configuration> NamedDomainObjectProvider<T>.fileCollection(dependencySpec: Spec<Dependency>): FileCollection =
     get().fileCollection(dependencySpec)
@@ -265,6 +268,7 @@ fun <T : Configuration> NamedDomainObjectProvider<T>.fileCollection(dependencySp
 /**
  * See [Configuration.fileCollection].
  */
+@Suppress("DEPRECATION")
 @Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().fileCollection(dependencies)"), level = DeprecationLevel.HIDDEN)
 fun <T : Configuration> NamedDomainObjectProvider<T>.fileCollection(vararg dependencies: Dependency): FileCollection =
     get().fileCollection(*dependencies)

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -116,6 +116,86 @@ For the following use cases, consider these alternatives when replacing a `befor
 * **Hierarchy**: Configuration hierarchy (`extendsFrom`) should be set upon creation. Mutating the hierarchy prior to resolution is highly discouraged, but is permitted within a `withDependencies` hook.
 * **Resolution Strategy**: Mutating a configuration's ResolutionStrategy is still permitted in a `beforeResolve` hook; however, this is not recommended.
 
+[[deprecate_filtered_configuration_file_and_filecollection_methods]]
+==== Filtered Configuration `file` and `fileCollection` methods are deprecated
+
+In an ongoing effort to simplify the Gradle API, the following methods on
+link:{javadocPath}/org/gradle/api/artifacts/Configuration.html--[Configuration] have been deprecated:
+
+- `files(Dependency...)`
+- `files(Spec)`
+- `files(Closure)`
+- `fileCollection(Dependency...)`
+- `fileCollection(Spec)`
+- `fileCollection(Closure)`
+
+To mitigate this deprecation, consider the example below that leverages the `ArtifactView`
+API along with the `componentFilter` method to select a subset of a Configuration's artifacts:
+
+====
+[.multi-language-sample]
+=====
+.build.gradle.kts
+[source,kotlin]
+----
+val conf by configurations.creating
+
+dependencies {
+    conf("com.thing:foo:1.0")
+    conf("org.example:bar:1.0")
+}
+
+tasks.register("filterDependencies") {
+    val files: FileCollection = conf.incoming.artifactView {
+        componentFilter {
+            when(it) {
+                is ModuleComponentIdentifier ->
+                    it.group == "com.thing" && it.module == "foo"
+                else -> false
+            }
+        }
+    }.files
+
+    doLast {
+        assert(files.map { it.name } == listOf("foo-1.0.jar"))
+    }
+}
+----
+=====
+[.multi-language-sample]
+=====
+.build.gradle
+[source,groovy]
+----
+configurations {
+    conf
+}
+
+dependencies {
+    conf "com.thing:foo:1.0"
+    conf "org.example:bar:1.0"
+}
+
+tasks.register("filterDependencies") {
+    FileCollection files = configurations.conf.incoming.artifactView {
+        componentFilter {
+            it instanceof ModuleComponentIdentifier
+                && it.group == "com.thing"
+                && it.module == "foo"
+        }
+    }.files
+
+    doLast {
+        assert files*.name == ["foo-1.0.jar"]
+    }
+}
+----
+=====
+====
+
+Note that as contrary to the behavior of the deprecated `Dependency` filtering methods,
+`componentFilter` does not consider the transitive dependencies of the component being
+selected. This allows for more granular control over which artifacts are selected.
 
 [[deprecated_namers]]
 ==== Deprecated `Namer` of `Task` and `Configuration`

--- a/platforms/documentation/docs/src/snippets/buildCache/caching-android-projects/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/buildCache/caching-android-projects/groovy/build.gradle
@@ -1,5 +1,6 @@
 plugins {
-    id('java')
+    id("org.jetbrains.kotlin.jvm") version "1.9.22"
+    id("org.jetbrains.kotlin.kapt") version "1.9.22"
 }
 
 // tag::cacheKapt[]

--- a/platforms/documentation/docs/src/snippets/buildCache/caching-android-projects/tests/sanityCheck.out
+++ b/platforms/documentation/docs/src/snippets/buildCache/caching-android-projects/tests/sanityCheck.out
@@ -1,0 +1,1 @@
+The Configuration.fileCollection(Spec) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration.getIncoming().artifactView(Action) with a componentFilter instead. Consult the upgrading guide for further information: https://docs.gradle.org/0.0.0/userguide/upgrading_version_8.html#deprecate_filtered_configuration_file_and_filecollection_methods

--- a/platforms/documentation/docs/src/snippets/buildCache/caching-android-projects/tests/sanityCheck.sample.conf
+++ b/platforms/documentation/docs/src/snippets/buildCache/caching-android-projects/tests/sanityCheck.sample.conf
@@ -1,0 +1,10 @@
+executable: gradle
+args: tasks
+# Kapt produces deprecation warnings
+flags: "--warning-mode=all"
+expected-output-file: sanityCheck.out
+allow-additional-output: true
+
+# Note, upon upgrading Kapt to a version that does not emit a warning,
+# this test will fail. Simply delete this sanityCheck test, as it is
+# automatically generated (and it defaults to --warning-mode="fail")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ConfigurationBuildDependenciesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ConfigurationBuildDependenciesIntegrationTest.groovy
@@ -67,6 +67,7 @@ class ConfigurationBuildDependenciesIntegrationTest extends AbstractHttpDependen
 '''
 
         when:
+        executer.expectDocumentedDeprecationWarning("The Configuration.fileCollection(Closure) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration.getIncoming().artifactView(Action) with a componentFilter instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_filtered_configuration_file_and_filecollection_methods")
         run taskName
 
         then:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/FilteredConfigurationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/FilteredConfigurationIntegrationTest.groovy
@@ -79,6 +79,9 @@ task verify {
 """
 
         when:
+        executer.expectDocumentedDeprecationWarning("The Configuration.files(Closure) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration.getIncoming().artifactView(Action) with a componentFilter instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_filtered_configuration_file_and_filecollection_methods")
+        executer.expectDocumentedDeprecationWarning("The Configuration.files(Closure) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration.getIncoming().artifactView(Action) with a componentFilter instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_filtered_configuration_file_and_filecollection_methods")
+        executer.expectDocumentedDeprecationWarning("The Configuration.files(Closure) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration.getIncoming().artifactView(Action) with a componentFilter instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_filtered_configuration_file_and_filecollection_methods")
         run "verify"
 
         then:
@@ -138,6 +141,8 @@ task verify {
 """
 
         when:
+        executer.expectDocumentedDeprecationWarning("The Configuration.files(Closure) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration.getIncoming().artifactView(Action) with a componentFilter instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_filtered_configuration_file_and_filecollection_methods")
+        executer.expectDocumentedDeprecationWarning("The Configuration.files(Closure) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration.getIncoming().artifactView(Action) with a componentFilter instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_filtered_configuration_file_and_filecollection_methods")
         run "verify"
 
         then:
@@ -187,6 +192,7 @@ task verify {
 """
 
         when:
+        executer.expectDocumentedDeprecationWarning("The Configuration.fileCollection(Closure) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration.getIncoming().artifactView(Action) with a componentFilter instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_filtered_configuration_file_and_filecollection_methods")
         run "verify"
 
         then:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ParallelDownloadsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ParallelDownloadsIntegrationTest.groovy
@@ -73,6 +73,9 @@ class ParallelDownloadsIntegrationTest extends AbstractHttpDependencyResolutionT
             blockingServer.get(m4.artifact.path).sendFile(m4.artifact.file))
 
         expect:
+        if (expression == "configurations.compile.fileCollection { true }") {
+            executer.expectDocumentedDeprecationWarning("The Configuration.fileCollection(Closure) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration.getIncoming().artifactView(Action) with a componentFilter instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_filtered_configuration_file_and_filecollection_methods")
+        }
         executer.withArguments('--max-workers', '4')
         succeeds("resolve")
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolvedArtifactOrderingIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolvedArtifactOrderingIntegrationTest.groovy
@@ -58,23 +58,25 @@ class ResolvedArtifactOrderingIntegrationTest extends AbstractHttpDependencyReso
         checkLegacyArtifacts("unordered", ordered)
         checkLegacyArtifacts("consumerFirst", ordered)
         checkLegacyArtifacts("dependencyFirst", ordered)
+
+        3.times { executer.expectDocumentedDeprecationWarning("The Configuration.files(Closure) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration.getIncoming().artifactView(Action) with a componentFilter instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_filtered_configuration_file_and_filecollection_methods") }
+        assert succeeds("checkLegacyunordered", "checkLegacyconsumerFirst", "checkLegacydependencyFirst")
     }
 
     private void checkLegacyArtifacts(String name, List<?> modules) {
         def fileNames = toFileNames(modules).join(',')
         buildFile << """
             task checkLegacy${name} {
+                def filteredFiles = configurations.${name}.files { true }
                 doLast {
+                    assert filteredFiles.collect { it.name } == [${fileNames}]
                     if (${!GradleContextualExecuter.configCache}) {
                         // Don't check eager methods when CC is enabled
                         assert configurations.${name}.resolvedConfiguration.getFiles { true }.collect { it.name } == [${fileNames}]
-                        assert configurations.${name}.files { true }.collect { it.name } == [${fileNames}]
                     }
                 }
             }
-"""
-
-        assert succeeds("checkLegacy${name}")
+        """
     }
 
     private void checkArtifacts(String name, List<?> modules) {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolvedFileOrderingIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolvedFileOrderingIntegrationTest.groovy
@@ -155,7 +155,10 @@ task show {
 """
 
         when:
-        run 'show'
+        executer.expectDocumentedDeprecationWarning("The Configuration.files(Closure) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration.getIncoming().artifactView(Action) with a componentFilter instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_filtered_configuration_file_and_filecollection_methods")
+        executer.expectDocumentedDeprecationWarning("The Configuration.fileCollection(Closure) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration.getIncoming().artifactView(Action) with a componentFilter instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_filtered_configuration_file_and_filecollection_methods")
+        executer.expectDocumentedDeprecationWarning("The Configuration.fileCollection(Closure) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration.getIncoming().artifactView(Action) with a componentFilter instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_filtered_configuration_file_and_filecollection_methods")
+        succeeds 'show'
 
         then:
         // local artifacts are not de-duplicated. This is documenting existing behaviour rather than desired behaviour

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/UnsafeConfigurationResolutionDeprecationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/UnsafeConfigurationResolutionDeprecationIntegrationTest.groovy
@@ -97,6 +97,11 @@ class UnsafeConfigurationResolutionDeprecationIntegrationTest extends AbstractDe
         """
 
         when:
+        if (expression == "files { true }" ) {
+            executer.expectDocumentedDeprecationWarning("The Configuration.files(Closure) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration.getIncoming().artifactView(Action) with a componentFilter instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_filtered_configuration_file_and_filecollection_methods")
+        } else if (expression == "fileCollection { true }.files") {
+            executer.expectDocumentedDeprecationWarning("The Configuration.fileCollection(Closure) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration.getIncoming().artifactView(Action) with a componentFilter instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_filtered_configuration_file_and_filecollection_methods")
+        }
         fails(":resolve")
 
         then:
@@ -166,7 +171,14 @@ class UnsafeConfigurationResolutionDeprecationIntegrationTest extends AbstractDe
             }
         """
 
-        expect:
+        when:
+        if (expression == "files { true }") {
+            executer.expectDocumentedDeprecationWarning("The Configuration.files(Closure) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration.getIncoming().artifactView(Action) with a componentFilter instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_filtered_configuration_file_and_filecollection_methods")
+        } else if (expression == "fileCollection { true }.files") {
+            executer.expectDocumentedDeprecationWarning("The Configuration.fileCollection(Closure) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration.getIncoming().artifactView(Action) with a componentFilter instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_filtered_configuration_file_and_filecollection_methods")
+        }
+
+        then:
         succeeds(":resolve")
 
         where:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationDefaultsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationDefaultsIntegrationTest.groovy
@@ -379,8 +379,10 @@ task check {
             }
         """
 
-        expect:
-        executer.expectDocumentedDeprecationWarning("Calling the Configuration.getAll() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use the configurations container to access the set of configurations instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_configuration_get_all")
+        when:
+        executer.expectDocumentedDeprecationWarning("The Configuration.getAll() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use the configurations container to access the set of configurations instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_configuration_get_all")
+
+        then:
         succeeds "help"
     }
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/DependencyHandlerApiResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/DependencyHandlerApiResolveIntegrationTest.groovy
@@ -150,9 +150,9 @@ class DependencyHandlerApiResolveIntegrationTest extends AbstractIntegrationSpec
         def groovyVersion = GroovySystem.version
         def kotlinVersion = getGradleKotlinVersion()
         def groovyModules = ["groovy-${groovyVersion}.jar", "groovy-ant-${groovyVersion}.jar", "groovy-astbuilder-${groovyVersion}.jar", "groovy-console-${groovyVersion}.jar", "groovy-datetime-${groovyVersion}.jar", "groovy-dateutil-${groovyVersion}.jar", "groovy-groovydoc-${groovyVersion}.jar", "groovy-json-${groovyVersion}.jar", "groovy-nio-${groovyVersion}.jar", "groovy-sql-${groovyVersion}.jar", "groovy-templates-${groovyVersion}.jar", "groovy-test-${groovyVersion}.jar", "groovy-xml-${groovyVersion}.jar", "javaparser-core-3.17.0.jar"]
-        def expectedGradleApiFiles = "gradle-api-${gradleVersion}.jar, ${groovyModules.join(", ")}, kotlin-reflect-${kotlinVersion}.jar, kotlin-stdlib-${kotlinVersion}.jar, gradle-installation-beacon-${gradleBaseVersion}.jar"
+        def expectedGradleApiFiles = "gradle-api-${gradleVersion}.jar, ${groovyModules.join(", ")}, kotlin-stdlib-${kotlinVersion}.jar, kotlin-reflect-${kotlinVersion}.jar, gradle-installation-beacon-${gradleBaseVersion}.jar"
         def expectedGradleApiIds = { id ->
-            "gradle-api-${gradleVersion}.jar ($id), ${groovyModules.collect({ it + " ($id)" }).join(", ")}, kotlin-reflect-${kotlinVersion}.jar ($id), kotlin-stdlib-${kotlinVersion}.jar ($id), gradle-installation-beacon-${gradleBaseVersion}.jar ($id)"
+            "gradle-api-${gradleVersion}.jar ($id), ${groovyModules.collect({ it + " ($id)" }).join(", ")}, kotlin-stdlib-${kotlinVersion}.jar ($id), kotlin-reflect-${kotlinVersion}.jar ($id), gradle-installation-beacon-${gradleBaseVersion}.jar ($id)"
         }
         outputContains("gradleApi() files: [$expectedGradleApiFiles]")
         outputContains("gradleApi() ids: [${expectedGradleApiIds("Gradle API")}]")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolvedFilesApiIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolvedFilesApiIntegrationTest.groovy
@@ -101,6 +101,9 @@ task show {
 """
 
         when:
+        executer.expectDocumentedDeprecationWarning("The Configuration.files(Closure) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration.getIncoming().artifactView(Action) with a componentFilter instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_filtered_configuration_file_and_filecollection_methods")
+        executer.expectDocumentedDeprecationWarning("The Configuration.fileCollection(Closure) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration.getIncoming().artifactView(Action) with a componentFilter instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_filtered_configuration_file_and_filecollection_methods")
+        executer.expectDocumentedDeprecationWarning("The Configuration.fileCollection(Closure) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration.getIncoming().artifactView(Action) with a componentFilter instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_filtered_configuration_file_and_filecollection_methods")
         run 'show'
 
         then:
@@ -184,6 +187,7 @@ task show {
 }
 """
         expect:
+        2.times { maybeExpectDeprecation(expression) }
         succeeds("show")
         output.contains("files: [a-free.jar, b-paid.jar]")
         result.assertTasksExecuted(':a:freeJar', ':b:paidJar', ':show')
@@ -248,6 +252,7 @@ task show {
 }
 """
         expect:
+        2.times { maybeExpectDeprecation(expression) }
         succeeds("show")
         output.contains("files: [a-free.jar, b-paid.jar]")
         result.assertTasksExecuted(':a:freeJar', ':b:paidJar', ':show')
@@ -296,6 +301,7 @@ task show {
 }
 """
         expect:
+        maybeExpectDeprecation(expression)
         fails("show")
         failure.assertHasCause("""The consumer was configured to find attribute 'usage' with value 'compile'. However we cannot choose between the following variants of project :a:
   - Configuration ':a:compile' variant free declares attribute 'usage' with value 'compile':
@@ -368,6 +374,7 @@ task show {
 """
 
         expect:
+        maybeExpectDeprecation(expression)
         fails("show")
         failure.assertHasCause("""No variants of project :a match the consumer attributes:
   - Configuration ':a:compile' variant free declares attribute 'usage' with value 'compile':
@@ -427,6 +434,7 @@ task show {
         m.pom.expectGetBroken()
 
         when:
+        maybeExpectDeprecation(expression)
         fails 'show'
 
         then:
@@ -475,6 +483,7 @@ task show {
         m2.artifact.expectGet()
 
         when:
+        maybeExpectDeprecation(expression)
         fails 'show'
 
         then:
@@ -510,6 +519,7 @@ task show {
 }
 """
         when:
+        maybeExpectDeprecation(expression)
         fails 'show'
 
         then:
@@ -569,6 +579,7 @@ task show {
         m2.artifact.expectGetBroken()
 
         when:
+        maybeExpectDeprecation(expression)
         fails 'show'
 
         then:
@@ -643,5 +654,14 @@ task show {
                 }
             }
         """
+    }
+
+    def maybeExpectDeprecation(String expression) {
+        if (expression.contains("files { true }")) {
+            executer.expectDocumentedDeprecationWarning("The Configuration.files(Closure) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration.getIncoming().artifactView(Action) with a componentFilter instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_filtered_configuration_file_and_filecollection_methods")
+        } else if (expression.contains("fileCollection { true }")) {
+            executer.expectDocumentedDeprecationWarning("The Configuration.fileCollection(Closure) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration.getIncoming().artifactView(Action) with a componentFilter instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_filtered_configuration_file_and_filecollection_methods")
+        }
+        true
     }
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolvedFilesApiIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolvedFilesApiIntegrationTest.groovy
@@ -593,6 +593,40 @@ task show {
         "configurations.compile.incoming.artifactView({componentFilter { true }}).artifacts.artifactFiles" | _
     }
 
+    def "filtered file and fileCollection methods are deprecated"() {
+        given:
+        buildFile << """
+            configurations {
+                conf
+            }
+
+            def dep = dependencies.create("org:dep:1.0")
+
+            task resolve {
+                Closure depClosure = { d -> true }
+                Spec<Dependency> depSpec = (d) -> true
+
+                configurations.conf.files(dep)
+                configurations.conf.files(depSpec)
+                configurations.conf.files(depClosure)
+                configurations.conf.fileCollection(dep)
+                configurations.conf.fileCollection(depSpec)
+                configurations.conf.fileCollection(depClosure)
+            }
+        """
+
+        when:
+        executer.expectDocumentedDeprecationWarning("The Configuration.files(Dependency...) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration.getIncoming().artifactView(Action) with a componentFilter instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_filtered_configuration_file_and_filecollection_methods")
+        executer.expectDocumentedDeprecationWarning("The Configuration.files(Spec) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration.getIncoming().artifactView(Action) with a componentFilter instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_filtered_configuration_file_and_filecollection_methods")
+        executer.expectDocumentedDeprecationWarning("The Configuration.files(Closure) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration.getIncoming().artifactView(Action) with a componentFilter instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_filtered_configuration_file_and_filecollection_methods")
+        executer.expectDocumentedDeprecationWarning("The Configuration.fileCollection(Dependency...) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration.getIncoming().artifactView(Action) with a componentFilter instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_filtered_configuration_file_and_filecollection_methods")
+        executer.expectDocumentedDeprecationWarning("The Configuration.fileCollection(Spec) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration.getIncoming().artifactView(Action) with a componentFilter instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_filtered_configuration_file_and_filecollection_methods")
+        executer.expectDocumentedDeprecationWarning("The Configuration.fileCollection(Closure) method has been deprecated. This is scheduled to be removed in Gradle 9.0. Use Configuration.getIncoming().artifactView(Action) with a componentFilter instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_filtered_configuration_file_and_filecollection_methods")
+
+        then:
+        succeeds "help"
+    }
+
     private String freeAndPaidFlavoredJars(String prefix) {
         """
             task freeJar(type: Jar) { archiveFileName = '$prefix-free.jar' }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -128,7 +128,6 @@ import org.gradle.internal.file.RelativeFilePathResolver;
 import org.gradle.internal.hash.ChecksumService;
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher;
 import org.gradle.internal.hash.FileHasher;
-import org.gradle.internal.installation.CurrentGradleInstallation;
 import org.gradle.internal.instantiation.InstanceGenerator;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
@@ -234,7 +233,6 @@ class DependencyManagementBuildScopeServices {
         Instantiator instantiator,
         DefaultProjectDependencyFactory factory,
         ClassPathRegistry classPathRegistry,
-        CurrentGradleInstallation currentGradleInstallation,
         FileCollectionFactory fileCollectionFactory,
         RuntimeShadedJarFactory runtimeShadedJarFactory,
         ImmutableAttributesFactory attributesFactory,
@@ -246,7 +244,7 @@ class DependencyManagementBuildScopeServices {
 
         return new DefaultDependencyFactory(
             instantiator,
-            DependencyNotationParser.create(instantiator, factory, classPathRegistry, fileCollectionFactory, runtimeShadedJarFactory, currentGradleInstallation, stringInterner),
+            DependencyNotationParser.create(instantiator, factory, classPathRegistry, fileCollectionFactory, runtimeShadedJarFactory, stringInterner),
             new ClientModuleNotationParserFactory(instantiator, stringInterner).create(),
             capabilityNotationParser, objectFactory, projectDependencyFactory,
             attributesFactory);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementProjectScopeServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementProjectScopeServices.java
@@ -34,7 +34,6 @@ import org.gradle.api.internal.notations.ProjectDependencyFactory;
 import org.gradle.api.internal.runtimeshaded.RuntimeShadedJarFactory;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.model.ObjectFactory;
-import org.gradle.internal.installation.CurrentGradleInstallation;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resource.cached.ByUrlCachedExternalResourceIndex;
 import org.gradle.internal.resource.cached.DefaultExternalResourceFileStore;
@@ -70,7 +69,6 @@ class DependencyManagementProjectScopeServices {
         Instantiator instantiator,
         DefaultProjectDependencyFactory factory,
         ClassPathRegistry classPathRegistry,
-        CurrentGradleInstallation currentGradleInstallation,
         FileCollectionFactory fileCollectionFactory,
         RuntimeShadedJarFactory runtimeShadedJarFactory,
         ImmutableAttributesFactory attributesFactory,
@@ -82,7 +80,7 @@ class DependencyManagementProjectScopeServices {
 
         return new DefaultDependencyFactory(
                 instantiator,
-                DependencyNotationParser.create(instantiator, factory, classPathRegistry, fileCollectionFactory, runtimeShadedJarFactory, currentGradleInstallation, stringInterner),
+                DependencyNotationParser.create(instantiator, factory, classPathRegistry, fileCollectionFactory, runtimeShadedJarFactory, stringInterner),
                 new ClientModuleNotationParserFactory(instantiator, stringInterner).create(),
                 capabilityNotationParser,
                 objectFactory,

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -501,7 +501,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
     @Deprecated
     @Override
     public Set<Configuration> getAll() {
-        DeprecationLogger.deprecateAction("Calling the Configuration.getAll() method")
+        DeprecationLogger.deprecateMethod(Configuration.class, "getAll()")
             .withAdvice("Use the configurations container to access the set of configurations instead.")
             .willBeRemovedInGradle9()
             .withUpgradeGuideSection(8, "deprecated_configuration_get_all")
@@ -549,38 +549,52 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
     }
 
     @Override
+    @Deprecated
     public Set<File> files(Dependency... dependencies) {
-        return fileCollection(dependencies).getFiles();
-    }
-
-    @Override
-    public Set<File> files(Closure dependencySpecClosure) {
-        return fileCollection(dependencySpecClosure).getFiles();
-    }
-
-    @Override
-    public Set<File> files(Spec<? super Dependency> dependencySpec) {
-        return fileCollection(dependencySpec).getFiles();
-    }
-
-    @Override
-    public FileCollection fileCollection(Closure dependencySpecClosure) {
-        warnOnDeprecatedUsage("fileCollection(Closure)", ProperMethodUsage.RESOLVABLE);
-        return fileCollection(Specs.convertClosureToSpec(dependencySpecClosure));
-    }
-
-    @Override
-    public FileCollection fileCollection(Dependency... dependencies) {
-        warnOnDeprecatedUsage("fileCollection(Dependency...)", ProperMethodUsage.RESOLVABLE);
         Set<Dependency> deps = WrapUtil.toLinkedSet(dependencies);
-        return fileCollection(deps::contains);
+        return fileCollectionInternal("files(Dependency...)", deps::contains).getFiles();
     }
 
     @Override
+    @Deprecated
+    public Set<File> files(Closure dependencySpecClosure) {
+        return fileCollectionInternal("files(Closure)", Specs.convertClosureToSpec(dependencySpecClosure)).getFiles();
+    }
+
+    @Override
+    @Deprecated
+    public Set<File> files(Spec<? super Dependency> dependencySpec) {
+        return fileCollectionInternal("files(Spec)", dependencySpec).getFiles();
+    }
+
+    @Override
+    @Deprecated
+    public FileCollection fileCollection(Closure dependencySpecClosure) {
+        return fileCollectionInternal("fileCollection(Closure)", Specs.convertClosureToSpec(dependencySpecClosure));
+    }
+
+    @Override
+    @Deprecated
+    public FileCollection fileCollection(Dependency... dependencies) {
+        Set<Dependency> deps = WrapUtil.toLinkedSet(dependencies);
+        return fileCollectionInternal("fileCollection(Dependency...)", deps::contains);
+    }
+
+    @Override
+    @Deprecated
     public FileCollection fileCollection(Spec<? super Dependency> dependencySpec) {
+        return fileCollectionInternal("fileCollection(Spec)", dependencySpec);
+    }
+
+    private FileCollection fileCollectionInternal(String methodName, Spec<? super Dependency> dependencySpec) {
         assertIsResolvable();
-        // After asserting, we are definitely allowed, but might be deprecated, so check to warn now
-        warnOnDeprecatedUsage("fileCollection(Spec)", ProperMethodUsage.RESOLVABLE);
+
+        DeprecationLogger.deprecateMethod(Configuration.class, methodName)
+            .withAdvice("Use Configuration.getIncoming().artifactView(Action) with a componentFilter instead.")
+            .willBeRemovedInGradle9()
+            .withUpgradeGuideSection(8, "deprecate_filtered_configuration_file_and_filecollection_methods")
+            .nagUser();
+
         return new ResolutionBackedFileCollection(
             new ResolverResultsResolutionResultProvider(false).map(resolverResults ->
                 resolverResults.getLegacyResults().getLegacyVisitedArtifactSet().select(dependencySpec)

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyClassPathNotationConverter.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyClassPathNotationConverter.java
@@ -28,7 +28,6 @@ import org.gradle.api.internal.runtimeshaded.RuntimeShadedJarFactory;
 import org.gradle.api.internal.runtimeshaded.RuntimeShadedJarType;
 import org.gradle.internal.component.local.model.OpaqueComponentIdentifier;
 import org.gradle.internal.exceptions.DiagnosticsVisitor;
-import org.gradle.internal.installation.CurrentGradleInstallation;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.typeconversion.NotationConvertResult;
 import org.gradle.internal.typeconversion.NotationConverter;
@@ -52,20 +51,18 @@ public class DependencyClassPathNotationConverter implements NotationConverter<D
     private final Instantiator instantiator;
     private final FileCollectionFactory fileCollectionFactory;
     private final RuntimeShadedJarFactory runtimeShadedJarFactory;
-    private final CurrentGradleInstallation currentGradleInstallation;
     private final ConcurrentMap<DependencyFactoryInternal.ClassPathNotation, FileCollectionDependency> internCache = new ConcurrentHashMap<>();
 
     public DependencyClassPathNotationConverter(
         Instantiator instantiator,
         ClassPathRegistry classPathRegistry,
         FileCollectionFactory fileCollectionFactory,
-        RuntimeShadedJarFactory runtimeShadedJarFactory,
-        CurrentGradleInstallation currentGradleInstallation) {
+        RuntimeShadedJarFactory runtimeShadedJarFactory
+    ) {
         this.instantiator = instantiator;
         this.classPathRegistry = classPathRegistry;
         this.fileCollectionFactory = fileCollectionFactory;
         this.runtimeShadedJarFactory = runtimeShadedJarFactory;
-        this.currentGradleInstallation = currentGradleInstallation;
     }
 
     @Override
@@ -83,16 +80,15 @@ public class DependencyClassPathNotationConverter implements NotationConverter<D
     }
 
     private FileCollectionDependency create(final DependencyFactoryInternal.ClassPathNotation notation) {
-        boolean runningFromInstallation = currentGradleInstallation.getInstallation() != null;
         FileCollectionInternal fileCollectionInternal;
-        if (runningFromInstallation && notation.equals(GRADLE_API)) {
+        if (notation.equals(GRADLE_API)) {
             fileCollectionInternal = fileCollectionFactory.create(new GeneratedFileCollection(notation.displayName) {
                 @Override
                 Set<File> generateFileCollection() {
                     return gradleApiFileCollection(getClassPath(notation));
                 }
             });
-        } else if (runningFromInstallation && notation.equals(GRADLE_TEST_KIT)) {
+        } else if (notation.equals(GRADLE_TEST_KIT)) {
             fileCollectionInternal = fileCollectionFactory.create(new GeneratedFileCollection(notation.displayName) {
                 @Override
                 Set<File> generateFileCollection() {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyNotationParser.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyNotationParser.java
@@ -33,7 +33,6 @@ import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactoryInter
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.runtimeshaded.RuntimeShadedJarFactory;
 import org.gradle.internal.exceptions.DiagnosticsVisitor;
-import org.gradle.internal.installation.CurrentGradleInstallation;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.typeconversion.MapNotationConverter;
 import org.gradle.internal.typeconversion.NotationConvertResult;
@@ -51,7 +50,6 @@ public class DependencyNotationParser {
                                                   ClassPathRegistry classPathRegistry,
                                                   FileCollectionFactory fileCollectionFactory,
                                                   RuntimeShadedJarFactory runtimeShadedJarFactory,
-                                                  CurrentGradleInstallation currentGradleInstallation,
                                                   Interner<String> stringInterner) {
         NotationConverter<String, ? extends ExternalModuleDependency> stringNotationConverter =
             new DependencyStringNotationConverter<>(instantiator, DefaultExternalModuleDependency.class, stringInterner);
@@ -63,7 +61,7 @@ public class DependencyNotationParser {
             new DependencyFilesNotationConverter(instantiator);
         NotationConverter<Project, ? extends ProjectDependency> projectNotationConverter =
             new DependencyProjectNotationConverter(dependencyFactory);
-        DependencyClassPathNotationConverter dependencyClassPathNotationConverter = new DependencyClassPathNotationConverter(instantiator, classPathRegistry, fileCollectionFactory, runtimeShadedJarFactory, currentGradleInstallation);
+        DependencyClassPathNotationConverter dependencyClassPathNotationConverter = new DependencyClassPathNotationConverter(instantiator, classPathRegistry, fileCollectionFactory, runtimeShadedJarFactory);
         NotationParser<Object, Dependency> notationParser = NotationParserBuilder
             .toType(Dependency.class)
             .noImplicitConverters()

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/notations/DependencyClassPathNotationConverterTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/notations/DependencyClassPathNotationConverterTest.groovy
@@ -24,8 +24,6 @@ import org.gradle.api.internal.runtimeshaded.RuntimeShadedJarFactory
 import org.gradle.api.internal.runtimeshaded.RuntimeShadedJarType
 import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.classpath.DefaultClassPath
-import org.gradle.internal.installation.CurrentGradleInstallation
-import org.gradle.internal.installation.GradleInstallation
 import org.gradle.internal.typeconversion.NotationParserBuilder
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.TestUtil
@@ -47,8 +45,7 @@ class DependencyClassPathNotationConverterTest extends Specification {
     def classPathRegistry = Mock(ClassPathRegistry)
     def fileCollectionFactory = TestFiles.fileCollectionFactory()
     def shadedJarFactory = Mock(RuntimeShadedJarFactory)
-    def gradleInstallation = Mock(CurrentGradleInstallation)
-    def factory = new DependencyClassPathNotationConverter(instantiator, classPathRegistry, fileCollectionFactory, shadedJarFactory, gradleInstallation)
+    def factory = new DependencyClassPathNotationConverter(instantiator, classPathRegistry, fileCollectionFactory, shadedJarFactory)
     def shadedApiJar = testDirectoryProvider.file('gradle-api-shaded.jar')
     def localGroovyFiles = [testDirectoryProvider.file('groovy.jar')]
     def installationBeaconFiles = [testDirectoryProvider.file('gradle-installation.jar')]
@@ -62,8 +59,6 @@ class DependencyClassPathNotationConverterTest extends Specification {
         classPathRegistry.getClassPath('GRADLE_TEST_KIT') >> DefaultClassPath.of(gradleTestKitFiles)
         classPathRegistry.getClassPath('LOCAL_GROOVY') >> DefaultClassPath.of(localGroovyFiles)
         classPathRegistry.getClassPath('GRADLE_INSTALLATION_BEACON') >> DefaultClassPath.of(installationBeaconFiles)
-
-        gradleInstallation.installation >> new GradleInstallation(testDirectoryProvider.file("gradle-home"))
 
         shadedJarFactory.get(RuntimeShadedJarType.API, _) >> shadedApiJar
     }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
@@ -231,7 +231,10 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
      *
      * @param dependencySpecClosure The closure describing a filter applied to the all the dependencies of this configuration (including dependencies from extended configurations).
      * @return The files of a subset of dependencies of this configuration.
+     *
+     * @deprecated Use {@code getIncoming().artifactView(Action)} with a {@code componentFilter} instead.
      */
+    @Deprecated
     Set<File> files(Closure dependencySpecClosure);
 
     /**
@@ -245,7 +248,10 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
      *
      * @param dependencySpec The spec describing a filter applied to the all the dependencies of this configuration (including dependencies from extended configurations).
      * @return The files of a subset of dependencies of this configuration.
+     *
+     * @deprecated Use {@code getIncoming().artifactView(Action)} with a {@code componentFilter} instead.
      */
+    @Deprecated
     Set<File> files(Spec<? super Dependency> dependencySpec);
 
     /**
@@ -259,7 +265,10 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
      *
      * @param dependencies The dependencies to be resolved
      * @return The files of a subset of dependencies of this configuration.
+     *
+     * @deprecated Use {@code getIncoming().artifactView(Action)} with a {@code componentFilter} instead.
      */
+    @Deprecated
     Set<File> files(Dependency... dependencies);
 
     /**
@@ -273,7 +282,10 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
      *
      * @param dependencySpec The spec describing a filter applied to the all the dependencies of this configuration (including dependencies from extended configurations).
      * @return The FileCollection with a subset of dependencies of this configuration.
+     *
+     * @deprecated Use {@code getIncoming().artifactView(Action)} with a {@code componentFilter} instead.
      */
+    @Deprecated
     FileCollection fileCollection(Spec<? super Dependency> dependencySpec);
 
     /**
@@ -286,7 +298,10 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
      *
      * @param dependencySpecClosure The closure describing a filter applied to the all the dependencies of this configuration (including dependencies from extended configurations).
      * @return The FileCollection with a subset of dependencies of this configuration.
+     *
+     * @deprecated Use {@code getIncoming().artifactView(Action)} with a {@code componentFilter} instead.
      */
+    @Deprecated
     FileCollection fileCollection(Closure dependencySpecClosure);
 
     /**
@@ -300,7 +315,10 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
      *
      * @param dependencies The dependencies for which the FileCollection should contain the files.
      * @return The FileCollection with a subset of dependencies of this configuration.
+     *
+     * @deprecated Use {@code getIncoming().artifactView(Action)} with a {@code componentFilter} instead.
      */
+    @Deprecated
     FileCollection fileCollection(Dependency... dependencies);
 
     /**

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/NestedConfigureDslIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/NestedConfigureDslIntegrationTest.groovy
@@ -248,7 +248,7 @@ configurations {
 task resolve {
     dependsOn configurations.conf
     doFirst {
-        configurations.conf.files() // Trigger `afterResolve`
+        configurations.conf.files // Trigger `afterResolve`
         assert distributions*.name.contains('myDist')
     }
 }

--- a/subprojects/performance/src/templates/kts-project-with-source/build.gradle.kts
+++ b/subprojects/performance/src/templates/kts-project-with-source/build.gradle.kts
@@ -30,7 +30,7 @@ repositories {
 
 dependencies {
     implementation("commons-lang:commons-lang:2.5")
-    implementation("commons-httpclient:commons-httpclient:4.0")
+    implementation("org.apache.httpcomponents:httpclient:4.0")
     implementation("commons-codec:commons-codec:1.2")
     implementation("org.slf4j:jcl-over-slf4j:1.7.10")
     implementation("org.codehaus.groovy:groovy:2.4.15")

--- a/subprojects/performance/src/templates/project-with-source/build.gradle
+++ b/subprojects/performance/src/templates/project-with-source/build.gradle
@@ -29,7 +29,7 @@ dependencyManagement {
 
 dependencies {
     implementation 'commons-lang:commons-lang:2.5'
-    implementation "commons-httpclient:commons-httpclient:4.0"
+    implementation "org.apache.httpcomponents:httpclient:4.0"
     implementation "commons-codec:commons-codec:1.2"
     implementation "org.slf4j:jcl-over-slf4j:1.7.10"
     implementation "org.codehaus.groovy:groovy:2.4.15"

--- a/subprojects/performance/src/templates/project-with-source/pom.xml
+++ b/subprojects/performance/src/templates/project-with-source/pom.xml
@@ -20,8 +20,8 @@
             <version>2.5</version>
         </dependency>
         <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
             <version>4.0</version>
         </dependency>
         <dependency>

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractAndroidSantaTrackerSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractAndroidSantaTrackerSmokeTest.groovy
@@ -73,8 +73,9 @@ class AbstractAndroidSantaTrackerSmokeTest extends AbstractSmokeTest {
                 expectAndroidBasePluginExtensionArchivesBaseNameDeprecation(VersionNumber.parse(agpVersion))
                 expectClientModuleDeprecationWarning(agpVersion)
                 expectConfigurationMutationDeprecationWarnings(agpVersion, getMutatedConfigurations())
+                expectFilteredFileCollectionDeprecationWarning()
             }
-            maybeexpectConfigurationMutationDeprecationWarnings(agpVersion, [":santa-tracker:debugCompileClasspath"])
+            maybeExpectConfigurationMutationDeprecationWarnings(agpVersion, [":santa-tracker:debugCompileClasspath"])
         }.build()
     }
 
@@ -89,6 +90,7 @@ class AbstractAndroidSantaTrackerSmokeTest extends AbstractSmokeTest {
                 expectAndroidBasePluginExtensionArchivesBaseNameDeprecation(VersionNumber.parse(agpVersion))
                 expectClientModuleDeprecationWarning(agpVersion)
                 expectConfigurationMutationDeprecationWarnings(agpVersion, getMutatedConfigurations())
+                expectFilteredFileCollectionDeprecationWarning()
             } else {
                 def agpVersionNumber = VersionNumber.parse(agpVersion)
 
@@ -102,9 +104,12 @@ class AbstractAndroidSantaTrackerSmokeTest extends AbstractSmokeTest {
                     expectBuildIdentifierIsCurrentBuildDeprecation(agpVersion)
                 }
                 maybeExpectClientModuleDeprecationWarning(agpVersion)
-                maybeexpectConfigurationMutationDeprecationWarnings(agpVersion, getMutatedConfigurations())
+                maybeExpectConfigurationMutationDeprecationWarnings(agpVersion, getMutatedConfigurations())
+                if (agpVersionNumber >= VersionNumber.parse("7.4") && agpVersionNumber <= VersionNumber.parse("8.0.2")) {
+                    expectFilteredFileCollectionDeprecationWarning()
+                }
             }
-            maybeexpectConfigurationMutationDeprecationWarnings(agpVersion, [":santa-tracker:debugCompileClasspath"])
+            maybeExpectConfigurationMutationDeprecationWarnings(agpVersion, [":santa-tracker:debugCompileClasspath"])
         }.build()
     }
 
@@ -120,10 +125,11 @@ class AbstractAndroidSantaTrackerSmokeTest extends AbstractSmokeTest {
                 expectAndroidBasePluginExtensionArchivesBaseNameDeprecation(VersionNumber.parse(agpVersion))
                 expectClientModuleDeprecationWarning(agpVersion)
                 expectConfigurationMutationDeprecationWarnings(agpVersion, getMutatedConfigurations())
-                maybeexpectConfigurationMutationDeprecationWarnings(agpVersion, [
+                maybeExpectConfigurationMutationDeprecationWarnings(agpVersion, [
                     ":santa-tracker:debugCompileClasspath",
                     ":common:debugCompileClasspath",
                 ])
+                expectFilteredFileCollectionDeprecationWarning()
             }.build()
     }
 
@@ -151,11 +157,14 @@ class AbstractAndroidSantaTrackerSmokeTest extends AbstractSmokeTest {
                     expectBuildIdentifierIsCurrentBuildDeprecation(agpVersion)
                 }
                 maybeExpectClientModuleDeprecationWarning(agpVersion)
-                maybeexpectConfigurationMutationDeprecationWarnings(agpVersion, getMutatedConfigurations())
-                maybeexpectConfigurationMutationDeprecationWarnings(agpVersion, [
+                maybeExpectConfigurationMutationDeprecationWarnings(agpVersion, getMutatedConfigurations())
+                maybeExpectConfigurationMutationDeprecationWarnings(agpVersion, [
                     ":santa-tracker:debugCompileClasspath",
                     ":common:debugCompileClasspath",
                 ])
+                if (agpVersionNumber >= VersionNumber.parse("7.4") && agpVersionNumber <= VersionNumber.parse("8.0.2")) {
+                    expectFilteredFileCollectionDeprecationWarning()
+                }
             }.build()
     }
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithAndroidDeprecations.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithAndroidDeprecations.groovy
@@ -120,7 +120,7 @@ trait WithAndroidDeprecations implements WithReportDeprecations {
         }
     }
 
-    void maybeexpectConfigurationMutationDeprecationWarnings(String agpVersion, List<String> confs) {
+    void maybeExpectConfigurationMutationDeprecationWarnings(String agpVersion, List<String> confs) {
         confs.each { conf ->
             runner.maybeExpectLegacyDeprecationWarningIf(
                 versionIsLower(agpVersion, AGP_VERSION_WITHOUT_CONFIGURATION_MUTATION),
@@ -132,6 +132,17 @@ trait WithAndroidDeprecations implements WithReportDeprecations {
                     "https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#mutate_configuration_after_locking"
             )
         }
+    }
+
+    void expectFilteredFileCollectionDeprecationWarning() {
+        // This warning is emitted by the Kotlin Kapt plugin
+        runner.expectLegacyDeprecationWarning(
+            "The Configuration.fileCollection(Spec) method has been deprecated. " +
+                "This is scheduled to be removed in Gradle 9.0. " +
+                "Use Configuration.getIncoming().artifactView(Action) with a componentFilter instead. " +
+                "Consult the upgrading guide for further information: " +
+                "https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#deprecate_filtered_configuration_file_and_filecollection_methods"
+        )
     }
 
     void expectBuildIdentifierIsCurrentBuildDeprecation(String agpVersion, String fixedVersion = '8.0.0') {


### PR DESCRIPTION
As part of idiomatic JVM, we want to simplify Gradle's API to reduce the number of ways to accomplish a single operation. ArtifactView can perform the same behaviors of this API, and more, and is actively being maintained and updated with new features. As such, we are deprecating this API for removal in 9.0

TODO: 

- [x] Verify correctness of upgrade guide code snippets
- [x] Protobuf uses it [here](https://github.com/google/protobuf-gradle-plugin/blob/9d2a328a0d577bf4439d3b482a953715b3a03027/src/main/groovy/com/google/protobuf/gradle/ToolsLocator.groovy#LL112C24-L112C24)
- [ ] [Used by Kotlin Kapt](https://github.com/JetBrains/kotlin/blob/304cbf1aea88cb5b0ecb831344c99ed857759070/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/internal/kapt/Kapt3KotlinGradleSubplugin.kt#L412): 
