### PR TITLE
Revert enablement of load-after-store for testing-jvm

### DIFF
--- a/subprojects/messaging/src/main/java/org/gradle/internal/event/BroadcastDispatch.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/event/BroadcastDispatch.java
@@ -82,8 +82,6 @@ public abstract class BroadcastDispatch<T> extends AbstractBroadcastDispatch<T> 
 
     public abstract void visitListeners(Action<T> visitor);
 
-    public abstract void visitListenersUntyped(Action<Object> visitor);
-
     private static class ActionInvocationHandler implements Dispatch<MethodInvocation> {
         private final String methodName;
         private final Action<Object> action;
@@ -138,10 +136,6 @@ public abstract class BroadcastDispatch<T> extends AbstractBroadcastDispatch<T> 
 
         @Override
         public void visitListeners(Action<T> visitor) {
-        }
-
-        @Override
-        public void visitListenersUntyped(Action<Object> visitor) {
         }
 
         @Override
@@ -259,11 +253,6 @@ public abstract class BroadcastDispatch<T> extends AbstractBroadcastDispatch<T> 
         }
 
         @Override
-        public void visitListenersUntyped(Action<Object> visitor) {
-            visitor.execute(handler);
-        }
-
-        @Override
         public void dispatch(MethodInvocation message) {
             dispatch(message, dispatch);
         }
@@ -356,13 +345,6 @@ public abstract class BroadcastDispatch<T> extends AbstractBroadcastDispatch<T> 
         public void visitListeners(Action<T> visitor) {
             for (SingletonDispatch<T> dispatcher : dispatchers) {
                 dispatcher.visitListeners(visitor);
-            }
-        }
-
-        @Override
-        public void visitListenersUntyped(Action<Object> visitor) {
-            for (SingletonDispatch<T> dispatcher : dispatchers) {
-                dispatcher.visitListenersUntyped(visitor);
             }
         }
 

--- a/subprojects/messaging/src/main/java/org/gradle/internal/event/ListenerBroadcast.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/event/ListenerBroadcast.java
@@ -152,10 +152,6 @@ public class ListenerBroadcast<T> implements Dispatch<MethodInvocation> {
         broadcast.visitListeners(visitor);
     }
 
-    public void visitListenersUntyped(Action<Object> visitor) {
-        broadcast.visitListenersUntyped(visitor);
-    }
-
     /**
      * Returns a new {@link ListenerBroadcast} with the same {@link BroadcastDispatch} as this class.
      */

--- a/subprojects/testing-base/src/testFixtures/groovy/org/gradle/testing/AbstractTestFrameworkIntegrationTest.groovy
+++ b/subprojects/testing-base/src/testFixtures/groovy/org/gradle/testing/AbstractTestFrameworkIntegrationTest.groovy
@@ -92,14 +92,10 @@ abstract class AbstractTestFrameworkIntegrationTest extends AbstractIntegrationS
                 def junitXmlOutputLocation = provider { ${testTaskName}.reports.junitXml.outputLocation }
                 def htmlOutputLocation = provider { ${testTaskName}.reports.html.outputLocation }
                 def binaryResultsDirectory = provider { ${testTaskName}.binaryResultsDirectory }
