### PR TITLE
Lock-in performance improvement from #25216 and #25156

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,4 +26,4 @@ systemProp.gradle.internal.testdistribution.writeTraceFile=true
 systemProp.gradle.internal.testdistribution.queryResponseTimeout=PT20S
 
 # Default performance baseline
-defaultPerformanceBaselines=8.3-commit-500e063
+defaultPerformanceBaselines=8.3-commit-03fd1466aed


### PR DESCRIPTION
`run assembleDebug | largeAndroidBuild | RealLifeAndroidBuildPerformanceTest for 8.3` is now around 10% faster again: 
<img width="1817" alt="image" src="https://github.com/gradle/gradle/assets/423186/8b9f7947-55f6-48a9-ba73-68bf6c1974a7">
