### PR TITLE
Update gitstream automations for various requests

### DIFF
--- a/.cm/change_categories.cm
+++ b/.cm/change_categories.cm
@@ -70,8 +70,8 @@ is:
   docs: {{ (files | allDocs) or (files | match(regex=r/\.adoc$/) | every) }} # This won't catch a mix of .adoc and non .adoc changes, see: https://github.com/linear-b/gitstream/issues/93
   tests: {{ files | allTests }}
 
-  # Also just an approximation
-  build_script_change: {{ files | reject(regex=r/\/src\/(samples|snippets)\//) | match(list=build_logic_files) | some }}
+  # Exclude anything under samples/snippets sourceSets, or any sort of test resource file
+  build_script_change: {{ files | reject(regex=r/.*\/src\/(samples|snippets)\//) | reject(regex=r/.*\/(crossVersionTest|docsTest|functionalTest|integTest|smokeTest|test|testFixtures)\/resources\//) | match(list=build_logic_files) | some }}
 
 build_logic_files:
   - 'build.gradle.kts'
@@ -82,7 +82,7 @@ build_logic_files:
 # Perhaps a task could generate this list from the CODEOWNERS, or both this and CODEOWNERS could be generated from different single source of truth?
 platforms:
   - bt_ge_build_cache:
-    name: 'bt-ge-build-cache'
+    name: 'bt_ge_build_cache'
     subprojects:
       - 'subprojects/build-cache/'
       - 'subprojects/build-cache-base/'
@@ -93,7 +93,7 @@ platforms:
       - 'subprojects/hashing/'
       - 'subprojects/snapshots/'
   - build_infrastructure:
-    name: 'build-infrastructure'
+    name: 'build_infrastructure'
     subprojects:
       - '.teamcity/'
       - '.github/'
@@ -103,33 +103,33 @@ platforms:
       - '/build.gradle*'
       - '/settings.gradle*'
       - 'gradle/shared-with-buildSrc/'
-      - 'subprojects/*/build.gradle*'
       - 'subprojects/internal-architecture-testing/'
       - 'subprojects/internal-build-reports/'
       - 'subprojects/internal-integ-testing/'
       - 'subprojects/internal-performance-testing/'
       - 'subprojects/internal-testing/'
   - cc:
-    name: 'configuration-cache'
+    name: 'configuration_cache'
     subprojects:
       - 'subprojects/api-metadata/'
       - 'subprojects/base-annotations/'
+      - 'subprojects/base-services-groovy/'
       - 'subprojects/configuration-cache/'
+      - 'subprojects/file-collections/'
       - 'subprojects/instrumentation-agent'
       - 'subprojects/internal-instrumentation-api/'
       - 'subprojects/internal-instrumentation-processor/'
+      - 'subprojects/model-core/'
+      - 'subprojects/model-groovy/'
   - core:
     name: 'core'
     subprojects:
       - 'subprojects/base-services/'
-      - 'subprojects/base-services-groovy/'
       - 'subprojects/bootstrap/'
       - 'subprojects/build-option/'
       - 'subprojects/cli/'
-      - 'subprojects/core-platform/'
       - 'subprojects/distributions-basics/'
       - 'subprojects/distributions-core/'
-      - 'subprojects/file-collections/'
       - 'subprojects/file-temp/'
       - 'subprojects/file-watching/'
       - 'subprojects/files/'
@@ -140,15 +140,11 @@ platforms:
       - 'subprojects/logging/'
       - 'subprojects/logging-api/'
       - 'subprojects/messaging/'
-      - 'subprojects/model-core/'
-      - 'subprojects/model-groovy/'
       - 'subprojects/persistent-cache/'
       - 'subprojects/problems/'
       - 'subprojects/process-services/'
       - 'subprojects/snapshots/'
-      - 'subprojects/worker-processes/'
       - 'subprojects/worker-services/'
-      - 'subprojects/workers/'
       - 'subprojects/wrapper/'
       - 'subprojects/wrapper-shared/'
   - documentation:
@@ -174,6 +170,8 @@ platforms:
       - 'subprojects/functional/'
       - 'subprojects/hashing/'
       - 'subprojects/snapshots/'
+      - 'subprojects/worker-processes/'
+      - 'subprojects/workers/'
   - extensibility:
     name: 'extensibility'
     subprojects:
@@ -181,7 +179,7 @@ platforms:
       - 'subprojects/plugin-use/'
       - 'subprojects/test-kit/'
   - gradle_enterprise:
-    name: 'gradle-enterprise'
+    name: 'gradle_enterprise'
     subprojects:
       - 'subprojects/build-scan-performance/'
       - 'subprojects/enterprise/'
@@ -191,15 +189,16 @@ platforms:
   - ide:
     name: 'ide'
     subprojects:
+      - 'platforms/ide/'
       - 'subprojects/ide/'
       - 'subprojects/tooling-api/'
       - 'subprojects/tooling-api-builders/'
   - jvm:
     name: 'jvm'
     subprojects:
+      - 'platforms/jvm/'
       - 'subprojects/distributions-jvm/'
       - 'subprojects/distributions-publishing/'
-      - 'platforms/jvm/ear/'
       - 'subprojects/jacoco/'
       - 'subprojects/java-compiler-plugin/'
       - 'subprojects/jvm-services/'
@@ -214,7 +213,7 @@ platforms:
       - 'subprojects/testing-jvm/'
       - 'subprojects/testing-jvm-infrastructure/'
   - kotlin_dsl:
-    name: 'kotlin-dsl'
+    name: 'kotlin_dsl'
     subprojects:
       - 'build-logic/kotlin-dsl/'
       - 'subprojects/kotlin-dsl/'
@@ -224,8 +223,9 @@ platforms:
       - 'subprojects/kotlin-dsl-tooling-builders/'
       - 'subprojects/kotlin-dsl-tooling-models/'
   - release_coordination:
-    name: 'release-coordination'
+    name: 'release_coordination'
     subprojects:
+      - 'subprojects/core-platform/'
       - 'subprojects/distributions-dependencies/'
       - 'subprojects/distributions-full/'
       - 'subprojects/performance/'
@@ -253,13 +253,16 @@ platforms:
       - 'subprojects/version-control/'
 
 author:
-  using_gitstream: {{ (pr.author | match(list=teams.jvm.members)) or (pr.author | match(list=teams.execution.members)) or (pr.author | match(list=teams.ide.members)) or (pr.author | match(list=teams.build_scan.members)) }}
+  using_gitstream: {{ (pr.author | match(list=teams.build_scan.members) | some) or (pr.author | match(list=teams.dev_prod.members) | some) or (pr.author | match(list=teams.execution.members) | some) or (pr.author | match(list=teams.ide.members) | some) or (pr.author | match(list=teams.jvm.members) | some) }}
 
 teams:
   build_scan:
     members:
       - 'alllex'
       - 'wolfs'
+  dev_prod:
+    members:
+      - 'blindpirate'
   execution:
     members:
       - 'asodja'
@@ -267,6 +270,7 @@ teams:
       - 'FrauBoes'
   ide:
     members:
+      - 'hegyibalint'
       - 'donat'
       - 'reinsch82'
   jvm:

--- a/.cm/code_experts.cm
+++ b/.cm/code_experts.cm
@@ -30,28 +30,27 @@ automations:
   # Also post a comment that lists the best experts for the files that were modified.
   comment_experts:
     if:
-      - {{ false }} # disabled for now
       - {{ author.using_gitstream }}
     run:
-      - action: add-comment@v1
+      - action: explain-code-experts@v1
         args:
-          # Note the comment starts with | and a new-line as explainCodeExperts generates a multiline comment.
-          comment: |
-            {{ repo | explainCodeExperts(gt=10) }}
-
+          gt: 10
 
 # To simplify the automations section, some calculations are placed under unique YAML keys defined here.
 # Read the "|" not as "or", but as a "pipe", taking the output of the previous command and passing it to the next command.
 # This section could also appear ahead of the automations section.
 
 author:
-  using_gitstream: {{ (pr.author | match(list=teams.jvm.members)) or (pr.author | match(list=teams.execution.members)) or (pr.author | match(list=teams.ide.members)) or (pr.author | match(list=teams.build_scan.members)) }}
+  using_gitstream: {{ (pr.author | match(list=teams.build_scan.members) | some) or (pr.author | match(list=teams.dev_prod.members) | some) or (pr.author | match(list=teams.execution.members) | some) or (pr.author | match(list=teams.ide.members) | some) or (pr.author | match(list=teams.jvm.members) | some) }}
 
 teams:
   build_scan:
     members:
       - 'alllex'
       - 'wolfs'
+  dev_prod:
+    members:
+      - 'blindpirate'
   execution:
     members:
       - 'asodja'
@@ -59,6 +58,7 @@ teams:
       - 'FrauBoes'
   ide:
     members:
+      - 'hegyibalint'
       - 'donat'
       - 'reinsch82'
   jvm:

--- a/.cm/complex_changes.cm
+++ b/.cm/complex_changes.cm
@@ -21,8 +21,8 @@ automations:
   complex_change:
     if:
       - {{ author.using_gitstream }}
-      - {{ branch | estimatedReviewTime >= 30 }}
-      - {{ files | length >= 20 }}
+      - {{ branch | estimatedReviewTime >= 4 }}
+      - {{ files | length >= 50 }}
       - {{ includes_src_changes }}
     run:
       - action: set-required-approvals@v1
@@ -36,13 +36,16 @@ automations:
 includes_src_changes: {{ files | match(regex=r/.*\/src\//) | some }}
 
 author:
-  using_gitstream: {{ (pr.author | match(list=teams.jvm.members)) or (pr.author | match(list=teams.execution.members)) or (pr.author | match(list=teams.ide.members)) or (pr.author | match(list=teams.build_scan.members)) }}
+  using_gitstream: {{ (pr.author | match(list=teams.build_scan.members) | some) or (pr.author | match(list=teams.dev_prod.members) | some) or (pr.author | match(list=teams.execution.members) | some) or (pr.author | match(list=teams.ide.members) | some) or (pr.author | match(list=teams.jvm.members) | some) }}
 
 teams:
   build_scan:
     members:
       - 'alllex'
       - 'wolfs'
+  dev_prod:
+    members:
+      - 'blindpirate'
   execution:
     members:
       - 'asodja'
@@ -50,6 +53,7 @@ teams:
       - 'FrauBoes'
   ide:
     members:
+      - 'hegyibalint'
       - 'donat'
       - 'reinsch82'
   jvm:

--- a/.cm/estimated_time_to_review.cm
+++ b/.cm/estimated_time_to_review.cm
@@ -38,13 +38,16 @@ calc:
   etr: {{ branch | estimatedReviewTime }}
 
 author:
-  using_gitstream: {{ (pr.author | match(list=teams.jvm.members)) or (pr.author | match(list=teams.execution.members)) or (pr.author | match(list=teams.ide.members)) or (pr.author | match(list=teams.build_scan.members)) }}
+  using_gitstream: {{ (pr.author | match(list=teams.build_scan.members) | some) or (pr.author | match(list=teams.dev_prod.members) | some) or (pr.author | match(list=teams.execution.members) | some) or (pr.author | match(list=teams.ide.members) | some) or (pr.author | match(list=teams.jvm.members) | some) }}
 
 teams:
   build_scan:
     members:
       - 'alllex'
       - 'wolfs'
+  dev_prod:
+    members:
+      - 'blindpirate'
   execution:
     members:
       - 'asodja'
@@ -52,6 +55,7 @@ teams:
       - 'FrauBoes'
   ide:
     members:
+      - 'hegyibalint'
       - 'donat'
       - 'reinsch82'
   jvm:

--- a/.cm/includes_todos.cm
+++ b/.cm/includes_todos.cm
@@ -33,13 +33,16 @@ automations:
 # This section could also appear ahead of the automations section.
 
 author:
-  using_gitstream: {{ (pr.author | match(list=teams.jvm.members)) or (pr.author | match(list=teams.execution.members)) or (pr.author | match(list=teams.ide.members)) or (pr.author | match(list=teams.build_scan.members)) }}
+  using_gitstream: {{ (pr.author | match(list=teams.build_scan.members) | some) or (pr.author | match(list=teams.dev_prod.members) | some) or (pr.author | match(list=teams.execution.members) | some) or (pr.author | match(list=teams.ide.members) | some) or (pr.author | match(list=teams.jvm.members) | some) }}
 
 teams:
   build_scan:
     members:
       - 'alllex'
       - 'wolfs'
+  dev_prod:
+    members:
+      - 'blindpirate'
   execution:
     members:
       - 'asodja'
@@ -47,6 +50,7 @@ teams:
       - 'FrauBoes'
   ide:
     members:
+      - 'hegyibalint'
       - 'donat'
       - 'reinsch82'
   jvm:

--- a/.cm/lacks_tests.cm
+++ b/.cm/lacks_tests.cm
@@ -41,13 +41,16 @@ is_docs_only_change: {{ (files | allDocs) or (files | match(regex=r/\.adoc$/) | 
 is_formatting_only_change: {{ source.diff.files | isFormattingChange }}
 
 author:
-  using_gitstream: {{ (pr.author | match(list=teams.jvm.members)) or (pr.author | match(list=teams.execution.members)) or (pr.author | match(list=teams.ide.members)) or (pr.author | match(list=teams.build_scan.members)) }}
+  using_gitstream: {{ (pr.author | match(list=teams.build_scan.members) | some) or (pr.author | match(list=teams.dev_prod.members) | some) or (pr.author | match(list=teams.execution.members) | some) or (pr.author | match(list=teams.ide.members) | some) or (pr.author | match(list=teams.jvm.members) | some) }}
 
 teams:
   build_scan:
     members:
       - 'alllex'
       - 'wolfs'
+  dev_prod:
+    members:
+      - 'blindpirate'
   execution:
     members:
       - 'asodja'
@@ -55,6 +58,7 @@ teams:
       - 'FrauBoes'
   ide:
     members:
+      - 'hegyibalint'
       - 'donat'
       - 'reinsch82'
   jvm:

--- a/.cm/percentage_new.cm
+++ b/.cm/percentage_new.cm
@@ -1,0 +1,51 @@
+# -*- mode: yaml -*-
+manifest:
+  version: 1.0
+
+automations:
+  percent_new_code:
+    if:
+      - {{ author.using_gitstream }}
+    run:
+      - action: add-comment@v1
+        args:
+          comment: |
+            This PR is {{ changes.ratio }}% new code.
+            There are {{ changes.additions }} added lines and {{ changes.deletions }} deleted lines.
+
+changes:
+  # Sum all the lines added/edited in the PR
+  additions: {{ branch.diff.files_metadata | map(attr='additions') | sum }}
+  # Sum all the line removed in the PR
+  deletions: {{ branch.diff.files_metadata | map(attr='deletions') | sum }}
+  # Calculate the ratio of new code
+  ratio: {{ (changes.additions / (changes.additions + changes.deletions)) * 100 }}
+
+author:
+  using_gitstream: {{ (pr.author | match(list=teams.build_scan.members) | some) or (pr.author | match(list=teams.dev_prod.members) | some) or (pr.author | match(list=teams.execution.members) | some) or (pr.author | match(list=teams.ide.members) | some) or (pr.author | match(list=teams.jvm.members) | some) }}
+
+teams:
+  build_scan:
+    members:
+      - 'alllex'
+      - 'wolfs'
+  dev_prod:
+    members:
+      - 'blindpirate'
+  execution:
+    members:
+      - 'asodja'
+      - 'lptr'
+      - 'FrauBoes'
+  ide:
+    members:
+      - 'hegyibalint'
+      - 'donat'
+      - 'reinsch82'
+  jvm:
+    members:
+      - 'big-guy'
+      - 'ghale'
+      - 'jvandort'
+      - 'octylFractal'
+      - 'tresat'


### PR DESCRIPTION
- Renable and use [new action](https://github.com/linear-b/gitstream/issues/197#issuecomment-1616409680) to avoid code-experts spam: the experts table will now edit in place rather than re-post
- Update project owners and platforms to match changes to `CODEOWNERS` since 2023-06-21
- Add Bálint in IDE and Bo in Dev-Prod to authors who trigger gitStream
- Increase thresholds for 2 approvals = 50 files changed and 40 min estimated time
- Build script changes label should not appear for samples/snippets or resources, etc. - it should now be a little smarter about ignoring resources
