### PR TITLE
Don't use `withVariantReselection` for Jacoco report aggregation with only the `classes` attribute present

### DIFF
--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoReportAggregationPlugin.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoReportAggregationPlugin.java
@@ -91,7 +91,7 @@ public abstract class JacocoReportAggregationPlugin implements Plugin<Project> {
         });
 
         ArtifactView classDirectories = codeCoverageResultsConf.getIncoming().artifactView(view -> {
-            view.withVariantReselection();
+            //view.withVariantReselection();
             view.componentFilter(id -> id instanceof ProjectComponentIdentifier);
             view.attributes(attributes -> {
                 attributes.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements.class, LibraryElements.CLASSES));

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoReportAggregationPlugin.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoReportAggregationPlugin.java
@@ -91,7 +91,6 @@ public abstract class JacocoReportAggregationPlugin implements Plugin<Project> {
         });
 
         ArtifactView classDirectories = codeCoverageResultsConf.getIncoming().artifactView(view -> {
-            //view.withVariantReselection();
             view.componentFilter(id -> id instanceof ProjectComponentIdentifier);
             view.attributes(attributes -> {
                 attributes.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements.class, LibraryElements.CLASSES));


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #25618 