### PR TITLE
Bump wrapper: remove next-gen build cache debug output from console

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.3-20230529221907+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.3-20230605222120+0000-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Introduces:
- https://github.com/gradle/gradle/pull/25281

As a result by default no debug messages from the next-gen build cache will appear. The can be enabled with `-Dorg.gradle.caching.debug=true`.