### PR TITLE
Add `allWarningsAsErrors` to Kotlin DSL script compilation and in-memory cache keys

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -124,7 +124,7 @@ See the [build init](userguide/build_init_plugin.html#sec:what_to_set_up) user m
 #### Fail on script compilation warnings
 
 Gradle [Kotlin DSL scripts](userguide/kotlin_dsl.html#sec:scripts) are compiled by Gradle during the configuration phase of your build.
-Deprecation warnings found by the Kotlin compiler are reported on the console when compiling the scripts.
+For example, deprecation warnings or unused variables found by the Kotlin compiler are reported on the console when compiling the scripts.
 
 In order to catch potential issues faster, it is now possible to configure your build to fail on any warning emitted during script compilation by setting the `org.gradle.kotlin.dsl.allWarningsAsErrors` Gradle property to `true`:
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/Interpreter.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/Interpreter.kt
@@ -177,7 +177,13 @@ class Interpreter(val host: Host) {
 
         val assignmentOverloadEnabled = KotlinDslAssignment.isAssignmentOverloadEnabled()
         val programId =
-            ProgramId(templateId, sourceHash, parentClassLoader, assignmentOverloadEnabled = assignmentOverloadEnabled)
+            ProgramId(
+                templateId,
+                sourceHash,
+                parentClassLoader,
+                allWarningsAsErrors = host.allWarningsAsErrors,
+                assignmentOverloadEnabled = assignmentOverloadEnabled
+            )
 
         val cachedProgram =
             host.cachedClassFor(programId)
@@ -419,6 +425,7 @@ class Interpreter(val host: Host) {
                 parentClassLoader,
                 host.hashOf(accessorsClassPath),
                 host.hashOf(compileClassPath),
+                host.allWarningsAsErrors,
                 assignmentOverloadEnabled
             )
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/ProgramId.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/ProgramId.kt
@@ -27,6 +27,7 @@ class ProgramId(
     parentClassLoader: ClassLoader,
     private val accessorsClassPathHash: HashCode? = null,
     private val classPathHash: HashCode? = null,
+    val allWarningsAsErrors: Boolean = false,
     val assignmentOverloadEnabled: Boolean = false
 ) {
 
@@ -45,6 +46,7 @@ class ProgramId(
             && sourceHash == that.sourceHash
             && accessorsClassPathHash == that.accessorsClassPathHash
             && classPathHash == that.classPathHash
+            && allWarningsAsErrors == that.allWarningsAsErrors
             && assignmentOverloadEnabled == that.assignmentOverloadEnabled
     }
 
@@ -60,6 +62,7 @@ class ProgramId(
         classPathHash?.let { classPathHash ->
             result = 31 * result + classPathHash.hashCode()
         }
+        result = 31 * result + allWarningsAsErrors.hashCode()
         return 31 * result + assignmentOverloadEnabled.hashCode()
     }
 }


### PR DESCRIPTION
* Follows up https://github.com/gradle/gradle/pull/24532
* Fixes https://github.com/gradle/gradle/issues/25407
