### PR TITLE
Add new g4 google analytics tracking code to BT docs

### DIFF
--- a/subprojects/docs-asciidoctor-extensions-base/src/main/java/org/gradle/docs/asciidoctor/AnalyticsInjectingPostprocessor.java
+++ b/subprojects/docs-asciidoctor-extensions-base/src/main/java/org/gradle/docs/asciidoctor/AnalyticsInjectingPostprocessor.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.docs.asciidoctor;
+
+import org.asciidoctor.ast.Document;
+import org.asciidoctor.extension.Postprocessor;
+
+import java.util.Map;
+
+/**
+ * Injects static assets for docs
+ */
+public class AnalyticsInjectingPostprocessor extends Postprocessor {
+    private final String googleAnalyticsHtml;
+
+    AnalyticsInjectingPostprocessor(Map<String, Object> config, String googleAnalyticsHtml) {
+        super(config);
+        this.googleAnalyticsHtml = googleAnalyticsHtml;
+    }
+
+    /**
+     * Inject google analytics noscript before page title.
+     */
+    @Override
+    public String process(Document document, String output) {
+        if (!document.isBasebackend("html")) {
+            return output;
+        }
+        return output.replaceAll("<div id=\"header\">", googleAnalyticsHtml + "<div id=\"header\">");
+    }
+
+    // This method is necessary to avoid https://github.com/asciidoctor/asciidoctorj-pdf/issues/7
+    // when generating PDFs.
+    // "(TypeError) cannot convert instance of class org.jruby.gen.RubyObject50 to class java.lang.String"
+    public Object process(Object document, Object output) {
+        return output;
+    }
+}

--- a/subprojects/docs-asciidoctor-extensions/src/main/java/org/gradle/docs/asciidoctor/GradleDocsHtmlAsciidoctorExtensionRegistry.java
+++ b/subprojects/docs-asciidoctor-extensions/src/main/java/org/gradle/docs/asciidoctor/GradleDocsHtmlAsciidoctorExtensionRegistry.java
@@ -30,10 +30,12 @@ public class GradleDocsHtmlAsciidoctorExtensionRegistry implements ExtensionRegi
 
     private static final String HEAD_HTML_PATH = "/head.html";
     private static final String HEADER_HTML_PATH = "/header.html";
+    private static final String GOOGLE_ANALYTICS_HTML_PATH = "/googleAnalytics.html";
     private static final String FOOTER_HTML_PATH = "/footer.html";
 
     private String headHtml;
     private String headerHtml;
+    private String googleAnalyticsHtml;
     private String footerHtml;
 
 
@@ -44,6 +46,8 @@ public class GradleDocsHtmlAsciidoctorExtensionRegistry implements ExtensionRegi
         JavaExtensionRegistry registry = asciidoctor.javaExtensionRegistry();
 
         registry.docinfoProcessor(new NavigationDocinfoProcessor(new HashMap<>(), headHtml));
+
+        registry.postprocessor(new AnalyticsInjectingPostprocessor(new HashMap<>(), googleAnalyticsHtml));
 
         registry.postprocessor(new HeaderInjectingPostprocessor(new HashMap<>(), headerHtml));
 
@@ -56,6 +60,7 @@ public class GradleDocsHtmlAsciidoctorExtensionRegistry implements ExtensionRegi
     private void initializeHtmlToInject() {
         headHtml = loadResource(HEAD_HTML_PATH);
         headerHtml = loadResource(HEADER_HTML_PATH);
+        googleAnalyticsHtml = loadResource(GOOGLE_ANALYTICS_HTML_PATH);
         footerHtml = loadResource(FOOTER_HTML_PATH);
     }
 

--- a/subprojects/docs/src/main/resources/googleAnalytics.html
+++ b/subprojects/docs/src/main/resources/googleAnalytics.html
@@ -1,0 +1,5 @@
+<!-- Google Tag Manager (noscript) -->
+<noscript>
+    <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WRTQKGT" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+</noscript>
+<!-- End Google Tag Manager (noscript) -->


### PR DESCRIPTION
Adds a new hook in asciidocs to add the noscript portion of the new Google Tag Manager (G4 tracking code) in the doc body.

### Context
Added the new Google analytics G4 tracking code since the GA code is expiring next month for the BT docs.
The new code is also used by marketing for ads.

