### PR TITLE
Extract ResolutionStrategy Factory

### DIFF
--- a/subprojects/core/src/test/groovy/org/gradle/util/internal/NameValidatorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/util/internal/NameValidatorTest.groovy
@@ -21,6 +21,8 @@ import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.DomainObjectContext
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer
+import org.gradle.api.internal.artifacts.configurations.DefaultConfigurationFactory
+import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyFactory
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.DefaultRootComponentMetadataBuilder
 import org.gradle.api.internal.artifacts.type.DefaultArtifactTypeContainer
 import org.gradle.api.internal.file.TestFiles
@@ -52,7 +54,7 @@ class NameValidatorTest extends Specification {
     @Shared
     def domainObjectContainersWithValidation = [
         ["artifact types", new DefaultArtifactTypeContainer(TestUtil.instantiatorFactory().decorateLenient(), AttributeTestUtil.attributesFactory(), CollectionCallbackActionDecorator.NOOP)],
-        ["configurations", new DefaultConfigurationContainer(TestUtil.instantiatorFactory().decorateLenient(), null, null, null, AttributeTestUtil.attributesFactory(), null, null, null, CollectionCallbackActionDecorator.NOOP, null, TestUtil.objectFactory(), rootComponentMetaDataBuilderFactory, null)],
+        ["configurations", new DefaultConfigurationContainer(TestUtil.instantiatorFactory().decorateLenient(), CollectionCallbackActionDecorator.NOOP, rootComponentMetaDataBuilderFactory, Mock(DefaultConfigurationFactory), Mock(ResolutionStrategyFactory))],
         ["flavors", new DefaultFlavorContainer(TestUtil.instantiatorFactory().decorateLenient(), CollectionCallbackActionDecorator.NOOP)],
         ["source sets", new DefaultSourceSetContainer(TestFiles.resolver(), TestFiles.taskDependencyFactory(), null, TestUtil.instantiatorFactory().decorateLenient(), TestUtil.objectFactory(), CollectionCallbackActionDecorator.NOOP)]
     ]

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -17,7 +17,6 @@ package org.gradle.api.internal.artifacts;
 
 import org.gradle.StartParameter;
 import org.gradle.api.Describable;
-import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.dsl.ArtifactHandler;
 import org.gradle.api.artifacts.dsl.ComponentMetadataHandler;
 import org.gradle.api.artifacts.dsl.ComponentModuleMetadataHandler;
@@ -36,6 +35,7 @@ import org.gradle.api.internal.artifacts.configurations.ConfigurationContainerIn
 import org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer;
 import org.gradle.api.internal.artifacts.configurations.DefaultConfigurationFactory;
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
+import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyFactory;
 import org.gradle.api.internal.artifacts.dsl.ComponentMetadataHandlerInternal;
 import org.gradle.api.internal.artifacts.dsl.DefaultArtifactHandler;
 import org.gradle.api.internal.artifacts.dsl.DefaultComponentMetadataHandler;
@@ -138,12 +138,10 @@ import org.gradle.internal.resource.local.LocallyAvailableResourceFinder;
 import org.gradle.internal.service.DefaultServiceRegistry;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.ServiceRegistry;
-import org.gradle.internal.typeconversion.NotationParser;
 import org.gradle.internal.vfs.FileSystemAccess;
 import org.gradle.internal.work.WorkerLeaseService;
 import org.gradle.internal.work.WorkerThreadRegistry;
 import org.gradle.util.internal.SimpleMapInterner;
-import org.gradle.vcs.internal.VcsMappingsStore;
 
 import java.util.List;
 import java.util.function.Supplier;
@@ -202,6 +200,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             registration.add(DefaultTransformedVariantFactory.class);
             registration.add(DefaultRootComponentMetadataBuilder.Factory.class);
             registration.add(ResolveExceptionContextualizer.class);
+            registration.add(ResolutionStrategyFactory.class);
         }
 
         AttributesSchemaInternal createConfigurationAttributesSchema(InstantiatorFactory instantiatorFactory, IsolatableFactory isolatableFactory, PlatformSupport platformSupport) {
@@ -359,33 +358,17 @@ public class DefaultDependencyManagementServices implements DependencyManagement
 
         ConfigurationContainerInternal createConfigurationContainer(
             Instantiator instantiator,
-            GlobalDependencyResolutionRules globalDependencyResolutionRules,
-            VcsMappingsStore vcsMappingsStore,
-            ComponentIdentifierFactory componentIdentifierFactory,
-            ImmutableAttributesFactory attributesFactory,
-            ImmutableModuleIdentifierFactory moduleIdentifierFactory,
-            ComponentSelectorConverter componentSelectorConverter,
-            DependencyLockingProvider dependencyLockingProvider,
             CollectionCallbackActionDecorator callbackDecorator,
-            NotationParser<Object, ComponentSelector> moduleSelectorNotationParser,
-            ObjectFactory objectFactory,
             DefaultRootComponentMetadataBuilder.Factory rootComponentMetadataBuilderFactory,
-            DefaultConfigurationFactory defaultConfigurationFactory
+            DefaultConfigurationFactory defaultConfigurationFactory,
+            ResolutionStrategyFactory resolutionStrategyFactory
         ) {
             return instantiator.newInstance(DefaultConfigurationContainer.class,
                 instantiator,
-                globalDependencyResolutionRules.getDependencySubstitutionRules(),
-                vcsMappingsStore,
-                componentIdentifierFactory,
-                attributesFactory,
-                moduleIdentifierFactory,
-                componentSelectorConverter,
-                dependencyLockingProvider,
                 callbackDecorator,
-                moduleSelectorNotationParser,
-                objectFactory,
                 rootComponentMetadataBuilderFactory,
-                defaultConfigurationFactory
+                defaultConfigurationFactory,
+                resolutionStrategyFactory
             );
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
@@ -22,30 +22,14 @@ import org.gradle.api.UnknownDomainObjectException;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.UnknownConfigurationException;
-import org.gradle.api.artifacts.component.ComponentSelector;
-import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.AbstractValidatingNamedDomainObjectContainer;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
-import org.gradle.api.internal.artifacts.ComponentSelectorConverter;
-import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
-import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory;
-import org.gradle.api.internal.artifacts.dsl.CapabilityNotationParserFactory;
-import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider;
-import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionRules;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.DefaultRootComponentMetadataBuilder;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.RootComponentMetadataBuilder;
-import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.CapabilitiesResolutionInternal;
-import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultCapabilitiesResolution;
-import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultResolutionStrategy;
-import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
-import org.gradle.api.internal.notations.ComponentIdentifierParserFactory;
-import org.gradle.api.model.ObjectFactory;
 import org.gradle.internal.Cast;
 import org.gradle.internal.Factory;
 import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.reflect.Instantiator;
-import org.gradle.internal.typeconversion.NotationParser;
-import org.gradle.vcs.internal.VcsMappingsStore;
 
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -67,27 +51,16 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
 
     public DefaultConfigurationContainer(
         Instantiator instantiator,
-        DependencySubstitutionRules globalDependencySubstitutionRules,
-        VcsMappingsStore vcsMappingsStore,
-        ComponentIdentifierFactory componentIdentifierFactory,
-        ImmutableAttributesFactory attributesFactory,
-        ImmutableModuleIdentifierFactory moduleIdentifierFactory,
-        ComponentSelectorConverter componentSelectorConverter,
-        DependencyLockingProvider dependencyLockingProvider,
         CollectionCallbackActionDecorator callbackDecorator,
-        NotationParser<Object, ComponentSelector> moduleSelectorNotationParser,
-        ObjectFactory objectFactory,
         DefaultRootComponentMetadataBuilder.Factory rootComponentMetadataBuilderFactory,
-        DefaultConfigurationFactory defaultConfigurationFactory
+        DefaultConfigurationFactory defaultConfigurationFactory,
+        ResolutionStrategyFactory resolutionStrategyFactory
     ) {
         super(Configuration.class, instantiator, new Configuration.Namer(), callbackDecorator);
-        NotationParser<Object, Capability> dependencyCapabilityNotationParser = new CapabilityNotationParserFactory(false).create();
-        resolutionStrategyFactory = () -> {
-            CapabilitiesResolutionInternal capabilitiesResolutionInternal = instantiator.newInstance(DefaultCapabilitiesResolution.class, new CapabilityNotationParserFactory(false).create(), new ComponentIdentifierParserFactory().create());
-            return instantiator.newInstance(DefaultResolutionStrategy.class, globalDependencySubstitutionRules, vcsMappingsStore, componentIdentifierFactory, moduleIdentifierFactory, componentSelectorConverter, dependencyLockingProvider, capabilitiesResolutionInternal, instantiator, objectFactory, attributesFactory, moduleSelectorNotationParser, dependencyCapabilityNotationParser);
-        };
+
         this.rootComponentMetadataBuilder = rootComponentMetadataBuilderFactory.create(this);
         this.defaultConfigurationFactory = defaultConfigurationFactory;
+        this.resolutionStrategyFactory = resolutionStrategyFactory;
         this.getEventRegister().registerLazyAddAction(x -> rootComponentMetadataBuilder.getValidator().validateMutation(MutationValidator.MutationType.HIERARCHY));
         this.whenObjectRemoved(x -> rootComponentMetadataBuilder.getValidator().validateMutation(MutationValidator.MutationType.HIERARCHY));
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionStrategyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionStrategyFactory.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.configurations;
+
+import org.gradle.api.artifacts.component.ComponentSelector;
+import org.gradle.api.capabilities.Capability;
+import org.gradle.api.internal.artifacts.ComponentSelectorConverter;
+import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
+import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory;
+import org.gradle.api.internal.artifacts.dsl.CapabilityNotationParserFactory;
+import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider;
+import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionRules;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.StartParameterResolutionOverride;
+import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.CapabilitiesResolutionInternal;
+import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultCapabilitiesResolution;
+import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultResolutionStrategy;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.api.internal.notations.ComponentIdentifierParserFactory;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.internal.Factory;
+import org.gradle.internal.reflect.Instantiator;
+import org.gradle.internal.typeconversion.NotationParser;
+import org.gradle.vcs.internal.VcsMappingsStore;
+
+/**
+ * Creates fully initialized {@link ResolutionStrategyInternal} instances.
+ */
+public class ResolutionStrategyFactory implements Factory<ResolutionStrategyInternal> {
+
+    private final Instantiator instantiator;
+    private final DependencySubstitutionRules globalDependencySubstitutionRules;
+    private final VcsMappingsStore vcsMappingsStore;
+    private final ComponentIdentifierFactory componentIdentifierFactory;
+    private final ImmutableAttributesFactory attributesFactory;
+    private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
+    private final ComponentSelectorConverter componentSelectorConverter;
+    private final DependencyLockingProvider dependencyLockingProvider;
+    private final NotationParser<Object, ComponentSelector> moduleSelectorNotationParser;
+    private final ObjectFactory objectFactory;
+    private final StartParameterResolutionOverride startParameterResolutionOverride;
+    private final NotationParser<Object, Capability> capabilityNotationParser;
+
+    public ResolutionStrategyFactory(
+        Instantiator instantiator,
+        DependencySubstitutionRules globalDependencySubstitutionRules,
+        VcsMappingsStore vcsMappingsStore,
+        ComponentIdentifierFactory componentIdentifierFactory,
+        ImmutableAttributesFactory attributesFactory,
+        ImmutableModuleIdentifierFactory moduleIdentifierFactory,
+        ComponentSelectorConverter componentSelectorConverter,
+        DependencyLockingProvider dependencyLockingProvider,
+        NotationParser<Object, ComponentSelector> moduleSelectorNotationParser,
+        ObjectFactory objectFactory,
+        StartParameterResolutionOverride startParameterResolutionOverride
+    ) {
+        this.instantiator = instantiator;
+        this.globalDependencySubstitutionRules = globalDependencySubstitutionRules;
+        this.vcsMappingsStore = vcsMappingsStore;
+        this.componentIdentifierFactory = componentIdentifierFactory;
+        this.attributesFactory = attributesFactory;
+        this.moduleIdentifierFactory = moduleIdentifierFactory;
+        this.componentSelectorConverter = componentSelectorConverter;
+        this.dependencyLockingProvider = dependencyLockingProvider;
+        this.moduleSelectorNotationParser = moduleSelectorNotationParser;
+        this.objectFactory = objectFactory;
+        this.startParameterResolutionOverride = startParameterResolutionOverride;
+        this.capabilityNotationParser = new CapabilityNotationParserFactory(false).create();
+    }
+
+    @Override
+    public ResolutionStrategyInternal create() {
+        CapabilitiesResolutionInternal capabilitiesResolutionInternal = instantiator.newInstance(DefaultCapabilitiesResolution.class,
+            capabilityNotationParser,
+            new ComponentIdentifierParserFactory().create()
+        );
+
+        ResolutionStrategyInternal resolutionStrategyInternal = instantiator.newInstance(DefaultResolutionStrategy.class,
+            globalDependencySubstitutionRules,
+            vcsMappingsStore,
+            componentIdentifierFactory,
+            moduleIdentifierFactory,
+            componentSelectorConverter,
+            dependencyLockingProvider,
+            capabilitiesResolutionInternal,
+            instantiator,
+            objectFactory,
+            attributesFactory,
+            moduleSelectorNotationParser,
+            capabilityNotationParser
+        );
+
+        startParameterResolutionOverride.applyToCachePolicy(resolutionStrategyInternal.getCachePolicy());
+
+        return resolutionStrategyInternal;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactory.java
@@ -117,8 +117,6 @@ public class ResolveIvyFactory {
         }
 
         CachePolicy cachePolicy = resolutionStrategy.getCachePolicy();
-        startParameterResolutionOverride.applyToCachePolicy(cachePolicy);
-
         UserResolverChain moduleResolver = new UserResolverChain(versionComparator, resolutionStrategy.getComponentSelection(), versionParser, consumerAttributes, attributesSchema, attributesFactory, metadataProcessor, componentMetadataSupplierRuleExecutor, calculatedValueContainerFactory, cachePolicy);
         ParentModuleLookupResolver parentModuleResolver = new ParentModuleLookupResolver(versionComparator, moduleIdentifierFactory, versionParser, consumerAttributes, attributesSchema, attributesFactory, metadataProcessor, componentMetadataSupplierRuleExecutor, calculatedValueContainerFactory, cachePolicy);
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
@@ -24,27 +24,21 @@ import org.gradle.api.artifacts.DependencyResolveDetails;
 import org.gradle.api.artifacts.DependencySubstitutions;
 import org.gradle.api.artifacts.ModuleVersionSelector;
 import org.gradle.api.artifacts.ResolutionStrategy;
-import org.gradle.api.artifacts.component.ComponentSelector;
-import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.ComponentSelectionRulesInternal;
 import org.gradle.api.internal.artifacts.ComponentSelectorConverter;
 import org.gradle.api.internal.artifacts.DependencySubstitutionInternal;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
-import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory;
 import org.gradle.api.internal.artifacts.configurations.ConflictResolution;
 import org.gradle.api.internal.artifacts.configurations.MutationValidator;
 import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal;
 import org.gradle.api.internal.artifacts.dsl.ModuleVersionSelectorParsers;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider;
-import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DefaultDependencySubstitutions;
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionRules;
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionsInternal;
-import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.internal.ImmutableActionSet;
 import org.gradle.internal.locking.NoOpDependencyLockingProvider;
-import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.rules.SpecRuleAction;
 import org.gradle.internal.typeconversion.NormalizedTimeUnit;
 import org.gradle.internal.typeconversion.NotationParser;
@@ -88,19 +82,27 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
     private final Property<Boolean> useGlobalDependencySubstitutionRules;
     private boolean returnAllVariants = false;
 
-    public DefaultResolutionStrategy(DependencySubstitutionRules globalDependencySubstitutionRules,
-                                     VcsResolver vcsResolver,
-                                     ComponentIdentifierFactory componentIdentifierFactory,
-                                     ImmutableModuleIdentifierFactory moduleIdentifierFactory,
-                                     ComponentSelectorConverter componentSelectorConverter,
-                                     DependencyLockingProvider dependencyLockingProvider,
-                                     CapabilitiesResolutionInternal capabilitiesResolution,
-                                     Instantiator instantiator,
-                                     ObjectFactory objectFactory,
-                                     ImmutableAttributesFactory attributesFactory,
-                                     NotationParser<Object, ComponentSelector> moduleSelectorNotationParser,
-                                     NotationParser<Object, Capability> capabilitiesNotationParser) {
-        this(new DefaultCachePolicy(), DefaultDependencySubstitutions.forResolutionStrategy(componentIdentifierFactory, moduleSelectorNotationParser, instantiator, objectFactory, attributesFactory, capabilitiesNotationParser), globalDependencySubstitutionRules, vcsResolver, moduleIdentifierFactory, componentSelectorConverter, dependencyLockingProvider, capabilitiesResolution, objectFactory);
+    public DefaultResolutionStrategy(
+        DependencySubstitutionRules globalDependencySubstitutionRules,
+        VcsResolver vcsResolver,
+        DependencySubstitutionsInternal dependencySubstitutions,
+        ImmutableModuleIdentifierFactory moduleIdentifierFactory,
+        ComponentSelectorConverter componentSelectorConverter,
+        DependencyLockingProvider dependencyLockingProvider,
+        CapabilitiesResolutionInternal capabilitiesResolution,
+        ObjectFactory objectFactory
+    ) {
+        this(
+            new DefaultCachePolicy(),
+            dependencySubstitutions,
+            globalDependencySubstitutionRules,
+            vcsResolver,
+            moduleIdentifierFactory,
+            componentSelectorConverter,
+            dependencyLockingProvider,
+            capabilitiesResolution,
+            objectFactory
+        );
     }
 
     DefaultResolutionStrategy(DefaultCachePolicy cachePolicy, DependencySubstitutionsInternal dependencySubstitutions, DependencySubstitutionRules globalDependencySubstitutionRules, VcsResolver vcsResolver, ImmutableModuleIdentifierFactory moduleIdentifierFactory, ComponentSelectorConverter componentSelectorConverter, DependencyLockingProvider dependencyLockingProvider, CapabilitiesResolutionInternal capabilitiesResolution, ObjectFactory objectFactory) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
@@ -19,16 +19,12 @@ import org.gradle.api.Action
 import org.gradle.api.artifacts.UnknownConfigurationException
 import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.DomainObjectContext
-import org.gradle.api.internal.artifacts.ComponentSelectorConverter
 import org.gradle.api.internal.artifacts.ConfigurationResolver
-import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
-import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.ResolveExceptionContextualizer
 import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory
 import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency
 import org.gradle.api.internal.artifacts.dsl.PublishArtifactNotationParserFactory
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider
-import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionRules
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.DefaultRootComponentMetadataBuilder
 import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.file.TestFiles
@@ -40,12 +36,10 @@ import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.model.CalculatedValueContainerFactory
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.reflect.Instantiator
-import org.gradle.internal.typeconversion.NotationParser
 import org.gradle.internal.work.WorkerThreadRegistry
 import org.gradle.util.AttributeTestUtil
 import org.gradle.util.Path
 import org.gradle.util.TestUtil
-import org.gradle.vcs.internal.VcsMappingsStore
 import spock.lang.Specification
 
 class DefaultConfigurationContainerSpec extends Specification {
@@ -57,15 +51,7 @@ class DefaultConfigurationContainerSpec extends Specification {
     private DependencyMetaDataProvider metaDataProvider = Mock()
     private FileCollectionFactory fileCollectionFactory = Mock()
     private ComponentIdentifierFactory componentIdentifierFactory = Mock()
-    private DependencySubstitutionRules globalSubstitutionRules = Mock()
-    private VcsMappingsStore vcsMappingsInternal = Mock()
     private BuildOperationExecutor buildOperationExecutor = Mock()
-    private ImmutableModuleIdentifierFactory moduleIdentifierFactory = Mock() {
-        module(_, _) >> { args ->
-            DefaultModuleIdentifier.newId(*args)
-        }
-    }
-    private ComponentSelectorConverter componentSelectorConverter = Mock()
     private DependencyLockingProvider dependencyLockingProvider = Mock()
     private ProjectStateRegistry projectStateRegistry = Mock()
     private UserCodeApplicationContext userCodeApplicationContext = Mock()
@@ -104,18 +90,10 @@ class DefaultConfigurationContainerSpec extends Specification {
     )
     private DefaultConfigurationContainer configurationContainer = new DefaultConfigurationContainer(
         instantiator,
-        globalSubstitutionRules,
-        vcsMappingsInternal,
-        componentIdentifierFactory,
-        immutableAttributesFactory,
-        moduleIdentifierFactory,
-        componentSelectorConverter,
-        dependencyLockingProvider,
         domainObjectCollectionCallbackActionDecorator,
-        Mock(NotationParser),
-        TestUtil.objectFactory(),
         rootComponentMetadataBuilderFactory,
-        configurationFactory
+        configurationFactory,
+        Mock(ResolutionStrategyFactory)
     )
 
     def "adds and gets"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
@@ -22,15 +22,11 @@ import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.UnknownConfigurationException
 import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.DomainObjectContext
-import org.gradle.api.internal.artifacts.ComponentSelectorConverter
 import org.gradle.api.internal.artifacts.ConfigurationResolver
-import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
-import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.ResolveExceptionContextualizer
 import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory
 import org.gradle.api.internal.artifacts.dsl.PublishArtifactNotationParserFactory
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider
-import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionRules
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.DefaultRootComponentMetadataBuilder
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory
 import org.gradle.api.internal.file.TestFiles
@@ -41,11 +37,9 @@ import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.model.CalculatedValueContainerFactory
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.reflect.Instantiator
-import org.gradle.internal.typeconversion.NotationParser
 import org.gradle.internal.work.WorkerThreadRegistry
 import org.gradle.util.AttributeTestUtil
 import org.gradle.util.TestUtil
-import org.gradle.vcs.internal.VcsMappingsStore
 import spock.lang.Specification
 
 class DefaultConfigurationContainerTest extends Specification {
@@ -56,8 +50,6 @@ class DefaultConfigurationContainerTest extends Specification {
     }
     private DependencyMetaDataProvider metaDataProvider = Mock(DependencyMetaDataProvider.class)
     private ComponentIdentifierFactory componentIdentifierFactory = Mock(ComponentIdentifierFactory)
-    private DependencySubstitutionRules globalSubstitutionRules = Mock(DependencySubstitutionRules)
-    private VcsMappingsStore vcsMappingsInternal = Mock(VcsMappingsStore)
     private BuildOperationExecutor buildOperationExecutor = Mock(BuildOperationExecutor)
     private DependencyLockingProvider lockingProvider = Mock(DependencyLockingProvider)
     private ProjectStateRegistry projectStateRegistry = Mock(ProjectStateRegistry)
@@ -68,12 +60,6 @@ class DefaultConfigurationContainerTest extends Specification {
     private CalculatedValueContainerFactory calculatedValueContainerFactory = Mock()
     private Instantiator instantiator = TestUtil.instantiatorFactory().decorateLenient()
     private ImmutableAttributesFactory immutableAttributesFactory = AttributeTestUtil.attributesFactory()
-    private ImmutableModuleIdentifierFactory moduleIdentifierFactory = Mock() {
-        module(_, _) >> { args ->
-            DefaultModuleIdentifier.newId(*args)
-        }
-    }
-    private ComponentSelectorConverter componentSelectorConverter = Mock()
     private DomainObjectContext domainObjectContext = new RootScriptDomainObjectContext()
     private DefaultRootComponentMetadataBuilder metadataBuilder = Mock(DefaultRootComponentMetadataBuilder) {
         getValidator() >> Mock(MutationValidator)
@@ -108,18 +94,10 @@ class DefaultConfigurationContainerTest extends Specification {
     )
     private DefaultConfigurationContainer configurationContainer = instantiator.newInstance(DefaultConfigurationContainer.class,
         instantiator,
-        globalSubstitutionRules,
-        vcsMappingsInternal,
-        componentIdentifierFactory,
-        immutableAttributesFactory,
-        moduleIdentifierFactory,
-        componentSelectorConverter,
-        lockingProvider,
         callbackActionDecorator,
-        Mock(NotationParser),
-        TestUtil.objectFactory(),
         rootComponentMetadataBuilderFactory,
-        configurationFactory
+        configurationFactory,
+        Mock(ResolutionStrategyFactory)
     )
 
     def addsNewConfigurationWhenConfiguringSelf() {


### PR DESCRIPTION
Create a standalone ResolutionStrategyFactory. This logic should be separate from a ConfigurationContainer.

The primary motivation for this was to avoid calling 'startParameterResolutionOverride.applyToCachePolicy(cachePolicy)' during resolution, as this mutates the resolution strategy. Ideally, we should not be mutating the resolution strategy _after_ resolution has been initiated.

Making this change centralizes the logic required to build a resolution strategy. But more importantly, by avoiding mutating the resolution strategy after resolution has been initiated, we can leverage this change to be more strict about when we lock configurations for mutation.

The actual changes to mutation will happen in a future PR. This was simply an easily-extractable change which will simplify reasoning about the future configuration mutation changes. 
