### PR TITLE
Fix broken looking link to JavaCompile on Build Environment docs page

### DIFF
--- a/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
@@ -382,7 +382,7 @@ Otherwise the client VM will fork a new VM to run the actual build in order to h
 Certain tasks, like the `test` task, also fork additional JVM processes. You can configure these through the tasks themselves.
 They all use `-Xmx512m` by default.
 
-.Set Java compile options for link:{groovyDslPath}/org.gradle.api.tasks.compile.JavaCompile.html[JavaCompile] tasks
+.Set compile options for Java compilation tasks
 ====
 include::sample[dir="snippets/buildEnvironment/javaCompileOptions/kotlin",files="build.gradle.kts[]"]
 include::sample[dir="snippets/buildEnvironment/javaCompileOptions/groovy",files="build.gradle[]"]


### PR DESCRIPTION
This looked broken
https://docs.gradle.org/current/userguide/build_environment.html#ex-set-java-compile-options-for-linkgroovydslpathorg-gradle-api-tasks-compile-javacompile-htmljavacompile-tasks

<img width="1002" alt="image" src="https://github.com/gradle/gradle/assets/5387972/c3fae7fa-42b5-492c-a8c3-d4d41ab26cc6">
