### PR TITLE
Omit link to CC report when no CC problems exist

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/AbstractConfigurationCacheIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/AbstractConfigurationCacheIntegrationTest.groovy
@@ -31,6 +31,8 @@ abstract class AbstractConfigurationCacheIntegrationTest extends AbstractOptInFe
     static final String DISABLE_CLI_OPT = "--no-${ConfigurationCacheOption.LONG_OPTION}"
     static final String DISABLE_GRADLE_PROP = "${ConfigurationCacheOption.PROPERTY_NAME}=false"
     static final String DISABLE_SYS_PROP = "-D$DISABLE_GRADLE_PROP"
+    // Should be provided if a link to the report is expected even if no errors were found
+    static final String LOG_REPORT_LINK_AS_WARNING = "-Dorg.gradle.configuration-cache.internal.report-link-as-warning=true"
 
     static final String MAX_PROBLEMS_GRADLE_PROP = "${ConfigurationCacheMaxProblemsOption.PROPERTY_NAME}"
     static final String MAX_PROBLEMS_SYS_PROP = "-D$MAX_PROBLEMS_GRADLE_PROP"
@@ -41,17 +43,17 @@ abstract class AbstractConfigurationCacheIntegrationTest extends AbstractOptInFe
 
     @Override
     void configurationCacheRun(String... tasks) {
-        run(ENABLE_CLI_OPT, *tasks)
+        run(ENABLE_CLI_OPT, LOG_REPORT_LINK_AS_WARNING, *tasks)
     }
 
     @Override
     void configurationCacheRunLenient(String... tasks) {
-        run(ENABLE_CLI_OPT, WARN_PROBLEMS_CLI_OPT, *tasks)
+        run(ENABLE_CLI_OPT, LOG_REPORT_LINK_AS_WARNING, WARN_PROBLEMS_CLI_OPT, *tasks)
     }
 
     @Override
     void configurationCacheFails(String... tasks) {
-        fails(ENABLE_CLI_OPT, *tasks)
+        fails(ENABLE_CLI_OPT, LOG_REPORT_LINK_AS_WARNING, *tasks)
     }
 
     String relativePath(String path) {

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheProblemReportingIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheProblemReportingIntegrationTest.groovy
@@ -175,7 +175,7 @@ class ConfigurationCacheProblemReportingIntegrationTest extends AbstractConfigur
         reportDir.isDirectory()
 
         def reportLocationShown = resolveConfigurationCacheReport(testDirectory.file('out'), output)
-        reportDir.isDescendent(reportLocationShown)
+        reportDir.isDescendant(reportLocationShown)
     }
 
     def "report is not created when there are no CC problems or inputs"() {

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/initialization/ConfigurationCacheStartParameter.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/initialization/ConfigurationCacheStartParameter.kt
@@ -51,6 +51,12 @@ class ConfigurationCacheStartParameter(
 
     val encryptionAlgorithm: String = options.getInternalString("org.gradle.configuration-cache.internal.encryption-alg", SupportedEncryptionAlgorithm.AES_ECB_PADDING.transformation)
 
+    /**
+     * Should be provided if a link to the report is expected even if no errors were found.
+     * Useful in testing.
+     */
+    val alwaysLogReportLinkAsWarning: Boolean = options.getInternalFlag("org.gradle.configuration-cache.internal.report-link-as-warning", false)
+
     val gradleProperties: Map<String, Any?>
         get() = startParameter.projectProperties
 

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheProblems.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheProblems.kt
@@ -177,7 +177,8 @@ class ConfigurationCacheProblems(
             }
 
             else -> {
-                val log: (String) -> Unit = if (hasNoProblems) logger::info else logger::warn
+                val logReportAsInfo = hasNoProblems && !startParameter.alwaysLogReportLinkAsWarning
+                val log: (String) -> Unit = if (logReportAsInfo) logger::info else logger::warn
                 log(summary.textForConsole(cacheActionText, htmlReportFile))
             }
         }

--- a/subprojects/docs/src/snippets/configurationCache/problemsFixed/tests/store-another.out
+++ b/subprojects/docs/src/snippets/configurationCache/problemsFixed/tests/store-another.out
@@ -1,9 +1,5 @@
 Calculating task graph as configuration cache cannot be reused because system property 'someDestination' has changed.
 > Task :someTask
 
-0 problems were found storing the configuration cache.
-
-See the complete report at file:///home/user/gradle/samples/build/reports/configuration-cache/<hash>/configuration-cache-report.html
-
 BUILD SUCCESSFUL in 0s
 1 actionable task: 1 executed

--- a/subprojects/docs/src/snippets/configurationCache/problemsFixed/tests/store.out
+++ b/subprojects/docs/src/snippets/configurationCache/problemsFixed/tests/store.out
@@ -1,9 +1,5 @@
 Calculating task graph as no configuration cache is available for tasks: someTask
 > Task :someTask
 
-0 problems were found storing the configuration cache.
-
-See the complete report at file:///home/user/gradle/samples/build/reports/configuration-cache/<hash>/configuration-cache-report.html
-
 BUILD SUCCESSFUL in 0s
 1 actionable task: 1 executed

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -1106,7 +1106,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
     private void ensureSettingsFileAvailable() {
         TestFile workingDir = new TestFile(getWorkingDir());
         TestFile dir = workingDir;
-        while (dir != null && getTestDirectoryProvider().getTestDirectory().isSelfOrDescendent(dir)) {
+        while (dir != null && getTestDirectoryProvider().getTestDirectory().isSelfOrDescendant(dir)) {
             if (hasSettingsFile(dir) || hasSettingsFile(dir.file("master"))) {
                 return;
             }

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFile.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFile.java
@@ -637,14 +637,14 @@ public class TestFile extends File {
         }
     }
 
-    public boolean isSelfOrDescendent(File file) {
+    public boolean isSelfOrDescendant(File file) {
         if (file.getAbsolutePath().equals(getAbsolutePath())) {
             return true;
         }
-        return isDescendent(file);
+        return isDescendant(file);
     }
 
-    public boolean isDescendent(File file) {
+    public boolean isDescendant(File file) {
         return file.getAbsolutePath().startsWith(getAbsolutePath() + File.separatorChar);
     }
 

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFile.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFile.java
@@ -641,6 +641,10 @@ public class TestFile extends File {
         if (file.getAbsolutePath().equals(getAbsolutePath())) {
             return true;
         }
+        return isDescendent(file);
+    }
+
+    public boolean isDescendent(File file) {
         return file.getAbsolutePath().startsWith(getAbsolutePath() + File.separatorChar);
     }
 


### PR DESCRIPTION
A link to a CC report is considered distracting if there are no CC
problems - even more so if the build is already
failing for non-CC reasons. This change set no longer includes a link
to the CC report if no CC errors occur (no matter whether there are
other non-CC failures). The link is still shown with info logging level.

Fixes: #24248
