### PR TITLE
Fix build operations emitted for next-gen build cache

### DIFF
--- a/subprojects/build-cache/src/integTest/groovy/org/gradle/caching/internal/NextGenBuildCacheBuildOperationsIntegrationTest.groovy
+++ b/subprojects/build-cache/src/integTest/groovy/org/gradle/caching/internal/NextGenBuildCacheBuildOperationsIntegrationTest.groovy
@@ -327,7 +327,8 @@ class NextGenBuildCacheBuildOperationsIntegrationTest extends AbstractIntegratio
         packOp.result.archiveEntryCount == 2
         remoteStoreOp.details.archiveSize > 0
 
-        operations.orderedSerialSiblings(remoteMissLoadOp, packOp, remoteStoreOp)
+        operations.orderedSerialSiblings(remoteMissLoadOp, packOp)
+        operations.parentsOf(remoteStoreOp).contains(packOp)
     }
 
     def "records ops for remote hit"() {
@@ -379,6 +380,6 @@ class NextGenBuildCacheBuildOperationsIntegrationTest extends AbstractIntegratio
         unpackOp.details.archiveSize > 0
         remoteHitLoadOp.result.archiveSize > 0
 
-        operations.orderedSerialSiblings(remoteHitLoadOp, unpackOp)
+        operations.parentsOf(unpackOp).contains(remoteHitLoadOp)
     }
 }

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/CacheManifest.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/CacheManifest.java
@@ -25,15 +25,27 @@ import java.util.Map;
 
 public class CacheManifest {
     private final OriginMetadata originMetadata;
+    private final String workType;
+    private final String identity;
     private final Map<String, List<ManifestEntry>> propertyManifests;
 
-    public CacheManifest(OriginMetadata originMetadata, Map<String, List<ManifestEntry>> propertyManifests) {
+    public CacheManifest(OriginMetadata originMetadata, String workType, String identity, Map<String, List<ManifestEntry>> propertyManifests) {
         this.originMetadata = originMetadata;
+        this.workType = workType;
+        this.identity = identity;
         this.propertyManifests = propertyManifests;
     }
 
     public OriginMetadata getOriginMetadata() {
         return originMetadata;
+    }
+
+    public String getWorkType() {
+        return workType;
+    }
+
+    public String getIdentity() {
+        return identity;
     }
 
     public Map<String, List<ManifestEntry>> getPropertyManifests() {

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/DefaultNextGenBuildCacheAccess.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/DefaultNextGenBuildCacheAccess.java
@@ -88,7 +88,7 @@ public class DefaultNextGenBuildCacheAccess implements NextGenBuildCacheAccess {
                 }
                 if (!foundLocally && remote.canLoad()) {
                     // TODO Improve error handling
-                    handler.startLoadOperation(key);
+                    handler.ensureLoadOperationStarted(key);
                     return Stream.of(CompletableFuture.runAsync(counter.wrap(new RemoteDownload<>(key, payload, handler)), remoteProcessor));
                 } else {
                     return Stream.empty();
@@ -115,7 +115,7 @@ public class DefaultNextGenBuildCacheAccess implements NextGenBuildCacheAccess {
                 }
                 // TODO Improve error handling
                 if (remote.canStore()) {
-                    handler.startStoreOperation(key);
+                    handler.ensureStoreOperationStarted(key);
                     return Stream.of(CompletableFuture.runAsync(counter.wrap(new RemoteUpload(key, handler)), remoteProcessor));
                 } else {
                     return Stream.empty();

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/DefaultNextGenBuildCacheAccess.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/DefaultNextGenBuildCacheAccess.java
@@ -25,8 +25,6 @@ import org.gradle.internal.UncheckedException;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.concurrent.ManagedThreadPoolExecutor;
 import org.gradle.internal.file.BufferProvider;
-import org.gradle.internal.operations.BuildOperationRef;
-import org.gradle.internal.operations.CurrentBuildOperationRef;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -90,6 +88,7 @@ public class DefaultNextGenBuildCacheAccess implements NextGenBuildCacheAccess {
                 }
                 if (!foundLocally && remote.canLoad()) {
                     // TODO Improve error handling
+                    handler.startLoadOperation(key);
                     return Stream.of(CompletableFuture.runAsync(counter.wrap(new RemoteDownload<>(key, payload, handler)), remoteProcessor));
                 } else {
                     return Stream.empty();
@@ -116,6 +115,7 @@ public class DefaultNextGenBuildCacheAccess implements NextGenBuildCacheAccess {
                 }
                 // TODO Improve error handling
                 if (remote.canStore()) {
+                    handler.startStoreOperation(key);
                     return Stream.of(CompletableFuture.runAsync(counter.wrap(new RemoteUpload(key, handler)), remoteProcessor));
                 } else {
                     return Stream.empty();
@@ -170,28 +170,7 @@ public class DefaultNextGenBuildCacheAccess implements NextGenBuildCacheAccess {
         }
     }
 
-    private static abstract class OperationPreservingRunnable implements Runnable {
-        private final BuildOperationRef mainThreadOperation;
-
-        public OperationPreservingRunnable() {
-            this.mainThreadOperation = CurrentBuildOperationRef.instance().get();
-        }
-
-        @Override
-        public void run() {
-            BuildOperationRef originalOperation = CurrentBuildOperationRef.instance().get();
-            CurrentBuildOperationRef.instance().set(mainThreadOperation);
-            try {
-                doRun();
-            } finally {
-                CurrentBuildOperationRef.instance().set(originalOperation);
-            }
-        }
-
-        abstract protected void doRun();
-    }
-
-    private class RemoteDownload<T> extends OperationPreservingRunnable {
+    private class RemoteDownload<T> implements Runnable {
         private final BuildCacheKey key;
         private final T payload;
         private final LoadHandler<T> handler;
@@ -203,8 +182,7 @@ public class DefaultNextGenBuildCacheAccess implements NextGenBuildCacheAccess {
         }
 
         @Override
-        protected void doRun() {
-            handler.startLoadOperation(key);
+        public void run() {
             try {
                 long size = load();
                 if (size >= 0) {
@@ -252,7 +230,7 @@ public class DefaultNextGenBuildCacheAccess implements NextGenBuildCacheAccess {
         }
     }
 
-    private class RemoteUpload extends OperationPreservingRunnable {
+    private class RemoteUpload implements Runnable {
         private final BuildCacheKey key;
         private final StoreHandler<?> handler;
 
@@ -262,7 +240,7 @@ public class DefaultNextGenBuildCacheAccess implements NextGenBuildCacheAccess {
         }
 
         @Override
-        protected void doRun() {
+        public void run() {
             // TODO Check contains only above a threshold
             if (remote.contains(key)) {
                 LOGGER.warn("Not storing {} in remote", key);
@@ -281,7 +259,6 @@ public class DefaultNextGenBuildCacheAccess implements NextGenBuildCacheAccess {
         }
 
         private void store(UnsynchronizedByteArrayOutputStream data) {
-            handler.startStoreOperation(key);
             try {
                 boolean stored = storeInner(data);
                 handler.recordStoreFinished(key, stored);

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/NextGenBuildCacheAccess.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/NextGenBuildCacheAccess.java
@@ -57,7 +57,7 @@ public interface NextGenBuildCacheAccess extends Closeable {
         /**
          * Starts the legacy {@link BuildCacheRemoteLoadBuildOperationType} build operation when the first download starts.
          */
-        void startLoadOperation(BuildCacheKey key);
+        void ensureLoadOperationStarted(BuildCacheKey key);
 
         /**
          * Record that the load operation was successful in loading a result.
@@ -99,7 +99,7 @@ public interface NextGenBuildCacheAccess extends Closeable {
         /**
          * Starts the legacy {@link BuildCacheRemoteStoreBuildOperationType} build operation when the first upload starts.
          */
-        void startStoreOperation(BuildCacheKey key);
+        void ensureStoreOperationStarted(BuildCacheKey key);
 
         /**
          * Record that the store operation has finished successfully.
@@ -131,8 +131,8 @@ public interface NextGenBuildCacheAccess extends Closeable {
         }
 
         @Override
-        public void startLoadOperation(BuildCacheKey key) {
-            delegate.startLoadOperation(key);
+        public void ensureLoadOperationStarted(BuildCacheKey key) {
+            delegate.ensureLoadOperationStarted(key);
         }
 
         @Override
@@ -164,8 +164,8 @@ public interface NextGenBuildCacheAccess extends Closeable {
         }
 
         @Override
-        public void startStoreOperation(BuildCacheKey key) {
-            delegate.startStoreOperation(key);
+        public void ensureStoreOperationStarted(BuildCacheKey key) {
+            delegate.ensureStoreOperationStarted(key);
         }
 
         @Override

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/NextGenBuildCacheController.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/NextGenBuildCacheController.java
@@ -540,6 +540,8 @@ public class NextGenBuildCacheController implements BuildCacheController {
 
         CacheManifest manifest = new CacheManifest(
             new OriginMetadata(buildInvocationId, executionTime),
+            entity.getType().getName(),
+            entity.getIdentity(),
             propertyManifests.build());
 
         String manifestJson = gson.toJson(manifest);


### PR DESCRIPTION
We are seeing some problems with build operations, especially around Kotlin script compilation, when building Gradle:

```text
Caused by: java.lang.IllegalStateException: Cannot start operation (Identifying work) as parent operation (Pack build cache entry 770fa2b2a73b593bec3aa63e836fe7e5) has already completed.	
at org.gradle.internal.operations.DefaultBuildOperationRunner.assertParentRunning(DefaultBuildOperationRunner.java:169)	
•••
at org.gradle.kotlin.dsl.provider.StandardKotlinScriptEvaluator$InterpreterHost.cachedDirFor(KotlinScriptEvaluator.kt:278)	
at org.gradle.kotlin.dsl.execution.Interpreter$ProgramHost.compileSecondStageOf(Interpreter.kt:468)	
•••
at org.gradle.kotlin.dsl.execution.Interpreter$ProgramHost.evaluateSecondStageOf(Interpreter.kt:432)	
•••
at org.gradle.kotlin.dsl.execution.Interpreter$ProgramHost.eval(Interpreter.kt:516)	
at org.gradle.kotlin.dsl.execution.Interpreter.eval(Interpreter.kt:192)	
at org.gradle.kotlin.dsl.provider.StandardKotlinScriptEvaluator.evaluate(KotlinScriptEvaluator.kt:121)	
at org.gradle.kotlin.dsl.provider.KotlinScriptPluginFactory$create$1.invoke(KotlinScriptPluginFactory.kt:51)	
at org.gradle.kotlin.dsl.provider.KotlinScriptPluginFactory$create$1.invoke(KotlinScriptPluginFactory.kt:48)	
at org.gradle.kotlin.dsl.provider.KotlinScriptPlugin.apply(KotlinScriptPlugin.kt:35)	
•••
```

This PR simplifies how we capture pack/store (and unpack/load) operations. Instead of trying to make them siblings of each other, we are now okay with them being parents/children of each other.