### PR TITLE
Update Gradle Documentation for getResolutionResult method

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ResolvableDependencies.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ResolvableDependencies.java
@@ -104,7 +104,11 @@ public interface ResolvableDependencies extends ArtifactView {
     void afterResolve(@DelegatesTo(ResolvableDependencies.class) Closure action);
 
     /**
-     * Returns the resolved dependency graph, performing the resolution if required. This will resolve the dependency graph but will not resolve or download the files.
+     * Returns the resolved dependency graph, performing the resolution lazily.
+     *
+     * <p>The lazy aspect depends on what is done with the returned {@code ResolutionResult}.</p>
+     *
+     * This will resolve the dependency graph but will not resolve or download the artifacts.
      *
      * <p>You should note that when resolution fails, the exceptions are included in the {@link ResolutionResult} returned from this method. This method will not throw these exceptions.</p>
      *


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #24326 

### Context
The Gradle documentation previously did not mention if the getResolutionResult was eager or lazy method.

This fix will help Gradle users understand that Resolution happens when other methods are invoked on the result.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
