### PR TITLE
Log next gen cache operations only when cache debugging is enabled

### DIFF
--- a/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/NextGenBuildCacheController.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/NextGenBuildCacheController.java
@@ -76,7 +76,6 @@ import org.gradle.internal.snapshot.SnapshotUtil;
 import org.gradle.internal.snapshot.SnapshotVisitResult;
 import org.gradle.internal.vfs.FileSystemAccess;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.io.File;
@@ -148,8 +147,6 @@ import static org.gradle.internal.snapshot.DirectorySnapshotBuilder.EmptyDirecto
  */
 public class NextGenBuildCacheController implements BuildCacheController {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(NextGenBuildCacheController.class);
-
     public static final String NEXT_GEN_CACHE_SYSTEM_PROPERTY = "org.gradle.unsafe.cache.ng";
 
     private final BufferProvider bufferProvider;
@@ -157,12 +154,14 @@ public class NextGenBuildCacheController implements BuildCacheController {
     private final NextGenBuildCacheAccess cacheAccess;
     private final FileSystemAccess fileSystemAccess;
     private final String buildInvocationId;
+    private final Logger logger;
     private final Deleter deleter;
     private final StringInterner stringInterner;
     private final Gson gson;
 
     public NextGenBuildCacheController(
         String buildInvocationId,
+        Logger logger,
         Deleter deleter,
         FileSystemAccess fileSystemAccess,
         BufferProvider bufferProvider,
@@ -171,6 +170,7 @@ public class NextGenBuildCacheController implements BuildCacheController {
         NextGenBuildCacheAccess cacheAccess
     ) {
         this.buildInvocationId = buildInvocationId;
+        this.logger = logger;
         this.deleter = deleter;
         this.fileSystemAccess = fileSystemAccess;
         this.bufferProvider = bufferProvider;
@@ -179,7 +179,7 @@ public class NextGenBuildCacheController implements BuildCacheController {
         this.stringInterner = stringInterner;
         this.gson = createGson();
 
-        LOGGER.warn("Creating next-generation build cache controller");
+        logger.warn("Creating next-generation build cache controller");
     }
 
     @VisibleForTesting
@@ -739,7 +739,7 @@ public class NextGenBuildCacheController implements BuildCacheController {
 
     @Override
     public void close() throws IOException {
-        LOGGER.warn("Closing next-generation build cache controller");
+        logger.warn("Closing next-generation build cache controller");
         cacheAccess.close();
     }
 

--- a/subprojects/build-cache/src/test/groovy/org/gradle/caching/internal/controller/NextGenBuildCacheControllerTest.groovy
+++ b/subprojects/build-cache/src/test/groovy/org/gradle/caching/internal/controller/NextGenBuildCacheControllerTest.groovy
@@ -36,6 +36,7 @@ import org.gradle.internal.vfs.FileSystemAccess
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
+import org.slf4j.Logger
 import spock.lang.Specification
 
 class NextGenBuildCacheControllerTest extends Specification {
@@ -50,6 +51,7 @@ class NextGenBuildCacheControllerTest extends Specification {
         fileSystemAccess = TestFiles.fileSystemAccess()
         controller = new NextGenBuildCacheController(
             "id",
+            Stub(Logger),
             TestFiles.deleter(),
             fileSystemAccess,
             new ThreadLocalBufferProvider(64 * 1024),

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/services/NextGenBuildCacheControllerFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/services/NextGenBuildCacheControllerFactory.java
@@ -40,6 +40,9 @@ import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.scopeids.id.BuildInvocationScopeId;
 import org.gradle.internal.vfs.FileSystemAccess;
 import org.gradle.util.internal.IncubationLogger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.helpers.NOPLogger;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -87,9 +90,13 @@ public final class NextGenBuildCacheControllerFactory extends AbstractBuildCache
         }
         NextGenBuildCacheService local = localDescribedService.service;
         RemoteNextGenBuildCacheServiceHandler remote = resolveRemoteService(remoteDescribedService);
+        Logger logger = startParameter.isBuildCacheDebugLogging()
+            ? LoggerFactory.getLogger(NextGenBuildCacheController.class)
+            : NOPLogger.NOP_LOGGER;
 
         return new NextGenBuildCacheController(
             buildInvocationScopeId.getId().asString(),
+            logger,
             deleter,
             fileSystemAccess,
             bufferProvider,
@@ -100,7 +107,8 @@ public final class NextGenBuildCacheControllerFactory extends AbstractBuildCache
                     local,
                     remote,
                     bufferProvider,
-                    executorFactory
+                    executorFactory,
+                    logger
                 ),
                 bufferProvider
             )


### PR DESCRIPTION
Can be enabled via `-Dorg.gradle.caching.debug=true`.