### PR TITLE
Verify support for running on Java 20

### DIFF
--- a/.teamcity/src/main/kotlin/common/JvmCategory.kt
+++ b/.teamcity/src/main/kotlin/common/JvmCategory.kt
@@ -24,7 +24,7 @@ enum class JvmCategory(
     // Oracle doesn't provide zip JDK distribution for Windows anymore, we avoid using it
     MIN_VERSION_WINDOWS(JvmVendor.openjdk, JvmVersion.java8),
     MAX_LTS_VERSION(JvmVendor.openjdk, JvmVersion.java17),
-    MAX_VERSION(JvmVendor.openjdk, JvmVersion.java19),
+    MAX_VERSION(JvmVendor.openjdk, JvmVersion.java20),
     SANTA_TRACKER_SMOKE_TEST_VERSION(JvmVendor.openjdk, JvmVersion.java17),
-    EXPERIMENTAL_VERSION(JvmVendor.openjdk, JvmVersion.java19)
+    EXPERIMENTAL_VERSION(JvmVendor.openjdk, JvmVersion.java20)
 }

--- a/.teamcity/src/main/kotlin/common/JvmCategory.kt
+++ b/.teamcity/src/main/kotlin/common/JvmCategory.kt
@@ -24,7 +24,7 @@ enum class JvmCategory(
     // Oracle doesn't provide zip JDK distribution for Windows anymore, we avoid using it
     MIN_VERSION_WINDOWS(JvmVendor.openjdk, JvmVersion.java8),
     MAX_LTS_VERSION(JvmVendor.openjdk, JvmVersion.java17),
-    MAX_VERSION(JvmVendor.openjdk, JvmVersion.java20),
+    MAX_VERSION(JvmVendor.oracle, JvmVersion.java20),
     SANTA_TRACKER_SMOKE_TEST_VERSION(JvmVendor.openjdk, JvmVersion.java17),
-    EXPERIMENTAL_VERSION(JvmVendor.openjdk, JvmVersion.java20)
+    EXPERIMENTAL_VERSION(JvmVendor.oracle, JvmVersion.java20)
 }

--- a/.teamcity/src/main/kotlin/common/JvmVendor.kt
+++ b/.teamcity/src/main/kotlin/common/JvmVendor.kt
@@ -18,6 +18,6 @@ package common
 
 enum class JvmVendor(val displayName: String) {
     oracle("Oracle"),
-    openjdk("Openjdk"),
+    openjdk("Adoptium"),
     zulu("Zulu")
 }

--- a/.teamcity/src/main/kotlin/common/JvmVersion.kt
+++ b/.teamcity/src/main/kotlin/common/JvmVersion.kt
@@ -20,5 +20,5 @@ enum class JvmVersion(val major: Int) {
     java8(8),
     java11(11),
     java17(17),
-    java19(19)
+    java20(20)
 }

