### PR TITLE
Simplify task validation code

### DIFF
--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/DefaultWorkValidationContext.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/DefaultWorkValidationContext.java
@@ -51,8 +51,7 @@ public class DefaultWorkValidationContext implements WorkValidationContext {
 
             @Override
             protected void recordProblem(TypeValidationProblem problem) {
-                boolean onlyAffectsCacheableWork = problem.isOnlyAffectsCacheableWork();
-                if (onlyAffectsCacheableWork && !cacheable) {
+                if (problem.getId().onlyAffectsCacheableWork() && !cacheable) {
                     return;
                 }
                 problems.add(problem);

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/model/annotations/AbstractInputFilePropertyAnnotationHandler.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/model/annotations/AbstractInputFilePropertyAnnotationHandler.java
@@ -113,7 +113,6 @@ public abstract class AbstractInputFilePropertyAnnotationHandler extends Abstrac
                 String propertyName = propertyMetadata.getPropertyName();
                 problem.withId(ValidationProblemId.MISSING_NORMALIZATION_ANNOTATION)
                     .reportAs(Severity.ERROR)
-                    .onlyAffectsCacheableWork()
                     .forProperty(propertyName)
                     .withDescription(() -> String.format("is annotated with @%s but missing a normalization strategy", getAnnotationType().getSimpleName()))
                     .happensBecause("If you don't declare the normalization, outputs can't be re-used between machines or locations on the same machine, therefore caching efficiency drops significantly")

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/DefaultTypeValidationContext.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/DefaultTypeValidationContext.java
@@ -48,8 +48,7 @@ public class DefaultTypeValidationContext extends ProblemRecordingTypeValidation
 
     @Override
     protected void recordProblem(TypeValidationProblem problem) {
-        boolean onlyAffectsCacheableWork = problem.isOnlyAffectsCacheableWork();
-        if (onlyAffectsCacheableWork && !reportCacheabilityProblems) {
+        if (problem.getId().onlyAffectsCacheableWork() && !reportCacheabilityProblems) {
             return;
         }
         problems.put(TypeValidationProblemRenderer.renderMinimalInformationAbout(problem), problem.getSeverity());

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/problems/ValidationProblemId.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/problems/ValidationProblemId.java
@@ -49,5 +49,9 @@ public enum ValidationProblemId {
     UNSUPPORTED_VALUE_TYPE,
     SERVICE_REFERENCE_MUST_BE_A_BUILD_SERVICE,
     NESTED_MAP_UNSUPPORTED_KEY_TYPE,
-    NESTED_TYPE_UNSUPPORTED,
+    NESTED_TYPE_UNSUPPORTED;
+
+    public boolean onlyAffectsCacheableWork() {
+        return this == MISSING_NORMALIZATION_ANNOTATION;
+    }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/AbstractValidationProblemBuilder.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/AbstractValidationProblemBuilder.java
@@ -37,7 +37,6 @@ abstract class AbstractValidationProblemBuilder<T extends ValidationProblemBuild
     protected Supplier<String> reason = () -> null;
     protected UserManualReference userManualReference;
     protected final List<Supplier<Solution>> possibleSolutions = Lists.newArrayListWithExpectedSize(1);
-    protected boolean cacheabilityProblemOnly = false;
     protected boolean typeIrrelevantInErrorMessage = false;
 
     public AbstractValidationProblemBuilder(DocumentationRegistry documentationRegistry, @Nullable PluginId pluginId) {
@@ -86,12 +85,6 @@ abstract class AbstractValidationProblemBuilder<T extends ValidationProblemBuild
         DefaultSolutionBuilder builder = new DefaultSolutionBuilder(documentationRegistry, solution);
         solutionSpec.execute(builder);
         possibleSolutions.add(builder.build());
-        return Cast.uncheckedCast(this);
-    }
-
-    @Override
-    public T onlyAffectsCacheableWork() {
-        this.cacheabilityProblemOnly = true;
         return Cast.uncheckedCast(this);
     }
 

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/DefaultPropertyValidationProblemBuilder.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/DefaultPropertyValidationProblemBuilder.java
@@ -75,7 +75,6 @@ public class DefaultPropertyValidationProblemBuilder extends AbstractValidationP
             shortProblemDescription,
             longDescription,
             reason,
-            cacheabilityProblemOnly,
             userManualReference,
             possibleSolutions
         );

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/DefaultTypeValidationProblemBuilder.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/DefaultTypeValidationProblemBuilder.java
@@ -51,7 +51,6 @@ public class DefaultTypeValidationProblemBuilder extends AbstractValidationProbl
             shortProblemDescription,
             longDescription,
             reason,
-            cacheabilityProblemOnly,
             userManualReference,
             possibleSolutions
         );

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/TypeValidationProblem.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/TypeValidationProblem.java
@@ -24,7 +24,6 @@ import java.util.function.Supplier;
 
 public class TypeValidationProblem extends BaseProblem<ValidationProblemId, Severity, TypeValidationProblemLocation> {
     private final UserManualReference userManualReference;
-    private final boolean onlyAffectsCacheableWork;
 
     public TypeValidationProblem(ValidationProblemId id,
                                  Severity severity,
@@ -32,7 +31,6 @@ public class TypeValidationProblem extends BaseProblem<ValidationProblemId, Seve
                                  Supplier<String> shortDescription,
                                  Supplier<String> longDescription,
                                  Supplier<String> reason,
-                                 boolean onlyAffectsCacheableWork,
                                  UserManualReference userManualReference,
                                  List<Supplier<Solution>> solutions) {
         super(id,
@@ -44,14 +42,9 @@ public class TypeValidationProblem extends BaseProblem<ValidationProblemId, Seve
             () -> userManualReference == null ? null : userManualReference.toDocumentationLink(),
             solutions);
         this.userManualReference = userManualReference;
-        this.onlyAffectsCacheableWork = onlyAffectsCacheableWork;
     }
 
     public UserManualReference getUserManualReference() {
         return userManualReference;
-    }
-
-    public boolean isOnlyAffectsCacheableWork() {
-        return onlyAffectsCacheableWork;
     }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/ValidationProblemBuilder.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/ValidationProblemBuilder.java
@@ -57,9 +57,6 @@ public interface ValidationProblemBuilder<T extends ValidationProblemBuilder<T>>
         return addPossibleSolution(() -> solution);
     }
 
-    T onlyAffectsCacheableWork();
-
-
     /**
      * Indicates that whenever this error is reported to the user,
      * it's not important, or even sometimes confusing, to report the type


### PR DESCRIPTION
The `onlyAffectsCacheableWork` field is set to true if and only if a problem with `MISSING_NORMALIZATION_ANNOTATION` id is reported. Consequently, we don't need to store `onlyAffectsCacheableWork` in a dedicated field.
