### PR TITLE
Clear root metadata when extending configurations [backport]

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -371,7 +371,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
 
     @Override
     public Configuration setExtendsFrom(Iterable<Configuration> extendsFrom) {
-        validateMutation(MutationType.DEPENDENCIES);
+        validateMutation(MutationType.HIERARCHY);
         for (Configuration configuration : this.extendsFrom) {
             if (inheritedArtifacts != null) {
                 inheritedArtifacts.removeCollection(configuration.getAllArtifacts());
@@ -393,7 +393,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
 
     @Override
     public Configuration extendsFrom(Configuration... extendsFrom) {
-        validateMutation(MutationType.DEPENDENCIES);
+        validateMutation(MutationType.HIERARCHY);
         for (Configuration configuration : extendsFrom) {
             if (configuration.getHierarchy().contains(this)) {
                 throw new InvalidUserDataException(String.format(

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/MutationValidator.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/MutationValidator.java
@@ -46,7 +46,12 @@ public interface MutationValidator {
         /**
          * The mutation of the role of the configuration (can be queries, resolved, ...)
          */
-        ROLE("role");
+        ROLE("role"),
+
+        /**
+         * The mutation of the hierarchy of the configuration, i.e. which configurations this configuration extends from.
+         */
+        HIERARCHY("hierarchy");
 
         private final String displayName;
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilder.java
@@ -154,6 +154,11 @@ public class DefaultRootComponentMetadataBuilder implements RootComponentMetadat
                         cachedValue.reevaluate();
                     }
                 }
+            } else if (type == MutationType.HIERARCHY) {
+                // The hierarchy is provided to the configuration metadata on construction. Since it is not
+                // computed lazily, there is no lazy value to invalidate. Thus, we need to recompute the
+                // entire component in order to reconstruct new configuration metadatas with new hierarchy values.
+                cachedValue = null;
             }
         }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilderTest.groovy
@@ -137,6 +137,28 @@ class DefaultRootComponentMetadataBuilderTest extends Specification {
         ]
     }
 
+    def "discards component metadata when hierarchy changes"() {
+        componentIdentifierFactory.createComponentIdentifier(_) >> {
+            new DefaultModuleComponentIdentifier(mid, '1.0')
+        }
+        def root = builder.toRootComponentMetaData()
+
+        def conf = root.getConfiguration("conf")
+        assert conf.needsReevaluate()
+        conf.realizeDependencies()
+        assert !conf.needsReevaluate()
+
+        when:
+        builder.validator.validateMutation(MutationValidator.MutationType.HIERARCHY)
+        def otherRoot = builder.toRootComponentMetaData()
+        def otherConf = otherRoot.getConfiguration("conf")
+
+        then:
+        root != otherRoot
+        conf != otherConf
+        otherConf.needsReevaluate()
+    }
+
     def "does not reevaluate component metadata when #mutationType change"() {
         componentIdentifierFactory.createComponentIdentifier(_) >> {
             new DefaultModuleComponentIdentifier(mid, '1.0')


### PR DESCRIPTION
The hierarchy is saved as an instance variable in configuration metadata. The mutation type for configuration extension was DEPENDENCIES, which only caused the cached metadata to be reevaluated. This is not sufficient. We add a new mutation type for HIERARCHY which completely discards the metadata, allowing it to be recalculated and the new hierarchy value to be passed to the configuration metadata
