### PR TITLE
Enable supportTestRetry for Teamcity builds

### DIFF
--- a/.teamcity/src/main/kotlin/common/extensions.kt
+++ b/.teamcity/src/main/kotlin/common/extensions.kt
@@ -135,6 +135,7 @@ fun BuildType.applyDefaultSettings(os: Os = Os.LINUX, arch: Arch = Arch.AMD64, b
             executionTimeoutMin = timeout
         }
         testFailure = false
+        supportTestRetry = true
         add {
             failOnText {
                 conditionType = BuildFailureOnText.ConditionType.CONTAINS

--- a/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
@@ -73,6 +73,8 @@ class PerformanceTest(
         failureConditions {
             // We have test-retry to handle the crash in tests
             javaCrash = false
+            // We want to see the flaky tests for flakiness detection
+            supportTestRetry = (performanceTestBuildSpec.type != PerformanceTestType.flakinessDetection)
         }
         if (testProjects.isNotEmpty()) {
             steps {

--- a/.teamcity/src/main/kotlin/util/RerunFlakyTest.kt
+++ b/.teamcity/src/main/kotlin/util/RerunFlakyTest.kt
@@ -46,6 +46,10 @@ class RerunFlakyTest(os: Os, arch: Arch = Arch.AMD64) : BuildType({
     val testTaskOptionsParameterName = "testTaskOptions"
     val daemon = true
     applyDefaultSettings(os, arch, buildJvm = BuildToolBuildJvm, timeout = 0)
+
+    // Show all failed tests here, since that is what we are interested in
+    failureConditions.supportTestRetry = false
+
     val extraParameters = functionalTestExtraParameters("RerunFlakyTest", os, arch, "%$testJvmVersionParameter%", "%$testJvmVendorParameter%")
     val parameters = (
         buildToolGradleParameters(daemon) +


### PR DESCRIPTION
So that flaky tests are muted and don't appear as false positives on the summary pages.