### PR TITLE
Enable CC load-after-store testing in `:kotlin-dsl-plugins` and `:kotlin-dsl-integ-tests`

### DIFF
--- a/subprojects/kotlin-dsl-integ-tests/build.gradle.kts
+++ b/subprojects/kotlin-dsl-integ-tests/build.gradle.kts
@@ -30,8 +30,3 @@ dependencies {
 }
 
 testFilesCleanup.reportOnly = true
-
-// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
-tasks.configCacheIntegTest {
-    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
-}

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
@@ -7,7 +7,6 @@ import org.gradle.api.Project
 import org.gradle.api.internal.DocumentationRegistry
 import org.gradle.api.tasks.TaskAction
 import org.gradle.integtests.fixtures.RepoScriptBlockUtil
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.kotlin.dsl.fixtures.classEntriesFor
 import org.gradle.kotlin.dsl.fixtures.normalisedPath
 import org.gradle.test.fixtures.dsl.GradleDsl
@@ -941,7 +940,6 @@ class PrecompiledScriptPluginIntegrationTest : AbstractPluginIntegrationTest() {
 
     @Test
     @Issue("https://github.com/gradle/gradle/issues/12955")
-    @ToBeFixedForConfigurationCache(because = "KGP uses project at execution time")
     fun `captures output of schema collection and displays it on errors`() {
 
         fun outputFrom(origin: String, logger: Boolean = true) = buildString {
@@ -1022,7 +1020,6 @@ class PrecompiledScriptPluginIntegrationTest : AbstractPluginIntegrationTest() {
 
     @Test
     @Issue("https://github.com/gradle/gradle/issues/12955")
-    @ToBeFixedForConfigurationCache(because = "KGP uses project at execution time")
     fun `captures output of schema collection but not of concurrent tasks`() {
 
         val repeatOutput = 50

--- a/subprojects/kotlin-dsl-plugins/build.gradle.kts
+++ b/subprojects/kotlin-dsl-plugins/build.gradle.kts
@@ -98,8 +98,3 @@ pluginPublish {
         pluginClass = "org.gradle.kotlin.dsl.plugins.precompiled.PrecompiledScriptPlugins"
     )
 }
-
-// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
-tasks.configCacheIntegTest {
-    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
-}

--- a/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinCompilerWarningsTest.kt
+++ b/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinCompilerWarningsTest.kt
@@ -16,6 +16,7 @@
 
 package org.gradle.kotlin.dsl.plugins.dsl
 
+import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.kotlin.dsl.fixtures.AbstractPluginTest
 import org.junit.Test
 
@@ -32,6 +33,7 @@ class KotlinCompilerWarningsTest : AbstractPluginTest() {
     val experimentalFeatureToWarnAbout = "-XXLanguage:+FunctionReferenceWithDefaultValueAsOtherType"
 
     @Test
+    @ToBeFixedForConfigurationCache(because = "https://github.com/gradle/gradle/issues/25483")
     fun `experimental compiler warnings are not shown for known experimental features`() {
         withBuildScriptForKotlinCompile()
         withKotlinSourceFile()
@@ -43,6 +45,7 @@ class KotlinCompilerWarningsTest : AbstractPluginTest() {
     }
 
     @Test
+    @ToBeFixedForConfigurationCache(because = "https://github.com/gradle/gradle/issues/25483")
     fun `experimental compiler warnings are not shown for known experimental features with allWarningsAsErrors`() {
         withBuildScriptForKotlinCompile("allWarningsAsErrors.set(true)")
         withKotlinSourceFile()
@@ -55,6 +58,7 @@ class KotlinCompilerWarningsTest : AbstractPluginTest() {
 
 
     @Test
+    @ToBeFixedForConfigurationCache(because = "https://github.com/gradle/gradle/issues/25483")
     fun `compileKotlin task output is retained when known experimental feature warnings are silenced`() {
         withBuildScriptForKotlinCompile(
             "",
@@ -78,6 +82,7 @@ class KotlinCompilerWarningsTest : AbstractPluginTest() {
     }
 
     @Test
+    @ToBeFixedForConfigurationCache(because = "https://github.com/gradle/gradle/issues/25483")
     fun `compiler warning for an explicitly enabled experimental feature is shown`() {
         withBuildScriptForKotlinCompile("freeCompilerArgs.add(\"$experimentalFeatureToWarnAbout\")")
         withKotlinSourceFile()
@@ -90,6 +95,7 @@ class KotlinCompilerWarningsTest : AbstractPluginTest() {
     }
 
     @Test
+    @ToBeFixedForConfigurationCache(because = "https://github.com/gradle/gradle/issues/25483")
     fun `compiler warning for an explicitly enabled experimental feature is shown with allWarningsAsErrors`() {
         withBuildScriptForKotlinCompile(
             """


### PR DESCRIPTION
* Fixed tests in `:kotlin-dsl-integ-tests`.
* Disabled tests in `:kotlin-dsl-plugins` because of https://github.com/gradle/gradle/issues/25483