### PR TITLE
Remove individual build files from dev-prod ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -91,7 +91,6 @@ subprojects/kotlin-dsl-tooling-models/                                          
 /build.gradle*                              @gradle/bt-developer-productivity
 /settings.gradle*                           @gradle/bt-developer-productivity
 gradle/shared-with-buildSrc/                @gradle/bt-developer-productivity
-subprojects/*/build.gradle*                 @gradle/bt-developer-productivity
 subprojects/internal-architecture-testing/  @gradle/bt-developer-productivity
 subprojects/internal-build-reports/         @gradle/bt-developer-productivity
 subprojects/internal-integ-testing/         @gradle/bt-developer-productivity


### PR DESCRIPTION
The platform owners should own their build files and can ask for help from the dev-prod team. It currently creates a lot of noise for the dev-prod team if all the subproject build files are owned by the dev-prod team.