### PR TITLE
Update copyright year on documentation footer

### DIFF
--- a/subprojects/docs/src/main/resources/footer.html
+++ b/subprojects/docs/src/main/resources/footer.html
@@ -62,7 +62,7 @@
 <div class="site-footer-secondary">
     <div class="site-footer-secondary__contents">
         <div class="site-footer__copy">© <a href="https://gradle.com">Gradle Inc.</a>
-            <time>2022</time>
+            <time>2023</time>
             All rights reserved.
         </div>
         <div class="site-footer__logo"><a href="/">


### PR DESCRIPTION
Fixes outdated date in documentation footer.

### Context
![Gradle gasp 2022](https://github.com/gradle/gradle/assets/5684849/709d4f60-d6ac-460f-ad9a-0045b48cd749)
Updates to **2023 All rights reserved**.