-                def buildDir = layout.buildDirectory
-                def expectedJunitXmlOutputLocation = file('build/test-results/${testTaskName}')
-                def expectedHtmlOutputLocation = file('build/reports/tests/${testTaskName}')
-                def expectedBinaryResultsDirectory = file('build/test-results/${testTaskName}/binary')
                 doLast {
-                    assert junitXmlOutputLocation.flatMap { it.asFile }.get() == expectedJunitXmlOutputLocation
-                    assert htmlOutputLocation.flatMap { it.asFile }.get() == expectedHtmlOutputLocation
-                    assert binaryResultsDirectory.flatMap { it.asFile }.get() == expectedBinaryResultsDirectory
+                    assert junitXmlOutputLocation.flatMap { it.asFile }.get() == file('build/test-results/${testTaskName}')
+                    assert htmlOutputLocation.flatMap { it.asFile }.get() == file('build/reports/tests/${testTaskName}')
+                    assert binaryResultsDirectory.flatMap { it.asFile }.get() == file('build/test-results/${testTaskName}/binary')
                 }
             }
         """

--- a/subprojects/testing-jvm/build.gradle.kts
+++ b/subprojects/testing-jvm/build.gradle.kts
@@ -54,3 +54,8 @@ packageCycles {
 }
 
 integTest.usesJavadocCodeSnippets = true
+
+// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
+tasks.configCacheIntegTest {
+    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
+}

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/AbstractTestListenerBuildOperationAdapterIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/AbstractTestListenerBuildOperationAdapterIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.testing
 
 import org.gradle.api.internal.tasks.testing.operations.ExecuteTestBuildOperationType
 import org.gradle.integtests.fixtures.BuildOperationsFixture
+import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.internal.operations.trace.BuildOperationRecord
 import org.gradle.testing.fixture.AbstractTestingMultiVersionIntegrationTest
 
@@ -27,6 +28,7 @@ abstract class AbstractTestListenerBuildOperationAdapterIntegrationTest extends 
     abstract boolean isEmitsTestClassOperations()
     abstract void writeTestSources()
 
+    @ToBeFixedForConfigurationCache(because = "load-after-store")
     def "emits build operations for junit tests"() {
         given:
         buildFile << """

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/AbstractTestListenerBuildOperationAdapterIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/AbstractTestListenerBuildOperationAdapterIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.testing
 
 import org.gradle.api.internal.tasks.testing.operations.ExecuteTestBuildOperationType
 import org.gradle.integtests.fixtures.BuildOperationsFixture
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.internal.operations.trace.BuildOperationRecord
 import org.gradle.testing.fixture.AbstractTestingMultiVersionIntegrationTest
 
@@ -28,7 +27,6 @@ abstract class AbstractTestListenerBuildOperationAdapterIntegrationTest extends 
     abstract boolean isEmitsTestClassOperations()
     abstract void writeTestSources()
 
