### PR TITLE
Remove beforeLocking

### DIFF
--- a/build-logic/basics/src/main/kotlin/gradlebuild.minify.gradle.kts
+++ b/build-logic/basics/src/main/kotlin/gradlebuild.minify.gradle.kts
@@ -16,7 +16,6 @@
 import gradlebuild.basics.classanalysis.Attributes.artifactType
 import gradlebuild.basics.classanalysis.Attributes.minified
 import gradlebuild.basics.transforms.Minify
-import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal
 
 /**
  * A map from artifact name to a set of class name prefixes that should be kept.

--- a/build-logic/basics/src/main/kotlin/gradlebuild.minify.gradle.kts
+++ b/build-logic/basics/src/main/kotlin/gradlebuild.minify.gradle.kts
@@ -55,6 +55,8 @@ plugins.withId("java-base") {
         attributesSchema {
             attribute(minified)
         }
+        // It would be nice if we could be more selective about which variants to apply this to.
+        // TODO https://github.com/gradle/gradle/issues/11831#issuecomment-580686994
         artifactTypes.getByName("jar") {
             attributes.attribute(minified, java.lang.Boolean.FALSE)
         }
@@ -72,19 +74,17 @@ plugins.withId("java-base") {
             }
         }
     }
-    configurations.all {
-        // TODO we should be able to solve this only by requesting attributes for artifacts - https://github.com/gradle/gradle/issues/11831#issuecomment-580686994
-        (this as ConfigurationInternal).beforeLocking {
-            // everywhere where we resolve, prefer the minified version
-            if (isCanBeResolved && !isCanBeConsumed && name !in setOf("currentApiClasspath", "codenarc")) {
-                attributes.attribute(minified, true)
-            }
-            // local projects are already minified
-            if (isCanBeConsumed && !isCanBeResolved) {
-                if (attributes.getAttribute(Category.CATEGORY_ATTRIBUTE)?.name == Category.LIBRARY
-                    && attributes.getAttribute(Bundling.BUNDLING_ATTRIBUTE)?.name == Bundling.EXTERNAL
-                ) {
-                    attributes.attribute(minified, true)
+    afterEvaluate {
+        // Without afterEvaluate, configurations.all runs before the configurations' roles are set.
+        // This is yet another reason we need configuration factory methods.
+        configurations.all {
+            if (isCanBeResolved && !isCanBeConsumed) {
+                resolutionStrategy.dependencySubstitution {
+                    substitute(module("it.unimi.dsi:fastutil")).using(variant(module("it.unimi.dsi:fastutil:8.5.2")) {
+                        attributes {
+                            attribute(minified, true)
+                        }
+                    })
                 }
             }
         }

--- a/build-logic/basics/src/main/kotlin/gradlebuild/basics/transforms/Minify.kt
+++ b/build-logic/basics/src/main/kotlin/gradlebuild/basics/transforms/Minify.kt
@@ -17,11 +17,11 @@
 package gradlebuild.basics.transforms
 
 import com.google.common.io.Files
-import gradlebuild.basics.classanalysis.addJarEntry
 import gradlebuild.basics.classanalysis.ClassAnalysisException
 import gradlebuild.basics.classanalysis.ClassDetails
 import gradlebuild.basics.classanalysis.ClassGraph
 import gradlebuild.basics.classanalysis.JarAnalyzer
+import gradlebuild.basics.classanalysis.addJarEntry
 import org.gradle.api.artifacts.transform.CacheableTransform
 import org.gradle.api.artifacts.transform.InputArtifact
 import org.gradle.api.artifacts.transform.TransformAction

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/JavaEcosystemAttributesDescriber.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/JavaEcosystemAttributesDescriber.java
@@ -263,7 +263,11 @@ class JavaEcosystemAttributesDescriber implements AttributeDescriber {
     }
 
     private static void describeTargetJvm(Object targetJvm, StringBuilder sb) {
-        sb.append("Java ").append(targetJvm);
+        if (targetJvm.equals(Integer.MAX_VALUE)) {
+            sb.append("any Java version");
+        } else {
+            sb.append("Java ").append(targetJvm);
+        }
     }
 
     private static void describeTargetJvmEnvironment(Object targetJvmEnvironment, StringBuilder sb) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/JavaEcosystemSupport.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/JavaEcosystemSupport.java
@@ -27,14 +27,12 @@ import org.gradle.api.attributes.AttributesSchema;
 import org.gradle.api.attributes.Bundling;
 import org.gradle.api.attributes.Category;
 import org.gradle.api.attributes.CompatibilityCheckDetails;
-import org.gradle.api.attributes.HasAttributes;
 import org.gradle.api.attributes.LibraryElements;
 import org.gradle.api.attributes.MultipleCandidatesDetails;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.attributes.java.TargetJvmEnvironment;
 import org.gradle.api.attributes.java.TargetJvmVersion;
 import org.gradle.api.internal.ReusableAction;
-import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.DescribableAttributesSchema;
 import org.gradle.api.model.ObjectFactory;
 
@@ -107,14 +105,6 @@ public abstract class JavaEcosystemSupport {
 
     private static void configureConsumerDescriptors(DescribableAttributesSchema attributesSchema) {
         attributesSchema.addConsumerDescriber(new JavaEcosystemAttributesDescriber());
-    }
-
-    public static void configureDefaultTargetPlatform(HasAttributes configuration, int majorVersion) {
-        AttributeContainerInternal attributes = (AttributeContainerInternal) configuration.getAttributes();
-        // If nobody said anything about this variant's target platform, use whatever the convention says
-        if (!attributes.contains(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE)) {
-            attributes.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, majorVersion);
-        }
     }
 
     private static void configureTargetPlatform(AttributesSchema attributesSchema) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultMutableAttributeContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultMutableAttributeContainer.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.attributes;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
@@ -52,7 +53,10 @@ class DefaultMutableAttributeContainer extends AbstractAttributeContainer implem
 
     @Override
     public Set<Attribute<?>> keySet() {
-        return Sets.union(state.keySet(), lazyAttributes.keySet());
+        // Need to copy the result since if the user calls getAttribute() while iterating over the returned set,
+        // realizing a lazy attribute will add to `state` and remove from `lazyAttributes`.
+        // This avoids a ConcurrentModificationException.
+        return ImmutableSet.copyOf(Sets.union(state.keySet(), lazyAttributes.keySet()));
     }
 
     @Override

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/JavaEcosystemAttributesDescriberTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/JavaEcosystemAttributesDescriberTest.groovy
@@ -49,6 +49,18 @@ class JavaEcosystemAttributesDescriberTest extends Specification {
         describer.describeAttributeSet(attributes.asMap()) == "a library for use during compile-time, with a release status, compatible with Java 11, packaged as a jar"
     }
 
+    def "describes a library with MAX_VALUE target JVM version"() {
+        when:
+        attributes.attribute(Usage.USAGE_ATTRIBUTE, named(Usage, "java-api"))
+            .attribute(Category.CATEGORY_ATTRIBUTE, named(Category, "library"))
+            .attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, named(LibraryElements, "jar"))
+            .attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, Integer.MAX_VALUE)
+            .attribute(ProjectInternal.STATUS_ATTRIBUTE, "release")
+
+        then:
+        describer.describeAttributeSet(attributes.asMap()) == "a library for use during compile-time, with a release status, compatible with any Java version, packaged as a jar"
+    }
+
     def "describes arbitrary attributes"() {
         when:
         attributes.attribute(Category.CATEGORY_ATTRIBUTE, named(Category, Category.DOCUMENTATION))

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultMutableAttributeContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultMutableAttributeContainerTest.groovy
@@ -281,4 +281,17 @@ class DefaultMutableAttributeContainerTest extends Specification {
         container.toString() == "{a=fixed(class java.lang.String, a), b=b, c=c}"
         container.asImmutable().toString() == "{a=a, b=b, c=c}"
     }
+
+    def "can access lazy elements while iterating over keySet"() {
+        def container = new DefaultMutableAttributeContainer(attributesFactory)
+
+        when:
+        container.attributeProvider(Attribute.of("a", String), Providers.of("foo"))
+        container.attributeProvider(Attribute.of("b", String), Providers.of("foo"))
+
+        then:
+        for (Attribute<?> attribute : container.keySet()) {
+            container.getAttribute(attribute)
+        }
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.internal.artifacts.configurations;
 
-import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ExcludeRule;
@@ -61,15 +60,6 @@ public interface ConfigurationInternal extends ResolveContext, DeprecatableConfi
      * Visits the variants of this configuration.
      */
     void collectVariants(VariantVisitor visitor);
