### PR TITLE
Align name on IdentifyTransformExecutionProgressDetails

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformExecutionBuildOperationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformExecutionBuildOperationIntegrationTest.groovy
@@ -94,8 +94,8 @@ class ArtifactTransformExecutionBuildOperationIntegrationTest extends AbstractIn
 
         def executionIdentifications = buildOperations.progress(IdentifyTransformExecutionProgressDetails)*.details
         executionIdentifications.size() == 2
-        def projectTransformIdentification = executionIdentifications.find { it.inputArtifactName == 'producer.jar' }
-        def externalTransformIdentification = executionIdentifications.find { it.inputArtifactName == 'test-4.2.jar' }
+        def projectTransformIdentification = executionIdentifications.find { it.artifactName == 'producer.jar' }
+        def externalTransformIdentification = executionIdentifications.find { it.artifactName == 'test-4.2.jar' }
 
         List<BuildOperationRecord> executions = getTransformExecutions()
         executions.size() == 2

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AbstractTransformExecution.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AbstractTransformExecution.java
@@ -343,12 +343,12 @@ abstract class AbstractTransformExecution implements UnitOfWork {
         }
 
         @Override
-        public org.gradle.operations.dependencies.variants.ComponentIdentifier getInputArtifactComponentIdentifier() {
+        public org.gradle.operations.dependencies.variants.ComponentIdentifier getComponentId() {
             return ComponentToOperationConverter.convertComponentIdentifier(componentIdentifier);
         }
 
         @Override
-        public String getInputArtifactName() {
+        public String getArtifactName() {
             return inputArtifact.getName();
         }
 

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/operations/dependencies/transforms/IdentifyTransformExecutionProgressDetails.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/operations/dependencies/transforms/IdentifyTransformExecutionProgressDetails.java
@@ -44,7 +44,7 @@ public interface IdentifyTransformExecutionProgressDetails {
     /**
      * The component identifier of the input artifact.
      */
-    ComponentIdentifier getInputArtifactComponentIdentifier();
+    ComponentIdentifier getComponentId();
 
     /**
      * The from attributes of the registered transform.
@@ -59,7 +59,7 @@ public interface IdentifyTransformExecutionProgressDetails {
     /**
      * The file name of the input artifact that is about to be transformed.
      */
-    String getInputArtifactName();
+    String getArtifactName();
 
     /**
      * The class of the transform action.


### PR DESCRIPTION
with `PlannedTransformStepIdentity`. The String `inputArtifact` doesn't add any value and we didn't use it on `PlannedTransformStepIdentity` either.