--- a/.teamcity/src/test/kotlin/ApplyDefaultConfigurationTest.kt
+++ b/.teamcity/src/test/kotlin/ApplyDefaultConfigurationTest.kt
@@ -141,8 +141,8 @@ class ApplyDefaultConfigurationTest {
 
     private
     fun expectedRunnerParam(daemon: String = "--daemon", extraParameters: String = "", os: Os = Os.LINUX): String {
-        val linuxPaths = "-Porg.gradle.java.installations.paths=%linux.java8.oracle.64bit%,%linux.java11.openjdk.64bit%,%linux.java17.openjdk.64bit%,%linux.java19.openjdk.64bit%,%linux.java8.openjdk.64bit%"
-        val windowsPaths = "-Porg.gradle.java.installations.paths=%windows.java8.oracle.64bit%,%windows.java11.openjdk.64bit%,%windows.java17.openjdk.64bit%,%windows.java19.openjdk.64bit%,%windows.java8.openjdk.64bit%"
+        val linuxPaths = "-Porg.gradle.java.installations.paths=%linux.java8.oracle.64bit%,%linux.java11.openjdk.64bit%,%linux.java17.openjdk.64bit%,%linux.java20.openjdk.64bit%,%linux.java8.openjdk.64bit%"
+        val windowsPaths = "-Porg.gradle.java.installations.paths=%windows.java8.oracle.64bit%,%windows.java11.openjdk.64bit%,%windows.java17.openjdk.64bit%,%windows.java20.openjdk.64bit%,%windows.java8.openjdk.64bit%"
         val expectedInstallationPaths = if (os == Os.WINDOWS) windowsPaths else linuxPaths
         return "-Dorg.gradle.workers.max=%maxParallelForks% -PmaxParallelForks=%maxParallelForks% $pluginPortalUrlOverride -s --no-configuration-cache %additional.gradle.parameters% $daemon --continue $extraParameters \"-Dscan.tag.Check\" \"-Dscan.tag.\" -PteamCityBuildId=%teamcity.build.id% \"$expectedInstallationPaths\" -Porg.gradle.java.installations.auto-download=false"
     }

--- a/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
+++ b/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
@@ -91,7 +91,7 @@ class PerformanceTestBuildTypeTest {
             "-PautoDownloadAndroidStudio=true",
             "-PrunAndroidStudioInHeadlessMode=true",
             "-Porg.gradle.java.installations.auto-download=false",
-            "\"-Porg.gradle.java.installations.paths=%linux.java8.oracle.64bit%,%linux.java11.openjdk.64bit%,%linux.java17.openjdk.64bit%,%linux.java19.openjdk.64bit%,%linux.java8.openjdk.64bit%\"",
+            "\"-Porg.gradle.java.installations.paths=%linux.java8.oracle.64bit%,%linux.java11.openjdk.64bit%,%linux.java17.openjdk.64bit%,%linux.java20.openjdk.64bit%,%linux.java8.openjdk.64bit%\"",
             "\"-Porg.gradle.performance.branchName=%teamcity.build.branch%\"",
             "\"-Porg.gradle.performance.db.url=%performance.db.url%\"",
             "\"-Porg.gradle.performance.db.username=%performance.db.username%\"",

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionDynamicPomIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionDynamicPomIntegrationTest.groovy
@@ -19,6 +19,8 @@ package org.gradle.buildinit.plugins
 import org.gradle.api.JavaVersion
 import org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl
 import org.gradle.internal.jvm.Jvm
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.UnitTestPreconditions
 
 /**
  * MavenConversionIntegrationTest tests that use a dynamically-generated POM to ensure cross-version compatibility.
@@ -111,6 +113,7 @@ abstract class MavenConversionDynamicPomIntegrationTest extends AbstractInitInte
         failure.assertHasCause("There were failing tests.")
     }
 
+    @Requires(UnitTestPreconditions.Jdk9OrLater)
     def "singleModule with just source"() {
         def source = Jvm.current().javaVersion
         writePom(source, null)
@@ -138,6 +141,7 @@ abstract class MavenConversionDynamicPomIntegrationTest extends AbstractInitInte
         errorOutput.contains("source release ${source} requires target release ${source}")
     }
 
+    @Requires(UnitTestPreconditions.Jdk9OrLater)
     def "singleModule with just target"() {
         def target = Jvm.current().javaVersion
         writePom(null, target)

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionDynamicPomIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionDynamicPomIntegrationTest.groovy
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+//file:noinspection HttpUrlsUsage
+
+package org.gradle.buildinit.plugins
+
+import org.gradle.api.JavaVersion
+import org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl
+import org.gradle.internal.jvm.Jvm
+
+/**
+ * MavenConversionIntegrationTest tests that use a dynamically-generated POM to ensure cross-version compatibility.
+ */
+abstract class MavenConversionDynamicPomIntegrationTest extends AbstractInitIntegrationSpec {
+
+    @Override
+    String subprojectName() { null }
+
+    abstract BuildInitDsl getScriptDsl()
+
+    def setup() {
+        /**
+         * We need to configure the local maven repository explicitly as
+         * RepositorySystem.defaultUserLocalRepository is statically initialised and used when
+         * creating multiple ProjectBuildingRequest.
+         * */
+        m2.generateUserSettingsFile(m2.mavenRepo())
+        using m2
+    }
+
+    def "singleModule (source=#source, target=#target)"() {
+        // Dynamically generated POM file, based on MavenConversionIntegrationTest#singleModule pom.xml
+        targetDir.file("pom.xml") << """
+            <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                <modelVersion>4.0.0</modelVersion>
+
+                <groupId>util</groupId>
+                <artifactId>util</artifactId>
+                <version>2.5</version>
+                <packaging>jar</packaging>
+
+                <dependencies>
+                    <dependency>
+                        <groupId>commons-lang</groupId>
+                        <artifactId>commons-lang</artifactId>
+                        <version>2.6</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>junit</groupId>
+                        <artifactId>junit</artifactId>
+                        <version>4.13.1</version>
+                        <scope>test</scope>
+                    </dependency>
+                </dependencies>
+                <build>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-compiler-plugin</artifactId>
+                            <configuration>
+                                <source>${source}</source>
+                                <target>${target}</target>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </build>
+            </project>
+        """
+        targetDir.file("src/main/java/Foo.java") << """
+            import org.apache.commons.lang.StringUtils;
+
+            public class Foo {
+              public String toString() {
+                return StringUtils.normalizeSpace("hi  there!");
+              }
+            }
+        """
+        targetDir.file("src/test/java/FooTest.java") << """
+            import org.junit.Test;
+
+            public class FooTest {
+              @Test public void test() {
+                assert false: "test failure";
+              }
+            }
+        """
+
+        def dsl = dslFixtureFor(scriptDsl)
+
+        when:
+        run 'init', '--dsl', scriptDsl.id as String
+
+        then:
+        dsl.assertGradleFilesGenerated()
+        dsl.getSettingsFile().text.contains("rootProject.name = 'util'") || dsl.getSettingsFile().text.contains('rootProject.name = "util"')
+        MavenConversionIntegrationTest.assertContainsPublishingConfig(dsl.getBuildFile(), scriptDsl)
+        dsl.getBuildFile(targetDir).text.contains("java.sourceCompatibility = JavaVersion.${source.name()}")
+        // only shows up if the target is different
+        def targetDiffers = source != target
+        targetDiffers == dsl.getBuildFile(targetDir).text.contains("java.targetCompatibility = JavaVersion.${target.name()}")
+
+        when:
+        fails 'clean', 'build'
+
+        then:
+        if (targetDiffers) {
+            // if the source and target are different, we can't actually compile because javac requires them to be the same
+            failure.assertHasDescription("Execution failed for task ':compileJava'.")
+            failure.assertHasCause("warning: source release ${source} requires target release ${source}")
+        } else {
+            // when tests fail, jar may not exist
+            failure.assertHasDescription("Execution failed for task ':test'.")
+            failure.assertHasCause("There were failing tests.")
+        }
+
+        where:
+        source                    | target
+        Jvm.current().javaVersion | Jvm.current().javaVersion
+        Jvm.current().javaVersion | Jvm.current().javaVersion.previous() as JavaVersion
+    }
+}
+
+class KotlinDslMavenConversionDynamicPomIntegrationTest extends MavenConversionDynamicPomIntegrationTest {
+    BuildInitDsl scriptDsl = BuildInitDsl.KOTLIN
+}
+
+class GroovyDslMavenConversionDynamicPomIntegrationTest extends MavenConversionDynamicPomIntegrationTest {
+    BuildInitDsl scriptDsl = BuildInitDsl.GROOVY
+}

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionIntegrationTest.groovy
@@ -287,7 +287,7 @@ tasks.withType<Javadoc>() {
         }
     }
 
-    private static void assertContainsPublishingConfig(TestFile buildScript, BuildInitDsl dsl, String indent = "", List<String> additionalArchiveTasks = []) {
+    static void assertContainsPublishingConfig(TestFile buildScript, BuildInitDsl dsl, String indent = "", List<String> additionalArchiveTasks = []) {
         def text = buildScript.text
         if (dsl == BuildInitDsl.GROOVY) {
             assert text.contains("id 'maven-publish'")

--- a/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/emptySource/some-thing/pom.xml
+++ b/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/emptySource/some-thing/pom.xml
@@ -12,7 +12,6 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <source/>
-                    <target>1.7</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/emptyTarget/some-thing/pom.xml
+++ b/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/emptyTarget/some-thing/pom.xml
@@ -11,7 +11,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.7</source>
                     <target/>
                 </configuration>
             </plugin>

--- a/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/enforcerplugin/some-thing/pom.xml
+++ b/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/enforcerplugin/some-thing/pom.xml
@@ -41,10 +41,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/expandProperties/some-thing/pom.xml
+++ b/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/expandProperties/some-thing/pom.xml
@@ -30,10 +30,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${compiler-version}</version>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/flatmultimodule/some-thing/webinar-parent/pom.xml
+++ b/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/flatmultimodule/some-thing/webinar-parent/pom.xml
@@ -33,10 +33,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/insecureProtocolAllow/some-thing/pom.xml
+++ b/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/insecureProtocolAllow/some-thing/pom.xml
@@ -44,10 +44,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/insecureProtocolDefaultHandling/some-thing/pom.xml
+++ b/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/insecureProtocolDefaultHandling/some-thing/pom.xml
@@ -44,10 +44,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/insecureProtocolFail/some-thing/pom.xml
+++ b/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/insecureProtocolFail/some-thing/pom.xml
@@ -44,10 +44,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/insecureProtocolUpgrade/some-thing/pom.xml
+++ b/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/insecureProtocolUpgrade/some-thing/pom.xml
@@ -44,10 +44,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/insecureProtocolWarn/some-thing/pom.xml
+++ b/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/insecureProtocolWarn/some-thing/pom.xml
@@ -44,10 +44,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/multiModule/some-thing/pom.xml
+++ b/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/multiModule/some-thing/pom.xml
@@ -33,10 +33,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/multiModuleNoBackReferences/some-thing/pom.xml
+++ b/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/multiModuleNoBackReferences/some-thing/pom.xml
@@ -33,10 +33,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/multiModuleWithNestedParent/some-thing/pom.xml
+++ b/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/multiModuleWithNestedParent/some-thing/pom.xml
@@ -25,10 +25,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/multiModuleWithRemoteParent/some-thing/pom.xml
+++ b/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/multiModuleWithRemoteParent/some-thing/pom.xml
@@ -47,10 +47,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/remoteparent/some-thing/pom.xml
+++ b/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/remoteparent/some-thing/pom.xml
@@ -23,10 +23,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/singleModule/some-thing/pom.xml
+++ b/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/singleModule/some-thing/pom.xml
@@ -25,10 +25,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/testsJar/some-thing/pom.xml
+++ b/subprojects/build-init/src/integTest/resources/org/gradle/buildinit/plugins/MavenConversionIntegrationTest/testsJar/some-thing/pom.xml
@@ -36,10 +36,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/library-versions.properties
+++ b/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/library-versions.properties
@@ -1,16 +1,16 @@
 #Generated file, please do not edit - Version values used in build-init templates
 commons-math=3.6.1
 commons-text=1.10.0
-groovy=3.0.17
-guava=31.1-jre
-junit-jupiter=5.9.2
+groovy=3.0.18
+guava=32.1.1-jre
+junit-jupiter=5.9.3
 junit=4.13.2
 kotlin=1.9.0
-scala-library=2.13.10
+scala-library=2.13.11
 scala-xml=1.2.0
 scala=2.13
-scalatest=3.2.15
+scalatest=3.2.16
 scalatestplus-junit=3.2.2.0
 slf4j=2.0.7
 spock=2.2-groovy-3.0
-testng=7.5
+testng=7.5.1

--- a/subprojects/core/src/integTest/groovy/org/gradle/JansiEndUserIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/JansiEndUserIntegrationTest.groovy
@@ -19,7 +19,6 @@ package org.gradle
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.integtests.fixtures.jvm.JavaToolchainFixture
-import org.gradle.internal.jvm.Jvm
 import spock.lang.Ignore
 import spock.lang.Issue
 
@@ -90,7 +89,7 @@ class JansiEndUserIntegrationTest extends AbstractIntegrationSpec implements Jav
             public class MyClass {}
         """
 
-        withInstallations(Jvm.current(), AvailableJavaHomes.jdk11).succeeds 'compileJava'
+        withInstallations(AvailableJavaHomes.jdk11).succeeds 'compileJava'
 
         then:
         outputContains('Hello World')
@@ -100,7 +99,7 @@ class JansiEndUserIntegrationTest extends AbstractIntegrationSpec implements Jav
         when:
         AnnotationProcessorPublisher annotationProcessorPublisher = new AnnotationProcessorPublisher()
         annotationProcessorPublisher.writeSourceFiles()
-        withInstallations(Jvm.current(), AvailableJavaHomes.jdk11)
+        withInstallations(AvailableJavaHomes.jdk11)
             .inDirectory(annotationProcessorPublisher.projectDir)
             .withTasks('publish')
             .run()
@@ -129,7 +128,7 @@ class JansiEndUserIntegrationTest extends AbstractIntegrationSpec implements Jav
             class MyClass {}
         """
 
-        withInstallations(Jvm.current(), AvailableJavaHomes.jdk11).succeeds 'compileGroovy'
+        withInstallations(AvailableJavaHomes.jdk11).succeeds 'compileGroovy'
 
         then:
         outputContains('Hello World')

--- a/subprojects/core/src/integTest/groovy/org/gradle/JansiEndUserIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/JansiEndUserIntegrationTest.groovy
@@ -17,12 +17,15 @@
 package org.gradle
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.AvailableJavaHomes
+import org.gradle.integtests.fixtures.jvm.JavaToolchainFixture
+import org.gradle.internal.jvm.Jvm
 import spock.lang.Ignore
 import spock.lang.Issue
 
 import static org.gradle.internal.nativeintegration.jansi.JansiBootPathConfigurer.JANSI_LIBRARY_PATH_SYS_PROP
 
-class JansiEndUserIntegrationTest extends AbstractIntegrationSpec {
+class JansiEndUserIntegrationTest extends AbstractIntegrationSpec implements JavaToolchainFixture {
 
     private final static String JANSI_VERSION = '1.11'
 
@@ -87,7 +90,7 @@ class JansiEndUserIntegrationTest extends AbstractIntegrationSpec {
             public class MyClass {}
         """
 
-        succeeds 'compileJava'
+        withInstallations(Jvm.current(), AvailableJavaHomes.jdk11).succeeds 'compileJava'
 
         then:
         outputContains('Hello World')
@@ -97,7 +100,10 @@ class JansiEndUserIntegrationTest extends AbstractIntegrationSpec {
         when:
         AnnotationProcessorPublisher annotationProcessorPublisher = new AnnotationProcessorPublisher()
         annotationProcessorPublisher.writeSourceFiles()
-        inDirectory(annotationProcessorPublisher.projectDir).withTasks('publish').run()
+        withInstallations(Jvm.current(), AvailableJavaHomes.jdk11)
+            .inDirectory(annotationProcessorPublisher.projectDir)
+            .withTasks('publish')
+            .run()
 
         then:
         annotationProcessorPublisher.publishedJarFile.isFile()
@@ -123,7 +129,7 @@ class JansiEndUserIntegrationTest extends AbstractIntegrationSpec {
             class MyClass {}
         """
 
-        succeeds 'compileGroovy'
+        withInstallations(Jvm.current(), AvailableJavaHomes.jdk11).succeeds 'compileGroovy'
 
         then:
         outputContains('Hello World')
@@ -139,6 +145,7 @@ class JansiEndUserIntegrationTest extends AbstractIntegrationSpec {
 
     static String annotationProcessorDependency(File repoDir, String processorDependency) {
         """
+            java.toolchain.languageVersion = JavaLanguageVersion.of(11)
             java.sourceCompatibility = '1.7'
 
             repositories {
@@ -200,6 +207,7 @@ class JansiEndUserIntegrationTest extends AbstractIntegrationSpec {
 
                 group = '$group'
                 version = '$version'
+                java.toolchain.languageVersion = JavaLanguageVersion.of(11)
                 java.sourceCompatibility = '1.7'
 
                 dependencies {

--- a/subprojects/internal-instrumentation-processor/src/test/groovy/org/gradle/internal/instrumentation/InstrumentationCodeGenTest.groovy
+++ b/subprojects/internal-instrumentation-processor/src/test/groovy/org/gradle/internal/instrumentation/InstrumentationCodeGenTest.groovy
@@ -26,6 +26,7 @@ import spock.lang.Specification
 import javax.tools.JavaFileObject
 
 import static com.google.testing.compile.Compiler.javac
+import static org.junit.Assume.assumeTrue
 
 abstract class InstrumentationCodeGenTest extends Specification {
 
@@ -49,6 +50,7 @@ abstract class InstrumentationCodeGenTest extends Specification {
     }
 
     private static com.google.testing.compile.Compiler getCompiler() {
+        assumeTrue("Java 20+ do not support --release=8", Jvm.current().javaVersion < JavaVersion.VERSION_20)
         if (Jvm.current().javaVersion.isCompatibleWith(JavaVersion.VERSION_1_9)) {
             return javac().withOptions("--release=8")
         }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.groovy
@@ -142,7 +142,12 @@ class DefaultGradleDistribution implements GradleDistribution {
             return javaVersion >= JavaVersion.VERSION_1_8 && javaVersion <= JavaVersion.VERSION_18
         }
 
-        return javaVersion >= JavaVersion.VERSION_1_8 && maybeEnforceHighestVersion(javaVersion, JavaVersion.VERSION_19)
+        // 8.3 added JDK 20 support
+        if (isSameOrOlder("8.2.1")) {
+            return javaVersion >= JavaVersion.VERSION_1_8 && javaVersion <= JavaVersion.VERSION_19
+        }
+
+        return javaVersion >= JavaVersion.VERSION_1_8 && maybeEnforceHighestVersion(javaVersion, JavaVersion.VERSION_20)
     }
 
     @Override

--- a/subprojects/internal-testing/src/main/resources/valid-precondition-combinations.csv
+++ b/subprojects/internal-testing/src/main/resources/valid-precondition-combinations.csv
@@ -18,6 +18,7 @@ UnitTestPreconditions$HighPerformance
 UnitTestPreconditions$Jdk10OrEarlier
 UnitTestPreconditions$Jdk11OrEarlier
 UnitTestPreconditions$Jdk11OrLater
+UnitTestPreconditions$Jdk12OrLater
 UnitTestPreconditions$Jdk14OrLater
 UnitTestPreconditions$Jdk14OrLater,IntegTestPreconditions$NotEmbeddedExecutor
 UnitTestPreconditions$Jdk15OrEarlier

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/BaseIncrementalCompilationAfterFailureIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/BaseIncrementalCompilationAfterFailureIntegrationTest.groovy
@@ -444,7 +444,7 @@ class GroovyIncrementalCompilationAfterFailureIntegrationTest extends BaseIncrem
             }
             ${mavenCentralRepository()}
             dependencies {
-                testImplementation 'org.codehaus.groovy:groovy:3.0.13'
+                testImplementation 'org.codehaus.groovy:groovy:3.0.18'
                 testImplementation 'org.spockframework:spock-core:2.1-groovy-3.0'
             }
             tasks.withType(GroovyCompile) {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/AbstractIncrementalCompileIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/AbstractIncrementalCompileIntegrationTest.groovy
@@ -21,7 +21,6 @@ import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.integtests.fixtures.CompiledLanguage
 import org.gradle.integtests.fixtures.FeaturePreviewsFixture
 import org.gradle.integtests.fixtures.jvm.JavaToolchainFixture
-import org.gradle.internal.jvm.Jvm
 
 abstract class AbstractIncrementalCompileIntegrationTest extends AbstractIntegrationSpec implements IncrementalCompileMultiProjectTestFixture, JavaToolchainFixture {
     abstract CompiledLanguage getLanguage()
@@ -45,27 +44,27 @@ abstract class AbstractIncrementalCompileIntegrationTest extends AbstractIntegra
         """.stripIndent()
 
         when:
-        withInstallations(Jvm.current(), AvailableJavaHomes.jdk11).succeeds ":${language.compileTaskName}"
+        withInstallations(AvailableJavaHomes.jdk11).succeeds ":${language.compileTaskName}"
 
         then:
         executedAndNotSkipped ":${language.compileTaskName}"
 
         when:
         buildFile << 'java.sourceCompatibility = 1.8\n'
-        withInstallations(Jvm.current(), AvailableJavaHomes.jdk11).succeeds ":${language.compileTaskName}"
+        withInstallations(AvailableJavaHomes.jdk11).succeeds ":${language.compileTaskName}"
 
         then:
         executedAndNotSkipped ":${language.compileTaskName}"
 
         when:
         buildFile << "${language.compileTaskName}.options.debug = false\n"
-        withInstallations(Jvm.current(), AvailableJavaHomes.jdk11).succeeds ":${language.compileTaskName}"
+        withInstallations(AvailableJavaHomes.jdk11).succeeds ":${language.compileTaskName}"
 
         then:
         executedAndNotSkipped ":${language.compileTaskName}"
 
         when:
-        withInstallations(Jvm.current(), AvailableJavaHomes.jdk11).succeeds ":${language.compileTaskName}"
+        withInstallations(AvailableJavaHomes.jdk11).succeeds ":${language.compileTaskName}"
 
         then:
         skipped ":${language.compileTaskName}"

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/BasicJavaCompilerIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/BasicJavaCompilerIntegrationSpec.groovy
@@ -19,16 +19,13 @@ package org.gradle.java.compile
 
 import org.gradle.api.Action
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.AvailableJavaHomes
-import org.gradle.integtests.fixtures.jvm.JavaToolchainFixture
 import org.gradle.internal.classanalysis.JavaClassUtil
-import org.gradle.internal.jvm.Jvm
 import org.gradle.test.fixtures.file.ClassFile
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions
 import org.gradle.test.preconditions.UnitTestPreconditions
 
-abstract class BasicJavaCompilerIntegrationSpec extends AbstractIntegrationSpec implements JavaToolchainFixture {
+abstract class BasicJavaCompilerIntegrationSpec extends AbstractIntegrationSpec {
 
     abstract String compilerConfiguration()
 
@@ -221,11 +218,11 @@ compileJava {
 """
     }
 
+    @Requires(UnitTestPreconditions.Jdk11OrLater)
     def "compile with release flag using #notation notation"() {
         given:
         goodCode()
         buildFile << """
-java.toolchain.languageVersion = JavaLanguageVersion.of(11)
 java.targetCompatibility = JavaVersion.VERSION_1_7
 compileJava.options.compilerArgs.addAll(['--release', $notation])
 compileJava {
@@ -237,35 +234,34 @@ compileJava {
     def compileClasspathTarget = targetVersionOf(configurations.compileClasspath)
     def runtimeClasspathTarget = targetVersionOf(configurations.runtimeClasspath)
     doFirst {
-        assert apiElementsTarget.get() == 8
-        assert runtimeElementsTarget.get() == 8
-        assert compileClasspathTarget.get() == 8
-        assert runtimeClasspathTarget.get() == 8
+        assert apiElementsTarget.get() == 11
+        assert runtimeElementsTarget.get() == 11
+        assert compileClasspathTarget.get() == 11
+        assert runtimeClasspathTarget.get() == 11
     }
 }
 """
 
         expect:
-        withInstallations(Jvm.current(), AvailableJavaHomes.jdk11).succeeds 'compileJava'
-        bytecodeVersion() == 52
+        succeeds 'compileJava'
+        bytecodeVersion() == 55
 
         where:
         notation << [
-            "'8'",
-            '8', // Integer, see #13351
-            '"${8}"' // GString, see #13351
+            "'11'",
+            '11', // Integer, see #13351
+            '"${11}"' // GString, see #13351
         ]
     }
 
-    @Requires(UnitTestPreconditions.Jdk9OrLater)
+    @Requires(UnitTestPreconditions.Jdk11OrLater)
     def "compile with release property set"() {
         given:
         goodCode()
         buildFile << """
-java.toolchain.languageVersion = JavaLanguageVersion.of(11)
 java.targetCompatibility = JavaVersion.VERSION_1_7 // ignored
 compileJava.targetCompatibility = '10' // ignored
-compileJava.options.release.set(8)
+compileJava.options.release.set(11)
 compileJava {
     def targetVersionOf = { config ->
         provider { config.attributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) }
@@ -275,17 +271,17 @@ compileJava {
     def compileClasspathTarget = targetVersionOf(configurations.compileClasspath)
     def runtimeClasspathTarget = targetVersionOf(configurations.runtimeClasspath)
     doFirst {
-        assert apiElementsTarget.get() == 8
-        assert runtimeElementsTarget.get() == 8
-        assert compileClasspathTarget.get() == 8
-        assert runtimeClasspathTarget.get() == 8
+        assert apiElementsTarget.get() == 11
+        assert runtimeElementsTarget.get() == 11
+        assert compileClasspathTarget.get() == 11
+        assert runtimeClasspathTarget.get() == 11
     }
 }
 """
 
         expect:
-        withInstallations(Jvm.current(), AvailableJavaHomes.jdk11).succeeds 'compileJava'
-        bytecodeVersion() == 52
+        succeeds 'compileJava'
+        bytecodeVersion() == 55
     }
 
     @Requires(UnitTestPreconditions.Jdk9OrLater)
@@ -302,15 +298,14 @@ compileJava.options.release.set(8)
         failureHasCause('Cannot specify --release via `CompileOptions.compilerArgs` when using `JavaCompile.release`.')
     }
 
-    @Requires(UnitTestPreconditions.Jdk9OrLater)
+    @Requires(UnitTestPreconditions.Jdk11OrLater)
     def "compile with release property and autoTargetJvmDisabled"() {
         given:
         goodCode()
         buildFile << """
-java.toolchain.languageVersion = JavaLanguageVersion.of(11)
 java.targetCompatibility = JavaVersion.VERSION_1_7 // ignored
 compileJava.targetCompatibility = '10' // ignored
-compileJava.options.release.set(8)
+compileJava.options.release.set(11)
 java.disableAutoTargetJvm()
 compileJava {
     def apiElementsAttributes = configurations.apiElements.attributes
@@ -318,8 +313,8 @@ compileJava {
     def compileClasspathAttributes = configurations.compileClasspath.attributes
     def runtimeClasspathAttributes = configurations.runtimeClasspath.attributes
     doFirst {
-        assert apiElementsAttributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 8
-        assert runtimeElementsAttributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 8
+        assert apiElementsAttributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 11
+        assert runtimeElementsAttributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == 11
         assert compileClasspathAttributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == Integer.MAX_VALUE
         assert runtimeClasspathAttributes.getAttribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE) == Integer.MAX_VALUE
     }
@@ -327,8 +322,8 @@ compileJava {
 """
 
         expect:
-        withInstallations(Jvm.current(), AvailableJavaHomes.jdk11).succeeds 'compileJava'
-        bytecodeVersion() == 52
+        succeeds 'compileJava'
+        bytecodeVersion() == 55
     }
 
     def "compile with target compatibility"() {
@@ -390,60 +385,58 @@ compileJava {
         bytecodeVersion() == 52
     }
 
-    @Requires(UnitTestPreconditions.Jdk9OrLater)
+    @Requires(UnitTestPreconditions.Jdk12OrLater)
     def "compile fails when using newer API with release option"() {
         given:
-        file("src/main/java/compile/test/FailsOnJava8.java") << '''
+        file("src/main/java/compile/test/FailsOnJava11.java") << '''
 package compile.test;
 
 import java.util.stream.Stream;
 import java.util.function.Predicate;
 
-public class FailsOnJava8<T> {
-    public Stream<T> takeFromStream(Stream<T> stream) {
-        return stream.takeWhile(Predicate.isEqual("foo"));
+public class FailsOnJava11<T> {
+    static {
+        System.out.println("Hello, world!".describeConstable());
     }
 }
 '''
 
         buildFile << """
-java.toolchain.languageVersion = JavaLanguageVersion.of(11)
-compileJava.options.compilerArgs.addAll(['--release', '8'])
+compileJava.options.compilerArgs.addAll(['--release', '11'])
 """
 
         expect:
-        withInstallations(Jvm.current(), AvailableJavaHomes.jdk11).fails 'compileJava'
+        fails 'compileJava'
         output.contains(logStatement())
         failure.assertHasErrorOutput("cannot find symbol")
-        failure.assertHasErrorOutput("method takeWhile")
+        failure.assertHasErrorOutput("method describeConstable")
     }
 
-    @Requires(UnitTestPreconditions.Jdk9OrLater)
+    @Requires(UnitTestPreconditions.Jdk12OrLater)
     def "compile fails when using newer API with release property"() {
         given:
-        file("src/main/java/compile/test/FailsOnJava8.java") << '''
+        file("src/main/java/compile/test/FailsOnJava11.java") << '''
 package compile.test;
 
 import java.util.stream.Stream;
 import java.util.function.Predicate;
 
-public class FailsOnJava8<T> {
-    public Stream<T> takeFromStream(Stream<T> stream) {
-        return stream.takeWhile(Predicate.isEqual("foo"));
+public class FailsOnJava11<T> {
+    static {
+        System.out.println("Hello, world!".describeConstable());
     }
 }
 '''
 
         buildFile << """
-java.toolchain.languageVersion = JavaLanguageVersion.of(11)
-compileJava.options.release.set(8)
+compileJava.options.release.set(11)
 """
 
         expect:
-        withInstallations(Jvm.current(), AvailableJavaHomes.jdk11).fails 'compileJava'
+        fails 'compileJava'
         output.contains(logStatement())
         failure.assertHasErrorOutput("cannot find symbol")
-        failure.assertHasErrorOutput("method takeWhile")
+        failure.assertHasErrorOutput("method describeConstable")
     }
 
     def buildScript() {
@@ -531,7 +524,6 @@ class Main {
         when:
         buildFile << """
             apply plugin: "java"
-            java.toolchain.languageVersion = JavaLanguageVersion.of(11)
             dependencies {
                 compileOnly project(":processor")
                 annotationProcessor project(":processor")
@@ -545,7 +537,7 @@ class Main {
         }"""
 
         then:
-        withInstallations(Jvm.current(), AvailableJavaHomes.jdk11).succeeds("compileJava")
+        succeeds("compileJava")
         javaGeneratedSourceFile('Java$$Generated.java').exists()
     }
 
@@ -553,7 +545,6 @@ class Main {
         file("processor").create {
             file("build.gradle") << """
                 apply plugin: 'java'
-                java.toolchain.languageVersion = JavaLanguageVersion.of(11)
             """
             "src/main" {
                 file("resources/META-INF/services/javax.annotation.processing.Processor") << "com.test.SimpleAnnotationProcessor"

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/CommandLineJavaCompilerForExecutableIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/CommandLineJavaCompilerForExecutableIntegrationTest.groovy
@@ -17,7 +17,7 @@
 
 package org.gradle.java.compile
 
-import org.gradle.integtests.fixtures.AvailableJavaHomes
+import org.gradle.internal.jvm.Jvm
 
 import org.gradle.util.internal.TextUtil
 
@@ -25,11 +25,10 @@ class CommandLineJavaCompilerForExecutableIntegrationTest extends JavaCompilerIn
 
     @Override
     String compilerConfiguration() {
-        def executablePath = AvailableJavaHomes.jdk11.getExecutable("javac").absolutePath
         """
             compileJava.options.with {
                 fork = true
-                forkOptions.executable = "${TextUtil.normaliseFileSeparators(executablePath)}"
+                forkOptions.executable = "${TextUtil.normaliseFileSeparators(Jvm.current().getExecutable("javac").absolutePath)}"
             }
         """
     }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/CommandLineJavaCompilerForExecutableIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/CommandLineJavaCompilerForExecutableIntegrationTest.groovy
@@ -17,7 +17,7 @@
 
 package org.gradle.java.compile
 
-import org.gradle.internal.jvm.Jvm
+import org.gradle.integtests.fixtures.AvailableJavaHomes
 
 import org.gradle.util.internal.TextUtil
 
@@ -25,10 +25,11 @@ class CommandLineJavaCompilerForExecutableIntegrationTest extends JavaCompilerIn
 
     @Override
     String compilerConfiguration() {
+        def executablePath = AvailableJavaHomes.jdk11.getExecutable("javac").absolutePath
         """
             compileJava.options.with {
                 fork = true
-                forkOptions.executable = "${TextUtil.normaliseFileSeparators(Jvm.current().getExecutable("javac").absolutePath)}"
+                forkOptions.executable = "${TextUtil.normaliseFileSeparators(executablePath)}"
             }
         """
     }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/CommandLineJavaCompilerIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/CommandLineJavaCompilerIntegrationTest.groovy
@@ -17,18 +17,17 @@
 
 package org.gradle.java.compile
 
-import org.gradle.integtests.fixtures.AvailableJavaHomes
+import org.gradle.internal.jvm.Jvm
 import org.gradle.util.internal.TextUtil
 
 class CommandLineJavaCompilerIntegrationTest extends JavaCompilerIntegrationSpec {
 
     @Override
     String compilerConfiguration() {
-        def javaHomePath = AvailableJavaHomes.jdk11.javaHome.toString()
         """
             compileJava.options.with {
                 fork = true
-                forkOptions.javaHome = file("${TextUtil.normaliseFileSeparators(javaHomePath)}")
+                forkOptions.javaHome = file("${TextUtil.normaliseFileSeparators(Jvm.current().javaHome.toString())}")
             }
         """
     }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/CommandLineJavaCompilerIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/CommandLineJavaCompilerIntegrationTest.groovy
@@ -17,17 +17,18 @@
 
 package org.gradle.java.compile
 
-import org.gradle.internal.jvm.Jvm
+import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.util.internal.TextUtil
 
 class CommandLineJavaCompilerIntegrationTest extends JavaCompilerIntegrationSpec {
 
     @Override
     String compilerConfiguration() {
+        def javaHomePath = AvailableJavaHomes.jdk11.javaHome.toString()
         """
             compileJava.options.with {
                 fork = true
-                forkOptions.javaHome = file("${TextUtil.normaliseFileSeparators(Jvm.current().javaHome.toString())}")
+                forkOptions.javaHome = file("${TextUtil.normaliseFileSeparators(javaHomePath)}")
             }
         """
     }

--- a/subprojects/scala/src/integTest/groovy/org/gradle/integtests/ScalaAnnotationProcessingIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/integtests/ScalaAnnotationProcessingIntegrationTest.groovy
@@ -181,8 +181,6 @@ class ScalaAnnotationProcessingIntegrationTest extends AbstractIntegrationSpec {
 
     static String annotationProcessorDependency(File repoDir, String processorDependency) {
         """
-            java.sourceCompatibility = '1.7'
-
             repositories {
                 maven {
                     url '${repoDir.toURI()}'
@@ -266,7 +264,6 @@ class ScalaAnnotationProcessingIntegrationTest extends AbstractIntegrationSpec {
 
                 group = '$group'
                 version = '$version'
-                java.sourceCompatibility = '1.7'
 
                 publishing {
                    publications {

--- a/subprojects/scala/src/integTest/groovy/org/gradle/integtests/fixtures/ScalaCoverage.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/integtests/fixtures/ScalaCoverage.groovy
@@ -20,13 +20,32 @@ import org.gradle.api.JavaVersion
 
 class ScalaCoverage {
 
-    static final String[] SCALA_2 = ["2.11.12", "2.12.17", "2.13.10"]
-    static final String[] SCALA_3 = ["3.1.3", "3.2.1"]
+    private static final Map<String, JavaVersion> SCALA_2_VERSIONS = [
+        "2.11.12": JavaVersion.VERSION_1_9,
+        "2.12.18": JavaVersion.VERSION_20,
+        "2.13.11": JavaVersion.VERSION_20,
+    ]
+    private static final Map<String, JavaVersion> SCALA_3_VERSIONS = [
+        "3.1.3": JavaVersion.VERSION_18,
+        "3.2.2": JavaVersion.VERSION_19,
+        "3.3.0": JavaVersion.VERSION_20,
+    ]
+    static final String[] SCALA_2 = SCALA_2_VERSIONS.keySet().toArray(new String[0])
+    static final String[] SCALA_3 = SCALA_3_VERSIONS.keySet().toArray(new String[0])
 
     static final String[] DEFAULT = SCALA_2 + SCALA_3
     static final String[] LATEST_IN_MAJOR = [SCALA_2.last(), SCALA_3.last()]
 
-    //to be used with getOrDefault(version, JavaVersion.VERSION_1_8)
-    static final Map<String, JavaVersion> SCALA_VERSION_TO_MAX_JAVA_VERSION = ["2.13.6" : JavaVersion.VERSION_17, "2.13.1": JavaVersion.VERSION_12]
+    static JavaVersion getJavaVersionForScalaVersion(Object scalaVersion) {
+        def v2 = SCALA_2_VERSIONS.get(scalaVersion)
+        if (v2 != null) {
+            return v2
+        }
+        def v3 = SCALA_3_VERSIONS.get(scalaVersion)
+        if (v3 != null) {
+            return v3
+        }
+        throw new IllegalArgumentException("Unknown Scala version: " + scalaVersion)
+    }
 
 }

--- a/subprojects/scala/src/integTest/groovy/org/gradle/integtests/fixtures/ScalaCoverage.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/integtests/fixtures/ScalaCoverage.groovy
@@ -36,7 +36,7 @@ class ScalaCoverage {
     static final String[] DEFAULT = SCALA_2 + SCALA_3
     static final String[] LATEST_IN_MAJOR = [SCALA_2.last(), SCALA_3.last()]
 
-    static JavaVersion getJavaVersionForScalaVersion(Object scalaVersion) {
+    static JavaVersion getMaximumJavaVersionForScalaVersion(Object scalaVersion) {
         def v2 = SCALA_2_VERSIONS.get(scalaVersion)
         if (v2 != null) {
             return v2

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/AbstractToolchainZincScalaCompileIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/AbstractToolchainZincScalaCompileIntegrationTest.groovy
@@ -29,7 +29,7 @@ abstract class AbstractToolchainZincScalaCompileIntegrationTest extends BasicZin
     def setup() {
         jdk = computeJdkForTest()
         Assume.assumeNotNull(jdk)
-        Assume.assumeTrue(ScalaCoverage.getJavaVersionForScalaVersion(version).isCompatibleWith(jdk.javaVersion))
+        Assume.assumeTrue(jdk.javaVersion <= ScalaCoverage.getMaximumJavaVersionForScalaVersion(version))
         executer.beforeExecute {
             withInstallations(jdk)
         }

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/AbstractToolchainZincScalaCompileIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/AbstractToolchainZincScalaCompileIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.scala.compile
 
-import org.gradle.api.JavaVersion
+
 import org.gradle.integtests.fixtures.ScalaCoverage
 import org.gradle.integtests.fixtures.jvm.JavaToolchainFixture
 import org.gradle.internal.jvm.Jvm
@@ -29,7 +29,7 @@ abstract class AbstractToolchainZincScalaCompileIntegrationTest extends BasicZin
     def setup() {
         jdk = computeJdkForTest()
         Assume.assumeNotNull(jdk)
-        Assume.assumeTrue(ScalaCoverage.SCALA_VERSION_TO_MAX_JAVA_VERSION.getOrDefault(version, JavaVersion.VERSION_1_8).isCompatibleWith(jdk.javaVersion))
+        Assume.assumeTrue(ScalaCoverage.getJavaVersionForScalaVersion(version).isCompatibleWith(jdk.javaVersion))
         executer.beforeExecute {
             withInstallations(jdk)
         }

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerMiscEndUserIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerMiscEndUserIntegrationTest.groovy
@@ -41,6 +41,9 @@ class GradleRunnerMiscEndUserIntegrationTest extends BaseTestKitEndUserIntegrati
                 suites {
                     test {
                         useSpock()
+                        dependencies {
+                            implementation localGroovy()
+                        }
                     }
                 }
             }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskJdkRelocationIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskJdkRelocationIntegrationTest.groovy
@@ -32,7 +32,7 @@ class TestTaskJdkRelocationIntegrationTest extends AbstractTaskRelocationIntegra
 
     def setup() {
         executer.beforeExecute {
-            withInstallations(Jvm.current(), AvailableJavaHomes.jdk11)
+            withInstallations(AvailableJavaHomes.jdk11)
         }
     }
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskJdkRelocationIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskJdkRelocationIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.testing
 import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractTaskRelocationIntegrationTest
 import org.gradle.integtests.fixtures.AvailableJavaHomes
+import org.gradle.integtests.fixtures.jvm.JavaToolchainFixture
 import org.gradle.internal.jvm.Jvm
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions
@@ -27,7 +28,13 @@ import org.gradle.util.internal.TextUtil
 import static org.gradle.util.internal.TextUtil.normaliseLineSeparators
 
 @Requires(IntegTestPreconditions.MoreThanOneJava8HomeAvailable)
-class TestTaskJdkRelocationIntegrationTest extends AbstractTaskRelocationIntegrationTest {
+class TestTaskJdkRelocationIntegrationTest extends AbstractTaskRelocationIntegrationTest implements JavaToolchainFixture {
+
+    def setup() {
+        executer.beforeExecute {
+            withInstallations(Jvm.current(), AvailableJavaHomes.jdk11)
+        }
+    }
 
     private File getOriginalJavaExecutable() {
         getAvailableJdk8s()[0].javaExecutable
@@ -70,6 +77,9 @@ class TestTaskJdkRelocationIntegrationTest extends AbstractTaskRelocationIntegra
             }
 
             java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(11)
+                }
                 sourceCompatibility = "1.7"
                 targetCompatibility = "1.7"
             }

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r25/TestProgressCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r25/TestProgressCrossVersionSpec.groovy
@@ -17,7 +17,7 @@
 
 package org.gradle.integtests.tooling.r25
 
-import org.gradle.api.JavaVersion
+
 import org.gradle.integtests.tooling.fixture.ProgressEvents
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.integtests.tooling.fixture.WithOldConfigurationsSupport
@@ -482,7 +482,6 @@ class TestProgressCrossVersionSpec extends ToolingApiSpecification implements Wi
     def goodCode() {
         buildFile << """
             apply plugin: 'java'
-            ${javaSourceCompatibility(JavaVersion.VERSION_1_7)}
             ${mavenCentralRepository()}
             dependencies { ${testImplementationConfiguration} 'junit:junit:4.13' }
             compileTestJava.options.fork = true  // forked as 'Gradle Test Executor 1'
@@ -496,13 +495,5 @@ class TestProgressCrossVersionSpec extends ToolingApiSpecification implements Wi
                 }
             }
         """
-    }
-
-    private String javaSourceCompatibility(JavaVersion javaVersion) {
-        if (targetVersion >= GradleVersion.version("5.0")) {
-            return "java.sourceCompatibility = JavaVersion.${javaVersion.name()}"
-        } else {
-            return "sourceCompatibility = '${javaVersion.toString()}'"
-        }
     }
 }

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonIntegrationTest.groovy
@@ -167,7 +167,7 @@ class WorkerDaemonIntegrationTest extends AbstractWorkerExecutorIntegrationTest 
         """
 
         when:
-        withInstallations(Jvm.current(), AvailableJavaHomes.jdk11).succeeds("runInDaemon")
+        withInstallations(AvailableJavaHomes.jdk11).succeeds("runInDaemon")
 
         then:
         assertWorkerExecuted("runInDaemon")

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.workers.internal
 
 import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.gradle.integtests.fixtures.jvm.JavaToolchainFixture
 import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.internal.jvm.Jvm
 import org.gradle.test.precondition.TestPrecondition
@@ -30,7 +31,7 @@ import static org.gradle.api.internal.file.TestFiles.systemSpecificAbsolutePath
 import static org.gradle.util.internal.TextUtil.normaliseFileSeparators
 
 @IntegrationTestTimeout(180)
-class WorkerDaemonIntegrationTest extends AbstractWorkerExecutorIntegrationTest {
+class WorkerDaemonIntegrationTest extends AbstractWorkerExecutorIntegrationTest implements JavaToolchainFixture {
     boolean isOracleJDK = TestPrecondition.satisfied(UnitTestPreconditions.JdkOracle) && (Jvm.current().jre != null)
 
     WorkerExecutorFixture.WorkActionClass workActionThatPrintsWorkingDirectory
@@ -166,7 +167,7 @@ class WorkerDaemonIntegrationTest extends AbstractWorkerExecutorIntegrationTest 
         """
 
         when:
-        succeeds("runInDaemon")
+        withInstallations(Jvm.current(), AvailableJavaHomes.jdk11).succeeds("runInDaemon")
 
         then:
         assertWorkerExecuted("runInDaemon")

--- a/subprojects/workers/src/testFixtures/groovy/org/gradle/workers/fixtures/WorkerExecutorFixture.groovy
+++ b/subprojects/workers/src/testFixtures/groovy/org/gradle/workers/fixtures/WorkerExecutorFixture.groovy
@@ -201,6 +201,7 @@ class WorkerExecutorFixture {
 
     void withJava7CompatibleClasses() {
         file('buildSrc/build.gradle') << """
+            java.toolchain.languageVersion = JavaLanguageVersion.of(11)
             tasks.withType(JavaCompile) {
                 sourceCompatibility = "1.7"
                 targetCompatibility = "1.7"


### PR DESCRIPTION
This contains no actual production changes, as with the Kotlin 1.9.0 upgrade this already works. These are simply test changes to verify that Gradle indeed runs on Java 20.

Fixes #23488 