### PR TITLE
Recognize certain options as making workers unreliable on Windows

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ForkCapableRelocationIntegrationTest.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ForkCapableRelocationIntegrationTest.groovy
@@ -40,9 +40,6 @@ abstract class ForkCapableRelocationIntegrationTest extends AbstractProjectReloc
 
         when:
         inDirectory(originalDir)
-        // On Windows, we have issues with file locking when the persistent Java compiler daemons
-        // hold on to the java agent jars
-        args("-Dorg.gradle.internal.java.compile.daemon.keepAlive=SESSION")
         withBuildCache().run taskName
 
         then:
@@ -53,7 +50,6 @@ abstract class ForkCapableRelocationIntegrationTest extends AbstractProjectReloc
 
         when:
         inDirectory(originalDir)
-        args("-Dorg.gradle.internal.java.compile.daemon.keepAlive=SESSION")
         withBuildCache().run taskName
 
         then:
@@ -61,7 +57,6 @@ abstract class ForkCapableRelocationIntegrationTest extends AbstractProjectReloc
 
         when:
         inDirectory(relocatedDir)
-        args("-Dorg.gradle.internal.java.compile.daemon.keepAlive=SESSION")
         withBuildCache().run taskName
 
         then:

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/daemon/JavaCompilerDaemonReuseIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/daemon/JavaCompilerDaemonReuseIntegrationTest.groovy
@@ -19,8 +19,11 @@ package org.gradle.java.compile.daemon
 import org.gradle.api.internal.tasks.execution.ExecuteTaskBuildOperationType
 import org.gradle.api.tasks.compile.AbstractCompilerDaemonReuseIntegrationTest
 import org.gradle.integtests.fixtures.BuildOperationsFixture
+import org.gradle.integtests.fixtures.JavaAgentFixture
 import org.gradle.integtests.fixtures.jvm.TestJvmComponent
 import org.gradle.language.fixtures.TestJavaComponent
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.UnitTestPreconditions
 import org.gradle.workers.internal.ExecuteWorkItemBuildOperationType
 import org.gradle.workers.internal.KeepAliveMode
 
@@ -77,6 +80,47 @@ class JavaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReuse
         def firstCompilerIdentity = old(runningCompilerDaemons[0])
         def secondCompilerIdentity = runningCompilerDaemons[0]
         firstCompilerIdentity != secondCompilerIdentity
