### PR TITLE
Add support for relative distribution URIs in the `Wrapper` task

### DIFF
--- a/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
+++ b/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
@@ -140,7 +140,7 @@ public abstract class Wrapper extends DefaultTask {
         Properties existingProperties = propertiesFile.exists() ? GUtil.loadProperties(propertiesFile) : null;
 
         checkProperties(existingProperties);
-        validateDistributionUrl();
+        validateDistributionUrl(propertiesFile.getParentFile());
         writeProperties(propertiesFile, existingProperties);
         writeWrapperTo(jarFileDestination);
 
@@ -171,10 +171,10 @@ public abstract class Wrapper extends DefaultTask {
 
     private static final String DISTRIBUTION_URL_EXCEPTION_MESSAGE = "Test of distribution url %s failed. Please check the values set with --gradle-distribution-url and --gradle-version.";
 
-    private void validateDistributionUrl() {
+    private void validateDistributionUrl(File uriRoot) {
         if (distributionUrlConfigured && getValidateDistributionUrl().get()) {
             String url = getDistributionUrl();
-            URI uri = getDistributionUri(url);
+            URI uri = getDistributionUri(uriRoot, url);
             if (uri.getScheme().equals("file")) {
                 if (!Files.exists(Paths.get(uri).toAbsolutePath())) {
                     throw new UncheckedIOException(String.format(DISTRIBUTION_URL_EXCEPTION_MESSAGE, url));
@@ -189,10 +189,9 @@ public abstract class Wrapper extends DefaultTask {
         }
     }
 
-    private URI getDistributionUri(String url) {
+    private static URI getDistributionUri(File uriRoot, String url) {
         try {
-            File projectDir = getProject().getLayout().getProjectDirectory().getAsFile();
-            return WrapperDistributionUrlConverter.toUri(projectDir, url);
+            return WrapperDistributionUrlConverter.toUri(uriRoot, url);
         } catch (URISyntaxException e) {
             throw new GradleException("Distribution URL String cannot be parsed: " + url, e);
         }

--- a/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
+++ b/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
@@ -39,6 +39,7 @@ import org.gradle.util.GradleVersion;
 import org.gradle.util.internal.DistributionLocator;
 import org.gradle.util.internal.GUtil;
 import org.gradle.util.internal.WrapUtil;
+import org.gradle.util.internal.WrapperDistributionUrlConverter;
 import org.gradle.work.DisableCachingByDefault;
 import org.gradle.wrapper.Download;
 import org.gradle.wrapper.GradleWrapperMain;
@@ -57,7 +58,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
@@ -191,20 +191,11 @@ public abstract class Wrapper extends DefaultTask {
 
     private URI getDistributionUri(String url) {
         try {
-            if (hasNoRequiredScheme(url)) {
-                Path projectDir = getProject().getLayout().getProjectDirectory().getAsFile().toPath();
-                String absolutePath = Paths.get(url).isAbsolute() ? url : projectDir.resolve(url).toAbsolutePath().toString();
-                return new URI("file", null, absolutePath, null);
-            } else {
-                return new URI(url);
-            }
+            File projectDir = getProject().getLayout().getProjectDirectory().getAsFile();
+            return WrapperDistributionUrlConverter.toUri(projectDir, url);
         } catch (URISyntaxException e) {
             throw new GradleException("Distribution URL String cannot be parsed: " + url, e);
         }
-    }
-
-    private static boolean hasNoRequiredScheme(String url) {
-        return !url.startsWith("http:") && !url.startsWith("https:") && !url.startsWith("file:");
     }
 
     private void writeWrapperTo(File destination) {

--- a/subprojects/wrapper-shared/build.gradle.kts
+++ b/subprojects/wrapper-shared/build.gradle.kts
@@ -8,7 +8,9 @@ gradlebuildJava.usedInWorkers()
 
 dependencies {
 
-    implementation(project(":base-annotations"))
+    compileOnly(project(":base-annotations")) {
+        because("Compile only because we want to keep the wrapper.jar small")
+    }
     testImplementation(project(":base-services"))
     testImplementation(project(":core-api"))
     testImplementation(project(":native"))

--- a/subprojects/wrapper-shared/build.gradle.kts
+++ b/subprojects/wrapper-shared/build.gradle.kts
@@ -8,6 +8,7 @@ gradlebuildJava.usedInWorkers()
 
 dependencies {
 
+    implementation(project(":base-annotations"))
     testImplementation(project(":base-services"))
     testImplementation(project(":core-api"))
     testImplementation(project(":native"))

--- a/subprojects/wrapper-shared/src/main/java/org/gradle/util/internal/WrapperDistributionUrlConverter.java
+++ b/subprojects/wrapper-shared/src/main/java/org/gradle/util/internal/WrapperDistributionUrlConverter.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.util.internal;
+
+import org.gradle.api.NonNullApi;
+
+import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/**
+ * Converts a wrapper distribution url to a URI.
+ */
+@NonNullApi
+public class WrapperDistributionUrlConverter {
+    public static URI toUri(File projectDir, String distributionUrl) throws URISyntaxException {
+        URI source = new URI(distributionUrl);
+        if (source.getScheme() == null) {
+            //  no scheme means someone passed a relative url.
+            //  In our context only file relative urls make sense.
+            return new File(projectDir, source.getSchemeSpecificPart()).toURI();
+        } else {
+            return source;
+        }
+    }
+}

--- a/subprojects/wrapper-shared/src/main/java/org/gradle/util/internal/WrapperDistributionUrlConverter.java
+++ b/subprojects/wrapper-shared/src/main/java/org/gradle/util/internal/WrapperDistributionUrlConverter.java
@@ -27,12 +27,12 @@ import java.net.URISyntaxException;
  */
 @NonNullApi
 public class WrapperDistributionUrlConverter {
-    public static URI toUri(File projectDir, String distributionUrl) throws URISyntaxException {
+    public static URI toUri(File uriRoot, String distributionUrl) throws URISyntaxException {
         URI source = new URI(distributionUrl);
         if (source.getScheme() == null) {
-            //  no scheme means someone passed a relative url.
+            //  No scheme means someone passed a relative url.
             //  In our context only file relative urls make sense.
-            return new File(projectDir, source.getSchemeSpecificPart()).toURI();
+            return new File(uriRoot, source.getSchemeSpecificPart()).toURI();
         } else {
             return source;
         }

--- a/subprojects/wrapper-shared/src/main/java/org/gradle/wrapper/WrapperExecutor.java
+++ b/subprojects/wrapper-shared/src/main/java/org/gradle/wrapper/WrapperExecutor.java
@@ -15,12 +15,13 @@
  */
 package org.gradle.wrapper;
 
+import org.gradle.util.internal.WrapperDistributionUrlConverter;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Properties;
 
 public class WrapperExecutor {
@@ -53,7 +54,7 @@ public class WrapperExecutor {
         if (propertiesFile.exists()) {
             try {
                 loadProperties(propertiesFile, properties);
-                config.setDistribution(prepareDistributionUri());
+                config.setDistribution(WrapperDistributionUrlConverter.toUri(propertiesFile.getParentFile(), readDistroUrl()));
                 config.setDistributionBase(getProperty(DISTRIBUTION_BASE_PROPERTY, config.getDistributionBase()));
                 config.setDistributionPath(getProperty(DISTRIBUTION_PATH_PROPERTY, config.getDistributionPath()));
                 config.setDistributionSha256Sum(getProperty(DISTRIBUTION_SHA_256_SUM, config.getDistributionSha256Sum(), false));
@@ -67,21 +68,11 @@ public class WrapperExecutor {
         }
     }
 
-    private URI prepareDistributionUri() throws URISyntaxException {
-        URI source = readDistroUrl();
-        if (source.getScheme() == null) {
-            //no scheme means someone passed a relative url. In our context only file relative urls make sense.
-            return new File(propertiesFile.getParentFile(), source.getSchemeSpecificPart()).toURI();
-        } else {
-            return source;
-        }
-    }
-
-    private URI readDistroUrl() throws URISyntaxException {
+    private String readDistroUrl() {
         if (properties.getProperty(DISTRIBUTION_URL_PROPERTY) == null) {
             reportMissingProperty(DISTRIBUTION_URL_PROPERTY);
         }
-        return new URI(getProperty(DISTRIBUTION_URL_PROPERTY));
+        return getProperty(DISTRIBUTION_URL_PROPERTY);
     }
 
     private static void loadProperties(File propertiesFile, Properties properties) throws IOException {

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import org.gradle.test.fixtures.server.http.HttpServer
 import org.gradle.util.internal.TextUtil
 import org.junit.Rule
 import spock.lang.IgnoreIf
+import spock.lang.Issue
 
 import java.util.jar.Attributes
 import java.util.jar.Manifest
@@ -257,6 +258,20 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
 
         when:
         run( "wrapper", "--gradle-distribution-url", url, "--validate-url")
+
+        then:
+        succeeds()
+    }
+
+    @Issue('https://github.com/gradle/gradle/issues/25252')
+    def "wrapper task succeeds if file distribution url results in relative uri (no scheme)"() {
+        given:
+        def target = file("/distributions/8.0-rc-5") << "some content"
+
+        def url = target.toString()
+
+        when:
+        run "wrapper", "--gradle-distribution-url", url
 
         then:
         succeeds()

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
@@ -60,7 +60,7 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         // wrapper needs to be small. Let's check it's smaller than some arbitrary 'small' limit
-        file("gradle/wrapper/gradle-wrapper.jar").length() < 105 * 1024
+        file("gradle/wrapper/gradle-wrapper.jar").length() < 62 * 1024
     }
 
     def "generated wrapper scripts for given version from command-line"() {
@@ -77,7 +77,7 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
         executer.inDirectory(file("second")).withTasks("wrapper").run()
 
         then: "the checksum should be constant (unless there are code changes)"
-        Hashing.sha256().hashFile(file("first/gradle/wrapper/gradle-wrapper.jar")) == HashCode.fromString("8e01a7aa2a4bd01bc1472128da56ffeb7d7f37445df1e53fb98f0da1a9c5a8ea")
+        Hashing.sha256().hashFile(file("first/gradle/wrapper/gradle-wrapper.jar")) == HashCode.fromString("5c9a1a6f50b4f8c0264b1ac69013bef9f8363733275fafa56c70c84be3276bb8")
 
         and:
         file("first/gradle/wrapper/gradle-wrapper.jar").md5Hash == file("second/gradle/wrapper/gradle-wrapper.jar").md5Hash
@@ -266,7 +266,7 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
     @Issue('https://github.com/gradle/gradle/issues/25252')
     def "wrapper task succeeds if distribution url from command-line results in relative uri (no scheme)"() {
         given:
-        def target = file("../distributions/8.0-rc-5") << "some content"
+        file("gradle/wrapper/../distributions/8.0-rc-5") << "some content"
 
         def url = "../distributions/8.0-rc-5"
 
@@ -275,6 +275,5 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         succeeds()
-        target.deleteDir()
     }
 }

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
@@ -60,7 +60,7 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         // wrapper needs to be small. Let's check it's smaller than some arbitrary 'small' limit
-        file("gradle/wrapper/gradle-wrapper.jar").length() < 62 * 1024
+        file("gradle/wrapper/gradle-wrapper.jar").length() < 105 * 1024
     }
 
     def "generated wrapper scripts for given version from command-line"() {
@@ -77,7 +77,7 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
         executer.inDirectory(file("second")).withTasks("wrapper").run()
 
         then: "the checksum should be constant (unless there are code changes)"
-        Hashing.sha256().hashFile(file("first/gradle/wrapper/gradle-wrapper.jar")) == HashCode.fromString("55e949185c26ba3ddcd2c6a4217d043bfa0ce3cc002bbbb52b709a181a513e81")
+        Hashing.sha256().hashFile(file("first/gradle/wrapper/gradle-wrapper.jar")) == HashCode.fromString("8e01a7aa2a4bd01bc1472128da56ffeb7d7f37445df1e53fb98f0da1a9c5a8ea")
 
         and:
         file("first/gradle/wrapper/gradle-wrapper.jar").md5Hash == file("second/gradle/wrapper/gradle-wrapper.jar").md5Hash
@@ -264,23 +264,9 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Issue('https://github.com/gradle/gradle/issues/25252')
-    def "wrapper task succeeds if distribution url results in relative uri (no scheme)"() {
+    def "wrapper task succeeds if distribution url from command-line results in relative uri (no scheme)"() {
         given:
-        def target = file("/distributions/8.0-rc-5") << "some content"
-
-        def url = target.toString()
-
-        when:
-        run "wrapper", "--gradle-distribution-url", url
-
-        then:
-        succeeds()
-    }
-
-    @Issue('https://github.com/gradle/gradle/issues/25252')
-    def "wrapper task succeeds if distribution url results in relative file path"() {
-        given:
-        file("../distributions/8.0-rc-5") << "some content"
+        def target = file("../distributions/8.0-rc-5") << "some content"
 
         def url = "../distributions/8.0-rc-5"
 
@@ -289,5 +275,6 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         succeeds()
+        target.deleteDir()
     }
 }

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
@@ -264,11 +264,25 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Issue('https://github.com/gradle/gradle/issues/25252')
-    def "wrapper task succeeds if file distribution url results in relative uri (no scheme)"() {
+    def "wrapper task succeeds if distribution url results in relative uri (no scheme)"() {
         given:
         def target = file("/distributions/8.0-rc-5") << "some content"
 
         def url = target.toString()
+
+        when:
+        run "wrapper", "--gradle-distribution-url", url
+
+        then:
+        succeeds()
+    }
+
+    @Issue('https://github.com/gradle/gradle/issues/25252')
+    def "wrapper task succeeds if distribution url results in relative file path"() {
+        given:
+        file("../distributions/8.0-rc-5") << "some content"
+
+        def url = "../distributions/8.0-rc-5"
 
         when:
         run "wrapper", "--gradle-distribution-url", url


### PR DESCRIPTION
Fixes #25252

Support relative URIs (URIs with no scheme specified)