### PR TITLE
Update tested AGP versions

### DIFF
--- a/gradle/dependency-management/agp-versions.properties
+++ b/gradle/dependency-management/agp-versions.properties
@@ -1,4 +1,4 @@
 # Generated - Update by running `./gradlew updateAgpVersions`
-latests=7.3.1,7.4.2,8.0.2,8.1.0-beta04,8.2.0-alpha06
-nightlyBuildId=10247337
+latests=7.3.1,7.4.2,8.0.2,8.1.0-rc01,8.2.0-alpha12
+nightlyBuildId=10482386
 nightlyVersion=8.2.0-dev

--- a/subprojects/docs/src/docs/userguide/compatibility.adoc
+++ b/subprojects/docs/src/docs/userguide/compatibility.adoc
@@ -89,5 +89,5 @@ Gradle is tested with Groovy 1.5.8 through 4.0.0.
 Gradle plugins written in Groovy must use Groovy 3.x for compatibility with Gradle and Groovy DSL build scripts.
 
 == Android
-Gradle is tested with Android Gradle Plugin 7.3 through 8.0.
+Gradle is tested with Android Gradle Plugin 7.3 through 8.1.
 Alpha and beta versions may or may not work.


### PR DESCRIPTION
from 8.1.0-beta04 to 8.1.0-rc01
from 8.2.0-alpha06 to 8.2.0-alpha12
bumping the nightly
