### PR TITLE
Allow Configurations with only outgoing attributes to be selected

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
@@ -341,7 +341,7 @@ public final class DefaultLocalComponentMetadata implements LocalComponentMetada
 
                     @Override
                     public boolean hasAttributes() {
-                        return !configuration.getAttributes().isEmpty();
+                        return !configuration.getOutgoing().getAttributes().isEmpty();
                     }
                 });
             });


### PR DESCRIPTION
Configurations with no attributes cannot be selected via variant-aware dependency management. When checking for configurations with no attributes, we only consider the attributes defined on the base configuration. This PR updates the check to also check for attributes declared on `ConfigurationPublications`, since those attributes are also added to configuration metadata during selection
