### PR TITLE
Add minimum version to finalizer test

### DIFF
--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
@@ -113,6 +113,7 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionPerformanc
         given:
         AndroidTestProject testProject = androidTestProject
         testProject.configure(runner)
+        runner.setMinimumBaseVersion('8.3')
         runner.addBuildMutator {invocation -> new TestFinalizerMutator(invocation) }
         runner.tasksToRun = [':phthalic:test', '--dry-run']
         runner.args.add('-Dorg.gradle.parallel=true')


### PR DESCRIPTION
We can't run this test with versions before 8.3 as the performance is so bad, the test will not finish before timing out.