### PR TITLE
Exclude unused tasks in FlakyTestQuarantine

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/FlakyTestQuarantine.kt
+++ b/.teamcity/src/main/kotlin/configurations/FlakyTestQuarantine.kt
@@ -48,7 +48,14 @@ class FlakyTestQuarantine(model: CIBuildModel, stage: Stage, os: Os, arch: Arch 
         val extraParameters = functionalTestExtraParameters("FlakyTestQuarantine", os, arch, testCoverage.testJvmVersion.major.toString(), testCoverage.vendor.name)
         val parameters = (
             buildToolGradleParameters(true) +
-                listOf("-PflakyTests=only", "-x", ":docs:platformTest", "-x", ":distributions-integ-tests:quickTest", "-x", ":distributions-integ-tests:platformTest") +
+                listOf(
+                    "-PflakyTests=only",
+                    "-x", ":docs:platformTest",
+                    "-x", ":docs:configCacheTest",
+                    "-x", ":distributions-integ-tests:quickTest",
+                    "-x", ":distributions-integ-tests:platformTest",
+                    "-x", ":distributions-integ-tests:configCacheTest"
+                ) +
                 listOf(extraParameters) +
                 functionalTestParameters(os) +
                 listOf(buildScanTag(functionalTestTag))


### PR DESCRIPTION
I noticed that there are a lot of unused tasks running in FlakyTestQuarantine: https://ge.gradle.org/s/gmi4nfvdah5g4/timeline?name=docs&page=12

This PR excludes them. The build scan after the change: https://ge.gradle.org/s/nleu6iqnnldno/timeline?name=docs

