### PR TITLE
Support building security advisory fork on TeamCity

### DIFF
--- a/.teamcity/src/main/kotlin/common/VersionedSettingsBranch.kt
+++ b/.teamcity/src/main/kotlin/common/VersionedSettingsBranch.kt
@@ -2,6 +2,15 @@ package common
 
 import jetbrains.buildServer.configs.kotlin.v2019_2.DslContext
 
+fun isSecurityAdvisoryFork(): Boolean {
+    return DslContext.settingsRoot.id.toString().lowercase().contains("security")
+}
+
+// GradleMaster -> Master
+// GradleSecurityAdvisory84mwRelease -> SecurityAdvisory84mwRelease
+val DslContext.uuidPrefix: String
+    get() = settingsRoot.name.substringAfter("Gradle")
+
 data class VersionedSettingsBranch(val branchName: String) {
     /**
      * 0~23.
@@ -38,9 +47,6 @@ data class VersionedSettingsBranch(val branchName: String) {
         private
         val OLD_RELEASE_PATTERN = "release(\\d+)x".toRegex()
 
-        private
-        val mainBranches = setOf(MASTER_BRANCH, RELEASE_BRANCH)
-
         fun fromDslContext(): VersionedSettingsBranch {
             val branch = DslContext.getParameter("Branch")
             // TeamCity uses a dummy name when first running the DSL
@@ -75,7 +81,7 @@ data class VersionedSettingsBranch(val branchName: String) {
     val isExperimental: Boolean
         get() = branchName == EXPERIMENTAL_BRANCH
 
-    fun vcsRootId() = "Gradle${branchName.toCapitalized()}"
+    fun vcsRootId() = DslContext.settingsRoot.id.toString()
 
     fun promoteNightlyTaskName() = nightlyTaskName("promote")
     fun prepNightlyTaskName() = nightlyTaskName("prep")

--- a/.teamcity/src/main/kotlin/configurations/PartialTrigger.kt
+++ b/.teamcity/src/main/kotlin/configurations/PartialTrigger.kt
@@ -16,14 +16,14 @@
 
 package configurations
 
-import common.VersionedSettingsBranch
 import common.applyDefaultSettings
-import common.toCapitalized
+import common.uuidPrefix
+import jetbrains.buildServer.configs.kotlin.v2019_2.DslContext
 import model.CIBuildModel
 
 class PartialTrigger<T : BaseGradleBuildType>(triggerName: String, triggerId: String, model: CIBuildModel, dependencies: Iterable<T>) : BaseGradleBuildType(init = {
     id("${model.projectId}_${triggerId}_Trigger")
-    uuid = "${VersionedSettingsBranch.fromDslContext().branchName.toCapitalized()}_${model.projectId}_${triggerId}_Trigger"
+    uuid = "${DslContext.uuidPrefix}_${model.projectId}_${triggerId}_Trigger"
     name = "$triggerName (Trigger)"
     type = Type.COMPOSITE
 

--- a/.teamcity/src/main/kotlin/configurations/StagePasses.kt
+++ b/.teamcity/src/main/kotlin/configurations/StagePasses.kt
@@ -1,9 +1,9 @@
 package configurations
 
-import common.VersionedSettingsBranch
 import common.applyDefaultSettings
-import common.toCapitalized
+import common.uuidPrefix
 import jetbrains.buildServer.configs.kotlin.v2019_2.Dependencies
+import jetbrains.buildServer.configs.kotlin.v2019_2.DslContext
 import jetbrains.buildServer.configs.kotlin.v2019_2.FailureAction
 import jetbrains.buildServer.configs.kotlin.v2019_2.RelativeId
 import jetbrains.buildServer.configs.kotlin.v2019_2.SnapshotDependency
@@ -82,7 +82,7 @@ fun stageTriggerUuid(model: CIBuildModel, stage: Stage) = stageTriggerUuid(model
 
 fun stageTriggerId(model: CIBuildModel, stageName: StageName) = "${model.projectId}_Stage_${stageName.id}_Trigger"
 
-fun stageTriggerUuid(model: CIBuildModel, stageName: StageName) = "${VersionedSettingsBranch.fromDslContext().branchName.toCapitalized()}_${model.projectId}_Stage_${stageName.uuid}_Trigger"
+fun stageTriggerUuid(model: CIBuildModel, stageName: StageName) = "${DslContext.uuidPrefix}_${model.projectId}_Stage_${stageName.uuid}_Trigger"
 
 fun <T : BaseGradleBuildType> Dependencies.snapshotDependencies(buildTypes: Iterable<T>, snapshotConfig: SnapshotDependency.(T) -> Unit = {}) {
     buildTypes.forEach { buildType ->

--- a/.teamcity/src/main/kotlin/projects/GradleBuildToolRootProject.kt
+++ b/.teamcity/src/main/kotlin/projects/GradleBuildToolRootProject.kt
@@ -1,6 +1,7 @@
 package projects
 
 import common.VersionedSettingsBranch
+import common.isSecurityAdvisoryFork
 import jetbrains.buildServer.configs.kotlin.v2019_2.Project
 import model.CIBuildModel
 import model.DefaultFunctionalTestBucketProvider
@@ -20,7 +21,9 @@ class GradleBuildToolRootProject(branch: VersionedSettingsBranch) : Project({
     val gradleBuildBucketProvider = DefaultFunctionalTestBucketProvider(model, File("./test-buckets.json"))
     subProject(CheckProject(model, gradleBuildBucketProvider))
 
-    subProject(PromotionProject(model.branch))
-    subProject(UtilProject)
-    subProject(UtilPerformanceProject)
+    if (!isSecurityAdvisoryFork()) {
+        subProject(PromotionProject(model.branch))
+        subProject(UtilProject)
+        subProject(UtilPerformanceProject)
+    }
 })

--- a/.teamcity/src/main/kotlin/projects/StageProject.kt
+++ b/.teamcity/src/main/kotlin/projects/StageProject.kt
@@ -1,8 +1,7 @@
 package projects
 
-import common.VersionedSettingsBranch
 import common.hiddenArtifactDestination
-import common.toCapitalized
+import common.uuidPrefix
 import configurations.BaseGradleBuildType
 import configurations.DocsTestProject
 import configurations.DocsTestTrigger
@@ -13,6 +12,7 @@ import configurations.PerformanceTest
 import configurations.PerformanceTestsPass
 import configurations.SmokeTests
 import configurations.buildReportTab
+import jetbrains.buildServer.configs.kotlin.v2019_2.DslContext
 import jetbrains.buildServer.configs.kotlin.v2019_2.Project
 import jetbrains.buildServer.configs.kotlin.v2019_2.RelativeId
 import model.CIBuildModel
@@ -35,7 +35,7 @@ class StageProject(
     previousPerformanceTestPasses: List<PerformanceTestsPass>
 ) : Project({
     this.id("${model.projectId}_Stage_${stage.stageName.id}")
-    this.uuid = "${VersionedSettingsBranch.fromDslContext().branchName.toCapitalized()}_${model.projectId}_Stage_${stage.stageName.uuid}"
+    this.uuid = "${DslContext.uuidPrefix}_${model.projectId}_Stage_${stage.stageName.uuid}"
     this.name = stage.stageName.stageName
     this.description = stage.stageName.description
 }) {

--- a/.teamcity/src/test/kotlin/CIConfigIntegrationTests.kt
+++ b/.teamcity/src/test/kotlin/CIConfigIntegrationTests.kt
@@ -3,7 +3,6 @@ import common.JvmVersion
 import common.Os
 import common.VersionedSettingsBranch
 import configurations.BaseGradleBuildType
-import jetbrains.buildServer.configs.kotlin.v2019_2.AbsoluteId
 import jetbrains.buildServer.configs.kotlin.v2019_2.DslContext
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.GradleBuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnText
@@ -27,9 +26,7 @@ import java.io.File
 
 class CIConfigIntegrationTests {
     init {
-        // Set the project id here, so we can use methods on the DslContext
-        DslContext.projectId = AbsoluteId("Gradle_Master")
-        DslContext.addParameters("Branch" to "master")
+        DslContext.initForTest()
     }
 
     private val subprojectProvider = JsonBasedGradleSubprojectProvider(File("../.teamcity/subprojects.json"))

--- a/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
+++ b/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
@@ -21,7 +21,6 @@ import common.VersionedSettingsBranch
 import common.pluginPortalUrlOverride
 import configurations.BaseGradleBuildType
 import configurations.PerformanceTest
-import jetbrains.buildServer.configs.kotlin.v2019_2.AbsoluteId
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.DslContext
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.GradleBuildStep
@@ -40,9 +39,7 @@ import java.io.File
 
 class PerformanceTestBuildTypeTest {
     init {
-        // Set the project id here, so we can use methods on the DslContext
-        DslContext.projectId = AbsoluteId("Gradle_Master")
-        DslContext.addParameters("Branch" to "master")
+        DslContext.initForTest()
     }
 
     private

--- a/.teamcity/src/test/kotlin/PromotionProjectTests.kt
+++ b/.teamcity/src/test/kotlin/PromotionProjectTests.kt
@@ -29,6 +29,10 @@ import org.junit.jupiter.params.provider.CsvSource
 import promotion.PromotionProject
 
 class PromotionProjectTests {
+    init {
+        DslContext.initForTest()
+    }
+
     @Test
     fun `promotion project has expected build types for master branch`() {
         val model = setupModelFor("master")

--- a/.teamcity/src/test/kotlin/common.kt
+++ b/.teamcity/src/test/kotlin/common.kt
@@ -1,0 +1,11 @@
+import jetbrains.buildServer.configs.kotlin.v2019_2.AbsoluteId
+import jetbrains.buildServer.configs.kotlin.v2019_2.DslContext
+
+fun DslContext.initForTest() {
+    // Set the project id here, so we can use methods on the DslContext
+    parentProjectId = AbsoluteId("Gradle")
+    projectId = AbsoluteId("Gradle_Master")
+    settingsRootId = AbsoluteId("GradleMaster")
+    settingsRoot.name = "GradleMaster"
+    addParameters("Branch" to "master")
+}


### PR DESCRIPTION
We want to build a private fork to fix some security issues. This PR supports using the private fork as TeamCity Kotlin DSL versioned settings root.