### PR TITLE
Avoid carrying current build op into worker context

### DIFF
--- a/subprojects/build-operations/src/main/java/org/gradle/internal/operations/CurrentBuildOperationRef.java
+++ b/subprojects/build-operations/src/main/java/org/gradle/internal/operations/CurrentBuildOperationRef.java
@@ -56,4 +56,14 @@ public class CurrentBuildOperationRef {
         ref.remove();
     }
 
+    public void with(@Nullable BuildOperationRef state, Runnable block) {
+        BuildOperationRef oldState = get();
+        try {
+            set(state);
+            block.run();
+        } finally {
+            set(oldState);
+        }
+    }
+
 }

--- a/subprojects/build-operations/src/test/groovy/org/gradle/internal/operations/CurrentBuildOperationPreservingRunnableTest.groovy
+++ b/subprojects/build-operations/src/test/groovy/org/gradle/internal/operations/CurrentBuildOperationPreservingRunnableTest.groovy
@@ -20,7 +20,8 @@ import spock.lang.Specification
 
 class CurrentBuildOperationPreservingRunnableTest extends Specification {
 
-    private static final EXPECTED_BUILD_OPERATION = new DefaultBuildOperationRef(new OperationIdentifier(42L), new OperationIdentifier(1))
+    private static final EXPECTED_INNER_BUILD_OPERATION = new DefaultBuildOperationRef(new OperationIdentifier(42L), new OperationIdentifier(1))
+    private static final EXPECTED_OUTER_BUILD_OPERATION = new DefaultBuildOperationRef(new OperationIdentifier(43L), new OperationIdentifier(2))
 
     def delegate = Mock(Runnable)
     def currentBuildOperationRef = new CurrentBuildOperationRef()
@@ -40,15 +41,19 @@ class CurrentBuildOperationPreservingRunnableTest extends Specification {
 
     def "preserve build operation identifier during execution of the delegate runnable"() {
         given:
-        currentBuildOperationRef.set(EXPECTED_BUILD_OPERATION)
+        // Set the current build operation to a known value for initializing the runner
+        currentBuildOperationRef.set(EXPECTED_INNER_BUILD_OPERATION)
+        def runner = runner()
+        // Then act as if we've been moved to a code section with a new build operation active
+        currentBuildOperationRef.set(EXPECTED_OUTER_BUILD_OPERATION)
 
         when:
-        runner().run()
+        runner.run()
 
         then:
         1 * delegate.run() >> {
-            assert currentBuildOperationRef.get() == EXPECTED_BUILD_OPERATION
+            assert currentBuildOperationRef.get() == EXPECTED_INNER_BUILD_OPERATION
         }
-        currentBuildOperationRef.get() != EXPECTED_BUILD_OPERATION
+        currentBuildOperationRef.get() == EXPECTED_OUTER_BUILD_OPERATION
     }
 }

--- a/subprojects/build-operations/src/test/groovy/org/gradle/internal/operations/CurrentBuildOperationPreservingRunnableTest.groovy
+++ b/subprojects/build-operations/src/test/groovy/org/gradle/internal/operations/CurrentBuildOperationPreservingRunnableTest.groovy
@@ -26,7 +26,7 @@ class CurrentBuildOperationPreservingRunnableTest extends Specification {
     def currentBuildOperationRef = new CurrentBuildOperationRef()
 
     def runner() {
-        new CurrentBuildOperationPreservingRunnable(delegate, currentBuildOperationRef)
+        CurrentBuildOperationPreservingRunnable.wrapIfNeeded(delegate, currentBuildOperationRef)
     }
 
     def "forward execution to delegate runnable"() {

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultBuildController.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultBuildController.java
@@ -195,12 +195,7 @@ class DefaultBuildController implements BuildController {
 
         @Override
         public void run() {
-            CurrentBuildOperationRef.instance().set(parentBuildOperation);
-            try {
-                completionHandler.accept(doRun());
-            } finally {
-                CurrentBuildOperationRef.instance().set(null);
-            }
+            CurrentBuildOperationRef.instance().with(parentBuildOperation, () -> completionHandler.accept(doRun()));
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionGraph.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionGraph.java
@@ -311,13 +311,7 @@ public class DefaultTaskExecutionGraph implements TaskExecutionGraphInternal {
 
         @Override
         public void execute(Node node) {
-            BuildOperationRef previous = CurrentBuildOperationRef.instance().get();
-            CurrentBuildOperationRef.instance().set(parentOperation);
-            try {
-                delegate.execute(node);
-            } finally {
-                CurrentBuildOperationRef.instance().set(previous);
-            }
+            CurrentBuildOperationRef.instance().with(parentOperation, () -> delegate.execute(node));
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecHandle.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecHandle.java
@@ -265,7 +265,7 @@ public class DefaultExecHandle implements ExecHandle, ProcessSettings {
 
             broadcast.getSource().beforeExecutionStarted(this);
             execHandleRunner = new ExecHandleRunner(this, new CompositeStreamsHandler(), processLauncher, executor);
-            executor.execute(new CurrentBuildOperationPreservingRunnable(execHandleRunner));
+            executor.execute(CurrentBuildOperationPreservingRunnable.wrapIfNeeded(execHandleRunner));
 
             while (stateIn(ExecHandleState.STARTING)) {
                 LOGGER.debug("Waiting until process started: {}.", displayName);

--- a/subprojects/core/src/main/java/org/gradle/process/internal/streams/OutputStreamsForwarder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/streams/OutputStreamsForwarder.java
@@ -55,13 +55,9 @@ public class OutputStreamsForwarder implements StreamsHandler {
     @Override
     public void start() {
         if (readErrorStream) {
-            executor.execute(wrapInBuildOperation(standardErrorReader));
+            executor.execute(CurrentBuildOperationPreservingRunnable.wrapIfNeeded(standardErrorReader));
         }
-        executor.execute(wrapInBuildOperation(standardOutputReader));
-    }
-
-    private Runnable wrapInBuildOperation(Runnable runnable) {
-        return new CurrentBuildOperationPreservingRunnable(runnable);
+        executor.execute(CurrentBuildOperationPreservingRunnable.wrapIfNeeded(standardOutputReader));
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/DefaultMultiRequestWorkerProcessBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/DefaultMultiRequestWorkerProcessBuilder.java
@@ -23,6 +23,7 @@ import org.gradle.internal.Cast;
 import org.gradle.internal.classloader.ClasspathUtil;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.logging.events.OutputEventListener;
+import org.gradle.internal.operations.BuildOperationRef;
 import org.gradle.internal.operations.CurrentBuildOperationRef;
 import org.gradle.internal.serialize.Serializer;
 import org.gradle.process.ExecResult;
@@ -150,10 +151,15 @@ class DefaultMultiRequestWorkerProcessBuilder<IN, OUT> implements MultiRequestWo
 
             @Override
             public WorkerProcess start() {
+                // Temporarily un-set the current build operation, since it shouldn't be leaked to the worker management code.
+                BuildOperationRef currentRef = CurrentBuildOperationRef.instance().get();
+                CurrentBuildOperationRef.instance().clear();
                 try {
                     workerProcess.start();
                 } catch (Exception e) {
                     throw WorkerProcessException.runFailed(getBaseName(), e);
+                } finally {
+                    CurrentBuildOperationRef.instance().set(currentRef);
                 }
                 workerProcess.getConnection().addIncoming(ResponseProtocol.class, receiver);
                 workerProcess.getConnection().useJavaSerializationForParameters(workerImplementation.getClassLoader());

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/timeout/impl/DefaultTimeoutHandler.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/timeout/impl/DefaultTimeoutHandler.java
@@ -154,13 +154,7 @@ public class DefaultTimeoutHandler implements TimeoutHandler, Stoppable {
         }
 
         private void doAsPartOfBuildOperation(Runnable runnable) {
-            BuildOperationRef previousBuildOperationRef = currentBuildOperationRef.get();
-            try {
-                currentBuildOperationRef.set(this.buildOperationRef);
-                runnable.run();
-            } finally {
-                currentBuildOperationRef.set(previousBuildOperationRef);
-            }
+            currentBuildOperationRef.with(this.buildOperationRef, runnable);
         }
 
         @Override

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DaemonJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DaemonJavaCompiler.java
@@ -33,7 +33,7 @@ import java.io.File;
 
 public class DaemonJavaCompiler extends AbstractDaemonCompiler<JavaCompileSpec> {
 
-    private static final String KEEP_DAEMON_ALIVE_PROPERTY = "org.gradle.internal.java.compile.daemon.keepAlive";
+    public static final String KEEP_DAEMON_ALIVE_PROPERTY = "org.gradle.internal.java.compile.daemon.keepAlive";
     private final Class<? extends Compiler<JavaCompileSpec>> compilerClass;
     private final Object[] compilerConstructorArguments;
     private final JavaForkOptionsFactory forkOptionsFactory;

--- a/subprojects/language-jvm/src/testFixtures/groovy/org/gradle/api/tasks/compile/AbstractCompilerDaemonReuseIntegrationTest.groovy
+++ b/subprojects/language-jvm/src/testFixtures/groovy/org/gradle/api/tasks/compile/AbstractCompilerDaemonReuseIntegrationTest.groovy
@@ -75,7 +75,7 @@ abstract class AbstractCompilerDaemonReuseIntegrationTest extends AbstractIntegr
         executedAndNotSkipped "${compileTaskPath('main')}", "${compileTaskPath('main2')}"
 
         and:
-        assertOneCompilerDaemonIsCreated()
+        assertOneCompilerDaemonIsRunning()
     }
 
     @IgnoreIf({ GradleContextualExecuter.parallel })
@@ -90,7 +90,7 @@ abstract class AbstractCompilerDaemonReuseIntegrationTest extends AbstractIntegr
         executedAndNotSkipped "${compileTaskPath('main')}", ":child${compileTaskPath('main')}"
 
         and:
-        assertOneCompilerDaemonIsCreated()
+        assertOneCompilerDaemonIsRunning()
     }
 
     @IgnoreIf({ GradleContextualExecuter.parallel })
@@ -106,7 +106,7 @@ abstract class AbstractCompilerDaemonReuseIntegrationTest extends AbstractIntegr
         executedAndNotSkipped "${compileTaskPath('main')}", ":child${compileTaskPath('main')}"
 
         and:
-        assertOneCompilerDaemonIsCreated()
+        assertOneCompilerDaemonIsRunning()
     }
 
     @IgnoreIf({ GradleContextualExecuter.parallel })
@@ -127,17 +127,17 @@ abstract class AbstractCompilerDaemonReuseIntegrationTest extends AbstractIntegr
         executedAndNotSkipped "${compileTaskPath('main')}", ":child${compileTaskPath('main')}"
 
         and:
-        assertTwoCompilerDaemonsAreCreated()
+        assertTwoCompilerDaemonsAreRunning()
     }
 
-    void assertOneCompilerDaemonIsCreated() {
+    void assertOneCompilerDaemonIsRunning() {
         def compilerDaemonSets = compilerDaemonIdentityFile.readLines()
         assert compilerDaemonSets.size() > 0
         assert compilerDaemonSets[0].trim() != ""
         assert compilerDaemonSets[0].split(" ").size() == 1
     }
 
-    void assertTwoCompilerDaemonsAreCreated() {
+    void assertTwoCompilerDaemonsAreRunning() {
         def compilerDaemonSets = compilerDaemonIdentityFile.readLines()
         assert compilerDaemonSets.size() > 0
         assert compilerDaemonSets[0].split(" ").size() == 2

--- a/subprojects/language-jvm/src/testFixtures/groovy/org/gradle/api/tasks/compile/AbstractCompilerDaemonReuseIntegrationTest.groovy
+++ b/subprojects/language-jvm/src/testFixtures/groovy/org/gradle/api/tasks/compile/AbstractCompilerDaemonReuseIntegrationTest.groovy
@@ -130,26 +130,23 @@ abstract class AbstractCompilerDaemonReuseIntegrationTest extends AbstractIntegr
         assertTwoCompilerDaemonsAreRunning()
     }
 
-    String assertOneCompilerDaemonIsRunning() {
+    List<String> getRunningCompilerDaemons() {
         def compilerDaemonSets = compilerDaemonIdentityFile.readLines()
-        assert compilerDaemonSets.size() > 0
+        assert compilerDaemonSets.size() == 1
         assert compilerDaemonSets[0].trim() != ""
-        assert compilerDaemonSets[0].split(" ").size() == 1
-        return compilerDaemonSets[0].trim()
+        return Arrays.asList(compilerDaemonSets[0].split(" "))
     }
 
-    void assertRunningCompilerDaemonIs(String whichOne) {
-        def compilerDaemonSets = compilerDaemonIdentityFile.readLines()
-        assert compilerDaemonSets.size() > 0
-        assert compilerDaemonSets[0].trim() != ""
-        assert compilerDaemonSets[0].split(" ").size() == 1
-        assert compilerDaemonSets[0].trim() == whichOne
+    void assertOneCompilerDaemonIsRunning() {
+        assert runningCompilerDaemons.size() == 1
+    }
+
+    void assertRunningCompilerDaemonIs(String expected) {
+        assert runningCompilerDaemons == [ expected ]
     }
 
     void assertTwoCompilerDaemonsAreRunning() {
-        def compilerDaemonSets = compilerDaemonIdentityFile.readLines()
-        assert compilerDaemonSets.size() > 0
-        assert compilerDaemonSets[0].split(" ").size() == 2
+        assert runningCompilerDaemons.size() == 2
     }
 
     String newSourceSet(String name) {

--- a/subprojects/language-jvm/src/testFixtures/groovy/org/gradle/api/tasks/compile/AbstractCompilerDaemonReuseIntegrationTest.groovy
+++ b/subprojects/language-jvm/src/testFixtures/groovy/org/gradle/api/tasks/compile/AbstractCompilerDaemonReuseIntegrationTest.groovy
@@ -130,11 +130,20 @@ abstract class AbstractCompilerDaemonReuseIntegrationTest extends AbstractIntegr
         assertTwoCompilerDaemonsAreRunning()
     }
 
-    void assertOneCompilerDaemonIsRunning() {
+    String assertOneCompilerDaemonIsRunning() {
         def compilerDaemonSets = compilerDaemonIdentityFile.readLines()
         assert compilerDaemonSets.size() > 0
         assert compilerDaemonSets[0].trim() != ""
         assert compilerDaemonSets[0].split(" ").size() == 1
+        return compilerDaemonSets[0].trim()
+    }
+
+    void assertRunningCompilerDaemonIs(String whichOne) {
+        def compilerDaemonSets = compilerDaemonIdentityFile.readLines()
+        assert compilerDaemonSets.size() > 0
+        assert compilerDaemonSets[0].trim() != ""
+        assert compilerDaemonSets[0].split(" ").size() == 1
+        assert compilerDaemonSets[0].trim() == whichOne
     }
 
     void assertTwoCompilerDaemonsAreRunning() {

--- a/subprojects/language-jvm/src/testFixtures/groovy/org/gradle/api/tasks/compile/AbstractCompilerDaemonReuseIntegrationTest.groovy
+++ b/subprojects/language-jvm/src/testFixtures/groovy/org/gradle/api/tasks/compile/AbstractCompilerDaemonReuseIntegrationTest.groovy
@@ -53,7 +53,7 @@ abstract class AbstractCompilerDaemonReuseIntegrationTest extends AbstractIntegr
             task writeCompilerIdentities {
                 def compilerDaemonIdentityFile = file("$compilerDaemonIdentityFileName")
                 doLast { task ->
-                    compilerDaemonIdentityFile << services.get(WorkerDaemonClientsManager).allClients.collect { System.identityHashCode(it) }.sort().join(" ") + "\\n"
+                    compilerDaemonIdentityFile.text = services.get(WorkerDaemonClientsManager).allClients.collect { System.identityHashCode(it) }.sort().join(" ") + "\\n"
                 }
             }
 

--- a/subprojects/messaging/src/main/java/org/gradle/internal/dispatch/AsyncDispatch.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/dispatch/AsyncDispatch.java
@@ -75,7 +75,7 @@ public class AsyncDispatch<T> implements Dispatch<T>, AsyncStoppable {
             }
         });
         onDispatchThreadStart(dispatch, dispatcher);
-        executor.execute(new CurrentBuildOperationPreservingRunnable(dispatcher));
+        executor.execute(CurrentBuildOperationPreservingRunnable.wrapIfNeeded(dispatcher));
     }
 
     private void dispatchMessages(Dispatch<? super T> dispatch) {

--- a/subprojects/plugins/build.gradle.kts
+++ b/subprojects/plugins/build.gradle.kts
@@ -65,6 +65,7 @@ dependencies {
     testFixturesImplementation(libs.guava)
 
     integTestImplementation(testFixtures(project(":model-core")))
+    integTestImplementation(testFixtures(project(":enterprise-operations")))
 
     testRuntimeOnly(project(":distributions-core")) {
         because("ProjectBuilder tests load services from a Gradle distribution.")

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/daemon/JavaCompilerDaemonFailureIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/daemon/JavaCompilerDaemonFailureIntegrationTest.groovy
@@ -50,6 +50,6 @@ class JavaCompilerDaemonFailureIntegrationTest extends AbstractIntegrationSpec {
         taskOperation != null
         // there's only the task start progress, no failure progress
         taskOperation.progress.size() == 1
-        errorOutput.contains("Unrecognized option: --not-a-real-argument")
+        errorOutput.contains("option: --not-a-real-argument")
     }
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/daemon/JavaCompilerDaemonFailureIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/daemon/JavaCompilerDaemonFailureIntegrationTest.groovy
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.java.compile.daemon
+
+import org.gradle.api.internal.tasks.compile.CompileJavaBuildOperationType
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.BuildOperationsFixture
+
+class JavaCompilerDaemonFailureIntegrationTest extends AbstractIntegrationSpec {
+    def "startup failure messages from a compiler daemon are NOT associated with the task that starts it"() {
+        def buildOperations = new BuildOperationsFixture(executer, temporaryFolder)
+
+        buildFile << """
+            apply plugin: "java"
+
+            tasks.compileJava {
+                options.fork = true
+                options.forkOptions.jvmArgs = ['--not-a-real-argument']
+            }
+        """
+
+        file('src/main/java/ClassToCompile.java') << """
+            class ClassToCompile {
+            }
+        """
+
+        when:
+        executer.withStackTraceChecksDisabled()
+        fails("compileJava")
+
+        then:
+        failure.assertTasksExecuted(":compileJava")
+
+        and:
+        def taskOperation = buildOperations.first(CompileJavaBuildOperationType)
+        taskOperation != null
+        // there's only the task start progress, no failure progress
+        taskOperation.progress.size() == 1
+        errorOutput.contains("Unrecognized option: --not-a-real-argument")
+    }
+}

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/daemon/JavaCompilerDaemonReuseIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/daemon/JavaCompilerDaemonReuseIntegrationTest.groovy
@@ -16,9 +16,18 @@
 
 package org.gradle.java.compile.daemon
 
+import org.gradle.api.internal.tasks.execution.ExecuteTaskBuildOperationType
 import org.gradle.api.tasks.compile.AbstractCompilerDaemonReuseIntegrationTest
+import org.gradle.integtests.fixtures.BuildOperationsFixture
+import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.jvm.TestJvmComponent
 import org.gradle.language.fixtures.TestJavaComponent
+import org.gradle.workers.internal.ExecuteWorkItemBuildOperationType
+import org.gradle.workers.internal.KeepAliveMode
+import spock.lang.IgnoreIf
+
+import static org.gradle.api.internal.tasks.compile.DaemonJavaCompiler.KEEP_DAEMON_ALIVE_PROPERTY
 
 
 class JavaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReuseIntegrationTest {
@@ -37,5 +46,87 @@ class JavaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReuse
     @Override
     TestJvmComponent getComponent() {
         return new TestJavaComponent()
+    }
+
+    @IgnoreIf({ GradleContextualExecuter.parallel })
+    @UnsupportedWithConfigurationCache(because = "parallel by default")
+    def "reuses compiler daemons across multiple builds when enabled"() {
+        withSingleProjectSources()
+
+        when:
+        args("-D${KEEP_DAEMON_ALIVE_PROPERTY}=${KeepAliveMode.DAEMON.name()}")
+        succeeds("compileAll")
+
+        then:
+        executedAndNotSkipped "${compileTaskPath('main')}", "${compileTaskPath('main2')}"
+
+        and:
+        def firstCompilerIdentity = compilerDaemonIdentityFile.text.trim()
+        assertOneCompilerDaemonIsCreated()
+
+        when:
+        executer.withWorkerDaemonsExpirationDisabled()
+        args("-D${KEEP_DAEMON_ALIVE_PROPERTY}=${KeepAliveMode.DAEMON.name()}")
+        succeeds("clean", "compileAll")
+
+        then:
+        executedAndNotSkipped "${compileTaskPath('main')}", "${compileTaskPath('main2')}"
+
+        and:
+        assertOneCompilerDaemonIsCreated()
+
+        and:
+        compilerDaemonIdentityFile.text.trim() == firstCompilerIdentity
+    }
+
+    def "log messages from a compiler daemon are associated with the task that generates them"() {
+        def buildOperations = new BuildOperationsFixture(executer, temporaryFolder)
+
+        withSingleProjectSources()
+        def classWithWarning = """
+            class ClassWithWarning {
+                java.util.Date date = new java.util.Date (100, 11, 07);
+            }
+        """
+        file('src/main/java/ClassWithWarning.java') << classWithWarning
+        file('src/main2/java/ClassWithWarning.java') << classWithWarning
+
+        when:
+        args("-D${KEEP_DAEMON_ALIVE_PROPERTY}=${KeepAliveMode.DAEMON.name()}")
+        succeeds("compileAll")
+
+        then:
+        executedAndNotSkipped "${compileTaskPath('main')}", "${compileTaskPath('main2')}"
+
+        and:
+        def firstCompilerIdentity = compilerDaemonIdentityFile.text.trim()
+        assertOneCompilerDaemonIsCreated()
+
+        when:
+        executer.withWorkerDaemonsExpirationDisabled()
+        args("-D${KEEP_DAEMON_ALIVE_PROPERTY}=${KeepAliveMode.DAEMON.name()}")
+        succeeds("clean", "compileAll")
+
+        then:
+        executedAndNotSkipped "${compileTaskPath('main')}", "${compileTaskPath('main2')}"
+
+        and:
+        assertOneCompilerDaemonIsCreated()
+
+        and:
+        compilerDaemonIdentityFile.text.trim() == firstCompilerIdentity
+
+        and:
+        def compilerOperations = buildOperations.all(ExecuteWorkItemBuildOperationType)
+        def taskOperations =
+            compilerOperations.collect {
+                buildOperations.parentsOf(it).reverse().find {parent -> buildOperations.isType(parent, ExecuteTaskBuildOperationType) }
+            }
+
+        compilerOperations.size() == 2
+        compilerOperations.each {operation ->
+            assert operation.progress.find {progress -> progress.details.spans.any { it.text.contains "ClassWithWarning.java uses or overrides a deprecated API" } }
+        }
+        taskOperations.collect {it.displayName }.containsAll(['Task :compileJava', 'Task :compileMain2Java'])
     }
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/daemon/JavaCompilerDaemonReuseIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/daemon/JavaCompilerDaemonReuseIntegrationTest.groovy
@@ -79,6 +79,8 @@ class JavaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReuse
         compilerDaemonIdentityFile.text.trim() == firstCompilerIdentity
     }
 
+    @IgnoreIf({ GradleContextualExecuter.parallel })
+    @UnsupportedWithConfigurationCache(because = "parallel by default")
     def "log messages from a compiler daemon are associated with the task that generates them"() {
         def buildOperations = new BuildOperationsFixture(executer, temporaryFolder)
 

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/daemon/JavaCompilerDaemonReuseIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/daemon/JavaCompilerDaemonReuseIntegrationTest.groovy
@@ -19,16 +19,12 @@ package org.gradle.java.compile.daemon
 import org.gradle.api.internal.tasks.execution.ExecuteTaskBuildOperationType
 import org.gradle.api.tasks.compile.AbstractCompilerDaemonReuseIntegrationTest
 import org.gradle.integtests.fixtures.BuildOperationsFixture
-import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.jvm.TestJvmComponent
 import org.gradle.language.fixtures.TestJavaComponent
 import org.gradle.workers.internal.ExecuteWorkItemBuildOperationType
 import org.gradle.workers.internal.KeepAliveMode
-import spock.lang.IgnoreIf
 
 import static org.gradle.api.internal.tasks.compile.DaemonJavaCompiler.KEEP_DAEMON_ALIVE_PROPERTY
-
 
 class JavaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReuseIntegrationTest {
     @Override
@@ -48,10 +44,13 @@ class JavaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReuse
         return new TestJavaComponent()
     }
 
-    @IgnoreIf({ GradleContextualExecuter.parallel })
-    @UnsupportedWithConfigurationCache(because = "parallel by default")
     def "reuses compiler daemons across multiple builds when enabled"() {
         withSingleProjectSources()
+        buildFile << """
+            tasks.compileMain2Java {
+                dependsOn("compileJava")
+            }
+        """
 
         when:
         args("-D${KEEP_DAEMON_ALIVE_PROPERTY}=${KeepAliveMode.DAEMON.name()}")
@@ -79,19 +78,22 @@ class JavaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReuse
         compilerDaemonIdentityFile.text.trim() == firstCompilerIdentity
     }
 
-    @IgnoreIf({ GradleContextualExecuter.parallel })
-    @UnsupportedWithConfigurationCache(because = "parallel by default")
     def "log messages from a compiler daemon are associated with the task that generates them"() {
         def buildOperations = new BuildOperationsFixture(executer, temporaryFolder)
 
         withSingleProjectSources()
+        buildFile << """
+            tasks.compileMain2Java {
+                dependsOn("compileJava")
+            }
+        """
         def classWithWarning = """
             class ClassWithWarning {
                 java.util.Date date = new java.util.Date (100, 11, 07);
             }
         """
-        file('src/main/java/ClassWithWarning.java') << classWithWarning
-        file('src/main2/java/ClassWithWarning.java') << classWithWarning
+        file('src/main/java/ClassWithWarning1.java') << classWithWarning
+        file('src/main2/java/ClassWithWarning2.java') << classWithWarning
 
         when:
         args("-D${KEEP_DAEMON_ALIVE_PROPERTY}=${KeepAliveMode.DAEMON.name()}")
@@ -121,14 +123,16 @@ class JavaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReuse
         and:
         def compilerOperations = buildOperations.all(ExecuteWorkItemBuildOperationType)
         def taskOperations =
-            compilerOperations.collect {
-                buildOperations.parentsOf(it).reverse().find {parent -> buildOperations.isType(parent, ExecuteTaskBuildOperationType) }
+            compilerOperations.collectEntries {
+                def op = buildOperations.parentsOf(it).reverse().find {parent -> buildOperations.isType(parent, ExecuteTaskBuildOperationType) }
+                [op.displayName, it]
             }
 
-        compilerOperations.size() == 2
-        compilerOperations.each {operation ->
-            assert operation.progress.find {progress -> progress.details.spans.any { it.text.contains "ClassWithWarning.java uses or overrides a deprecated API" } }
+        def tasks = ['Task :compileJava', 'Task :compileMain2Java']
+        taskOperations.keySet() == tasks.toSet()
+        tasks.eachWithIndex { taskName, index ->
+            def operation = taskOperations[taskName]
+            assert operation.progress.find {progress -> progress.details.spans.any { it.text.contains "ClassWithWarning${index + 1}.java uses or overrides a deprecated API" } }
         }
-        taskOperations.collect {it.displayName }.containsAll(['Task :compileJava', 'Task :compileMain2Java'])
     }
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/daemon/JavaCompilerDaemonReuseIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/daemon/JavaCompilerDaemonReuseIntegrationTest.groovy
@@ -60,8 +60,7 @@ class JavaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReuse
         executedAndNotSkipped "${compileTaskPath('main')}", "${compileTaskPath('main2')}"
 
         and:
-        def firstCompilerIdentity = compilerDaemonIdentityFile.text.trim()
-        assertOneCompilerDaemonIsRunning()
+        def firstCompilerIdentity = assertOneCompilerDaemonIsRunning()
 
         when:
         executer.withWorkerDaemonsExpirationDisabled()
@@ -72,10 +71,7 @@ class JavaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReuse
         executedAndNotSkipped "${compileTaskPath('main')}", "${compileTaskPath('main2')}"
 
         and:
-        assertOneCompilerDaemonIsRunning()
-
-        and:
-        compilerDaemonIdentityFile.text.trim() == firstCompilerIdentity
+        assertRunningCompilerDaemonIs(firstCompilerIdentity)
     }
 
     def "log messages from a compiler daemon are associated with the task that generates them"() {
@@ -103,8 +99,7 @@ class JavaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReuse
         executedAndNotSkipped "${compileTaskPath('main')}", "${compileTaskPath('main2')}"
 
         and:
-        def firstCompilerIdentity = compilerDaemonIdentityFile.text.trim()
-        assertOneCompilerDaemonIsRunning()
+        def firstCompilerIdentity = assertOneCompilerDaemonIsRunning()
 
         when:
         executer.withWorkerDaemonsExpirationDisabled()
@@ -115,10 +110,7 @@ class JavaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReuse
         executedAndNotSkipped "${compileTaskPath('main')}", "${compileTaskPath('main2')}"
 
         and:
-        assertOneCompilerDaemonIsRunning()
-
-        and:
-        compilerDaemonIdentityFile.text.trim() == firstCompilerIdentity
+        assertRunningCompilerDaemonIs(firstCompilerIdentity)
 
         and:
         def compilerOperations = buildOperations.all(ExecuteWorkItemBuildOperationType)

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/daemon/JavaCompilerDaemonReuseIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/daemon/JavaCompilerDaemonReuseIntegrationTest.groovy
@@ -60,7 +60,7 @@ class JavaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReuse
         executedAndNotSkipped "${compileTaskPath('main')}", "${compileTaskPath('main2')}"
 
         and:
-        def firstCompilerIdentity = assertOneCompilerDaemonIsRunning()
+        assertOneCompilerDaemonIsRunning()
 
         when:
         executer.withWorkerDaemonsExpirationDisabled()
@@ -71,6 +71,7 @@ class JavaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReuse
         executedAndNotSkipped "${compileTaskPath('main')}", "${compileTaskPath('main2')}"
 
         and:
+        def firstCompilerIdentity = old(runningCompilerDaemons[0])
         assertRunningCompilerDaemonIs(firstCompilerIdentity)
     }
 
@@ -99,7 +100,7 @@ class JavaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReuse
         executedAndNotSkipped "${compileTaskPath('main')}", "${compileTaskPath('main2')}"
 
         and:
-        def firstCompilerIdentity = assertOneCompilerDaemonIsRunning()
+        assertOneCompilerDaemonIsRunning()
 
         when:
         executer.withWorkerDaemonsExpirationDisabled()
@@ -110,6 +111,7 @@ class JavaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReuse
         executedAndNotSkipped "${compileTaskPath('main')}", "${compileTaskPath('main2')}"
 
         and:
+        def firstCompilerIdentity = old(runningCompilerDaemons[0])
         assertRunningCompilerDaemonIs(firstCompilerIdentity)
 
         and:

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/daemon/JavaCompilerDaemonReuseIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/daemon/JavaCompilerDaemonReuseIntegrationTest.groovy
@@ -61,7 +61,7 @@ class JavaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReuse
 
         and:
         def firstCompilerIdentity = compilerDaemonIdentityFile.text.trim()
-        assertOneCompilerDaemonIsCreated()
+        assertOneCompilerDaemonIsRunning()
 
         when:
         executer.withWorkerDaemonsExpirationDisabled()
@@ -72,7 +72,7 @@ class JavaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReuse
         executedAndNotSkipped "${compileTaskPath('main')}", "${compileTaskPath('main2')}"
 
         and:
-        assertOneCompilerDaemonIsCreated()
+        assertOneCompilerDaemonIsRunning()
 
         and:
         compilerDaemonIdentityFile.text.trim() == firstCompilerIdentity
@@ -104,7 +104,7 @@ class JavaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReuse
 
         and:
         def firstCompilerIdentity = compilerDaemonIdentityFile.text.trim()
-        assertOneCompilerDaemonIsCreated()
+        assertOneCompilerDaemonIsRunning()
 
         when:
         executer.withWorkerDaemonsExpirationDisabled()
@@ -115,7 +115,7 @@ class JavaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReuse
         executedAndNotSkipped "${compileTaskPath('main')}", "${compileTaskPath('main2')}"
 
         and:
-        assertOneCompilerDaemonIsCreated()
+        assertOneCompilerDaemonIsRunning()
 
         and:
         compilerDaemonIdentityFile.text.trim() == firstCompilerIdentity

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/daemon/ScalaCompilerDaemonReuseIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/daemon/ScalaCompilerDaemonReuseIntegrationTest.groovy
@@ -63,7 +63,7 @@ class ScalaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReus
         executedAndNotSkipped "${compileTaskPath('main')}", "${compileTaskPath('main2')}"
 
         and:
-        def firstDaemonId = assertOneCompilerDaemonIsRunning()
+        assertOneCompilerDaemonIsRunning()
 
         when:
         executer.withWorkerDaemonsExpirationDisabled()
@@ -73,6 +73,7 @@ class ScalaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReus
         executedAndNotSkipped "${compileTaskPath('main')}", "${compileTaskPath('main2')}"
 
         and:
+        def firstDaemonId = old(runningCompilerDaemons[0])
         assertRunningCompilerDaemonIs(firstDaemonId)
     }
 
@@ -89,7 +90,7 @@ class ScalaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReus
         executedAndNotSkipped "${compileTaskPath('main')}", ":child${compileTaskPath('main')}"
 
         and:
-        def firstDaemonId = assertOneCompilerDaemonIsRunning()
+        assertOneCompilerDaemonIsRunning()
 
         when:
         executer.withWorkerDaemonsExpirationDisabled()
@@ -99,6 +100,7 @@ class ScalaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReus
         executedAndNotSkipped "${compileTaskPath('main')}", ":child${compileTaskPath('main')}"
 
         and:
+        def firstDaemonId = old(runningCompilerDaemons[0])
         assertRunningCompilerDaemonIs(firstDaemonId)
     }
 
@@ -117,7 +119,7 @@ class ScalaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReus
         executedAndNotSkipped "${compileTaskPath('main')}", ":child${compileTaskPath('main')}"
 
         and:
-        def firstDaemonId = assertOneCompilerDaemonIsRunning()
+        assertOneCompilerDaemonIsRunning()
 
         when:
         executer.withWorkerDaemonsExpirationDisabled()
@@ -127,6 +129,7 @@ class ScalaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReus
         executedAndNotSkipped "${compileTaskPath('main')}", ":child${compileTaskPath('main')}"
 
         and:
+        def firstDaemonId = old(runningCompilerDaemons[0])
         assertRunningCompilerDaemonIs(firstDaemonId)
     }
 
@@ -144,7 +147,7 @@ class ScalaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReus
         executedAndNotSkipped "${compileTaskPath('main')}", "${compileTaskPath('main2')}"
 
         and:
-        def firstDaemonId = assertOneCompilerDaemonIsRunning()
+        assertOneCompilerDaemonIsRunning()
 
         when:
         executer.withWorkerDaemonsExpirationDisabled()
@@ -155,6 +158,7 @@ class ScalaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReus
         executedAndNotSkipped "${compileTaskPath('main')}", "${compileTaskPath('main2')}"
 
         and:
+        def firstDaemonId = old(runningCompilerDaemons[0])
         assertRunningCompilerDaemonIs(firstDaemonId)
     }
 

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/daemon/ScalaCompilerDaemonReuseIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/daemon/ScalaCompilerDaemonReuseIntegrationTest.groovy
@@ -63,7 +63,7 @@ class ScalaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReus
         executedAndNotSkipped "${compileTaskPath('main')}", "${compileTaskPath('main2')}"
 
         and:
-        assertOneCompilerDaemonIsCreated()
+        assertOneCompilerDaemonIsRunning()
         def firstDaemonId = compilerDaemonIdentityFile.text
 
         when:
@@ -74,7 +74,7 @@ class ScalaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReus
         executedAndNotSkipped "${compileTaskPath('main')}", "${compileTaskPath('main2')}"
 
         and:
-        assertOneCompilerDaemonIsCreated()
+        assertOneCompilerDaemonIsRunning()
 
         and:
         compilerDaemonIdentityFile.text == firstDaemonId
@@ -94,7 +94,7 @@ class ScalaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReus
         executedAndNotSkipped "${compileTaskPath('main')}", ":child${compileTaskPath('main')}"
 
         and:
-        assertOneCompilerDaemonIsCreated()
+        assertOneCompilerDaemonIsRunning()
 
         when:
         executer.withWorkerDaemonsExpirationDisabled()
@@ -104,7 +104,7 @@ class ScalaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReus
         executedAndNotSkipped "${compileTaskPath('main')}", ":child${compileTaskPath('main')}"
 
         and:
-        assertOneCompilerDaemonIsCreated()
+        assertOneCompilerDaemonIsRunning()
 
         and:
         compilerDaemonIdentityFile.text == firstDaemonId
@@ -126,7 +126,7 @@ class ScalaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReus
         executedAndNotSkipped "${compileTaskPath('main')}", ":child${compileTaskPath('main')}"
 
         and:
-        assertOneCompilerDaemonIsCreated()
+        assertOneCompilerDaemonIsRunning()
 
         when:
         executer.withWorkerDaemonsExpirationDisabled()
@@ -136,7 +136,7 @@ class ScalaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReus
         executedAndNotSkipped "${compileTaskPath('main')}", ":child${compileTaskPath('main')}"
 
         and:
-        assertOneCompilerDaemonIsCreated()
+        assertOneCompilerDaemonIsRunning()
 
         and:
         compilerDaemonIdentityFile.text == firstDaemonId
@@ -156,7 +156,7 @@ class ScalaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReus
         executedAndNotSkipped "${compileTaskPath('main')}", "${compileTaskPath('main2')}"
 
         and:
-        assertOneCompilerDaemonIsCreated()
+        assertOneCompilerDaemonIsRunning()
         def firstDaemonId = compilerDaemonIdentityFile.text
 
         when:
@@ -168,7 +168,7 @@ class ScalaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReus
         executedAndNotSkipped "${compileTaskPath('main')}", "${compileTaskPath('main2')}"
 
         and:
-        assertOneCompilerDaemonIsCreated()
+        assertOneCompilerDaemonIsRunning()
 
         and:
         compilerDaemonIdentityFile.text == firstDaemonId

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/daemon/ScalaCompilerDaemonReuseIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/daemon/ScalaCompilerDaemonReuseIntegrationTest.groovy
@@ -63,8 +63,7 @@ class ScalaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReus
         executedAndNotSkipped "${compileTaskPath('main')}", "${compileTaskPath('main2')}"
 
         and:
-        assertOneCompilerDaemonIsRunning()
-        def firstDaemonId = compilerDaemonIdentityFile.text
+        def firstDaemonId = assertOneCompilerDaemonIsRunning()
 
         when:
         executer.withWorkerDaemonsExpirationDisabled()
@@ -74,10 +73,7 @@ class ScalaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReus
         executedAndNotSkipped "${compileTaskPath('main')}", "${compileTaskPath('main2')}"
 
         and:
-        assertOneCompilerDaemonIsRunning()
-
-        and:
-        compilerDaemonIdentityFile.text == firstDaemonId
+        assertRunningCompilerDaemonIs(firstDaemonId)
     }
 
     @IgnoreIf({ GradleContextualExecuter.parallel })
@@ -88,13 +84,12 @@ class ScalaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReus
 
         when:
         succeeds("compileAll")
-        def firstDaemonId = compilerDaemonIdentityFile.text
 
         then:
         executedAndNotSkipped "${compileTaskPath('main')}", ":child${compileTaskPath('main')}"
 
         and:
-        assertOneCompilerDaemonIsRunning()
+        def firstDaemonId = assertOneCompilerDaemonIsRunning()
 
         when:
         executer.withWorkerDaemonsExpirationDisabled()
@@ -104,10 +99,7 @@ class ScalaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReus
         executedAndNotSkipped "${compileTaskPath('main')}", ":child${compileTaskPath('main')}"
 
         and:
-        assertOneCompilerDaemonIsRunning()
-
-        and:
-        compilerDaemonIdentityFile.text == firstDaemonId
+        assertRunningCompilerDaemonIs(firstDaemonId)
     }
 
     @IgnoreIf({ GradleContextualExecuter.parallel })
@@ -120,13 +112,12 @@ class ScalaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReus
 
         when:
         succeeds("compileAll")
-        def firstDaemonId = compilerDaemonIdentityFile.text
 
         then:
         executedAndNotSkipped "${compileTaskPath('main')}", ":child${compileTaskPath('main')}"
 
         and:
-        assertOneCompilerDaemonIsRunning()
+        def firstDaemonId = assertOneCompilerDaemonIsRunning()
 
         when:
         executer.withWorkerDaemonsExpirationDisabled()
@@ -136,10 +127,7 @@ class ScalaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReus
         executedAndNotSkipped "${compileTaskPath('main')}", ":child${compileTaskPath('main')}"
 
         and:
-        assertOneCompilerDaemonIsRunning()
-
-        and:
-        compilerDaemonIdentityFile.text == firstDaemonId
+        assertRunningCompilerDaemonIs(firstDaemonId)
     }
 
     @IgnoreIf({ GradleContextualExecuter.parallel })
@@ -156,8 +144,7 @@ class ScalaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReus
         executedAndNotSkipped "${compileTaskPath('main')}", "${compileTaskPath('main2')}"
 
         and:
-        assertOneCompilerDaemonIsRunning()
-        def firstDaemonId = compilerDaemonIdentityFile.text
+        def firstDaemonId = assertOneCompilerDaemonIsRunning()
 
         when:
         executer.withWorkerDaemonsExpirationDisabled()
@@ -168,10 +155,7 @@ class ScalaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReus
         executedAndNotSkipped "${compileTaskPath('main')}", "${compileTaskPath('main2')}"
 
         and:
-        assertOneCompilerDaemonIsRunning()
-
-        and:
-        compilerDaemonIdentityFile.text == firstDaemonId
+        assertRunningCompilerDaemonIs(firstDaemonId)
     }
 
     private TestFile withPersistentScalaCompilerDaemons(TestFile buildDir = testDirectory) {

--- a/subprojects/soak/src/integTest/groovy/org/gradle/jvm/JavaCompilationSoakTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/jvm/JavaCompilationSoakTest.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class JavaCompilationSoakTest extends AbstractIntegrationSpec {
+    def setup() {
+        // projectCount * memoryHog ~= 50% default JVM heap size
+        def projectCount = 5
+
+        def subprojects = []
+        projectCount.times {
+            subprojects << "sub" + it
+        }
+        multiProjectBuild("root", subprojects) {
+            buildFile << """
+                allprojects {
+                    apply plugin: 'java'
+
+                    // ~50MB
+                    ext.memoryHog = new byte[1024*1024*50]
+
+                    tasks.withType(JavaCompile).configureEach {
+                        options.fork = true
+                    }
+                }
+            """
+        }
+    }
+
+    def "can recompile many times in a row"() {
+        expect:
+        10.times {
+            println("Run $it")
+            args("-Dorg.gradle.internal.java.compile.daemon.keepAlive=DAEMON")
+            succeeds("clean", "assemble")
+        }
+    }
+}

--- a/subprojects/workers/build.gradle.kts
+++ b/subprojects/workers/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     integTestRuntimeOnly(project(":test-kit"))
 
     integTestImplementation(project(":jvm-services"))
+    integTestImplementation(project(":enterprise-operations"))
 
     testFixturesImplementation(libs.inject)
     testFixturesImplementation(libs.groovyJson)

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonFailureLoggingIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonFailureLoggingIntegrationTest.groovy
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.workers.internal
+
+import org.gradle.api.internal.tasks.execution.ExecuteTaskBuildOperationType
+import org.gradle.integtests.fixtures.BuildOperationsFixture
+
+class WorkerDaemonFailureLoggingIntegrationTest extends AbstractDaemonWorkerExecutorIntegrationSpec {
+    def setup() {
+        def workAction = fixture.getWorkActionThatCreatesFiles("NormalWorkAction")
+        workAction.writeToBuildFile()
+        fixture.withWorkActionClassInBuildScript()
+        buildFile << """
+            task runInWorker(type: WorkerTask) {
+                isolationMode = 'processIsolation'
+                additionalForkOptions = { jvmArgs('--not-a-real-argument') }
+                workActionClass = ${workAction.name}.class
+            }
+        """
+    }
+
+    def "worker startup failure messages are NOT associated with the task that starts it"() {
+        def buildOperations = new BuildOperationsFixture(executer, temporaryFolder)
+
+        expect:
+        executer.withStackTraceChecksDisabled()
+        fails("runInWorker")
+
+        and:
+        def taskOperation = buildOperations.first(ExecuteTaskBuildOperationType) {
+            it.displayName == "Task :runInWorker"
+        }
+        taskOperation != null
+        // there's only the task start progress, no failure progress
+        taskOperation.progress.size() == 1
+        errorOutput.contains("Unrecognized option: --not-a-real-argument")
+    }
+}

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonFailureLoggingIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonFailureLoggingIntegrationTest.groovy
@@ -47,6 +47,6 @@ class WorkerDaemonFailureLoggingIntegrationTest extends AbstractDaemonWorkerExec
         taskOperation != null
         // there's only the task start progress, no failure progress
         taskOperation.progress.size() == 1
-        errorOutput.contains("Unrecognized option: --not-a-real-argument")
+        errorOutput.contains("option: --not-a-real-argument")
     }
 }


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle-private/issues/3891 for the most part, but further investigation into worker management code may be needed.

The current build operation for JavaCompile contains information about the project, and as such carrying it into a worker thread would result in permanent retention of that project and its entire build until the death of the worker. This information is likely unnecessary and confusing as the workers should be re-used across different projects and builds, so this PR prevents it from being added by clearing the thread local when spawning a new worker.

There is still a potential issue in that many new threads are spawned for every new worker, ~~and it seems like they don't all clean up properly over time. Despite many worker processes starting and stopping, the number of `Exec process thread`s present continues to climb, rather than stabilizing. This will eventually cause memory issues as well, but at a much slower pace.~~ This also affects all workers, not just the Java compilation one. Edit: this turns out to be untrue, but it can still climb to rather ridiculous numbers such as around ~150 workers and ~480 threads for them. It would be nice to try reducing these using async I/O to wait for processes or copy streams, which could be confined to as little as a single thread. This is tracked as https://github.com/gradle/gradle/issues/25488.