### PR TITLE
Don't calculate fork point commit on security fork

### DIFF
--- a/build-logic/basics/src/main/kotlin/gradlebuild/basics/kotlindsl/kotlin-dsl-upstream-candidates.kt
+++ b/build-logic/basics/src/main/kotlin/gradlebuild/basics/kotlindsl/kotlin-dsl-upstream-candidates.kt
@@ -16,10 +16,10 @@ operator fun File.div(child: String): File =
     resolve(child)
 
 
-fun Project.execAndGetStdout(workingDir: File, vararg args: String): String {
+fun Project.execAndGetStdout(workingDir: File, ignoreExitValue: Boolean, vararg args: String): String {
     val out = ByteArrayOutputStream()
     exec {
-        isIgnoreExitValue = true
+        isIgnoreExitValue = ignoreExitValue
         commandLine(*args)
         standardOutput = out
         this.workingDir = workingDir
@@ -28,4 +28,7 @@ fun Project.execAndGetStdout(workingDir: File, vararg args: String): String {
 }
 
 
-fun Project.execAndGetStdout(vararg args: String) = execAndGetStdout(File("."), *args)
+fun Project.execAndGetStdoutIgnoringError(vararg args: String) = execAndGetStdout(File("."), true, *args)
+
+
+fun Project.execAndGetStdout(vararg args: String) = execAndGetStdout(File("."), false, *args)

--- a/build-logic/buildquality/src/main/kotlin/gradlebuild/quickcheck/tasks/QuickCheckTask.kt
+++ b/build-logic/buildquality/src/main/kotlin/gradlebuild/quickcheck/tasks/QuickCheckTask.kt
@@ -16,7 +16,7 @@
 
 package gradlebuild.quickcheck.tasks
 
-import gradlebuild.basics.kotlindsl.execAndGetStdout
+import gradlebuild.basics.kotlindsl.execAndGetStdoutIgnoringError
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskAction
@@ -48,7 +48,7 @@ abstract class QuickCheckTask : DefaultTask() {
 
     private
     fun getChangedFiles(): List<String> =
-        project.execAndGetStdout("git", "diff", "--cached", "--name-status", "HEAD")
+        project.execAndGetStdoutIgnoringError("git", "diff", "--cached", "--name-status", "HEAD")
             .lines()
             .map { it.trim() }
             .filter { it.isNotBlank() && !it.startsWith("D") }

--- a/build-logic/performance-testing/src/test/kotlin/gradlebuild/performance/tasks/DetermineBaselinesTest.kt
+++ b/build-logic/performance-testing/src/test/kotlin/gradlebuild/performance/tasks/DetermineBaselinesTest.kt
@@ -49,6 +49,7 @@ class DetermineBaselinesTest {
 
         // mock project.execAndGetStdout
         mockkStatic("gradlebuild.basics.kotlindsl.Kotlin_dsl_upstream_candidatesKt")
+        mockGitOperation(listOf("git", "remote", "-v"), "origin https://github.com/gradle/gradle.git (fetch)")
     }
 
     @After
@@ -83,6 +84,15 @@ class DetermineBaselinesTest {
 
         // then
         verifyBaselineDetermination("my-branch", false, null, "5.1-commit-master-fork-point")
+    }
+
+    @Test
+    fun `not determines fork point commit in security advisory fork`() {
+        // given
+        mockGitOperation(listOf("git", "remote", "-v"), "origin https://github.com/gradle/gradle-ghsa-84mw-qh6q-v842.git (fetch)")
+
+        // then
+        verifyBaselineDetermination("my-branch", false, null, defaultPerformanceBaselines)
     }
 
     @Test

--- a/build-logic/profiling/src/main/kotlin/gradlebuild.buildscan.gradle.kts
+++ b/build-logic/profiling/src/main/kotlin/gradlebuild.buildscan.gradle.kts
@@ -23,7 +23,7 @@ import gradlebuild.basics.BuildEnvironment.isTravis
 import gradlebuild.basics.buildBranch
 import gradlebuild.basics.environmentVariable
 import gradlebuild.basics.isPromotionBuild
-import gradlebuild.basics.kotlindsl.execAndGetStdout
+import gradlebuild.basics.kotlindsl.execAndGetStdoutIgnoringError
 import gradlebuild.basics.logicalBranch
 import gradlebuild.basics.predictiveTestSelectionEnabled
 import gradlebuild.basics.testDistributionEnabled
@@ -86,7 +86,7 @@ fun Project.extractCiData() {
     if (isCiServer) {
         buildScan {
             background {
-                setCompileAllScanSearch(execAndGetStdout("git", "rev-parse", "--verify", "HEAD"))
+                setCompileAllScanSearch(execAndGetStdoutIgnoringError("git", "rev-parse", "--verify", "HEAD"))
             }
             if (isEc2Agent()) {
                 tag("EC2")


### PR DESCRIPTION
In the past, we calculated the "fork point commit" as performance baseline on feature branches. However, in security fork, because the forked repository is private, `git fetch` and subsequent `git merge-base` command would fail, resulting in the calculated performance baseline to be `8.2-commit-`. ([Example](https://builds.gradle.org/buildConfiguration/Gradle_Security84mwRelease_Check_PerformanceTest7bucket2/67326226))

This PR checks if the current repostory is a security fork (gradle/gradle-ghsa) and skip calculating fork point commit in this situation.