-
-    /**
-     * Registers an action to execute before locking for further mutation.
-     *
-     * <p><strong>Do not use this method.</strong> It is used in the gradle/gradle
-     * build but it is otherwise unused. We should remove it after removing its usage
-     * from the gradle/gradle build.</p>
-     */
-    void beforeLocking(Action<? super ConfigurationInternal> action);
 
     boolean isCanBeMutated();
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
@@ -64,6 +64,10 @@ public interface ConfigurationInternal extends ResolveContext, DeprecatableConfi
 
     /**
      * Registers an action to execute before locking for further mutation.
+     *
+     * <p><strong>Do not use this method.</strong> It is used in the gradle/gradle
+     * build but it is otherwise unused. We should remove it after removing its usage
+     * from the gradle/gradle build.</p>
      */
     void beforeLocking(Action<? super ConfigurationInternal> action);
 

--- a/subprojects/distributions-dependencies/build.gradle.kts
+++ b/subprojects/distributions-dependencies/build.gradle.kts
@@ -66,7 +66,6 @@ dependencies {
         api(libs.commonsLang)           { version { strictly("2.6") }}
         api(libs.commonsLang3)          { version { strictly("3.12.0") }}
         api(libs.commonsMath)           { version { strictly("3.6.1") }}
-        api(libs.fastutil)              { version { strictly("8.5.2") }}
         api(libs.gradleProfiler)        { version { strictly("0.20.0-alpha01") }}
         api(libs.gradleEnterpriseTestAnnotation) { version { strictly("1.0") }}
         api(libs.gcs)                   { version { strictly("v1-rev20220705-1.32.1") }}

--- a/subprojects/docs/src/snippets/java/toolchain-filters/tests/matchingVendorWithCC.out
+++ b/subprojects/docs/src/snippets/java/toolchain-filters/tests/matchingVendorWithCC.out
@@ -1,2 +1,4 @@
-Configuration cache state could not be cached: field `javaCompiler` of task `:compileJava` of type `org.gradle.api.tasks.compile.JavaCompile`: error writing value of type 'org.gradle.api.internal.provider.DefaultProperty'
-> No matching toolchains found for requested specification: {languageVersion=11, vendor=matching('customString'), implementation=vendor-specific} for %OS% on %ARCH%.
+Could not determine the dependencies of task ':compileJava'.
+> Failed to calculate the value of task ':compileJava' property 'javaCompiler'.
+   > No matching toolchains found for requested specification: {languageVersion=11, vendor=matching('customString'), implementation=vendor-specific} for %OS% on %ARCH%.
+      > No locally installed toolchains match and toolchain auto-provisioning is not enabled.

--- a/subprojects/docs/src/snippets/java/toolchain-filters/tests/matchingVendorWithoutCC.out
+++ b/subprojects/docs/src/snippets/java/toolchain-filters/tests/matchingVendorWithoutCC.out
@@ -1,4 +1,4 @@
-Execution failed for task ':compileJava'.
-> Error while evaluating property 'javaCompiler' of task ':compileJava'.
-   > Failed to calculate the value of task ':compileJava' property 'javaCompiler'.
-      > No matching toolchains found for requested specification: {languageVersion=11, vendor=matching('customString'), implementation=vendor-specific} for %OS% on %ARCH%.
+Could not determine the dependencies of task ':compileJava'.
+> Failed to calculate the value of task ':compileJava' property 'javaCompiler'.
+   > No matching toolchains found for requested specification: {languageVersion=11, vendor=matching('customString'), implementation=vendor-specific} for %OS% on %ARCH%.
+      > No locally installed toolchains match and toolchain auto-provisioning is not enabled.

--- a/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadIntegrationTest.groovy
+++ b/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.jvm.toolchain
 
 import net.rubygrapefruit.platform.internal.DefaultSystemInfo
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.executer.DocumentationUtils
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.platform.internal.DefaultBuildPlatform
@@ -31,7 +30,6 @@ import static org.gradle.integtests.fixtures.SuggestionsMessages.STACKTRACE_MESS
 
 class JavaToolchainDownloadIntegrationTest extends AbstractIntegrationSpec {
 
-    @ToBeFixedForConfigurationCache(because = "Fails the build with an additional error")
     def "fails for missing combination"() {
         setFoojayDiscoToolchainProvider()
 
@@ -58,21 +56,19 @@ class JavaToolchainDownloadIntegrationTest extends AbstractIntegrationSpec {
             .runWithFailure()
 
         then:
-        failure.assertHasDescription("Execution failed for task ':compileJava'.")
-            .assertHasCause("Error while evaluating property 'javaCompiler' of task ':compileJava'.")
-            .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'")
-            .assertHasCause("No matching toolchains found for requested specification: {languageVersion=14, vendor=ADOPTIUM, implementation=J9} ${getFailureMessageBuildPlatform()}.")
-            .assertHasCause("No locally installed toolchains match and the configured toolchain download repositories aren't able to provide a match either.")
-            .assertHasResolutions(
-                DocumentationUtils.normalizeDocumentationLink("Learn more about toolchain auto-detection at https://docs.gradle.org/current/userguide/toolchains.html#sec:auto_detection."),
-                DocumentationUtils.normalizeDocumentationLink("Learn more about toolchain repositories at https://docs.gradle.org/current/userguide/toolchains.html#sub:download_repositories."),
-                STACKTRACE_MESSAGE,
-                INFO_DEBUG,
-                SCAN,
-                GET_HELP)
+        failure.assertHasDescription("Could not determine the dependencies of task ':compileJava'.")
+               .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'")
+               .assertHasCause("No matching toolchains found for requested specification: {languageVersion=14, vendor=ADOPTIUM, implementation=J9} ${getFailureMessageBuildPlatform()}.")
+               .assertHasCause("No locally installed toolchains match and the configured toolchain download repositories aren't able to provide a match either.")
+               .assertHasResolutions(
+                   DocumentationUtils.normalizeDocumentationLink("Learn more about toolchain auto-detection at https://docs.gradle.org/current/userguide/toolchains.html#sec:auto_detection."),
+                   DocumentationUtils.normalizeDocumentationLink("Learn more about toolchain repositories at https://docs.gradle.org/current/userguide/toolchains.html#sub:download_repositories."),
+                   STACKTRACE_MESSAGE,
+                   INFO_DEBUG,
+                   SCAN,
+                   GET_HELP)
     }
 
-    @ToBeFixedForConfigurationCache(because = "Fails the build with an additional error")
     def 'toolchain selection that requires downloading fails when it is disabled'() {
         setFoojayDiscoToolchainProvider()
 
@@ -99,20 +95,18 @@ class JavaToolchainDownloadIntegrationTest extends AbstractIntegrationSpec {
             .runWithFailure()
 
         then:
-        failure.assertHasDescription("Execution failed for task ':compileJava'.")
-            .assertHasCause("Error while evaluating property 'javaCompiler' of task ':compileJava'.")
-            .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'")
-            .assertHasCause("No matching toolchains found for requested specification: {languageVersion=14, vendor=any, implementation=vendor-specific} ${getFailureMessageBuildPlatform()}.")
-            .assertHasCause("No locally installed toolchains match and toolchain auto-provisioning is not enabled.")
-            .assertHasResolutions(
-                DocumentationUtils.normalizeDocumentationLink("Learn more about toolchain auto-detection at https://docs.gradle.org/current/userguide/toolchains.html#sec:auto_detection."),
-                STACKTRACE_MESSAGE,
-                INFO_DEBUG,
-                SCAN,
-                GET_HELP)
+        failure.assertHasDescription("Could not determine the dependencies of task ':compileJava'.")
+               .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'")
+               .assertHasCause("No matching toolchains found for requested specification: {languageVersion=14, vendor=any, implementation=vendor-specific} ${getFailureMessageBuildPlatform()}.")
+               .assertHasCause("No locally installed toolchains match and toolchain auto-provisioning is not enabled.")
+               .assertHasResolutions(
+                   DocumentationUtils.normalizeDocumentationLink("Learn more about toolchain auto-detection at https://docs.gradle.org/current/userguide/toolchains.html#sec:auto_detection."),
+                   STACKTRACE_MESSAGE,
+                   INFO_DEBUG,
+                   SCAN,
+                   GET_HELP)
     }
 
-    @ToBeFixedForConfigurationCache(because = "Fails the build with an additional error")
     def 'toolchain download on http fails'() {
         setUnsecuredToolchainProvider()
 
@@ -137,10 +131,10 @@ class JavaToolchainDownloadIntegrationTest extends AbstractIntegrationSpec {
             .runWithFailure()
 
         then:
-        failure.assertHasDescription("Execution failed for task ':compileJava'.")
-            .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'")
-            .assertHasCause("Unable to download toolchain matching the requirements ({languageVersion=99, vendor=any, implementation=vendor-specific}) from 'http://exoticJavaToolchain.com/java-99'.")
-            .assertHasCause("Attempting to download a file from an insecure URI http://exoticJavaToolchain.com/java-99. This is not supported, use a secure URI instead.")
+        failure.assertHasDescription("Could not determine the dependencies of task ':compileJava'.")
+               .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'")
+               .assertHasCause("Unable to download toolchain matching the requirements ({languageVersion=99, vendor=any, implementation=vendor-specific}) from 'http://exoticJavaToolchain.com/java-99'.")
+               .assertHasCause("Attempting to download a file from an insecure URI http://exoticJavaToolchain.com/java-99. This is not supported, use a secure URI instead.")
     }
 
     private TestFile setFoojayDiscoToolchainProvider() {

--- a/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadSpiAuthenticationIntegrationTest.groovy
+++ b/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadSpiAuthenticationIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.jvm.toolchain
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.server.http.HttpServer
 import org.junit.Rule
@@ -39,10 +38,9 @@ class JavaToolchainDownloadSpiAuthenticationIntegrationTest extends AbstractJava
         archiveUri = server.uri.resolve("/path/toolchain.zip").toString()
     }
 
-    @ToBeFixedForConfigurationCache(because = "Fails the build with an additional error")
     def "can download without authentication"() {
         settingsFile << """
-            ${applyToolchainResolverPlugin("CustomToolchainResolver", customToolchainResolverCode(archiveUri))}               
+            ${applyToolchainResolverPlugin("CustomToolchainResolver", customToolchainResolverCode(archiveUri))}
             toolchainManagement {
                 jvm {
                     javaRepositories {
@@ -78,15 +76,13 @@ class JavaToolchainDownloadSpiAuthenticationIntegrationTest extends AbstractJava
                 .runWithFailure()
 
         then:
-        failure.assertHasDescription("Execution failed for task ':compileJava'.")
-                .assertHasCause("Error while evaluating property 'javaCompiler' of task ':compileJava'.")
-                .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'.")
-                .assertHasCause("Unable to download toolchain matching the requirements ({languageVersion=99, vendor=matching('exotic'), implementation=vendor-specific}) from '" + archiveUri + "'.")
-                .assertHasCause("Provisioned toolchain '" + temporaryFolder.testDirectory.file("user-home", "jdks", "toolchain") + "' could not be probed: " +
-                        "A problem occurred starting process 'command '")
+        failure.assertHasDescription("Could not determine the dependencies of task ':compileJava'.")
+               .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'.")
+               .assertHasCause("Unable to download toolchain matching the requirements ({languageVersion=99, vendor=matching('exotic'), implementation=vendor-specific}) from '" + archiveUri + "'.")
+               .assertHasCause("Provisioned toolchain '" + temporaryFolder.testDirectory.file("user-home", "jdks", "toolchain") + "' could not be probed: " +
+                   "A problem occurred starting process 'command '")
     }
 
-    @ToBeFixedForConfigurationCache(because = "Fails the build with an additional error")
     def "can download with basic authentication"() {
         settingsFile << """
             ${applyToolchainResolverPlugin("CustomToolchainResolver", customToolchainResolverCode(archiveUri))}
@@ -105,7 +101,7 @@ class JavaToolchainDownloadSpiAuthenticationIntegrationTest extends AbstractJava
                         }
                     }
                 }
-            } 
+            }
         """
 
         buildFile << """
@@ -132,12 +128,11 @@ class JavaToolchainDownloadSpiAuthenticationIntegrationTest extends AbstractJava
                 .runWithFailure()
 
         then:
-        failure.assertHasDescription("Execution failed for task ':compileJava'.")
-                .assertHasCause("Error while evaluating property 'javaCompiler' of task ':compileJava'")
-                .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'.")
-                .assertHasCause("Unable to download toolchain matching the requirements ({languageVersion=99, vendor=matching('exotic'), implementation=vendor-specific}) from '" + archiveUri + "'.")
-                .assertHasCause("Provisioned toolchain '" + temporaryFolder.testDirectory.file("user-home", "jdks", "toolchain") + "' could not be probed: " +
-                        "A problem occurred starting process 'command '")
+        failure.assertHasDescription("Could not determine the dependencies of task ':compileJava'.")
+               .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'.")
+               .assertHasCause("Unable to download toolchain matching the requirements ({languageVersion=99, vendor=matching('exotic'), implementation=vendor-specific}) from '" + archiveUri + "'.")
+               .assertHasCause("Provisioned toolchain '" + temporaryFolder.testDirectory.file("user-home", "jdks", "toolchain") + "' could not be probed: " +
+                   "A problem occurred starting process 'command '")
     }
 
     private static String customToolchainResolverCode(String uri) {

--- a/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadSpiIntegrationTest.groovy
+++ b/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadSpiIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.jvm.toolchain
 
 import net.rubygrapefruit.platform.SystemInfo
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.executer.DocumentationUtils
 import org.gradle.internal.nativeintegration.services.NativeServices
 import org.gradle.internal.os.OperatingSystem
@@ -29,7 +28,6 @@ import static org.gradle.integtests.fixtures.SuggestionsMessages.STACKTRACE_MESS
 
 class JavaToolchainDownloadSpiIntegrationTest extends AbstractJavaToolchainDownloadSpiIntegrationTest {
 
-    @ToBeFixedForConfigurationCache(because = "Fails the build with an additional error")
     def "can inject custom toolchain registry via settings plugin"() {
         settingsFile << """
             ${applyToolchainResolverPlugin("CustomToolchainResolver", customToolchainResolverCode())}
@@ -65,13 +63,12 @@ class JavaToolchainDownloadSpiIntegrationTest extends AbstractJavaToolchainDownl
                 .runWithFailure()
 
         then:
-        failure.assertHasDescription("Execution failed for task ':compileJava'.")
-                .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'.")
-                .assertHasCause("Unable to download toolchain matching the requirements ({languageVersion=99, vendor=matching('exotic'), implementation=vendor-specific}) from 'https://exoticJavaToolchain.com/java-99'.")
-                .assertHasCause("Could not HEAD 'https://exoticJavaToolchain.com/java-99'.")
+        failure.assertHasDescription("Could not determine the dependencies of task ':compileJava'.")
+               .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'.")
+               .assertHasCause("Unable to download toolchain matching the requirements ({languageVersion=99, vendor=matching('exotic'), implementation=vendor-specific}) from 'https://exoticJavaToolchain.com/java-99'.")
+               .assertHasCause("Could not HEAD 'https://exoticJavaToolchain.com/java-99'.")
     }
 
-    @ToBeFixedForConfigurationCache(because = "Fails the build with an additional error")
     def "downloaded JDK is checked against the spec"() {
         settingsFile << """
             ${applyToolchainResolverPlugin("BrokenToolchainResolver", brokenToolchainResolverCode())}
@@ -106,14 +103,12 @@ class JavaToolchainDownloadSpiIntegrationTest extends AbstractJavaToolchainDownl
                 .runWithFailure()
 
         then:
-        failure.assertHasDescription("Execution failed for task ':compileJava'.")
-                .assertHasCause("Error while evaluating property 'javaCompiler' of task ':compileJava'.")
-                .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'.")
-                .assertHasCause("Unable to download toolchain matching the requirements ({languageVersion=11, vendor=any, implementation=vendor-specific}) from 'https://api.adoptium.net/v3/binary/latest/17/ga/${os()}/${architecture()}/jdk/hotspot/normal/eclipse'.")
-                .assertHasCause("Toolchain provisioned from 'https://api.adoptium.net/v3/binary/latest/17/ga/${os()}/${architecture()}/jdk/hotspot/normal/eclipse' doesn't satisfy the specification: {languageVersion=11, vendor=any, implementation=vendor-specific}.")
+        failure.assertHasDescription("Could not determine the dependencies of task ':compileJava'.")
+               .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'.")
+               .assertHasCause("Unable to download toolchain matching the requirements ({languageVersion=11, vendor=any, implementation=vendor-specific}) from 'https://api.adoptium.net/v3/binary/latest/17/ga/${os()}/${architecture()}/jdk/hotspot/normal/eclipse'.")
+               .assertHasCause("Toolchain provisioned from 'https://api.adoptium.net/v3/binary/latest/17/ga/${os()}/${architecture()}/jdk/hotspot/normal/eclipse' doesn't satisfy the specification: {languageVersion=11, vendor=any, implementation=vendor-specific}.")
     }
 
-    @ToBeFixedForConfigurationCache(because = "Fails the build with an additional error")
     def "custom toolchain registries are consulted in order"() {
         settingsFile << """
             ${applyToolchainResolverPlugin("CustomToolchainResolver", customToolchainResolverCode())}
@@ -153,10 +148,10 @@ class JavaToolchainDownloadSpiIntegrationTest extends AbstractJavaToolchainDownl
                 .runWithFailure()
 
         then:
-        failure.assertHasDescription("Execution failed for task ':compileJava'.")
-                .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'.")
-                .assertHasCause("Unable to download toolchain matching the requirements ({languageVersion=99, vendor=matching('exotic'), implementation=vendor-specific}) from 'https://exoticJavaToolchain.com/java-99'.")
-                .assertHasCause("Could not HEAD 'https://exoticJavaToolchain.com/java-99'.")
+        failure.assertHasDescription("Could not determine the dependencies of task ':compileJava'.")
+               .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'.")
+               .assertHasCause("Unable to download toolchain matching the requirements ({languageVersion=99, vendor=matching('exotic'), implementation=vendor-specific}) from 'https://exoticJavaToolchain.com/java-99'.")
+               .assertHasCause("Could not HEAD 'https://exoticJavaToolchain.com/java-99'.")
     }
 
     def "fails on registration collision"() {
@@ -400,7 +395,6 @@ class JavaToolchainDownloadSpiIntegrationTest extends AbstractJavaToolchainDownl
         failure.assertHasCause("Mutation of toolchain repositories declared in settings is only allowed during settings evaluation")
     }
 
-    @ToBeFixedForConfigurationCache(because = "Fails the build with an additional error")
     def "throws informative error on repositories not being configured"() {
         settingsFile << """
             ${applyToolchainResolverPlugin("CustomToolchainResolver", customToolchainResolverCode())}
@@ -426,17 +420,16 @@ class JavaToolchainDownloadSpiIntegrationTest extends AbstractJavaToolchainDownl
                 .runWithFailure()
 
         then:
-        failure.assertHasDescription("Execution failed for task ':compileJava'.")
-                .assertHasCause("Error while evaluating property 'javaCompiler' of task ':compileJava'.")
-                .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'.")
-                .assertHasCause("No locally installed toolchains match and toolchain download repositories have not been configured.")
-                .assertHasResolutions(
-                    DocumentationUtils.normalizeDocumentationLink("Learn more about toolchain auto-detection at https://docs.gradle.org/current/userguide/toolchains.html#sec:auto_detection."),
-                    DocumentationUtils.normalizeDocumentationLink("Learn more about toolchain repositories at https://docs.gradle.org/current/userguide/toolchains.html#sub:download_repositories."),
-                    STACKTRACE_MESSAGE,
-                    INFO_DEBUG,
-                    SCAN,
-                    GET_HELP)
+        failure.assertHasDescription("Could not determine the dependencies of task ':compileJava'.")
+               .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'.")
+               .assertHasCause("No locally installed toolchains match and toolchain download repositories have not been configured.")
+               .assertHasResolutions(
+                   DocumentationUtils.normalizeDocumentationLink("Learn more about toolchain auto-detection at https://docs.gradle.org/current/userguide/toolchains.html#sec:auto_detection."),
+                   DocumentationUtils.normalizeDocumentationLink("Learn more about toolchain repositories at https://docs.gradle.org/current/userguide/toolchains.html#sub:download_repositories."),
+                   STACKTRACE_MESSAGE,
+                   INFO_DEBUG,
+                   SCAN,
+                   GET_HELP)
     }
 
     private static String customToolchainResolverCode() {

--- a/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadSpiKotlinIntegrationTest.groovy
+++ b/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadSpiKotlinIntegrationTest.groovy
@@ -17,14 +17,12 @@
 package org.gradle.jvm.toolchain
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 
 class JavaToolchainDownloadSpiKotlinIntegrationTest extends AbstractIntegrationSpec {
 
-    @ToBeFixedForConfigurationCache(because = "Fails the build with an additional error")
     def "can inject custom toolchain registry via settings plugin"() {
         settingsKotlinFile << """
-            ${applyToolchainRegistryPlugin("CustomToolchainResolver", customToolchainRegistryCode())}               
+            ${applyToolchainRegistryPlugin("CustomToolchainResolver", customToolchainRegistryCode())}
             toolchainManagement {
                 jvm {
                     javaRepositories {
@@ -59,10 +57,10 @@ class JavaToolchainDownloadSpiKotlinIntegrationTest extends AbstractIntegrationS
                 .runWithFailure()
 
         then:
-        failure.assertHasDescription("Execution failed for task ':compileJava'.")
-                .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'.")
-                .assertHasCause("Unable to download toolchain matching the requirements ({languageVersion=99, vendor=matching('exotic'), implementation=vendor-specific}) from 'https://exoticJavaToolchain.com/java-99'.")
-                .assertHasCause("Could not HEAD 'https://exoticJavaToolchain.com/java-99'.")
+        failure.assertHasDescription("Could not determine the dependencies of task ':compileJava'.")
+               .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'.")
+               .assertHasCause("Unable to download toolchain matching the requirements ({languageVersion=99, vendor=matching('exotic'), implementation=vendor-specific}) from 'https://exoticJavaToolchain.com/java-99'.")
+               .assertHasCause("Could not HEAD 'https://exoticJavaToolchain.com/java-99'.")
     }
 
     private static String applyToolchainRegistryPlugin(String className, String code) {
@@ -71,18 +69,18 @@ class JavaToolchainDownloadSpiKotlinIntegrationTest extends AbstractIntegrationS
             import java.util.Optional
 
             abstract class ${className}Plugin: Plugin<Settings> {
-   
+
                 @get:Inject
                 protected abstract val toolchainResolverRegistry: JavaToolchainResolverRegistry
-            
+
                 override fun apply(settings: Settings) {
                     settings.plugins.apply("jvm-toolchain-management")
                     val registry: JavaToolchainResolverRegistry = toolchainResolverRegistry
                     registry.register(${className}::class.java)
                 }
-                
+
             }
-            
+
             ${code}
 
             apply<${className}Plugin>()

--- a/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainIntegrationTest.groovy
+++ b/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainIntegrationTest.groovy
@@ -16,10 +16,8 @@
 
 package org.gradle.jvm.toolchain
 
-
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AvailableJavaHomes
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.jvm.JavaToolchainFixture
 import org.gradle.internal.jvm.Jvm
 
@@ -162,7 +160,6 @@ class JavaToolchainIntegrationTest extends AbstractIntegrationSpec implements Ja
         failure.assertHasCause("The value for property 'languageVersion' is final and cannot be changed any further")
     }
 
-    @ToBeFixedForConfigurationCache(because = "CC toolchain provisioning but we don't have an IBM one on CI")
     def "nag user when toolchain spec is IBM_SEMERU"() {
         given:
         buildScript """
@@ -183,6 +180,9 @@ class JavaToolchainIntegrationTest extends AbstractIntegrationSpec implements Ja
             "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#ibm_semeru_should_not_be_used"
 
         then:
-        succeeds ':build'
+        fails ':build'
+        failure.assertHasDescription("Could not determine the dependencies of task ':compileJava'.")
+               .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'.")
+               .assertHasCause("No locally installed toolchains match and toolchain auto-provisioning is not enabled.")
     }
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryCrossProjectTargetJvmVersionIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryCrossProjectTargetJvmVersionIntegrationTest.groovy
@@ -139,7 +139,7 @@ class JavaLibraryCrossProjectTargetJvmVersionIntegrationTest extends AbstractInt
         expected = "apiElementsJdk$selected"
     }
 
-    def "can disable automatic setting of target JVM attribute"() {
+    def "can disable selection of dependencies based on jvm version"() {
         file("producer/build.gradle") << """
             java {
                 targetCompatibility = JavaVersion.VERSION_1_7

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/BasicJavaCompilerIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/BasicJavaCompilerIntegrationSpec.groovy
@@ -315,8 +315,8 @@ compileJava {
     doFirst {
         assert apiElementsAttributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 8
         assert runtimeElementsAttributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 8
-        assert !compileClasspathAttributes.contains(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE)
-        assert !runtimeClasspathAttributes.contains(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE)
+        assert compileClasspathAttributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == Integer.MAX_VALUE
+        assert runtimeClasspathAttributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == Integer.MAX_VALUE
     }
 }
 """

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -27,10 +27,8 @@ import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.internal.ConventionMapping;
 import org.gradle.api.internal.GeneratedSubclasses;
 import org.gradle.api.internal.IConventionAware;
-import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationRoles;
 import org.gradle.api.internal.artifacts.configurations.RoleBasedConfigurationContainerInternal;
-import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.file.FileTreeInternal;
 import org.gradle.api.internal.plugins.DslObject;
 import org.gradle.api.internal.tasks.DefaultSourceSetOutput;
@@ -74,6 +72,7 @@ import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.function.BiFunction;
@@ -170,22 +169,28 @@ public abstract class JavaBasePlugin implements Plugin<Project> {
         });
     }
 
-    private void configureLibraryElements(TaskProvider<JavaCompile> compileTaskProvider, SourceSet sourceSet, ConfigurationContainer configurations, ObjectFactory objectFactory) {
-        ConfigurationInternal compileClasspath = (ConfigurationInternal) configurations.getByName(sourceSet.getCompileClasspathConfigurationName());
-        // TODO:configuration-cache this is a callback that affects configuration attributes #23732
-        compileClasspath.beforeLocking(conf -> {
-            AttributeContainerInternal attributes = conf.getAttributes();
-            if (!attributes.contains(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE)) {
-                String libraryElements;
-                // If we are compiling a module, we require JARs of all dependencies as they may potentially include an Automatic-Module-Name
-                if (javaClasspathPackaging || JavaModuleDetector.isModuleSource(compileTaskProvider.get().getModularity().getInferModulePath().get(), CompilationSourceDirs.inferSourceRoots((FileTreeInternal) sourceSet.getJava().getAsFileTree()))) {
-                    libraryElements = LibraryElements.JAR;
-                } else {
-                    libraryElements = LibraryElements.CLASSES;
+    private void configureLibraryElements(TaskProvider<JavaCompile> compileJava, SourceSet sourceSet, ConfigurationContainer configurations, ObjectFactory objectFactory) {
+        Provider<LibraryElements> libraryElements = compileJava.flatMap(x -> x.getModularity().getInferModulePath())
+            .map(inferModulePath -> {
+                if (javaClasspathPackaging) {
+                    return LibraryElements.JAR;
                 }
-                attributes.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objectFactory.named(LibraryElements.class, libraryElements));
-            }
-        });
+
+                // If we are compiling a module, we require JARs of all dependencies as they may potentially include an Automatic-Module-Name
+                List<File> sourcesRoots = CompilationSourceDirs.inferSourceRoots((FileTreeInternal) sourceSet.getJava().getAsFileTree());
+                if (JavaModuleDetector.isModuleSource(inferModulePath, sourcesRoots)) {
+                    return LibraryElements.JAR;
+                } else {
+                    return LibraryElements.CLASSES;
+                }
+            })
+            .map(value -> objectFactory.named(LibraryElements.class, value));
+
+        Configuration compileClasspath = configurations.getByName(sourceSet.getCompileClasspathConfigurationName());
+        compileClasspath.getAttributes().attributeProvider(
+            LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
+            libraryElements
+        );
     }
 
     private void configureTargetPlatform(TaskProvider<JavaCompile> compileTask, SourceSet sourceSet, ConfigurationContainer configurations) {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmPluginServices.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmPluginServices.java
@@ -23,9 +23,9 @@ import org.gradle.api.artifacts.ConfigurationVariant;
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
 import org.gradle.api.attributes.HasConfigurableAttributes;
 import org.gradle.api.attributes.LibraryElements;
+import org.gradle.api.attributes.java.TargetJvmVersion;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.artifacts.ConfigurationVariantInternal;
-import org.gradle.api.internal.artifacts.JavaEcosystemSupport;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.artifacts.publish.AbstractPublishArtifact;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
@@ -46,6 +46,7 @@ import org.gradle.internal.instantiation.InstanceGenerator;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.io.File;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -114,19 +115,6 @@ public class DefaultJvmPluginServices implements JvmPluginServices {
         AttributeContainerInternal attributes = (AttributeContainerInternal) configurable.getAttributes();
         DefaultJvmEcosystemAttributesDetails details = instanceGenerator.newInstance(DefaultJvmEcosystemAttributesDetails.class, objectFactory, attributes);
         configuration.execute(details);
-    }
-
-    @Override
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    public <COMPILE extends AbstractCompile & HasCompileOptions> void useDefaultTargetPlatformInference(Configuration configuration, TaskProvider<COMPILE> compileTask) {
-        ConfigurationInternal configurationInternal = (ConfigurationInternal) configuration;
-        Set<TaskProvider<?>> compileTasks = configurationToCompileTasks.computeIfAbsent(configurationInternal, key -> {
-            HashSet<TaskProvider<?>> taskProviders = new HashSet<>();
-            configurationInternal.beforeLocking(
-                configureDefaultTargetPlatform(configuration.isCanBeConsumed(), (Set) taskProviders));
-            return taskProviders;
-        });
-        compileTasks.add(compileTask);
     }
 
     @Override
@@ -202,37 +190,41 @@ public class DefaultJvmPluginServices implements JvmPluginServices {
         return variant;
     }
 
-    private <COMPILE extends AbstractCompile & HasCompileOptions> Action<ConfigurationInternal> configureDefaultTargetPlatform(boolean alwaysEnabled, Set<TaskProvider<COMPILE>> compileTasks) {
-        return conf -> {
-            JavaPluginExtension javaPluginExtension = project.getExtensions().findByType(JavaPluginExtension.class);
-            if (alwaysEnabled || javaPluginExtension == null || !javaPluginExtension.getAutoTargetJvmDisabled()) {
-                int majorVersion = 0;
-                for (TaskProvider<COMPILE> compileTaskProvider : compileTasks) {
-                    COMPILE compileTask = compileTaskProvider.get();
-                    if (compileTask.getOptions().getRelease().isPresent()) {
-                        majorVersion = Math.max(majorVersion, compileTask.getOptions().getRelease().get());
-                    } else {
-                        int releaseFlag = getReleaseOption(compileTask.getOptions().getCompilerArgs());
-                        if (releaseFlag != 0) {
-                            majorVersion = Math.max(majorVersion, releaseFlag);
-                        } else {
-                            majorVersion = Math.max(majorVersion, Integer.parseInt(JavaVersion.toVersion(compileTask.getTargetCompatibility()).getMajorVersion()));
-                        }
-                    }
-                }
-                if (majorVersion != 0) {
-                    JavaEcosystemSupport.configureDefaultTargetPlatform(conf, majorVersion);
-                }
-            }
-        };
+    @Override
+    public <COMPILE extends AbstractCompile & HasCompileOptions> void useDefaultTargetPlatformInference(Configuration configuration, TaskProvider<COMPILE> compileTask) {
+        ConfigurationInternal configurationInternal = (ConfigurationInternal) configuration;
+        Set<TaskProvider<COMPILE>> compileTasks = Cast.uncheckedCast(configurationToCompileTasks.computeIfAbsent(configurationInternal, key -> new HashSet<>()));
+        compileTasks.add(compileTask);
+
+        JavaPluginExtension java = project.getExtensions().getByType(JavaPluginExtension.class);
+        configurationInternal.getAttributes().attributeProvider(
+            TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE,
+            providerFactory.provider(() -> getDefaultTargetPlatform(configuration, java, compileTasks))
+        );
     }
 
-    private static int getReleaseOption(List<String> compilerArgs) {
-        int flagIndex = compilerArgs.indexOf("--release");
-        if (flagIndex != -1 && flagIndex + 1 < compilerArgs.size()) {
-            return Integer.parseInt(String.valueOf(compilerArgs.get(flagIndex + 1)));
+    private static <COMPILE extends AbstractCompile & HasCompileOptions> int getDefaultTargetPlatform(Configuration configuration, JavaPluginExtension java, Set<TaskProvider<COMPILE>> compileTasks) {
+        assert !compileTasks.isEmpty();
+
+        if (!configuration.isCanBeConsumed() && java.getAutoTargetJvmDisabled()) {
+            return Integer.MAX_VALUE;
         }
-        return 0;
+
+        return compileTasks.stream().map(provider -> {
+            COMPILE compileTask = provider.get();
+            if (compileTask.getOptions().getRelease().isPresent()) {
+                return compileTask.getOptions().getRelease().get();
+            }
+
+            List<String> compilerArgs = compileTask.getOptions().getCompilerArgs();
+            int flagIndex = compilerArgs.indexOf("--release");
+
+            if (flagIndex != -1 && flagIndex + 1 < compilerArgs.size()) {
+                return Integer.parseInt(String.valueOf(compilerArgs.get(flagIndex + 1)));
+            } else {
+                return Integer.parseInt(JavaVersion.toVersion(compileTask.getTargetCompatibility()).getMajorVersion());
+            }
+        }).max(Comparator.naturalOrder()).get();
     }
 
     /**

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/jvm/internal/AbstractJvmPluginServicesTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/jvm/internal/AbstractJvmPluginServicesTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.internal.plugins.ExtensionContainerInternal
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.tasks.TaskContainerInternal
 import org.gradle.api.plugins.Convention
+import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.util.TestUtil
 import spock.lang.Specification
 import spock.lang.Subject
@@ -48,7 +49,7 @@ abstract class AbstractJvmPluginServicesTest extends Specification {
             findPlugin(_) >> null
         }
         getExtensions() >> Stub(ExtensionContainerInternal) {
-            findByType(_) >> null
+            getByType(JavaPluginExtension) >> Mock(JavaPluginExtension)
         }
         getTasks() >> tasks
         getConfigurations() >> configurations

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/jvm/internal/DefaultJvmPluginServicesTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/jvm/internal/DefaultJvmPluginServicesTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.api.plugins.jvm.internal
 
-import org.gradle.api.Action
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ConfigurationPublications
@@ -61,10 +60,8 @@ class DefaultJvmPluginServicesTest extends AbstractJvmPluginServicesTest {
     def "configures compileClasspath"() {
         def mutable = AttributeTestUtil.attributesFactory().mutable()
         def attrs = Mock(HasConfigurableAttributes)
-        Action[] action = new Action[1]
         def config
         config = Stub(ConfigurationInternal) {
-            beforeLocking(_) >> { args -> action[0] = args[0] }
             getAttributes() >> mutable
         }
         def javaCompileProvider = Stub(TaskProvider) {
@@ -87,7 +84,6 @@ class DefaultJvmPluginServicesTest extends AbstractJvmPluginServicesTest {
 
         when:
         services.useDefaultTargetPlatformInference(config, javaCompileProvider)
-        action[0].execute(config)
 
         then:
         mutable.asMap() == [


### PR DESCRIPTION
`beforeLocking` is a bad way to achieve laziness. It is only used to add attributes to an attribute container, which itself supports Providers. 

This PR updates our usages of beforeLocking to use providers and removes one usage in the build logic.

Now that this method is removed entirely, we have more freedom to cleanup the mutation situation for Configurations -- particularly, we will not need to lock all configurations for mutation when a single configuration is resolved. 
