### PR TITLE
Update percentage display in comment

### DIFF
--- a/.cm/percentage_new.cm
+++ b/.cm/percentage_new.cm
@@ -10,7 +10,7 @@ automations:
       - action: add-comment@v1
         args:
           comment: |
-            This PR is {{ changes.ratio }}% new code.
+            This PR is {{ changes.ratio | round(2) }}% new code.
             There are {{ changes.additions }} added lines and {{ changes.deletions }} deleted lines.
 
 changes:


### PR DESCRIPTION
The code change updates the percentage display in the comment to round to 2 decimal places. The comment now shows the ratio of new code, as well as the number of added and deleted lines.

