### PR TITLE
Nag at uses of Provider.forUseAtConfigurationTime

### DIFF
--- a/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
@@ -409,7 +409,7 @@ performanceTest.registerAndroidTestProject("largeAndroidBuild2", RemoteProject) 
 performanceTest.registerAndroidTestProject("santaTrackerAndroidBuild", RemoteProject) {
     remoteUri = 'https://github.com/gradle/santa-tracker-android.git'
     // Pinned from main branch
-    ref = '70b2fec935b82d8783579290512690fe2eca8884'
+    ref = 'e9419cad3583427caca97958301ff98fc8e9a1c3'
     doLast {
         addGoogleServicesJson(outputDirectory)
     }

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
@@ -21,6 +21,7 @@ import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.gradle.integtests.fixtures.RepoScriptBlockUtil
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.kotlin.dsl.embeddedKotlinVersion
 import org.gradle.kotlin.dsl.fixtures.DeepThought
 import org.gradle.kotlin.dsl.fixtures.LightThought
@@ -263,6 +264,14 @@ class GradleKotlinDslIntegrationTest : AbstractPluginIntegrationTest() {
                 "Consult the upgrading guide for further information: " +
                 "https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_access_to_conventions"
         )
+        if (GradleContextualExecuter.isConfigCache()) {
+            executer.expectDocumentedDeprecationWarning(
+                "The Provider.forUseAtConfigurationTime method has been deprecated. " +
+                    "This is scheduled to be removed in Gradle 9.0. " +
+                    "Simply remove the call. " +
+                    "Consult the upgrading guide for further information: " +
+                    "https://docs.gradle.org/current/userguide/upgrading_version_7.html#for_use_at_configuration_time_deprecation")
+        }
 
         assertThat(
             build("print-kotlin-version").output,

--- a/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginCrossVersionSmokeTest.kt
+++ b/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginCrossVersionSmokeTest.kt
@@ -16,6 +16,7 @@
 
 package org.gradle.kotlin.dsl.plugins.dsl
 
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.kotlin.dsl.fixtures.AbstractKotlinIntegrationTest
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.MatcherAssert.assertThat
@@ -57,6 +58,15 @@ class KotlinDslPluginCrossVersionSmokeTest : AbstractKotlinIntegrationTest() {
                 "Consult the upgrading guide for further information: " +
                 "https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_access_to_conventions"
         )
+        if (GradleContextualExecuter.isConfigCache()) {
+            executer.expectDocumentedDeprecationWarning(
+                "The Provider.forUseAtConfigurationTime method has been deprecated. " +
+                    "This is scheduled to be removed in Gradle 9.0. " +
+                    "Simply remove the call. " +
+                    "Consult the upgrading guide for further information: " +
+                    "https://docs.gradle.org/current/userguide/upgrading_version_7.html#for_use_at_configuration_time_deprecation"
+            )
+        }
 
         build("help").apply {
 

--- a/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginGradlePluginCrossVersionSmokeTest.kt
+++ b/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginGradlePluginCrossVersionSmokeTest.kt
@@ -136,6 +136,14 @@ class KotlinDslPluginGradlePluginCrossVersionSmokeTest(
                     "https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_access_to_conventions"
             )
         }
+        if (VersionNumber.parse(kotlinVersion) < VersionNumber.parse("1.8.0") && GradleContextualExecuter.isConfigCache()) {
+            executer.expectDocumentedDeprecationWarning(
+                "The Provider.forUseAtConfigurationTime method has been deprecated. " +
+                    "This is scheduled to be removed in Gradle 9.0. " +
+                    "Simply remove the call. " +
+                    "Consult the upgrading guide for further information: " +
+                    "https://docs.gradle.org/current/userguide/upgrading_version_7.html#for_use_at_configuration_time_deprecation")
+        }
 
         build("classes").apply {
             assertThat(

--- a/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProviderTest.kt
+++ b/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProviderTest.kt
@@ -1,5 +1,6 @@
 package org.gradle.kotlin.dsl.support
 
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.kotlin.dsl.embeddedKotlinVersion
 import org.gradle.kotlin.dsl.fixtures.AbstractKotlinIntegrationTest
 import org.hamcrest.CoreMatchers.containsString
@@ -56,6 +57,15 @@ class EmbeddedKotlinProviderTest : AbstractKotlinIntegrationTest() {
             }
             """
         )
+
+        if (GradleContextualExecuter.isConfigCache()) {
+            executer.expectDocumentedDeprecationWarning(
+                "The Provider.forUseAtConfigurationTime method has been deprecated. " +
+                    "This is scheduled to be removed in Gradle 9.0. " +
+                    "Simply remove the call. " +
+                    "Consult the upgrading guide for further information: " +
+                    "https://docs.gradle.org/current/userguide/upgrading_version_7.html#for_use_at_configuration_time_deprecation")
+        }
 
         val result = build("buildEnvironment")
         listOf("stdlib", "reflect").forEach { module ->

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
@@ -469,6 +469,16 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
                     "Consult the upgrading guide for further information: " +
                     "https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_access_to_conventions")
         }
+        if (!isKotlin1dot8) {
+            if (GradleContextualExecuter.isConfigCache()) {
+                executer.expectDocumentedDeprecationWarning(
+                    "The Provider.forUseAtConfigurationTime method has been deprecated. " +
+                        "This is scheduled to be removed in Gradle 9.0. " +
+                        "Simply remove the call. " +
+                        "Consult the upgrading guide for further information: " +
+                        "https://docs.gradle.org/current/userguide/upgrading_version_7.html#for_use_at_configuration_time_deprecation")
+            }
+        }
         withInstallations(jdkMetadata).run(":compileKotlin", ":test")
         def eventsOnCompile = toolchainEvents(":compileKotlin")
         def eventsOnTest = toolchainEvents(":test")

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishIssuesIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishIssuesIntegTest.groovy
@@ -378,7 +378,7 @@ subprojects {
              plugins {
                 java
                 `maven-publish`
-                kotlin("jvm") version "1.7.21"
+                kotlin("jvm") version "1.8.22"
             }
             repositories {
                 mavenCentral()
@@ -418,7 +418,7 @@ subprojects {
              plugins {
                 java
                 `ivy-publish`
-                kotlin("jvm") version "1.7.21"
+                kotlin("jvm") version "1.8.22"
             }
             repositories {
                 mavenCentral()

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
@@ -22,6 +22,7 @@ import org.gradle.api.provider.Provider;
 import org.gradle.internal.Cast;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.logging.text.TreeFormatter;
 import org.gradle.internal.state.Managed;
 
@@ -121,14 +122,11 @@ public abstract class AbstractMinimalProvider<T> implements ProviderInternal<T>,
     @Deprecated
     @Override
     public final Provider<T> forUseAtConfigurationTime() {
-        /*
- TODO:configuration-cache start nagging in Gradle 8.x
         DeprecationLogger.deprecateMethod(Provider.class, "forUseAtConfigurationTime")
             .withAdvice("Simply remove the call.")
             .willBeRemovedInGradle9()
             .withUpgradeGuideSection(7, "for_use_at_configuration_time_deprecation")
             .nagUser();
-*/
         return this;
     }
 

--- a/subprojects/smoke-test/build.gradle.kts
+++ b/subprojects/smoke-test/build.gradle.kts
@@ -60,7 +60,7 @@ tasks {
     val santaTracker by registering(RemoteProject::class) {
         remoteUri = santaGitUri
         // Pinned from branch main
-        ref = "70b2fec935b82d8783579290512690fe2eca8884"
+        ref = "e9419cad3583427caca97958301ff98fc8e9a1c3"
     }
 
     val gradleBuildCurrent by registering(RemoteProject::class) {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractKotlinPluginAndroidSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractKotlinPluginAndroidSmokeTest.groovy
@@ -65,6 +65,9 @@ abstract class AbstractKotlinPluginAndroidSmokeTest extends AbstractSmokeTest im
                     2.times {
                         maybeExpectOrgGradleUtilGUtilDeprecation(androidPluginVersion)
                     }
+                    if (GradleContextualExecuter.configCache) {
+                        expectForUseAtConfigurationTimeDeprecation(kotlinPluginVersionNumber)
+                    }
                 }.build()
 
         then:

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -121,7 +121,7 @@ abstract class AbstractSmokeTest extends Specification {
         static errorProne = "3.1.0"
 
         // https://plugins.gradle.org/plugin/com.google.protobuf
-        static protobufPlugin = "0.9.2"
+        static protobufPlugin = "0.9.3"
 
         // https://central.sonatype.com/artifact/com.google.protobuf/protobuf-java/4.0.0-rc-2/versions
         static protobufTools = "3.22.3"

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AsciidoctorPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AsciidoctorPluginSmokeTest.groovy
@@ -94,6 +94,12 @@ class AsciidoctorPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
                     " Please use the mainClass property instead." +
                     " ${String.format(DocumentationRegistry.RECOMMENDATION, "information", "${BASE_URL}/dsl/org.gradle.process.JavaExecSpec.html#org.gradle.process.JavaExecSpec:main")}"
             )
+
+            runner.expectDeprecationWarningIf(
+                VersionNumber.parse(asciidoctorVersion).major >= 4,
+                FOR_USE_AT_CONFIGURATION_TIME_DEPRECATION,
+                "Seems to be fixed in main branch, but no releases with a fix"
+            )
         }
     }
 }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BaseDeprecations.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BaseDeprecations.groovy
@@ -57,6 +57,12 @@ class BaseDeprecations {
         "Consult the upgrading guide for further information: " +
         DOCUMENTATION_REGISTRY.getDocumentationFor("upgrading_version_8","java_convention_deprecation")
 
+    public static final String FOR_USE_AT_CONFIGURATION_TIME_DEPRECATION = "The Provider.forUseAtConfigurationTime method has been deprecated. " +
+        "This is scheduled to be removed in Gradle 9.0. " +
+        "Simply remove the call. " +
+        "Consult the upgrading guide for further information: " +
+        DOCUMENTATION_REGISTRY.getDocumentationFor("upgrading_version_7", "for_use_at_configuration_time_deprecation")
+
     final SmokeTestGradleRunner runner
 
     BaseDeprecations(SmokeTestGradleRunner runner) {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinMultiplatformPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinMultiplatformPluginSmokeTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.smoketests
 
 import org.gradle.api.internal.DocumentationRegistry
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.util.internal.VersionNumber
 import spock.lang.Issue
 import org.gradle.smoketests.WithKotlinDeprecations.ProjectTypes
@@ -139,6 +140,9 @@ class KotlinMultiplatformPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
             expectConventionTypeDeprecation(kotlinVersionNumber)
             2.times { expectJavaPluginConventionDeprecation(kotlinVersionNumber) }
             expectBuildIdentifierNameDeprecation(kotlinVersionNumber)
+            if (GradleContextualExecuter.configCache || kotlinVersionNumber == VersionNumber.parse("1.7.22")) {
+                expectForUseAtConfigurationTimeDeprecation(kotlinVersionNumber)
+            }
         }
         testRunner.expectLegacyDeprecationWarningIf(
                 kotlinVersionNumber == VersionNumber.parse("1.7.0"),

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
@@ -49,6 +49,7 @@ class KotlinPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
                 expectJavaPluginConventionDeprecation(versionNumber)
                 if (GradleContextualExecuter.isConfigCache()) {
                     expectBasePluginConventionDeprecation(versionNumber)
+                    expectForUseAtConfigurationTimeDeprecation(versionNumber)
                 }
             }.build()
 
@@ -101,6 +102,9 @@ class KotlinPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
                 expectConventionTypeDeprecation(versionNumber)
                 expectJavaPluginConventionDeprecation(versionNumber)
                 expectBasePluginConventionDeprecation(versionNumber)
+                if (GradleContextualExecuter.isConfigCache()) {
+                    expectForUseAtConfigurationTimeDeprecation(versionNumber)
+                }
             }.build()
 
         then:
@@ -158,6 +162,7 @@ class KotlinPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
                 expectJavaPluginConventionDeprecation(versionNumber)
                 if (GradleContextualExecuter.isConfigCache()) {
                     expectBasePluginConventionDeprecation(versionNumber)
+                    expectForUseAtConfigurationTimeDeprecation(versionNumber)
                 }
             }.build()
 
@@ -202,6 +207,9 @@ class KotlinPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
                 expectProjectConventionDeprecation(versionNumber)
                 expectConventionTypeDeprecation(versionNumber)
                 expectJavaPluginConventionDeprecation(versionNumber)
+                if (GradleContextualExecuter.isConfigCache()) {
+                    expectForUseAtConfigurationTimeDeprecation(versionNumber)
+                }
             }.build()
 
         then:

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyGradleModuleMetadataSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyGradleModuleMetadataSmokeTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.smoketests
 
 import groovy.json.JsonSlurper
 import org.gradle.api.JavaVersion
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.UnitTestPreconditions
@@ -155,6 +156,9 @@ class ThirdPartyGradleModuleMetadataSmokeTest extends AbstractSmokeTest {
             expectJavaPluginConventionDeprecation(kotlinVersionNumber)
             expectBasePluginConventionDeprecation(kotlinVersionNumber, agpVersionNumber)
             maybeExpectOrgGradleUtilGUtilDeprecation(agpVersion)
+            if (GradleContextualExecuter.isConfigCache()) {
+                expectForUseAtConfigurationTimeDeprecation(kotlinVersionNumber)
+            }
         }
     }
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithKotlinDeprecations.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithKotlinDeprecations.groovy
@@ -17,6 +17,7 @@
 package org.gradle.smoketests
 
 import groovy.transform.SelfType
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.smoketests.KotlinRunnerFactory.ParallelTasksInProject
 import org.gradle.util.GradleVersion
 import org.gradle.util.internal.VersionNumber
@@ -164,6 +165,13 @@ trait WithKotlinDeprecations extends WithReportDeprecations {
         )
     }
 
+    void expectForUseAtConfigurationTimeDeprecation(VersionNumber versionNumber) {
+        runner.expectLegacyDeprecationWarningIf(
+            versionNumber < VersionNumber.parse("1.8.0"),
+            FOR_USE_AT_CONFIGURATION_TIME_DEPRECATION
+        )
+    }
+
     void expectBuildIdentifierNameDeprecation(VersionNumber versionNumber) {
         runner.expectDeprecationWarningIf(versionNumber >= VersionNumber.parse("1.8.20"),
             "The BuildIdentifier.getName() method has been deprecated. " +
@@ -186,6 +194,9 @@ trait WithKotlinDeprecations extends WithReportDeprecations {
         expectTestReportReportOnDeprecation(versionNumber)
         expectTestReportDestinationDirOnDeprecation(versionNumber)
         expectBuildIdentifierNameDeprecation(versionNumber)
+        if (GradleContextualExecuter.configCache || versionNumber == VersionNumber.parse("1.7.22")) {
+            expectForUseAtConfigurationTimeDeprecation(versionNumber)
+        }
     }
 
     protected static enum ProjectTypes {


### PR DESCRIPTION
This has been soft-deprecated since Gradle 7.4 and is a no-op.

Fixes #21796.