### PR TITLE
Only replay JUnit XMLs with Parallel Tests enabled

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/FunctionalTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/FunctionalTest.kt
@@ -66,6 +66,9 @@ class FunctionalTest(
     ).filter { it.isNotBlank() }.joinToString(separator = " ")
 
     if (parallelizationMethod is ParallelizationMethod.TeamCityParallelTests && parallelizationMethod.numberOfBatches > 1) {
+        params {
+            param("env.TEAMCITY_PARALLEL_TESTS_ENABLED", "1")
+        }
         features {
             parallelTests {
                 this.numberOfBatches = parallelizationMethod.numberOfBatches

--- a/build-logic/basics/src/main/kotlin/gradlebuild/basics/BuildEnvironment.kt
+++ b/build-logic/basics/src/main/kotlin/gradlebuild/basics/BuildEnvironment.kt
@@ -114,6 +114,7 @@ object BuildEnvironment {
     val isTravis = "TRAVIS" in System.getenv()
     val isGhActions = "GITHUB_ACTIONS" in System.getenv()
     val isTeamCity = "TEAMCITY_VERSION" in System.getenv()
+    val isTeamCityParallelTestsEnabled = "TEAMCITY_PARALLEL_TESTS_ENABLED" in System.getenv()
     val isCodeQl: Boolean by lazy {
         // This logic is kept here instead of `codeql-analysis.init.gradle` because that file will hopefully be removed in the future.
         // Removing that file is waiting on the GitHub team fixing an issue in Autobuilder logic.

--- a/build-logic/lifecycle/src/main/kotlin/gradlebuild.teamcity-import-test-data.gradle.kts
+++ b/build-logic/lifecycle/src/main/kotlin/gradlebuild.teamcity-import-test-data.gradle.kts
@@ -13,19 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import org.gradle.api.provider.Provider
-import org.gradle.api.services.BuildService
-import org.gradle.api.services.BuildServiceParameters
-import org.gradle.api.tasks.testing.Test
-import org.gradle.build.event.BuildEventsListenerRegistry
+import gradlebuild.basics.BuildEnvironment.isTeamCityParallelTestsEnabled
+import gradlebuild.basics.repoRoot
 import org.gradle.kotlin.dsl.support.serviceOf
 import org.gradle.tooling.events.FinishEvent
 import org.gradle.tooling.events.OperationCompletionListener
 import org.gradle.tooling.events.task.TaskFinishEvent
 import org.gradle.tooling.events.task.TaskSuccessResult
-import org.gradle.work.DisableCachingByDefault
-import gradlebuild.basics.repoRoot
-import gradlebuild.basics.BuildEnvironment.isTeamCity
 
 /**
  * This is a workaround for https://youtrack.jetbrains.com/issue/TW-76894.
@@ -60,7 +54,7 @@ abstract class EmitTeamCityImportDataServiceMessageBuildService : BuildService<E
     }
 }
 
-if (isTeamCity) {
+if (isTeamCityParallelTestsEnabled) {
     val gradleRootDir = repoRoot().asFile.toPath()
     project.gradle.taskGraph.whenReady {
         val buildService: Provider<EmitTeamCityImportDataServiceMessageBuildService> = gradle.sharedServices.registerIfAbsent("emitTeamCityImportDataServiceMessageBuildService-$name", EmitTeamCityImportDataServiceMessageBuildService::class.java) {


### PR DESCRIPTION
Previously, to workaround https://youtrack.jetbrains.com/issue/TW-76894, we "replay" the build-cached test result XMLs.
This causes some confusions, let's replay the XMls only with Parallel Tests enabled.
