### PR TITLE
Move some project configuration at project creation time

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectFactory.java
@@ -63,12 +63,11 @@ public class ProjectFactory implements IProjectFactory {
             selfClassLoaderScope,
             baseClassLoaderScope
         );
+        gradle.getServices().get(DependencyResolutionManagementInternal.class).configureProject(project);
         project.beforeEvaluate(p -> {
             NameValidator.validate(project.getName(), "project name", DefaultProjectDescriptor.INVALID_NAME_IN_INCLUDE_HINT);
             gradle.getServices().get(DependenciesAccessors.class).createExtensions(project);
-            gradle.getServices().get(DependencyResolutionManagementInternal.class).configureProject(project);
         });
-
         gradle.getProjectRegistry().addProject(project);
         return project;
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
@@ -194,6 +194,8 @@ class DefaultProjectSpec extends Specification {
             createFor(_) >> serviceRegistry
         }
 
+        build.services >> serviceRegistry
+
         def container = Mock(ProjectState)
         _ * container.projectPath >> (parent == null ? Path.ROOT : parent.projectPath.child(name))
         _ * container.identityPath >> (parent == null ? build.identityPath : build.identityPath.append(parent.projectPath).child(name))


### PR DESCRIPTION
Previously, this was done in the `beforeEvaluate` hook, but it runs after `allprojects` and `subprojecs` invocations in Gradle or parent projects.

Fixes #25307