### PR TITLE
Bump OpenTest4j required version in testing from 1.3.0-RC2 to 1.3.0

### DIFF
--- a/subprojects/testing-jvm-infrastructure/build.gradle.kts
+++ b/subprojects/testing-jvm-infrastructure/build.gradle.kts
@@ -47,7 +47,7 @@ dependencies {
     testImplementation("org.opentest4j:opentest4j") {
         version {
             // MultipleFailuresError appears only since 1.3.0-RC2
-            require("1.3.0-RC2")
+            require("1.3.0")
         }
         because("We test assertion errors coming from OpenTest4J")
     }


### PR DESCRIPTION
We worked against an RC of OpenTest4j to develop #25382.
As GA is out, it feels more appropriate to have that version form now on.