### PR TITLE
Add an option to ignore file-system-check inputs

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/UndeclaredBuildInputsIgnoringIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/UndeclaredBuildInputsIgnoringIntegrationTest.groovy
@@ -20,7 +20,7 @@ import org.gradle.configurationcache.AbstractConfigurationCacheIntegrationTest
 import org.gradle.initialization.StartParameterBuildOptions
 
 class UndeclaredBuildInputsIgnoringIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
-    def 'can ignore a file system check configuration inputs #location'() {
+    def 'can ignore a file system check configuration input'() {
         given:
         buildFile("""
             println("exists = " + new File("build/test.lock").exists())

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/UndeclaredBuildInputsIgnoringIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/UndeclaredBuildInputsIgnoringIntegrationTest.groovy
@@ -75,5 +75,14 @@ class UndeclaredBuildInputsIgnoringIntegrationTest extends AbstractConfiguration
         }
     }
 
+    def 'paths ignored in file system checks are included in the configuration cache fingerprint'() {
+        when:
+        configurationCacheRun()
+        configurationCacheRun("-D$IGNORE_FS_CHECKS_PROPERTY=test")
+
+        then:
+        outputContains("the set of paths ignored in file-system-check input tracking has changed")
+    }
+
     private static final String IGNORE_FS_CHECKS_PROPERTY = StartParameterBuildOptions.ConfigurationCacheIgnoredFileSystemCheckInputs.PROPERTY_NAME
 }

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/UndeclaredBuildInputsIgnoringIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/UndeclaredBuildInputsIgnoringIntegrationTest.groovy
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache.inputs.undeclared
+
+import org.gradle.configurationcache.AbstractConfigurationCacheIntegrationTest
+import org.gradle.initialization.StartParameterBuildOptions
+import org.gradle.test.fixtures.file.TestFile
+
+class UndeclaredBuildInputsIgnoringIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
+    def 'can ignore a file system check configuration inputs #location'() {
+        given:
+        def inputFile = fileClosure.call(testDirectory)
+        buildFile("""
+            println("exists = " + new File("${inputFile.absolutePath}").exists())
+        """)
+
+        when:
+        configurationCacheRun()
+
+        then:
+        outputContains("exists = false")
+        problems.assertResultHasProblems(result) {
+            withInput("Build file 'build.gradle': file system entry")
+        }
+
+        when:
+        file("gradle.properties") << """$IGNORE_FS_CHECKS_PROPERTY=$pattern"""
+        configurationCacheRun()
+
+        then:
+        outputContains("exists = false")
+        problems.assertResultHasProblems(result) {
+            withNoInputs()
+        }
+
+        where:
+        location                        | pattern            | fileClosure
+        "inside the project directory"  | "build/*.lock"     | { TestFile testDir -> testDir.file("build/test.lock").absoluteFile }
+        "outside the project directory" | "../../*.lock"     | { TestFile testDir -> testDir.file("../../test.lock").absoluteFile }
+        "in user home directory"        | "~/.gradle/*.lock" | { TestFile testDir -> new File(System.getProperty("user.home"), ".gradle/test.lock") }
+        "by absolute path"              | "/test/*.lock"     | { TestFile testDir -> new File("/test/test.lock") }
+    }
+
+    def 'can ignore file system checks in multiple paths if separated by semicolon'() {
+        given:
+        buildFile("""
+            println("exists = " + new File(projectDir, "file1.txt").exists())
+            println("exists = " + new File(projectDir, "file2.txt").exists())
+            println("exists = " + new File(projectDir, "file3.txt").exists())
+        """)
+
+        when:
+        file("gradle.properties") << """
+            $IGNORE_FS_CHECKS_PROPERTY=file1.txt;file2.txt
+        """
+        configurationCacheRun()
+
+        then:
+        problems.assertResultHasProblems(result) {
+            withInput("Build file 'build.gradle': file system entry 'file3.txt'")
+        }
+    }
+
+    private static final String IGNORE_FS_CHECKS_PROPERTY = StartParameterBuildOptions.ConfigurationCacheIgnoredFileSystemCheckInputs.PROPERTY_NAME
+}

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheServices.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheServices.kt
@@ -31,11 +31,13 @@ import org.gradle.execution.ExecutionAccessListener
 import org.gradle.internal.buildtree.BuildModelParameters
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.execution.WorkExecutionTracker
+import org.gradle.internal.nativeintegration.filesystem.FileSystem
 import org.gradle.internal.resource.connector.ResourceConnectorFactory
 import org.gradle.internal.resource.connector.ResourceConnectorSpecification
 import org.gradle.internal.resource.transfer.ExternalResourceConnector
 import org.gradle.internal.service.ServiceRegistration
 import org.gradle.internal.service.scopes.AbstractPluginServiceRegistry
+import java.io.File
 
 
 class ConfigurationCacheServices : AbstractPluginServiceRegistry() {
@@ -62,8 +64,8 @@ class ConfigurationCacheServices : AbstractPluginServiceRegistry() {
             add(ConfigurationCacheRepository::class.java)
             add(InputTrackingState::class.java)
             add(InstrumentedInputAccessListener::class.java)
-            add(DefaultIgnoredConfigurationInputs::class.java)
             add(InstrumentedExecutionAccessListener::class.java)
+            addProvider(IgnoredConfigurationInputsProvider)
             addProvider(RemoteScriptUpToDateCheckerProvider)
             addProvider(ExecutionAccessCheckerProvider)
         }
@@ -144,5 +146,22 @@ class ConfigurationCacheServices : AbstractPluginServiceRegistry() {
                 else -> TaskExecutionAccessCheckers.ConfigurationTimeBarrierBased(configurationTimeBarrier, broadcast, workExecutionTracker)
             }
         }
+    }
+
+    private
+    object IgnoredConfigurationInputsProvider {
+        fun createIgnoredConfigurationInputs(
+            configurationCacheStartParameter: ConfigurationCacheStartParameter,
+            fileSystem: FileSystem
+        ): IgnoredConfigurationInputs =
+            if (hasIgnoredPaths(configurationCacheStartParameter))
+                DefaultIgnoredConfigurationInputs(configurationCacheStartParameter, fileSystem)
+            else object : IgnoredConfigurationInputs {
+                override fun isFileSystemCheckIgnoredFor(file: File): Boolean = false
+            }
+
+        private
+        fun hasIgnoredPaths(configurationCacheStartParameter: ConfigurationCacheStartParameter): Boolean =
+            !configurationCacheStartParameter.ignoredFileSystemCheckInputs.isNullOrEmpty()
     }
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheServices.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheServices.kt
@@ -62,6 +62,7 @@ class ConfigurationCacheServices : AbstractPluginServiceRegistry() {
             add(ConfigurationCacheRepository::class.java)
             add(InputTrackingState::class.java)
             add(InstrumentedInputAccessListener::class.java)
+            add(DefaultIgnoredConfigurationInputs::class.java)
             add(InstrumentedExecutionAccessListener::class.java)
             addProvider(RemoteScriptUpToDateCheckerProvider)
             addProvider(ExecutionAccessCheckerProvider)

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultIgnoredConfigurationInputs.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultIgnoredConfigurationInputs.kt
@@ -74,11 +74,8 @@ class DefaultIgnoredConfigurationInputs(
         else file
 
     private
-    fun maybeRelativize(file: File): File {
-        if (!file.isAbsolute)
-            return file
-        return File(GFileUtils.relativePathOf(file, rootDirectory))
-    }
+    fun maybeRelativize(file: File): File =
+        if (!file.isAbsolute) file else File(GFileUtils.relativePathOf(file, rootDirectory))
 
     private
     fun wildcardsToRegexPatternString(pathWithWildcards: String): String {

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultIgnoredConfigurationInputs.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultIgnoredConfigurationInputs.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache
+
+import org.gradle.configurationcache.initialization.ConfigurationCacheStartParameter
+import org.gradle.internal.service.scopes.Scopes.BuildTree
+import org.gradle.internal.service.scopes.ServiceScope
+import org.gradle.util.internal.GFileUtils
+import java.io.File
+import javax.inject.Inject
+
+
+@ServiceScope(BuildTree::class)
+class DefaultIgnoredConfigurationInputs(
+    ignoredPathsString: String,
+    private val rootDirectory: File
+) : IgnoredConfigurationInputs {
+
+    @Inject
+    @Suppress("unused") // used in DI
+    constructor(configurationCacheStartParameter: ConfigurationCacheStartParameter) :
+        this(configurationCacheStartParameter.ignoredFileSystemCheckInputs.orEmpty(), configurationCacheStartParameter.rootDirectory)
+
+    private
+    val userHome = File(System.getProperty("user.home"))
+
+    private
+    val jointRegex = createJointRegexForPatterns(ignoredPathsString)
+
+    override fun isFileSystemCheckIgnoredFor(file: File): Boolean =
+        jointRegex.matches(normalizeActualInputPath(file))
+
+    private
+    fun normalizeActualInputPath(file: File): String =
+        file.let(::relativize)
+            .let(File::normalize)
+            .invariantSeparatorsPath
+
+    private
+    fun normalizeFilePattern(pathWithWildcards: String): File =
+        File(pathWithWildcards)
+            .let(::substituteUserHome)
+            .let(::relativize)
+            .let(File::normalize)
+
+    private
+    fun substituteUserHome(file: File): File =
+        if (file.invariantSeparatorsPath.startsWith("~/"))
+            File(userHome, file.path.substringAfter(File.separatorChar))
+        else file
+
+    private
+    fun relativize(file: File): File {
+        val absoluteFile = if (file.isAbsolute) file else File(rootDirectory, file.path)
+        return File(GFileUtils.relativePathOf(absoluteFile, rootDirectory))
+    }
+
+    private
+    fun wildcardsToRegexPatternString(pathWithWildcards: String): String =
+        pathWithWildcards.split("**").joinToString(".*") { outerPart ->
+            outerPart.takeIf { it.isNotEmpty() }?.split("*")?.joinToString("[^/]*") { innerPart ->
+                innerPart.takeIf { it.isNotEmpty() }?.let(Regex::escape).orEmpty()
+            }.orEmpty()
+        }
+
+    private
+    fun createJointRegexForPatterns(paths: String) =
+        paths.split(PATHS_SEPARATOR).joinToString("|") {
+            wildcardsToRegexPatternString(normalizeFilePattern(it).invariantSeparatorsPath)
+        }.toRegex()
+
+    internal
+    companion object {
+        internal
+        const val PATHS_SEPARATOR = ";"
+    }
+}

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultIgnoredConfigurationInputs.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultIgnoredConfigurationInputs.kt
@@ -71,7 +71,7 @@ class DefaultIgnoredConfigurationInputs(
 
     private
     fun wildcardsToRegexPatternString(pathWithWildcards: String): String =
-        pathWithWildcards.split("**").joinToString(".*") { outerPart ->
+        pathWithWildcards.split("**").joinToString(separator = ".*", prefix = "^", postfix = "$") { outerPart ->
             outerPart.takeIf { it.isNotEmpty() }?.split("*")?.joinToString("[^/]*") { innerPart ->
                 innerPart.takeIf { it.isNotEmpty() }?.let(Regex::escape).orEmpty()
             }.orEmpty()

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/IgnoredConfigurationInputs.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/IgnoredConfigurationInputs.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache
+
+import java.io.File
+
+
+/**
+ * Defines specific configuration inputs that should not be included in the configuration cache fingerprint.
+ */
+interface IgnoredConfigurationInputs {
+    /**
+     * Checks if the [file] should be excluded from the configuration inputs fingerprint if it participates
+     * in file system checks, such as [File.exists], [File.isFile] etc.
+     */
+    fun isFileSystemCheckIgnoredFor(file: File): Boolean
+}

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/InstrumentedInputAccessListener.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/InstrumentedInputAccessListener.kt
@@ -69,6 +69,7 @@ class InstrumentedInputAccessListener(
     listenerManager: ListenerManager,
     configurationCacheProblemsListener: ConfigurationCacheProblemsListener,
     private val environmentChangeTracker: ConfigurationCacheEnvironmentChangeTracker,
+    private val ignoredConfigurationInputs: IgnoredConfigurationInputs
 ) : Instrumented.Listener {
 
     private
@@ -123,6 +124,9 @@ class InstrumentedInputAccessListener(
 
     override fun fileSystemEntryObserved(file: File, consumer: String) {
         if (Workarounds.canReadFiles(consumer)) {
+            return
+        }
+        if (ignoredConfigurationInputs.isFileSystemCheckIgnoredFor(file)) {
             return
         }
         undeclaredInputBroadcast.fileSystemEntryObserved(file, consumer)

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprint.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprint.kt
@@ -36,7 +36,12 @@ sealed class ConfigurationCacheFingerprint {
          * Whether the instrumentation agent was used when computing the cache.
          * With the agent, the class paths may be stored differently, making the caches incompatible with one another.
          */
-        val instrumentationAgentUsed: Boolean
+        val instrumentationAgentUsed: Boolean,
+        /**
+         * The file system paths that will be ignored during file system checks tracking for the cache fingerprint.
+         * @see org.gradle.configurationcache.DefaultIgnoredConfigurationInputs
+         */
+        val ignoredFileSystemCheckInputPaths: String?
     ) : ConfigurationCacheFingerprint()
 
     data class InitScripts(

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintChecker.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintChecker.kt
@@ -52,6 +52,7 @@ class ConfigurationCacheFingerprintChecker(private val host: Host) {
         val buildStartTime: Long
         val invalidateCoupledProjects: Boolean
         val instrumentationAgentUsed: Boolean
+        val ignoredFileSystemCheckInputs: String?
         fun gradleProperty(propertyName: String): String?
         fun fingerprintOf(fileCollection: FileCollectionInternal): HashCode
         fun hashCodeOf(file: File): HashCode?
@@ -221,6 +222,9 @@ class ConfigurationCacheFingerprintChecker(private val host: Host) {
                         false -> "is now applied"
                     }
                     return "the instrumentation Java agent $statusChangeString"
+                }
+                if (host.ignoredFileSystemCheckInputs != ignoredFileSystemCheckInputPaths) {
+                    return "the set of paths ignored in file-system-check input tracking has changed"
                 }
             }
             is ConfigurationCacheFingerprint.EnvironmentVariablesPrefixedBy -> input.run {

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintController.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintController.kt
@@ -334,6 +334,9 @@ class ConfigurationCacheFingerprintController internal constructor(
         override val instrumentationAgentUsed: Boolean
             get() = agentStatus.isAgentInstrumentationEnabled
 
+        override val ignoredFileSystemCheckInputs: String?
+            get() = startParameter.ignoredFileSystemCheckInputs
+
         override fun hashCodeOf(file: File) =
             fileSystemAccess.read(file.absolutePath).hash
 
@@ -387,6 +390,9 @@ class ConfigurationCacheFingerprintController internal constructor(
 
         override val instrumentationAgentUsed: Boolean
             get() = agentStatus.isAgentInstrumentationEnabled
+
+        override val ignoredFileSystemCheckInputs: String?
+            get() = startParameter.ignoredFileSystemCheckInputs
 
         override fun gradleProperty(propertyName: String): String? =
             gradleProperties.find(propertyName)?.uncheckedCast()

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintWriter.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintWriter.kt
@@ -118,6 +118,7 @@ class ConfigurationCacheFingerprintWriter(
         val buildStartTime: Long
         val cacheIntermediateModels: Boolean
         val instrumentationAgentUsed: Boolean
+        val ignoredFileSystemCheckInputs: String?
         fun fingerprintOf(fileCollection: FileCollectionInternal): HashCode
         fun hashCodeOf(file: File): HashCode
         fun hashCodeOfDirectoryContent(file: File): HashCode
@@ -179,7 +180,8 @@ class ConfigurationCacheFingerprintWriter(
                 host.gradleUserHomeDir,
                 jvmFingerprint(),
                 host.startParameterProperties,
-                host.instrumentationAgentUsed
+                host.instrumentationAgentUsed,
+                host.ignoredFileSystemCheckInputs
             )
         )
     }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/initialization/ConfigurationCacheStartParameter.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/initialization/ConfigurationCacheStartParameter.kt
@@ -63,6 +63,9 @@ class ConfigurationCacheStartParameter(
     val maxProblems: Int
         get() = startParameter.configurationCacheMaxProblems
 
+    val ignoredFileSystemCheckInputs: String?
+        get() = startParameter.configurationCacheIgnoredFileSystemCheckInputs
+
     val isDebug: Boolean
         get() = startParameter.isConfigurationCacheDebug
 

--- a/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/DefaultIgnoredConfigurationInputsTest.kt
+++ b/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/DefaultIgnoredConfigurationInputsTest.kt
@@ -33,6 +33,15 @@ class DefaultIgnoredConfigurationInputsTest {
     }
 
     @Test
+    fun `if created with an empty or null paths list, does not recognize an empty string`() {
+        val instance = createFromPaths(emptyList())
+        assertFalse(instance.isFileSystemCheckIgnoredFor(File("")))
+
+        val instanceFromNull = DefaultIgnoredConfigurationInputs(null, rootDir)
+        assertFalse(instanceFromNull.isFileSystemCheckIgnoredFor(File("")))
+    }
+
+    @Test
     fun `does not recognize arbitrary paths by default`() {
         val instance = createFromPaths(emptyList())
         assertFalse(instance.isFileSystemCheckIgnoredFor(File("test")))

--- a/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/DefaultIgnoredConfigurationInputsTest.kt
+++ b/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/DefaultIgnoredConfigurationInputsTest.kt
@@ -16,6 +16,7 @@
 
 package org.gradle.configurationcache
 
+import org.gradle.internal.os.OperatingSystem
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -25,7 +26,7 @@ import java.io.File
 class DefaultIgnoredConfigurationInputsTest {
 
     private
-    val rootDir = File("/test/rootDir")
+    val rootDir = File(if (OperatingSystem.current().isWindows) "C:/test/rootDir" else "/test/rootDir")
 
     private
     fun createFromPaths(paths: List<String>): DefaultIgnoredConfigurationInputs {

--- a/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/DefaultIgnoredConfigurationInputsTest.kt
+++ b/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/DefaultIgnoredConfigurationInputsTest.kt
@@ -17,6 +17,7 @@
 package org.gradle.configurationcache
 
 import org.gradle.internal.os.OperatingSystem
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -119,5 +120,12 @@ class DefaultIgnoredConfigurationInputsTest {
         val instance = createFromPaths(listOf("abc", "DEF/*/GHI"), isCaseSensitive = false)
         assertTrue(instance.isFileSystemCheckIgnoredFor(File("Abc")))
         assertTrue(instance.isFileSystemCheckIgnoredFor(File("Def/123/ghi")))
+    }
+
+    @Test
+    fun `accepts backslash-separated path patterns on Windows`() {
+        val instance = createFromPaths(listOf("abc\\*\\ghi"))
+        val isRecognized = instance.isFileSystemCheckIgnoredFor(File("abc/test/ghi"))
+        assertEquals(OperatingSystem.current().isWindows, isRecognized)
     }
 }

--- a/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/DefaultIgnoredConfigurationInputsTest.kt
+++ b/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/DefaultIgnoredConfigurationInputsTest.kt
@@ -39,6 +39,16 @@ class DefaultIgnoredConfigurationInputsTest {
     }
 
     @Test
+    fun `does not recognize partial matches unless wildcarded`() {
+        val instance = createFromPaths(listOf("abc"))
+        assertTrue(instance.isFileSystemCheckIgnoredFor(File("abc")))
+        assertFalse(instance.isFileSystemCheckIgnoredFor(File("abcdef")))
+        assertFalse(instance.isFileSystemCheckIgnoredFor(File("123abc")))
+        assertFalse(instance.isFileSystemCheckIgnoredFor(File("abc/def")))
+        assertFalse(instance.isFileSystemCheckIgnoredFor(File("xyz/abc")))
+    }
+
+    @Test
     fun `recognizes relative paths against rootDirectory`() {
         val instance = createFromPaths(listOf("test/123"))
         assertTrue(instance.isFileSystemCheckIgnoredFor(rootDir.resolve("test/123")))

--- a/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/DefaultIgnoredConfigurationInputsTest.kt
+++ b/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/DefaultIgnoredConfigurationInputsTest.kt
@@ -29,8 +29,8 @@ class DefaultIgnoredConfigurationInputsTest {
     val rootDir = File(if (OperatingSystem.current().isWindows) "C:/test/rootDir" else "/test/rootDir")
 
     private
-    fun createFromPaths(paths: List<String>): DefaultIgnoredConfigurationInputs {
-        return DefaultIgnoredConfigurationInputs(paths.joinToString(";"), rootDir)
+    fun createFromPaths(paths: List<String>, isCaseSensitive: Boolean = true): DefaultIgnoredConfigurationInputs {
+        return DefaultIgnoredConfigurationInputs(paths.joinToString(";"), isCaseSensitive, rootDir)
     }
 
     @Test
@@ -38,7 +38,7 @@ class DefaultIgnoredConfigurationInputsTest {
         val instance = createFromPaths(emptyList())
         assertFalse(instance.isFileSystemCheckIgnoredFor(File("")))
 
-        val instanceFromNull = DefaultIgnoredConfigurationInputs(null, rootDir)
+        val instanceFromNull = DefaultIgnoredConfigurationInputs(null, true, rootDir)
         assertFalse(instanceFromNull.isFileSystemCheckIgnoredFor(File("")))
     }
 
@@ -105,5 +105,19 @@ class DefaultIgnoredConfigurationInputsTest {
     fun `recognizes relative paths pointing outside the root directory`() {
         val instance = createFromPaths(listOf("../../test1"))
         assertTrue(instance.isFileSystemCheckIgnoredFor(rootDir.parentFile.parentFile.resolve("test1")))
+    }
+
+    @Test
+    fun `if created as case-sensitive, does not recognize paths in a different case`() {
+        val instance = createFromPaths(listOf("abc", "DEF/*/GHI"), isCaseSensitive = true)
+        assertFalse(instance.isFileSystemCheckIgnoredFor(File("Abc")))
+        assertFalse(instance.isFileSystemCheckIgnoredFor(File("Def/123/ghi")))
+    }
+
+    @Test
+    fun `if created as case-insensitive, recognizes paths in a different case`() {
+        val instance = createFromPaths(listOf("abc", "DEF/*/GHI"), isCaseSensitive = false)
+        assertTrue(instance.isFileSystemCheckIgnoredFor(File("Abc")))
+        assertTrue(instance.isFileSystemCheckIgnoredFor(File("Def/123/ghi")))
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
@@ -23,6 +23,7 @@ import org.gradle.internal.buildoption.Option;
 import org.gradle.internal.buildtree.BuildModelParameters;
 import org.gradle.internal.watch.registry.WatchMode;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.time.Duration;
 
@@ -36,6 +37,7 @@ public class StartParameterInternal extends StartParameter {
     private ConfigurationCacheProblemsOption.Value configurationCacheProblems = ConfigurationCacheProblemsOption.Value.FAIL;
     private boolean configurationCacheDebug;
     private int configurationCacheMaxProblems = 512;
+    private @Nullable String configurationCacheIgnoredFileSystemCheckInputs = null;
     private boolean configurationCacheRecreateCache;
     private boolean configurationCacheQuiet;
     private boolean searchUpwards = true;
@@ -69,6 +71,7 @@ public class StartParameterInternal extends StartParameter {
         p.isolatedProjects = isolatedProjects;
         p.configurationCacheProblems = configurationCacheProblems;
         p.configurationCacheMaxProblems = configurationCacheMaxProblems;
+        p.configurationCacheIgnoredFileSystemCheckInputs = configurationCacheIgnoredFileSystemCheckInputs;
         p.configurationCacheDebug = configurationCacheDebug;
         p.configurationCacheRecreateCache = configurationCacheRecreateCache;
         p.configurationCacheQuiet = configurationCacheQuiet;
@@ -181,6 +184,15 @@ public class StartParameterInternal extends StartParameter {
 
     public void setConfigurationCacheMaxProblems(int configurationCacheMaxProblems) {
         this.configurationCacheMaxProblems = configurationCacheMaxProblems;
+    }
+
+    @Nullable
+    public String getConfigurationCacheIgnoredFileSystemCheckInputs() {
+        return configurationCacheIgnoredFileSystemCheckInputs;
+    }
+
+    public void setConfigurationCacheIgnoredFileSystemCheckInputs(@Nullable String configurationCacheIgnoredFileSystemCheckInputs) {
+        this.configurationCacheIgnoredFileSystemCheckInputs = configurationCacheIgnoredFileSystemCheckInputs;
     }
 
     public boolean isConfigurationCacheRecreateCache() {

--- a/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
@@ -76,6 +76,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
         options.add(new ConfigurationCacheProblemsOption());
         options.add(new ConfigurationCacheOption());
         options.add(new ConfigurationCacheMaxProblemsOption());
+        options.add(new ConfigurationCacheIgnoredFileSystemCheckInputs());
         options.add(new ConfigurationCacheDebugOption());
         options.add(new ConfigurationCacheRecreateOption());
         options.add(new ConfigurationCacheQuietOption());
@@ -90,7 +91,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
 
     public static class ProjectCacheDirOption extends StringBuildOption<StartParameterInternal> {
         public static final String PROPERTY_NAME = "org.gradle.projectcachedir";
-        
+
         public ProjectCacheDirOption() {
             super(PROPERTY_NAME, CommandLineOptionConfiguration.create("project-cache-dir", "Specify the project-specific cache directory. Defaults to .gradle in the root project directory."));
         }
@@ -539,6 +540,20 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
         @Override
         public void applyTo(int value, StartParameterInternal settings, Origin origin) {
             settings.setConfigurationCacheMaxProblems(value);
+        }
+    }
+
+    public static class ConfigurationCacheIgnoredFileSystemCheckInputs extends StringBuildOption<StartParameterInternal> {
+
+        public static final String PROPERTY_NAME = "org.gradle.configuration-cache.inputs.unsafe.ignore.file-system-checks";
+
+        public ConfigurationCacheIgnoredFileSystemCheckInputs() {
+            super(PROPERTY_NAME);
+        }
+
+        @Override
+        public void applyTo(String value, StartParameterInternal settings, Origin origin) {
+            settings.setConfigurationCacheIgnoredFileSystemCheckInputs(value);
         }
     }
 

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/action/BuildActionSerializer.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/action/BuildActionSerializer.java
@@ -148,6 +148,7 @@ public class BuildActionSerializer {
             valueSerializer.write(encoder, startParameter.getIsolatedProjects());
             encoder.writeString(startParameter.getConfigurationCacheProblems().name());
             encoder.writeSmallInt(startParameter.getConfigurationCacheMaxProblems());
+            encoder.writeNullableString(startParameter.getConfigurationCacheIgnoredFileSystemCheckInputs());
             encoder.writeBoolean(startParameter.isConfigurationCacheDebug());
             encoder.writeBoolean(startParameter.isConfigurationCacheRecreateCache());
             encoder.writeBoolean(startParameter.isConfigurationCacheQuiet());
@@ -237,6 +238,7 @@ public class BuildActionSerializer {
             startParameter.setIsolatedProjects(valueSerializer.read(decoder));
             startParameter.setConfigurationCacheProblems(ConfigurationCacheProblemsOption.Value.valueOf(decoder.readString()));
             startParameter.setConfigurationCacheMaxProblems(decoder.readSmallInt());
+            startParameter.setConfigurationCacheIgnoredFileSystemCheckInputs(decoder.readNullableString());
             startParameter.setConfigurationCacheDebug(decoder.readBoolean());
             startParameter.setConfigurationCacheRecreateCache(decoder.readBoolean());
             startParameter.setConfigurationCacheQuiet(decoder.readBoolean());


### PR DESCRIPTION
Introduce a Gradle option
`org.gradle.configuration-cache.inputs.unsafe.ignore.file-system-checks`
that can be used to exclude file system checks on the
specified path from configuration cache inputs
fingerprinting.<!--- The issue this PR addresses -->

Fixes #25418