### PR TITLE
Reduce heap used by dependency resolution in composite builds

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/hash/DefaultChecksumService.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/hash/DefaultChecksumService.java
@@ -21,12 +21,9 @@ import org.gradle.api.internal.changedetection.state.CrossBuildFileHashCache;
 import org.gradle.api.internal.changedetection.state.FileHasherStatistics;
 import org.gradle.api.internal.changedetection.state.FileTimeStampInspector;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
-import org.gradle.internal.service.scopes.Scopes;
-import org.gradle.internal.service.scopes.ServiceScope;
 
 import java.io.File;
 
-@ServiceScope(Scopes.BuildSession.class)
 public class DefaultChecksumService implements ChecksumService {
     private final CachingFileHasher md5;
     private final CachingFileHasher sha1;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildSessionScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildSessionScopeServices.java
@@ -17,6 +17,9 @@ package org.gradle.api.internal.artifacts;
 
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.CachingComponentSelectionDescriptorFactory;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorFactory;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.DesugaredAttributeContainerSerializer;
+import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory;
+import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory;
 import org.gradle.api.internal.attributes.DefaultImmutableAttributesFactory;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.catalog.DependenciesAccessorsWorkspaceProvider;
@@ -29,6 +32,9 @@ public class DependencyManagementBuildSessionScopeServices {
     void configure(ServiceRegistration registration) {
         registration.add(DependenciesAccessorsWorkspaceProvider.class);
         registration.add(DefaultImmutableAttributesFactory.class);
+        registration.add(DesugaredAttributeContainerSerializer.class);
+        registration.add(MavenMutableModuleMetadataFactory.class);
+        registration.add(IvyMutableModuleMetadataFactory.class);
     }
 
     ComponentSelectionDescriptorFactory createComponentSelectionDescriptorFactory() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildTreeScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildTreeScopeServices.java
@@ -25,13 +25,38 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ConnectionFailure
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ModuleDescriptorHashCodec;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ModuleDescriptorHashModuleSource;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.StartParameterResolutionOverride;
+import org.gradle.api.internal.artifacts.ivyservice.modulecache.AbstractModuleMetadataCache;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.FileStoreAndIndexProvider;
+import org.gradle.api.internal.artifacts.ivyservice.modulecache.InMemoryModuleMetadataCache;
+import org.gradle.api.internal.artifacts.ivyservice.modulecache.ModuleRepositoryCacheProvider;
+import org.gradle.api.internal.artifacts.ivyservice.modulecache.ModuleRepositoryCaches;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.ModuleSourcesSerializer;
+import org.gradle.api.internal.artifacts.ivyservice.modulecache.PersistentModuleMetadataCache;
+import org.gradle.api.internal.artifacts.ivyservice.modulecache.ReadOnlyModuleMetadataCache;
+import org.gradle.api.internal.artifacts.ivyservice.modulecache.TwoStageModuleMetadataCache;
+import org.gradle.api.internal.artifacts.ivyservice.modulecache.artifacts.AbstractArtifactsCache;
+import org.gradle.api.internal.artifacts.ivyservice.modulecache.artifacts.DefaultModuleArtifactCache;
+import org.gradle.api.internal.artifacts.ivyservice.modulecache.artifacts.DefaultModuleArtifactsCache;
+import org.gradle.api.internal.artifacts.ivyservice.modulecache.artifacts.InMemoryModuleArtifactCache;
+import org.gradle.api.internal.artifacts.ivyservice.modulecache.artifacts.InMemoryModuleArtifactsCache;
+import org.gradle.api.internal.artifacts.ivyservice.modulecache.artifacts.ModuleArtifactCache;
+import org.gradle.api.internal.artifacts.ivyservice.modulecache.artifacts.ReadOnlyModuleArtifactCache;
+import org.gradle.api.internal.artifacts.ivyservice.modulecache.artifacts.ReadOnlyModuleArtifactsCache;
+import org.gradle.api.internal.artifacts.ivyservice.modulecache.artifacts.TwoStageArtifactsCache;
+import org.gradle.api.internal.artifacts.ivyservice.modulecache.artifacts.TwoStageModuleArtifactCache;
+import org.gradle.api.internal.artifacts.ivyservice.modulecache.dynamicversions.AbstractModuleVersionsCache;
+import org.gradle.api.internal.artifacts.ivyservice.modulecache.dynamicversions.DefaultModuleVersionsCache;
+import org.gradle.api.internal.artifacts.ivyservice.modulecache.dynamicversions.InMemoryModuleVersionsCache;
+import org.gradle.api.internal.artifacts.ivyservice.modulecache.dynamicversions.ReadOnlyModuleVersionsCache;
+import org.gradle.api.internal.artifacts.ivyservice.modulecache.dynamicversions.TwoStageModuleVersionsCache;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectArtifactResolver;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.AttributeContainerSerializer;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ThisBuildOnlyComponentDetailsSerializer;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ThisBuildOnlySelectedVariantSerializer;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.store.ResolutionResultsStoreFactory;
 import org.gradle.api.internal.artifacts.repositories.metadata.DefaultMetadataFileSourceCodec;
+import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory;
+import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory;
 import org.gradle.api.internal.artifacts.repositories.metadata.MetadataFileSource;
 import org.gradle.api.internal.artifacts.transform.TransformStepNodeFactory;
 import org.gradle.api.internal.attributes.AttributeDesugaring;
@@ -44,6 +69,7 @@ import org.gradle.internal.component.external.model.ModuleComponentGraphResolveS
 import org.gradle.internal.component.local.model.LocalComponentGraphResolveStateFactory;
 import org.gradle.internal.component.model.ComponentIdGenerator;
 import org.gradle.internal.component.model.PersistentModuleSource;
+import org.gradle.internal.hash.ChecksumService;
 import org.gradle.internal.resource.cached.ByUrlCachedExternalResourceIndex;
 import org.gradle.internal.resource.cached.CachedExternalResourceIndex;
 import org.gradle.internal.resource.cached.DefaultExternalResourceFileStore;
@@ -55,7 +81,10 @@ import org.gradle.util.internal.BuildCommencedTimeProvider;
 import org.gradle.util.internal.SimpleMapInterner;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * The set of dependency management services that are created per build tree.
@@ -129,5 +158,113 @@ class DependencyManagementBuildTreeScopeServices {
         File rootDirectory = buildLayout.getRootDirectory();
         File gradleDir = new File(rootDirectory, "gradle");
         return new StartParameterResolutionOverride(startParameter, gradleDir);
+    }
+
+    ModuleRepositoryCacheProvider createModuleRepositoryCacheProvider(
+        BuildCommencedTimeProvider timeProvider,
+        ImmutableModuleIdentifierFactory moduleIdentifierFactory,
+        ArtifactCachesProvider artifactCaches,
+        AttributeContainerSerializer attributeContainerSerializer,
+        MavenMutableModuleMetadataFactory mavenMetadataFactory,
+        IvyMutableModuleMetadataFactory ivyMetadataFactory,
+        SimpleMapInterner stringInterner,
+        FileStoreAndIndexProvider fileStoreAndIndexProvider,
+        ModuleSourcesSerializer moduleSourcesSerializer,
+        ChecksumService checksumService
+    ) {
+        ArtifactIdentifierFileStore artifactIdentifierFileStore = fileStoreAndIndexProvider.getArtifactIdentifierFileStore();
+        ModuleRepositoryCaches writableCaches = artifactCaches.withWritableCache((md, manager) -> prepareModuleRepositoryCaches(md, manager, timeProvider, moduleIdentifierFactory, attributeContainerSerializer, mavenMetadataFactory, ivyMetadataFactory, stringInterner, artifactIdentifierFileStore, moduleSourcesSerializer, checksumService));
+        AtomicReference<Path> roCachePath = new AtomicReference<>();
+        Optional<ModuleRepositoryCaches> readOnlyCaches = artifactCaches.withReadOnlyCache((ro, manager) -> {
+            roCachePath.set(ro.getCacheDir().toPath());
+            return prepareReadOnlyModuleRepositoryCaches(ro, manager, timeProvider, moduleIdentifierFactory, attributeContainerSerializer, mavenMetadataFactory, ivyMetadataFactory, stringInterner, artifactIdentifierFileStore, moduleSourcesSerializer, checksumService);
+        });
+        AbstractModuleVersionsCache moduleVersionsCache = readOnlyCaches.map(mrc -> (AbstractModuleVersionsCache) new TwoStageModuleVersionsCache(timeProvider, mrc.moduleVersionsCache, writableCaches.moduleVersionsCache)).orElse(writableCaches.moduleVersionsCache);
+        AbstractModuleMetadataCache persistentModuleMetadataCache = readOnlyCaches.map(mrc -> (AbstractModuleMetadataCache) new TwoStageModuleMetadataCache(timeProvider, mrc.moduleMetadataCache, writableCaches.moduleMetadataCache)).orElse(writableCaches.moduleMetadataCache);
+        AbstractArtifactsCache moduleArtifactsCache = readOnlyCaches.map(mrc -> (AbstractArtifactsCache) new TwoStageArtifactsCache(timeProvider, mrc.moduleArtifactsCache, writableCaches.moduleArtifactsCache)).orElse(writableCaches.moduleArtifactsCache);
+        ModuleArtifactCache moduleArtifactCache = readOnlyCaches.map(mrc -> (ModuleArtifactCache) new TwoStageModuleArtifactCache(roCachePath.get(), mrc.moduleArtifactCache, writableCaches.moduleArtifactCache)).orElse(writableCaches.moduleArtifactCache);
+        ModuleRepositoryCaches persistentCaches = new ModuleRepositoryCaches(
+            new InMemoryModuleVersionsCache(timeProvider, moduleVersionsCache),
+            new InMemoryModuleMetadataCache(timeProvider, persistentModuleMetadataCache),
+            new InMemoryModuleArtifactsCache(timeProvider, moduleArtifactsCache),
+            new InMemoryModuleArtifactCache(timeProvider, moduleArtifactCache)
+        );
+        ModuleRepositoryCaches inMemoryOnlyCaches = new ModuleRepositoryCaches(
+            new InMemoryModuleVersionsCache(timeProvider),
+            new InMemoryModuleMetadataCache(timeProvider),
+            new InMemoryModuleArtifactsCache(timeProvider),
+            new InMemoryModuleArtifactCache(timeProvider)
+        );
+        return new ModuleRepositoryCacheProvider(persistentCaches, inMemoryOnlyCaches);
+    }
+
+    private static ModuleRepositoryCaches prepareModuleRepositoryCaches(ArtifactCacheMetadata artifactCacheMetadata, ArtifactCacheLockingAccessCoordinator cacheAccessCoordinator, BuildCommencedTimeProvider timeProvider, ImmutableModuleIdentifierFactory moduleIdentifierFactory, AttributeContainerSerializer attributeContainerSerializer, MavenMutableModuleMetadataFactory mavenMetadataFactory, IvyMutableModuleMetadataFactory ivyMetadataFactory, SimpleMapInterner stringInterner, ArtifactIdentifierFileStore artifactIdentifierFileStore, ModuleSourcesSerializer moduleSourcesSerializer, ChecksumService checksumService) {
+        DefaultModuleVersionsCache moduleVersionsCache = new DefaultModuleVersionsCache(
+            timeProvider,
+            cacheAccessCoordinator,
+            moduleIdentifierFactory);
+        PersistentModuleMetadataCache moduleMetadataCache = new PersistentModuleMetadataCache(
+            timeProvider,
+            cacheAccessCoordinator,
+            artifactCacheMetadata,
+            moduleIdentifierFactory,
+            attributeContainerSerializer,
+            mavenMetadataFactory,
+            ivyMetadataFactory,
+            stringInterner,
+            moduleSourcesSerializer,
+            checksumService);
+        DefaultModuleArtifactsCache moduleArtifactsCache = new DefaultModuleArtifactsCache(
+            timeProvider,
+            cacheAccessCoordinator
+        );
+        DefaultModuleArtifactCache moduleArtifactCache = new DefaultModuleArtifactCache(
+            "module-artifact",
+            timeProvider,
+            cacheAccessCoordinator,
+            artifactIdentifierFileStore.getFileAccessTracker(),
+            artifactCacheMetadata.getCacheDir().toPath()
+        );
+        return new ModuleRepositoryCaches(
+            moduleVersionsCache,
+            moduleMetadataCache,
+            moduleArtifactsCache,
+            moduleArtifactCache
+        );
+    }
+
+    private static ModuleRepositoryCaches prepareReadOnlyModuleRepositoryCaches(ArtifactCacheMetadata artifactCacheMetadata, ArtifactCacheLockingAccessCoordinator cacheAccessCoordinator, BuildCommencedTimeProvider timeProvider, ImmutableModuleIdentifierFactory moduleIdentifierFactory, AttributeContainerSerializer attributeContainerSerializer, MavenMutableModuleMetadataFactory mavenMetadataFactory, IvyMutableModuleMetadataFactory ivyMetadataFactory, SimpleMapInterner stringInterner, ArtifactIdentifierFileStore artifactIdentifierFileStore, ModuleSourcesSerializer moduleSourcesSerializer, ChecksumService checksumService) {
+        ReadOnlyModuleVersionsCache moduleVersionsCache = new ReadOnlyModuleVersionsCache(
+            timeProvider,
+            cacheAccessCoordinator,
+            moduleIdentifierFactory);
+        ReadOnlyModuleMetadataCache moduleMetadataCache = new ReadOnlyModuleMetadataCache(
+            timeProvider,
+            cacheAccessCoordinator,
+            artifactCacheMetadata,
+            moduleIdentifierFactory,
+            attributeContainerSerializer,
+            mavenMetadataFactory,
+            ivyMetadataFactory,
+            stringInterner,
+            moduleSourcesSerializer,
+            checksumService);
+        ReadOnlyModuleArtifactsCache moduleArtifactsCache = new ReadOnlyModuleArtifactsCache(
+            timeProvider,
+            cacheAccessCoordinator
+        );
+        ReadOnlyModuleArtifactCache moduleArtifactCache = new ReadOnlyModuleArtifactCache(
+            "module-artifact",
+            timeProvider,
+            cacheAccessCoordinator,
+            artifactIdentifierFileStore.getFileAccessTracker(),
+            artifactCacheMetadata.getCacheDir().toPath()
+        );
+        return new ModuleRepositoryCaches(
+            moduleVersionsCache,
+            moduleMetadataCache,
+            moduleArtifactsCache,
+            moduleArtifactCache
+        );
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ArtifactCachesProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ArtifactCachesProvider.java
@@ -16,11 +16,14 @@
 package org.gradle.api.internal.artifacts.ivyservice;
 
 import org.gradle.cache.GlobalCache;
+import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 import java.io.Closeable;
 import java.util.Optional;
 import java.util.function.BiFunction;
 
+@ServiceScope(Scopes.UserHome.class)
 public interface ArtifactCachesProvider extends Closeable, GlobalCache {
     String READONLY_CACHE_ENV_VAR = "GRADLE_RO_DEP_CACHE";
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/FileStoreAndIndexProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/FileStoreAndIndexProvider.java
@@ -18,7 +18,10 @@ package org.gradle.api.internal.artifacts.ivyservice.modulecache;
 import org.gradle.api.internal.filestore.ArtifactIdentifierFileStore;
 import org.gradle.internal.resource.cached.CachedExternalResourceIndex;
 import org.gradle.internal.resource.cached.ExternalResourceFileStore;
+import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.ServiceScope;
 
+@ServiceScope(Scopes.BuildTree.class)
 public class FileStoreAndIndexProvider {
     private final CachedExternalResourceIndex<String> externalResourceIndex;
     private final ExternalResourceFileStore externalResourceFileStore;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleSourcesSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleSourcesSerializer.java
@@ -22,11 +22,14 @@ import org.gradle.internal.component.model.PersistentModuleSource;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
 import org.gradle.internal.serialize.Serializer;
+import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Map;
 
+@ServiceScope(Scopes.BuildTree.class)
 public class ModuleSourcesSerializer implements Serializer<ModuleSources> {
     private final Map<Integer, PersistentModuleSource.Codec<? extends PersistentModuleSource>> moduleSourceCodecs;
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DesugaredAttributeContainerSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DesugaredAttributeContainerSerializer.java
@@ -23,6 +23,8 @@ import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.internal.serialize.AbstractSerializer;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
+import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.internal.snapshot.impl.CoercingStringValueSnapshot;
 
 import java.io.IOException;
@@ -32,6 +34,7 @@ import java.io.IOException;
  * types: it will serialize the contents as strings, and read them as strings, only for reporting
  * purposes.
  */
+@ServiceScope(Scopes.BuildSession.class)
 public class DesugaredAttributeContainerSerializer extends AbstractSerializer<AttributeContainer> implements AttributeContainerSerializer {
     private final ImmutableAttributesFactory attributesFactory;
     private final NamedObjectInstantiator instantiator;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/IvyMutableModuleMetadataFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/IvyMutableModuleMetadataFactory.java
@@ -30,10 +30,13 @@ import org.gradle.internal.component.external.model.ivy.IvyDependencyDescriptor;
 import org.gradle.internal.component.external.model.ivy.MutableIvyModuleResolveMetadata;
 import org.gradle.internal.component.model.DefaultIvyArtifactName;
 import org.gradle.internal.component.model.Exclude;
+import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 import java.util.Collection;
 import java.util.List;
 
+@ServiceScope(Scopes.BuildSession.class)
 public class IvyMutableModuleMetadataFactory implements MutableModuleMetadataFactory<MutableIvyModuleResolveMetadata> {
     private static final Configuration DEFAULT_CONFIGURATION = new Configuration(Dependency.DEFAULT_CONFIGURATION, true, true, ImmutableSet.of());
     private static final List<Configuration> DEFAULT_CONFIGURATION_LIST = ImmutableList.of(DEFAULT_CONFIGURATION);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/MavenMutableModuleMetadataFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/MavenMutableModuleMetadataFactory.java
@@ -26,10 +26,13 @@ import org.gradle.internal.component.external.model.PreferJavaRuntimeVariant;
 import org.gradle.internal.component.external.model.maven.DefaultMutableMavenModuleResolveMetadata;
 import org.gradle.internal.component.external.model.maven.MavenDependencyDescriptor;
 import org.gradle.internal.component.external.model.maven.MutableMavenModuleResolveMetadata;
+import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 import java.util.Collections;
 import java.util.List;
 
+@ServiceScope(Scopes.BuildSession.class)
 public class MavenMutableModuleMetadataFactory implements MutableModuleMetadataFactory<MutableMavenModuleResolveMetadata> {
     private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
     private final MavenImmutableAttributesFactory attributesFactory;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/PreferJavaRuntimeVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/PreferJavaRuntimeVariant.java
@@ -24,6 +24,8 @@ import org.gradle.api.internal.attributes.EmptySchema;
 import org.gradle.api.internal.attributes.MultipleCandidatesResult;
 import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.internal.Cast;
+import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 import javax.annotation.Nullable;
 import java.util.Set;
@@ -38,6 +40,7 @@ import java.util.Set;
  * metadata format by default without breaking a bunch of consumers that depend on this assumption,
  * declaring no preference for a particular variant.
  */
+@ServiceScope(Scope.Global.class)
 public class PreferJavaRuntimeVariant extends EmptySchema {
     private static final Set<Attribute<?>> SUPPORTED_ATTRIBUTES = Sets.newHashSet(Usage.USAGE_ATTRIBUTE, LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE);
     private final PreferRuntimeVariantUsageDisambiguationRule usageDisambiguationRule;

--- a/subprojects/hashing/src/main/java/org/gradle/internal/hash/ChecksumService.java
+++ b/subprojects/hashing/src/main/java/org/gradle/internal/hash/ChecksumService.java
@@ -15,8 +15,12 @@
  */
 package org.gradle.internal.hash;
 
+import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.ServiceScope;
+
 import java.io.File;
 
+@ServiceScope(Scopes.BuildSession.class)
 public interface ChecksumService {
     HashCode md5(File file);
 


### PR DESCRIPTION
This PR moves the caching of resolution state and metadata for external components up from build scope to build tree scope, so that it is shared by all builds in the tree.