### PR TITLE
Ensure the transform identities are unique per execution history store

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -954,6 +954,88 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
         projectDir1.relativePath(project1OutputDir) == projectDir2.relativePath(project2OutputDir)
     }
 
+    def "workspace id of project transforms is unique per build"() {
+        buildFile << declareAttributes() << multiProjectWithJarSizeTransform()
+        file("project-artifact.jar").text = "project artifact"
+        buildFile << """
+            project(':lib') {
+                artifacts {
+                    compile rootProject.file("project-artifact.jar")
+                }
+            }
+            project(':util') {
+                artifacts {
+                    compile rootProject.file("project-artifact.jar")
+                }
+            }
+        """
+
+        when:
+        succeeds ":app:resolve"
+
+        then:
+        def outputDirs = projectOutputDirs("project-artifact.jar", "project-artifact.jar.txt")
+        outputDirs.size() == 2
+        (outputDirs.parentFile.name as Set).size() == 2
+    }
+
+    def "workspace id of project transforms is unique per build with included builds"() {
+        // The setup here is in a way that the project path of the project dependency in the same build
+        // is the same as the buildTreePath of the substituted project dependency in the included build.
+        // This way we test that you can't do special handling for "local" project dependencies when calculating
+        // a transform workspace.
+        def includedBuild = new BuildTestFile(file("lib-project"), "lib-project")
+        includedBuild.with {
+            settingsFile << """
+                include(":producer")
+            """
+            file("project-artifact.jar").text = "project artifact"
+            buildFile << declareAttributes() << """
+                project(':producer') {
+                    group = "com.test"
+                    artifacts {
+                        compile rootProject.file("project-artifact.jar")
+                    }
+                }
+            """
+        }
+        def consumerIncludedBuild = new BuildTestFile(file("consumer-included-build"), "consumer-included-build")
+        consumerIncludedBuild.with {
+            settingsFile << """
+                include(":lib-project:producer")
+                include 'app'
+                include 'util'
+                include 'lib'
+            """
+            file("project-artifact.jar").text = "project artifact"
+            buildFile << resolveTask << declareAttributes() << multiProjectWithJarSizeTransform() <<"""
+                project(':lib-project:producer') {
+                    artifacts {
+                        compile rootProject.file("project-artifact.jar")
+                    }
+                }
+                project(':app') {
+                    dependencies {
+                        compile project(':lib-project:producer')
+                        compile 'com.test:producer:1.0'
+                    }
+                }
+            """
+        }
+        settingsFile << """
+            includeBuild('lib-project')
+            includeBuild('consumer-included-build')
+        """
+
+        when:
+        succeeds ":consumer-included-build:app:resolve"
+
+        then:
+        def outputDirs = projectOutputDirs("project-artifact.jar", "project-artifact.jar.txt")
+        outputDirs.size() == 2
+        (outputDirs.parentFile.name as Set).size() == 2
+    }
+
     def "transform is re-executed when input file content changes between builds"() {
         given:
         buildFile << declareAttributes() << multiProjectWithJarSizeTransform() << withClassesSizeTransform() << withFileLibDependency()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -979,6 +979,7 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
         (outputDirs.parentFile.name as Set).size() == 2
     }
 
