### PR TITLE
Allow unstable dependencies in Kotlin DSL buildscripts

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -107,7 +107,7 @@ tasks.withType<KotlinCompile>().configureEach {
 }
 ```
 
-Moreover, at this stage K2 doesn't support scripting, it will not work with [precompiled script plugins](userguide/custom_plugins.html#sec:precompiled_plugins).
+Moreover, at this stage, K2 doesn't support scripting, so it will not work with [precompiled script plugins](userguide/custom_plugins.html#sec:precompiled_plugins).
 
 ### Improved CodeNarc output
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -91,7 +91,7 @@ Add `-Pkotlin.experimental.tryK2=true` to your command line invocations or add i
 kotlin.experimental.tryK2=true
 ```
 
-This Gradle property automatically sets the language version to 2.0.
+Setting this Gradle property also sets the language version to 2.0.
 
 Starting with this version of Gradle the compilation of `.gradle.kts` build scripts accept dependencies compiled with Kotlin K2 compiler.
 This allows for example to try out K2 in builds that use Kotlin 1.9 and have Kotlin code in `buildSrc` or in included builds for build logic.

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -81,6 +81,34 @@ plugins {
 }
 ```
 
+#### Build scripts now accept dependencies compiled with Kotlin K2 compiler
+
+The Kotlin team continues to stabilize the [K2 compiler](https://blog.jetbrains.com/kotlin/2023/02/k2-kotlin-2-0/).
+Starting with Kotlin 1.9.0-RC and until the release of Kotlin 2.0, you can easily test the K2 compiler in your projects.
+Add `-Pkotlin.experimental.tryK2=true` to your command line invocations or add it to your `gradle.properties` file:
+
+```properties
+kotlin.experimental.tryK2=true
+```
+
+This Gradle property automatically sets the language version to 2.0.
+
+Starting with this version of Gradle the compilation of `.gradle.kts` build scripts accept dependencies compiled with Kotlin K2 compiler.
+This allows for example to try out K2 in builds that use Kotlin 1.9 and have Kotlin code in `buildSrc` or in included builds for build logic.
+
+Note that if you use the [`kotlin-dsl` plugin](userguide/kotlin_dsl.html#sec:kotlin-dsl_plugin) in your build logic, you will also need to explicitly set the Kotlin language version to 2.0:
+
+```kotlin
+tasks.withType<KotlinCompile>().configureEach {
+    compilerOptions {
+        apiVersion = KotlinVersion.KOTLIN_2_0
+        languageVersion = KotlinVersion.KOTLIN_2_0
+    }
+}
+```
+
+Moreover, at this stage K2 doesn't support scripting, it will not work with [precompiled script plugins](userguide/custom_plugins.html#sec:precompiled_plugins).
+
 ### Improved CodeNarc output
 
 The `CodeNarc` plugin produces IDE-clickable links when reporting failures to the console.

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -93,7 +93,7 @@ kotlin.experimental.tryK2=true
 
 Setting this Gradle property also sets the language version to 2.0.
 
-Starting with this version of Gradle the compilation of `.gradle.kts` build scripts accept dependencies compiled with Kotlin K2 compiler.
+Starting with this version of Gradle, the compilation of `.gradle.kts` build scripts accepts dependencies compiled with Kotlin K2 compiler.
 This allows for example to try out K2 in builds that use Kotlin 1.9 and have Kotlin code in `buildSrc` or in included builds for build logic.
 
 Note that if you use the [`kotlin-dsl` plugin](userguide/kotlin_dsl.html#sec:kotlin-dsl_plugin) in your build logic, you will also need to explicitly set the Kotlin language version to 2.0:

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -94,7 +94,7 @@ kotlin.experimental.tryK2=true
 Setting this Gradle property also sets the language version to 2.0.
 
 Starting with this version of Gradle, the compilation of `.gradle.kts` build scripts accepts dependencies compiled with Kotlin K2 compiler.
-This allows for example to try out K2 in builds that use Kotlin 1.9 and have Kotlin code in `buildSrc` or in included builds for build logic.
+This makes it possible to try out K2 in builds that use Kotlin 1.9 and have Kotlin code in `buildSrc` or in included builds for build logic.
 
 Note that if you use the [`kotlin-dsl` plugin](userguide/kotlin_dsl.html#sec:kotlin-dsl_plugin) in your build logic, you will also need to explicitly set the Kotlin language version to 2.0:
 

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/K2IntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/K2IntegrationTest.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.integration
+
+import org.gradle.integtests.fixtures.RepoScriptBlockUtil.mavenCentralRepository
+import org.gradle.integtests.fixtures.versions.KotlinGradlePluginVersions
+import org.gradle.test.fixtures.dsl.GradleDsl.KOTLIN
+import org.junit.Test
+
+
+class K2IntegrationTest : AbstractPluginIntegrationTest() {
+
+    private
+    val kotlinVersion = KotlinGradlePluginVersions().latestStableOrRC
+
+    @Test
+    fun `can try k2 with included build for build logic using kotlin-jvm plugin`() {
+
+        withDefaultSettingsIn("build-logic")
+        withBuildScriptIn("build-logic", """
+            plugins {
+                id("java-gradle-plugin")
+                kotlin("jvm") version "$kotlinVersion"
+            }
+            ${mavenCentralRepository(KOTLIN)}
+            gradlePlugin {
+                plugins {
+                    register("my-plugin") {
+                        id = "my-plugin"
+                        implementationClass = "MyPlugin"
+                    }
+                }
+            }
+        """)
+        withK2BuildLogic()
+
+        withK2BuildLogicConsumingBuild()
+
+        assertCanConsumeK2BuildLogic()
+    }
+
+    @Test
+    fun `can try k2 with included build for build logic using kotlin-dsl plugin`() {
+
+        // This test doesn't use a .gradle.kts precompiled script because K2 doesn't support scripts yet
+
+        withDefaultSettingsIn("build-logic")
+        withBuildScriptIn("build-logic", """
+            import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+            import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+            plugins {
+                `kotlin-dsl`
+                kotlin("jvm") version "$kotlinVersion"
+            }
+            ${mavenCentralRepository(KOTLIN)}
+            tasks.withType<KotlinCompile>().configureEach {
+                compilerOptions {
+                    apiVersion = KotlinVersion.KOTLIN_2_0
+                    languageVersion = KotlinVersion.KOTLIN_2_0
+                }
+            }
+            gradlePlugin {
+                plugins {
+                    register("my-plugin") {
+                        id = "my-plugin"
+                        implementationClass = "MyPlugin"
+                    }
+                }
+            }
+        """)
+        withK2BuildLogic()
+
+        withK2BuildLogicConsumingBuild()
+
+        assertCanConsumeK2BuildLogic()
+    }
+
+    private
+    fun withK2BuildLogic() {
+        withFile("build-logic/gradle.properties", "kotlin.experimental.tryK2=true")
+        withFile("build-logic/src/main/kotlin/MyTask.kt", """
+            import org.gradle.api.DefaultTask
+            import org.gradle.api.tasks.TaskAction
+
+            abstract class MyTask : DefaultTask() {
+                @TaskAction fun action() { println("Doing something") }
+            }
+        """)
+        withFile("build-logic/src/main/kotlin/MyPlugin.kt", """
+            import org.gradle.api.Project
+            import org.gradle.api.Plugin
+
+            class MyPlugin : Plugin<Project> {
+                override fun apply(project: Project) {}
+            }
+        """)
+    }
+
+    private
+    fun withK2BuildLogicConsumingBuild() {
+        withSettings("""
+            pluginManagement {
+                ${mavenCentralRepository(KOTLIN)}
+                includeBuild("build-logic")
+            }
+            rootProject.name = "k2-gradle"
+        """)
+        withBuildScript("""
+            plugins { id("my-plugin") }
+            project.tasks.register("myTask", MyTask::class)
+        """)
+    }
+
+    private
+    fun assertCanConsumeK2BuildLogic() {
+        build("help").apply {
+            assertOutputContains("ATTENTION: 'kotlin.experimental.tryK2' is an experimental option enabled in the project for trying out the new Kotlin K2 compiler only.")
+            assertOutputContains("w: Language version 2.0 is experimental, there are no backwards compatibility guarantees for new language and library features")
+        }
+    }
+}

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/K2IntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/K2IntegrationTest.kt
@@ -30,6 +30,8 @@ class K2IntegrationTest : AbstractPluginIntegrationTest() {
     @Test
     fun `can try k2 with included build for build logic using kotlin-jvm plugin`() {
 
+        assumeNonEmbeddedGradleExecuter()
+
         withDefaultSettingsIn("build-logic")
         withBuildScriptIn("build-logic", """
             plugins {
@@ -55,6 +57,8 @@ class K2IntegrationTest : AbstractPluginIntegrationTest() {
 
     @Test
     fun `can try k2 with included build for build logic using kotlin-dsl plugin`() {
+
+        assumeNonEmbeddedGradleExecuter()
 
         // This test doesn't use a .gradle.kts precompiled script because K2 doesn't support scripts yet
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinBuildScript.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinBuildScript.kt
@@ -46,6 +46,7 @@ import kotlin.script.templates.ScriptTemplateDefinition
         "-Xjsr305=strict",
         "-Xskip-metadata-version-check",
         "-Xskip-prerelease-check",
+        "-Xallow-unstable-dependencies",
         "-XXLanguage:+DisableCompatibilityModeForNewInference",
         "-XXLanguage:-TypeEnhancementImprovementsInStrictMode",
     ],

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinBuildScript.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinBuildScript.kt
@@ -44,6 +44,8 @@ import kotlin.script.templates.ScriptTemplateDefinition
         "-api-version", "1.8",
         "-Xjvm-default=all",
         "-Xjsr305=strict",
+        "-Xskip-metadata-version-check",
+        "-Xskip-prerelease-check",
         "-XXLanguage:+DisableCompatibilityModeForNewInference",
         "-XXLanguage:-TypeEnhancementImprovementsInStrictMode",
     ],

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinDslStandaloneScriptCompilationConfiguration.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinDslStandaloneScriptCompilationConfiguration.kt
@@ -40,6 +40,7 @@ abstract class KotlinDslStandaloneScriptCompilationConfiguration protected const
         "-Xjsr305=strict",
         "-Xskip-metadata-version-check",
         "-Xskip-prerelease-check",
+        "-Xallow-unstable-dependencies",
         "-XXLanguage:+DisableCompatibilityModeForNewInference",
         "-XXLanguage:-TypeEnhancementImprovementsInStrictMode",
     ))

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinDslStandaloneScriptCompilationConfiguration.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinDslStandaloneScriptCompilationConfiguration.kt
@@ -38,6 +38,8 @@ abstract class KotlinDslStandaloneScriptCompilationConfiguration protected const
         "-api-version", "1.8",
         "-Xjvm-default=all",
         "-Xjsr305=strict",
+        "-Xskip-metadata-version-check",
+        "-Xskip-prerelease-check",
         "-XXLanguage:+DisableCompatibilityModeForNewInference",
         "-XXLanguage:-TypeEnhancementImprovementsInStrictMode",
     ))

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinInitScript.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinInitScript.kt
@@ -46,6 +46,7 @@ import kotlin.script.templates.ScriptTemplateDefinition
         "-Xjsr305=strict",
         "-Xskip-metadata-version-check",
         "-Xskip-prerelease-check",
+        "-Xallow-unstable-dependencies",
         "-XXLanguage:+DisableCompatibilityModeForNewInference",
         "-XXLanguage:-TypeEnhancementImprovementsInStrictMode",
     ],

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinInitScript.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinInitScript.kt
@@ -44,6 +44,8 @@ import kotlin.script.templates.ScriptTemplateDefinition
         "-api-version", "1.8",
         "-Xjvm-default=all",
         "-Xjsr305=strict",
+        "-Xskip-metadata-version-check",
+        "-Xskip-prerelease-check",
         "-XXLanguage:+DisableCompatibilityModeForNewInference",
         "-XXLanguage:-TypeEnhancementImprovementsInStrictMode",
     ],

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScript.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScript.kt
@@ -45,6 +45,7 @@ import kotlin.script.templates.ScriptTemplateDefinition
         "-Xjsr305=strict",
         "-Xskip-metadata-version-check",
         "-Xskip-prerelease-check",
+        "-Xallow-unstable-dependencies",
         "-XXLanguage:+DisableCompatibilityModeForNewInference",
         "-XXLanguage:-TypeEnhancementImprovementsInStrictMode",
     ],

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScript.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScript.kt
@@ -43,6 +43,8 @@ import kotlin.script.templates.ScriptTemplateDefinition
         "-api-version", "1.8",
         "-Xjvm-default=all",
         "-Xjsr305=strict",
+        "-Xskip-metadata-version-check",
+        "-Xskip-prerelease-check",
         "-XXLanguage:+DisableCompatibilityModeForNewInference",
         "-XXLanguage:-TypeEnhancementImprovementsInStrictMode",
     ],

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
@@ -402,6 +402,7 @@ val gradleKotlinDslLanguageVersionSettings = LanguageVersionSettingsImpl(
     analysisFlags = mapOf(
         AnalysisFlags.skipMetadataVersionCheck to true,
         AnalysisFlags.skipPrereleaseCheck to true,
+        AnalysisFlags.allowUnstableDependencies to true,
         JvmAnalysisFlags.jvmDefaultMode to JvmDefaultMode.ENABLE,
     ),
     specificFeatures = mapOf(


### PR DESCRIPTION
* Fix for https://github.com/gradle/gradle/issues/25460
