### PR TITLE
Normalize absolute path for mutable transforms

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformInvocationFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformInvocationFactory.java
@@ -93,6 +93,7 @@ public class DefaultTransformInvocationFactory implements TransformInvocationFac
                 inputArtifact,
                 dependencies,
                 subject,
+                producerProject,
 
                 transformExecutionListener,
                 buildOperationExecutor,


### PR DESCRIPTION
For the workspace for project transforms we have been using the absolute path of the input artifact. This will not be stable between builds, even when the project artifact transform is stable. The workspace id for external artifacts is stable, since it only uses the name and the content hash of the artifact and not an absolute path.

To make it simpler to compare transformed project artifacts between builds and especially between workspaces, this PR normalizes the path of the input artifact for the workspace id relative to the root project directory of the build.