### PR TITLE
Fix documentation link for 'Disabling up-to-date checks' section

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyErrorIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyErrorIntegrationTest.groovy
@@ -102,7 +102,7 @@ The following types/formats are supported:
             failure.assertHasDocumentedCause("Cannot access input property 'rootSpec\$1' of task ':copy'. " +
                 "Accessing unreadable inputs or outputs is not supported. " +
                 "Declare the task as untracked by using Task.doNotTrackState(). " +
-                new DocumentationRegistry().getDocumentationRecommendationFor("information", "incremental_build", "disable-state-tracking")
+                new DocumentationRegistry().getDocumentationRecommendationFor("information", "incremental_build", "sec:disable-state-tracking")
             )
             failure.assertHasCause("java.nio.file.AccessDeniedException: ${dir}")
         } finally {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/UnreadableCopyDestinationFixture.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/UnreadableCopyDestinationFixture.groovy
@@ -25,7 +25,7 @@ trait UnreadableCopyDestinationFixture {
     private static final String COPY_UNREADABLE_DESTINATION_FAILURE = "Cannot access a file in the destination directory. " +
         "Copying to a directory which contains unreadable content is not supported. " +
         "Declare the task as untracked by using Task.doNotTrackState(). " +
-        new DocumentationRegistry().getDocumentationRecommendationFor("information", "incremental_build", "disable-state-tracking")
+        new DocumentationRegistry().getDocumentationRecommendationFor("information", "incremental_build", "sec:disable-state-tracking")
 
     void expectUnreadableCopyDestinationFailure() {
         failure.assertHasDocumentedCause(COPY_UNREADABLE_DESTINATION_FAILURE)

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/UntrackedTaskIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/UntrackedTaskIntegrationTest.groovy
@@ -289,7 +289,7 @@ class UntrackedTaskIntegrationTest extends AbstractIntegrationSpec implements Di
     }
 
     def getDisableStateTrackingLink() {
-        documentationRegistry.getDocumentationRecommendationFor("information", "incremental_build", "disable-state-tracking")
+        documentationRegistry.getDocumentationRecommendationFor("information", "incremental_build", "sec:disable-state-tracking")
     }
 
     def "does not clean up stale outputs for untracked tasks"() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecution.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecution.java
@@ -382,7 +382,7 @@ public class TaskExecution implements UnitOfWork {
                 .withContext("Accessing unreadable inputs or outputs is not supported.")
                 .withAdvice("Declare the task as untracked by using Task.doNotTrackState().");
         }
-        return builder.withUserManual("incremental_build", "disable-state-tracking")
+        return builder.withUserManual("incremental_build", "sec:disable-state-tracking")
             .build(cause);
     }
 

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
@@ -463,7 +463,7 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
         failure.assertHasDocumentedCause("Cannot access a file in the destination directory. " +
             "Syncing to a directory which contains unreadable content is not supported. " +
             "Use a Copy task with Task.doNotTrackState() instead. " +
-            documentationRegistry.getDocumentationRecommendationFor("information", "incremental_build", "disable-state-tracking"))
+            documentationRegistry.getDocumentationRecommendationFor("information", "incremental_build", "sec:disable-state-tracking"))
         failureHasCause("Failed to create MD5 hash for file '${unreadableOutput}' as it does not exist.")
 
         cleanup:


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!--- Fixes #? -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
https://docs.gradle.org/8.1.1/userguide/incremental_build.html#sec:disable-state-tracking

There are some broken links in the command line log, which seem to be designated to the above anchor.

![image](https://github.com/gradle/gradle/assets/6624567/a1530622-a19b-4ad1-9397-d581ddf503b5)

```diff
-https://docs.gradle.org/8.1.1/userguide/incremental_build.html#disable-state-tracking
+https://docs.gradle.org/8.1.1/userguide/incremental_build.html#sec:disable-state-tracking
```

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- n/a Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- n/a Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
