### PR TITLE
Exclude .gradle and build directories from top-level IDEA module

### DIFF
--- a/build-logic/idea/src/main/kotlin/gradlebuild.ide.gradle.kts
+++ b/build-logic/idea/src/main/kotlin/gradlebuild.ide.gradle.kts
@@ -51,7 +51,11 @@ tasks.idea {
 if (idea.project != null) { // may be null during script compilation
     idea {
         module {
-            excludeDirs = setOf(repoRoot().dir("intTestHomeDir").asFile)
+            // We exclude some top-level directories, so their content is not indexed
+            // and does not appear in search results by default
+            excludeDirs = listOf(".gradle", "build", "intTestHomeDir")
+                .map { repoRoot().dir(it).asFile }
+                .toSet()
         }
         project {
             settings {


### PR DESCRIPTION
Without this, when the project is imported in IntelliJ, the default "Project Files" scope includes `.gradle` and `build` directories as content source polluting the search results.

