### PR TITLE
Fix resolution of excluded tasks for included builds

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/execution/selection/DefaultBuildTaskSelector.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/selection/DefaultBuildTaskSelector.java
@@ -61,6 +61,12 @@ public class DefaultBuildTaskSelector implements BuildTaskSelector {
             // Too early to resolve excludes
             return new Filter(defaultBuild, Specs.satisfyNone());
         }
+        for (ProjectState project : defaultBuild.getProjects().getAllProjects()) {
+            if (!project.isCreated()) {
+                // Too early to resolve excludes
+                return new Filter(defaultBuild, Specs.satisfyNone());
+            }
+        }
         TaskSelector.SelectionContext selection = sanityCheckPath(taskName, "excluded tasks");
         ProjectResolutionResult resolutionResult = resolveProject(selection, selection.getOriginalPath(), defaultBuild);
         return new Filter(resolutionResult.build, new LazyFilter(selection, resolutionResult));

--- a/subprojects/core/src/test/groovy/org/gradle/execution/selection/DefaultBuildTaskSelectorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/selection/DefaultBuildTaskSelectorTest.groovy
@@ -292,12 +292,14 @@ class DefaultBuildTaskSelectorTest extends Specification {
 
         build.projects >> projects
         projects.rootProject >> rootProjectState
+        projects.allProjects >> [rootProjectState]
         rootProjectState.name >> "root"
         rootProjectState.displayName >> Describables.of("<root project>")
         rootProjectState.projectPath >> Path.ROOT
         rootProjectState.identityPath >> Path.ROOT
         rootProjectState.owner >> build
         rootProjectState.childProjects >> rootChildProjects
+        rootProjectState.created >> true
 
         return new RootBuildFixture(build, rootProjectState, rootChildProjects, defaultProjectState)
     }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #24341

### Context
When a project with an included build, where the included build in turn includes a build for a convention plugin, Gradle will try to resolve excluded tasks before the main project is fully created when trying to configure convention plugin project.

This change fixes the behavior of the resolveExcludedTaskName method to return an empty filter if any of the build's projects have not yet created, the same that already occurs when the project is not yet loaded.

See also: #21936 where this bug was first introduced

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
