### PR TITLE
Emit ExecuteWorkBuildOperationType only when necessary

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsOperationIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.tasks
 
-import com.google.common.collect.Iterables
 import org.gradle.api.Action
 import org.gradle.api.DefaultTask
 import org.gradle.api.internal.tasks.execution.ExecuteTaskBuildOperationType
@@ -37,7 +36,6 @@ import org.gradle.internal.enterprise.core.GradleEnterprisePluginManager
 import org.gradle.internal.reflect.problems.ValidationProblemId
 import org.gradle.internal.reflect.validation.ValidationMessageChecker
 import org.gradle.internal.reflect.validation.ValidationTestFor
-import org.gradle.operations.execution.ExecuteWorkBuildOperationType
 
 import static com.google.common.base.CaseFormat.UPPER_CAMEL
 import static com.google.common.base.CaseFormat.UPPER_UNDERSCORE
@@ -599,8 +597,7 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
         def aCompileJavaTask = operations.first(ExecuteTaskBuildOperationType) {
             it.details.taskPath == taskPath
         }
-        def executeWorkOperation = Iterables.getOnlyElement(operations.children(aCompileJavaTask, ExecuteWorkBuildOperationType))
-        def results = operations.children(executeWorkOperation, SnapshotTaskInputsBuildOperationType)
+        def results = operations.children(aCompileJavaTask, SnapshotTaskInputsBuildOperationType)
         assert results.size() == 1
         results.first().result
     }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskTimeoutIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskTimeoutIntegrationTest.groovy
@@ -16,14 +16,12 @@
 
 package org.gradle.api.tasks
 
-import com.google.common.collect.Iterables
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.internal.execution.timeout.impl.DefaultTimeoutHandler
 import org.gradle.internal.logging.events.operations.LogEventBuildOperationProgressDetails
-import org.gradle.operations.execution.ExecuteWorkBuildOperationType
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import spock.lang.IgnoreIf
 
@@ -286,8 +284,7 @@ class TaskTimeoutIntegrationTest extends AbstractIntegrationSpec {
 
     List<String> taskLogging(String taskPath) {
         def taskExecutionOp = operations.only("Task $taskPath")
-        def workExecutionOp = Iterables.getOnlyElement(operations.children(taskExecutionOp, ExecuteWorkBuildOperationType))
-        def logging = workExecutionOp.progress(LogEventBuildOperationProgressDetails)*.details
+        def logging = taskExecutionOp.progress(LogEventBuildOperationProgressDetails)*.details
         def timeoutLogging = logging.findAll { it.category == DefaultTimeoutHandler.name }
         timeoutLogging.collect { it.message } as List<String>
     }


### PR DESCRIPTION
to avoid some problems on the GE side. In the long run, we'd always want to emit the build operation, though not yet for Gradle 8.3.