### PR TITLE
Add Github action to manage to-triage label

### DIFF
--- a/.github/workflows/closed_issue_labels.yml
+++ b/.github/workflows/closed_issue_labels.yml
@@ -1,0 +1,28 @@
+name: Closed issue labels
+
+on:
+  issues:
+    types: closed
+
+jobs:
+  remove_triage_label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: remove label for closed issue
+        uses: actions-ecosystem/action-remove-labels@v1
+        if: ${{ github.event.issue.state_reason == 'not_planned' }}
+        with:
+          labels: to-triage
+
+  add_triage_label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: add label for issue without milestone
+        uses: actions-ecosystem/action-add-labels@v1
+        if: ${{ github.event.issue.state_reason == 'completed' && github.event.issue.milestone == null }}
+        with:
+          labels: to-triage

--- a/.github/workflows/opened_issue_labels.yml
+++ b/.github/workflows/opened_issue_labels.yml
@@ -1,0 +1,17 @@
+name: Opened issue labels
+
+on:
+  issues:
+    types: opened
+
+jobs:
+  add_label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: add label for issue without labels
+        uses: actions-ecosystem/action-add-labels@v1
+        if: ${{ github.event.issue.labels[0] == null }}
+        with:
+          labels: to-triage


### PR DESCRIPTION
1. Add triage label to issues without any labels
2. Remove triage label from issue closed as "not planned"
3. Add triage label to completed issue without milestone

Can be tested [here](https://github.com/ov7a/issue-management-test/issues)