### PR TITLE
Resolve poor performance when running a subset of finalized tasks

### DIFF
--- a/.teamcity/performance-test-durations.json
+++ b/.teamcity/performance-test-durations.json
@@ -774,4 +774,10 @@
     "testProject" : "largeMonolithicJavaProject",
     "linux" : 83000
   } ]
+}, {
+    "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.calculate task graph with test finalizer",
+    "durations" : [ {
+        "testProject" : "largeAndroidBuild",
+        "linux" : 1200000
+    } ]
 } ]

--- a/.teamcity/performance-tests-ci.json
+++ b/.teamcity/performance-tests-ci.json
@@ -151,6 +151,14 @@
       }
     } ]
   }, {
+    "testId" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.calculate task graph with test finalizer",
+    "groups" : [ {
+      "testProject" : "largeAndroidBuild",
+      "coverage" : {
+        "per_commit" : [ "linux" ]
+      }
+    } ]
+  }, {
     "testId" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.clean assembleDebug with clean transforms cache",
     "groups" : [ {
       "testProject" : "largeAndroidBuild",

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,4 +26,4 @@ systemProp.gradle.internal.testdistribution.writeTraceFile=true
 systemProp.gradle.internal.testdistribution.queryResponseTimeout=PT20S
 
 # Default performance baseline
-defaultPerformanceBaselines=8.3-commit-8763dae0858
+defaultPerformanceBaselines=8.3-commit-288417f2d85

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/FinalizerGroup.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/FinalizerGroup.java
@@ -43,6 +43,7 @@ public class FinalizerGroup extends HasFinalizers {
     @Nullable
     private ElementSuccessors successors;
     private boolean finalizedNodeHasStarted;
+    private boolean hasBeenScheduled;
 
     public FinalizerGroup(TaskNode node, NodeGroup delegate) {
         this.ordinal = delegate.asOrdinal();
@@ -159,6 +160,12 @@ public class FinalizerGroup extends HasFinalizers {
     }
 
     public void scheduleMembers(SetMultimap<FinalizerGroup, FinalizerGroup> reachableGroups) {
+        if (hasBeenScheduled) {
+            return;
+        } else {
+            hasBeenScheduled = true;
+        }
+
         Set<Node> finalizedNodesToBlockOn = findFinalizedNodesThatDoNotIntroduceACycle(reachableGroups);
         WaitForNodesToComplete waitForFinalizers = new WaitForNodesToComplete(finalizedNodesToBlockOn);
 
@@ -280,11 +287,6 @@ public class FinalizerGroup extends HasFinalizers {
             }
         }
         return dependenciesThatAreMembers;
-    }
-
-    private boolean dependsOn(Node fromNode, Node toNode) {
-
-        return false;
     }
 
     private boolean hasACycle(Node finalized, SetMultimap<FinalizerGroup, FinalizerGroup> reachableGroups) {

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/FinalizerGroup.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/FinalizerGroup.java
@@ -272,7 +272,11 @@ public class FinalizerGroup extends HasFinalizers {
                 if (members.contains(toNode) && !blockedFinalizedMembers.contains(toNode)) {
                     dependenciesThatAreMembers.add(toNode);
                 }
-                toNode.visitHardSuccessors(queue::add);
+                toNode.visitHardSuccessors(node -> {
+                    if (!seen.contains(node)) {
+                        queue.add(node);
+                    }
+                });
             }
         }
         return dependenciesThatAreMembers;

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/FinalizerGroup.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/FinalizerGroup.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.SetMultimap;
+import kotlin.collections.ArrayDeque;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -269,18 +270,15 @@ public class FinalizerGroup extends HasFinalizers {
         Set<Node> seen = new HashSet<>(1024);
 
         for (Node fromNode : blockedFinalizedMembers) {
-            List<Node> queue = new ArrayList<>(1024);
-            fromNode.visitHardSuccessors(queue::add);
+            ArrayDeque<Node> queue = new ArrayDeque<>(1024);
+            queue.add(fromNode);
             while (!queue.isEmpty()) {
-                Node toNode = queue.remove(0);
-                if (!seen.add(toNode)) {
-                    continue;
-                }
+                Node toNode = queue.removeFirst();
                 if (members.contains(toNode) && !blockedFinalizedMembers.contains(toNode)) {
                     dependenciesThatAreMembers.add(toNode);
                 }
                 toNode.visitHardSuccessors(node -> {
-                    if (!seen.contains(node)) {
+                    if (seen.add(node)) {
                         queue.add(node);
                     }
                 });

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/FinalizerGroup.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/FinalizerGroup.java
@@ -269,8 +269,8 @@ public class FinalizerGroup extends HasFinalizers {
         Set<Node> dependenciesThatAreMembers = new HashSet<>(members.size());
         Set<Node> seen = new HashSet<>(1024);
 
+        ArrayDeque<Node> queue = new ArrayDeque<>(1024);
         for (Node fromNode : blockedFinalizedMembers) {
-            ArrayDeque<Node> queue = new ArrayDeque<>(1024);
             queue.add(fromNode);
             while (!queue.isEmpty()) {
                 Node toNode = queue.removeFirst();

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/Node.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/Node.java
@@ -532,6 +532,16 @@ public abstract class Node {
         return dependencyNodes.getDependencySuccessors();
     }
 
+    /**
+     * Iterates over the nodes which are hard successors applying a visitor, i.e. which have a non-removable relationship to the current node.
+     *
+     * This can be a more efficient way to iterate over the successors than {@link #getHardSuccessors()}.
+     */
+    @OverridingMethodsMustInvokeSuper
+    public void visitHardSuccessors(Consumer<? super Node> visitor) {
+        dependencyNodes.getDependencySuccessors().forEach(visitor);
+    }
+
     public SortedSet<Node> getFinalizers() {
         return dependentNodes.getFinalizers();
     }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNode.java
@@ -22,6 +22,7 @@ import org.gradle.api.internal.TaskInternal;
 
 import java.util.NavigableSet;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import static org.gradle.execution.plan.NodeSets.newSortedNodeSet;
 
@@ -90,6 +91,13 @@ public abstract class TaskNode extends Node {
             getMustSuccessors(),
             super.getHardSuccessors()
         );
+    }
+
+    @Override
+    public void visitHardSuccessors(Consumer<? super Node> visitor) {
+        finalizingSuccessors.forEach(visitor);
+        getMustSuccessors().forEach(visitor);
+        super.visitHardSuccessors(visitor);
     }
 
     public abstract TaskInternal getTask();

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanTest.groovy
@@ -457,7 +457,7 @@ class DefaultExecutionPlanTest extends AbstractExecutionPlanSpec {
         orderingRule << ['dependsOn', 'mustRunAfter', 'shouldRunAfter']
     }
 
-    def "finalizer groups that finalize each other form a cycle"() {
+    def "finalizer groups that finalize each other do not form a cycle"() {
         given:
         TaskInternal finalizerA = createTask("finalizerA")
         TaskInternal finalizerB = createTask("finalizerB")

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
@@ -22,8 +22,12 @@ import org.gradle.performance.AbstractCrossVersionPerformanceTest
 import org.gradle.performance.annotations.RunFor
 import org.gradle.performance.annotations.Scenario
 import org.gradle.performance.fixture.AndroidTestProject
+import org.gradle.profiler.BuildMutator
+import org.gradle.profiler.InvocationSettings
+import org.gradle.profiler.ScenarioContext
 import org.gradle.profiler.mutations.AbstractCleanupMutator
 import org.gradle.profiler.mutations.ClearArtifactTransformCacheMutator
+import spock.lang.Issue
 
 import static org.gradle.performance.annotations.ScenarioType.PER_COMMIT
 import static org.gradle.performance.annotations.ScenarioType.PER_DAY
@@ -99,5 +103,51 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionPerformanc
 
         where:
         tasks << ['assembleDebug', 'phthalic:assembleDebug']
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/25361")
+    @RunFor([
+        @Scenario(type = PER_COMMIT, operatingSystems = LINUX, testProjects = "largeAndroidBuild"),
+    ])
+    def "calculate task graph with test finalizer"() {
+        given:
+        AndroidTestProject testProject = androidTestProject
+        testProject.configure(runner)
+        runner.addBuildMutator {invocation -> new TestFinalizerMutator(invocation) }
+        runner.tasksToRun = [':phthalic:test', '--dry-run']
+        runner.args.add('-Dorg.gradle.parallel=true')
+        runner.warmUpRuns = 2
+        runner.runs = 8
+        applyEnterprisePlugin()
+
+        when:
+        def result = runner.run()
+
+        then:
+        result.assertCurrentVersionHasNotRegressed()
+    }
+
+    private class TestFinalizerMutator implements BuildMutator {
+        private final InvocationSettings invocation
+
+        TestFinalizerMutator(InvocationSettings invocation) {
+            this.invocation = invocation
+        }
+
+        @Override
+        void beforeScenario(ScenarioContext context) {
+            def buildFile = new File(invocation.projectDir, "build.gradle")
+            buildFile << """
+                def finalizerTask = tasks.register("testFinalizer")
+                subprojects {
+                    tasks.withType(com.android.build.gradle.tasks.factory.AndroidUnitTest) { testTask ->
+                        testTask.finalizedBy(finalizerTask)
+                        finalizerTask.configure {
+                            dependsOn testTask
+                        }
+                    }
+                }
+            """.stripIndent()
+        }
     }
 }


### PR DESCRIPTION
When a finalizer finalizes multiple tasks, and also has dependencies, performance for calculating the task graph can be exceedingly poor for large task graphs when a subset of the finalized tasks are executed.  For instance, if a task finalizes all of the test tasks in a build, and also sets them as dependencies, and then only one test task is requested on the command line, it will trigger this behavior (oddly, requesting all test tasks avoids the problem).

This addresses the problem in two ways:

- Only schedule the members of a finalizer group once.
- Instead of iterating over every member and deciding if it is a dependency of a finalized node, iterate over the finalized nodes and calculate its dependencies that are also members.

This dramatically reduces the time to calculate the task graph in large builds that exhibit this behavior.  The performance is still not great, but it's at least manageable even for very large builds.  We can improve this more over time.

Fixes #25361