### PR TITLE
Update Composite Builds Declared Substitutions Sample to `using` instead of `with`

### DIFF
--- a/subprojects/docs/src/samples/build-organization/composite-builds/declared-substitution/README.adoc
+++ b/subprojects/docs/src/samples/build-organization/composite-builds/declared-substitution/README.adoc
@@ -8,7 +8,7 @@ In `dependencySubstitution` terms, the default substitutions are:
 ```
 dependencySubstitution {
     ... for each project in included build ...
-    substitute module("${project.group}:${project.name}") with project(":${project.name}")
+    substitute module("${project.group}:${project.name}") using project(":${project.name}")
 }
 ```
 


### PR DESCRIPTION
I believe these docs were outdated and the new syntax uses `using` instead of `with`