+    @ToBeFixedForConfigurationCache(because = "project :lib-project:producer not found.")
     def "workspace id of project transforms is unique per build with included builds"() {
         // The setup here is in a way that the project path of the project dependency in the same build
         // is the same as the buildTreePath of the substituted project dependency in the included build.

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/MutableTransformExecution.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/MutableTransformExecution.java
@@ -28,6 +28,7 @@ import java.util.Map;
 
 class MutableTransformExecution extends AbstractTransformExecution {
     private final String rootProjectLocation;
+    private final String producerBuildTreePath;
 
     public MutableTransformExecution(
         Transform transform,
@@ -47,12 +48,14 @@ class MutableTransformExecution extends AbstractTransformExecution {
             transformExecutionListener, buildOperationExecutor, fileCollectionFactory, inputFingerprinter, workspaceServices
         );
         this.rootProjectLocation = producerProject.getRootDir().getAbsolutePath() + File.separator;
+        this.producerBuildTreePath = producerProject.getBuildTreePath();
     }
 
     @Override
     public Identity identify(Map<String, ValueSnapshot> identityInputs, Map<String, CurrentFileCollectionFingerprint> identityFileInputs) {
         return new MutableTransformWorkspaceIdentity(
             normalizeAbsolutePath(inputArtifact.getAbsolutePath()),
+            producerBuildTreePath,
             identityInputs.get(AbstractTransformExecution.SECONDARY_INPUTS_HASH_PROPERTY_NAME),
             identityFileInputs.get(AbstractTransformExecution.DEPENDENCIES_PROPERTY_NAME).getHash()
         );

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/MutableTransformWorkspaceIdentity.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/MutableTransformWorkspaceIdentity.java
@@ -24,11 +24,13 @@ import org.gradle.internal.snapshot.ValueSnapshot;
 
 class MutableTransformWorkspaceIdentity implements UnitOfWork.Identity {
     private final String inputArtifactAbsolutePath;
+    private final String producerBuildTreePath;
     private final ValueSnapshot secondaryInputsSnapshot;
     private final HashCode dependenciesHash;
 
-    public MutableTransformWorkspaceIdentity(String inputArtifactAbsolutePath, ValueSnapshot secondaryInputsSnapshot, HashCode dependenciesHash) {
+    public MutableTransformWorkspaceIdentity(String inputArtifactAbsolutePath, String producerBuildTreePath, ValueSnapshot secondaryInputsSnapshot, HashCode dependenciesHash) {
         this.inputArtifactAbsolutePath = inputArtifactAbsolutePath;
+        this.producerBuildTreePath = producerBuildTreePath;
         this.secondaryInputsSnapshot = secondaryInputsSnapshot;
         this.dependenciesHash = dependenciesHash;
     }
@@ -37,6 +39,7 @@ class MutableTransformWorkspaceIdentity implements UnitOfWork.Identity {
     public String getUniqueId() {
         Hasher hasher = Hashing.newHasher();
         hasher.putString(inputArtifactAbsolutePath);
+        hasher.putString(producerBuildTreePath);
         secondaryInputsSnapshot.appendToHasher(hasher);
         hasher.putHash(dependenciesHash);
         return hasher.hash().toString();
@@ -57,6 +60,9 @@ class MutableTransformWorkspaceIdentity implements UnitOfWork.Identity {
             return false;
         }
         if (!dependenciesHash.equals(that.dependenciesHash)) {
+            return false;
+        }
+        if (!producerBuildTreePath.equals(that.producerBuildTreePath)) {
             return false;
         }
         return inputArtifactAbsolutePath.equals(that.inputArtifactAbsolutePath);


### PR DESCRIPTION
TL;DR: The uniqueId for project artifact transforms that is used in the execution history store is not unique, we fix it by adding the `buildTreePath` of the producer project to it.

The following is only about workspaces and transforms on project artifacts.

The unique workspace id of an artifact transform is used in two places:
* key in the execution history in the current build (Gradle scoped)
* workspace location in the producer project

That means the unique id needs to be unique:
* per artifact to transform in the producer project <- This is simple, we are currently using the relative path of the artifact to the root in the producer project
* per artifact to transform in the consumer build <- This is violated currently; see the two tests added in this PR.

To fix the problem, we can add additional data to the uniqueId related to the producer and consumer projects. Anything we'll add that is related to the consumer project will not help with the unique id problem, since the execution history is for the consumer build. So we need to add something from the producer project.

As the tests show, we must add the identity path to make it unique. That has the downside that if add the same build as an included build, then project artifacts within that included build will be re-executed since a new workspace will be assigned to them. Though while running the same included build constellation, everything will be re-used as expected.

As an additional advantage, this change makes the uniqueId unique within the whole build tree.