### PR TITLE
Emit progress event with Project Isolation switch info

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/operations/initialization/ProjectIsolationInitializationBuildOperationsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/operations/initialization/ProjectIsolationInitializationBuildOperationsIntegrationTest.groovy
@@ -1,0 +1,47 @@
+package org.gradle.operations.initialization
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.BuildOperationsFixture
+
+class ProjectIsolationInitializationBuildOperationsIntegrationTest extends AbstractIntegrationSpec {
+
+    def operations = new BuildOperationsFixture(executer, temporaryFolder)
+
+    def "emits settings finalized event when not configured"() {
+        given:
+        file("buildSrc/src/main/java/Thing.java") << "class Thing {}"
+
+        when:
+        succeeds("help")
+
+        then:
+        events().enabled == [false]
+    }
+
+    def "emits settings finalized event when explicitly #status"() {
+        given:
+        file("buildSrc/src/main/java/Thing.java") << "class Thing {}"
+
+        when:
+        succeeds("help", "-Dorg.gradle.unsafe.isolated-projects=$enabled")
+
+        then:
+        events().enabled == [enabled]
+
+        when:
+        succeeds("help", "-Dorg.gradle.unsafe.isolated-projects=$enabled")
+
+        then:
+        events().enabled == [enabled]
+
+        where:
+        status     | enabled
+        "enabled"  | true
+        "disabled" | false
+    }
+
+    List<ProjectIsolationSettingsFinalizedProgressDetails> events() {
+        return operations.progress(ProjectIsolationSettingsFinalizedProgressDetails).details
+    }
+
+}

--- a/subprojects/core/src/main/java/org/gradle/initialization/BuildOptionBuildOperationProgressEventsEmitter.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/BuildOptionBuildOperationProgressEventsEmitter.java
@@ -22,6 +22,7 @@ import org.gradle.internal.configurationcache.options.ConfigurationCacheSettings
 import org.gradle.internal.operations.BuildOperationProgressEventEmitter;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
+import org.gradle.operations.initialization.ProjectIsolationSettingsFinalizedProgressDetails;
 
 import javax.inject.Inject;
 
@@ -43,6 +44,13 @@ public class BuildOptionBuildOperationProgressEventsEmitter implements BuildTree
             @Override
             public boolean isEnabled() {
                 return buildModelParameters.isConfigurationCache();
+            }
+        });
+
+        eventEmitter.emitNowForCurrent(new ProjectIsolationSettingsFinalizedProgressDetails() {
+            @Override
+            public boolean isEnabled() {
+                return buildModelParameters.isIsolatedProjects();
             }
         });
     }

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/operations/initialization/ProjectIsolationSettingsFinalizedProgressDetails.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/operations/initialization/ProjectIsolationSettingsFinalizedProgressDetails.java
@@ -1,0 +1,15 @@
+package org.gradle.operations.initialization;
+
+/**
+ *
+ * @since 8.3
+ */
+public interface ProjectIsolationSettingsFinalizedProgressDetails {
+
+    /**
+     *
+     * @return
+     */
+    boolean isEnabled();
+
+}

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/operations/initialization/package-info.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/operations/initialization/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Build operations used during build initialization.
+ */
+@org.gradle.api.NonNullApi
+package org.gradle.operations.initialization;


### PR DESCRIPTION
Introduce a new progress event to expose whether Project Isolation was enabled via build operations.