### PR TITLE
Remove reference to predictiveSelection extension

### DIFF
--- a/subprojects/architecture-test/build.gradle.kts
+++ b/subprojects/architecture-test/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.gradle.enterprise.gradleplugin.testselection.PredictiveTestSelectionExtension
 import gradlebuild.basics.FlakyTestStrategy
 import gradlebuild.basics.PublicApi
 import gradlebuild.basics.PublicKotlinDslApi
@@ -60,7 +61,7 @@ tasks.test {
     dependsOn(verifyAcceptedApiChangesOrdering)
     enabled = flakyTestStrategy !=  FlakyTestStrategy.ONLY
 
-    predictiveSelection {
+    extensions.findByType<PredictiveTestSelectionExtension>()?.apply {
         // PTS doesn't work well with architecture tests which scan all classes
         enabled = false
     }


### PR DESCRIPTION
Test selection doesn't work with composite builds, so the extension isn't there when Gradle is included into another build. We want to support including Gradle into other builds, so let's access the property in a null-safe way.