### PR TITLE
Resolution failures caused by ArtifactViews now indicate this in the exception

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ArtifactView.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ArtifactView.java
@@ -43,6 +43,17 @@ public interface ArtifactView extends HasAttributes {
     FileCollection getFiles();
 
     /**
+     * Describes this artifact view for diagnostic and error reporting purposes.
+     *
+     * @return a human-readable name or description of this view
+     * @since 8.3
+     */
+    @Incubating
+    default String getDisplayName() {
+        return "Artifact View";
+    }
+
+    /**
      * Configuration for a defined artifact view.
      *
      * @since 4.0

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/ArtifactViewResolutionErrorIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/ArtifactViewResolutionErrorIntegrationTest.groovy
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.attributes
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+/**
+ * Tests that resolution failures caused by {@link org.gradle.api.artifacts.ArtifactView ArtifactView}
+ * rather than configurations indicate this in the error message.
+ */
+class ArtifactViewResolutionErrorIntegrationTest extends AbstractIntegrationSpec {
+    def setup() {
+        settingsFile << """
+            rootProject.name = "consumer"
+            include "producer"
+        """
+    }
+
+    def "artifact view resolution error mentions artifact view"() {
+        file("producer/build.gradle.kts") << """
+            val flavor: Attribute<String> = Attribute.of("flavor", String::class.java)
+
+            configurations {
+                register("producerConfVanilla") {
+                    attributes.attribute(flavor, "vanilla")
+                    outgoing.artifact(file("vanilla.jar"))
+                }
+                register("producerConfChocolate") {
+                    attributes.attribute(flavor, "chocolate")
+                    outgoing.artifact(file("chocolate.jar"))
+                }
+            }
+        """
+
+        buildKotlinFile << """
+            val flavor: Attribute<String> = Attribute.of("flavor", String::class.java)
+
+            configurations {
+                register("consumerConf") {
+                    attributes.attribute(flavor, "chocolate")
+                }
+            }
+
+            dependencies {
+                configurations["consumerConf"](project(":producer"))
+            }
+
+            tasks.register("verifyFiles") {
+                val consumerConf = configurations.named("consumerConf").get()
+
+                doLast {
+                    val incomingFiles = consumerConf.incoming.files
+                    val artifactViewFiles = consumerConf.incoming.artifactView { }.files
+                    configurations["consumerConf"].attributes.attribute(flavor, "vanilla")
+                    incomingFiles.forEach { it.exists() } // Force resolution
+                    artifactViewFiles.forEach { it.exists() } // Force resolution
+                }
+            }
+        """
+
+        expect:
+        fails("verifyFiles")
+        failureCauseContains("Could not resolve all files for ArtifactView for configuration ':consumerConf'.")
+        !errorOutput.contains("Could not resolve all files for configuration ':consumerConf'.")
+    }
+
+    def "configuration resolution error does not mention artifact view"() {
+        file("producer/build.gradle.kts") << """
+            val flavor: Attribute<String> = Attribute.of("flavor", String::class.java)
+
+            configurations {
+                register("producerConfVanilla") {
+                    attributes.attribute(flavor, "vanilla")
+                    outgoing.artifact(file("vanilla.jar"))
+                }
+                register("producerConfChocolate") {
+                    attributes.attribute(flavor, "chocolate")
+                    outgoing.artifact(file("chocolate.jar"))
+                }
+            }
+        """
+
+        buildKotlinFile << """
+            val flavor: Attribute<String> = Attribute.of("flavor", String::class.java)
+
+            configurations {
+                register("consumerConf") {
+                    attributes.attribute(flavor, "cinnamon")
+                }
+            }
+
+            dependencies {
+                configurations["consumerConf"](project(":producer"))
+            }
+
+            tasks.register("verifyFiles") {
+                val consumerConf = configurations.named("consumerConf").get()
+
+                doLast {
+                    val incomingFiles = consumerConf.incoming.files
+                    incomingFiles.forEach { it.exists() } // Force resolution
+                }
+            }
+        """
+
+        expect:
+        fails("verifyFiles")
+        failureCauseContains("Could not resolve all files for configuration ':consumerConf'.")
+        !errorOutput.contains("Could not resolve all files for ArtifactView for configuration ':consumerConf'.")
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionHost.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionHost.java
@@ -21,6 +21,14 @@ import org.gradle.internal.DisplayName;
 import java.util.Collection;
 import java.util.Optional;
 
+/**
+ * This type represents a container in which resolution happens (i.e. it "hosts" the resolution),
+ * such as a {@link org.gradle.internal.component.external.descriptor.Configuration Configuration} or
+ * {@link org.gradle.api.artifacts.ArtifactView ArtifactView}.
+ *
+ * It provides context about the resolution for error reporting and utility methods to combine multiple
+ * resolution failures into a single exception to throw and report.
+ */
 public interface ResolutionHost {
     String getDisplayName();
 


### PR DESCRIPTION
Indicating this will help debug exactly which resolution failed - the configuration itself or an `ArtifactView` created from the configuration.

