### PR TITLE
Deprecate getTaskDependencyFromProjectDependency

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Configuration.java
@@ -52,7 +52,7 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
      * Returns the resolution strategy used by this configuration.
      * The resolution strategy provides extra details on how to resolve this configuration.
      * See docs for {@link ResolutionStrategy} for more info and examples.
-     * 
+     *
      * @implSpec Usage: This method should only be called on resolvable configurations, but will not warn if used otherwise.
      *
      * @return resolution strategy
@@ -63,7 +63,7 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
     /**
      * The resolution strategy provides extra details on how to resolve this configuration.
      * See docs for {@link ResolutionStrategy} for more info and examples.
-     * 
+     *
      * @implSpec Usage: This method should only be called on resolvable configurations, but will not warn if used otherwise.
      *
      * @param closure closure applied to the {@link ResolutionStrategy}
@@ -75,7 +75,7 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
     /**
      * The resolution strategy provides extra details on how to resolve this configuration.
      * See docs for {@link ResolutionStrategy} for more info and examples.
-     * 
+     *
      * @implSpec Usage: This method should only be called on resolvable configurations, but will not warn if used otherwise.
      *
      * @param action action applied to the {@link ResolutionStrategy}
@@ -92,7 +92,7 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
 
     /**
      * Returns the state of the configuration.
-     * 
+     *
      * @implSpec Usage: This method should only be called on resolvable configurations, but will not warn if used otherwise.
      *
      * @see org.gradle.api.artifacts.Configuration.State
@@ -128,7 +128,7 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
     /**
      * Sets the visibility of this configuration. When visible is set to true, this configuration is visible outside
      * the project it belongs to. The default value is true.
-     * 
+     *
      * @implSpec Usage: This method should only be called on consumable configurations, but will not warn if used otherwise.
      *
      * @param visible true if this is a visible configuration
@@ -204,7 +204,7 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
     /**
      * Resolves this configuration. This locates and downloads the files which make up this configuration, and returns
      * the resulting set of files.
-     * 
+     *
      * @implSpec Usage: This method should only be called on resolvable configurations and will emit a deprecation warning if
      * called on a configuration that does not permit this usage, or has allowed this usage but marked it as deprecated.
      *
@@ -215,7 +215,7 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
     /**
      * Takes a closure which gets coerced into a {@link Spec}. Behaves otherwise in the same way as
      * {@link #files(org.gradle.api.specs.Spec)}.
-     * 
+     *
      * @implSpec Usage: This method should only be called on resolvable configurations and should fail if
      * called on a configuration that does not permit this usage.  It should warn if called on a configuration that has
      * allowed this usage but marked it as deprecated.
@@ -319,7 +319,7 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
     /**
      * Returns a {@code TaskDependency} object containing all required dependencies to build the local dependencies
      * (e.g. project dependencies) belonging to this configuration or to one of its super configurations.
-     * 
+     *
      * @implSpec Usage: This method should only be called on resolvable configurations, but will not warn if used otherwise.
      *
      * @return a TaskDependency object
@@ -336,8 +336,12 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
      * @param useDependedOn if true, add tasks from project dependencies in this configuration, otherwise use projects
      *                      from configurations with the same name that depend on this one.
      * @param taskName name of task to depend on
+     *
      * @return the populated TaskDependency object
+     *
+     * @deprecated This method will be removed without replacement in Gradle 9.0
      */
