### PR TITLE
Skip RemotePreconditionProbingTest on non-remote executor

### DIFF
--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/preconditions/UnitTestPreconditions.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/preconditions/UnitTestPreconditions.groovy
@@ -523,4 +523,11 @@ class UnitTestPreconditions {
         }
     }
 
+    static final class OnRemoteTestDistributionExecutor implements TestPrecondition {
+        @Override
+        boolean isSatisfied() throws Exception {
+            return System.getenv("RUNNING_ON_REMOTE_AGENT") != null
+        }
+    }
+
 }

--- a/subprojects/internal-testing/src/main/resources/valid-precondition-combinations.csv
+++ b/subprojects/internal-testing/src/main/resources/valid-precondition-combinations.csv
@@ -69,6 +69,7 @@ UnitTestPreconditions$Windows
 UnitTestPreconditions$Windows,UnitTestPreconditions$Jdk7OrLater,UnitTestPreconditions$Jdk8OrEarlier
 UnitTestPreconditions$Windows,IntegTestPreconditions$IsEmbeddedExecutor
 UnitTestPreconditions$WorkingDir
+UnitTestPreconditions$OnRemoteTestDistributionExecutor
 
 IntegTestPreconditions$CanPublishToS3
 IntegTestPreconditions$HasMsBuild

--- a/subprojects/precondition-tester/src/test/groovy/org/gradle/test/precondition/RemotePreconditionProbingTest.groovy
+++ b/subprojects/precondition-tester/src/test/groovy/org/gradle/test/precondition/RemotePreconditionProbingTest.groovy
@@ -16,9 +16,8 @@
 
 package org.gradle.test.precondition
 
+import org.gradle.test.preconditions.UnitTestPreconditions
 
-import com.gradle.enterprise.testing.annotations.RemoteOnly
-
-@RemoteOnly
+@Requires(UnitTestPreconditions.OnRemoteTestDistributionExecutor)
 class RemotePreconditionProbingTest extends PreconditionProbingTest {
 }


### PR DESCRIPTION
With `@RemoteOnly`, if there's network issue connecting to remote executor, that test fails with an error. This is not what we want, we want it to be skipped in this case.