### PR TITLE
Fix configuration cache incompatibility in Java Gradle Plugin Plugin

### DIFF
--- a/subprojects/docs/build.gradle
+++ b/subprojects/docs/build.gradle
@@ -764,10 +764,6 @@ tasks.named("docsTest") { task ->
                 // TODO(https://github.com/gradle/gradle/issues/22879) The snippet extracts build logic into a method and calls the method at execution time
                 "snippet-tutorial-ant-loadfile-with-method_groovy_antLoadfileWithMethod.sample",
                 "snippet-tutorial-ant-loadfile-with-method_kotlin_antLoadfileWithMethod.sample",
-
-                // TODO(https://github.com/gradle/gradle/issues/22545)
-                "snippet-developing-plugins-plugin-with-variants_groovy_localPublish.sample",
-                "snippet-developing-plugins-plugin-with-variants_kotlin_localPublish.sample",
             ]
 
             // Tests that can and has to be fixed to run with the configuration cache enabled.

--- a/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
@@ -837,6 +837,43 @@ Instead, tasks should be connected using <<lazy_configuration#working_with_task_
 
 Note that this requirement makes it unsupported to write tasks that configure other tasks at execution time.
 
+[[config_cache:requirements:shared_objects]]
+=== Sharing mutable objects
+When storing a task to the configuration cache, all objects directly or indirectly referenced through the task's fields are serialized.
+In most cases, deserialization preserves reference equality: if two fields `a` and `b` referenced the same instance at configuration time, then upon deserialization they will reference the same instance again, so `a == b` (or `a === b` in Groovy and Kotlin syntax) still holds.
+However, for performance reasons, some classes, in particular `java.lang.String`, `java.io.File`, and many implementations of `java.util.Collection` interface, are serialized without preserving the reference equality.
+Upon deserialization, fields that referred to the object of such a class can refer to different but equal objects.
+
+Let's look at a task that stores a user-defined object and an `ArrayList` in task fields.
+====
+include::sample[dir="snippets/configurationCache/sharedObjects/kotlin",files="build.gradle.kts[]"]
+include::sample[dir="snippets/configurationCache/sharedObjects/groovy",files="build.gradle[]"]
+====
+<1> `doLast` action captures the references from the enclosing scope. These captured references are also serialized to the configuration cache.
+<2> Compare the reference to an object of user-defined class stored in the task field and the reference captured in the `doLast` action.
+<3> Compare the reference to `ArrayList` instance stored in the task field and the reference captured in the `doLast` action.
+<4> Check the equality of stored and captured lists.
+
+Running the build without configuration cache shows that reference equality is preserved in both cases.
+----
+❯ gradle --no-configuration-cache checkEquality
+include::{snippetsPath}/configurationCache/sharedObjects/tests/sharingObjectsWithoutConfigurationCache.out[]
+----
+
+However, with the configuration cache enabled, only the user-defined object references are the same.
+List references are different, though the referenced lists are equal.
+----
+❯ gradle --configuration-cache checkEquality
+include::{snippetsPath}/configurationCache/sharedObjects/tests/sharingObjectsWithConfigurationCache.out[]
+----
+
+In general, it isn't recommended to share mutable objects between configuration and execution phases.
+If you need to do this, you should always wrap the state in a class you define.
+There's no guarantee that the reference equality is preserved for standard Java, Groovy, and Kotlin types, or for Gradle-defined types.
+
+Note that no reference equality is preserved between tasks: each task is its own "realm", so it is not possible to share objects between tasks.
+Instead, you can use a <<build_services#build_services,build service>> to wrap the shared state.
+
 [[config_cache:requirements:task_extensions]]
 === Accessing task extensions or conventions
 

--- a/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
@@ -840,7 +840,7 @@ Note that this requirement makes it unsupported to write tasks that configure ot
 [[config_cache:requirements:shared_objects]]
 === Sharing mutable objects
 When storing a task to the configuration cache, all objects directly or indirectly referenced through the task's fields are serialized.
