### PR TITLE
Fix and clean JacocoAggregationReportPlugin

### DIFF
--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoReportAggregationPlugin.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoReportAggregationPlugin.java
@@ -60,6 +60,7 @@ public abstract class JacocoReportAggregationPlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
+        project.getPluginManager().apply("org.gradle.reporting-base");
         project.getPluginManager().apply("jvm-ecosystem");
         project.getPluginManager().apply("jacoco");
 

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoReportAggregationPlugin.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoReportAggregationPlugin.java
@@ -24,7 +24,6 @@ import org.gradle.api.artifacts.ArtifactView;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
-import org.gradle.api.attributes.Bundling;
 import org.gradle.api.attributes.Category;
 import org.gradle.api.attributes.LibraryElements;
 import org.gradle.api.attributes.TestSuiteType;

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoReportAggregationPlugin.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoReportAggregationPlugin.java
@@ -29,8 +29,7 @@ import org.gradle.api.attributes.Category;
 import org.gradle.api.attributes.LibraryElements;
 import org.gradle.api.attributes.TestSuiteType;
 import org.gradle.api.attributes.VerificationType;
-import org.gradle.api.file.FileCollection;
-import org.gradle.api.internal.artifacts.configurations.ConfigurationRolesForMigration;
+import org.gradle.api.internal.artifacts.configurations.ConfigurationRoles;
 import org.gradle.api.internal.artifacts.configurations.RoleBasedConfigurationContainerInternal;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.model.ObjectFactory;
@@ -44,7 +43,6 @@ import org.gradle.testing.base.TestingExtension;
 import org.gradle.testing.jacoco.tasks.JacocoReport;
 
 import javax.inject.Inject;
