### PR TITLE
Allow lazy configuration dependencies to resolve current project

### DIFF
--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalConfigurationMetadataBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalConfigurationMetadataBuilderTest.groovy
@@ -96,11 +96,15 @@ class DefaultLocalConfigurationMetadataBuilderTest extends Specification {
 
         then:
         1 * configuration.runDependencyActions()
+
+        when:
+        def dependencies = metaData.dependencies
+
+        then:
         1 * dependencySet.iterator() >> [dependency1, dependency2].iterator()
         1 * dependencyMetadataFactory.createDependencyMetadata(componentId, "config", _, dependency1) >> dependencyDescriptor1
         1 * dependencyMetadataFactory.createDependencyMetadata(componentId, "config", _, dependency2) >> dependencyDescriptor2
-
-        metaData.dependencies == [dependencyDescriptor1, dependencyDescriptor2]
+        dependencies == [dependencyDescriptor1, dependencyDescriptor2]
     }
 
     def "adds DependencyConstraint instances from configuration"() {
@@ -114,11 +118,15 @@ class DefaultLocalConfigurationMetadataBuilderTest extends Specification {
 
         then:
         1 * configuration.runDependencyActions()
+
+        when:
+        def dependencies = metaData.dependencies
+
+        then:
         1 * dependencyConstraintSet.iterator() >> [dependencyConstraint1, dependencyConstraint2].iterator()
         1 * dependencyMetadataFactory.createDependencyConstraintMetadata(componentId, "config", _, dependencyConstraint1) >> dependencyDescriptor1
         1 * dependencyMetadataFactory.createDependencyConstraintMetadata(componentId, "config", _, dependencyConstraint2) >> dependencyDescriptor2
-
-        metaData.dependencies == [dependencyDescriptor1, dependencyDescriptor2]
+        dependencies == [dependencyDescriptor1, dependencyDescriptor2]
     }
 
     def "adds FileCollectionDependency instances from configuration"() {
@@ -130,9 +138,13 @@ class DefaultLocalConfigurationMetadataBuilderTest extends Specification {
 
         then:
         1 * configuration.runDependencyActions()
-        1 * dependencySet.iterator() >> [dependency1, dependency2].iterator()
 
-        metaData.files*.source == [dependency1, dependency2]
+        when:
+        def files = metaData.files
+
+        then:
+        1 * dependencySet.iterator() >> [dependency1, dependency2].iterator()
+        files*.source == [dependency1, dependency2]
     }
 
     def "adds exclude rule from configuration"() {
@@ -144,10 +156,14 @@ class DefaultLocalConfigurationMetadataBuilderTest extends Specification {
 
         then:
         1 * configuration.runDependencyActions()
+
+        when:
+        def excludes = metaData.excludes
+
+        then:
         1 * configuration.excludeRules >> ([excludeRule] as Set)
         1 * excludeRuleConverter.convertExcludeRule(excludeRule) >> ivyExcludeRule
-
-        metaData.getExcludes() == ImmutableList.of(ivyExcludeRule)
+        excludes == ImmutableList.of(ivyExcludeRule)
     }
 
     def create() {


### PR DESCRIPTION
Prior to 8.2, addAllLater hooks on a configuration could resolve other configurations in the same project in order to determine the dependencies to add. 8.2 added a change which eager calculated confguration metadata dependenices for all consumable variants in the same project, causing a stackoverflow. This once again makes configuration dependency calculation lazy, avoiding a stackoverflow. Note, a stackoverflow will likely still happen if the configuration with the lazy dependencies selects itself. But, this makes no sense conceptually.

Fixes: https://github.com/gradle/gradle/issues/25579