### PR TITLE
Fix build-cache-http project for configuration cache

### DIFF
--- a/subprojects/build-cache-http/build.gradle.kts
+++ b/subprojects/build-cache-http/build.gradle.kts
@@ -26,8 +26,3 @@ dependencies {
 
     integTestDistributionRuntimeOnly(project(":distributions-basics"))
 }
-
-// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
-tasks.configCacheIntegTest {
-    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
-}

--- a/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceErrorHandlingIntegrationTest.groovy
+++ b/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceErrorHandlingIntegrationTest.groovy
@@ -50,11 +50,12 @@ class HttpBuildCacheServiceErrorHandlingIntegrationTest extends HttpBuildCacheFi
                 }
             }
 
-            task customTask(type: CustomTask) {
+            def customTask = tasks.register("customTask", CustomTask) {
                 outputFile = file('build/outputFile.bin')
             }
 
-            task customTask2(type: CustomTask) {
+            tasks.register("customTask2", CustomTask) {
+                mustRunAfter(customTask)
                 outputFile = file('build/outputFile2.bin')
             }
         """.stripIndent()


### PR DESCRIPTION
It looks like the only issue is extra parallelism of tasks.

`HttpBuildCacheServiceErrorHandlingIntegrationTest.build cache is deactivated if response is not successful` was failing since these two tasks run in parallel.