### PR TITLE
Allow TestLauncher to configure more task types

### DIFF
--- a/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/TestExecutionBuildTaskSchedulerTest.groovy
+++ b/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/TestExecutionBuildTaskSchedulerTest.groovy
@@ -24,6 +24,7 @@ import org.gradle.api.internal.project.ProjectState
 import org.gradle.api.internal.tasks.TaskContainerInternal
 import org.gradle.api.specs.Specs
 import org.gradle.api.tasks.TaskCollection
+import org.gradle.api.tasks.testing.AbstractTestTask
 import org.gradle.api.tasks.testing.Test
 import org.gradle.api.tasks.testing.TestFilter
 import org.gradle.execution.EntryTaskSelector
@@ -147,7 +148,7 @@ class TestExecutionBuildTaskSchedulerTest extends Specification {
         _ * tasksContainerInternal.findByPath(TEST_TASK_NAME) >> testTask
         TaskCollection<Test> testTaskCollection = Mock()
         _ * testTaskCollection.iterator() >> [testTask].iterator()
-        _ * tasksContainerInternal.withType(Test) >> testTaskCollection
+        _ * tasksContainerInternal.withType(AbstractTestTask) >> testTaskCollection
         _ * testTask.getOutputs() >> outputsInternal
         _ * testTask.getPath() >> TEST_TASK_NAME
         _ * taskSelectionResult.collectTasks(_) >> { args ->

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/TestLauncherSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/TestLauncherSpec.groovy
@@ -143,7 +143,7 @@ abstract class TestLauncherSpec extends ToolingApiSpecification implements WithO
         }
 
         return descriptorByClassAndMethod.findAll {
-            def parent = it.parent
+            def parent = it
             while (parent.parent != null) {
                 parent = parent.parent
                 if (parent instanceof TaskOperationDescriptor) {

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/fixture/Snippets.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/fixture/Snippets.groovy
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.fixture
+
+import org.gradle.test.fixtures.file.TestFile
+
+abstract class Snippets {
+
+    /**
+     * Defines the 'myTestTask' test task in the build script with a custom AbstractTestTask implementation in buildSrc.
+     */
+    static void customTestTask(TestFile buildScript, TestFile buildSrcDir) {
+        buildSrcDir.file('src/main/groovy/CustomTestExecuter.groovy') << '''
+            import org.gradle.api.internal.tasks.testing.*
+            import org.gradle.api.tasks.testing.TestResult
+            import org.gradle.internal.operations.OperationIdentifier
+
+            class CustomTestExecuter implements TestExecuter<CustomTestExecutionSpec> {
+
+                @Override
+                void execute(CustomTestExecutionSpec customTestExecutionSpec, TestResultProcessor testResultProcessor) {
+                    OperationIdentifier rootId = new OperationIdentifier(40L)
+                    DefaultTestSuiteDescriptor rootDescr = new DefaultTestSuiteDescriptor(rootId, "MyCustomTestRoot")
+                    testResultProcessor.started(rootDescr, new TestStartEvent(System.currentTimeMillis()))
+
+                    OperationIdentifier testId = new OperationIdentifier(42L)
+                    DefaultTestDescriptor testDescr = new DefaultTestDescriptor(testId, "org.my.MyClass", "MyCustomTest", null, "org.my.MyClass descriptor")
+                    testResultProcessor.started(testDescr, new TestStartEvent(System.currentTimeMillis()))
+                    testResultProcessor.completed(testId, new TestCompleteEvent(System.currentTimeMillis(), TestResult.ResultType.SUCCESS))
+                    testResultProcessor.completed(rootId, new TestCompleteEvent(System.currentTimeMillis()))
+                }
+
+                @Override
+                void stopNow() {}
+            }
+        '''
+        buildSrcDir.file('src/main/groovy/CustomTestExecutionSpec.groovy') << '''
+            import org.gradle.api.internal.tasks.testing.TestExecutionSpec
+
+            class CustomTestExecutionSpec implements TestExecutionSpec {
+            }
+        '''
+        buildSrcDir.file('src/main/groovy/CustomTestTask.groovy') << '''
+            import org.gradle.api.internal.tasks.testing.TestExecuter
+            import org.gradle.api.internal.tasks.testing.TestExecutionSpec
+            import org.gradle.api.tasks.testing.AbstractTestTask
+
+            class CustomTestTask extends AbstractTestTask {
+                CustomTestTask() {
+                    binaryResultsDirectory.set(new File(getProject().buildDir, "CustomTestTask"))
+                    reports.html.required.set(false)
+                    reports.junitXml.required.set(false)
+                }
+
+                @Override
+                protected TestExecuter<? extends TestExecutionSpec> createTestExecuter() {
+                    return new CustomTestExecuter()
+                }
+
+                @Override
+                protected TestExecutionSpec createTestExecutionSpec() {
+                    return new CustomTestExecutionSpec()
+                }
+            }
+        '''
+        buildScript << 'tasks.register("myTestTask", CustomTestTask)'
+    }
+}

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r83/TestLauncherCustomTestTaskCrossVersionTest.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r83/TestLauncherCustomTestTaskCrossVersionTest.groovy
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r83
+
+import org.gradle.integtests.tooling.TestLauncherSpec
+import org.gradle.integtests.tooling.fixture.Snippets
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.tooling.TestExecutionException
+import org.gradle.tooling.TestLauncher
+import org.gradle.tooling.TestSpecs
+import spock.lang.Issue
+
+@ToolingApiVersion('>=7.6')
+@TargetGradleVersion(">=8.3")
+class TestLauncherCustomTestTaskCrossVersionTest extends TestLauncherSpec {
+
+    def setup() {
+        Snippets.customTestTask(buildFile, file('buildSrc'))
+    }
+
+    @Issue('https://github.com/gradle/gradle/issues/25370')
+    @TargetGradleVersion(">=7.6 <8.3")
+    def "Cannot run tests with custom task implementation in older Gradle versions"() {
+        when:
+        launchTests { TestLauncher launcher ->
+            launcher.withTestsFor { TestSpecs specs ->
+                specs.forTaskPath(':myTestTask').includeClass('org.my.MyClass')
+            }
+        }
+
+        then:
+        Throwable exception = thrown(TestExecutionException)
+        exception.cause.message == "Task ':myTestTask' of type 'CustomTestTask_Decorated' not supported for executing tests via TestLauncher API."
+    }
+
+    @Issue('https://github.com/gradle/gradle/issues/25370')
+    def "Can run tests with custom task implementation"() {
+        when:
+        launchTests { TestLauncher launcher ->
+            launcher.withTestsFor { TestSpecs specs ->
+                specs.forTaskPath(':myTestTask').includeClass('org.my.MyClass')
+            }
+        }
+
+        then:
+        events.testClassesAndMethods.size() == 1
+        assertTestExecuted(className: 'org.my.MyClass', methodName: 'MyCustomTest', task: ':myTestTask')
+    }
+}


### PR DESCRIPTION
Allow TestLauncher to configure all more task types

There are a few classes involved in defining test tasks. The common functionality is defined in AbstractTestTask. The Test type extends AbstractTestTask and contains the implementation for JVM tests. Also, separate AbstractTestTask implementations exist for native test frameworks (e.g. XCTest for Swift).

The TestLauncher API, however, only supports test tasks of type Test. This blocks the API's adoption in IntelliJ for test frameworks, such as the one in Kotlin MPP.

This PR fixes the problem by only requiring the AbstractTestTask task type in TestLauncher invocations.

Fixes #25370