### PR TITLE
Remove all unwanted occurrences of o.g.unsafe.c-c

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx2500m -XX:MaxMetaspaceSize=768m -XX:+HeapDumpOnOutOfMemor
 org.gradle.parallel=true
 org.gradle.caching=true
 
-org.gradle.unsafe.configuration-cache=true
+org.gradle.configuration-cache=true
 
 systemProp.gradle.publish.skip.namespace.check=true
 

--- a/subprojects/docs/src/docs/userguide/running-builds/performance.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/performance.adoc
@@ -178,7 +178,7 @@ To enable the configuration cache by default, add the following setting to the `
 .gradle.properties
 [source,properties]
 ----
-org.gradle.unsafe.configuration-cache=true
+org.gradle.configuration-cache=true
 ----
 ====
 

--- a/subprojects/docs/src/snippets/configurationCache/disallowedTypes/groovy/gradle.properties
+++ b/subprojects/docs/src/snippets/configurationCache/disallowedTypes/groovy/gradle.properties
@@ -1,1 +1,1 @@
-org.gradle.unsafe.configuration-cache=true
+org.gradle.configuration-cache=true

--- a/subprojects/docs/src/snippets/configurationCache/disallowedTypes/kotlin/gradle.properties
+++ b/subprojects/docs/src/snippets/configurationCache/disallowedTypes/kotlin/gradle.properties
@@ -1,1 +1,1 @@
-org.gradle.unsafe.configuration-cache=true
+org.gradle.configuration-cache=true

--- a/subprojects/docs/src/snippets/configurationCache/noProblem/groovy/gradle.properties
+++ b/subprojects/docs/src/snippets/configurationCache/noProblem/groovy/gradle.properties
@@ -1,1 +1,1 @@
-org.gradle.unsafe.configuration-cache=true
+org.gradle.configuration-cache=true

--- a/subprojects/docs/src/snippets/configurationCache/problemsFixed/groovy/gradle.properties
+++ b/subprojects/docs/src/snippets/configurationCache/problemsFixed/groovy/gradle.properties
@@ -1,1 +1,1 @@
-org.gradle.unsafe.configuration-cache=true
+org.gradle.configuration-cache=true

--- a/subprojects/docs/src/snippets/configurationCache/problemsFixed/kotlin/gradle.properties
+++ b/subprojects/docs/src/snippets/configurationCache/problemsFixed/kotlin/gradle.properties
@@ -1,1 +1,1 @@
-org.gradle.unsafe.configuration-cache=true
+org.gradle.configuration-cache=true

--- a/subprojects/docs/src/snippets/configurationCache/problemsFixedReuse/groovy/gradle.properties
+++ b/subprojects/docs/src/snippets/configurationCache/problemsFixedReuse/groovy/gradle.properties
@@ -1,1 +1,1 @@
-org.gradle.unsafe.configuration-cache=true
+org.gradle.configuration-cache=true

--- a/subprojects/docs/src/snippets/configurationCache/problemsFixedReuse/kotlin/gradle.properties
+++ b/subprojects/docs/src/snippets/configurationCache/problemsFixedReuse/kotlin/gradle.properties
@@ -1,1 +1,1 @@
-org.gradle.unsafe.configuration-cache=true
+org.gradle.configuration-cache=true

--- a/subprojects/docs/src/snippets/configurationCache/problemsGroovy/groovy/gradle.properties
+++ b/subprojects/docs/src/snippets/configurationCache/problemsGroovy/groovy/gradle.properties
@@ -1,1 +1,1 @@
-org.gradle.unsafe.configuration-cache=true
+org.gradle.configuration-cache=true

--- a/subprojects/docs/src/snippets/configurationCache/problemsKotlin/kotlin/gradle.properties
+++ b/subprojects/docs/src/snippets/configurationCache/problemsKotlin/kotlin/gradle.properties
@@ -1,1 +1,1 @@
-org.gradle.unsafe.configuration-cache=true
+org.gradle.configuration-cache=true

--- a/subprojects/docs/src/snippets/configurationCache/projectAtExecution/groovy/gradle.properties
+++ b/subprojects/docs/src/snippets/configurationCache/projectAtExecution/groovy/gradle.properties
@@ -1,1 +1,1 @@
-org.gradle.unsafe.configuration-cache=true
+org.gradle.configuration-cache=true

--- a/subprojects/docs/src/snippets/configurationCache/projectAtExecution/kotlin/gradle.properties
+++ b/subprojects/docs/src/snippets/configurationCache/projectAtExecution/kotlin/gradle.properties
@@ -1,1 +1,1 @@
-org.gradle.unsafe.configuration-cache=true
+org.gradle.configuration-cache=true

--- a/subprojects/docs/src/snippets/configurationCache/projectAtExecutionFixed/groovy/gradle.properties
+++ b/subprojects/docs/src/snippets/configurationCache/projectAtExecutionFixed/groovy/gradle.properties
@@ -1,1 +1,1 @@
-org.gradle.unsafe.configuration-cache=true
+org.gradle.configuration-cache=true

--- a/subprojects/docs/src/snippets/configurationCache/projectAtExecutionFixed/kotlin/gradle.properties
+++ b/subprojects/docs/src/snippets/configurationCache/projectAtExecutionFixed/kotlin/gradle.properties
@@ -1,1 +1,1 @@
-org.gradle.unsafe.configuration-cache=true
+org.gradle.configuration-cache=true

--- a/subprojects/docs/src/snippets/configurationCache/stableFeatureFlag/common/gradle.properties
+++ b/subprojects/docs/src/snippets/configurationCache/stableFeatureFlag/common/gradle.properties
@@ -1,2 +1,2 @@
 # This is a workaround for https://github.com/gradle/gradle/issues/22481.
-org.gradle.unsafe.configuration-cache=true
+org.gradle.configuration-cache=true

--- a/subprojects/docs/src/snippets/configurationCache/topLevel/common/gradle.properties
+++ b/subprojects/docs/src/snippets/configurationCache/topLevel/common/gradle.properties
@@ -1,1 +1,1 @@
-org.gradle.unsafe.configuration-cache=true
+org.gradle.configuration-cache=true

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/StartParameterConverterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/StartParameterConverterTest.groovy
@@ -96,13 +96,13 @@ class StartParameterConverterTest extends Specification {
 
     def "can provide start parameter option as system property on command-line"() {
         expect:
-        def parameter = convert("-Dorg.gradle.unsafe.configuration-cache=true")
+        def parameter = convert("-Dorg.gradle.configuration-cache=true")
         parameter.configurationCache.get()
     }
 
     def "can provide start parameter option as persistent property"() {
         expect:
-        userHome.file("gradle.properties") << "org.gradle.unsafe.configuration-cache=true"
+        userHome.file("gradle.properties") << "org.gradle.configuration-cache=true"
         def parameter = convert()
         parameter.configurationCache.get()
     }


### PR DESCRIPTION
@alllex points out that we left an occurrence of the legacy (`o.g.unsafe.configuration-cache') CC enablement property key on this doc page:

https://docs.gradle.org/8.2/userguide/performance.html#enable_configuration_cache 

Also, some sample/snippet projects also used the legacy key. This PR attempts to address updating it at all places it should be updated .