### PR TITLE
FileWalkers refactoring

### DIFF
--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AttributeBasedFileVisitDetailsFactory.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AttributeBasedFileVisitDetailsFactory.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.file;
+
+import org.gradle.api.file.FileVisitDetails;
+import org.gradle.api.file.RelativePath;
+import org.gradle.internal.nativeintegration.filesystem.FileSystem;
+import org.gradle.internal.os.OperatingSystem;
+
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class AttributeBasedFileVisitDetailsFactory {
+    public static FileVisitDetails getRootFileVisitDetails(
+        Path path,
+        RelativePath relativePath,
+        @Nullable BasicFileAttributes attrs,
+        AtomicBoolean stopFlag,
+        FileSystem fileSystem
+    ) {
+        File file = path.toFile();
+        if (attrs == null) {
+            return new UnauthorizedFileVisitDetails(file, relativePath);
+        } else if (attrs.isDirectory() && OperatingSystem.current() == OperatingSystem.WINDOWS) {
+            // Workaround for https://github.com/gradle/gradle/issues/11577
+            return new DefaultFileVisitDetails(file, relativePath, stopFlag, fileSystem, fileSystem);
+        } else {
+            return new AttributeBasedFileVisitDetails(file, relativePath, stopFlag, fileSystem, fileSystem, attrs);
+        }
+    }
+
+    public static FileVisitDetails getRootFileVisitDetails(
+        Path path,
+        RelativePath relativePath,
+        AtomicBoolean stopFlag,
+        FileSystem fileSystem
+    ) {
+        BasicFileAttributes attrs = getAttributes(path);
+        return getRootFileVisitDetails(path, relativePath, attrs, stopFlag, fileSystem);
+    }
+
+    public static FileVisitDetails getFileVisitDetails(
+        Path path,
+        RelativePath parentPath,
+        @Nullable BasicFileAttributes attrs,
+        AtomicBoolean stopFlag,
+        FileSystem fileSystem
+    ) {
+        boolean isDirectory = attrs != null && attrs.isDirectory();
+        RelativePath relativePath = parentPath.append(!isDirectory, path.getFileName().toString());
+        return getRootFileVisitDetails(path, relativePath, attrs, stopFlag, fileSystem);
+    }
+
+
+    public static FileVisitDetails getFileVisitDetails(
+        Path path,
+        RelativePath parentPath,
+        AtomicBoolean stopFlag,
+        FileSystem fileSystem
+    ) {
+        BasicFileAttributes attrs = getAttributes(path);
+        return getFileVisitDetails(path, parentPath, attrs, stopFlag, fileSystem);
+    }
+
+    private static @Nullable BasicFileAttributes getAttributes(Path path) {
+        try {
+            return Files.readAttributes(path, BasicFileAttributes.class);
+        } catch (IOException e) {
+            try {
+                return Files.readAttributes(path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+            } catch (IOException next) {
+                return null;
+            }
+        }
+    }
+}

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AttributeBasedFileVisitDetailsFactory.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AttributeBasedFileVisitDetailsFactory.java
@@ -30,7 +30,23 @@ import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+/**
+ * A factory for creating {@link AttributeBasedFileVisitDetails} instances.
+ * Fallbacks to UnauthorizedFileVisitDetails in cases when attributes are not available.
+ * Fallbacks to DefaultFileVisitDetails in cases when attributes are not reliable.
+ */
 public class AttributeBasedFileVisitDetailsFactory {
+
+    /**
+     * Returns FileVisitDetails for the given relativePath.
+     *
+     * @param path Path of the file
+     * @param relativePath RelativePath of the file
+     * @param attrs attributes of the path, null if not available
+     * @param stopFlag transient flag to stop visiting
+     * @param fileSystem for Chmod and Stat
+     * @return FileVisitDetails
+     */
     public static FileVisitDetails getRootFileVisitDetails(
         Path path,
         RelativePath relativePath,
@@ -49,6 +65,15 @@ public class AttributeBasedFileVisitDetailsFactory {
         }
     }
 
+    /**
+     * Gets attributes and returns FileVisitDetails for the given relativePath.
+     *
+     * @param path Path of the file
+     * @param relativePath RelativePath of the file
+     * @param stopFlag transient flag to stop visiting
+     * @param fileSystem for Chmod and Stat
+     * @return FileVisitDetails
+     */
     public static FileVisitDetails getRootFileVisitDetails(
         Path path,
         RelativePath relativePath,
@@ -59,6 +84,16 @@ public class AttributeBasedFileVisitDetailsFactory {
         return getRootFileVisitDetails(path, relativePath, attrs, stopFlag, fileSystem);
     }
 
+    /**
+     * Constructs proper RelativePath based on attributes and returns FileVisitDetails for the given relativePath.
+     *
+     * @param path Path of the file
+     * @param parentPath RelativePath of the parent
+     * @param attrs attributes of the path, null if not available
+     * @param stopFlag transient flag to stop visiting
+     * @param fileSystem for Chmod and Stat
+     * @return FileVisitDetails
+     */
     public static FileVisitDetails getFileVisitDetails(
         Path path,
         RelativePath parentPath,
@@ -71,7 +106,15 @@ public class AttributeBasedFileVisitDetailsFactory {
         return getRootFileVisitDetails(path, relativePath, attrs, stopFlag, fileSystem);
     }
 
-
+    /**
+     * Gets attributes, constructs proper RelativePath and returns FileVisitDetails for the given relativePath.
+     *
+     * @param path Path of the file
+     * @param parentPath RelativePath of the parent
+     * @param stopFlag transient flag to stop visiting
+     * @param fileSystem for Chmod and Stat
+     * @return FileVisitDetails
+     */
     public static FileVisitDetails getFileVisitDetails(
         Path path,
         RelativePath parentPath,

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFileVisitDetails.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFileVisitDetails.java
@@ -32,10 +32,6 @@ public class DefaultFileVisitDetails extends DefaultFileTreeElement implements F
         this.stop = stop;
     }
 
-    public DefaultFileVisitDetails(File file, Chmod chmod, Stat stat) {
-        this(file, new RelativePath(!file.isDirectory(), file.getName()), new AtomicBoolean(), chmod, stat);
-    }
-
     @Override
     public void stopVisiting() {
         stop.set(true);

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultDirectoryWalker.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultDirectoryWalker.java
@@ -18,27 +18,15 @@ package org.gradle.api.internal.file.collections;
 
 import org.gradle.api.GradleException;
 import org.gradle.api.file.FileTreeElement;
-import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.file.FileVisitor;
 import org.gradle.api.file.RelativePath;
-import org.gradle.api.internal.file.AttributeBasedFileVisitDetails;
-import org.gradle.api.internal.file.DefaultFileVisitDetails;
-import org.gradle.api.internal.file.UnauthorizedFileVisitDetails;
 import org.gradle.api.specs.Spec;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
-import org.gradle.internal.os.OperatingSystem;
 
-import javax.annotation.Nullable;
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.FileSystemLoopException;
 import java.nio.file.FileVisitOption;
-import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.util.ArrayDeque;
-import java.util.Deque;
 import java.util.EnumSet;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -49,121 +37,13 @@ public class DefaultDirectoryWalker implements DirectoryWalker {
         this.fileSystem = fileSystem;
     }
 
-    static boolean shouldVisit(FileTreeElement element, Spec<? super FileTreeElement> spec) {
-        return spec.isSatisfiedBy(element);
-    }
-
     @Override
-    public void walkDir(File rootDir, RelativePath rootPath, FileVisitor visitor, Spec<? super FileTreeElement> spec, AtomicBoolean stopFlag, boolean postfix) {
-        Deque<FileVisitDetails> directoryDetailsHolder = new ArrayDeque<>();
-
+    public void walkDir(Path rootDir, RelativePath rootPath, FileVisitor visitor, Spec<? super FileTreeElement> spec, AtomicBoolean stopFlag, boolean postfix) {
         try {
-            PathVisitor pathVisitor = new PathVisitor(directoryDetailsHolder, spec, postfix, visitor, stopFlag, rootPath, fileSystem);
-            Files.walkFileTree(rootDir.toPath(), EnumSet.of(FileVisitOption.FOLLOW_LINKS), Integer.MAX_VALUE, pathVisitor);
+            PathVisitor pathVisitor = new PathVisitor(spec, postfix, visitor, stopFlag, rootPath, fileSystem);
+            Files.walkFileTree(rootDir, EnumSet.of(FileVisitOption.FOLLOW_LINKS), Integer.MAX_VALUE, pathVisitor);
         } catch (IOException e) {
             throw new GradleException(String.format("Could not list contents of directory '%s'.", rootDir), e);
-        }
-    }
-
-    private static class PathVisitor implements java.nio.file.FileVisitor<Path> {
-        private final Deque<FileVisitDetails> directoryDetailsHolder;
-        private final Spec<? super FileTreeElement> spec;
-        private final boolean postfix;
-        private final FileVisitor visitor;
-        private final AtomicBoolean stopFlag;
-        private final RelativePath rootPath;
-        private final FileSystem fileSystem;
-
-        public PathVisitor(Deque<FileVisitDetails> directoryDetailsHolder, Spec<? super FileTreeElement> spec, boolean postfix, FileVisitor visitor, AtomicBoolean stopFlag, RelativePath rootPath, FileSystem fileSystem) {
-            this.directoryDetailsHolder = directoryDetailsHolder;
-            this.spec = spec;
-            this.postfix = postfix;
-            this.visitor = visitor;
-            this.stopFlag = stopFlag;
-            this.rootPath = rootPath;
-            this.fileSystem = fileSystem;
-        }
-
-        @Override
-        public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
-            FileVisitDetails details = getFileVisitDetails(dir, attrs, true);
-            if (directoryDetailsHolder.size() == 0 || shouldVisit(details, spec)) {
-                directoryDetailsHolder.push(details);
-                if (directoryDetailsHolder.size() > 1 && !postfix) {
-                    visitor.visitDir(details);
-                }
-                return checkStopFlag();
-            } else {
-                return FileVisitResult.SKIP_SUBTREE;
-            }
-        }
-
-        private FileVisitResult checkStopFlag() {
-            return stopFlag.get()
-                ? FileVisitResult.TERMINATE
-                : FileVisitResult.CONTINUE;
-        }
-
-        @Override
-        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
-            FileVisitDetails details = getFileVisitDetails(file, attrs, false);
-            if (shouldVisit(details, spec)) {
-                if (attrs.isSymbolicLink()) {
-                    // when FileVisitOption.FOLLOW_LINKS, we only get here when link couldn't be followed
-                    throw new GradleException(String.format("Couldn't follow symbolic link '%s'.", file));
-                }
-                visitor.visitFile(details);
-            }
-            return checkStopFlag();
-        }
-
-        private FileVisitDetails getFileVisitDetails(Path file, @Nullable BasicFileAttributes attrs, boolean isDirectory) {
-            File child = file.toFile();
-            FileVisitDetails dirDetails = directoryDetailsHolder.peek();
-            RelativePath childPath = dirDetails != null ? dirDetails.getRelativePath().append(!isDirectory, child.getName()) : rootPath;
-            if (attrs == null) {
-                return new UnauthorizedFileVisitDetails(child, childPath);
-            } else if (isDirectory && OperatingSystem.current() == OperatingSystem.WINDOWS) {
-                // Workaround for https://github.com/gradle/gradle/issues/11577
-                return new DefaultFileVisitDetails(child, childPath, stopFlag, fileSystem, fileSystem);
-            } else {
-                return new AttributeBasedFileVisitDetails(child, childPath, stopFlag, fileSystem, fileSystem, attrs);
-            }
-        }
-
-        private FileVisitDetails getUnauthorizedFileVisitDetails(Path file) {
-            return getFileVisitDetails(file, null, false);
-        }
-
-        @Override
-        public FileVisitResult visitFileFailed(Path file, IOException exc) {
-            FileVisitDetails details = getUnauthorizedFileVisitDetails(file);
-            if (isNotFileSystemLoopException(exc) && shouldVisit(details, spec)) {
-                throw new GradleException(String.format("Could not read path '%s'.", file), exc);
-            }
-            return checkStopFlag();
-        }
-
-        private boolean isNotFileSystemLoopException(IOException e) {
-            return e != null && !(e instanceof FileSystemLoopException);
-        }
-
-        @Override
-        public FileVisitResult postVisitDirectory(Path dir, IOException exc) {
-            if (exc != null) {
-                if (!(exc instanceof FileSystemLoopException)) {
-                    throw new GradleException(String.format("Could not read directory path '%s'.", dir), exc);
-                }
-            } else {
-                if (postfix) {
-                    FileVisitDetails details = directoryDetailsHolder.peek();
-                    if (directoryDetailsHolder.size() > 1 && details != null) {
-                        visitor.visitDir(details);
-                    }
-                }
-            }
-            directoryDetailsHolder.pop();
-            return checkStopFlag();
         }
     }
 }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/DirectoryFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/DirectoryFileTree.java
@@ -23,7 +23,7 @@ import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.file.FileVisitor;
 import org.gradle.api.file.RelativePath;
 import org.gradle.api.file.ReproducibleFileVisitor;
-import org.gradle.api.internal.file.DefaultFileVisitDetails;
+import org.gradle.api.internal.file.AttributeBasedFileVisitDetailsFactory;
 import org.gradle.api.internal.file.FileTreeInternal;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.util.PatternFilterable;
@@ -131,7 +131,7 @@ public class DirectoryFileTree implements MinimalFileTree, PatternFilterableFile
 
     private void processSingleFile(File file, FileVisitor visitor, Spec<FileTreeElement> spec, AtomicBoolean stopFlag) {
         RelativePath path = new RelativePath(true, file.getName());
-        FileVisitDetails details = new DefaultFileVisitDetails(file, path, stopFlag, fileSystem, fileSystem);
+        FileVisitDetails details = AttributeBasedFileVisitDetailsFactory.getRootFileVisitDetails(file.toPath(), path, stopFlag, fileSystem);
         if (isAllowed(details, spec)) {
             visitor.visitFile(details);
         }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/DirectoryFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/DirectoryFileTree.java
@@ -145,7 +145,7 @@ public class DirectoryFileTree implements MinimalFileTree, PatternFilterableFile
         } else {
             directoryWalker = DEFAULT_DIRECTORY_WALKER;
         }
-        directoryWalker.walkDir(file, path, visitor, spec, stopFlag, postfix);
+        directoryWalker.walkDir(file.toPath(), path, visitor, spec, stopFlag, postfix);
     }
 
     static boolean isAllowed(FileTreeElement element, Spec<? super FileTreeElement> spec) {

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/DirectoryFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/DirectoryFileTree.java
@@ -108,7 +108,7 @@ public class DirectoryFileTree implements MinimalFileTree, PatternFilterableFile
 
     @Override
     public void visit(FileVisitor visitor) {
-        visitFrom(visitor, dir, RelativePath.EMPTY_ROOT);
+        visitFrom(visitor, dir, RelativePath.EMPTY_ROOT, new AtomicBoolean());
     }
 
     /**
@@ -116,8 +116,7 @@ public class DirectoryFileTree implements MinimalFileTree, PatternFilterableFile
      * (but not the directory itself) will be checked with {@link #isAllowed(FileTreeElement, Spec)} and notified to
      * the listener.  If it is a file, the file will be checked and notified.
      */
-    public void visitFrom(FileVisitor visitor, File fileOrDirectory, RelativePath path) {
-        AtomicBoolean stopFlag = new AtomicBoolean();
+    public void visitFrom(FileVisitor visitor, File fileOrDirectory, RelativePath path, AtomicBoolean stopFlag) {
         Spec<FileTreeElement> spec = patternSet.getAsSpec();
         if (fileOrDirectory.exists()) {
             if (fileOrDirectory.isFile()) {

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/DirectoryWalker.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/DirectoryWalker.java
@@ -21,9 +21,9 @@ import org.gradle.api.file.FileVisitor;
 import org.gradle.api.file.RelativePath;
 import org.gradle.api.specs.Spec;
 
-import java.io.File;
+import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public interface DirectoryWalker {
-    void walkDir(File file, RelativePath path, FileVisitor visitor, Spec<? super FileTreeElement> spec, AtomicBoolean stopFlag, boolean postfix);
+    void walkDir(Path rootDir, RelativePath rootPath, FileVisitor visitor, Spec<? super FileTreeElement> spec, AtomicBoolean stopFlag, boolean postfix);
 }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/PathVisitor.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/PathVisitor.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.file.collections;
+
+import org.gradle.api.GradleException;
+import org.gradle.api.file.FileTreeElement;
+import org.gradle.api.file.FileVisitDetails;
+import org.gradle.api.file.FileVisitor;
+import org.gradle.api.file.RelativePath;
+import org.gradle.api.internal.file.AttributeBasedFileVisitDetails;
+import org.gradle.api.internal.file.DefaultFileVisitDetails;
+import org.gradle.api.internal.file.UnauthorizedFileVisitDetails;
+import org.gradle.api.specs.Spec;
+import org.gradle.internal.nativeintegration.filesystem.FileSystem;
+import org.gradle.internal.os.OperatingSystem;
+
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileSystemLoopException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+class PathVisitor implements java.nio.file.FileVisitor<Path> {
+    private final Deque<FileVisitDetails> directoryDetailsHolder = new ArrayDeque<>();
+    private final Spec<? super FileTreeElement> spec;
+    private final boolean postfix;
+    private final FileVisitor visitor;
+    private final AtomicBoolean stopFlag;
+    private final RelativePath rootPath;
+    private final FileSystem fileSystem;
+
+    public PathVisitor(Spec<? super FileTreeElement> spec, boolean postfix, FileVisitor visitor, AtomicBoolean stopFlag, RelativePath rootPath, FileSystem fileSystem) {
+        this.spec = spec;
+        this.postfix = postfix;
+        this.visitor = visitor;
+        this.stopFlag = stopFlag;
+        this.rootPath = rootPath;
+        this.fileSystem = fileSystem;
+    }
+
+    private boolean shouldVisit(FileTreeElement element) {
+        return spec.isSatisfiedBy(element);
+    }
+
+    @Override
+    public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+        FileVisitDetails details = getFileVisitDetails(dir, attrs, true);
+        if (directoryDetailsHolder.size() == 0 || shouldVisit(details)) {
+            directoryDetailsHolder.push(details);
+            if (directoryDetailsHolder.size() > 1 && !postfix) {
+                visitor.visitDir(details);
+            }
+            return checkStopFlag();
+        } else {
+            return FileVisitResult.SKIP_SUBTREE;
+        }
+    }
+
+    private FileVisitResult checkStopFlag() {
+        return stopFlag.get()
+            ? FileVisitResult.TERMINATE
+            : FileVisitResult.CONTINUE;
+    }
+
+    @Override
+    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+        FileVisitDetails details = getFileVisitDetails(file, attrs, false);
+        if (shouldVisit(details)) {
+            if (attrs.isSymbolicLink()) {
+                // when FileVisitOption.FOLLOW_LINKS, we only get here when link couldn't be followed
+                throw new GradleException(String.format("Couldn't follow symbolic link '%s'.", file));
+            }
+            visitor.visitFile(details);
+        }
+        return checkStopFlag();
+    }
+
+    private FileVisitDetails getFileVisitDetails(Path file, @Nullable BasicFileAttributes attrs, boolean isDirectory) {
+        File child = file.toFile();
+        FileVisitDetails dirDetails = directoryDetailsHolder.peek();
+        RelativePath childPath = dirDetails != null ? dirDetails.getRelativePath().append(!isDirectory, child.getName()) : rootPath;
+        if (attrs == null) {
+            return new UnauthorizedFileVisitDetails(child, childPath);
+        } else if (isDirectory && OperatingSystem.current() == OperatingSystem.WINDOWS) {
+            // Workaround for https://github.com/gradle/gradle/issues/11577
+            return new DefaultFileVisitDetails(child, childPath, stopFlag, fileSystem, fileSystem);
+        } else {
+            return new AttributeBasedFileVisitDetails(child, childPath, stopFlag, fileSystem, fileSystem, attrs);
+        }
+    }
+
+    private FileVisitDetails getUnauthorizedFileVisitDetails(Path file) {
+        return getFileVisitDetails(file, null, false);
+    }
+
+    @Override
+    public FileVisitResult visitFileFailed(Path file, IOException exc) {
+        FileVisitDetails details = getUnauthorizedFileVisitDetails(file);
+        if (isNotFileSystemLoopException(exc) && shouldVisit(details)) {
+            throw new GradleException(String.format("Could not read path '%s'.", file), exc);
+        }
+        return checkStopFlag();
+    }
+
+    private static boolean isNotFileSystemLoopException(@Nullable IOException e) {
+        return e != null && !(e instanceof FileSystemLoopException);
+    }
+
+    @Override
+    public FileVisitResult postVisitDirectory(Path dir, @Nullable IOException exc) {
+        if (exc != null) {
+            if (!(exc instanceof FileSystemLoopException)) {
+                throw new GradleException(String.format("Could not read directory path '%s'.", dir), exc);
+            }
+        } else {
+            if (postfix) {
+                FileVisitDetails details = directoryDetailsHolder.peek();
+                if (directoryDetailsHolder.size() > 1 && details != null) {
+                    visitor.visitDir(details);
+                }
+            }
+        }
+        directoryDetailsHolder.pop();
+        return checkStopFlag();
+    }
+}

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/ReproducibleDirectoryWalker.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/ReproducibleDirectoryWalker.java
@@ -16,21 +16,22 @@
 
 package org.gradle.api.internal.file.collections;
 
-import org.apache.commons.io.comparator.PathFileComparator;
 import org.gradle.api.GradleException;
 import org.gradle.api.file.FileTreeElement;
-import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.file.FileVisitor;
 import org.gradle.api.file.RelativePath;
-import org.gradle.api.internal.file.DefaultFileVisitDetails;
 import org.gradle.api.specs.Spec;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Comparator;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
 
 public class ReproducibleDirectoryWalker implements DirectoryWalker {
     private final FileSystem fileSystem;
@@ -39,49 +40,50 @@ public class ReproducibleDirectoryWalker implements DirectoryWalker {
         this.fileSystem = fileSystem;
     }
 
-    protected File[] getChildren(File file) {
-        File[] children = file.listFiles();
-        if (children != null) {
-            Arrays.sort(children, PathFileComparator.PATH_COMPARATOR);
-        }
-        return children;
-    }
-
     @Override
-    public void walkDir(File file, RelativePath path, FileVisitor visitor, Spec<? super FileTreeElement> spec, AtomicBoolean stopFlag, boolean postfix) {
-        File[] children = getChildren(file);
-        if (children == null) {
-            if (file.isDirectory() && !file.canRead()) {
-                throw new GradleException(String.format("Could not list contents of directory '%s' as it is not readable.", file));
-            }
-            // else, might be a link which points to nothing, or has been removed while we're visiting, or ...
-            throw new GradleException(String.format("Could not list contents of '%s'.", file));
+    public void walkDir(Path rootDir, RelativePath rootPath, FileVisitor visitor, Spec<? super FileTreeElement> spec, AtomicBoolean stopFlag, boolean postfix) {
+        try {
+            PathVisitor pathVisitor = new PathVisitor(spec, postfix, visitor, stopFlag, rootPath, fileSystem);
+            visit(rootDir, pathVisitor);
+        } catch (IOException e) {
+            throw new GradleException(String.format("Could not list contents of directory '%s'.", rootDir), e);
         }
-        List<FileVisitDetails> dirs = new ArrayList<FileVisitDetails>();
-        for (int i = 0; !stopFlag.get() && i < children.length; i++) {
-            File child = children[i];
-            boolean isFile = child.isFile();
-            RelativePath childPath = path.append(isFile, child.getName());
-            FileVisitDetails details = new DefaultFileVisitDetails(child, childPath, stopFlag, fileSystem, fileSystem);
-            if (DirectoryFileTree.isAllowed(details, spec)) {
-                if (isFile) {
-                    visitor.visitFile(details);
-                } else {
-                    dirs.add(details);
-                }
+    }
+
+    private static FileVisitResult visit(Path path, PathVisitor pathVisitor) throws IOException {
+        BasicFileAttributes attrs;
+        try {
+            attrs = Files.readAttributes(path, BasicFileAttributes.class);
+        } catch (IOException e) {
+            try {
+                attrs = Files.readAttributes(path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+            } catch (IOException next) {
+                return pathVisitor.visitFileFailed(path, next);
             }
         }
 
-        // now handle dirs
-        for (int i = 0; !stopFlag.get() && i < dirs.size(); i++) {
-            FileVisitDetails dir = dirs.get(i);
-            if (postfix) {
-                walkDir(dir.getFile(), dir.getRelativePath(), visitor, spec, stopFlag, postfix);
-                visitor.visitDir(dir);
-            } else {
-                visitor.visitDir(dir);
-                walkDir(dir.getFile(), dir.getRelativePath(), visitor, spec, stopFlag, postfix);
+        if (attrs.isDirectory()) {
+            FileVisitResult fvr = pathVisitor.preVisitDirectory(path, attrs);
+            if (fvr == FileVisitResult.SKIP_SUBTREE || fvr == FileVisitResult.TERMINATE) {
+                return fvr;
             }
+            IOException exception = null;
+            try (Stream<Path> fileStream = Files.list(path)) {
+                Iterable<Path> files = () -> fileStream.sorted(FILES_FIRST).iterator();
+                for (Path child : files) {
+                    FileVisitResult childResult = visit(child, pathVisitor);
+                    if (childResult == FileVisitResult.TERMINATE) {
+                        return childResult;
+                    }
+                }
+            } catch (IOException e) {
+                exception = e;
+            }
+            return pathVisitor.postVisitDirectory(path, exception);
+        } else {
+            return pathVisitor.visitFile(path, attrs);
         }
     }
+
+    private final static Comparator<Path> FILES_FIRST = Comparator.<Path, Boolean>comparing(x -> x.toFile().isDirectory()).thenComparing(Path::toString);
 }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/SingleIncludePatternFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/SingleIncludePatternFileTree.java
@@ -21,7 +21,7 @@ import org.gradle.api.file.FileTreeElement;
 import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.file.FileVisitor;
 import org.gradle.api.file.RelativePath;
-import org.gradle.api.internal.file.DefaultFileVisitDetails;
+import org.gradle.api.internal.file.AttributeBasedFileVisitDetailsFactory;
 import org.gradle.api.internal.file.FileTreeInternal;
 import org.gradle.api.internal.file.pattern.PatternStep;
 import org.gradle.api.internal.file.pattern.PatternStepFactory;
@@ -130,14 +130,14 @@ public class SingleIncludePatternFileTree implements MinimalFileTree, LocalFileT
         if (file.isFile()) {
             if (segmentIndex == patternSegments.size()) {
                 RelativePath path = new RelativePath(true, pathSegments.toArray(new String[0]));
-                FileVisitDetails details = new DefaultFileVisitDetails(file, path, stopFlag, fileSystem, fileSystem);
+                FileVisitDetails details = AttributeBasedFileVisitDetailsFactory.getRootFileVisitDetails(file.toPath(), path, stopFlag, fileSystem);
                 if (!excludeSpec.isSatisfiedBy(details)) {
                     visitor.visitFile(details);
                 }
             }
         } else if (file.isDirectory()) {
             RelativePath path = new RelativePath(false, pathSegments.toArray(new String[0]));
-            FileVisitDetails details = new DefaultFileVisitDetails(file, path, stopFlag, fileSystem, fileSystem);
+            FileVisitDetails details = AttributeBasedFileVisitDetailsFactory.getRootFileVisitDetails(file.toPath(), path, stopFlag, fileSystem);
             if (!excludeSpec.isSatisfiedBy(details)) {
                 visitor.visitDir(details);
             }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/SingleIncludePatternFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/SingleIncludePatternFileTree.java
@@ -32,8 +32,9 @@ import org.gradle.internal.nativeintegration.filesystem.FileSystem;
 import org.gradle.internal.nativeintegration.services.FileSystems;
 
 import java.io.File;
+import java.util.ArrayDeque;
 import java.util.Arrays;
-import java.util.LinkedList;
+import java.util.Deque;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -81,10 +82,10 @@ public class SingleIncludePatternFileTree implements MinimalFileTree, LocalFileT
 
     @Override
     public void visit(FileVisitor visitor) {
-        doVisit(visitor, baseDir, new LinkedList<>(), 0, new AtomicBoolean());
+        doVisit(visitor, baseDir, new ArrayDeque<>(), 0, new AtomicBoolean());
     }
 
-    private void doVisit(FileVisitor visitor, File file, LinkedList<String> relativePath, int segmentIndex, AtomicBoolean stopFlag) {
+    private void doVisit(FileVisitor visitor, File file, Deque<String> pathSegments, int segmentIndex, AtomicBoolean stopFlag) {
         if (stopFlag.get()) {
             return;
         }
@@ -96,7 +97,7 @@ public class SingleIncludePatternFileTree implements MinimalFileTree, LocalFileT
             patternSet.include(includePattern);
             patternSet.exclude(excludeSpec);
             DirectoryFileTree fileTree = new DirectoryFileTree(baseDir, patternSet, fileSystem);
-            fileTree.visitFrom(visitor, file, new RelativePath(file.isFile(), relativePath.toArray(new String[relativePath.size()])));
+            fileTree.visitFrom(visitor, file, new RelativePath(file.isFile(), pathSegments.toArray(new String[0])), stopFlag);
         } else if (segment.contains("*") || segment.contains("?")) {
             PatternStep step = PatternStepFactory.getStep(segment, false);
             File[] children = file.listFiles();
@@ -113,35 +114,35 @@ public class SingleIncludePatternFileTree implements MinimalFileTree, LocalFileT
                 }
                 String childName = child.getName();
                 if (step.matches(childName)) {
-                    relativePath.addLast(childName);
-                    doVisitDirOrFile(visitor, child, relativePath, segmentIndex + 1, stopFlag);
-                    relativePath.removeLast();
+                    pathSegments.addLast(childName);
+                    doVisitDirOrFile(visitor, child, pathSegments, segmentIndex + 1, stopFlag);
+                    pathSegments.removeLast();
                 }
             }
         } else {
-            relativePath.addLast(segment);
-            doVisitDirOrFile(visitor, new File(file, segment), relativePath, segmentIndex + 1, stopFlag);
-            relativePath.removeLast();
+            pathSegments.addLast(segment);
+            doVisitDirOrFile(visitor, new File(file, segment), pathSegments, segmentIndex + 1, stopFlag);
+            pathSegments.removeLast();
         }
     }
 
-    private void doVisitDirOrFile(FileVisitor visitor, File file, LinkedList<String> relativePath, int segmentIndex, AtomicBoolean stopFlag) {
+    private void doVisitDirOrFile(FileVisitor visitor, File file, Deque<String> pathSegments, int segmentIndex, AtomicBoolean stopFlag) {
         if (file.isFile()) {
             if (segmentIndex == patternSegments.size()) {
-                RelativePath path = new RelativePath(true, relativePath.toArray(new String[relativePath.size()]));
+                RelativePath path = new RelativePath(true, pathSegments.toArray(new String[0]));
                 FileVisitDetails details = new DefaultFileVisitDetails(file, path, stopFlag, fileSystem, fileSystem);
                 if (!excludeSpec.isSatisfiedBy(details)) {
                     visitor.visitFile(details);
                 }
             }
         } else if (file.isDirectory()) {
-            RelativePath path = new RelativePath(false, relativePath.toArray(new String[relativePath.size()]));
+            RelativePath path = new RelativePath(false, pathSegments.toArray(new String[0]));
             FileVisitDetails details = new DefaultFileVisitDetails(file, path, stopFlag, fileSystem, fileSystem);
             if (!excludeSpec.isSatisfiedBy(details)) {
                 visitor.visitDir(details);
             }
             if (segmentIndex < patternSegments.size()) {
-                doVisit(visitor, file, relativePath, segmentIndex, stopFlag);
+                doVisit(visitor, file, pathSegments, segmentIndex, stopFlag);
             }
         }
     }


### PR DESCRIPTION
### Context
This refactoring arose as a part of #3982. 

1. ReproducibleFileWalker can use the same abstractions as DefaultDirectoryWalker
2. All file walkers should use attributes-based fileVisitDetails for consistency
3. SingleIncludePatternFileTree should pass `stopFlag` properly to DirectoryFileTree

I considered refactoring SingleIncludePatternFileTree to use PathVisitor, but it seems like it's not worth it.

