### PR TITLE
PreventFromFutherMutation for configurations on-demand

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -1493,6 +1493,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         preventIllegalParentMutation(type);
         markAsModified(type);
         notifyChildren(type);
+        maybePreventMutation(type);
     }
 
     @Override
@@ -1500,6 +1501,13 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         preventIllegalMutation(type);
         markAsModified(type);
         notifyChildren(type);
+        maybePreventMutation(type);
+    }
+
+    private void maybePreventMutation(MutationType type) {
+        if (!canBeMutated) {
+            throw new InvalidUserDataException(String.format("Cannot change %s of %s after mutation has been disabled.", type, getDisplayName()));
+        }
     }
 
     private void preventIllegalParentMutation(MutationType type) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilder.java
@@ -108,7 +108,7 @@ public class DefaultRootComponentMetadataBuilder implements RootComponentMetadat
             new DefaultLocalComponentMetadata.ConfigurationsProviderMetadataFactory(
                 configurationsProvider, configurationMetadataBuilder, model, calculatedValueContainerFactory);
 
-        configurationsProvider.visitAll(ConfigurationInternal::preventFromFurtherMutation);
+        configurationsProvider.visitAll(ConfigurationInternal::preventUsageMutation);
 
         return new DefaultLocalComponentMetadata(moduleVersionIdentifier, componentIdentifier, module.getStatus(), schema, configurationMetadataFactory, null);
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalConfigurationMetadataBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalConfigurationMetadataBuilder.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencie
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
+import org.gradle.api.Action;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.DependencyConstraint;
@@ -86,6 +87,11 @@ public class DefaultLocalConfigurationMetadataBuilder implements LocalConfigurat
         ComponentIdentifier componentId = parent.getId();
         ComponentConfigurationIdentifier configurationIdentifier = new ComponentConfigurationIdentifier(componentId, configuration.getName());
 
+        // We must run dependency actions before collecting dependency state, since they may modify the hierarchy.
+        runActionInHierarchy(configuration, ConfigurationInternal::runDependencyActions);
+        // We must prevent mutation before collecting variants, since beforeLocking actions may mutate the configuration.
+        runActionInHierarchy(configuration, ConfigurationInternal::preventFromFurtherMutation);
+
         // Collect all artifacts and sub-variants.
         ImmutableList.Builder<PublishArtifact> artifactBuilder = ImmutableList.builder();
         ImmutableSet.Builder<LocalVariantMetadata> variantsBuilder = ImmutableSet.builder();
@@ -105,9 +111,6 @@ public class DefaultLocalConfigurationMetadataBuilder implements LocalConfigurat
                 variantsBuilder.add(new LocalVariantMetadata(configuration.getName() + "-" + name, new NestedVariantIdentifier(configurationIdentifier, name), componentId, displayName, attributes, artifacts, ImmutableCapabilities.of(capabilities), model, calculatedValueContainerFactory));
             }
         });
-
-        // We must call this before collecting dependency state, since dependency actions may modify the hierarchy.
-        runDependencyActionsInHierarchy(configuration);
 
         // Collect all dependencies and excludes in hierarchy.
         ImmutableAttributes attributes = configuration.getAttributes().asImmutable();
@@ -138,12 +141,12 @@ public class DefaultLocalConfigurationMetadataBuilder implements LocalConfigurat
     }
 
     /**
-     * Runs the dependency actions for all configurations in {@code conf}'s hierarchy.
+     * Runs the provided action for all configurations in {@code conf}'s hierarchy.
      *
      * <p>Specifically handles the case where {@link Configuration#extendsFrom} is called during the
-     * dependency action execution.</p>
+     * action execution.</p>
      */
-    private static void runDependencyActionsInHierarchy(ConfigurationInternal conf) {
+    private static void runActionInHierarchy(ConfigurationInternal conf, Action<ConfigurationInternal> action) {
         Set<Configuration> seen = new HashSet<>();
         Queue<Configuration> remaining = new ArrayDeque<>();
         remaining.add(conf);
@@ -151,7 +154,7 @@ public class DefaultLocalConfigurationMetadataBuilder implements LocalConfigurat
 
         while (!remaining.isEmpty()) {
             Configuration current = remaining.remove();
-            ((ConfigurationInternal) current).runDependencyActions();
+            action.execute((ConfigurationInternal) current);
 
             for (Configuration parent : current.getExtendsFrom()) {
                 if (seen.add(parent)) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultProjectLocalComponentProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultProjectLocalComponentProvider.java
@@ -74,7 +74,7 @@ public class DefaultProjectLocalComponentProvider implements LocalComponentProvi
             new DefaultLocalComponentMetadata.ConfigurationsProviderMetadataFactory(
                 (DefaultConfigurationContainer) project.getConfigurations(), metadataBuilder, projectState, calculatedValueContainerFactory);
 
-        project.getConfigurations().forEach(conf -> ((ConfigurationInternal) conf).preventFromFurtherMutation());
+        project.getConfigurations().forEach(conf -> ((ConfigurationInternal) conf).preventUsageMutation());
 
         return new DefaultLocalComponentMetadata(moduleVersionIdentifier, componentIdentifier, module.getStatus(), schema, configurationMetadataFactory, null);
     }


### PR DESCRIPTION
Don't blanket call `preventFromFurtherMutation` until a configuration is actually observed. 