### PR TITLE
Fix gitstream complex-changes check always triggering

### DIFF
--- a/.cm/complex_changes.cm
+++ b/.cm/complex_changes.cm
@@ -21,7 +21,7 @@ automations:
   complex_change:
     if:
       - {{ author.using_gitstream }}
-      - {{ branch | estimatedReviewTime >= 4 }}
+      - {{ branch | estimatedReviewTime >= 40 }}
       - {{ files | length >= 50 }}
       - {{ includes_src_changes }}
     run:


### PR DESCRIPTION
Correct to say 40 min instead of 4, to avoid this always triggering