### PR TITLE
[Spike] Reconstruct original-to-instrumented mapping outside of transformation

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptClassPathResolver.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptClassPathResolver.java
@@ -31,6 +31,7 @@ import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.internal.classpath.CachedClasspathTransformer;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.classpath.DefaultClassPath;
+import org.gradle.internal.classpath.TransformedClassPath;
 import org.gradle.internal.component.local.model.OpaqueComponentIdentifier;
 import org.gradle.internal.logging.util.Log4jBannedVersion;
 import org.gradle.util.GradleVersion;
@@ -83,6 +84,6 @@ public class DefaultScriptClassPathResolver implements ScriptClassPathResolver {
                 return true;
             });
         });
-        return classpathTransformer.transform(DefaultClassPath.of(view.getFiles()), CachedClasspathTransformer.StandardTransform.BuildLogic);
+        return TransformedClassPath.handleInstrumentingArtifactTransform(classpathTransformer.transform(DefaultClassPath.of(view.getFiles()), CachedClasspathTransformer.StandardTransform.BuildLogic));
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/FileCacheBackedScriptClassCompiler.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/FileCacheBackedScriptClassCompiler.java
@@ -30,6 +30,7 @@ import org.gradle.internal.classpath.ClassData;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.classpath.ClasspathEntryVisitor;
 import org.gradle.internal.classpath.DefaultClassPath;
+import org.gradle.internal.classpath.TransformedClassPath;
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.hash.Hasher;
@@ -133,7 +134,7 @@ public class FileCacheBackedScriptClassCompiler implements ScriptClassCompiler, 
     private ClassPath remapClasses(File genericClassesDir, RemappingScriptSource source) {
         ScriptSource origin = source.getSource();
         String className = origin.getClassName();
-        return classpathTransformer.transform(DefaultClassPath.of(genericClassesDir), BuildLogic, new CachedClasspathTransformer.Transform() {
+        return TransformedClassPath.handleInstrumentingArtifactTransform(classpathTransformer.transform(DefaultClassPath.of(genericClassesDir), BuildLogic, new CachedClasspathTransformer.Transform() {
             @Override
             public void applyConfigurationTo(Hasher hasher) {
                 hasher.putString(FileCacheBackedScriptClassCompiler.class.getSimpleName());
@@ -154,7 +155,7 @@ public class FileCacheBackedScriptClassCompiler implements ScriptClassCompiler, 
                 BuildScriptRemapper remapper = new BuildScriptRemapper(visitor, origin, originalClassName, contentHash);
                 return Pair.of(entry.getPath().getParent().append(true, renamed), remapper);
             }
-        });
+        }));
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultCachedClasspathTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultCachedClasspathTransformer.java
@@ -134,9 +134,10 @@ public class DefaultCachedClasspathTransformer implements CachedClasspathTransfo
             List<File> transformedJars = transformedClassPath.getAsFiles();
             int size = copiedOriginalJars.size();
             assert size == transformedJars.size();
-            TransformedClassPath.Builder result = TransformedClassPath.builderWithExactSize(size);
+            DefaultClassPath.Builder result = DefaultClassPath.builderWithExactSize(size * 2);
             for (int i = 0; i < size; ++i) {
-                result.add(copiedOriginalJars.get(i), transformedJars.get(i));
+                result.add(transformedJars.get(i));
+                result.add(copiedOriginalJars.get(i));
             }
             return result.build();
         };

--- a/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/GeneratePrecompiledScriptPluginAccessors.kt
+++ b/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/GeneratePrecompiledScriptPluginAccessors.kt
@@ -44,6 +44,7 @@ import org.gradle.internal.build.NestedRootBuildRunner.createNestedBuildTree
 import org.gradle.internal.classpath.CachedClasspathTransformer
 import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.classpath.DefaultClassPath
+import org.gradle.internal.classpath.TransformedClassPath
 import org.gradle.internal.concurrent.CompositeStoppable.stoppable
 import org.gradle.internal.exceptions.LocationAwareException
 import org.gradle.internal.hash.HashCode
