### PR TITLE
Split multiplatform tests into separate class

### DIFF
--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractKotlinPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractKotlinPluginSmokeTest.groovy
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.smoketests
+
+import org.gradle.api.JavaVersion
+import org.gradle.api.internal.DocumentationRegistry
+import org.gradle.internal.reflect.validation.ValidationMessageChecker
+import org.gradle.util.GradleVersion
+import org.gradle.util.internal.VersionNumber
+
+import static org.gradle.api.internal.DocumentationRegistry.RECOMMENDATION
+
+abstract class AbstractKotlinPluginSmokeTest extends AbstractPluginValidatingSmokeTest implements ValidationMessageChecker {
+    protected static class KotlinDeprecations extends BaseDeprecations implements WithKotlinDeprecations {
+        public static final DocumentationRegistry DOC_REGISTRY = new DocumentationRegistry()
+
+        private static final String ARCHIVE_NAME_DEPRECATION = "The AbstractArchiveTask.archiveName property has been deprecated. " +
+            "This is scheduled to be removed in Gradle 8.0. Please use the archiveFileName property instead. " +
+            String.format(RECOMMENDATION, "information", DOC_REGISTRY.getDslRefForProperty("org.gradle.api.tasks.bundling.AbstractArchiveTask", "archiveName"))
+
+        KotlinDeprecations(SmokeTestGradleRunner runner) {
+            super(runner)
+        }
+
+        void expectKotlinArchiveNameDeprecation(String kotlinPluginVersion) {
+            VersionNumber kotlinVersionNumber = VersionNumber.parse(kotlinPluginVersion)
+            runner.expectLegacyDeprecationWarningIf(kotlinVersionNumber.minor == 3, ARCHIVE_NAME_DEPRECATION)
+        }
+
+        void expectKotlin2JsPluginDeprecation(String version) {
+            VersionNumber versionNumber = VersionNumber.parse(version)
+            runner.expectLegacyDeprecationWarningIf(versionNumber >= VersionNumber.parse('1.4.0'),
+                "The `kotlin2js` Gradle plugin has been deprecated."
+            )
+        }
+
+        void expectKotlinParallelTasksDeprecation(String version) {
+            VersionNumber versionNumber = VersionNumber.parse(version)
+            runner.expectLegacyDeprecationWarningIf(
+                versionNumber >= VersionNumber.parse('1.5.20') && versionNumber <= VersionNumber.parse('1.6.10'),
+                "Project property 'kotlin.parallel.tasks.in.project' is deprecated."
+            )
+        }
+
+        void expectAbstractCompileDestinationDirDeprecation(String version) {
+            VersionNumber versionNumber = VersionNumber.parse(version)
+            runner.expectLegacyDeprecationWarningIf(
+                versionNumber <= VersionNumber.parse("1.6.21"),
+                "The AbstractCompile.destinationDir property has been deprecated. " +
+                    "This is scheduled to be removed in Gradle 9.0. " +
+                    "Please use the destinationDirectory property instead. " +
+                    "Consult the upgrading guide for further information: ${DOC_REGISTRY.getDocumentationFor("upgrading_version_7", "compile_task_wiring")}"
+            )
+        }
+
+        void expectOrgGradleUtilWrapUtilDeprecation(String version) {
+            VersionNumber versionNumber = VersionNumber.parse(version)
+            runner.expectLegacyDeprecationWarningIf(
+                versionNumber < VersionNumber.parse("1.7.20"),
+                "The org.gradle.util.WrapUtil type has been deprecated. " +
+                    "This is scheduled to be removed in Gradle 9.0. " +
+                    "Consult the upgrading guide for further information: " +
+                    "${DOC_REGISTRY.getDocumentationFor("upgrading_version_7", "org_gradle_util_reports_deprecations")}"
+            )
+        }
+
+        void expectTestReportReportOnDeprecation(String version) {
+            VersionNumber versionNumber = VersionNumber.parse(version)
+            runner.expectLegacyDeprecationWarningIf(
+                versionNumber.baseVersion < VersionNumber.parse("1.8.20"),
+                "The TestReport.reportOn(Object...) method has been deprecated. " +
+                    "This is scheduled to be removed in Gradle 9.0. " +
+                    "Please use the testResults method instead. " +
+                    String.format(RECOMMENDATION,"information",  DOC_REGISTRY.getDslRefForProperty("org.gradle.api.tasks.testing.TestReport", "testResults"))
+            )
+        }
+
+        void expectTestReportDestinationDirOnDeprecation(String version) {
+            VersionNumber versionNumber = VersionNumber.parse(version)
+            runner.expectLegacyDeprecationWarningIf(
+                versionNumber.baseVersion < VersionNumber.parse("1.8.20"),
+                "The TestReport.destinationDir property has been deprecated. " +
+                    "This is scheduled to be removed in Gradle 9.0. " +
+                    "Please use the destinationDirectory property instead. " +
+                    String.format(RECOMMENDATION, "information", DOC_REGISTRY.getDslRefForProperty("org.gradle.api.tasks.testing.TestReport", "destinationDir"))
+            )
+        }
+
+        void expectProjectConventionDeprecation(String kotlinVersion) {
+            VersionNumber kotlinVersionNumber = VersionNumber.parse(kotlinVersion)
+            runner.expectLegacyDeprecationWarningIf(
+                kotlinVersionNumber < VersionNumber.parse("1.7.22"),
+                PROJECT_CONVENTION_DEPRECATION
+            )
+        }
+
+        void expectBasePluginConventionDeprecation(String kotlinVersion) {
+            VersionNumber kotlinVersionNumber = VersionNumber.parse(kotlinVersion)
+            runner.expectLegacyDeprecationWarningIf(
+                kotlinVersionNumber < VersionNumber.parse("1.7.0"),
+                BASE_PLUGIN_CONVENTION_DEPRECATION
+            )
+        }
+
+        void expectBasePluginConventionDeprecation(String kotlinVersion, String agpVersion) {
+            VersionNumber kotlinVersionNumber = VersionNumber.parse(kotlinVersion)
+            VersionNumber agpVersionNumber = VersionNumber.parse(agpVersion)
+            runner.expectLegacyDeprecationWarningIf(
+                agpVersionNumber < VersionNumber.parse("7.4.0") || kotlinVersionNumber < VersionNumber.parse("1.7.0"),
+                BASE_PLUGIN_CONVENTION_DEPRECATION
+            )
+        }
+
+        void expectJavaPluginConventionDeprecation(String kotlinVersion) {
+            VersionNumber kotlinVersionNumber = VersionNumber.parse(kotlinVersion)
+            runner.expectLegacyDeprecationWarningIf(
+                kotlinVersionNumber < VersionNumber.parse("1.7.22"),
+                JAVA_PLUGIN_CONVENTION_DEPRECATION
+            )
+        }
+
+        void expectProjectConventionDeprecation(String kotlinVersion, String agpVersion) {
+            VersionNumber kotlinVersionNumber = VersionNumber.parse(kotlinVersion)
+            VersionNumber agpVersionNumber = VersionNumber.parse(agpVersion)
+            runner.expectLegacyDeprecationWarningIf(
+                agpVersionNumber < VersionNumber.parse("7.4.0") || (agpVersionNumber >= VersionNumber.parse("7.4.0") && kotlinVersionNumber < VersionNumber.parse("1.7.0")),
+                PROJECT_CONVENTION_DEPRECATION
+            )
+        }
+
+        void expectConventionTypeDeprecation(String kotlinVersion) {
+            VersionNumber kotlinVersionNumber = VersionNumber.parse(kotlinVersion)
+            runner.expectLegacyDeprecationWarningIf(
+                kotlinVersionNumber < VersionNumber.parse("1.7.22"),
+                CONVENTION_TYPE_DEPRECATION
+            )
+        }
+
+        void expectConventionTypeDeprecation(String kotlinVersion, String agpVersion) {
+            VersionNumber kotlinVersionNumber = VersionNumber.parse(kotlinVersion)
+            VersionNumber agpVersionNumber = VersionNumber.parse(agpVersion)
+            runner.expectLegacyDeprecationWarningIf(
+                agpVersionNumber < VersionNumber.parse("7.4.0") || (agpVersionNumber >= VersionNumber.parse("7.4.0") && kotlinVersionNumber < VersionNumber.parse("1.7.22")),
+                CONVENTION_TYPE_DEPRECATION
+            )
+        }
+
+        void expectConfigureUtilDeprecation(String version) {
+            VersionNumber versionNumber = VersionNumber.parse(version)
+            runner.expectLegacyDeprecationWarningIf(
+                versionNumber < VersionNumber.parse("1.7.22"),
+                "The org.gradle.util.ConfigureUtil type has been deprecated. " +
+                    "This is scheduled to be removed in Gradle 9.0. " +
+                    "Consult the upgrading guide for further information: " +
+                    DOC_REGISTRY.getDocumentationFor("upgrading_version_8", "org_gradle_util_reports_deprecations")
+            )
+        }
+
+        void expectBuildIdentifierNameDeprecation(String kotlinVersion) {
+            VersionNumber versionNumber = VersionNumber.parse(kotlinVersion)
+            runner.expectDeprecationWarningIf(versionNumber >= VersionNumber.parse("1.8.20"),
+                "The BuildIdentifier.getName() method has been deprecated. " +
+                    "This is scheduled to be removed in Gradle 9.0. " +
+                    "Use getBuildPath() to get a unique identifier for the build. " +
+                    "Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation",
+                "https://youtrack.jetbrains.com/issue/KT-58157"
+            )
+        }
+    }
+
+    protected SmokeTestGradleRunner runner(boolean workers, VersionNumber kotlinVersion, String... tasks) {
+        return runnerFor(this, workers, kotlinVersion, tasks)
+    }
+
+    protected SmokeTestGradleRunner runnerFor(AbstractSmokeTest smokeTest, boolean workers, String... tasks) {
+        smokeTest.runner(tasks + ["--parallel", "-Pkotlin.parallel.tasks.in.project=$workers"] as String[])
+            .forwardOutput()
+    }
+
+    protected SmokeTestGradleRunner runnerFor(AbstractSmokeTest smokeTest, boolean workers, VersionNumber kotlinVersion, String... tasks) {
+        if (kotlinVersion.getMinor() < 5 && JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16)) {
+            String kotlinOpts = "-Dkotlin.daemon.jvm.options=--add-exports=java.base/sun.nio.ch=ALL-UNNAMED,--add-opens=java.base/java.util=ALL-UNNAMED"
+            return runnerFor(smokeTest, workers, tasks + [kotlinOpts] as String[])
+        }
+        runnerFor(smokeTest, workers, tasks)
+    }
+}

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinMultiplatformPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinMultiplatformPluginSmokeTest.groovy
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.smoketests
+
+import org.gradle.api.internal.DocumentationRegistry
+import org.gradle.util.internal.VersionNumber
+import spock.lang.Issue
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+class KotlinMultiplatformPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
+
+    /**
+     * This tests that the usage of deprecated methods in {@code org.gradle.api.tasks.testing.TestReport} task
+     * is okay, and ensures the methods are not removed until the versions of the kotlin plugin that uses them
+     * is no longer tested.
+     *
+     * See usage here: https://cs.android.com/android-studio/kotlin/+/master:libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/testing/internal/KotlinTestReport.kt;l=136?q=KotlinTestReport.kt:136&ss=android-studio
+     */
+    @Issue("https://github.com/gradle/gradle/issues/22246")
+    def 'ensure kotlin multiplatform allTests aggregation task can be created (kotlin=#kotlinVersion)'() {
+        given:
+        buildFile << """
+            plugins {
+                id 'org.jetbrains.kotlin.multiplatform' version '$kotlinVersion'
+            }
+
+            ${mavenCentralRepository()}
+
+            kotlin {
+                jvm()
+            }
+        """
+
+        when:
+        def result = runner(false, VersionNumber.parse(kotlinVersion), ':tasks')
+                .deprecations(KotlinDeprecations) {
+                    expectOrgGradleUtilWrapUtilDeprecation(kotlinVersion)
+                    expectTestReportReportOnDeprecation(kotlinVersion)
+                    expectTestReportDestinationDirOnDeprecation(kotlinVersion)
+                    expectProjectConventionDeprecation(kotlinVersion)
+                    expectConventionTypeDeprecation(kotlinVersion)
+                    expectJavaPluginConventionDeprecation(kotlinVersion)
+                    expectBuildIdentifierNameDeprecation(kotlinVersion)
+                }
+                .build()
+
+        then:
+        result.task(':tasks').outcome == SUCCESS
+        result.output.contains('allTests - Runs the tests for all targets and create aggregated report')
+
+        where:
+        kotlinVersion << TestedVersions.kotlin.versions
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/22952")
+    def "kotlin project can consume kotlin multiplatform java project"() {
+        given:
+        buildFile << """
+            plugins {
+                id 'org.jetbrains.kotlin.jvm' version '$kotlinVersion'
+            }
+
+            ${mavenCentralRepository()}
+
+            dependencies {
+                implementation project(":other")
+            }
+
+            task resolve {
+                def files = configurations.compileClasspath
+                doLast {
+                    println("Files: " + files.files)
+                }
+            }
+        """
+
+        settingsFile << "include 'other'"
+        file("other/build.gradle") << """
+            plugins {
+                id 'org.jetbrains.kotlin.multiplatform'
+            }
+
+            ${mavenCentralRepository()}
+
+            kotlin {
+                jvm {
+                    withJava()
+                }
+            }
+        """
+
+        when:
+        def versionNumber = VersionNumber.parse(kotlinVersion)
+        def testRunner = runner(false, versionNumber, ':resolve', '--stacktrace')
+
+        if (versionNumber < VersionNumber.parse('1.7.22')) {
+            testRunner.expectLegacyDeprecationWarning("The AbstractCompile.destinationDir property has been deprecated. This is scheduled to be removed in Gradle 9.0. " +
+                    "Please use the destinationDirectory property instead. " +
+                    "Consult the upgrading guide for further information: ${new DocumentationRegistry().getDocumentationFor("upgrading_version_7", "compile_task_wiring")}")
+        }
+
+        testRunner.deprecations(KotlinDeprecations) {
+            expectOrgGradleUtilWrapUtilDeprecation(kotlinVersion)
+            2.times {
+                expectProjectConventionDeprecation(kotlinVersion)
+                expectConventionTypeDeprecation(kotlinVersion)
+                expectJavaPluginConventionDeprecation(kotlinVersion)
+            }
+            expectConfigureUtilDeprecation(kotlinVersion)
+            expectBuildIdentifierNameDeprecation(kotlinVersion)
+        }
+
+        def result = testRunner.build()
+
+        then:
+        result.output.contains("other-jvm.jar")
+
+        where:
+        // withJava is incompatible pre 1.6.20 since it attempts to set the `archiveName` convention property on the Jar task.
+        kotlinVersion << TestedVersions.kotlin.versions.findAll { VersionNumber.parse(it) > VersionNumber.parse("1.6.10") }
+    }
+
+    @Override
+    Map<String, Versions> getPluginsToValidate() {
+        [
+                'org.jetbrains.kotlin.multiplatform': TestedVersions.kotlin
+        ]
+    }
+
+    @Override
+    void configureValidation(String testedPluginId, String version) {
+        validatePlugins {
+            alwaysPasses()
+            if (testedPluginId == 'org.jetbrains.kotlin.multiplatform') {
+                buildFile << """
+                    kotlin {
+                        jvm()
+                        js(IR) { browser() }
+                    }
+                """
+            }
+            settingsFile << """
+                pluginManagement {
+                    repositories {
+                        gradlePluginPortal()
+                        google()
+                    }
+                }
+            """
+        }
+    }
+}

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
@@ -16,21 +16,16 @@
 
 package org.gradle.smoketests
 