+    @Deprecated
     TaskDependency getTaskDependencyFromProjectDependency(boolean useDependedOn, final String taskName);
 
     /**
@@ -346,7 +350,7 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
      * <p>
      * This method does not resolve the configuration. Therefore, the return value does not include
      * transitive dependencies.
-     * 
+     *
      * @implSpec Usage: This method should only be called on declarable configurations, but will not warn if used otherwise.
      *
      * @return the set of dependencies
@@ -390,7 +394,7 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
 
     /**
      * Returns the artifacts of this configuration excluding the artifacts of extended configurations.
-     * 
+     *
      * @implSpec Usage: This method should only be called on consumable configurations, but will not warn if used otherwise.
      *
      * @return The set.
@@ -443,8 +447,8 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
      * <p>
      * If multiple actions are supplied, each action will be executed until the set of dependencies is no longer empty.
      * Remaining actions will be ignored.
-     * 
-     * @implSpec Usage: This method should only be called on resolvable configurations and will emit a deprecation warning if 
+     *
+     * @implSpec Usage: This method should only be called on resolvable configurations and will emit a deprecation warning if
      * called on a configuration that does not permit this usage, or has allowed this usage but marked it as deprecated.
      *
      * @param action the action to execute when the configuration has no defined dependencies.
@@ -493,7 +497,7 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
 
     /**
      * Returns the incoming dependencies of this configuration.
-     * 
+     *
      * @implSpec Usage: This method should only be called on consumable and resolvable configurations, but will not warn if used otherwise.
      *
      * @return The incoming dependencies of this configuration. Never {@code null}.
@@ -504,7 +508,7 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
      * Returns the outgoing {@link ConfigurationPublications} instance that advertises and allows configuring the artifacts and variants published by this configuration.
      * <p>
      * This allows adding additional artifacts and accessing and configuring variants to publish.
-     * 
+     *
      * @implSpec Usage: This method should only be called on consumable configurations, but will not warn if used otherwise.
      *
      * @return The outgoing publications object containing artifacts and variants published by this configuration.
@@ -514,7 +518,7 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
 
     /**
      * Configures the outgoing {@link ConfigurationPublications} instance that advertises and allows configuring the artifacts and variants published by this configuration.
-     * 
+     *
      * @implSpec Usage: This method should only be called on consumable configurations, but will not warn if used otherwise.
      *
      * @param action The action to perform the configuration.
@@ -663,7 +667,7 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
      * from the resolution result of another resolvable configuration. For example, it's
      * expected that the versions of the runtime classpath are the same as the versions
      * from the compile classpath.
-     * 
+     *
      * @implSpec Usage: This method should only be called on resolvable configurations and will emit a deprecation warning if
      * called on a configuration that does not permit this usage, or has had allowed this usage but marked it as deprecated.
      *
@@ -677,7 +681,7 @@ public interface Configuration extends FileCollection, HasConfigurableAttributes
 
     /**
      * Disables consistent resolution for this configuration.
-     * 
+     *
      * @implSpec Usage: This method should only be called on resolvable configurations and will emit a deprecation warning if
      * called on a configuration that does not permit this usage, or has had allowed this usage but marked it as deprecated.
      *

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ConfigurationBuildDependenciesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ConfigurationBuildDependenciesIntegrationTest.groovy
@@ -391,6 +391,21 @@ class ConfigurationBuildDependenciesIntegrationTest extends AbstractHttpDependen
         executed ":child:jar", ":useCompileConfiguration"
     }
 
+    def "getTaskDependencyFromProjectDependency is deprecated"() {
+        given:
+        buildFile << """
+            configurations {
+                foo {
+                    getTaskDependencyFromProjectDependency(true, 'bar')
+                }
+            }
+        """
+
+        expect:
+        executer.expectDocumentedDeprecationWarning("The Configuration.getTaskDependencyFromProjectDependency(boolean, String) method has been deprecated. This is scheduled to be removed in Gradle 9.0. This method will be removed without replacement. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#get_task_dependency_from_project_dependency_deprecated")
+        succeeds("help")
+    }
+
     void makeFluid(boolean fluid) {
         if (fluid) {
             buildFile << """

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
@@ -23,6 +23,7 @@ import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.ResolveContext;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.api.tasks.TaskDependency;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.FinalizableValue;
 import org.gradle.internal.deprecation.DeprecatableConfiguration;
@@ -118,6 +119,19 @@ public interface ConfigurationInternal extends ResolveContext, DeprecatableConfi
                     .anyMatch(ci -> ci.isDeclarableByExtension());
         }
     }
+
+    /**
+     * Returns a TaskDependency object containing dependencies on all tasks with the specified name from project
+     * dependencies related to this configuration or one of its super configurations.  These other projects may be
+     * projects this configuration depends on or projects with a similarly named configuration that depend on this one
+     * based on the useDependOn argument.
+     *
+     * @param useDependedOn if true, add tasks from project dependencies in this configuration, otherwise use projects
+     *                      from configurations with the same name that depend on this one.
+     * @param taskName name of task to depend on
+     * @return the populated TaskDependency object
+     */
+    TaskDependency getTaskDependencyFromProjectDependencyInternal(boolean useDependedOn, final String taskName);
 
     interface VariantVisitor {
         // The artifacts to use when this configuration is used as a configuration

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -936,11 +936,20 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         context.add(intrinsicFiles);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
+    @Deprecated
     public TaskDependency getTaskDependencyFromProjectDependency(final boolean useDependedOn, final String taskName) {
+        DeprecationLogger.deprecateMethod(Configuration.class, "getTaskDependencyFromProjectDependency(boolean, String)")
+            .withAdvice("This method will be removed without replacement.")
+            .willBeRemovedInGradle9()
+            .withUpgradeGuideSection(8, "get_task_dependency_from_project_dependency_deprecated")
+            .nagUser();
+
+        return getTaskDependencyFromProjectDependencyInternal(useDependedOn, taskName);
+    }
+
+    @Override
+    public TaskDependency getTaskDependencyFromProjectDependencyInternal(boolean useDependedOn, String taskName) {
         if (useDependedOn) {
             return new TasksFromProjectDependencies(taskName, this::getAllDependencies, taskDependencyFactory);
         } else {

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
@@ -235,6 +235,12 @@ Upgrade to version 3.13.1 or later of the Gradle Enterprise plugin.
 You can find the link:https://plugins.gradle.org/plugin/com.gradle.enterprise[latest available version on the Gradle Plugin Portal].
 More information on the compatibility can be found link:https://docs.gradle.com/enterprise/compatibility/#build_scans[here].
 
+[[get_task_dependency_from_project_dependency_deprecated]]
+==== Deprecated `Configuration#getTaskDependencyFromProjectDependency`
+
+link:{javadocPath}/org/gradle/api/artifacts/Configuration.html#getTaskDependencyFromProjectDependency-boolean-java.lang.String-[`Configuration#getTaskDependencyFromProjectDependency`] has been deprecated and will be removed in Gradle 9.0, without replacement.
+This method is inherently incompatible with project isolation.
+
 [[changes_8.2]]
 == Upgrading from 8.1 and earlier
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/ConfigurationDeprecatedExtensions.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/ConfigurationDeprecatedExtensions.kt
@@ -281,6 +281,7 @@ val <T : Configuration> NamedDomainObjectProvider<T>.resolvedConfiguration
 /**
  * See [Configuration.getTaskDependencyFromProjectDependency].
  */
+@Suppress("DEPRECATION")
 @Deprecated(deprecationMessage, replaceWith = ReplaceWith("get().getTaskDependencyFromProjectDependency(useDependedOn, taskName)"), level = DeprecationLevel.HIDDEN)
 fun <T : Configuration> NamedDomainObjectProvider<T>.getTaskDependencyFromProjectDependency(useDependedOn: Boolean, taskName: String): TaskDependency =
     get().getTaskDependencyFromProjectDependency(useDependedOn, taskName)

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -24,6 +24,7 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.component.SoftwareComponentContainerInternal;
 import org.gradle.api.internal.plugins.DslObject;
 import org.gradle.api.internal.project.ProjectInternal;
@@ -343,7 +344,7 @@ public abstract class JavaPlugin implements Plugin<Project> {
      */
     private static void addDependsOnTaskInOtherProjects(final Task task, boolean useDependedOn, String otherProjectTaskName, String configurationName) {
         Project project = task.getProject();
-        final Configuration configuration = project.getConfigurations().getByName(configurationName);
-        task.dependsOn(configuration.getTaskDependencyFromProjectDependency(useDependedOn, otherProjectTaskName));
+        ConfigurationInternal configuration = (ConfigurationInternal) project.getConfigurations().getByName(configurationName);
+        task.dependsOn(configuration.getTaskDependencyFromProjectDependencyInternal(useDependedOn, otherProjectTaskName));
     }
 }


### PR DESCRIPTION
This method is by definition incompatible with project isolation. We will remove it publicly in 9.0 and will transition away from it internally, where it is used for the `buildNeeded` and `buildDependents` tasks when the Java plugin is applied. We will need to figure out other ways to implement this sort of functionality. Though, efficiently implementing `buildNeeded` is likely impossible
