### PR TITLE
Add lock around build logic building

### DIFF
--- a/subprojects/composite-builds/build.gradle.kts
+++ b/subprojects/composite-builds/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     implementation(project(":core"))
     implementation(project(":dependency-management"))
     implementation(project(":plugin-use"))
+    implementation(projects.persistentCache)
 
     implementation(libs.slf4jApi)
     implementation(libs.guava)


### PR DESCRIPTION
Gradle has a lock around building buildSrc and putting the result in the JARs cache. So everything will be synchronized between builds and no bad things can end up in the JARs cache. The resulting JARs will end up on the classpath of the build this buildSrc belongs to.

For included builds, we don’t have such a lock. So when you run two builds concurrently, building and putting stuff from build-logic builds in the JARs cache will happen concurrently. That means it is quite probable that something bad ends up in the JARs cache.

One simple approach could be that Gradle adds a lock around building included builds necessary for build logic and putting the result in the JARs cache, similar to what we do for buildSrc.

This PR does currently something less: It adds a lock around building the included build logic build. That means bad things can still happen before something ends in the JARs cache.

Though it should avoid running concurrent builds on build logic, that may be causing build failures and wrong entries in the task history/build cache. The lock is currently around the requesting build. We could move it around the root build for more dead-lock avoidance.