### PR TITLE
Fix Property Upgrade codegen default values

### DIFF
--- a/subprojects/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/TypeUtils.java
+++ b/subprojects/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/TypeUtils.java
@@ -21,7 +21,30 @@ import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.TypeName;
 import org.objectweb.asm.Type;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 public class TypeUtils {
+
+    private static final Map<Type, Object> PRIMITIVE_TYPES_DEFAULT_VALUES;
+    static {
+        Map<Type, Object> map = new HashMap<>();
+        map.put(Type.BYTE_TYPE, (byte) 0);
+        map.put(Type.SHORT_TYPE, (short) 0);
+        map.put(Type.INT_TYPE, 0);
+        map.put(Type.LONG_TYPE, 0L);
+        map.put(Type.FLOAT_TYPE, 0.0f);
+        map.put(Type.DOUBLE_TYPE, 0.0d);
+        map.put(Type.CHAR_TYPE, '\u0000');
+        map.put(Type.BOOLEAN_TYPE, false);
+        PRIMITIVE_TYPES_DEFAULT_VALUES = Collections.unmodifiableMap(map);
+    }
+
+    public static Object getDefaultValue(Type type) {
+        return PRIMITIVE_TYPES_DEFAULT_VALUES.get(type);
+    }
+
     /**
      * Converts an ASM {@link Type} to a JavaPoet {@link TypeName}.
      */

--- a/subprojects/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/TypeUtils.java
+++ b/subprojects/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/processor/codegen/TypeUtils.java
@@ -27,22 +27,22 @@ import java.util.Map;
 
 public class TypeUtils {
 
-    private static final Map<Type, Object> PRIMITIVE_TYPES_DEFAULT_VALUES;
+    private static final Map<Type, String> PRIMITIVE_TYPES_DEFAULT_VALUES_AS_STRING;
     static {
-        Map<Type, Object> map = new HashMap<>();
-        map.put(Type.BYTE_TYPE, (byte) 0);
-        map.put(Type.SHORT_TYPE, (short) 0);
-        map.put(Type.INT_TYPE, 0);
-        map.put(Type.LONG_TYPE, 0L);
-        map.put(Type.FLOAT_TYPE, 0.0f);
-        map.put(Type.DOUBLE_TYPE, 0.0d);
-        map.put(Type.CHAR_TYPE, '\u0000');
-        map.put(Type.BOOLEAN_TYPE, false);
-        PRIMITIVE_TYPES_DEFAULT_VALUES = Collections.unmodifiableMap(map);
+        Map<Type, String> map = new HashMap<>();
+        map.put(Type.BYTE_TYPE, "0");
+        map.put(Type.SHORT_TYPE, "0");
+        map.put(Type.INT_TYPE, "0");
+        map.put(Type.LONG_TYPE, "0L");
+        map.put(Type.FLOAT_TYPE, "0.0f");
+        map.put(Type.DOUBLE_TYPE, "0.0");
+        map.put(Type.CHAR_TYPE, "'\\u0000'");
+        map.put(Type.BOOLEAN_TYPE, "false");
+        PRIMITIVE_TYPES_DEFAULT_VALUES_AS_STRING = Collections.unmodifiableMap(map);
     }
 
-    public static Object getDefaultValue(Type type) {
-        return PRIMITIVE_TYPES_DEFAULT_VALUES.get(type);
+    public static String getDefaultValue(Type type) {
+        return PRIMITIVE_TYPES_DEFAULT_VALUES_AS_STRING.getOrDefault(type, "null");
     }
 
     /**

--- a/subprojects/internal-instrumentation-processor/src/test/groovy/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeCodeGenTest.groovy
+++ b/subprojects/internal-instrumentation-processor/src/test/groovy/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeCodeGenTest.groovy
@@ -145,7 +145,7 @@ class PropertyUpgradeCodeGenTest extends InstrumentationCodeGenTest {
 
             @VisitForInstrumentation(value = {Task.class})
             public abstract class Task {
-                @UpgradedProperty
+                @UpgradedProperty(originalType = ${originalType}.class)
                 public abstract $upgradedType getProperty();
             }
         """
@@ -175,14 +175,16 @@ class PropertyUpgradeCodeGenTest extends InstrumentationCodeGenTest {
             .hasSourceEquivalentTo(generatedClass)
 
         where:
-        upgradedType                  | originalType     | getCall              | setCall            | fullImport
-        "Property<Integer>"           | "Integer"        | ".get()"             | ".set(arg0)"       | "java.lang.Integer"
-        "Property<String>"            | "String"         | ".get()"             | ".set(arg0)"       | "java.lang.String"
-        "ListProperty<String>"        | "List"           | ".get()"             | ".set(arg0)"       | "java.util.List"
-        "MapProperty<String, String>" | "Map"            | ".get()"             | ".set(arg0)"       | "java.util.Map"
-        "RegularFileProperty"         | "File"           | ".getAsFile().get()" | ".fileValue(arg0)" | "java.io.File"
-        "DirectoryProperty"           | "File"           | ".getAsFile().get()" | ".fileValue(arg0)" | "java.io.File"
-        "ConfigurableFileCollection"  | "FileCollection" | ""                   | ".setFrom(arg0)"   | "org.gradle.api.file.FileCollection"
+        upgradedType                  | originalType     | getCall                    | setCall            | fullImport
+        "Property<Integer>"           | "int"            | ".getOrElse(0)"            | ".set(arg0)"       | "java.lang.Integer"
+        "Property<Boolean>"           | "boolean"        | ".getOrElse(false)"        | ".set(arg0)"       | "java.lang.Boolean"
+        "Property<Integer>"           | "Integer"        | ".getOrElse(null)"         | ".set(arg0)"       | "java.lang.Integer"
+        "Property<String>"            | "String"         | ".getOrElse(null)"         | ".set(arg0)"       | "java.lang.String"
+        "ListProperty<String>"        | "List"           | ".getOrElse(null)"         | ".set(arg0)"       | "java.util.List"
+        "MapProperty<String, String>" | "Map"            | ".getOrElse(null)"         | ".set(arg0)"       | "java.util.Map"
+        "RegularFileProperty"         | "File"           | ".getAsFile().getOrNull()" | ".fileValue(arg0)" | "java.io.File"
+        "DirectoryProperty"           | "File"           | ".getAsFile().getOrNull()" | ".fileValue(arg0)" | "java.io.File"
+        "ConfigurableFileCollection"  | "FileCollection" | ""                         | ".setFrom(arg0)"   | "org.gradle.api.file.FileCollection"
     }
 
     def "should correctly generate interceptor when property name contains get"() {


### PR DESCRIPTION
Now we return default value instead of directly call `.get()` since property could be empty.

Fixes https://github.com/gradle/gradle/issues/25835