### PR TITLE
Bump version of Dokkatoo to 1.4.0

### DIFF
--- a/build-logic/build-platform/build.gradle.kts
+++ b/build-logic/build-platform/build.gradle.kts
@@ -58,7 +58,7 @@ dependencies {
         api("org.spockframework:spock-junit4:$spockVersion")
         api("org.asciidoctor:asciidoctorj:2.4.3")
         api("org.asciidoctor:asciidoctorj-pdf:1.5.4")
-        api("dev.adamko.dokkatoo:dokkatoo-plugin:1.3.0")
+        api("dev.adamko.dokkatoo:dokkatoo-plugin:1.4.0")
         api("org.jetbrains.dokka:dokka-core:1.8.10")
         api("com.beust:jcommander:1.78")
         api("org.codehaus.groovy:$groovyVersion")

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -766,9 +766,9 @@
             </sha256>
          </artifact>
       </component>
-      <component group="dev.adamko.dokkatoo" name="dokkatoo-plugin" version="1.3.0">
-         <artifact name="dokkatoo-plugin-1.3.0.jar">
-            <sha256 value="70ba2b912d823dd511be2ed6a033e86b0e62faef9f17d09eb5c50d96542a4254" origin="Verified" reason="Artifact is not signed"/>
+      <component group="dev.adamko.dokkatoo" name="dokkatoo-plugin" version="1.4.0">
+         <artifact name="dokkatoo-plugin-1.4.0.jar">
+            <sha256 value="6f04531f457902eae155e3132e602fa57dcd454d853cb99f7d09ee3e7a559a5a" origin="Verified" reason="Artifact is not signed"/>
          </artifact>
       </component>
       <component group="flot" name="flot" version="0.8.1">


### PR DESCRIPTION
Attempting to fix random failures like:

> A failure occurred while executing dev.adamko.dokkatoo.workers.DokkaGeneratorWorker
> /home/tcagent1/agent/work/f63322e10dd6b396/subprojects/docs/src/docs/kotlin/Module.md (No such file or directory)