### PR TITLE
Enable allWarningsAsErrors for gradle/gradle build scripts

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,9 @@ org.gradle.configuration-cache=true
 
 systemProp.gradle.publish.skip.namespace.check=true
 
+# Kotlin DSL settings
+org.gradle.kotlin.dsl.allWarningsAsErrors=true
+
 # Kotlin settings
 kotlin.incremental.useClasspathSnapshot=true
 kotlin.stdlib.default.dependency=false


### PR DESCRIPTION
See https://docs.gradle.org/current/userguide/kotlin_dsl.html#sec:compilation_warnings