### PR TITLE
Don't keep compiler daemons alive on Windows

### DIFF
--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DaemonJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DaemonJavaCompiler.java
@@ -88,7 +88,9 @@ public class DaemonJavaCompiler extends AbstractDaemonCompiler<JavaCompileSpec> 
 
     private static KeepAliveMode getDefaultKeepAliveMode() {
         if (OperatingSystem.current().isWindows()) {
-            // We don't track commit properly on Windows, so keeping extra workers alive is not safe
+            // Our physical memory monitoring on Windows is not quite accurate, which causes Gradle to think memory 
+            // is available, even when virtual memory is 100% committed, so worker daemon expiration does not occur 
+            // when it needs to. Keeping extra workers alive on Windows is not safe until we can improve this.
             return KeepAliveMode.SESSION;
         }
         // By default, we keep Java compiler daemons alive across builds until the daemon is shut down

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DaemonJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DaemonJavaCompiler.java
@@ -21,6 +21,7 @@ import org.gradle.api.internal.tasks.compile.daemon.CompilerWorkerExecutor;
 import org.gradle.internal.classloader.VisitableURLClassLoader;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.jvm.Jvm;
+import org.gradle.internal.os.OperatingSystem;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.process.JavaForkOptions;
 import org.gradle.process.internal.JavaForkOptionsFactory;
@@ -70,8 +71,7 @@ public class DaemonJavaCompiler extends AbstractDaemonCompiler<JavaCompileSpec> 
         ClassPath compilerClasspath = classPathRegistry.getClassPath("JAVA-COMPILER");
         FlatClassLoaderStructure classLoaderStructure = new FlatClassLoaderStructure(new VisitableURLClassLoader.Spec("compiler", compilerClasspath.getAsURLs()));
 
-        // By default, we keep Java compiler daemons alive across builds until the daemon is shut down
-        String keepAliveModeStr = System.getProperty(KEEP_DAEMON_ALIVE_PROPERTY, KeepAliveMode.DAEMON.name());
+        String keepAliveModeStr = System.getProperty(KEEP_DAEMON_ALIVE_PROPERTY, getDefaultKeepAliveMode().name());
         KeepAliveMode keepAliveMode;
         try {
             keepAliveMode = KeepAliveMode.valueOf(keepAliveModeStr);
@@ -84,6 +84,15 @@ public class DaemonJavaCompiler extends AbstractDaemonCompiler<JavaCompileSpec> 
             .withClassLoaderStructure(classLoaderStructure)
             .keepAliveMode(keepAliveMode)
             .build();
+    }
+
+    private static KeepAliveMode getDefaultKeepAliveMode() {
+        if (OperatingSystem.current().isWindows()) {
+            // We don't track commit properly on Windows, so keeping extra workers alive is not safe
+            return KeepAliveMode.SESSION;
+        }
+        // By default, we keep Java compiler daemons alive across builds until the daemon is shut down
+        return KeepAliveMode.DAEMON;
     }
 
     public static class JavaCompilerParameters extends CompilerWorkerExecutor.CompilerParameters {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/daemon/JavaCompilerDaemonReuseIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/daemon/JavaCompilerDaemonReuseIntegrationTest.groovy
@@ -96,6 +96,7 @@ class JavaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReuse
         """
 
         when:
+        args("-D${KEEP_DAEMON_ALIVE_PROPERTY}=${KeepAliveMode.DAEMON.name()}")
         succeeds("compileAll", "--info")
 
         then:
@@ -108,6 +109,7 @@ class JavaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReuse
 
         when:
         executer.withWorkerDaemonsExpirationDisabled()
+        args("-D${KEEP_DAEMON_ALIVE_PROPERTY}=${KeepAliveMode.DAEMON.name()}")
         succeeds("clean", "compileAll", "--info")
 
         then:
@@ -132,6 +134,7 @@ class JavaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReuse
         """
 
         when:
+        args("-D${KEEP_DAEMON_ALIVE_PROPERTY}=${KeepAliveMode.DAEMON.name()}")
         succeeds("compileAll")
 
         then:
@@ -142,6 +145,7 @@ class JavaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReuse
 
         when:
         executer.withWorkerDaemonsExpirationDisabled()
+        args("-D${KEEP_DAEMON_ALIVE_PROPERTY}=${KeepAliveMode.DAEMON.name()}")
         succeeds("clean", "compileAll")
 
         then:
@@ -170,6 +174,7 @@ class JavaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReuse
         file('src/main2/java/ClassWithWarning2.java') << classWithWarning
 
         when:
+        args("-D${KEEP_DAEMON_ALIVE_PROPERTY}=${KeepAliveMode.DAEMON.name()}")
         succeeds("compileAll")
 
         then:
@@ -180,6 +185,7 @@ class JavaCompilerDaemonReuseIntegrationTest extends AbstractCompilerDaemonReuse
 
         when:
         executer.withWorkerDaemonsExpirationDisabled()
+        args("-D${KEEP_DAEMON_ALIVE_PROPERTY}=${KeepAliveMode.DAEMON.name()}")
         succeeds("clean", "compileAll")
 
         then:

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonLifecycleTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonLifecycleTest.groovy
@@ -166,6 +166,8 @@ class WorkerDaemonLifecycleTest extends AbstractDaemonWorkerExecutorIntegrationS
 
         when:
         args("--info")
+        // force persistent compiler daemons, until Windows has them enabled by default again
+        executer.withArgument("-Dorg.gradle.internal.java.compile.daemon.keepAlive=${KeepAliveMode.DAEMON.name()}")
         succeeds "compileJava", "runInWorker"
 
         then:


### PR DESCRIPTION
Unfortunately, our memory tracking is lacking on Windows and this can cause major issues.