### PR TITLE
Adjust TAPI cross-version test

### DIFF
--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r76/TestLauncherTestSpecCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r76/TestLauncherTestSpecCrossVersionSpec.groovy
@@ -92,40 +92,6 @@ class TestLauncherTestSpecCrossVersionSpec extends TestLauncherSpec {
         assertTestExecuted(className: 'example2.MyOtherTest2', methodName: 'baz', task: ':secondTest')
     }
 
-    @TargetGradleVersion(">=8.2")
-    def "hits configuration cache with test filters changed"() {
-        setup:
-
-        when:
-        launchTests { TestLauncher launcher ->
-            launcher.withArguments("--configuration-cache")
-            launcher.withTestsFor { TestSpecs specs ->
-                specs.forTaskPath(':secondTest').includePackage('example2')
-            }
-        }
-
-        then:
-        events.testClassesAndMethods.size() == 4
-        assertTestExecuted(className: 'example2.MyOtherTest', methodName: 'bar', task: ':secondTest')
-        assertTestExecuted(className: 'example2.MyOtherTest2', methodName: 'baz', task: ':secondTest')
-
-        when:
-        events.clear()
-        stdout.reset() // we are interested in the output of the second build only
-        launchTests { TestLauncher launcher ->
-            launcher.withArguments("--configuration-cache")
-            launcher.withTestsFor { TestSpecs specs ->
-                specs.forTaskPath(':secondTest').includeClass("example.MyTest")
-            }
-        }
-
-        then:
-        stdout.toString().contains("Reusing configuration cache.")
-        events.testClassesAndMethods.size() == 3
-        assertTestExecuted(className: 'example.MyTest', methodName: 'foo', task: ':secondTest')
-        assertTestExecuted(className: 'example.MyTest', methodName: 'foo2', task: ':secondTest')
-    }
-
     def "can select tests with pattern"() {
         when:
         launchTests { TestLauncher launcher ->

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r82/TestLauncherTestSpecCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r82/TestLauncherTestSpecCrossVersionSpec.groovy
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r82
+
+import org.gradle.integtests.tooling.TestLauncherSpec
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.tooling.TestLauncher
+import org.gradle.tooling.TestSpecs
+import spock.lang.Issue
+
+@ToolingApiVersion('>=7.6')
+@TargetGradleVersion(">=8.2")
+class TestLauncherTestSpecCrossVersionSpec extends TestLauncherSpec {
+
+    def setup() {
+        withFailingTest() // ensures that withTestsFor statements are not ignored
+    }
+
+    @TargetGradleVersion(">=7.6 <8.2")
+    @Issue("https://github.com/gradle/gradle/pull/25229")
+    def "TestLauncher configuration ignored when configuration cache entry is reused in older Gradle versions"() {
+        when:
+        launchTests { TestLauncher launcher ->
+            launcher.withArguments("--configuration-cache")
+            launcher.withTestsFor { TestSpecs specs ->
+                specs.forTaskPath(':secondTest').includePackage('example2')
+            }
+        }
+
+        then:
+        // 2 test class + 2 test method events
+        events.testClassesAndMethods.size() == 4
+        assertTestExecuted(className: 'example2.MyOtherTest', methodName: 'bar', task: ':secondTest')
+        assertTestExecuted(className: 'example2.MyOtherTest2', methodName: 'baz', task: ':secondTest')
+
+        when:
+        events.clear()
+        stdout.reset() // we are interested in the output of the second build only
+        launchTests { TestLauncher launcher ->
+            launcher.withArguments("--configuration-cache")
+            launcher.withTestsFor { TestSpecs specs ->
+                specs.forTaskPath(':secondTest').includeClass("example.MyTest")
+            }
+        }
+
+        then:
+        // TestLauncher configuration ignored: only tests from the configuration cache entry is executed
+        stdout.toString().contains("Reusing configuration cache.")
+        events.testClassesAndMethods.size() == 4 // 2 test class + 2 test method events
+        assertTestExecuted(className: 'example2.MyOtherTest', methodName: 'bar', task: ':secondTest')
+        assertTestExecuted(className: 'example2.MyOtherTest2', methodName: 'baz', task: ':secondTest')
+    }
+
+    def "hits configuration cache with test filters changed"() {
+        when:
+        launchTests { TestLauncher launcher ->
+            launcher.withArguments("--configuration-cache")
+            launcher.withTestsFor { TestSpecs specs ->
+                specs.forTaskPath(':secondTest').includePackage('example2')
+            }
+        }
+
+        then:
+        // 2 test class + 2 test method events
+        events.testClassesAndMethods.size() == 4
+        assertTestExecuted(className: 'example2.MyOtherTest', methodName: 'bar', task: ':secondTest')
+        assertTestExecuted(className: 'example2.MyOtherTest2', methodName: 'baz', task: ':secondTest')
+
+        when:
+        events.clear()
+        stdout.reset() // we are interested in the output of the second build only
+        launchTests { TestLauncher launcher ->
+            launcher.withArguments("--configuration-cache")
+            launcher.withTestsFor { TestSpecs specs ->
+                specs.forTaskPath(':secondTest').includeClass("example.MyTest")
+            }
+        }
+
+        then:
+        // 1 test class + 2 test method events
+        stdout.toString().contains("Reusing configuration cache.")
+        events.testClassesAndMethods.size() == 3
+        assertTestExecuted(className: 'example.MyTest', methodName: 'foo', task: ':secondTest')
+        assertTestExecuted(className: 'example.MyTest', methodName: 'foo2', task: ':secondTest')
+    }
+}


### PR DESCRIPTION
- Move Gradle 8.2 test to the r82 package
- Add test for old behavior
