### PR TITLE
Fix NPE in incremental compilation of projects with '*' annotation processor and 'module-info.java' 

### DIFF
--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/AbstractIncrementalAnnotationProcessingIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/AbstractIncrementalAnnotationProcessingIntegrationTest.groovy
@@ -78,7 +78,7 @@ abstract class AbstractIncrementalAnnotationProcessingIntegrationTest extends Ab
         javaInPackage('', classBodies)
     }
 
-    protected final File javaInPackage(String packageName, String... classBodies) {
+    protected final File javaInPackage(String packageName, @Language("java") String... classBodies) {
         File out
         def packageStatement = packageName.empty ? "" : "package ${packageName};\n"
         def packagePathPrefix = packageName.empty ? '' : "${packageName.replace('.', '/')}/"

--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/AggregatingIncrementalAnnotationProcessingIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/AggregatingIncrementalAnnotationProcessingIntegrationTest.groovy
@@ -24,6 +24,8 @@ import org.gradle.language.fixtures.HelperProcessorFixture
 import org.gradle.language.fixtures.PackageInfoGeneratedClassProcessorFixture
 import org.gradle.language.fixtures.ResourceGeneratingProcessorFixture
 import org.gradle.language.fixtures.ServiceRegistryProcessorFixture
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.UnitTestPreconditions
 import spock.lang.Issue
 
 import javax.tools.StandardLocation
@@ -516,6 +518,7 @@ class AggregatingIncrementalAnnotationProcessingIntegrationTest extends Abstract
         outputs.recompiledClasses("Unrelated")
     }
 
+    @Requires(UnitTestPreconditions.Jdk9OrLater)
     def "module-info.java does not cause exception in annotation processor handling"() {
         given:
         withProcessor(new AnnotationProcessorFixture("foo", "FooAnnotation", true).withDeclaredType(IncrementalAnnotationProcessorType.AGGREGATING))

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/AggregatingProcessingStrategy.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/AggregatingProcessingStrategy.java
@@ -26,6 +26,7 @@ import javax.tools.JavaFileManager;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -75,6 +76,7 @@ class AggregatingProcessingStrategy extends IncrementalProcessingStrategy {
             .stream()
             .map(ElementUtils::getTopLevelType)
             .map(ElementUtils::getElementName)
+            .filter(Objects::nonNull)
             .collect(Collectors.toSet());
     }
 

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/ElementUtils.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/ElementUtils.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.tasks.compile.processing;
 
 import com.google.common.collect.Sets;
 
+import javax.annotation.Nullable;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
@@ -67,6 +68,7 @@ public class ElementUtils {
         throw new IllegalArgumentException("Unexpected element " + originatingElement);
     }
 
+    @Nullable
     public static String getElementName(Element current) {
         if (current instanceof PackageElement) {
             String packageName = ((PackageElement) current).getQualifiedName().toString();
@@ -80,7 +82,7 @@ public class ElementUtils {
             TypeElement typeElement = (TypeElement) current;
             return typeElement.getQualifiedName().toString();
         }
-        return null;
+        return null; // for ModuleElement, which is a top level element, this method currently returns 'null'
     }
 
     public static Element getTopLevelType(Element originatingElement) {

--- a/platforms/jvm/language-java/src/testFixtures/groovy/org/gradle/language/fixtures/AnnotationProcessorFixture.groovy
+++ b/platforms/jvm/language-java/src/testFixtures/groovy/org/gradle/language/fixtures/AnnotationProcessorFixture.groovy
@@ -30,8 +30,9 @@ import org.gradle.test.fixtures.file.TestFile
  * declares itself as incremental, but doesn't honor that contract.
  */
 @CompileStatic
-abstract class AnnotationProcessorFixture {
+class AnnotationProcessorFixture {
     protected final String annotationName
+    protected final String supportedAnnotationTypes;
     protected final String annotationPackageName
     protected final String fqAnnotationName
     IncrementalAnnotationProcessorType declaredType
@@ -40,8 +41,9 @@ abstract class AnnotationProcessorFixture {
         this('', annotationName)
     }
 
-    AnnotationProcessorFixture(String annotationPackageName, String annotationName) {
+    AnnotationProcessorFixture(String annotationPackageName, String annotationName, boolean processAllCode = false) {
         this.annotationName = annotationName
+        this.supportedAnnotationTypes = processAllCode ? '"*"' : "${annotationName}.class.getName()"
         this.annotationPackageName = annotationPackageName
         this.fqAnnotationName = annotationPackageName.empty ? annotationName : "${annotationPackageName}.${annotationName}"
     }
@@ -99,7 +101,7 @@ abstract class AnnotationProcessorFixture {
 
                 @Override
                 public Set<String> getSupportedAnnotationTypes() {
-                    return Collections.singleton(${annotationName}.class.getName());
+                    return Collections.singleton(${supportedAnnotationTypes});
                 }
 
                 ${supportedOptionsBlock}
@@ -150,8 +152,9 @@ abstract class AnnotationProcessorFixture {
         }
     }
 
-    protected abstract String getGeneratorCode();
-
+    protected String getGeneratorCode() {
+        ""
+    }
     protected String getSupportedOptionsBlock() {
         ""
     }


### PR DESCRIPTION
### Context

See test that reproduces the issue.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- ~[ ] Provide unit tests (under `<subproject>/src/test`) to verify logic~
- ~[ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes~
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
