### PR TITLE
Update to gradle-guides-plugin 0.22

### DIFF
--- a/build-logic/build-platform/build.gradle.kts
+++ b/build-logic/build-platform/build.gradle.kts
@@ -21,7 +21,7 @@ val kotlinVersion = providers.gradleProperty("buildKotlinVersion")
 
 dependencies {
     constraints {
-        api("org.gradle.guides:gradle-guides-plugin:0.21")
+        api("org.gradle.guides:gradle-guides-plugin:0.22")
         api("com.gradle:gradle-enterprise-gradle-plugin:3.13.4") // Sync with `settings.gradle.kts`
         api("com.gradle.publish:plugin-publish-plugin:1.1.0")
         api("gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext:1.0.1")

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -38,7 +38,6 @@ dependencyResolutionManagement {
         jcenter {
             content {
                 includeModule("org.openmbee.junit", "junit-xml-parser")
-                includeModule("org.codehaus.groovy.modules", "http-builder-ng-core")
             }
         }
         mavenCentral()

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -187,7 +187,6 @@
             <trusting group="com.github.javaparser"/>
             <trusting group="info.picocli"/>
             <trusting group="io.github.http-builder-ng"/>
-            <trusting group="org.codehaus.groovy.modules" name="http-builder-ng-core"/>
             <trusting group="org.testcontainers"/>
             <trusting group="^com[.]diffplug($|([.].*))" regex="true"/>
             <trusting group="^org[.]jetbrains($|([.].*))" regex="true"/>
@@ -1303,9 +1302,9 @@
             <sha256 value="5ef4102929b54c1b368be19178475c941bff09322c838484bb4dee66b6649419" reason="Artifact is not signed"/>
          </artifact>
       </component>
-      <component group="org.gradle.guides" name="gradle-guides-plugin" version="0.21">
-         <artifact name="gradle-guides-plugin-0.21.jar">
-            <sha256 value="c136d7744951e1541a121377a34d36e83f09f732c0e2b8d8deffbd48aa125c5d" origin="Verified" reason="Artifact is not signed"/>
+      <component group="org.gradle.guides" name="gradle-guides-plugin" version="0.22">
+         <artifact name="gradle-guides-plugin-0.22.jar">
+            <sha256 value="d6609bba9739659fb2cff4d3750ae97cabc4df4b1ffe7ca3211bc39517efadfb" origin="Verified" reason="Artifact is not signed"/>
          </artifact>
       </component>
       <component group="org.gradle.kotlin" name="gradle-kotlin-dsl-conventions" version="0.8.0">

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,7 +15,6 @@ pluginManagement {
         jcenter {
             content {
                 includeModule("org.openmbee.junit", "junit-xml-parser")
-                includeModule("org.codehaus.groovy.modules", "http-builder-ng-core")
             }
         }
         gradlePluginPortal()


### PR DESCRIPTION
This no longer depends on http-builder-ng-core, which is only available on JCenter.
