### PR TITLE
Allow running the build with the TD plugin

### DIFF
--- a/subprojects/precondition-tester/build.gradle.kts
+++ b/subprojects/precondition-tester/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.gradle.enterprise.gradleplugin.testselection.PredictiveTestSelectionExtension
 import gradlebuild.integrationtests.tasks.DistributionTest
 
 /*
@@ -79,7 +80,7 @@ fun Test.setupPreconditionTesting() {
     classpath += sourceSets.test.get().output
 
     // These tests should not be impacted by the predictive selection
-    predictiveSelection {
+    extensions.findByType<PredictiveTestSelectionExtension>()?.apply {
         enabled = false
     }
 


### PR DESCRIPTION
when it is used as an included build.

The TD plugin doesn't apply itself to included build, so the Gradle build needs to be prepared when the extension isn't there until this has been fixed in the TD plugin.