### PR TITLE
Remove failing CodeNarc version

### DIFF
--- a/platforms/jvm/code-quality/src/testFixtures/groovy/org/gradle/quality/integtest/fixtures/CodeNarcCoverage.groovy
+++ b/platforms/jvm/code-quality/src/testFixtures/groovy/org/gradle/quality/integtest/fixtures/CodeNarcCoverage.groovy
@@ -21,7 +21,7 @@ import org.gradle.api.plugins.quality.CodeNarcPlugin
 import org.gradle.util.internal.VersionNumber
 
 class CodeNarcCoverage {
-    public static final List<String> ALL = [CodeNarcPlugin.DEFAULT_CODENARC_VERSION, "0.17", "0.21", "0.23", "0.24.1", "0.25.2", "1.0", "1.6.1", "2.0.0", "2.2.0", "3.0.1"].asImmutable()
+    public static final List<String> ALL = [CodeNarcPlugin.DEFAULT_CODENARC_VERSION, "1.0", "1.6.1", "2.0.0", "2.2.0", "3.0.1"].asImmutable()
 
     private static boolean isAtLeastGroovy4() {
         return VersionNumber.parse(GroovySystem.version).major >= 4


### PR DESCRIPTION
Because they're very old (2005). We don't
want to invest time to maintain these old versions.

Failure example: https://ge.gradle.org/s/xj6zufynjmdky
