### PR TITLE
Enable load after store CC tests in launcher subproject

### DIFF
--- a/subprojects/launcher/build.gradle.kts
+++ b/subprojects/launcher/build.gradle.kts
@@ -89,7 +89,3 @@ strictCompile {
 
 testFilesCleanup.reportOnly = true
 
-// Remove as part of fixing https://github.com/gradle/configuration-cache/issues/585
-tasks.configCacheIntegTest {
-    systemProperties["org.gradle.configuration-cache.internal.test-disable-load-after-store"] = "true"
-}

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/ContinueIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/ContinueIntegrationTest.groovy
@@ -70,13 +70,14 @@ class ContinueIntegrationTest extends AbstractIntegrationSpec {
 
     private TestFile buildScript() {
         buildScript """
-            tasks.register("failTask") {
+            def failing = tasks.register("failTask") {
                 doFirst {
                     throw new RuntimeException("failTask failed")
                 }
             }
 
             tasks.register("successTask") {
+                mustRunAfter failing
                 doFirst {
                     println("successTask success")
                 }

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/AbstractDaemonLifecycleSpec.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/AbstractDaemonLifecycleSpec.groovy
@@ -72,13 +72,15 @@ class AbstractDaemonLifecycleSpec extends DaemonIntegrationSpec {
                 executer.withDefaultCharacterEncoding(buildEncoding)
             }
             executer.usingProjectDirectory buildDirWithScript(builds.size(), """
+                def stopFile = file("stop")
+                def existsFile = file("exists")
                 task('watch') {
                     doLast {
                         println "waiting for stop file"
                         long sanityCheck = System.currentTimeMillis() + 120000L
-                        while(!file("stop").exists()) {
+                        while (!stopFile.exists()) {
                             sleep 100
-                            if (file("exit").exists()) {
+                            if (existsFile.exists()) {
                                 println "found exit file, exiting"
                                 System.exit(1)
                             }

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonLifecycleEncodingSpec.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonLifecycleEncodingSpec.groovy
@@ -16,9 +16,9 @@
 
 package org.gradle.launcher.daemon
 
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.fixtures.file.DoesNotSupportNonAsciiPaths
-import spock.lang.IgnoreIf
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.IntegTestPreconditions
 
 @DoesNotSupportNonAsciiPaths(reason = "Requires running with ASCII file encoding")
 class DaemonLifecycleEncodingSpec extends AbstractDaemonLifecycleSpec {
@@ -58,7 +58,7 @@ class DaemonLifecycleEncodingSpec extends AbstractDaemonLifecycleSpec {
         }
     }
 
-    @IgnoreIf({ GradleContextualExecuter.embedded }) // need to start Gradle process from command line to use GRADLE_OPTS
+    @Requires(IntegTestPreconditions.NotEmbeddedExecutor) // need to start Gradle process from command line to use GRADLE_OPTS
     def "forks new daemon when file encoding is set to different value via GRADLE_OPTS"() {
         setup:
         buildScript """

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonLifecycleSpec.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonLifecycleSpec.groovy
@@ -22,7 +22,6 @@ import org.gradle.launcher.daemon.registry.DaemonDir
 import org.gradle.launcher.daemon.server.api.HandleStop
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.UnitTestPreconditions
-import spock.lang.Ignore
 import spock.lang.IgnoreIf
 
 /**
@@ -296,7 +295,6 @@ class DaemonLifecycleSpec extends AbstractDaemonLifecycleSpec {
 
     // GradleHandle.abort() does not work reliably on windows and creates flakiness
     @Requires(UnitTestPreconditions.NotWindows)
-    @Ignore("TODO: Fix GradleHandle.abort() so that it doesn't hang")
     def "daemon stops immediately if stop is requested and then client disconnects"() {
         when:
         startBuild()


### PR DESCRIPTION
This fixes some tests in the launcher subproject. I saw `SimpleJavaContinuousIntegrationTest` failing as well, though that one might be flaky.