### PR TITLE
Tidy up some filenames and documentation from #25382

### DIFF
--- a/subprojects/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestExecutionListener.java
+++ b/subprojects/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestExecutionListener.java
@@ -29,8 +29,8 @@ import org.gradle.api.internal.tasks.testing.failure.FailureMapper;
 import org.gradle.api.internal.tasks.testing.failure.mappers.AssertErrorMapper;
 import org.gradle.api.internal.tasks.testing.failure.mappers.AssertjMultipleAssertionsErrorMapper;
 import org.gradle.api.internal.tasks.testing.failure.mappers.JUnitComparisonFailureMapper;
-import org.gradle.api.internal.tasks.testing.failure.mappers.OpentestFailureFailedMapper;
-import org.gradle.api.internal.tasks.testing.failure.mappers.OpentestMultipleFailuresMapper;
+import org.gradle.api.internal.tasks.testing.failure.mappers.OpenTestAssertionFailedMapper;
+import org.gradle.api.internal.tasks.testing.failure.mappers.OpenTestMultipleFailuresErrorMapper;
 import org.gradle.api.internal.tasks.testing.junit.JUnitSupport;
 import org.gradle.api.tasks.testing.TestFailure;
 import org.gradle.api.tasks.testing.TestResult.ResultType;
@@ -70,8 +70,8 @@ public class JUnitPlatformTestExecutionListener implements TestExecutionListener
     private static final Logger LOGGER = LoggerFactory.getLogger(JUnitPlatformTestExecutionListener.class);
 
     private final static List<FailureMapper> MAPPERS = Arrays.asList(
-        new OpentestFailureFailedMapper(),
-        new OpentestMultipleFailuresMapper(),
+        new OpenTestAssertionFailedMapper(),
+        new OpenTestMultipleFailuresErrorMapper(),
         new JUnitComparisonFailureMapper(),
         new AssertjMultipleAssertionsErrorMapper(),
         new AssertErrorMapper()

--- a/subprojects/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/failure/RootAssertionToFailureMapper.java
+++ b/subprojects/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/failure/RootAssertionToFailureMapper.java
@@ -17,12 +17,13 @@
 package org.gradle.api.internal.tasks.testing.failure;
 
 import org.gradle.api.NonNullApi;
+import org.gradle.api.internal.tasks.testing.failure.mappers.OpenTestMultipleFailuresErrorMapper;
 import org.gradle.api.tasks.testing.TestFailure;
 
 /**
  * Interface implemented by root-level classes which transform between {@link Throwable} and {@link TestFailure}.
  * <p>
- * As sometimes failure processing needs to be recursive (e.g. {@link org.gradle.api.internal.tasks.testing.failure.mappers.OpentestMultipleFailuresMapper}),
+ * As sometimes failure processing needs to be recursive (e.g. {@link OpenTestMultipleFailuresErrorMapper}),
  * they receive an instance implementing this interface to transform inner failures.
  *
  * @see org.gradle.api.internal.tasks.testing.junit.JUnitTestEventAdapter

--- a/subprojects/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/failure/mappers/OpenTestAssertionFailedMapper.java
+++ b/subprojects/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/failure/mappers/OpenTestAssertionFailedMapper.java
@@ -27,9 +27,12 @@ import java.util.List;
 /**
  * Maps {@code org.opentest4j.AssertionFailedError} to {@link TestFailure}.
  * <p>
+ * This mapper is a bit more complex, as depending on the type of the expected and actual values,
+ * the assertion will be mapped as a string-based comparison failure or a file comparison failure.
+ * <p>
  * See {@link FailureMapper} for more details about failure mapping.
  */
-public class OpentestFailureFailedMapper extends FailureMapper {
+public class OpenTestAssertionFailedMapper extends FailureMapper {
 
     @Override
     protected List<String> getSupportedClassNames() {

--- a/subprojects/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/failure/mappers/OpenTestMultipleFailuresErrorMapper.java
+++ b/subprojects/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/failure/mappers/OpenTestMultipleFailuresErrorMapper.java
@@ -29,7 +29,7 @@ import java.util.List;
  * <p>
  * See {@link FailureMapper} for more details about failure mapping.
  */
-public class OpentestMultipleFailuresMapper extends FailureMapper {
+public class OpenTestMultipleFailuresErrorMapper extends FailureMapper {
 
     @Override
     protected List<String> getSupportedClassNames() {

--- a/subprojects/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestEventAdapter.java
+++ b/subprojects/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestEventAdapter.java
@@ -27,8 +27,8 @@ import org.gradle.api.internal.tasks.testing.failure.FailureMapper;
 import org.gradle.api.internal.tasks.testing.failure.mappers.AssertErrorMapper;
 import org.gradle.api.internal.tasks.testing.failure.mappers.AssertjMultipleAssertionsErrorMapper;
 import org.gradle.api.internal.tasks.testing.failure.mappers.JUnitComparisonFailureMapper;
-import org.gradle.api.internal.tasks.testing.failure.mappers.OpentestFailureFailedMapper;
-import org.gradle.api.internal.tasks.testing.failure.mappers.OpentestMultipleFailuresMapper;
+import org.gradle.api.internal.tasks.testing.failure.mappers.OpenTestAssertionFailedMapper;
+import org.gradle.api.internal.tasks.testing.failure.mappers.OpenTestMultipleFailuresErrorMapper;
 import org.gradle.api.tasks.testing.TestFailure;
 import org.gradle.api.tasks.testing.TestResult;
 import org.gradle.internal.id.IdGenerator;
@@ -55,8 +55,8 @@ public class JUnitTestEventAdapter extends RunListener implements RootAssertionT
 
     public static final List<FailureMapper> MAPPERS = Arrays.asList(
         new JUnitComparisonFailureMapper(),
-        new OpentestFailureFailedMapper(),
-        new OpentestMultipleFailuresMapper(),
+        new OpenTestAssertionFailedMapper(),
+        new OpenTestMultipleFailuresErrorMapper(),
         new AssertjMultipleAssertionsErrorMapper(),
         new AssertErrorMapper()
     );

--- a/subprojects/testing-jvm-infrastructure/src/test/groovy/org/gradle/api/internal/tasks/testing/failure/mappers/OpenTestMultipleFailuresMapperTestError.groovy
+++ b/subprojects/testing-jvm-infrastructure/src/test/groovy/org/gradle/api/internal/tasks/testing/failure/mappers/OpenTestMultipleFailuresMapperTestError.groovy
@@ -22,9 +22,9 @@ import org.gradle.api.tasks.testing.TestFailure
 import org.opentest4j.MultipleFailuresError
 import spock.lang.Specification
 
-class OpentestMultipleFailuresMapperTest extends Specification {
+class OpenTestMultipleFailuresMapperTestError extends Specification {
     // SUT
-    def mapper = new OpentestMultipleFailuresMapper()
+    def mapper = new OpenTestMultipleFailuresErrorMapper()
 
     // Our error being mapped
     def error = new MultipleFailuresError(


### PR DESCRIPTION
OpenTest4j classes were named incorrectly (`Opentest` instead `OpenTest`), with some documentation missing.