### PR TITLE
Add section on binary compatibility checks to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,6 +139,43 @@ Then force push your branch:
 
 `git push --force origin test-branch`
 
+### Fixing sanity check failures after public API changes
+
+If your PR includes any changes to the Gradle Public API, it will cause the binary compatibility check to fail.
+The binary compatibility check runs as a part of the broader sanity check.
+The latter runs on every PR and is a prerequisite for merging.
+
+If you run the sanity check locally with the `./gradlew sanityCheck`, you can see the binary compatibility error in the output.
+It looks like the following:
+
+```
+Execution failed for task ':architecture-test:checkBinaryCompatibility'.
+> A failure occurred while executing me.champeau.gradle.japicmp.JApiCmpWorkAction
+   > Detected binary changes.
+         - current: ...
+         - baseline: ...
+     
+     See failure report at file:///<path to Gradle checkout>/subprojects/architecture-test/build/reports/binary-compatibility/report.html
+```
+
+Here are the steps to resolve the issue:
+
+1. Open the failure report mentioned in the output.\
+If you don't see the report link in the output in the IDE, make sure to select the top-level node in the structured output panel.
+The report will explain the errors in detail.
+Perhaps, you forgot to add an `@Incubating` annotation or `@since` in the javadoc.
+
+2. Accept the changes.\
+If you are sure that the changes are intentional, follow the steps described in the report.
+This includes adding the description of the changes to the `accepted-public-api-changes.json` file, and providing a reason for each change.
+You can add the changes to any place in the file, e.g. at the top.
+
+3. Make sure the file with accepted changes is sorted.\
+Use the `./gradlew :architecture-test:sortAcceptedApiChanges` task to sort the file.
+
+4. Validate your changes before committing.\
+Run the `./gradlew sanityCheck` task again to make sure there are no more errors.
+
 ### Java Toolchain
 
 The Gradle build uses [Java Toolchain](https://docs.gradle.org/current/userguide/toolchains.html) support to compile and execute tests across multiple versions of Java.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,6 +176,23 @@ Use the `./gradlew :architecture-test:sortAcceptedApiChanges` task to sort the f
 4. Validate your changes before committing.\
 Run the `./gradlew sanityCheck` task again to make sure there are no more errors.
 
+#### Filtering changes by severity
+
+There is a somewhat non-obvious filter present on the page that allows you to control which type of messages are displayed.
+The filter is a dropdown box that appears when you click the `Severity ⬇️ ` label in the black header bar to the immediate right of the Gradle version.
+
+If you have a large number of messages of different types, filtering by severity to see only `Error`s can be helpful when processing the report.
+Errors are the only type of issues that must be resolved for the `checkBinaryCompatibility` task to succeed.
+
+You can set the 'bin.cmp.report.severity.filter' property in your `gradle.properties` to one of the available values in the dropdown box to automatically filter issues to that severity level upon opening this report.
+
+#### Accepting multiple changes
+
+If you have multiple changes to accept (and you're sure they ought to be accepted instead of corrected), you can use the `Accept Changes for all Errors` button to speed the process.
+This button will cause a Javascript alert dialog to appear asking you to type a reason for accepting the changes, e.g. "Added new API for Gradle 8.x".
+
+Clicking okay on the dialog will cause a copy of the `accepted-public-api-changes.json` containing your (properly sorted) addition to be downloaded.
+You can then replace the existing file with this new downloaded version. 
 ### Java Toolchain
 
 The Gradle build uses [Java Toolchain](https://docs.gradle.org/current/userguide/toolchains.html) support to compile and execute tests across multiple versions of Java.


### PR DESCRIPTION
...as this does not seem to have been documented before.

This could serve as a reference for the contributors if they touch the public API.