### PR TITLE
Full nagging for deprecation of GUtil

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/util/NameMatcher.java
+++ b/subprojects/core/src/main/java/org/gradle/util/NameMatcher.java
@@ -21,6 +21,7 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.lang.StringUtils;
 import org.gradle.internal.deprecation.DeprecationLogger;
+import org.gradle.util.internal.GUtil;
 
 /**
  * This class is only here to maintain binary compatibility with existing plugins.

--- a/subprojects/logging/src/main/java/org/gradle/util/GUtil.java
+++ b/subprojects/logging/src/main/java/org/gradle/util/GUtil.java
@@ -70,7 +70,7 @@ import static java.util.Collections.emptyList;
 @Deprecated
 public class GUtil {
 
-    private static void logDeprecation(int majorVersion) {
+    static {
         DeprecationLogger.deprecateType(GUtil.class)
             .willBeRemovedInGradle9()
             .withUpgradeGuideSection(7, "org_gradle_util_reports_deprecations")
@@ -80,9 +80,7 @@ public class GUtil {
     private static final Pattern WORD_SEPARATOR = Pattern.compile("\\W+");
     private static final Pattern UPPER_LOWER = Pattern.compile("(?m)([A-Z]*)([a-z0-9]*)");
 
-    public GUtil() {
-        logDeprecation(7);
-    }
+    public GUtil() {}
 
     public static <T extends Collection<?>> T flatten(Object[] elements, T addTo, boolean flattenMaps) {
         return flatten(asList(elements), addTo, flattenMaps);
@@ -107,7 +105,6 @@ public class GUtil {
     }
 
     public static <T extends Collection<?>> T flatten(Collection<?> elements, T addTo, boolean flattenMaps, boolean flattenArrays) {
-        logDeprecation(7);
         Iterator<?> iter = elements.iterator();
         while (iter.hasNext()) {
             Object element = iter.next();
@@ -155,12 +152,10 @@ public class GUtil {
     }
 
     public static String asPath(Iterable<?> collection) {
-        logDeprecation(7);
         return CollectionUtils.join(File.pathSeparator, collection);
     }
 
     public static List<String> prefix(String prefix, Collection<String> strings) {
-        logDeprecation(7);
         List<String> prefixed = new ArrayList<String>();
         for (String string : strings) {
             prefixed.add(prefix + string);
@@ -169,7 +164,6 @@ public class GUtil {
     }
 
     public static boolean isTrue(@Nullable Object object) {
-        logDeprecation(7);
         if (object == null) {
             return false;
         }
@@ -196,7 +190,6 @@ public class GUtil {
     }
 
     public static <V, T extends Collection<? super V>> T addToCollection(T dest, boolean failOnNull, Iterable<? extends V> src) {
-        logDeprecation(7);
         for (V v : src) {
             if (failOnNull && v == null) {
                 throw new IllegalArgumentException("Illegal null value provided in this collection: " + src);
@@ -212,7 +205,6 @@ public class GUtil {
 
     @Deprecated
     public static <V, T extends Collection<? super V>> T addToCollection(T dest, boolean failOnNull, Iterable<? extends V>... srcs) {
-        logDeprecation(7);
         for (Iterable<? extends V> src : srcs) {
             for (V v : src) {
                 if (failOnNull && v == null) {
@@ -230,7 +222,6 @@ public class GUtil {
     }
 
     public static Comparator<String> caseInsensitive() {
-        logDeprecation(7);
         return new Comparator<String>() {
             @Override
             public int compare(String o1, String o2) {
@@ -244,7 +235,6 @@ public class GUtil {
     }
 
     public static <K, V> Map<K, V> addMaps(Map<K, V> map1, Map<K, V> map2) {
-        logDeprecation(7);
         HashMap<K, V> map = new HashMap<K, V>();
         map.putAll(map1);
         map.putAll(map2);
@@ -252,14 +242,12 @@ public class GUtil {
     }
 
     public static void addToMap(Map<String, String> dest, Map<?, ?> src) {
-        logDeprecation(7);
         for (Map.Entry<?, ?> entry : src.entrySet()) {
             dest.put(entry.getKey().toString(), entry.getValue().toString());
         }
     }
 
     public static Properties loadProperties(File propertyFile) {
-        logDeprecation(7);
         try {
             FileInputStream inputStream = new FileInputStream(propertyFile);
             try {
@@ -273,7 +261,6 @@ public class GUtil {
     }
 
     public static Properties loadProperties(URL url) {
-        // TODO log deprecation when nebula-lint plugin and idea are fixed
         try {
             URLConnection uc = url.openConnection();
             uc.setUseCaches(false);
@@ -284,7 +271,6 @@ public class GUtil {
     }
 
     public static Properties loadProperties(InputStream inputStream) {
-        // TODO log deprecation when nebula-lint plugin and idea are fixed
         Properties properties = new Properties();
         try {
             properties.load(inputStream);
@@ -297,7 +283,6 @@ public class GUtil {
     }
 
     public static void saveProperties(Properties properties, File propertyFile) {
-        logDeprecation(7);
         try {
             FileOutputStream propertiesFileOutputStream = new FileOutputStream(propertyFile);
             try {
@@ -311,7 +296,6 @@ public class GUtil {
     }
 
     public static void saveProperties(Properties properties, OutputStream outputStream) {
-        logDeprecation(7);
         try {
             try {
                 properties.store(outputStream, null);
@@ -324,7 +308,6 @@ public class GUtil {
     }
 
     public static Map<Object, Object> map(Object... objects) {
-        logDeprecation(7);
         Map<Object, Object> map = new HashMap<Object, Object>();
         assert objects.length % 2 == 0;
         for (int i = 0; i < objects.length; i += 2) {
@@ -334,7 +317,6 @@ public class GUtil {
     }
 
     public static String toString(Iterable<?> names) {
-        logDeprecation(7);
         Formatter formatter = new Formatter();
         boolean first = true;
         for (Object name : names) {
@@ -360,10 +342,6 @@ public class GUtil {
     }
 
     private static String toCamelCase(CharSequence string, boolean lower) {
-        logDeprecation(8);
-        if (lower) {
-            logDeprecation(7);
-        }
         if (string == null) {
             return null;
         }
@@ -400,7 +378,6 @@ public class GUtil {
      */
     public static String toConstant(CharSequence string) {
         if (string == null) {
-            logDeprecation(7);
             return null;
         }
         return toWords(string, '_').toUpperCase();
@@ -414,7 +391,6 @@ public class GUtil {
     }
 
     public static String toWords(CharSequence string, char separator) {
-        // TODO log deprecation once android 8.0 stable is released
         if (string == null) {
             return null;
         }
@@ -452,14 +428,12 @@ public class GUtil {
     }
 
     public static byte[] serialize(Object object) {
-        logDeprecation(7);
         StreamByteBuffer buffer = new StreamByteBuffer();
         serialize(object, buffer.getOutputStream());
         return buffer.readAsByteArray();
     }
 
     public static void serialize(Object object, OutputStream outputStream) {
-        logDeprecation(7);
         try {
             ObjectOutputStream objectOutputStream = new ObjectOutputStream(outputStream);
             objectOutputStream.writeObject(object);
@@ -470,7 +444,6 @@ public class GUtil {
     }
 
     public static <T> Comparator<T> last(final Comparator<? super T> comparator, final T lastValue) {
-        logDeprecation(7);
         return new Comparator<T>() {
             @Override
             public int compare(T o1, T o2) {
@@ -499,7 +472,6 @@ public class GUtil {
      */
     @Nullable
     public static <T> T uncheckedCall(Callable<T> callable) {
-        logDeprecation(7);
         try {
             return callable.call();
         } catch (Exception e) {
@@ -508,7 +480,6 @@ public class GUtil {
     }
 
     public static <T extends Enum<T>> T toEnum(Class<? extends T> enumType, Object value) {
-        logDeprecation(7);
         if (enumType.isInstance(value)) {
             return enumType.cast(value);
         }
@@ -556,7 +527,6 @@ public class GUtil {
     }
 
     public static <T extends Enum<T>> EnumSet<T> toEnumSet(Class<T> enumType, Iterable<?> values) {
-        logDeprecation(7);
         EnumSet<T> result = EnumSet.noneOf(enumType);
         for (Object value : values) {
             result.add(toEnum(enumType, value));
@@ -571,7 +541,6 @@ public class GUtil {
      * this check is faster than converting them to Strings and using {@link String#endsWith(String)}.
      */
     public static boolean endsWith(CharSequence longer, CharSequence shorter) {
-        logDeprecation(7);
         if (longer instanceof String && shorter instanceof String) {
             return ((String) longer).endsWith((String) shorter);
         }
@@ -589,7 +558,6 @@ public class GUtil {
     }
 
     public static URI toSecureUrl(URI scriptUri) {
-        logDeprecation(7);
         try {
             return new URI("https", null, scriptUri.getHost(), scriptUri.getPort(), scriptUri.getPath(), scriptUri.getQuery(), scriptUri.getFragment());
         } catch (URISyntaxException e) {
@@ -598,7 +566,6 @@ public class GUtil {
     }
 
     public static boolean isSecureUrl(URI url) {
-        logDeprecation(7);
         /*
          * TL;DR: http://127.0.0.1 will bypass this validation, http://localhost will fail this validation.
          *

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractAndroidSantaTrackerSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractAndroidSantaTrackerSmokeTest.groovy
@@ -107,6 +107,7 @@ class AbstractAndroidSantaTrackerSmokeTest extends AbstractSmokeTest {
                 expectConfigUtilDeprecationWarning(agpVersion)
                 expectBuildIdentifierIsCurrentBuildDeprecation(agpVersion)
                 expectBuildIdentifierNameDeprecation()
+                maybeExpectOrgGradleUtilGUtilDeprecation(agpVersion)
             }.build()
     }
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractKotlinPluginAndroidSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractKotlinPluginAndroidSmokeTest.groovy
@@ -62,6 +62,9 @@ abstract class AbstractKotlinPluginAndroidSmokeTest extends AbstractSmokeTest im
                     if (GradleContextualExecuter.configCache || kotlinPluginVersionNumber >= VersionNumber.parse("1.8.0")) {
                         expectBuildIdentifierIsCurrentBuildDeprecation(androidPluginVersion)
                     }
+                    2.times {
+                        maybeExpectOrgGradleUtilGUtilDeprecation(androidPluginVersion)
+                    }
                 }.build()
 
         then:

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
@@ -24,6 +24,7 @@ import org.gradle.internal.reflect.validation.ValidationMessageChecker
 import org.gradle.testkit.runner.TaskOutcome
 
 import static org.gradle.internal.reflect.validation.Severity.ERROR
+
 /**
  * For these tests to run you need to set ANDROID_SDK_ROOT to your Android SDK directory
  *
@@ -85,38 +86,6 @@ class AndroidPluginsSmokeTest extends AbstractPluginValidatingSmokeTest implemen
         ].combinations()
     }
 
-    def "simpler android library and application APK assembly test (agp=#agpVersion)"() {
-
-        given:
-        AGP_VERSIONS.assumeCurrentJavaVersionIsSupportedBy(agpVersion)
-
-        and:
-        androidLibraryAndApplicationBuild(agpVersion)
-
-        and:
-        def runner = useAgpVersion(agpVersion, runner(
-            'assembleDebug'
-        ))
-
-        when:
-        SantaTrackerConfigurationCacheWorkaround.beforeBuild(runner.projectDir, IntegrationTestBuildContext.INSTANCE.gradleUserHomeDir)
-        def result = runner.deprecations(AbstractAndroidSantaTrackerSmokeTest.SantaTrackerDeprecations) {
-            expectAndroidWorkerExecutionSubmitDeprecationWarning(agpVersion)
-            expectReportDestinationPropertyDeprecation(agpVersion)
-            expectProjectConventionDeprecationWarning(agpVersion)
-            expectAndroidConventionTypeDeprecationWarning(agpVersion)
-            expectBasePluginConventionDeprecation(agpVersion)
-            expectBuildIdentifierNameDeprecation()
-            expectBuildIdentifierIsCurrentBuildDeprecation(agpVersion)
-        }.build()
-
-        then:
-        result.task(':app:compileDebugJavaWithJavac').outcome == TaskOutcome.SUCCESS
-
-        where:
-        agpVersion << ["7.4.2"]
-    }
-
     def "android library and application APK assembly (agp=#agpVersion, ide=#ide)"() {
 
         given:
@@ -143,6 +112,9 @@ class AndroidPluginsSmokeTest extends AbstractPluginValidatingSmokeTest implemen
             expectBasePluginConventionDeprecation(agpVersion)
             expectBuildIdentifierNameDeprecation()
             expectBuildIdentifierIsCurrentBuildDeprecation(agpVersion)
+            if ((ide && !GradleContextualExecuter.configCache) || (!ide && GradleContextualExecuter.configCache)) {
+                maybeExpectOrgGradleUtilGUtilDeprecation(agpVersion)
+            }
         }.build()
 
         then:

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerSmokeTest.groovy
@@ -122,6 +122,7 @@ class AndroidSantaTrackerLintSmokeTest extends AndroidSantaTrackerSmokeTest {
             if (agpVersion.startsWith('7.')) {
                 expectBuildIdentifierNameDeprecation()
             }
+            maybeExpectOrgGradleUtilGUtilDeprecation(agpVersion)
         }
         def result = runner.buildAndFail()
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/SmokeTestGradleRunner.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/SmokeTestGradleRunner.groovy
@@ -30,6 +30,7 @@ class SmokeTestGradleRunner extends GradleRunner {
 
     private final DefaultGradleRunner delegate
     private final List<String> expectedDeprecationWarnings = []
+    private final List<String> maybeExpectedDeprecationWarnings = []
     private boolean ignoreDeprecationWarnings
 
     SmokeTestGradleRunner(DefaultGradleRunner delegate) {
@@ -119,6 +120,44 @@ class SmokeTestGradleRunner extends GradleRunner {
         return this
     }
 
+    /**
+     * Maybe expect a deprecation warning to appear when {@link #build()} or {@link #buildAndFail()} is called
+     * for an old version of a third-party plugin. The assumption is that the deprecation has already
+     * been fixed in a later version of the plugin, and thus no followup is needed.
+     *
+     * Does not fail the test if the warning does not appear in the output.
+     *
+     * WARNING: Only use for warnings that occurs intermittently. For example a deprecation warning for a function
+     * that is only called once per Gradle daemon from a third party plugin.
+     *
+     * @param warning the text of the warning to match.
+     */
+    SmokeTestGradleRunner maybeExpectLegacyDeprecationWarning(String warning) {
+        maybeExpectedDeprecationWarnings.add(warning)
+        return this
+    }
+
+    /**
+     * Maybe expect a deprecation warning to appear when {@link #build()} or {@link #buildAndFail()} is called
+     * for an old version of a third-party plugin if the given condition is true.
+     * The assumption is that the deprecation has already been fixed in a later version of the plugin,
+     * and thus no followup is needed.
+     *
+     * Does not fail the test if the warning does not appear in the output.
+     *
+     * WARNING: Only use for warnings that occurs intermittently. For example a deprecation warning for a function
+     * that is only called once per Gradle daemon from a third party plugin.
+     *
+     * @param condition only expect the warning to be produced when this condition is {@code true}.
+     * @param warning the text of the warning to match.
+     */
+    SmokeTestGradleRunner maybeExpectLegacyDeprecationWarningIf(boolean condition, String warning) {
+        if (condition) {
+            maybeExpectLegacyDeprecationWarning(warning)
+        }
+        return this
+    }
+
     SmokeTestGradleRunner ignoreDeprecationWarnings(String reason) {
         LOGGER.warn("Ignoring deprecation warnings because: {}", reason)
         ignoreDeprecationWarnings = true
@@ -148,7 +187,7 @@ class SmokeTestGradleRunner extends GradleRunner {
             return
         }
         def lines = result.output.readLines()
-        def remainingWarnings = new ArrayList<>(expectedDeprecationWarnings)
+        def remainingWarnings = new ArrayList<>(expectedDeprecationWarnings + maybeExpectedDeprecationWarnings)
         def totalExpectedDeprecations = remainingWarnings.size()
         int foundDeprecations = 0
         lines.eachWithIndex { String line, int lineIndex ->
@@ -158,6 +197,7 @@ class SmokeTestGradleRunner extends GradleRunner {
             }
             assert !line.contains("has been deprecated"), "Found an unexpected deprecation warning on line ${lineIndex + 1}: $line"
         }
+        remainingWarnings.removeAll(maybeExpectedDeprecationWarnings)
         assert remainingWarnings.empty, "Expected ${totalExpectedDeprecations} deprecation warnings, found ${foundDeprecations} deprecation warnings. Did not match the following:\n${remainingWarnings.collect { " - $it" }.join("\n")}"
         expectedDeprecationWarnings.clear()
     }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyGradleModuleMetadataSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyGradleModuleMetadataSmokeTest.groovy
@@ -148,12 +148,13 @@ class ThirdPartyGradleModuleMetadataSmokeTest extends AbstractSmokeTest {
     private static SmokeTestGradleRunner expectingDeprecations(SmokeTestGradleRunner runner, String kotlinVersion, String agpVersion) {
         VersionNumber kotlinVersionNumber = VersionNumber.parse(kotlinVersion)
         VersionNumber agpVersionNumber = VersionNumber.parse(agpVersion)
-        return runner.deprecations(KotlinPluginSmokeTest.KotlinDeprecations) {
+        return runner.deprecations(KotlinAndroidDeprecations) {
             expectOrgGradleUtilWrapUtilDeprecation(kotlinVersionNumber)
             expectProjectConventionDeprecation(kotlinVersionNumber, agpVersionNumber)
             expectConventionTypeDeprecation(kotlinVersionNumber, agpVersionNumber)
             expectJavaPluginConventionDeprecation(kotlinVersionNumber)
             expectBasePluginConventionDeprecation(kotlinVersionNumber, agpVersionNumber)
+            maybeExpectOrgGradleUtilGUtilDeprecation(agpVersion)
         }
     }
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithAndroidDeprecations.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithAndroidDeprecations.groovy
@@ -96,4 +96,14 @@ trait WithAndroidDeprecations implements WithReportDeprecations {
             "https://issuetracker.google.com/issues/279306626"
         )
     }
+
+    void maybeExpectOrgGradleUtilGUtilDeprecation(String agpVersion) {
+        runner.maybeExpectLegacyDeprecationWarningIf(
+            VersionNumber.parse(agpVersion) < VersionNumber.parse("7.5"),
+            "The org.gradle.util.GUtil type has been deprecated. " +
+                "This is scheduled to be removed in Gradle 9.0. " +
+                "Consult the upgrading guide for further information: " +
+                "${DOCUMENTATION_REGISTRY.getDocumentationFor("upgrading_version_7", "org_gradle_util_reports_deprecations")}"
+        )
+    }
 }


### PR DESCRIPTION
* Fix https://github.com/gradle/gradle/issues/21912
* Fix https://github.com/gradle/gradle/issues/21899
* Follow up for https://github.com/gradle/gradle/pull/21843

No change in the deprecation documentation link as it already said the type was deprecated even if a couple functions from it did not nag yet because of some consumers.

AGP < 7.5 still uses `GUtil`, in some cases only once per Gradle daemon. This makes it hard to assert on deprecation warnings without making all tests use a fresh daemon which would make these tests take way too long. Instead this PR introduces a way to ignore selected deprecation warnings on old version of third party plugins in smoke tests.