-In most cases, deserialization preserves reference equality: if two fields `a` and `b` referenced the same instance at configuration time, then upon deserialization they will reference the same instance again, so `a == b` (or `a === b` in Groovy and Kotlin syntax) still holds.
+In most cases, deserialization preserves reference equality: if two fields `a` and `b` reference the same instance at configuration time, then upon deserialization they will reference the same instance again, so `a == b` (or `a === b` in Groovy and Kotlin syntax) still holds.
 However, for performance reasons, some classes, in particular `java.lang.String`, `java.io.File`, and many implementations of `java.util.Collection` interface, are serialized without preserving the reference equality.
 Upon deserialization, fields that referred to the object of such a class can refer to different but equal objects.
 
@@ -854,7 +854,7 @@ include::sample[dir="snippets/configurationCache/sharedObjects/groovy",files="bu
 <3> Compare the reference to `ArrayList` instance stored in the task field and the reference captured in the `doLast` action.
 <4> Check the equality of stored and captured lists.
 
-Running the build without configuration cache shows that reference equality is preserved in both cases.
+Running the build without the configuration cache shows that reference equality is preserved in both cases.
 ----
 ❯ gradle --no-configuration-cache checkEquality
 include::{snippetsPath}/configurationCache/sharedObjects/tests/sharingObjectsWithoutConfigurationCache.out[]
@@ -869,7 +869,7 @@ include::{snippetsPath}/configurationCache/sharedObjects/tests/sharingObjectsWit
 
 In general, it isn't recommended to share mutable objects between configuration and execution phases.
 If you need to do this, you should always wrap the state in a class you define.
-There's no guarantee that the reference equality is preserved for standard Java, Groovy, and Kotlin types, or for Gradle-defined types.
+There is no guarantee that the reference equality is preserved for standard Java, Groovy, and Kotlin types, or for Gradle-defined types.
 
 Note that no reference equality is preserved between tasks: each task is its own "realm", so it is not possible to share objects between tasks.
 Instead, you can use a <<build_services#build_services,build service>> to wrap the shared state.

--- a/subprojects/docs/src/snippets/configurationCache/sharedObjects/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/configurationCache/sharedObjects/groovy/build.gradle
@@ -1,0 +1,26 @@
+class StateObject {
+    // ...
+}
+
+abstract class StatefulTask extends DefaultTask {
+    @Internal
+    StateObject stateObject
+
+    @Internal
+    List<String> strings
+}
+
+
+tasks.register("checkEquality", StatefulTask) {
+    def objectValue = new StateObject()
+    def stringsValue = ["a", "b"] as ArrayList<String>
+
+    stateObject = objectValue
+    strings = stringsValue
+
+    doLast { // <1>
+        println("POJO reference equality: ${stateObject === objectValue}") // <2>
+        println("Collection reference equality: ${strings === stringsValue}") // <3>
+        println("Collection equality: ${strings == stringsValue}") // <4>
+    }
+}

--- a/subprojects/docs/src/snippets/configurationCache/sharedObjects/groovy/gradle.properties
+++ b/subprojects/docs/src/snippets/configurationCache/sharedObjects/groovy/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.configuration-cache=true

--- a/subprojects/docs/src/snippets/configurationCache/sharedObjects/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/configurationCache/sharedObjects/kotlin/build.gradle.kts
@@ -1,0 +1,26 @@
+class StateObject {
+    // ...
+}
+
+abstract class StatefulTask : DefaultTask() {
+    @get:Internal
+    var stateObject: StateObject? = null
+
+    @get:Internal
+    var strings: List<String>? = null
+}
+
+
+tasks.register<StatefulTask>("checkEquality") {
+    val objectValue = StateObject()
+    val stringsValue = arrayListOf("a", "b")
+
+    stateObject = objectValue
+    strings = stringsValue
+
+    doLast { // <1>
+        println("POJO reference equality: ${stateObject === objectValue}") // <2>
+        println("Collection reference equality: ${strings === stringsValue}") // <3>
+        println("Collection equality: ${strings == stringsValue}") // <4>
+    }
+}

--- a/subprojects/docs/src/snippets/configurationCache/sharedObjects/kotlin/gradle.properties
+++ b/subprojects/docs/src/snippets/configurationCache/sharedObjects/kotlin/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.configuration-cache=true

--- a/subprojects/docs/src/snippets/configurationCache/sharedObjects/tests/sharingObjectsWithConfigurationCache.out
+++ b/subprojects/docs/src/snippets/configurationCache/sharedObjects/tests/sharingObjectsWithConfigurationCache.out
@@ -1,0 +1,4 @@
+> Task :checkEquality
+POJO reference equality: true
+Collection reference equality: false
+Collection equality: true

--- a/subprojects/docs/src/snippets/configurationCache/sharedObjects/tests/sharingObjectsWithConfigurationCache.sample.conf
+++ b/subprojects/docs/src/snippets/configurationCache/sharedObjects/tests/sharingObjectsWithConfigurationCache.sample.conf
@@ -1,0 +1,4 @@
+executable: gradle
+args: checkEquality
+expected-output-file: sharingObjectsWithConfigurationCache.out
+allow-additional-output: true

--- a/subprojects/docs/src/snippets/configurationCache/sharedObjects/tests/sharingObjectsWithoutConfigurationCache.out
+++ b/subprojects/docs/src/snippets/configurationCache/sharedObjects/tests/sharingObjectsWithoutConfigurationCache.out
@@ -1,0 +1,4 @@
+> Task :checkEquality
+POJO reference equality: true
+Collection reference equality: true
+Collection equality: true

--- a/subprojects/docs/src/snippets/configurationCache/sharedObjects/tests/sharingObjectsWithoutConfigurationCache.sample.conf
+++ b/subprojects/docs/src/snippets/configurationCache/sharedObjects/tests/sharingObjectsWithoutConfigurationCache.sample.conf
@@ -1,0 +1,5 @@
+executable: gradle
+args: checkEquality
+flags: "--no-configuration-cache"
+expected-output-file: sharingObjectsWithoutConfigurationCache.out
+allow-additional-output: true

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java
@@ -64,7 +64,6 @@ import org.gradle.plugin.use.internal.DefaultPluginId;
 import org.gradle.plugin.use.resolve.internal.local.PluginPublication;
 import org.gradle.process.CommandLineArgumentProvider;
 
-import javax.annotation.Nullable;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -164,12 +163,11 @@ public abstract class JavaGradlePluginPlugin implements Plugin<Project> {
 
     private void configureJarTask(Project project, GradlePluginDevelopmentExtension extension) {
         project.getTasks().named(JAR_TASK, Jar.class, jarTask -> {
-            List<PluginDescriptor> descriptors = new ArrayList<>();
-            Set<String> classList = new HashSet<>();
-            PluginDescriptorCollectorAction pluginDescriptorCollector = new PluginDescriptorCollectorAction(descriptors);
-            ClassManifestCollectorAction classManifestCollector = new ClassManifestCollectorAction(classList);
+            PluginValidationActionsState actionsState = new PluginValidationActionsState();
+            PluginDescriptorCollectorAction pluginDescriptorCollector = new PluginDescriptorCollectorAction(actionsState);
+            ClassManifestCollectorAction classManifestCollector = new ClassManifestCollectorAction(actionsState);
             Provider<Collection<PluginDeclaration>> pluginsProvider = project.provider(() -> extension.getPlugins().getAsMap().values());
-            PluginValidationAction pluginValidationAction = new PluginValidationAction(pluginsProvider, descriptors, classList);
+            PluginValidationAction pluginValidationAction = new PluginValidationAction(pluginsProvider, actionsState);
 
             jarTask.filesMatching(PLUGIN_DESCRIPTOR_PATTERN, pluginDescriptorCollector);
             jarTask.filesMatching(CLASSES_PATTERN, classManifestCollector);
@@ -283,22 +281,58 @@ public abstract class JavaGradlePluginPlugin implements Plugin<Project> {
     }
 
     /**
-     * Implements plugin validation tasks to validate that a proper plugin jar is produced.
+     * A state shared by the validation process.
+     * <p>
+     * This separate class is required to ensure the shared state remains shared after deserialization of actions from the configuration cache.
+     *
+     * @see #configureJarTask(Project, GradlePluginDevelopmentExtension)
      */
-    static class PluginValidationAction implements Action<Task> {
-        private final Provider<Collection<PluginDeclaration>> plugins;
-        private final Collection<PluginDescriptor> descriptors;
+    static class PluginValidationActionsState {
+        private final List<PluginDescriptor> descriptors;
         private final Set<String> classes;
 
-        PluginValidationAction(Provider<Collection<PluginDeclaration>> plugins, @Nullable Collection<PluginDescriptor> descriptors, Set<String> classes) {
-            this.plugins = plugins;
+        public PluginValidationActionsState() {
+            this(new ArrayList<>(), new HashSet<>());
+        }
+
+        public PluginValidationActionsState(List<PluginDescriptor> descriptors, Set<String> classes) {
             this.descriptors = descriptors;
             this.classes = classes;
         }
 
+        public void addPluginClass(String className) {
+            classes.add(className);
+        }
+
+        public void addPluginDescriptor(PluginDescriptor descriptor) {
+            descriptors.add(descriptor);
+        }
+
+        public Set<String> getCollectedClasses() {
+            return classes;
+        }
+
+        public List<PluginDescriptor> getCollectedDescriptors() {
+            return descriptors;
+        }
+    }
+
+    /**
+     * Implements plugin validation tasks to validate that a proper plugin jar is produced.
+     */
+    static class PluginValidationAction implements Action<Task> {
+        private final Provider<Collection<PluginDeclaration>> plugins;
+        private final PluginValidationActionsState actionsState;
+
+        PluginValidationAction(Provider<Collection<PluginDeclaration>> plugins, PluginValidationActionsState actionsState) {
+            this.plugins = plugins;
+            this.actionsState = actionsState;
+        }
+
         @Override
         public void execute(Task task) {
-            if (descriptors == null || descriptors.isEmpty()) {
+            List<PluginDescriptor> descriptors = actionsState.getCollectedDescriptors();
+            if (descriptors.isEmpty()) {
                 LOGGER.warn(String.format(NO_DESCRIPTOR_WARNING_MESSAGE, task.getPath()));
             } else {
                 Set<String> pluginFileNames = Sets.newHashSet();
@@ -330,7 +364,7 @@ public abstract class JavaGradlePluginPlugin implements Plugin<Project> {
         }
 
         boolean hasFullyQualifiedClass(String fqClass) {
-            return classes.contains(fqClass.replaceAll("\\.", "/") + ".class");
+            return actionsState.getCollectedClasses().contains(fqClass.replaceAll("\\.", "/") + ".class");
         }
     }
 
@@ -338,10 +372,10 @@ public abstract class JavaGradlePluginPlugin implements Plugin<Project> {
      * A file copy action that collects plugin descriptors as they are added to the jar.
      */
     static class PluginDescriptorCollectorAction implements Action<FileCopyDetails> {
-        List<PluginDescriptor> descriptors;
+        private final PluginValidationActionsState actionsState;
 
-        PluginDescriptorCollectorAction(List<PluginDescriptor> descriptors) {
-            this.descriptors = descriptors;
+        PluginDescriptorCollectorAction(PluginValidationActionsState actionsState) {
+            this.actionsState = actionsState;
         }
 
         @Override
@@ -355,7 +389,7 @@ public abstract class JavaGradlePluginPlugin implements Plugin<Project> {
                 return;
             }
             if (descriptor.getImplementationClassName() != null) {
-                descriptors.add(descriptor);
+                actionsState.addPluginDescriptor(descriptor);
             }
         }
     }
@@ -364,15 +398,15 @@ public abstract class JavaGradlePluginPlugin implements Plugin<Project> {
      * A file copy action that collects class file paths as they are added to the jar.
      */
     static class ClassManifestCollectorAction implements Action<FileCopyDetails> {
-        Set<String> classList;
+        private final PluginValidationActionsState actionsState;
 
-        ClassManifestCollectorAction(Set<String> classList) {
-            this.classList = classList;
+        ClassManifestCollectorAction(PluginValidationActionsState actionsState) {
+            this.actionsState = actionsState;
         }
 
         @Override
         public void execute(FileCopyDetails fileCopyDetails) {
-            classList.add(fileCopyDetails.getRelativePath().toString());
+            actionsState.addPluginClass(fileCopyDetails.getRelativePath().toString());
         }
     }
 


### PR DESCRIPTION
Plugin validation action relied on sharing List and Set between the validating action and file handlers. This doesn't work well with the configuration cache serialization, as it treats collections as values without identity. As a result of deserialization, each Action got a different copy of the collection, so the mutations weren't visible to the validation action.

The fix wraps the collections into a class. The class identity is preserved when deserializing, so all Actions share the same instance of the state class.

Fixes #22545 
