### PR TITLE
Restore compatibility for reportsDir on java plugin convention

### DIFF
--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaPluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaPluginIntegrationTest.groovy
@@ -534,4 +534,27 @@ Artifacts
         then:
         result.assertTasksExecuted(":compileJava", ":bar")
     }
+
+    def "accessing reportsDir convention from the java plugin convention is deprecated"() {
+        given:
+        buildScript("""
+            plugins { id 'java' }
+            println(reportsDir)
+        """)
+
+        expect:
+        executer.expectDocumentedDeprecationWarning(
+            "The org.gradle.api.plugins.JavaPluginConvention type has been deprecated. " +
+                "This is scheduled to be removed in Gradle 9.0. " +
+                "Consult the upgrading guide for further information: " +
+                "https://docs.gradle.org/current/userguide/upgrading_version_8.html#java_convention_deprecation"
+        )
+        executer.expectDocumentedDeprecationWarning(
+            "The org.gradle.api.plugins.Convention type has been deprecated. " +
+                "This is scheduled to be removed in Gradle 9.0. " +
+                "Consult the upgrading guide for further information: " +
+                "https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_access_to_conventions"
+        )
+        succeeds('help')
+    }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/NaggingJavaPluginConvention.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/NaggingJavaPluginConvention.java
@@ -29,9 +29,9 @@ import java.io.File;
 
 @org.gradle.api.NonNullApi
 public class NaggingJavaPluginConvention extends JavaPluginConvention {
-    private final JavaPluginConvention delegate;
+    private final DefaultJavaPluginConvention delegate;
 
-    public NaggingJavaPluginConvention(JavaPluginConvention delegate) {
+    public NaggingJavaPluginConvention(DefaultJavaPluginConvention delegate) {
         this.delegate = delegate;
     }
 
@@ -171,6 +171,11 @@ public class NaggingJavaPluginConvention extends JavaPluginConvention {
     public boolean getAutoTargetJvmDisabled() {
         logDeprecation();
         return delegate.getAutoTargetJvmDisabled();
+    }
+
+    File getReportsDir() {
+        logDeprecation();
+        return delegate.getReportsDir();
     }
 
     private static void logDeprecation() {


### PR DESCRIPTION
https://github.com/gradle/gradle/blob/eb4ff204762719a09b5dbdc8beb0e1b7311c9496/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginConvention.java#L169

was kept for backwards compatibility but removed in 8.2 with the introduction of [NaggingJavaPluginConvention](https://github.com/gradle/gradle/blob/eb4ff204762719a09b5dbdc8beb0e1b7311c9496/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/NaggingJavaPluginConvention.java).

Documentation was still referring to it in Gradle 8.1 Groovy snippets:
https://docs.gradle.org/8.1/userguide/java_testing.html#test_reporting