@@ -411,10 +412,10 @@ abstract class GeneratePrecompiledScriptPluginAccessors @Inject internal constru
 
     private
     fun buildLogicClassPath(): ClassPath =
-        services.get<CachedClasspathTransformer>().transform(
+        TransformedClassPath.handleInstrumentingArtifactTransform(services.get<CachedClasspathTransformer>().transform(
             DefaultClassPath.of(runtimeClassPathFiles),
             CachedClasspathTransformer.StandardTransform.BuildLogic
-        )
+        ))
 
     private
     fun uniqueTempDirectory() =

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptEvaluator.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptEvaluator.kt
@@ -34,6 +34,7 @@ import org.gradle.internal.classpath.CachedClasspathTransformer
 import org.gradle.internal.classpath.CachedClasspathTransformer.StandardTransform.BuildLogic
 import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.classpath.DefaultClassPath
+import org.gradle.internal.classpath.TransformedClassPath
 import org.gradle.internal.execution.ExecutionEngine
 import org.gradle.internal.execution.InputFingerprinter
 import org.gradle.internal.execution.UnitOfWork
@@ -291,7 +292,7 @@ class StandardKotlinScriptEvaluator(
             className: String,
             accessorsClassPath: ClassPath
         ): CompiledScript {
-            val instrumentedClasses = cachedClasspathTransformer.transform(DefaultClassPath.of(location), BuildLogic)
+            val instrumentedClasses = TransformedClassPath.handleInstrumentingArtifactTransform(cachedClasspathTransformer.transform(DefaultClassPath.of(location), BuildLogic))
             val classpath = instrumentedClasses.plus(accessorsClassPath)
             return ScopeBackedCompiledScript(classLoaderScope, childScopeId, origin, classpath, className)
         }

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/resolve/service/internal/DefaultInjectedClasspathPluginResolver.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/resolve/service/internal/DefaultInjectedClasspathPluginResolver.java
@@ -26,6 +26,7 @@ import org.gradle.api.internal.plugins.PluginInspector;
 import org.gradle.api.internal.plugins.PluginRegistry;
 import org.gradle.internal.classpath.CachedClasspathTransformer;
 import org.gradle.internal.classpath.ClassPath;
+import org.gradle.internal.classpath.TransformedClassPath;
 import org.gradle.plugin.management.internal.InvalidPluginRequestException;
 import org.gradle.plugin.management.internal.PluginRequestInternal;
 import org.gradle.plugin.use.PluginId;
@@ -44,7 +45,7 @@ public class DefaultInjectedClasspathPluginResolver implements ClientInjectedCla
 
     public DefaultInjectedClasspathPluginResolver(ClassLoaderScope parentScope, CachedClasspathTransformer classpathTransformer, PluginInspector pluginInspector, ClassPath injectedClasspath, InjectedClasspathInstrumentationStrategy instrumentationStrategy) {
         this.injectedClasspath = injectedClasspath;
-        ClassPath cachedClassPath = classpathTransformer.transform(injectedClasspath, instrumentationStrategy.getTransform());
+        ClassPath cachedClassPath = TransformedClassPath.handleInstrumentingArtifactTransform(classpathTransformer.transform(injectedClasspath, instrumentationStrategy.getTransform()));
         this.pluginRegistry = new DefaultPluginRegistry(pluginInspector,
             parentScope.createChild("injected-plugin", null)
                 .local(cachedClassPath)


### PR DESCRIPTION
As a precondition to migrating the configuration cache instrumentation to ArtifactTransform, we must be able to build the classloader from the ArtifactTransform output. The latter is limited compared to the ad-hoc transformation we have, and cannot carry necessary original-to-instrumented mappings as a TransformedClassPath object. The only available option is a list of files.

This CL makes CachedClasspathTransformer more similar to the ArtifactTransform in this regard. It now outputs a list of instrumented JAR-original JAR pairs. This list is converted to TransformedClassPath quite fast to avoid further changes downstream, as I believe that only a small, known subset of classloaders should deal with the instrumentation.

Fixes #25188 