### PR TITLE
Do not use VFS to snapshot results of File.list and the likes

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/extensions/FileSystemExtensions.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/extensions/FileSystemExtensions.kt
@@ -31,8 +31,13 @@ fun fileSystemEntryType(file: File): FileType =
     }
 
 
+// This value is returned from directoryChildrenNamesHash when its argument doesn't exist or is not a directory.
+private
+val NON_DIRECTORY_CHILDREN_NAMES_HASH = HashCode.fromBytes(byteArrayOf(0, 0, 0, 0))
+
+
 internal
-fun directoryContentHash(file: File): HashCode {
+fun directoryChildrenNamesHash(file: File): HashCode {
     return file.list()?.let { entries ->
         val hasher = Hashing.newHasher()
         // This routine is used to snapshot results of File.list(), File.listFiles() and similar calls.
@@ -42,5 +47,5 @@ fun directoryContentHash(file: File): HashCode {
         Arrays.sort(entries)
         entries.forEach(hasher::putString)
         hasher.hash()
-    } ?: HashCode.fromBytes(byteArrayOf(0, 0, 0, 0))
+    } ?: NON_DIRECTORY_CHILDREN_NAMES_HASH
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintController.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintController.kt
@@ -337,8 +337,7 @@ class ConfigurationCacheFingerprintController internal constructor(
         override fun hashCodeOf(file: File) =
             fileSystemAccess.read(file.absolutePath).hash
 
-        override fun hashCodeOfDirectoryContent(file: File): HashCode =
-            fileSystemAccess.directoryContentHash(file)
+        override fun hashCodeOfDirectoryContent(file: File): HashCode = directoryContentHash(file)
 
         override fun displayNameOf(file: File): String =
             GFileUtils.relativePathOf(file, rootDirectory)
@@ -394,8 +393,7 @@ class ConfigurationCacheFingerprintController internal constructor(
         override fun hashCodeOf(file: File) =
             fileSystemAccess.read(file.absolutePath).hash
 
-        override fun hashCodeOfDirectoryContent(file: File): HashCode? =
-            fileSystemAccess.directoryContentHash(file)
+        override fun hashCodeOfDirectoryContent(file: File): HashCode = directoryContentHash(file)
 
         override fun fingerprintOf(fileCollection: FileCollectionInternal): HashCode =
             fileCollectionFingerprinter.fingerprint(fileCollection).hash

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintController.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintController.kt
@@ -27,7 +27,7 @@ import org.gradle.configurationcache.ConfigurationCacheStateFile
 import org.gradle.configurationcache.ConfigurationCacheStateStore.StateFile
 import org.gradle.configurationcache.EncryptionService
 import org.gradle.configurationcache.InputTrackingState
-import org.gradle.configurationcache.extensions.directoryContentHash
+import org.gradle.configurationcache.extensions.directoryChildrenNamesHash
 import org.gradle.configurationcache.extensions.uncheckedCast
 import org.gradle.configurationcache.initialization.ConfigurationCacheStartParameter
 import org.gradle.configurationcache.problems.ConfigurationCacheProblems
@@ -337,7 +337,7 @@ class ConfigurationCacheFingerprintController internal constructor(
         override fun hashCodeOf(file: File) =
             fileSystemAccess.read(file.absolutePath).hash
 
-        override fun hashCodeOfDirectoryContent(file: File): HashCode = directoryContentHash(file)
+        override fun hashCodeOfDirectoryChildrenNames(file: File): HashCode = directoryChildrenNamesHash(file)
 
         override fun displayNameOf(file: File): String =
             GFileUtils.relativePathOf(file, rootDirectory)
@@ -393,7 +393,7 @@ class ConfigurationCacheFingerprintController internal constructor(
         override fun hashCodeOf(file: File) =
             fileSystemAccess.read(file.absolutePath).hash
 
-        override fun hashCodeOfDirectoryContent(file: File): HashCode = directoryContentHash(file)
+        override fun hashCodeOfDirectoryContent(file: File): HashCode = directoryChildrenNamesHash(file)
 
         override fun fingerprintOf(fileCollection: FileCollectionInternal): HashCode =
             fileCollectionFingerprinter.fingerprint(fileCollection).hash

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintWriter.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintWriter.kt
@@ -120,7 +120,7 @@ class ConfigurationCacheFingerprintWriter(
         val instrumentationAgentUsed: Boolean
         fun fingerprintOf(fileCollection: FileCollectionInternal): HashCode
         fun hashCodeOf(file: File): HashCode
-        fun hashCodeOfDirectoryContent(file: File): HashCode
+        fun hashCodeOfDirectoryChildrenNames(file: File): HashCode
         fun displayNameOf(file: File): String
         fun reportProblem(exception: Throwable? = null, documentationSection: DocumentationSection? = null, message: StructuredMessageBuilder)
         fun reportInput(input: PropertyProblem)
@@ -792,7 +792,7 @@ class ConfigurationCacheFingerprintWriter(
             if (!capturedDirectories.add(file)) {
                 return
             }
-            write(ConfigurationCacheFingerprint.DirectoryChildren(file, host.hashCodeOfDirectoryContent(file)))
+            write(ConfigurationCacheFingerprint.DirectoryChildren(file, host.hashCodeOfDirectoryChildrenNames(file)))
         }
 
         fun captureRemoteScript(uri: URI) {


### PR DESCRIPTION
Here we only need to snapshot the list of immediate directory's children. VFS does much more than that internally, snapshotting the whole subtree and gathering file hashes. This causes issues when files aren't accessible because of permissions or locks. These issues aren't present without the configuration cache, and are surprising from the user's perspective. Snapshotting the whole hierarchy may also have performance downsides.

While one can limit the snaphotting depth of the VFS, it is impossible to disable file content snapshotting (with the current API). Limiting also effectively disables the VFS cache.

Replacing VFS with the ad hoc directory listing we're likely to slightly regress the performance of the "happy" path, though the initial fingerprinting and fingerprint check in case of unrelated, "deep" changes will avoid unnecessary work.

Overall, making CC behave more like the non-cached build seems to be a better trade-off, as it isn't obvious that the directory list fingerprint check is really a hotspot worth optimizing.

Fixes #25164 
