### PR TITLE
Polish code quality plugins

### DIFF
--- a/subprojects/code-quality/build.gradle.kts
+++ b/subprojects/code-quality/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     implementation(project(":reporting"))
     implementation(project(":platform-jvm"))
     implementation(project(":file-collections"))
+    implementation(project(":dependency-management"))
     compileOnly(project(":internal-instrumentation-api"))
 
     implementation(libs.groovy)
@@ -25,6 +26,7 @@ dependencies {
     implementation(libs.guava)
     implementation(libs.inject)
     implementation(libs.ant)
+    implementation(libs.commonsLang)
 
     testImplementation(project(":file-collections"))
     testImplementation(testFixtures(project(":core")))

--- a/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/CheckstylePluginTest.groovy
+++ b/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/CheckstylePluginTest.groovy
@@ -78,7 +78,7 @@ class CheckstylePluginTest extends AbstractProjectBuilderSpec {
         assert task instanceof Checkstyle
         task.with {
             assert description == "Run Checkstyle analysis for ${sourceSet.name} classes".toString()
-            assert checkstyleClasspath == project.configurations.checkstyle
+            assert checkstyleClasspath != null
             assert classpath.files == (sourceSet.output + sourceSet.compileClasspath).files
             assert configFile == project.file("config/checkstyle/checkstyle.xml")
             assert configDirectory.get().getAsFile() == project.file("config/checkstyle")
@@ -99,7 +99,7 @@ class CheckstylePluginTest extends AbstractProjectBuilderSpec {
         expect:
         task.description == null
         task.source.isEmpty()
-        task.checkstyleClasspath == project.configurations.checkstyle
+        task.checkstyleClasspath != null
         task.configFile == project.file("config/checkstyle/checkstyle.xml")
         task.configDirectory.get().getAsFile() == project.file("config/checkstyle")
         task.config.inputFiles.singleFile == project.file("config/checkstyle/checkstyle.xml")
@@ -156,7 +156,7 @@ class CheckstylePluginTest extends AbstractProjectBuilderSpec {
         task.with {
             assert description == "Run Checkstyle analysis for ${sourceSet.name} classes"
             assert source as List == sourceSet.allJava as List
-            assert checkstyleClasspath == project.configurations["checkstyle"]
+            assert checkstyleClasspath != null
             assert configFile == project.file("checkstyle-config")
             assert configDirectory.get().getAsFile() == project.file("custom")
             assert config.inputFiles.singleFile == project.file("checkstyle-config")
@@ -183,7 +183,7 @@ class CheckstylePluginTest extends AbstractProjectBuilderSpec {
         expect:
         task.description == null
         task.source.isEmpty()
-        task.checkstyleClasspath == project.configurations.checkstyle
+        task.checkstyleClasspath != null
         task.configFile == project.file("checkstyle-config")
         task.configDirectory.get().getAsFile() == project.file("custom")
         task.config.inputFiles.singleFile == project.file("checkstyle-config")

--- a/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/CodeNarcPluginTest.groovy
+++ b/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/CodeNarcPluginTest.groovy
@@ -49,7 +49,7 @@ class CodeNarcPluginTest extends AbstractProjectBuilderSpec {
         codenarc.maxPriority3Violations == 0
         codenarc.reportFormat == "html"
         codenarc.reportsDir == project.file("build/reports/codenarc")
-        codenarc.sourceSets == []
+        codenarc.sourceSets.isEmpty()
         !codenarc.ignoreFailures
     }
 
@@ -59,7 +59,7 @@ class CodeNarcPluginTest extends AbstractProjectBuilderSpec {
         expect:
         task.description == null
         task.source.isEmpty()
-        task.codenarcClasspath == project.configurations.codenarc
+        task.codenarcClasspath != null
         task.config.inputFiles.singleFile == project.file("config/codenarc/codenarc.xml")
         task.configFile == project.file("config/codenarc/codenarc.xml")
         task.maxPriority1Violations == 0
@@ -86,7 +86,7 @@ class CodeNarcPluginTest extends AbstractProjectBuilderSpec {
         expect:
         task.description == null
         task.source.isEmpty()
-        task.codenarcClasspath == project.configurations.codenarc
+        task.codenarcClasspath != null
         task.config.inputFiles.singleFile == project.file("codenarc-config")
         task.configFile == project.file("codenarc-config")
         task.maxPriority1Violations == 10

--- a/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/PmdPluginTest.groovy
+++ b/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/PmdPluginTest.groovy
@@ -124,7 +124,7 @@ class PmdPluginTest extends AbstractProjectBuilderSpec {
         task.with {
             assert description == "Run PMD analysis for ${sourceSet.name} classes"
             source as List == sourceSet.allJava as List
-            assert pmdClasspath == project.configurations.pmd
+            assert pmdClasspath != null
             assert ruleSets == ["category/java/errorprone.xml"]
             assert ruleSetConfig == null
             assert ruleSetFiles.empty
@@ -144,7 +144,7 @@ class PmdPluginTest extends AbstractProjectBuilderSpec {
         expect:
         task.description == null
         task.source.empty
-        task.pmdClasspath == project.configurations.pmd
+        task.pmdClasspath != null
         task.ruleSets == ["category/java/errorprone.xml"]
         task.ruleSetConfig == null
         task.ruleSetFiles.empty
@@ -203,7 +203,7 @@ class PmdPluginTest extends AbstractProjectBuilderSpec {
         task.with {
             assert description == "Run PMD analysis for ${sourceSet.name} classes"
             source as List == sourceSet.allJava as List
-            assert pmdClasspath == project.configurations.pmd
+            assert pmdClasspath != null
             assert ruleSets == ["java-braces", "java-unusedcode"]
             assert ruleSetConfig.asString() == "ruleset contents"
             assert ruleSetFiles.singleFile == project.file("my-ruleset.xml")
@@ -232,7 +232,7 @@ class PmdPluginTest extends AbstractProjectBuilderSpec {
         expect:
         task.description == null
         task.source.empty
-        task.pmdClasspath == project.configurations.pmd
+        task.pmdClasspath != null
         task.ruleSets == ["java-braces", "java-unusedcode"]
         task.ruleSetConfig.asString() == "ruleset contents"
         task.ruleSetFiles.singleFile == project.file("my-ruleset.xml")

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
@@ -40,6 +40,12 @@ The previous step will help you identify potential problems by issuing deprecati
 
 === Potential breaking changes
 
+=== Deprecations
+
+[[deprecate_get_default_target_jdk_pmd]]
+<<pmd_plugin#pmd_plugin, The PMD plugin>>'s `getDefaultTargetJdk(JavaVersion)` method has been deprecated for removal in Gradle 9.0.
+This method was never intended for public usage.
+
 [[kotlin_1_8.20]]
 ==== Upgrade to Kotlin 1.8.21
 


### PR DESCRIPTION
The AbstractCodeQualityPlugin presented poor abstractions to the child code quality plugins
and as such led to duplication and unnecessary code. Particularly, all child implementations
were jvm-specific and the abstract plugin was also JVM specific, but there were abstractions
which avoided applying the java base plugin by default. This was unnecessary and complicated.

Further changes updated the abstract plugin to avoid exclude rules in favor of artifact views
and component fiters. Furthermore, resolvable configurations which intended to resolve JVM
artifacts were updated to be configured as runtime classpaths.

Finally, a public method on PmdPlugin was deprecated for removal in 9.0 since it does not
need to be public.