### PR TITLE
Document configuration cache instrumentation

### DIFF
--- a/subprojects/docs/src/docs/userguide/authoring-builds/tutorial_using_tasks.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/tutorial_using_tasks.adoc
@@ -301,6 +301,10 @@ For multi-project builds, the dependencies declared with a project's `buildscrip
 
 Build script dependencies may be Gradle plugins. Please consult <<plugins.adoc#plugins,Using Gradle Plugins>> for more information on Gradle plugins.
 
+NOTE: Gradle instruments the bytecode on the build script classpath to provide backward compatibility and improved usability.
+Some libraries may fail integrity self-checks because of this.
+In this case, the use of such libraries should be <<configuration_cache#config_cache:requirements:bytecode_modifications_and_isolation,isolated>>.
+
 Every project automatically has a `buildEnvironment` task of type link:{groovyDslPath}/org.gradle.api.tasks.diagnostics.BuildEnvironmentReportTask.html[BuildEnvironmentReportTask] that can be invoked to report on the resolution of the build script dependencies.
 
 == Further Reading

--- a/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
@@ -964,6 +964,19 @@ include::sample[dir="snippets/valueProviders/fileContentsDo/groovy",files="build
 In general, you should avoid reading files at configuration time, to avoid invalidating configuration cache entries when the file content changes.
 Instead, you can connect the `Provider` returned by link:{javadocPath}/org/gradle/api/provider/ProviderFactory.html#fileContents-org.gradle.api.file.RegularFile-[providers.fileContents()] to task properties.
 
+[[config_cache:requirements:bytecode_modifications_and_isolation]]
+=== Bytecode modifications and Java agent
+
+To detect the configuration inputs, Gradle modifies the bytecode of classes on the build script classpath, like plugins and their dependencies.
+Gradle uses a Java agent to modify the bytecode.
+Integrity self-checks of some libraries may fail because of changed bytecode or agent's presence.
+
+To work around that, you can use the <<worker_api.adoc#tasks_parallel_worker, Worker API>> with classloader or process isolation to encapsulate the library code.
+The bytecode of the worker's classpath is not modified, so the self-checks should pass.
+When process isolation is used, the worker action is executed in a separate worker process that doesn't have the Gradle Java agent installed.
+
+In simple cases, when the libraries also provide command-line entry points (`public static void main()` method), you can also use the link:{javadocPath}/org/gradle/api/tasks/JavaExec.html[JavaExec] task to isolate the library.
+
 [[config_cache:not_yet_implemented]]
 == Not yet implemented
 

--- a/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
@@ -969,9 +969,9 @@ Instead, you can connect the `Provider` returned by link:{javadocPath}/org/gradl
 
 To detect the configuration inputs, Gradle modifies the bytecode of classes on the build script classpath, like plugins and their dependencies.
 Gradle uses a Java agent to modify the bytecode.
-Integrity self-checks of some libraries may fail because of changed bytecode or agent's presence.
+Integrity self-checks of some libraries may fail because of the changed bytecode or the agent's presence.
 
-To work around that, you can use the <<worker_api.adoc#tasks_parallel_worker, Worker API>> with classloader or process isolation to encapsulate the library code.
+To work around this, you can use the <<worker_api.adoc#tasks_parallel_worker, Worker API>> with classloader or process isolation to encapsulate the library code.
 The bytecode of the worker's classpath is not modified, so the self-checks should pass.
 When process isolation is used, the worker action is executed in a separate worker process that doesn't have the Gradle Java agent installed.
 


### PR DESCRIPTION
Gradle's bytecode instrumentation can break self-checking JARs, so it has to be documented for users to know about the possibility. The Worker API is recommended as a workaround.

