### PR TITLE
Inherit encoding from parent process in worker daemons on Linux

### DIFF
--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/SupportsNonAsciiPaths.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/SupportsNonAsciiPaths.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.test.fixtures.file;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to mark tests that does support non-ascii characters on the path of the test directory.
+ * <p>
+ * The future goal is to turn this into {@code @DoesNotSupportNonAsciiPaths} and force all integration tests
+ * to support non-ASCII paths, but we need to start small.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
+public @interface SupportsNonAsciiPaths {
+    String reason();
+}

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestNameTestDirectoryProvider.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestNameTestDirectoryProvider.java
@@ -24,12 +24,23 @@ import java.io.File;
  */
 public class TestNameTestDirectoryProvider extends AbstractTestDirectoryProvider {
     public TestNameTestDirectoryProvider(Class<?> klass) {
-        // NOTE: the space in the directory name is intentional
-        super(new TestFile(new File("build/tmp/test files")), klass);
+        super(new TestFile(new File("build/tmp/" + determineTestDirectoryName(klass))), klass);
     }
 
     public TestNameTestDirectoryProvider(TestFile root, Class<?> klass) {
         super(root, klass);
+    }
+
+    private static String determineTestDirectoryName(Class<?> klass) {
+        // NOTE: the space in the directory name is intentional to shake out problems with paths that contain spaces
+        // NOTE: and so is the "s with comma below" character (U+0219), to shake out problems with non-ASCII folder names
+        return supportsNonAsciiPaths(klass)
+            ? "teșt files"
+            : "test files";
+    }
+
+    private static boolean supportsNonAsciiPaths(Class<?> klass) {
+        return klass.isAnnotationPresent(SupportsNonAsciiPaths.class);
     }
 
     public static TestNameTestDirectoryProvider forFatDrive(Class<?> klass) {

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonEncodingIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonEncodingIntegrationTest.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.workers.internal
+
+import org.gradle.test.fixtures.file.SupportsNonAsciiPaths
+import spock.lang.Issue
+
+@SupportsNonAsciiPaths
+class WorkerDaemonEncodingIntegrationTest extends AbstractWorkerExecutorIntegrationTest {
+
+    @Issue("https://github.com/gradle/gradle/issues/25198")
+    def "worker daemon can read non-ascii path"() {
+        fixture.withWorkActionClassInBuildSrc()
+
+        buildFile << """
+            task runInDaemon(type: WorkerTask) {
+                isolationMode = 'processIsolation'
+                workActionClass = ${fixture.workActionThatCreatesFiles.name}.class
+            }
+        """
+
+        when:
+        succeeds("runInDaemon")
+
+        then:
+        assertWorkerExecuted("runInDaemon")
+    }
+}

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorCompositeBuildIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorCompositeBuildIntegrationTest.groovy
@@ -16,12 +16,9 @@
 
 package org.gradle.workers.internal
 
-import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.workers.fixtures.WorkerExecutorFixture
 import spock.lang.Issue
 
-class WorkerExecutorCompositeBuildIntegrationTest extends AbstractIntegrationSpec {
-    WorkerExecutorFixture fixture = new WorkerExecutorFixture(temporaryFolder)
+class WorkerExecutorCompositeBuildIntegrationTest extends AbstractWorkerExecutorIntegrationTest {
     def plugin = testDirectory.createDir("plugin")
     def lib = testDirectory.createDir("lib")
 

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParametersIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParametersIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.workers.internal
 
 import org.gradle.api.services.BuildServiceParameters
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.workers.fixtures.WorkerExecutorFixture
 import spock.lang.Ignore
 import spock.lang.Issue
 
@@ -27,8 +26,6 @@ import java.util.concurrent.atomic.AtomicInteger
 import static org.gradle.workers.fixtures.WorkerExecutorFixture.ISOLATION_MODES
 
 class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
-    WorkerExecutorFixture fixture = new WorkerExecutorFixture(temporaryFolder)
-
     def setup() {
         buildFile << """
             import org.gradle.workers.WorkerExecutor

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultProcessWorkerSpec.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultProcessWorkerSpec.java
@@ -25,7 +25,6 @@ import org.gradle.workers.ClassLoaderWorkerSpec;
 import org.gradle.workers.ProcessWorkerSpec;
 
 import javax.inject.Inject;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.regex.Pattern;
 
@@ -56,16 +55,9 @@ public class DefaultProcessWorkerSpec extends DefaultClassLoaderWorkerSpec imple
         if (!OperatingSystem.current().isUnix()) {
             return ImmutableMap.of();
         }
-        Map<String, Object> environment = forkOptions.getEnvironment();
-        Iterator<String> iterator = environment.keySet().iterator();
-        //noinspection Java8CollectionRemoveIf
-        while (iterator.hasNext()) {
-            String key = iterator.next();
-            if (!INHERITED_UNIX_ENVIRONMENT.matcher(key).matches()) {
-                iterator.remove();
-            }
-        }
-        return environment;
+        return forkOptions.getEnvironment().entrySet().stream()
+            .filter(entry -> INHERITED_UNIX_ENVIRONMENT.matcher(entry.getKey()).matches())
+            .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     @Override

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultProcessWorkerSpec.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultProcessWorkerSpec.java
@@ -16,23 +16,56 @@
 
 package org.gradle.workers.internal;
 
-import com.google.common.collect.Maps;
+import com.google.common.collect.ImmutableMap;
 import org.gradle.api.Action;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.internal.os.OperatingSystem;
 import org.gradle.process.JavaForkOptions;
 import org.gradle.workers.ClassLoaderWorkerSpec;
 import org.gradle.workers.ProcessWorkerSpec;
 
 import javax.inject.Inject;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.regex.Pattern;
 
 public class DefaultProcessWorkerSpec extends DefaultClassLoaderWorkerSpec implements ProcessWorkerSpec, ClassLoaderWorkerSpec {
+    /**
+     * Environment variables inherited automatically on Unix systems.
+     *
+     * See <a href="https://www.gnu.org/software/gettext/manual/html_node/Locale-Environment-Variables.html">Locale Environment Variables for gettext</a>
+     */
+    private static final Pattern INHERITED_UNIX_ENVIRONMENT = Pattern.compile("(LANG|LANGUAGE|LC_.*)");
+
     protected final JavaForkOptions forkOptions;
 
     @Inject
     public DefaultProcessWorkerSpec(JavaForkOptions forkOptions, ObjectFactory objectFactory) {
         super(objectFactory);
         this.forkOptions = forkOptions;
-        this.forkOptions.setEnvironment(Maps.newHashMap());
+        this.forkOptions.setEnvironment(sanitizeEnvironment(forkOptions));
+    }
+
+    /**
+     * Inherit as little as possible from the parent process' environment.
+     *
+     * On Unix systems we need to pass a few environment variables to make sure
+     * the file system is accessed with the right encoding.
+     */
+    private static Map<String, Object> sanitizeEnvironment(JavaForkOptions forkOptions) {
+        if (!OperatingSystem.current().isUnix()) {
+            return ImmutableMap.of();
+        }
+        Map<String, Object> environment = forkOptions.getEnvironment();
+        Iterator<String> iterator = environment.keySet().iterator();
+        //noinspection Java8CollectionRemoveIf
+        while (iterator.hasNext()) {
+            String key = iterator.next();
+            if (!INHERITED_UNIX_ENVIRONMENT.matcher(key).matches()) {
+                iterator.remove();
+            }
+        }
+        return environment;
     }
 
     @Override

--- a/subprojects/workers/src/testFixtures/groovy/org/gradle/workers/fixtures/WorkerExecutorFixture.groovy
+++ b/subprojects/workers/src/testFixtures/groovy/org/gradle/workers/fixtures/WorkerExecutorFixture.groovy
@@ -24,7 +24,7 @@ class WorkerExecutorFixture {
     def outputFileDir
     def outputFileDirPath
     def list = [ 1, 2, 3 ]
-    private final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
+    private final TestNameTestDirectoryProvider temporaryFolder
     final WorkParameterClass testParameterType
     final WorkActionClass workActionThatCreatesFiles
     final WorkActionClass workActionThatFails


### PR DESCRIPTION
The `LANG`, `LANGUAGE` and `LC_*` (including `LC_ALL`) environment variables are now passed to worker API daemon processes on Unix. This fixes a problem where on Linux worker daemons would try to access the file system with the default `ASCII` encoding.

We are passing as few parameters as possible, though, to avoid making worker processes unnecessarily incompatible.

There is also a `@SupportsNonAsciiPaths` annotation for integration tests that should work when they are executed with file paths containing non-ASCII characters. These tests are executed in the `teșt files` (notice the [U+0219](https://www.compart.com/en/unicode/U+0219) character) instead of the usual `test files` folder.

(The intention is to run most integration tests with such a non-ASCII path to shake out more bugs, and annotate the ones that _cannot_ parse non-ASCII paths with `@DoesNotSupportNonAsciiPaths`. But this is a next step.)

Fixes https://github.com/gradle/gradle/issues/25198