+    }
+
+    @Requires(UnitTestPreconditions.Windows)
+    def "compiler daemon is not reused on Windows with Java agent"() {
+        withSingleProjectSources()
+        def javaAgent = new JavaAgentFixture()
+        javaAgent.writeProjectTo(testDirectory)
+
+        buildFile << """
+            tasks.compileMain2Java {
+                dependsOn("compileJava")
+            }
+            ${javaAgent.useJavaAgent('compileJava.options.forkOptions')}
+        """
+
+        when:
+        succeeds("compileAll", "--info")
+
+        then:
+        executedAndNotSkipped "${compileTaskPath('main')}", "${compileTaskPath('main2')}"
+
+        and:
+        outputContains("JavaAgent configured!")
+        result.groupedOutput.task(compileTaskPath('main')).assertOutputContains("Worker requested to be persistent, but its JVM arguments may make the worker unreliable. Worker will expire at the end of the build session.")
+        assertTwoCompilerDaemonsAreRunning()
+
+        when:
+        executer.withWorkerDaemonsExpirationDisabled()
+        succeeds("clean", "compileAll", "--info")
+
+        then:
+        executedAndNotSkipped "${compileTaskPath('main')}", "${compileTaskPath('main2')}"
+
+        and:
+        assertTwoCompilerDaemonsAreRunning()
+
+        def firstBuild = old(runningCompilerDaemons)
+        def secondBuild = runningCompilerDaemons
+        def diff = firstBuild - secondBuild
+        // We should reuse one daemon from the first build
+        diff.size() == 1
     }
 
     def "reuses compiler daemons across multiple builds when enabled"() {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/daemon/JavaCompilerDaemonReuseIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/daemon/JavaCompilerDaemonReuseIntegrationTest.groovy
@@ -103,7 +103,7 @@ class JavaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReuse
 
         and:
         outputContains("JavaAgent configured!")
-        result.groupedOutput.task(compileTaskPath('main')).assertOutputContains("Worker requested to be persistent, but its JVM arguments may make the worker unreliable. Worker will expire at the end of the build session.")
+        result.groupedOutput.task(compileTaskPath('main')).assertOutputContains("Worker requested to be persistent, but the JVM argument '-javaagent:${file("javaagent/build/libs/javaagent.jar")}' may make the worker unreliable when reused across multiple builds. Worker will expire at the end of the build session.")
         assertTwoCompilerDaemonsAreRunning()
 
         when:

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DaemonForkOptionsBuilder.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DaemonForkOptionsBuilder.java
@@ -60,7 +60,7 @@ public class DaemonForkOptionsBuilder {
         if (OperatingSystem.current().isWindows() && keepAliveMode == KeepAliveMode.DAEMON) {
             List<String> jvmArgs = forkOptions.getAllJvmArgs();
             if (containsUnreliableOptions(jvmArgs)) {
-                LOGGER.info("Worker requested to be persistent, but its JVM arguments may make the worker unreliable. Worker will expire at the end of the build.");
+                LOGGER.info("Worker requested to be persistent, but its JVM arguments may make the worker unreliable. Worker will expire at the end of the build session.");
                 return new DaemonForkOptions(forkOptions, KeepAliveMode.SESSION, classLoaderStructure);
             }
         }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DaemonForkOptionsBuilder.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DaemonForkOptionsBuilder.java
@@ -16,11 +16,20 @@
 
 package org.gradle.workers.internal;
 
+import com.google.common.annotations.VisibleForTesting;
+import org.gradle.internal.os.OperatingSystem;
 import org.gradle.process.JavaForkOptions;
 import org.gradle.process.internal.JavaForkOptionsFactory;
 import org.gradle.process.internal.JavaForkOptionsInternal;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
 
 public class DaemonForkOptionsBuilder {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DaemonForkOptionsBuilder.class);
+
     private final JavaForkOptionsInternal javaForkOptions;
     private final JavaForkOptionsFactory forkOptionsFactory;
     private KeepAliveMode keepAliveMode = KeepAliveMode.DAEMON;
@@ -47,7 +56,56 @@ public class DaemonForkOptionsBuilder {
     }
 
     public DaemonForkOptions build() {
-        return new DaemonForkOptions(buildJavaForkOptions(), keepAliveMode, classLoaderStructure);
+        JavaForkOptionsInternal forkOptions = buildJavaForkOptions();
+        if (OperatingSystem.current().isWindows() && keepAliveMode == KeepAliveMode.DAEMON) {
+            List<String> jvmArgs = forkOptions.getAllJvmArgs();
+            if (containsUnreliableOptions(jvmArgs)) {
+                LOGGER.info("Worker requested to be persistent, but its JVM arguments may make the worker unreliable. Worker will expire at the end of the build.");
+                return new DaemonForkOptions(forkOptions, KeepAliveMode.SESSION, classLoaderStructure);
+            }
+        }
+        return new DaemonForkOptions(forkOptions, keepAliveMode, classLoaderStructure);
+    }
+
+    /**
+     * Users can add files that are held open by the worker process. This causes problems on Windows with persistent workers because
+     * we cannot delete files that are held by the worker process.
+     *
+     * @param jvmArgs JVM arguments to check
+     * @return true if the command-line arguments contain options that could make the worker process unreliable
+     */
+    @VisibleForTesting
+    static boolean containsUnreliableOptions(List<String> jvmArgs) {
+        // This isn't exhaustive because there are more ways that extra files can be provided
+        // to the worker through diagnostic options, @files or JAVA_TOOL_OPTIONS.
+        List<String> unreliableOptions = Arrays.asList(
+            // Classpath options
+            "-cp", "-classpath", "--class-path",
+            // Module related options
+            "-p", "--module-path", "--upgrade-module-path", "--patch-module"
+        );
+        // These options allow you to use : instead of a space to separate the
+        // option from the value
+        List<String> unreliableOptionPrefixes = Arrays.asList(
+            // bootclasspath can also end with /a or /p
+            "-Xbootclasspath",
+            // Defining a java agent
+            "-javaagent"
+        );
+
+        for (String jvmArg : jvmArgs) {
+            if (jvmArg.startsWith("-")) {
+                if (unreliableOptions.contains(jvmArg)) {
+                    return true;
+                }
+                for (String prefix : unreliableOptionPrefixes) {
+                    if (jvmArg.startsWith(prefix)) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
     }
 
     private JavaForkOptionsInternal buildJavaForkOptions() {

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DaemonForkOptionsBuilderTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DaemonForkOptionsBuilderTest.groovy
@@ -21,12 +21,12 @@ import spock.lang.Specification
 class DaemonForkOptionsBuilderTest extends Specification {
     def "ignores other options"() {
         expect:
-        !DaemonForkOptionsBuilder.containsUnreliableOptions(["--show-version", "-ea", "pkg.Main"])
+        !DaemonForkOptionsBuilder.findUnreliableArgument(["--show-version", "-ea", "pkg.Main"]).isPresent()
     }
 
     def "recognizes unreliable options in JVM args"() {
         expect:
-        DaemonForkOptionsBuilder.containsUnreliableOptions(options)
+        DaemonForkOptionsBuilder.findUnreliableArgument(options).get() == options[0]
         where:
         options << [
             ["-cp", "/path/to/jar"],
@@ -41,11 +41,13 @@ class DaemonForkOptionsBuilderTest extends Specification {
 
     def "recognizes unreliable option prefixes in JVM args"() {
         expect:
-        DaemonForkOptionsBuilder.containsUnreliableOptions(options)
+        DaemonForkOptionsBuilder.findUnreliableArgument(options).get() == options[0]
         where:
         options << [
             ["-javaagent:/path/to/jar"],
             ["-javaagent", "/path/to/jar"],
+            ["-agentpath:/path/to/jar"],
+            ["-agentpath", "/path/to/jar"],
             ["-Xbootclasspath:/path/to/jar"],
             ["-Xbootclasspath", "path/to/jar"],
             ["-Xbootclasspath/a:/path/to/jar"],

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DaemonForkOptionsBuilderTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DaemonForkOptionsBuilderTest.groovy
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.workers.internal
+
+import spock.lang.Specification
+
+class DaemonForkOptionsBuilderTest extends Specification {
+    def "ignores other options"() {
+        expect:
+        !DaemonForkOptionsBuilder.containsUnreliableOptions(["--show-version", "-ea", "pkg.Main"])
+    }
+
+    def "recognizes unreliable options in JVM args"() {
+        expect:
+        DaemonForkOptionsBuilder.containsUnreliableOptions(options)
+        where:
+        options << [
+            ["-cp", "/path/to/jar"],
+            ["-classpath", "/path/to/jar"],
+            ["--class-path", "/path/to/jar"],
+            ["-p", "/path/to/jar"],
+            ["--module-path", "/path/to/jar"],
+            ["--upgrade-module-path", "/path/to/jar"],
+            ["--patch-module", "/path/to/jar"],
+        ]
+    }
+
+    def "recognizes unreliable option prefixes in JVM args"() {
+        expect:
+        DaemonForkOptionsBuilder.containsUnreliableOptions(options)
+        where:
+        options << [
+            ["-javaagent:/path/to/jar"],
+            ["-javaagent", "/path/to/jar"],
+            ["-Xbootclasspath:/path/to/jar"],
+            ["-Xbootclasspath", "path/to/jar"],
+            ["-Xbootclasspath/a:/path/to/jar"],
+            ["-Xbootclasspath/a", "/path/to/jar"],
+        ]
+    }
+}


### PR DESCRIPTION
When arguments like -javaagent are used with a worker, its possible
for this option to add a file that is held open by the worker across
builds.

If this is a jar that comes from the dependency cache, this is mostly
OK.

If this is a jar that comes from another project, this breaks simple
things like running clean because we're unable to delete the build
directory without stopping the worker process.

This change causes the daemon option builder to switch to SESSION-persistent
daemons. This has been the default for a long time and mostly works.

This change doesn't eliminate all possible avenues to cause this problem.
There are other ways to pass options to the worker process that
could cause it to hold on to files (even non-jars).<!--- The issue this PR addresses -->
Fixes #?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
