### PR TITLE
Add a compileAll job that runs with build cache NG remote and uses old cache

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/CompileAllBuildCacheNG.kt
+++ b/.teamcity/src/main/kotlin/configurations/CompileAllBuildCacheNG.kt
@@ -3,15 +3,22 @@ package configurations
 import model.CIBuildModel
 import model.Stage
 
-class CompileAllBuildCacheNG(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(stage = stage, failStage = false, init = {
-    id("${model.projectId}_CompileAllBuild_BuildCacheNG")
-    name = "Compile All BuildCacheNG"
-    description = "Compiles all production/test source code and warms up the build cache NG"
+class CompileAllBuildCacheNG(model: CIBuildModel, stage: Stage, oldCacheWithNgRemote: Boolean = false) : BaseGradleBuildType(stage = stage, failStage = false, init = {
+    if (oldCacheWithNgRemote) {
+        id("${model.projectId}_CompileAllBuild_NGRemote")
+        name = "Compile All With NG Remote"
+        description = "Compiles all production/test source code using old build cache but NG remote"
+    } else {
+        id("${model.projectId}_CompileAllBuild_BuildCacheNG")
+        name = "Compile All BuildCacheNG"
+        description = "Compiles all production/test source code and warms up the build cache NG"
+    }
 
+    val cacheNgEnabled = !oldCacheWithNgRemote
     applyDefaults(
         model,
         this,
-        "compileAllBuild -PignoreIncomingBuildReceipt=true -DdisableLocalCache=false -Dorg.gradle.unsafe.cache.ng=true",
+        "compileAllBuild -PignoreIncomingBuildReceipt=true -DdisableLocalCache=false -Dorg.gradle.unsafe.cache.ng=$cacheNgEnabled",
         extraParameters = "-Porg.gradle.java.installations.auto-download=false"
     )
 

--- a/.teamcity/src/main/kotlin/model/CIBuildModel.kt
+++ b/.teamcity/src/main/kotlin/model/CIBuildModel.kt
@@ -59,7 +59,7 @@ data class CIBuildModel(
         Stage(
             StageName.QUICK_FEEDBACK_LINUX_ONLY,
             specificBuilds = listOf(
-                SpecificBuild.CompileAll, SpecificBuild.SanityCheck, SpecificBuild.CompileAllBuildCacheNG
+                SpecificBuild.CompileAll, SpecificBuild.SanityCheck, SpecificBuild.CompileAllBuildCacheNG, SpecificBuild.CompileAllWithNGRemote
             ),
             functionalTests = listOf(
                 TestCoverage(1, TestType.quick, Os.LINUX, JvmCategory.MAX_VERSION, expectedBucketNumber = DEFAULT_LINUX_FUNCTIONAL_TEST_BUCKET_SIZE)
@@ -352,6 +352,11 @@ enum class SpecificBuild {
     CompileAllBuildCacheNG {
         override fun create(model: CIBuildModel, stage: Stage): BaseGradleBuildType {
             return CompileAllBuildCacheNG(model, stage)
+        }
+    },
+    CompileAllWithNGRemote {
+        override fun create(model: CIBuildModel, stage: Stage): BaseGradleBuildType {
+            return CompileAllBuildCacheNG(model, stage, oldCacheWithNgRemote = true)
         }
     },
     SanityCheck {


### PR DESCRIPTION
Tested on experimental branch:
https://builds.gradle.org/buildConfiguration/Gradle_Experimental_Check_Stage_QuickFeedbackLinuxOnly_Trigger/66829146?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true