-    @ToBeFixedForConfigurationCache(because = "load-after-store")
     def "emits build operations for junit tests"() {
         given:
         buildFile << """

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/AbstractTestTaskIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/AbstractTestTaskIntegrationTest.groovy
@@ -311,11 +311,11 @@ abstract class AbstractTestTaskIntegrationTest extends AbstractTestingMultiVersi
             }
 
             tasks.register('verifyTestOptions') {
-                def categoryOrTagExcludes = provider {
+                def testOption = provider {
                     tasks.getByName("test").getOptions().${buildScriptConfiguration.excludeCategoryOrTagConfigurationElement}
                 }
                 doLast {
-                    assert categoryOrTagExcludes.get().contains("MyTest\\\$Slow")
+                    assert testOption.get().contains("MyTest\\\$Slow")
                 }
             }
         """.stripIndent()

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/AbstractTestTaskIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/AbstractTestTaskIntegrationTest.groovy
@@ -311,11 +311,8 @@ abstract class AbstractTestTaskIntegrationTest extends AbstractTestingMultiVersi
             }
 
             tasks.register('verifyTestOptions') {
-                def testOption = provider {
-                    tasks.getByName("test").getOptions().${buildScriptConfiguration.excludeCategoryOrTagConfigurationElement}
-                }
                 doLast {
-                    assert testOption.get().contains("MyTest\\\$Slow")
+                    assert tasks.getByName("test").getOptions().${buildScriptConfiguration.excludeCategoryOrTagConfigurationElement}.contains("MyTest\\\$Slow")
                 }
             }
         """.stripIndent()

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/ParallelTestExecutionIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/ParallelTestExecutionIntegrationTest.groovy
@@ -16,12 +16,11 @@
 package org.gradle.testing
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.junit.Rule
-import spock.lang.IgnoreIf
 
 import static org.gradle.testing.fixture.JUnitCoverage.LATEST_JUNIT4_VERSION
 
@@ -129,11 +128,7 @@ class ParallelTestExecutionIntegrationTest extends AbstractIntegrationSpec {
         noExceptionThrown()
     }
 
-    // TODO:configuration-cache test currently flaky since cc might run tests in parallel
-    @IgnoreIf(
-        reason = "cc might cause tests to run in parallel",
-        value = { GradleContextualExecuter.configCache }
-    )
+    @ToBeFixedForConfigurationCache(because = "load-after-store")
     def "does not run tests from multiple tasks from the same project in parallel"() {
         withBlockingJUnitTests(2)
         withBlockingJUnitTests(2, "other")

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/ParallelTestExecutionIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/ParallelTestExecutionIntegrationTest.groovy
@@ -16,7 +16,6 @@
 package org.gradle.testing
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
@@ -128,7 +127,6 @@ class ParallelTestExecutionIntegrationTest extends AbstractIntegrationSpec {
         noExceptionThrown()
     }
 
-    @ToBeFixedForConfigurationCache(because = "load-after-store")
     def "does not run tests from multiple tasks from the same project in parallel"() {
         withBlockingJUnitTests(2)
         withBlockingJUnitTests(2, "other")

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/SampleTestNGIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/SampleTestNGIntegrationTest.groovy
@@ -27,8 +27,7 @@ import org.junit.Test
 
 class SampleTestNGIntegrationTest extends AbstractIntegrationTest {
 
-    @Rule
-    public final Sample sample = new Sample(testDirectoryProvider)
+    @Rule public final Sample sample = new Sample(testDirectoryProvider)
 
     @Before
     void setUp() {
@@ -38,7 +37,7 @@ class SampleTestNGIntegrationTest extends AbstractIntegrationTest {
     @ToBeFixedForConfigurationCache(because = "load-after-store")
     @Test
     @UsesSample('testing/testng-suitexmlbuilder')
-    void suiteXmlBuilder() {
+     void suiteXmlBuilder() {
         def testDir = sample.dir.file('groovy')
         executer.inDirectory(testDir).withTasks('clean', 'test').run()
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/SampleTestNGIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/SampleTestNGIntegrationTest.groovy
@@ -19,7 +19,6 @@ import org.gradle.integtests.fixtures.AbstractIntegrationTest
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import org.gradle.integtests.fixtures.Sample
 import org.gradle.integtests.fixtures.TestNGExecutionResult
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.UsesSample
 import org.junit.Before
 import org.junit.Rule
@@ -34,7 +33,6 @@ class SampleTestNGIntegrationTest extends AbstractIntegrationTest {
         executer.withRepositoryMirrors()
     }
 
-    @ToBeFixedForConfigurationCache(because = "load-after-store")
     @Test
     @UsesSample('testing/testng-suitexmlbuilder')
      void suiteXmlBuilder() {

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFilteringIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFilteringIntegrationTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.testing.testng
 
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import org.gradle.integtests.fixtures.TargetCoverage
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.testing.AbstractTestFilteringIntegrationTest
 import org.gradle.testing.fixture.TestNGCoverage
 import spock.lang.Issue
@@ -68,7 +67,6 @@ class TestNGFilteringIntegrationTest extends AbstractTestFilteringIntegrationTes
         """
     }
 
-    @ToBeFixedForConfigurationCache(because = "load-after-store")
     @Issue("GRADLE-3112")
     def "suites can be filtered from the command-line"() {
         given:
@@ -87,7 +85,6 @@ class TestNGFilteringIntegrationTest extends AbstractTestFilteringIntegrationTes
         result.testClass('BarTest').assertTestsExecuted('pass')
     }
 
