### PR TITLE
Ensure code-quality plugin tool configurations are configured as runtime classpaths

### DIFF
--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdPlugin.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdPlugin.java
@@ -26,7 +26,6 @@ import org.gradle.api.internal.ConventionMapping;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationRoles;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationRolesForMigration;
 import org.gradle.api.internal.artifacts.configurations.RoleBasedConfigurationContainerInternal;
-import org.gradle.api.plugins.jvm.internal.JvmPluginServices;
 import org.gradle.api.plugins.quality.internal.AbstractCodeQualityPlugin;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
@@ -69,12 +68,6 @@ public abstract class PmdPlugin extends AbstractCodeQualityPlugin<Pmd> {
     private static final String PMD_ADDITIONAL_AUX_DEPS_CONFIGURATION = "pmdAux";
 
     private PmdExtension extension;
-
-    @Inject
-    protected JvmPluginServices getJvmPluginServices() {
-        // Constructor injection is not used to keep binary compatibility
-        throw new UnsupportedOperationException();
-    }
 
     @Override
     protected String getToolName() {
@@ -119,10 +112,11 @@ public abstract class PmdPlugin extends AbstractCodeQualityPlugin<Pmd> {
     @Override
     protected void createConfigurations() {
         super.createConfigurations();
-        project.getConfigurations().createWithRole(PMD_ADDITIONAL_AUX_DEPS_CONFIGURATION, ConfigurationRoles.BUCKET, additionalAuxDepsConfiguration -> {
+        Configuration auxClasspath = project.getConfigurations().createWithRole(PMD_ADDITIONAL_AUX_DEPS_CONFIGURATION, ConfigurationRoles.BUCKET, additionalAuxDepsConfiguration -> {
             additionalAuxDepsConfiguration.setDescription("The additional libraries that are available for type resolution during analysis");
             additionalAuxDepsConfiguration.setVisible(false);
         });
+        getJvmPluginServices().configureAsRuntimeClasspath(auxClasspath);
     }
 
     @Override

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/AbstractCodeQualityPlugin.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/AbstractCodeQualityPlugin.java
@@ -30,6 +30,7 @@ import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.plugins.ReportingBasePlugin;
+import org.gradle.api.plugins.jvm.internal.JvmPluginServices;
 import org.gradle.api.plugins.quality.CodeQualityExtension;
 import org.gradle.api.reporting.ReportingExtension;
 import org.gradle.api.tasks.SourceSet;
@@ -38,6 +39,7 @@ import org.gradle.internal.Cast;
 import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.workers.ForkingWorkerSpec;
 
+import javax.inject.Inject;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Map;
@@ -100,6 +102,7 @@ public abstract class AbstractCodeQualityPlugin<T> implements Plugin<ProjectInte
         configuration.setVisible(false);
         configuration.setTransitive(true);
         configuration.setDescription("The " + getToolName() + " libraries to be used for this project.");
+        getJvmPluginServices().configureAsRuntimeClasspath(configuration);
 
         // Don't need these things, they're provided by the runtime
         configuration.exclude(excludeProperties("ant", "ant"));
@@ -231,6 +234,9 @@ public abstract class AbstractCodeQualityPlugin<T> implements Plugin<ProjectInte
     protected JavaPluginExtension getJavaPluginExtension() {
         return project.getExtensions().getByType(JavaPluginExtension.class);
     }
+
+    @Inject
+    protected abstract JvmPluginServices getJvmPluginServices();
 
     public static void maybeAddOpensJvmArgs(JavaLauncher javaLauncher, ForkingWorkerSpec spec) {
         if (JavaVersion.toVersion(javaLauncher.getMetadata().getJavaRuntimeVersion()).isJava9Compatible()) {

--- a/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/CheckstylePluginTest.groovy
+++ b/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/CheckstylePluginTest.groovy
@@ -15,6 +15,11 @@
  */
 package org.gradle.api.plugins.quality
 
+import org.gradle.api.attributes.Bundling
+import org.gradle.api.attributes.Category
+import org.gradle.api.attributes.LibraryElements
+import org.gradle.api.attributes.Usage
+import org.gradle.api.attributes.java.TargetJvmEnvironment
 import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.ReportingBasePlugin
@@ -22,7 +27,9 @@ import org.gradle.api.tasks.SourceSet
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 
 import static org.gradle.api.tasks.TaskDependencyMatchers.dependsOn
-import static org.hamcrest.CoreMatchers.*
+import static org.hamcrest.CoreMatchers.hasItem
+import static org.hamcrest.CoreMatchers.hasItems
+import static org.hamcrest.CoreMatchers.not
 import static spock.util.matcher.HamcrestSupport.that
 
 class CheckstylePluginTest extends AbstractProjectBuilderSpec {
@@ -213,5 +220,16 @@ class CheckstylePluginTest extends AbstractProjectBuilderSpec {
         }
         expect:
         project.checkstyle.configFile == project.file("custom/checkstyle.xml") // computed property
+    }
+
+    def "tool configuration has correct attributes"() {
+        expect:
+        with(project.configurations.checkstyle.attributes) {
+            assert getAttribute(Category.CATEGORY_ATTRIBUTE).name == Category.LIBRARY
+            assert getAttribute(Usage.USAGE_ATTRIBUTE).name == Usage.JAVA_RUNTIME
+            assert getAttribute(Bundling.BUNDLING_ATTRIBUTE).name == Bundling.EXTERNAL
+            assert getAttribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE).name == LibraryElements.JAR
+            assert getAttribute(TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE).name == TargetJvmEnvironment.STANDARD_JVM
+        }
     }
 }

--- a/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/CodeNarcPluginTest.groovy
+++ b/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/CodeNarcPluginTest.groovy
@@ -15,6 +15,11 @@
  */
 package org.gradle.api.plugins.quality
 
+import org.gradle.api.attributes.Bundling
+import org.gradle.api.attributes.Category
+import org.gradle.api.attributes.LibraryElements
+import org.gradle.api.attributes.Usage
+import org.gradle.api.attributes.java.TargetJvmEnvironment
 import org.gradle.api.plugins.ReportingBasePlugin
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 
@@ -109,6 +114,17 @@ class CodeNarcPluginTest extends AbstractProjectBuilderSpec {
         task.reports {
             assert enabled == [html, xml] as Set
             assert xml.outputLocation.asFile.get() == project.file("build/foo.xml")
+        }
+    }
+
+    def "tool configuration has correct attributes"() {
+        expect:
+        with(project.configurations.codenarc.attributes) {
+            assert getAttribute(Category.CATEGORY_ATTRIBUTE).name == Category.LIBRARY
+            assert getAttribute(Usage.USAGE_ATTRIBUTE).name == Usage.JAVA_RUNTIME
+            assert getAttribute(Bundling.BUNDLING_ATTRIBUTE).name == Bundling.EXTERNAL
+            assert getAttribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE).name == LibraryElements.JAR
+            assert getAttribute(TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE).name == TargetJvmEnvironment.STANDARD_JVM
         }
     }
 }

--- a/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/PmdPluginTest.groovy
+++ b/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/PmdPluginTest.groovy
@@ -16,6 +16,11 @@
 package org.gradle.api.plugins.quality
 
 import com.google.common.collect.ImmutableSet
+import org.gradle.api.attributes.Bundling
+import org.gradle.api.attributes.Category
+import org.gradle.api.attributes.LibraryElements
+import org.gradle.api.attributes.Usage
+import org.gradle.api.attributes.java.TargetJvmEnvironment
 import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.plugins.ReportingBasePlugin
 import org.gradle.api.tasks.SourceSet
@@ -254,5 +259,47 @@ class PmdPluginTest extends AbstractProjectBuilderSpec {
         def pmdTask = project.tasks.getByName("pmdMain")
         expect:
         pmdTask.classpath.files == (mainSourceSet.output + mainSourceSet.compileClasspath).files
+    }
+
+    def "tool configuration has correct attributes"() {
+        expect:
+        with(project.configurations.pmd.attributes) {
+            assert getAttribute(Category.CATEGORY_ATTRIBUTE).name == Category.LIBRARY
+            assert getAttribute(Usage.USAGE_ATTRIBUTE).name == Usage.JAVA_RUNTIME
+            assert getAttribute(Bundling.BUNDLING_ATTRIBUTE).name == Bundling.EXTERNAL
+            assert getAttribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE).name == LibraryElements.JAR
+            assert getAttribute(TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE).name == TargetJvmEnvironment.STANDARD_JVM
+        }
+    }
+
+    def "pmdAux configuration has correct attributes"() {
+        expect:
+        with(project.configurations.pmdAux.attributes) {
+            assert getAttribute(Category.CATEGORY_ATTRIBUTE).name == Category.LIBRARY
+            assert getAttribute(Usage.USAGE_ATTRIBUTE).name == Usage.JAVA_RUNTIME
+            assert getAttribute(Bundling.BUNDLING_ATTRIBUTE).name == Bundling.EXTERNAL
+            assert getAttribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE).name == LibraryElements.JAR
+            assert getAttribute(TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE).name == TargetJvmEnvironment.STANDARD_JVM
+        }
+    }
+
+    def "task aux configurations have correct attributes"() {
+        given:
+        project.pluginManager.apply(JavaBasePlugin)
+        project.sourceSets {
+            main
+        }
+
+        when:
+        project.tasks.pmdMain
+
+        then:
+        with(project.configurations.mainPmdAuxClasspath.attributes) {
+            assert getAttribute(Category.CATEGORY_ATTRIBUTE).name == Category.LIBRARY
+            assert getAttribute(Usage.USAGE_ATTRIBUTE).name == Usage.JAVA_RUNTIME
+            assert getAttribute(Bundling.BUNDLING_ATTRIBUTE).name == Bundling.EXTERNAL
+            assert getAttribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE).name == LibraryElements.JAR
+            assert getAttribute(TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE).name == TargetJvmEnvironment.STANDARD_JVM
+        }
     }
 }


### PR DESCRIPTION
All JVM runtime classpaths should request with attributes. This PR ensures code quality plugins are requesting with the correct attributes