### PR TITLE
Add workflow to submit GitHub dependency graph

### DIFF
--- a/.github/workflows/submit-github-dependency-graph.yml
+++ b/.github/workflows/submit-github-dependency-graph.yml
@@ -1,0 +1,26 @@
+name: Submit Dependency Graph
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+  
+permissions: write-all
+
+jobs:
+  generate-and-submit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
+      with:
+        distribution: temurin
+        java-version: 11
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@dependency-graph
+      with:
+        dependency-graph: generate-and-submit
+    - name: Run 'compileAll' to generate dependency graph
+      run: ./gradlew compileAll --no-configuration-cache -DdisableLocalCache=true -DcacheNode=us
+      env:
+        GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}


### PR DESCRIPTION
This workflow uses the [gradle-build-action](https://github.com/gradle/gradle-build-action) combined with [org.gradle.github-dependency-graph-gradle-plugin](https://plugins.gradle.org/plugin/org.gradle.github-dependency-graph-gradle-plugin) to execute the `compileAll` task, collect the coordinates of all resolved dependencies, and submit these to the [GitHub Dependency Submission API](https://docs.github.com/en/rest/dependency-graph/dependency-submission?apiVersion=2022-11-28).

The submitted graph then allows GitHub to generate Dependabot Security Alerts for any vulnerable dependencies.

Example of the Dependency Graph view:
<img width="1400" alt="image" src="https://github.com/gradle/gradle/assets/179734/2d79fa2f-fa79-42e7-afcc-ce8622d62b26">

Example of the resulting Dependabot Alerts:
<img width="1371" alt="image" src="https://github.com/gradle/gradle/assets/179734/89c9b197-3196-4ad2-8153-0319260d0fb6">