-    @ToBeFixedForConfigurationCache(because = "load-after-store")
     @Issue("GRADLE-3112")
     def "suites can be filtered from the build file"() {
         given:

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGUpToDateCheckIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGUpToDateCheckIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.testing.testng
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.testing.fixture.TestNGCoverage
 import spock.lang.Issue
 
@@ -114,7 +113,6 @@ class TestNGUpToDateCheckIntegrationTest extends AbstractIntegrationSpec {
         'groupByInstances'    | '= true'
     }
 
-    @ToBeFixedForConfigurationCache(because = "load-after-store")
     @Issue('https://github.com/gradle/gradle/issues/4924')
     def "re-executes test when #property is changed"() {
         given:

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/dependencies/TestSuitesGroovyDSLDependenciesIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/dependencies/TestSuitesGroovyDSLDependenciesIntegrationTest.groovy
@@ -325,13 +325,10 @@ class TestSuitesGroovyDSLDependenciesIntegrationTest extends AbstractIntegration
             }
 
             tasks.register('checkConfiguration') {
-                def deps = provider {
-                    configurations.${suiteName}CompileClasspath
-                        .allDependencies.withType(ProjectDependency)
-                        *.reason
-                }
                 doLast {
-                    assert deps.get() == ['for testing purposes']
+                    def deps = configurations.${suiteName}CompileClasspath.allDependencies.withType(ProjectDependency)
+                    assert deps.size() == 1
+                    assert deps*.reason == ['for testing purposes']
                 }
             }
         """
@@ -557,7 +554,7 @@ class TestSuitesGroovyDSLDependenciesIntegrationTest extends AbstractIntegration
 
         expect:
         succeeds 'checkConfiguration'
-    }
+   }
 
     def 'can add dependencies to the implementation, compileOnly and runtimeOnly configurations of a suite via DependencyHandler using #desc'() {
         given:
@@ -790,9 +787,9 @@ class TestSuitesGroovyDSLDependenciesIntegrationTest extends AbstractIntegration
         succeeds 'checkConfiguration'
 
         where:
-        desc         | dependencyNotation
-        'GAV string' | "'commons-beanutils:commons-beanutils:1.9.4'"
-        'GAV map'    | "module(group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4')"
+        desc                | dependencyNotation
+        'GAV string'        | "'commons-beanutils:commons-beanutils:1.9.4'"
+        'GAV map'           | "module(group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4')"
     }
 
     def "can add dependencies using a non-String CharSequence: #type"() {
@@ -1056,7 +1053,7 @@ class TestSuitesGroovyDSLDependenciesIntegrationTest extends AbstractIntegration
 
     // region dependencies - dependency objects
     def 'can add dependency objects to the implementation, compileOnly and runtimeOnly configurations of a suite'() {
-        given:
+        given :
         buildFile << """
             plugins {
               id 'java-library'
@@ -1095,12 +1092,12 @@ class TestSuitesGroovyDSLDependenciesIntegrationTest extends AbstractIntegration
             }
         """
 
-        expect:
-        succeeds 'checkConfiguration'
-    }
+            expect:
+            succeeds 'checkConfiguration'
+        }
 
     def 'can add dependency objects with actions (using exclude) to #suiteDesc'() {
-        given:
+        given :
         buildFile << """
             plugins {
               id 'java-library'
@@ -1144,7 +1141,7 @@ class TestSuitesGroovyDSLDependenciesIntegrationTest extends AbstractIntegration
     }
 
     def 'can add dependency objects with actions (using because) to #suiteDesc'() {
-        given:
+        given :
         buildFile << """
             plugins {
               id 'java-library'
@@ -1168,14 +1165,10 @@ class TestSuitesGroovyDSLDependenciesIntegrationTest extends AbstractIntegration
 
             tasks.register('checkConfiguration') {
                 dependsOn $suiteName
-                def deps = provider {
-                    configurations.${suiteName}CompileClasspath
-                        .allDependencies.withType(ModuleDependency)
-                        .matching { it.group == 'commons-beanutils' }
-                        *.reason
-                }
                 doLast {
-                    assert deps.get() == ['for testing purposes']
+                    def deps = configurations.${suiteName}CompileClasspath.allDependencies.withType(ModuleDependency).matching { it.group == 'commons-beanutils' }
+                    assert deps.size() == 1
+                    assert deps*.reason == ['for testing purposes']
                 }
             }
         """
@@ -1192,7 +1185,7 @@ class TestSuitesGroovyDSLDependenciesIntegrationTest extends AbstractIntegration
 
     // region dependencies - dependency providers
     def 'can add dependency providers which provide dependency objects to the implementation, compileOnly and runtimeOnly configurations of a suite'() {
-        given:
+        given :
         buildFile << """
             plugins {
               id 'java-library'
@@ -1237,7 +1230,7 @@ class TestSuitesGroovyDSLDependenciesIntegrationTest extends AbstractIntegration
     }
 
     def 'can NOT add dependency providers which provide GAVs to the implementation, compileOnly and runtimeOnly configurations of a suite'() {
-        given:
+        given :
         buildFile << """
             plugins {
               id 'java-library'
@@ -1283,7 +1276,7 @@ class TestSuitesGroovyDSLDependenciesIntegrationTest extends AbstractIntegration
     }
 
     def 'can add dependency providers which provide dependency objects with actions (using exclude) to #suiteDesc'() {
-        given:
+        given :
         buildFile << """
             plugins {
               id 'java-library'
@@ -1327,7 +1320,7 @@ class TestSuitesGroovyDSLDependenciesIntegrationTest extends AbstractIntegration
     }
 
     def 'can add dependency providers which provide dependency objects with actions (using because) to #suiteDesc'() {
-        given:
+        given :
         buildFile << """
             plugins {
               id 'java-library'
@@ -1350,14 +1343,10 @@ class TestSuitesGroovyDSLDependenciesIntegrationTest extends AbstractIntegration
             }
 
             tasks.register('checkConfiguration') {
-                def deps = provider {
-                    configurations.${suiteName}CompileClasspath
-                        .allDependencies.withType(ModuleDependency)
-                        .matching { it.group == 'commons-beanutils' }
-                        *.reason
-                }
                 doLast {
-                    assert deps.get() == ['for testing purposes']
+                    def deps = configurations.${suiteName}CompileClasspath.allDependencies.withType(ModuleDependency).matching { it.group == 'commons-beanutils' }
+                    assert deps.size() == 1
+                    assert deps*.reason == ['for testing purposes']
                 }
             }
         """
@@ -1372,7 +1361,7 @@ class TestSuitesGroovyDSLDependenciesIntegrationTest extends AbstractIntegration
     }
 
     def 'can NOT add dependency providers which provide GAVs with actions (using excludes) to #suiteDesc'() {
-        given:
+        given :
         buildFile << """
             plugins {
               id 'java-library'
@@ -1418,7 +1407,7 @@ class TestSuitesGroovyDSLDependenciesIntegrationTest extends AbstractIntegration
     }
 
     def 'can NOT add dependency providers which provide GAVs with actions (using because) to #suiteDesc'() {
-        given:
+        given :
         buildFile << """
             plugins {
               id 'java-library'
@@ -1441,14 +1430,10 @@ class TestSuitesGroovyDSLDependenciesIntegrationTest extends AbstractIntegration
             }
 
             tasks.register('checkConfiguration') {
-                def deps = provider {
-                    configurations.${suiteName}CompileClasspath
-                        .allDependencies.withType(ModuleDependency)
-                        .matching { it.group == 'commons-beanutils' }
-                        *.reason
-                }
                 doLast {
-                    assert deps.get() == ['for testing purposes']
+                    def deps = configurations.${suiteName}CompileClasspath.allDependencies.withType(ModuleDependency).matching { it.group == 'commons-beanutils' }
+                    assert deps.size() == 1
+                    assert deps*.reason == ['for testing purposes']
                 }
             }
         """
@@ -1598,14 +1583,10 @@ class TestSuitesGroovyDSLDependenciesIntegrationTest extends AbstractIntegration
         }
 
         tasks.register('checkConfiguration') {
-            def deps = provider {
-                configurations.${suiteName}CompileClasspath
-                    .allDependencies.withType(ModuleDependency)
-                    .matching { it.group == 'commons-beanutils' }
-                    *.reason
-            }
             doLast {
-                assert deps.get() == ['for testing purposes']
+                def deps = configurations.${suiteName}CompileClasspath.allDependencies.withType(ModuleDependency).matching { it.group == 'commons-beanutils' }
+                assert deps.size() == 1
+                assert deps*.reason == ['for testing purposes']
             }
         }
         """
@@ -2281,7 +2262,7 @@ class TestSuitesGroovyDSLDependenciesIntegrationTest extends AbstractIntegration
         """
 
         expect: "test runs successfully"
-        succeeds(":consumer:integrationTest")
+        succeeds( ":consumer:integrationTest")
 
         where:
         suiteDesc           | suiteName   | suiteDeclaration
@@ -2334,7 +2315,7 @@ class TestSuitesGroovyDSLDependenciesIntegrationTest extends AbstractIntegration
         """
 
         expect: "test runs successfully"
-        succeeds(":integrationTest")
+        succeeds( ":integrationTest")
 
         where:
         suiteDesc           | suiteName   | suiteDeclaration


### PR DESCRIPTION
The base code changes in #25257 may have created some instability/non-determinism around filesystem cleanup during testing.

Reverting the change set while we investigate to hopefully unblock master.

Reverts changes from #25257

