### PR TITLE
Ignore new CompileAll_NGRemote for cache misses

### DIFF
--- a/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.cache-miss-monitor.gradle.kts
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.cache-miss-monitor.gradle.kts
@@ -97,7 +97,8 @@ fun Project.isExpectedCompileCacheMiss() =
         "Component_GradlePlugin_Performance_PerformanceLatestReleased",
         "Check_Gradleception",
         "Check_GradleceptionWithGroovy4",
-        "CompileAllBuild_BuildCacheNG"
+        "CompileAllBuild_BuildCacheNG",
+        "CompileAllBuild_NGRemote"
     ) || isBuildCommitDistribution
 
 val Project.isBuildCommitDistribution: Boolean


### PR DESCRIPTION
There is a new build called [Compile All With NG Remote](https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_CompileAllBuild_NGRemote?branch=pre-test%2Fmaster%2Fcurrent%2Fgradle%2Fbot-pull-request-master-2023-06-11-02-16-51&buildTypeTab=overview) now.