### PR TITLE
deprecate Task.didWork

### DIFF
--- a/subprojects/build-profile/src/main/java/org/gradle/profile/TaskExecution.java
+++ b/subprojects/build-profile/src/main/java/org/gradle/profile/TaskExecution.java
@@ -40,6 +40,7 @@ public class TaskExecution extends ContinuousOperation {
         return path;
     }
 
+    @SuppressWarnings("deprecation")
     public String getStatus() {
         return state.getSkipped() ? state.getSkipMessage() : (state.getDidWork()) ? "" : NO_WORK_MESSAGE;
     }

--- a/subprojects/core-api/src/main/java/org/gradle/api/Task.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Task.java
@@ -392,7 +392,9 @@ public interface Task extends Comparable<Task>, ExtensionAware {
      * Sets whether the task actually did any work.  Most built-in tasks will set this automatically, but
      * it may be useful to manually indicate this for custom user tasks.
      * @param didWork indicates if the task did any work
+     * @deprecated marking a task as did no work during execution is deprecated. See https://github.com/gradle/gradle/issues/23460.
      */
+    @Deprecated
     void setDidWork(boolean didWork);
 
     /**
@@ -401,8 +403,10 @@ public interface Task extends Comparable<Task>, ExtensionAware {
      * task was run.</p>
      *
      * @return true if this task did any work
+     @deprecated marking a task as did no work during execution is deprecated. See https://github.com/gradle/gradle/issues/23460.
      */
     @Internal
+    @Deprecated
     boolean getDidWork();
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskState.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskState.java
@@ -52,7 +52,9 @@ public interface TaskState {
      * task was run.</p>
      *
      * @return true if this task has been executed and did any work.
+     * @deprecated marking a task as did no work during execution is deprecated. See https://github.com/gradle/gradle/issues/23460.
      */
+    @Deprecated
     boolean getDidWork();
 
     /**

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/outputorigin/ManualUpToDateOutputOriginIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/outputorigin/ManualUpToDateOutputOriginIntegrationTest.groovy
@@ -71,6 +71,7 @@ class ManualUpToDateOutputOriginIntegrationTest extends AbstractIntegrationSpec 
         buildFile << """
             write.value = "b"
         """
+        expectAbstractTaskSetDidWorkDeprecationWarnings(1)
         succeeds("write")
 
         then:
@@ -84,6 +85,41 @@ class ManualUpToDateOutputOriginIntegrationTest extends AbstractIntegrationSpec 
         then:
         skipped(":write")
         originBuildInvocationId(":write") == secondBuildId
+
+        when:
+        buildFile << """
+            tasks.register("printStatus") {
+                doLast {
+                    println tasks.write.didWork
+                }
+            }
+        """
+        expectAbstractTaskGetDidWorkDeprecationWarnings(1)
+
+        then:
+        succeeds("printStatus")
+    }
+
+    private void expectAbstractTaskGetDidWorkDeprecationWarnings(int repeated = 1) {
+        repeated.times {
+            executer.expectDocumentedDeprecationWarning(
+                "The AbstractTask.getDidWork() method has been deprecated. " +
+                    "This is scheduled to be removed in Gradle 9.0. " +
+                    "Consult the upgrading guide for further information: " +
+                    "https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_task_did_work"
+            )
+        }
+    }
+
+    private void expectAbstractTaskSetDidWorkDeprecationWarnings(int repeated = 1) {
+        repeated.times {
+            executer.expectDocumentedDeprecationWarning(
+                "The AbstractTask.setDidWork(boolean) method has been deprecated. " +
+                    "This is scheduled to be removed in Gradle 9.0. " +
+                    "Consult the upgrading guide for further information: " +
+                    "https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_task_did_work"
+            )
+        }
     }
 
 }

--- a/subprojects/core/src/main/java/org/gradle/api/DefaultTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/DefaultTask.java
@@ -105,11 +105,13 @@ public abstract class DefaultTask extends org.gradle.api.internal.AbstractTask i
     }
 
     @Override
+    @Deprecated
     public boolean getDidWork() {
         return super.getDidWork();
     }
 
     @Override
+    @Deprecated
     public void setDidWork(boolean didWork) {
         super.setDidWork(didWork);
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
@@ -429,12 +429,31 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
 
     @Internal
     @Override
+    @Deprecated
     public boolean getDidWork() {
+        DeprecationLogger.deprecateMethod(AbstractTask.class, "getDidWork()")
+            .willBeRemovedInGradle9()
+            .withUpgradeGuideSection(8, "deprecated_task_did_work")
+            .nagUser();
         return state.getDidWork();
     }
 
     @Override
+    @Deprecated
     public void setDidWork(boolean didWork) {
+        DeprecationLogger.deprecateMethod(AbstractTask.class, "setDidWork(boolean)")
+            .willBeRemovedInGradle9()
+            .withUpgradeGuideSection(8, "deprecated_task_did_work")
+            .nagUser();
+        state.setDidWork(didWork);
+    }
+
+    /**
+     * Intermediate method to setDidWork in internal code without having to
+     * SuppressWarnings("deprecation") each time. Will be removed together with `didWork`.
+     */
+    @SuppressWarnings("deprecation")
+    protected void intermediateSetDidWork(boolean didWork) {
         state.setDidWork(didWork);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskStateInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskStateInternal.java
@@ -35,10 +35,12 @@ public class TaskStateInternal implements TaskState {
     private String skipReasonMessage;
 
     @Override
+    @Deprecated
     public boolean getDidWork() {
         return didWork;
     }
 
+    @Deprecated
     public void setDidWork(boolean didWork) {
         this.didWork = didWork;
     }

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractCopyTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractCopyTask.java
@@ -151,7 +151,7 @@ public abstract class AbstractCopyTask extends ConventionTask implements CopySpe
         CopyActionExecuter copyActionExecuter = createCopyActionExecuter();
         CopyAction copyAction = createCopyAction();
         WorkResult didWork = copyActionExecuter.execute(rootSpec, copyAction);
-        setDidWork(didWork.getDidWork());
+        intermediateSetDidWork(didWork.getDidWork());
     }
 
     protected CopyActionExecuter createCopyActionExecuter() {

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/Delete.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/Delete.java
@@ -53,7 +53,7 @@ public abstract class Delete extends ConventionTask implements DeleteSpec {
         for (File path : paths) {
             didWork |= getDeleter().deleteRecursively(path, followSymlinks);
         }
-        setDidWork(didWork);
+        intermediateSetDidWork(didWork);
     }
 
     /**

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependencies/HtmlDependencyReportTask.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependencies/HtmlDependencyReportTask.java
@@ -150,7 +150,7 @@ public abstract class HtmlDependencyReportTask extends ConventionTask implements
     @TaskAction
     public void generate() {
         if (!reports.getHtml().getRequired().get()) {
-            setDidWork(false);
+            intermediateSetDidWork(false);
             return;
         }
 

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
@@ -89,7 +89,7 @@ The embedded Kotlin has been updated to link:https://github.com/JetBrains/kotlin
 [[deprecated_task_did_work]]
 ==== Deprecated Task.didWork
 
-The following methods on `Task` are deprecated
+The following methods on `Task` are deprecated:
 
 - link:{javadocPath}/org/gradle/api/Task.html#setDidWork-boolean-[setDidWork]
 - link:{javadocPath}/org/gradle/api/Task.html#getDidWork--[getDidWork]

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
@@ -98,7 +98,7 @@ For some tasks, `Task.getDidWork` returns false even if the task executed and th
 did not change (aka "up-to-date after-the-fact"). Although the
 task executed and took time, the outcome label of the task is `UP-TO-DATE`. 
 This output is unexpected.
-the future, and as a step in that direction, `Task.didWork` was deprecated. You can check if
+As part of ongoing remediation efforts, `Task.didWork` was deprecated. 
 the task was "up-to-date up front" by using
 `task.getState().getExecuted() && !task.getState().getSkipped()`.
 

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
@@ -84,6 +84,23 @@ Some builds may have worked around this by also putting the additional attribute
 
 The embedded Kotlin has been updated to link:https://github.com/JetBrains/kotlin/releases/tag/v1.8.21[Kotlin 1.8.21].
 
+=== Deprecations
+
+[[deprecated_task_did_work]]
+==== Deprecated Task.didWork
+
+The following methods on `Task` are deprecated
+
+- link:{javadocPath}/org/gradle/api/Task.html#setDidWork-boolean-[setDidWork]
+- link:{javadocPath}/org/gradle/api/Task.html#getDidWork--[getDidWork]
+
+For some tasks, `Task.getDidWork` returns false even if the task did execute but the output
+did not change (aka "up-to-date after-the-fact"). This is unexpected, because although the
+task was executed and took time, the output of the task is `UP-TO-DATE`. This will change in
+the future, and as a step in that direction, `Task.didWork` was deprecated. You can check if
+the task was "up-to-date up front" by using
+`task.getState().getExecuted() && !task.getState().getSkipped()`.
+
 [[changes_8.2]]
 == Upgrading from 8.1 and earlier
 

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
@@ -99,7 +99,7 @@ did not change (aka "up-to-date after-the-fact"). Although the
 task executed and took time, the outcome label of the task is `UP-TO-DATE`. 
 This output is unexpected.
 As part of ongoing remediation efforts, `Task.didWork` was deprecated. 
-the task was "up-to-date up front" by using
+You can check if a task is "up-to-date up front" by using
 `task.getState().getExecuted() && !task.getState().getSkipped()`.
 
 [[changes_8.2]]

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
@@ -95,7 +95,7 @@ The following methods on `Task` are deprecated:
 - link:{javadocPath}/org/gradle/api/Task.html#getDidWork--[getDidWork]
 
 For some tasks, `Task.getDidWork` returns false even if the task executed and the output(s)
-did not change (aka "up-to-date after-the-fact"). This is unexpected, because although the
+did not change (aka "up-to-date after-the-fact"). Although the
 task was executed and took time, the output of the task is `UP-TO-DATE`. This will change in
 the future, and as a step in that direction, `Task.didWork` was deprecated. You can check if
 the task was "up-to-date up front" by using

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
@@ -94,7 +94,7 @@ The following methods on `Task` are deprecated:
 - link:{javadocPath}/org/gradle/api/Task.html#setDidWork-boolean-[setDidWork]
 - link:{javadocPath}/org/gradle/api/Task.html#getDidWork--[getDidWork]
 
-For some tasks, `Task.getDidWork` returns false even if the task did execute but the output
+For some tasks, `Task.getDidWork` returns false even if the task executed and the output(s)
 did not change (aka "up-to-date after-the-fact"). This is unexpected, because although the
 task was executed and took time, the output of the task is `UP-TO-DATE`. This will change in
 the future, and as a step in that direction, `Task.didWork` was deprecated. You can check if

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
@@ -96,11 +96,11 @@ The following methods on `Task` are deprecated:
 
 For some tasks, `Task.getDidWork` returns false even if the task executed and the output(s)
 did not change (aka "up-to-date after-the-fact"). Although the
-task executed and took time, the outcome label of the task is `UP-TO-DATE`. 
+task executed and took time, the outcome label of the task is `UP-TO-DATE`.
 This output is unexpected.
-As part of ongoing remediation efforts, `Task.didWork` was deprecated. 
+As part of ongoing remediation efforts, `Task.didWork` was deprecated.
 You can check if a task is "up-to-date up front" by using
-`task.getState().getExecuted() && !task.getState().getSkipped()`.
+`task.getState().getSkipped()` instead.
 
 [[changes_8.2]]
 == Upgrading from 8.1 and earlier

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
@@ -96,7 +96,8 @@ The following methods on `Task` are deprecated:
 
 For some tasks, `Task.getDidWork` returns false even if the task executed and the output(s)
 did not change (aka "up-to-date after-the-fact"). Although the
-task was executed and took time, the output of the task is `UP-TO-DATE`. This will change in
+task executed and took time, the outcome label of the task is `UP-TO-DATE`. 
+This output is unexpected.
 the future, and as a step in that direction, `Task.didWork` was deprecated. You can check if
 the task was "up-to-date up front" by using
 `task.getState().getExecuted() && !task.getState().getSkipped()`.

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
@@ -134,7 +134,7 @@ public abstract class GroovyCompile extends AbstractCompile implements HasCompil
         GroovyJavaJointCompileSpec spec = createSpec();
         maybeDisableIncrementalCompilationAfterFailure(spec);
         WorkResult result = createCompiler(spec, inputChanges).execute(spec);
-        setDidWork(result.getDidWork());
+        intermediateSetDidWork(result.getDidWork());
     }
 
     private void maybeDisableIncrementalCompilationAfterFailure(GroovyJavaJointCompileSpec spec) {

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -218,7 +218,7 @@ public abstract class JavaCompile extends AbstractCompile implements HasCompileO
 
     private void performCompilation(JavaCompileSpec spec, Compiler<JavaCompileSpec> compiler) {
         WorkResult result = new CompileJavaBuildOperationReportingCompiler(this, compiler, getServices().get(BuildOperationExecutor.class)).execute(spec);
-        setDidWork(result.getDidWork());
+        intermediateSetDidWork(result.getDidWork());
     }
 
     @VisibleForTesting

--- a/subprojects/language-jvm/src/main/java/org/gradle/language/jvm/tasks/ProcessResources.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/language/jvm/tasks/ProcessResources.java
@@ -34,7 +34,7 @@ public abstract class ProcessResources extends Copy {
         boolean cleanedOutputs = StaleOutputCleaner.cleanOutputs(getDeleter(), getOutputs().getPreviousOutputFiles(), getDestinationDir());
         super.copy();
         if (cleanedOutputs) {
-            setDidWork(true);
+            intermediateSetDidWork(true);
         }
     }
 

--- a/subprojects/language-native/src/main/java/org/gradle/language/assembler/tasks/Assemble.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/assembler/tasks/Assemble.java
@@ -113,7 +113,7 @@ public abstract class Assemble extends DefaultTask {
         NativePlatformInternal nativePlatform = (NativePlatformInternal) targetPlatform.get();
         Compiler<AssembleSpec> compiler = nativeToolChain.select(nativePlatform).newCompiler(AssembleSpec.class);
         WorkResult result = BuildOperationLoggingCompilerDecorator.wrap(compiler).execute(spec);
-        setDidWork(result.getDidWork() || cleanedOutputs);
+        intermediateSetDidWork(result.getDidWork() || cleanedOutputs);
     }
 
     @InputFiles

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/AbstractNativeCompileTask.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/AbstractNativeCompileTask.java
@@ -139,7 +139,7 @@ public abstract class AbstractNativeCompileTask extends DefaultTask {
         NativeToolChainInternal nativeToolChain = (NativeToolChainInternal) toolChain.get();
         NativePlatformInternal nativePlatform = (NativePlatformInternal) targetPlatform.get();
         PlatformToolProvider platformToolProvider = nativeToolChain.select(nativePlatform);
-        setDidWork(doCompile(spec, platformToolProvider).getDidWork());
+        intermediateSetDidWork(doCompile(spec, platformToolProvider).getDidWork());
     }
 
     protected void configureSpec(NativeCompileSpec spec) {

--- a/subprojects/language-native/src/main/java/org/gradle/language/rc/tasks/WindowsResourceCompile.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/rc/tasks/WindowsResourceCompile.java
@@ -120,7 +120,7 @@ public abstract class WindowsResourceCompile extends DefaultTask {
         NativePlatformInternal nativePlatform = (NativePlatformInternal) targetPlatform.get();
         PlatformToolProvider platformToolProvider = nativeToolChain.select(nativePlatform);
         WorkResult result = doCompile(spec, platformToolProvider);
-        setDidWork(result.getDidWork());
+        intermediateSetDidWork(result.getDidWork());
     }
 
     private <T extends NativeCompileSpec> WorkResult doCompile(T spec, PlatformToolProvider platformToolProvider) {

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/SwiftCompile.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/SwiftCompile.java
@@ -309,7 +309,7 @@ public abstract class SwiftCompile extends DefaultTask {
         );
         Compiler<SwiftCompileSpec> loggingCompiler = BuildOperationLoggingCompilerDecorator.wrap(baseCompiler);
         WorkResult result = loggingCompiler.execute(spec);
-        setDidWork(result.getDidWork());
+        intermediateSetDidWork(result.getDidWork());
     }
 
     private SwiftCompileSpec createSpec(BuildOperationLogger operationLogger, boolean isIncremental, Collection<File> changedFiles, Collection<File> removedFiles, NativePlatformInternal targetPlatform) {

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/AbstractLinkTask.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/AbstractLinkTask.java
@@ -229,7 +229,7 @@ public abstract class AbstractLinkTask extends DefaultTask implements ObjectFile
         );
 
         if (getSource().isEmpty()) {
-            setDidWork(cleanedOutputs);
+            intermediateSetDidWork(cleanedOutputs);
             return;
         }
 
@@ -249,7 +249,7 @@ public abstract class AbstractLinkTask extends DefaultTask implements ObjectFile
         Compiler<LinkerSpec> compiler = createCompiler();
         compiler = BuildOperationLoggingCompilerDecorator.wrap(compiler);
         WorkResult result = compiler.execute(spec);
-        setDidWork(result.getDidWork() || cleanedOutputs);
+        intermediateSetDidWork(result.getDidWork() || cleanedOutputs);
     }
 
     @SuppressWarnings("unchecked")

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/CreateStaticLibrary.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/CreateStaticLibrary.java
@@ -110,7 +110,7 @@ public abstract class CreateStaticLibrary extends DefaultTask implements ObjectF
 
         Compiler<StaticLibraryArchiverSpec> compiler = createCompiler();
         WorkResult result = BuildOperationLoggingCompilerDecorator.wrap(compiler).execute(spec);
-        setDidWork(result.getDidWork());
+        intermediateSetDidWork(result.getDidWork());
     }
 
     private Compiler<StaticLibraryArchiverSpec> createCompiler() {

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/ExtractSymbols.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/ExtractSymbols.java
@@ -114,7 +114,7 @@ public abstract class ExtractSymbols extends DefaultTask {
         Compiler<SymbolExtractorSpec> symbolExtractor = createCompiler();
         symbolExtractor = BuildOperationLoggingCompilerDecorator.wrap(symbolExtractor);
         WorkResult result = symbolExtractor.execute(spec);
-        setDidWork(result.getDidWork());
+        intermediateSetDidWork(result.getDidWork());
     }
 
     private Compiler<SymbolExtractorSpec> createCompiler() {

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/StripSymbols.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/StripSymbols.java
@@ -115,7 +115,7 @@ public abstract class StripSymbols extends DefaultTask {
         Compiler<StripperSpec> symbolStripper = createCompiler();
         symbolStripper = BuildOperationLoggingCompilerDecorator.wrap(symbolStripper);
         WorkResult result = symbolStripper.execute(spec);
-        setDidWork(result.getDidWork());
+        intermediateSetDidWork(result.getDidWork());
     }
 
     private Compiler<StripperSpec> createCompiler() {

--- a/subprojects/reporting/src/main/java/org/gradle/api/reporting/GenerateBuildDashboard.java
+++ b/subprojects/reporting/src/main/java/org/gradle/api/reporting/GenerateBuildDashboard.java
@@ -190,7 +190,7 @@ public abstract class GenerateBuildDashboard extends DefaultTask implements Repo
             BuildDashboardGenerator generator = new BuildDashboardGenerator();
             generator.render(getEnabledInputReports(), reports.getHtml().getEntryPoint());
         } else {
-            setDidWork(false);
+            intermediateSetDidWork(false);
         }
     }
 

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/TestReport.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/TestReport.java
@@ -172,7 +172,7 @@ public abstract class TestReport extends DefaultTask {
                 testReport.generateReport(resultsProvider, getDestinationDirectory().get().getAsFile());
             } else {
                 getLogger().info("{} - no binary test results found in dirs: {}.", getPath(), getTestResults().getFiles());
-                setDidWork(false);
+                intermediateSetDidWork(false);
             }
         } finally {
             stoppable(resultsProvider).stop();


### PR DESCRIPTION
This commit only deprecates Task.didWork and TaskState.didWork. Internally the current behavior is unchanged (#22120 will change that).

<!--- The issue this PR addresses -->
Fixes #23460

### Context
The definition of when a task "did work" is a bit confusing, and is not very useful. Let's deprecate Task.didWork. See reasoning in https://github.com/gradle/gradle/issues/21856.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
