### PR TITLE
Full nagging for deprecation of NameMatcher

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/util/NameMatcher.java
+++ b/subprojects/core/src/main/java/org/gradle/util/NameMatcher.java
@@ -30,7 +30,7 @@ import org.gradle.internal.deprecation.DeprecationLogger;
 @Deprecated
 public class NameMatcher {
 
-    private static void logDeprecation() {
+    static {
         DeprecationLogger.deprecateType(NameMatcher.class)
             .willBeRemovedInGradle9()
             .withUpgradeGuideSection(7, "org_gradle_util_reports_deprecations")
@@ -52,7 +52,6 @@ public class NameMatcher {
      * @see #find(String, Collection)
      */
     public <T> T find(String pattern, Map<String, ? extends T> items) {
-        logDeprecation();
         String name = find(pattern, items.keySet());
         if (name != null) {
             return items.get(name);
@@ -73,7 +72,6 @@ public class NameMatcher {
      * @return The match if exactly 1 match found, null if no matches or multiple matches.
      */
     public String find(String pattern, Collection<String> items) {
-        // TODO log deprecation once nebula.dependency-lock plugin is fixed
         this.pattern = pattern;
         matches.clear();
         candidates.clear();
@@ -193,7 +191,6 @@ public class NameMatcher {
      * @return The matches. Returns an empty set when there are no matches.
      */
     public Set<String> getMatches() {
-        logDeprecation();
         return matches;
     }
 
@@ -203,7 +200,6 @@ public class NameMatcher {
      * @return The matches. Returns an empty set when there are no potential matches.
      */
     public Set<String> getCandidates() {
-        logDeprecation();
         return candidates;
     }
 


### PR DESCRIPTION
* Fix for https://github.com/gradle/gradle/issues/21913
* Follow up for https://github.com/gradle/gradle/pull/21843

No change in the deprecation documentation link as it already said the type was deprecated even if a couple functions from it did not nag yet because of a single plugin still using them.

No test change because the last plugin using `NameMatcher` in our smoke tests has been upgraded to a fixed version already.