-import org.gradle.api.JavaVersion
-import org.gradle.api.internal.DocumentationRegistry
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
-import org.gradle.internal.reflect.validation.ValidationMessageChecker
-import org.gradle.util.GradleVersion
-import org.gradle.util.internal.VersionNumber
-import spock.lang.Issue
 
-import static org.gradle.api.internal.DocumentationRegistry.RECOMMENDATION
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.gradle.util.internal.VersionNumber
+
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 import static org.gradle.testkit.runner.TaskOutcome.UP_TO_DATE
 import static org.junit.Assume.assumeFalse
 import static org.junit.Assume.assumeTrue
 
-class KotlinPluginSmokeTest extends AbstractPluginValidatingSmokeTest implements ValidationMessageChecker {
+class KotlinPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
 
     def 'kotlin jvm (kotlin=#version, workers=#workers)'() {
         given:
@@ -225,127 +220,12 @@ class KotlinPluginSmokeTest extends AbstractPluginValidatingSmokeTest implements
         kotlinVersion << TestedVersions.kotlin.versions
     }
 
-    /**
-     * This tests that the usage of deprecated methods in {@code org.gradle.api.tasks.testing.TestReport} task
-     * is okay, and ensures the methods are not removed until the versions of the kotlin plugin that uses them
-     * is no longer tested.
-     *
-     * See usage here: https://cs.android.com/android-studio/kotlin/+/master:libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/testing/internal/KotlinTestReport.kt;l=136?q=KotlinTestReport.kt:136&ss=android-studio
-     */
-    @Issue("https://github.com/gradle/gradle/issues/22246")
-    def 'ensure kotlin multiplatform allTests aggregation task can be created (kotlin=#kotlinVersion)'() {
-        given:
-        buildFile << """
-            plugins {
-                id 'org.jetbrains.kotlin.multiplatform' version '$kotlinVersion'
-            }
-
-            ${mavenCentralRepository()}
-
-            kotlin {
-                jvm()
-            }
-        """
-
-        when:
-        def result = runner(false, VersionNumber.parse(kotlinVersion), ':tasks')
-            .deprecations(KotlinDeprecations) {
-                expectOrgGradleUtilWrapUtilDeprecation(kotlinVersion)
-                expectTestReportReportOnDeprecation(kotlinVersion)
-                expectTestReportDestinationDirOnDeprecation(kotlinVersion)
-                expectProjectConventionDeprecation(kotlinVersion)
-                expectConventionTypeDeprecation(kotlinVersion)
-                expectJavaPluginConventionDeprecation(kotlinVersion)
-                expectBuildIdentifierNameDeprecation(kotlinVersion)
-            }
-            .build()
-
-        then:
-        result.task(':tasks').outcome == SUCCESS
-        result.output.contains('allTests - Runs the tests for all targets and create aggregated report')
-
-        where:
-        kotlinVersion << TestedVersions.kotlin.versions
-    }
-
-    @Issue("https://github.com/gradle/gradle/issues/22952")
-    def "kotlin project can consume kotlin multiplatform java project"() {
-        given:
-        buildFile << """
-            plugins {
-                id 'org.jetbrains.kotlin.jvm' version '$kotlinVersion'
-            }
-
-            ${mavenCentralRepository()}
-
-            dependencies {
-                implementation project(":other")
-            }
-
-            task resolve {
-                def files = configurations.compileClasspath
-                doLast {
-                    println("Files: " + files.files)
-                }
-            }
-        """
-
-        settingsFile << "include 'other'"
-        file("other/build.gradle") << """
-            plugins {
-                id 'org.jetbrains.kotlin.multiplatform'
-            }
-
-            ${mavenCentralRepository()}
-
-            kotlin {
-                jvm {
-                    withJava()
-                }
-            }
-        """
-
-        when:
-        def versionNumber = VersionNumber.parse(kotlinVersion)
-        def testRunner = runner(false, versionNumber, ':resolve', '--stacktrace')
-
-        if (versionNumber < VersionNumber.parse('1.7.22')) {
-            testRunner.expectLegacyDeprecationWarning("The AbstractCompile.destinationDir property has been deprecated. This is scheduled to be removed in Gradle 9.0. " +
-                "Please use the destinationDirectory property instead. " +
-                "Consult the upgrading guide for further information: ${new DocumentationRegistry().getDocumentationFor("upgrading_version_7", "compile_task_wiring")}")
-        }
-
-        testRunner.deprecations(KotlinDeprecations) {
-            expectOrgGradleUtilWrapUtilDeprecation(kotlinVersion)
-            2.times {
-                expectProjectConventionDeprecation(kotlinVersion)
-                expectConventionTypeDeprecation(kotlinVersion)
-                expectJavaPluginConventionDeprecation(kotlinVersion)
-            }
-            expectConfigureUtilDeprecation(kotlinVersion)
-            expectBuildIdentifierNameDeprecation(kotlinVersion)
-        }
-
-        def result = testRunner.build()
-
-        then:
-        result.output.contains("other-jvm.jar")
-
-        where:
-        // withJava is incompatible pre 1.6.20 since it attempts to set the `archiveName` convention property on the Jar task.
-        kotlinVersion << TestedVersions.kotlin.versions.findAll { VersionNumber.parse(it) > VersionNumber.parse("1.6.10") }
-    }
-
-    private SmokeTestGradleRunner runner(boolean workers, VersionNumber kotlinVersion, String... tasks) {
-        return runnerFor(this, workers, kotlinVersion, tasks)
-    }
 
     @Override
     Map<String, Versions> getPluginsToValidate() {
         [
             'org.jetbrains.kotlin.jvm': TestedVersions.kotlin,
             'org.jetbrains.kotlin.js': TestedVersions.kotlin,
-            'org.jetbrains.kotlin.multiplatform': TestedVersions.kotlin,
             'org.jetbrains.kotlin.android': TestedVersions.kotlin,
             'org.jetbrains.kotlin.android.extensions': TestedVersions.kotlin,
             'org.jetbrains.kotlin.kapt': TestedVersions.kotlin,
@@ -389,14 +269,6 @@ class KotlinPluginSmokeTest extends AbstractPluginValidatingSmokeTest implements
                     kotlin { js(IR) { browser() } }
                 """
             }
-            if (testedPluginId == 'org.jetbrains.kotlin.multiplatform') {
-                buildFile << """
-                    kotlin {
-                        jvm()
-                        js(IR) { browser() }
-                    }
-                """
-            }
             settingsFile << """
                 pluginManagement {
                     repositories {
@@ -408,177 +280,7 @@ class KotlinPluginSmokeTest extends AbstractPluginValidatingSmokeTest implements
         }
     }
 
-    static SmokeTestGradleRunner runnerFor(AbstractSmokeTest smokeTest, boolean workers, String... tasks) {
-        smokeTest.runner(tasks + ["--parallel", "-Pkotlin.parallel.tasks.in.project=$workers"] as String[])
-            .forwardOutput()
-    }
-
-    static SmokeTestGradleRunner runnerFor(AbstractSmokeTest smokeTest, boolean workers, VersionNumber kotlinVersion, String... tasks) {
-        if (kotlinVersion.getMinor() < 5 && JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16)) {
-            String kotlinOpts = "-Dkotlin.daemon.jvm.options=--add-exports=java.base/sun.nio.ch=ALL-UNNAMED,--add-opens=java.base/java.util=ALL-UNNAMED"
-            return runnerFor(smokeTest, workers, tasks + [kotlinOpts] as String[])
-        }
-        runnerFor(smokeTest, workers, tasks)
-    }
-
     private static boolean isAndroidKotlinPlugin(String pluginId) {
         return pluginId.contains('android')
-    }
-
-    static class KotlinDeprecations extends BaseDeprecations implements WithKotlinDeprecations {
-        public static final DocumentationRegistry DOC_REGISTRY = new DocumentationRegistry()
-
-        private static final String ARCHIVE_NAME_DEPRECATION = "The AbstractArchiveTask.archiveName property has been deprecated. " +
-            "This is scheduled to be removed in Gradle 8.0. Please use the archiveFileName property instead. " +
-            String.format(RECOMMENDATION, "information", DOC_REGISTRY.getDslRefForProperty("org.gradle.api.tasks.bundling.AbstractArchiveTask", "archiveName"))
-
-        KotlinDeprecations(SmokeTestGradleRunner runner) {
-            super(runner)
-        }
-
-        void expectKotlinArchiveNameDeprecation(String kotlinPluginVersion) {
-            VersionNumber kotlinVersionNumber = VersionNumber.parse(kotlinPluginVersion)
-            runner.expectLegacyDeprecationWarningIf(kotlinVersionNumber.minor == 3, ARCHIVE_NAME_DEPRECATION)
-        }
-
-        void expectKotlin2JsPluginDeprecation(String version) {
-            VersionNumber versionNumber = VersionNumber.parse(version)
-            runner.expectLegacyDeprecationWarningIf(versionNumber >= VersionNumber.parse('1.4.0'),
-                "The `kotlin2js` Gradle plugin has been deprecated."
-            )
-        }
-
-        void expectKotlinParallelTasksDeprecation(String version) {
-            VersionNumber versionNumber = VersionNumber.parse(version)
-            runner.expectLegacyDeprecationWarningIf(
-                versionNumber >= VersionNumber.parse('1.5.20') && versionNumber <= VersionNumber.parse('1.6.10'),
-                "Project property 'kotlin.parallel.tasks.in.project' is deprecated."
-            )
-        }
-
-        void expectAbstractCompileDestinationDirDeprecation(String version) {
-            VersionNumber versionNumber = VersionNumber.parse(version)
-            runner.expectLegacyDeprecationWarningIf(
-                versionNumber <= VersionNumber.parse("1.6.21"),
-                "The AbstractCompile.destinationDir property has been deprecated. " +
-                    "This is scheduled to be removed in Gradle 9.0. " +
-                    "Please use the destinationDirectory property instead. " +
-                    "Consult the upgrading guide for further information: ${DOC_REGISTRY.getDocumentationFor("upgrading_version_7", "compile_task_wiring")}"
-            )
-        }
-
-        void expectOrgGradleUtilWrapUtilDeprecation(String version) {
-            VersionNumber versionNumber = VersionNumber.parse(version)
-            runner.expectLegacyDeprecationWarningIf(
-                versionNumber < VersionNumber.parse("1.7.20"),
-                "The org.gradle.util.WrapUtil type has been deprecated. " +
-                    "This is scheduled to be removed in Gradle 9.0. " +
-                    "Consult the upgrading guide for further information: " +
-                    "${DOC_REGISTRY.getDocumentationFor("upgrading_version_7", "org_gradle_util_reports_deprecations")}"
-            )
-        }
-
-        void expectTestReportReportOnDeprecation(String version) {
-            VersionNumber versionNumber = VersionNumber.parse(version)
-            runner.expectLegacyDeprecationWarningIf(
-                versionNumber.baseVersion < VersionNumber.parse("1.8.20"),
-                "The TestReport.reportOn(Object...) method has been deprecated. " +
-                    "This is scheduled to be removed in Gradle 9.0. " +
-                    "Please use the testResults method instead. " +
-                    String.format(RECOMMENDATION,"information",  DOC_REGISTRY.getDslRefForProperty("org.gradle.api.tasks.testing.TestReport", "testResults"))
-            )
-        }
-
-        void expectTestReportDestinationDirOnDeprecation(String version) {
-            VersionNumber versionNumber = VersionNumber.parse(version)
-            runner.expectLegacyDeprecationWarningIf(
-                versionNumber.baseVersion < VersionNumber.parse("1.8.20"),
-                "The TestReport.destinationDir property has been deprecated. " +
-                    "This is scheduled to be removed in Gradle 9.0. " +
-                    "Please use the destinationDirectory property instead. " +
-                    String.format(RECOMMENDATION, "information", DOC_REGISTRY.getDslRefForProperty("org.gradle.api.tasks.testing.TestReport", "destinationDir"))
-            )
-        }
-
-        void expectProjectConventionDeprecation(String kotlinVersion) {
-            VersionNumber kotlinVersionNumber = VersionNumber.parse(kotlinVersion)
-            runner.expectLegacyDeprecationWarningIf(
-                kotlinVersionNumber < VersionNumber.parse("1.7.22"),
-                PROJECT_CONVENTION_DEPRECATION
-            )
-        }
-
-        void expectBasePluginConventionDeprecation(String kotlinVersion) {
-            VersionNumber kotlinVersionNumber = VersionNumber.parse(kotlinVersion)
-            runner.expectLegacyDeprecationWarningIf(
-                kotlinVersionNumber < VersionNumber.parse("1.7.0"),
-                BASE_PLUGIN_CONVENTION_DEPRECATION
-            )
-        }
-
-        void expectBasePluginConventionDeprecation(String kotlinVersion, String agpVersion) {
-            VersionNumber kotlinVersionNumber = VersionNumber.parse(kotlinVersion)
-            VersionNumber agpVersionNumber = VersionNumber.parse(agpVersion)
-            runner.expectLegacyDeprecationWarningIf(
-                agpVersionNumber < VersionNumber.parse("7.4.0") || kotlinVersionNumber < VersionNumber.parse("1.7.0"),
-                BASE_PLUGIN_CONVENTION_DEPRECATION
-            )
-        }
-
-        void expectJavaPluginConventionDeprecation(String kotlinVersion) {
-            VersionNumber kotlinVersionNumber = VersionNumber.parse(kotlinVersion)
-            runner.expectLegacyDeprecationWarningIf(
-                kotlinVersionNumber < VersionNumber.parse("1.7.22"),
-                JAVA_PLUGIN_CONVENTION_DEPRECATION
-            )
-        }
-
-        void expectProjectConventionDeprecation(String kotlinVersion, String agpVersion) {
-            VersionNumber kotlinVersionNumber = VersionNumber.parse(kotlinVersion)
-            VersionNumber agpVersionNumber = VersionNumber.parse(agpVersion)
-            runner.expectLegacyDeprecationWarningIf(
-                agpVersionNumber < VersionNumber.parse("7.4.0") || (agpVersionNumber >= VersionNumber.parse("7.4.0") && kotlinVersionNumber < VersionNumber.parse("1.7.0")),
-                PROJECT_CONVENTION_DEPRECATION
-            )
-        }
-
-        void expectConventionTypeDeprecation(String kotlinVersion) {
-            VersionNumber kotlinVersionNumber = VersionNumber.parse(kotlinVersion)
-            runner.expectLegacyDeprecationWarningIf(
-                kotlinVersionNumber < VersionNumber.parse("1.7.22"),
-                CONVENTION_TYPE_DEPRECATION
-            )
-        }
-
-        void expectConventionTypeDeprecation(String kotlinVersion, String agpVersion) {
-            VersionNumber kotlinVersionNumber = VersionNumber.parse(kotlinVersion)
-            VersionNumber agpVersionNumber = VersionNumber.parse(agpVersion)
-            runner.expectLegacyDeprecationWarningIf(
-                agpVersionNumber < VersionNumber.parse("7.4.0") || (agpVersionNumber >= VersionNumber.parse("7.4.0") && kotlinVersionNumber < VersionNumber.parse("1.7.22")),
-                CONVENTION_TYPE_DEPRECATION
-            )
-        }
-
-        void expectConfigureUtilDeprecation(String version) {
-            VersionNumber versionNumber = VersionNumber.parse(version)
-            runner.expectLegacyDeprecationWarningIf(
-                versionNumber < VersionNumber.parse("1.7.22"),
-                "The org.gradle.util.ConfigureUtil type has been deprecated. " +
-                    "This is scheduled to be removed in Gradle 9.0. " +
-                    "Consult the upgrading guide for further information: " +
-                    DOC_REGISTRY.getDocumentationFor("upgrading_version_8", "org_gradle_util_reports_deprecations")
-            )
-        }
-
-        void expectBuildIdentifierNameDeprecation(String kotlinVersion) {
-            VersionNumber versionNumber = VersionNumber.parse(kotlinVersion)
-            runner.expectDeprecationWarningIf(versionNumber >= VersionNumber.parse("1.8.20"),
-                "The BuildIdentifier.getName() method has been deprecated. " +
-                    "This is scheduled to be removed in Gradle 9.0. " +
-                    "Use getBuildPath() to get a unique identifier for the build. " +
-                    "Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation",
-                "https://youtrack.jetbrains.com/issue/KT-58157"
-            )
-        }
     }
 }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
@@ -70,7 +70,7 @@ class KotlinPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
         where:
         [version, workers] << [
             TestedVersions.kotlin.versions,
-            [true, false]
+            Workers.values()
         ].combinations()
     }
 
