### PR TITLE
Only filter JVM environment variables for java processes

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaForkOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaForkOptions.java
@@ -20,6 +20,7 @@ import org.gradle.api.Action;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.internal.file.PathToFileResolver;
+import org.gradle.internal.jvm.Jvm;
 import org.gradle.process.CommandLineArgumentProvider;
 import org.gradle.process.JavaDebugOptions;
 import org.gradle.process.JavaForkOptions;
@@ -203,6 +204,12 @@ public class DefaultJavaForkOptions extends DefaultProcessForkOptions implements
     @Override
     public void debugOptions(Action<JavaDebugOptions> action) {
         action.execute(options.getDebugOptions());
+    }
+
+    @Override
+    protected Map<String, ?> getInheritableEnvironment() {
+        // Filter out any environment variables that should not be inherited.
+        return Jvm.getInheritableEnvironmentVariables(super.getInheritableEnvironment());
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultProcessForkOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultProcessForkOptions.java
@@ -17,7 +17,6 @@ package org.gradle.process.internal;
 
 import com.google.common.collect.Maps;
 import org.gradle.internal.file.PathToFileResolver;
-import org.gradle.internal.jvm.Jvm;
 import org.gradle.process.ProcessForkOptions;
 
 import java.io.File;
@@ -82,9 +81,13 @@ public class DefaultProcessForkOptions implements ProcessForkOptions {
     @Override
     public Map<String, Object> getEnvironment() {
         if (environment == null) {
-            setEnvironment(Jvm.getInheritableEnvironmentVariables(System.getenv()));
+            setEnvironment(getInheritableEnvironment());
         }
         return environment;
+    }
+
+    protected Map<String, ?> getInheritableEnvironment() {
+        return System.getenv();
     }
 
     public Map<String, String> getActualEnvironment() {


### PR DESCRIPTION
Previously, this filtering occurred for all processes, but only if the current JVM was Apple.  With #25220, we changed this to happen for all JVMs.  This means that in environments where these exist, but we're not using an Apple JVM, these were not being filtered before, but now are, and some non-Java process tests are failing.  The reality is, these variables only need to be filtered for Java processes where compatibility is being evaluated and not for all processes, so this changes the filtering to only occur for forked Java processes.