-import java.util.concurrent.Callable;
 
 /**
  * Adds configurations to for resolving variants containing JaCoCo code coverage results, which may span multiple subprojects.  Reacts to the presence of the jvm-test-suite plugin and creates
@@ -63,31 +61,31 @@ public abstract class JacocoReportAggregationPlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
-        project.getPluginManager().apply("org.gradle.reporting-base");
         project.getPluginManager().apply("jvm-ecosystem");
         project.getPluginManager().apply("jacoco");
+
 
         RoleBasedConfigurationContainerInternal configurations = ((ProjectInternal) project).getConfigurations();
         Configuration jacocoAggregation = configurations.bucket(JACOCO_AGGREGATION_CONFIGURATION_NAME);
         jacocoAggregation.setDescription("Collects project dependencies for purposes of JaCoCo coverage report aggregation");
         jacocoAggregation.setVisible(false);
-        jacocoAggregation.setTransitive(true);
 
-        ObjectFactory objects = project.getObjects();
-        @SuppressWarnings("deprecation") Configuration codeCoverageResultsConf = configurations.createWithRole("aggregateCodeCoverageReportResults", ConfigurationRolesForMigration.RESOLVABLE_BUCKET_TO_RESOLVABLE);
-        codeCoverageResultsConf.setDescription("Graph needed for the aggregated JaCoCo coverage report.");
+        Configuration codeCoverageResultsConf = configurations.createWithRole("aggregateCodeCoverageReportResults", ConfigurationRoles.RESOLVABLE);
+        codeCoverageResultsConf.setDescription("Resolvable configuration used to gather files for the JaCoCo coverage report aggregation via ArtifactViews, not intended to be used directly");
         codeCoverageResultsConf.extendsFrom(jacocoAggregation);
         codeCoverageResultsConf.setVisible(false);
-        jacocoAggregation.setTransitive(true);
+
+        project.getPlugins().withType(JavaBasePlugin.class, plugin -> {
+            // If the current project is jvm-based, aggregate dependent projects as jvm-based as well.
+            getEcosystemUtilities().configureAsRuntimeClasspath(codeCoverageResultsConf);
+        });
+
+        ObjectFactory objects = project.getObjects();
 
         ArtifactView sourceDirectories = codeCoverageResultsConf.getIncoming().artifactView(view -> {
             view.withVariantReselection();
             view.componentFilter(id -> id instanceof ProjectComponentIdentifier);
-            view.attributes(attributes -> {
-                attributes.attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.class, Bundling.EXTERNAL));
-                attributes.attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.class, Category.VERIFICATION));
-                attributes.attribute(VerificationType.VERIFICATION_TYPE_ATTRIBUTE, objects.named(VerificationType.class, VerificationType.MAIN_SOURCES));
-            });
+            getEcosystemUtilities().configureAsSources(view);
         });
 
         ArtifactView classDirectories = codeCoverageResultsConf.getIncoming().artifactView(view -> {
@@ -103,25 +101,19 @@ public abstract class JacocoReportAggregationPlugin implements Plugin<Project> {
         // Iterate and configure each user-specified report.
         reporting.getReports().withType(JacocoCoverageReport.class).all(report -> {
             report.getReportTask().configure(task -> {
-                Callable<FileCollection> executionData = () ->
-                    codeCoverageResultsConf.getIncoming().artifactView(view -> {
-                        view.withVariantReselection();
-                        view.componentFilter(id -> id instanceof ProjectComponentIdentifier);
-                        view.attributes(attributes -> {
-                            attributes.attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.class, Category.VERIFICATION));
-                            attributes.attributeProvider(TestSuiteType.TEST_SUITE_TYPE_ATTRIBUTE, report.getTestType().map(tt -> objects.named(TestSuiteType.class, tt)));
-                            attributes.attribute(VerificationType.VERIFICATION_TYPE_ATTRIBUTE, objects.named(VerificationType.class, VerificationType.JACOCO_RESULTS));
-                            attributes.attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.BINARY_DATA_TYPE);
-                        });
-                    }).getFiles();
+                ArtifactView executionData = codeCoverageResultsConf.getIncoming().artifactView(view -> {
+                    view.withVariantReselection();
+                    view.componentFilter(id -> id instanceof ProjectComponentIdentifier);
+                    view.attributes(attributes -> {
+                        attributes.attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.class, Category.VERIFICATION));
+                        attributes.attributeProvider(TestSuiteType.TEST_SUITE_TYPE_ATTRIBUTE, report.getTestType().map(tt -> objects.named(TestSuiteType.class, tt)));
+                        attributes.attribute(VerificationType.VERIFICATION_TYPE_ATTRIBUTE, objects.named(VerificationType.class, VerificationType.JACOCO_RESULTS));
+                        attributes.attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.BINARY_DATA_TYPE);
+                    });
+                });
 
                 configureReportTaskInputs(task, classDirectories, sourceDirectories, executionData);
             });
-        });
-
-        project.getPlugins().withType(JavaBasePlugin.class, plugin -> {
-            // If the current project is jvm-based, aggregate dependent projects as jvm-based as well.
-            getEcosystemUtilities().configureAsRuntimeClasspath(codeCoverageResultsConf);
         });
 
         // convention for synthesizing reports based on existing test suites in "this" project
@@ -140,8 +132,8 @@ public abstract class JacocoReportAggregationPlugin implements Plugin<Project> {
         });
     }
 
-    private void configureReportTaskInputs(JacocoReport task, ArtifactView classDirectories, ArtifactView sourceDirectories, Callable<FileCollection> executionData) {
-        task.getExecutionData().from(executionData);
+    private void configureReportTaskInputs(JacocoReport task, ArtifactView classDirectories, ArtifactView sourceDirectories, ArtifactView executionData) {
+        task.getExecutionData().from(executionData.getFiles());
         task.getClassDirectories().from(classDirectories.getFiles());
         task.getSourceDirectories().from(sourceDirectories.getFiles());
     }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmEcosystemAttributesDetails.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmEcosystemAttributesDetails.java
@@ -20,6 +20,7 @@ import org.gradle.api.attributes.Category;
 import org.gradle.api.attributes.DocsType;
 import org.gradle.api.attributes.LibraryElements;
 import org.gradle.api.attributes.Usage;
+import org.gradle.api.attributes.VerificationType;
 import org.gradle.api.attributes.java.TargetJvmEnvironment;
 import org.gradle.api.attributes.java.TargetJvmVersion;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
@@ -110,6 +111,13 @@ public class DefaultJvmEcosystemAttributesDetails implements JvmEcosystemAttribu
     @Override
     public JvmEcosystemAttributesDetails preferStandardJVM() {
         attributes.attribute(TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE, objectFactory.named(TargetJvmEnvironment.class, TargetJvmEnvironment.STANDARD_JVM));
+        return this;
+    }
+
+    @Override
+    public JvmEcosystemAttributesDetails asSources() {
+        attributes.attribute(Category.CATEGORY_ATTRIBUTE, objectFactory.named(Category.class, Category.VERIFICATION));
+        attributes.attribute(VerificationType.VERIFICATION_TYPE_ATTRIBUTE, objectFactory.named(VerificationType.class, VerificationType.MAIN_SOURCES));
         return this;
     }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmPluginServices.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmPluginServices.java
@@ -111,6 +111,14 @@ public class DefaultJvmPluginServices implements JvmPluginServices {
     }
 
     @Override
+    public void configureAsSources(HasConfigurableAttributes<?> configuration) {
+        configureAttributes(
+            configuration,
+            details -> details.withExternalDependencies().asSources()
+        );
+    }
+
+    @Override
     public <T> void configureAttributes(HasConfigurableAttributes<T> configurable, Action<? super JvmEcosystemAttributesDetails> configuration) {
         AttributeContainerInternal attributes = (AttributeContainerInternal) configurable.getAttributes();
         DefaultJvmEcosystemAttributesDetails details = instanceGenerator.newInstance(DefaultJvmEcosystemAttributesDetails.class, objectFactory, attributes);

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/JvmEcosystemAttributesDetails.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/JvmEcosystemAttributesDetails.java
@@ -94,4 +94,11 @@ public interface JvmEcosystemAttributesDetails {
      * Expresses that variants which are optimized for standard JVMs should be preferred.
      */
     JvmEcosystemAttributesDetails preferStandardJVM();
+
+    /**
+     * Provides or requires the source files of a component.
+     *
+     * @return {@code this}
+     */
+    JvmEcosystemAttributesDetails asSources();
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/JvmEcosystemUtilities.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/JvmEcosystemUtilities.java
@@ -79,6 +79,13 @@ public interface JvmEcosystemUtilities {
      */
     void configureAsRuntimeElements(HasConfigurableAttributes<?> configuration);
 
+    /**
+     * Configures a configuration with reasonable defaults to be resolved as a project's main sources variant.
+     *
+     * @param configuration the configuration to be configured
+     */
+    void configureAsSources(HasConfigurableAttributes<?> configuration);
+
     <T> void configureAttributes(HasConfigurableAttributes<T> configurableAttributes, Action<? super JvmEcosystemAttributesDetails> details);
 
     /**


### PR DESCRIPTION
Re-implements the fix from https://github.com/gradle/gradle/pull/25625 and tidies up the code in the plugin itself, removing redundancies and unnecessary calls and grouping related elements.
