### PR TITLE
Fix backward compatibility for task options where only negated option is set

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/options/BooleanOptionElement.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/options/BooleanOptionElement.java
@@ -37,21 +37,25 @@ public class BooleanOptionElement extends AbstractOptionElement {
     private static final String OPPOSITE_DESC_PREFIX = "Opposite option of --";
     private static final String DISABLE_NAME_PREFIX = "no-";
     private final PropertySetter setter;
+    private final boolean newOptionValue;
 
     public BooleanOptionElement(String optionName, Option option, PropertySetter setter) {
         super(optionName, option, Void.TYPE, setter.getDeclaringClass());
         this.setter = setter;
+        this.newOptionValue = true;
     }
 
-    private BooleanOptionElement(String optionName, String optionDescription, PropertySetter setter) {
+    private BooleanOptionElement(String optionName, String optionDescription, PropertySetter setter, boolean newOptionValue) {
         super(optionDescription, optionName, Void.TYPE);
         this.setter = setter;
+        this.newOptionValue = newOptionValue;
     }
 
     public static BooleanOptionElement oppositeOf(BooleanOptionElement optionElement) {
         String optionName = optionElement.getOptionName();
-        return optionElement.isDisableOption() ? new BooleanOptionElement(removeDisablePrefix(optionName), OPPOSITE_DESC_PREFIX + optionName, optionElement.setter)
-            : new BooleanOptionElement(DISABLE_NAME_PREFIX + optionName, DISABLE_DESC_PREFIX + optionName, optionElement.setter);
+        return optionElement.isDisableOption()
+            ? new BooleanOptionElement(removeDisablePrefix(optionName), OPPOSITE_DESC_PREFIX + optionName, optionElement.setter, false)
+            : new BooleanOptionElement(DISABLE_NAME_PREFIX + optionName, DISABLE_DESC_PREFIX + optionName, optionElement.setter, false);
     }
 
     public boolean isDisableOption() {
@@ -65,11 +69,7 @@ public class BooleanOptionElement extends AbstractOptionElement {
 
     @Override
     public void apply(Object object, List<String> parameterValues) throws TypeConversionException {
-        if (isDisableOption()) {
-            setter.setValue(object, Boolean.FALSE);
-        } else {
-            setter.setValue(object, Boolean.TRUE);
-        }
+        setter.setValue(object, newOptionValue);
     }
 
     private static String removeDisablePrefix(String optionName) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/options/OptionReaderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/options/OptionReaderTest.groovy
@@ -150,6 +150,24 @@ class OptionReaderTest extends Specification {
         options[2].description == "Causes the task to be re-run even if up-to-date."
     }
 
+    def "task only opposite option"() {
+        when:
+        List<InstanceOptionDescriptor> options = TaskOptionsGenerator.generate(new TestClassWithOnlyOppositeOption(), reader).getAll()
+        int ownOptions = 4
+        then:
+        options.size() == ownOptions + builtInOptionCount
+        options[0].name == "my-option1"
+        options[0].description == "Opposite option of --no-my-option1"
+        options[1].name == "my-option2"
+        options[1].description == "Opposite option of --no-my-option2"
+        options[2].name == "no-my-option1"
+        options[2].description == "Opposite option Boolean"
+        options[3].name == "no-my-option2"
+        options[3].description == "Opposite option Property<Boolean>"
+        options[4].name == "rerun"
+        options[4].description == "Causes the task to be re-run even if up-to-date."
+    }
+
     def "fail when multiple methods define same option"() {
         when:
         TaskOptionsGenerator.generate(new TestClass2(), reader).getAll()
@@ -557,6 +575,14 @@ class OptionReaderTest extends Specification {
         Boolean field1
         @Option(option = 'no-my-option', description = "Option clashing with opposite option")
         Boolean field2
+    }
+
+    public static class TestClassWithOnlyOppositeOption {
+        @Option(option = 'no-my-option1', description = "Opposite option Boolean")
+        Boolean field1
+
+        @Option(option = 'no-my-option2', description = "Opposite option Property<Boolean>")
+        Property<Boolean> field2
     }
 
     public static class TestClassWithFields {


### PR DESCRIPTION
When only `--no-feature` is defined on a task:
```
class MyTask : DefaultTask() {
   @Option("--no-feature")
   var noFeature = false
}

8.1.1
gradle task --no-feature -> noFeature = true
gradle task --feature -> error doesnt exists

8.2
gradle task --no-feature -> noFeature = false
gradle task --feature -> noFeature = true

8.2.1 with this change
gradle task --no-feature -> noFeature = true
gradle task --feature -> noFeature = false
```

Fixes https://github.com/gradle/gradle/issues/25658