### PR TITLE
Update dependency-graph workflow to action v2

### DIFF
--- a/.github/workflows/submit-github-dependency-graph.yml
+++ b/.github/workflows/submit-github-dependency-graph.yml
@@ -17,7 +17,7 @@ jobs:
         distribution: temurin
         java-version: 11
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@dependency-graph
+      uses: gradle/gradle-build-action@v2
       with:
         dependency-graph: generate-and-submit
     - name: Run 'compileAll' to generate dependency graph


### PR DESCRIPTION
This workflow was using an experimental branch of the `gradle-build-action` which no longer exists.