@@ -106,7 +106,7 @@ class KotlinPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
         where:
         [version, workers] << [
             TestedVersions.kotlin.versions,
-            [true, false]
+            Workers.values()
         ].combinations()
     }
 

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/kotlin-multiplatform-js-example/build.gradle.kts
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/kotlin-multiplatform-js-example/build.gradle.kts
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    kotlin("multiplatform") version "$kotlinVersion"
+}
+
+repositories {
+    mavenCentral()
+}
+
+kotlin {
+    js(IR) {
+        browser {
+            testTask {
+                useKarma {
+                    useChromeHeadless()
+                    $enableCssSupportOld
+                }
+            }
+
+            $enableCssSupportNew
+        }
+    }
+
+    sourceSets {
+        named("commonTest") {
+            dependencies {
+                implementation(kotlin("test-common"))
+                implementation(kotlin("test-annotations-common"))
+            }
+        }
+
+        named("jsTest") {
+            dependencies {
+                implementation(kotlin("test-js"))
+            }
+        }
+    }
+}

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/kotlin-multiplatform-js-example/gradle.properties
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/kotlin-multiplatform-js-example/gradle.properties
@@ -1,0 +1,19 @@
+#
+# Copyright 2023 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+kotlin.code.style=official
+kotlin.js.generate.executable.default=false
+kotlin.mpp.stability.nowarn=true

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/kotlin-multiplatform-js-example/src/commonMain/kotlin/samples/Base64.kt
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/kotlin-multiplatform-js-example/src/commonMain/kotlin/samples/Base64.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.smoketests.`kotlin-multiplatform-js-example`.src.commonMain.kotlin.samples
+
+interface Base64Encoder {
+    fun encode(src: ByteArray): ByteArray
+    fun encodeToString(src: ByteArray): String {
+        val encoded = encode(src)
+        return buildString(encoded.size) {
+            encoded.forEach { append(it.toChar()) }
+        }
+    }
+}
+
+expect object Base64Factory {
+    fun createEncoder(): Base64Encoder
+}

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/kotlin-multiplatform-js-example/src/commonTest/kotlin/samples/Base64Test.kt
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/kotlin-multiplatform-js-example/src/commonTest/kotlin/samples/Base64Test.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.smoketests.`kotlin-multiplatform-js-example`.src.commonTest.kotlin.samples
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class Base64Test {
+    @Test
+    fun testEncodeToString() {
+        checkEncodeToString("Kotlin is awesome", "S290bGluIGlzIGF3ZXNvbWU=")
+    }
+
+    @Test
+    fun testPaddedStrings() {
+        checkEncodeToString("", "")
+        checkEncodeToString("1", "MQ==")
+        checkEncodeToString("22", "MjI=")
+        checkEncodeToString("333", "MzMz")
+        checkEncodeToString("4444", "NDQ0NA==")
+    }
+
+    private fun checkEncodeToString(input: String, expectedOutput: String) {
+        assertEquals(expectedOutput, Base64Factory.createEncoder().encodeToString(input.asciiToByteArray()))
+    }
+
+    private fun String.asciiToByteArray() = ByteArray(length) {
+        get(it).code.toByte()
+    }
+}

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/kotlin-multiplatform-js-example/src/jsMain/kotlin/samples/Base64.kt
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/kotlin-multiplatform-js-example/src/jsMain/kotlin/samples/Base64.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package samples
+
+import kotlinx.browser.window
+
+actual object Base64Factory {
+    actual fun createEncoder(): Base64Encoder = JsBase64Encoder
+}
+
+object JsBase64Encoder : Base64Encoder {
+    override fun encode(src: ByteArray): ByteArray {
+        val string = src.decodeToString()
+        val encodedString = window.btoa(string)
+        return encodedString.encodeToByteArray()
+    }
+}


### PR DESCRIPTION
- Add sample based on project linked from Kotlin official docs.
- Refactor kotlin smoke test hierarchy to make adding KMP smoke tests easier.
- Minimize build warnings for new KMP project.
- Begin to refactor and consolidate version specific warnings to avoid repeat warnings block.
- Test with absent deprecated "kotlin.parallel.tasks.in.project" properties in addition to true and false.