### PR TITLE
Fix using modifiers with version catalogs

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyModifier.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyModifier.java
@@ -36,9 +36,9 @@ import javax.inject.Inject;
  * <li>For Kotlin DSL, we create {@code invoke(...)} equivalents for all the {@code modify(...)} methods.</li>
  * </ul>
  *
- * @implSpec The default implementation of all methods should not be overridden except {@link #modify(ModuleDependency)}. This method must be implemented.
- *
- * @implNote All other implementations of {@code modify(...)} delegate to {@link #modify(ModuleDependency)}.
+ * @implSpec The only method that should be implemented is {@link #modifyImplementation(ModuleDependency)}. Other overridable methods are used to inject necessary services,
+ * and should not be overridden.
+ * @implNote All implementations of {@code modify(...)} delegate to {@link #modifyImplementation(ModuleDependency)}.
  * <p>
  * Changes to this interface may require changes to the
  * {@link org.gradle.api.internal.artifacts.dsl.dependencies.DependenciesExtensionModule extension module for Groovy DSL} or
@@ -116,7 +116,7 @@ public abstract class DependencyModifier {
         // The unchecked cast can be incorrect if D is an implementation type, but it shouldn't be used in that way.
         @SuppressWarnings("unchecked")
         D copy = (D) dependency.copy();
-        modifyImpl(copy);
+        modifyImplementation(copy);
         return copy;
     }
 
@@ -127,6 +127,6 @@ public abstract class DependencyModifier {
      * @implSpec This method must be implemented.
      * @since 8.4
      */
-    protected abstract void modifyImpl(ModuleDependency dependency);
+    protected abstract void modifyImplementation(ModuleDependency dependency);
 
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyModifier.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyModifier.java
@@ -23,6 +23,7 @@ import org.gradle.api.artifacts.MinimalExternalModuleDependency;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderConvertible;
+import org.gradle.internal.Cast;
 
 import javax.inject.Inject;
 
@@ -35,9 +36,8 @@ import javax.inject.Inject;
  * <li>For Groovy DSL, we create {@code call(...)} equivalents for all the {@code modify(...)} methods.</li>
  * <li>For Kotlin DSL, we create {@code invoke(...)} equivalents for all the {@code modify(...)} methods.</li>
  * </ul>
- *
- * @implSpec The only method that should be implemented is {@link #modifyImplementation(ModuleDependency)}. Other overridable methods are used to inject necessary services,
- * and should not be overridden.
+ * @implSpec The only method that should be implemented is {@link #modifyImplementation(ModuleDependency)}. Other {@code abstract} methods are used to inject necessary services
+ * and should not be implemented.
  * @implNote All implementations of {@code modify(...)} delegate to {@link #modifyImplementation(ModuleDependency)}.
  * <p>
  * Changes to this interface may require changes to the
@@ -114,8 +114,7 @@ public abstract class DependencyModifier {
     public final <D extends ModuleDependency> D modify(D dependency) {
         // Enforce a copy of the dependency to avoid modifying the original dependency
         // The unchecked cast can be incorrect if D is an implementation type, but it shouldn't be used in that way.
-        @SuppressWarnings("unchecked")
-        D copy = (D) dependency.copy();
+        D copy = Cast.uncheckedNonnullCast(dependency.copy());
         modifyImplementation(copy);
         return copy;
     }

--- a/subprojects/core-api/src/main/java/org/gradle/api/plugins/jvm/PlatformDependencyModifiers.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/plugins/jvm/PlatformDependencyModifiers.java
@@ -72,7 +72,7 @@ public interface PlatformDependencyModifiers {
          * Selects the platform variant of the given dependency.
          */
         @Override
-        public void modifyImpl(ModuleDependency dependency) {
+        protected void modifyImplementation(ModuleDependency dependency) {
             dependency.endorseStrictVersions();
             dependency.attributes(attributeContainer -> attributeContainer.attribute(Category.CATEGORY_ATTRIBUTE, getObjectFactory().named(Category.class, Category.REGULAR_PLATFORM)));
         }
@@ -113,7 +113,7 @@ public interface PlatformDependencyModifiers {
          * Selects the enforced platform variant of the given dependency.
          */
         @Override
-        public void modifyImpl(ModuleDependency dependency) {
+        protected void modifyImplementation(ModuleDependency dependency) {
             if (dependency instanceof ExternalDependency) {
                 String version = dependency.getVersion();
                 ((ExternalDependency) dependency).version(constraint -> constraint.strictly(version));

--- a/subprojects/core-api/src/main/java/org/gradle/api/plugins/jvm/PlatformDependencyModifiers.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/plugins/jvm/PlatformDependencyModifiers.java
@@ -56,7 +56,7 @@ public interface PlatformDependencyModifiers {
      * @since 8.0
      */
     @Incubating
-    abstract class PlatformDependencyModifier implements DependencyModifier {
+    abstract class PlatformDependencyModifier extends DependencyModifier {
         /**
          * Injected service to create named objects.
          *
@@ -72,10 +72,9 @@ public interface PlatformDependencyModifiers {
          * Selects the platform variant of the given dependency.
          */
         @Override
-        public <D extends ModuleDependency> D modify(D dependency) {
+        public void modifyImpl(ModuleDependency dependency) {
             dependency.endorseStrictVersions();
             dependency.attributes(attributeContainer -> attributeContainer.attribute(Category.CATEGORY_ATTRIBUTE, getObjectFactory().named(Category.class, Category.REGULAR_PLATFORM)));
-            return dependency;
         }
     }
 
@@ -98,7 +97,7 @@ public interface PlatformDependencyModifiers {
      * @since 8.0
      */
     @Incubating
-    abstract class EnforcedPlatformDependencyModifier implements DependencyModifier {
+    abstract class EnforcedPlatformDependencyModifier extends DependencyModifier {
         /**
          * Injected service to create named objects.
          *
@@ -114,15 +113,12 @@ public interface PlatformDependencyModifiers {
          * Selects the enforced platform variant of the given dependency.
          */
         @Override
-        public <D extends ModuleDependency> D modify(D dependency) {
+        public void modifyImpl(ModuleDependency dependency) {
             if (dependency instanceof ExternalDependency) {
-                ((ExternalDependency) dependency).version(constraint -> {
-                    constraint.strictly(dependency.getVersion());
-                });
+                String version = dependency.getVersion();
+                ((ExternalDependency) dependency).version(constraint -> constraint.strictly(version));
             }
             dependency.attributes(attributeContainer -> attributeContainer.attribute(Category.CATEGORY_ATTRIBUTE, getObjectFactory().named(Category.class, Category.ENFORCED_PLATFORM)));
-
-            return dependency;
         }
     }
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/plugins/jvm/PlatformDependencyModifiers.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/plugins/jvm/PlatformDependencyModifiers.java
@@ -44,7 +44,7 @@ public interface PlatformDependencyModifiers {
      *
      * @implSpec Do not implement this method. Gradle generates the implementation automatically.
      *
-     * @see PlatformDependencyModifiers.PlatformDependencyModifier#modify(ModuleDependency)
+     * @see PlatformDependencyModifiers.PlatformDependencyModifier#modifyImplementation(ModuleDependency)
      */
     @Nested
     PlatformDependencyModifier getPlatform();
@@ -52,7 +52,7 @@ public interface PlatformDependencyModifiers {
     /**
      * Implementation for the platform dependency modifier.
      *
-     * @see #modify(ModuleDependency)
+     * @see #modifyImplementation(ModuleDependency)
      * @since 8.0
      */
     @Incubating
@@ -85,7 +85,7 @@ public interface PlatformDependencyModifiers {
      *
      * @implSpec Do not implement this method. Gradle generates the implementation automatically.
      *
-     * @see PlatformDependencyModifiers.EnforcedPlatformDependencyModifier#modify(ModuleDependency)
+     * @see PlatformDependencyModifiers.EnforcedPlatformDependencyModifier#modifyImplementation(ModuleDependency)
      */
     @Nested
     EnforcedPlatformDependencyModifier getEnforcedPlatform();
@@ -93,7 +93,7 @@ public interface PlatformDependencyModifiers {
     /**
      * Implementation for the enforced platform dependency modifier.
      *
-     * @see #modify(ModuleDependency)
+     * @see #modifyImplementation(ModuleDependency)
      * @since 8.0
      */
     @Incubating

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/plugins/jvm/internal/PlatformDependencyModifiersTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/plugins/jvm/internal/PlatformDependencyModifiersTest.groovy
@@ -25,25 +25,47 @@ import org.gradle.util.TestUtil
 import spock.lang.Specification
 
 class PlatformDependencyModifiersTest extends Specification {
-    def "modifies given external dependency to select platform"() {
+    def "copies given external dependency to select platform"() {
+        def modifier = TestUtil.objectFactory().newInstance(PlatformDependencyModifiers.PlatformDependencyModifier)
+        def dependency = new DefaultExternalModuleDependency("group", "name", "1.0")
+        dependency.setAttributesFactory(AttributeTestUtil.attributesFactory())
+        when:
+        dependency = modifier.modify(dependency)
+        then:
+        dependency.isEndorsingStrictVersions()
+        dependency.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE).toString() == "platform"
+    }
+
+    def "copies given external dependency to select enforced platform"() {
+        def modifier = TestUtil.objectFactory().newInstance(PlatformDependencyModifiers.EnforcedPlatformDependencyModifier)
+        def dependency = new DefaultExternalModuleDependency("group", "name", "1.0")
+        dependency.setAttributesFactory(AttributeTestUtil.attributesFactory())
+        when:
+        dependency = modifier.modify(dependency)
+        then:
+        dependency.getVersionConstraint().strictVersion == "1.0"
+        dependency.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE).toString() == "enforced-platform"
+    }
+
+    def "does not modify given external dependency to select platform"() {
         def modifier = TestUtil.objectFactory().newInstance(PlatformDependencyModifiers.PlatformDependencyModifier)
         def dependency = new DefaultExternalModuleDependency("group", "name", "1.0")
         dependency.setAttributesFactory(AttributeTestUtil.attributesFactory())
         when:
         modifier.modify(dependency)
         then:
-        dependency.isEndorsingStrictVersions()
-        dependency.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE).toString() == "platform"
+        !dependency.isEndorsingStrictVersions()
+        dependency.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE).toString() != "platform"
     }
 
-    def "modifies given external dependency to select enforced platform"() {
+    def "does not modify given external dependency to select enforced platform"() {
         def modifier = TestUtil.objectFactory().newInstance(PlatformDependencyModifiers.EnforcedPlatformDependencyModifier)
         def dependency = new DefaultExternalModuleDependency("group", "name", "1.0")
         dependency.setAttributesFactory(AttributeTestUtil.attributesFactory())
         when:
         modifier.modify(dependency)
         then:
-        dependency.getVersionConstraint().strictVersion == "1.0"
-        dependency.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE).toString() == "enforced-platform"
+        dependency.getVersionConstraint().requiredVersion == "1.0"
+        dependency.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE).toString() != "enforced-platform"
     }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/TestFixturesDependencyModifiers.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/TestFixturesDependencyModifiers.java
@@ -55,17 +55,19 @@ public interface TestFixturesDependencyModifiers {
      * @see #modify(ModuleDependency)
      */
     @Incubating
-    abstract class TestFixturesDependencyModifier implements DependencyModifier {
+    abstract class TestFixturesDependencyModifier extends DependencyModifier {
         /**
          * {@inheritDoc}
          *
          * Selects the test fixtures variant of the given dependency.
          */
         @Override
-        public <D extends ModuleDependency> D modify(D dependency) {
+        public void modifyImpl(ModuleDependency dependency) {
             if (dependency instanceof ExternalDependency) {
+                String group = dependency.getGroup();
+                String name = dependency.getName() + TestFixturesSupport.TEST_FIXTURES_CAPABILITY_APPENDIX;
                 dependency.capabilities(capabilities -> {
-                    capabilities.requireCapability(new DefaultImmutableCapability(dependency.getGroup(), dependency.getName() + TestFixturesSupport.TEST_FIXTURES_CAPABILITY_APPENDIX, null));
+                    capabilities.requireCapability(new DefaultImmutableCapability(group, name, null));
                 });
             } else if (dependency instanceof ProjectDependency) {
                 ProjectDependency projectDependency = Cast.uncheckedCast(dependency);
@@ -73,7 +75,6 @@ public interface TestFixturesDependencyModifiers {
             } else {
                 throw new IllegalStateException("Unknown dependency type: " + dependency.getClass());
             }
-            return dependency;
         }
     }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/TestFixturesDependencyModifiers.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/TestFixturesDependencyModifiers.java
@@ -43,7 +43,7 @@ public interface TestFixturesDependencyModifiers {
      * @return the dependency modifier
      * @implSpec Do not implement this method. Gradle generates the implementation automatically.
      *
-     * @see TestFixturesDependencyModifier#modify(ModuleDependency)
+     * @see TestFixturesDependencyModifier#modifyImplementation(ModuleDependency)
      */
     @Nested
     TestFixturesDependencyModifier getTestFixtures();
@@ -52,7 +52,7 @@ public interface TestFixturesDependencyModifiers {
      * Implementation for the test fixtures dependency modifier.
      *
      * @since 8.0
-     * @see #modify(ModuleDependency)
+     * @see #modifyImplementation(ModuleDependency)
      */
     @Incubating
     abstract class TestFixturesDependencyModifier extends DependencyModifier {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/TestFixturesDependencyModifiers.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/TestFixturesDependencyModifiers.java
@@ -62,7 +62,7 @@ public interface TestFixturesDependencyModifiers {
          * Selects the test fixtures variant of the given dependency.
          */
         @Override
-        public void modifyImpl(ModuleDependency dependency) {
+        protected void modifyImplementation(ModuleDependency dependency) {
             if (dependency instanceof ExternalDependency) {
                 String group = dependency.getGroup();
                 String name = dependency.getName() + TestFixturesSupport.TEST_FIXTURES_CAPABILITY_APPENDIX;


### PR DESCRIPTION
Because version catalog dependencies are immutable, the modifiers need to sometimes copy the dependency to modify it.

In order to make this work, we copy the dependencies regardless of implementation.

Fixes #25828