### PR TITLE
Remove unnecessary test

### DIFF
--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParametersIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParametersIntegrationTest.groovy
@@ -18,8 +18,6 @@ package org.gradle.workers.internal
 
 import org.gradle.api.services.BuildServiceParameters
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import spock.lang.Ignore
-import spock.lang.Issue
 
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -283,43 +281,6 @@ class WorkerExecutorParametersIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         outputContains("bar")
-
-        where:
-        isolationMode << ISOLATION_MODES
-    }
-
-    /**
-     * This is a reproduction test case for https://github.com/gradle/gradle/issues/13843.  This will only fail if the
-     * system default encoding does not match the encoding of the build process.  I was able to reliably get it to fail
-     * on Ubuntu Linux 16.04.
-     */
-    @Issue('https://github.com/gradle/gradle/issues/13843')
-    @Ignore
-    def "can provide a file property parameter with non-ASCII characters using isolation mode #isolationMode"() {
-        buildFile << """
-            ${parameterWorkAction('RegularFileProperty', '''
-                def file = parameters.testParam.get().getAsFile()
-                println file.text
-            ''')}
-
-            task runWork(type: ParameterTask) {
-                isolationMode = ${isolationMode}
-                def file = project.file("test!@#\\\$^&()_+=-.`~,你所有的基地都属于我们")
-                doFirst {
-                    file.parentFile.mkdirs()
-                    file.text = "foo"
-                }
-                parameters {
-                    testParam.set(file)
-                }
-            }
-        """
-
-        when:
-        succeeds("runWork")
-
-        then:
-        outputContains("foo")
 
         where:
         isolationMode << ISOLATION_MODES


### PR DESCRIPTION
We are now running all our integration tests with non-ASCII characters on the path, there is no need for a special test anymore.

The test was added for https://github.com/gradle/gradle/issues/13843. We've fixed this issue in https://github.com/gradle/gradle/pull/25319.

We've added the non-ASCII paths for Linux here:
- https://github.com/gradle/gradle/pull/25261