### PR TITLE
Update to latest version of Maven 3.x

### DIFF
--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -93,6 +93,7 @@
             <trusting group="com.fasterxml.jackson.core"/>
             <trusting group="^com[.]fasterxml[.]jackson($|([.].*))" regex="true"/>
          </trusted-key>
+         <trusted-key id="29bea2a645f2d6ced7fb12e02b172e3e156466e8" group="^org[.]apache[.]maven($|([.].*))" regex="true"/>
          <trusted-key id="2bcbdd0f23ea1cafcc11d4860374cf2e8dd1bdfd" group="org.sonatype.plexus"/>
          <trusted-key id="2be67ac00d699e04e840b7fe29967e804d85663f">
             <trusting group="com.eed3si9n" name="shaded-scalajson_2.13"/>
@@ -1068,9 +1069,19 @@
             <pgp value="f254b35617dc255d9344bcfa873a8e86b4372146"/>
          </artifact>
       </component>
+      <component group="org.apache.maven.shared" name="maven-shared-utils" version="3.3.4">
+         <artifact name="maven-shared-utils-3.3.4.jar">
+            <pgp value="82c9ec0e52c47a936a849e0113d979595e6d01e1"/>
+         </artifact>
+      </component>
       <component group="org.apache.maven.wagon" name="wagon-provider-api" version="3.3.4">
          <artifact name="wagon-provider-api-3.3.4.jar">
             <pgp value="fa77dcfef2ee6eb2debedd2c012579464d01c06a"/>
+         </artifact>
+      </component>
+      <component group="org.apache.maven.wagon" name="wagon-provider-api" version="3.5.3">
+         <artifact name="wagon-provider-api-3.5.3.jar">
+            <pgp value="6a814b1f869c2bbeab7cb7271a2a1c94bde89688"/>
          </artifact>
       </component>
       <component group="org.apache.mina" name="mina-core" version="2.0.17">
@@ -1173,9 +1184,24 @@
             <pgp value="f254b35617dc255d9344bcfa873a8e86b4372146"/>
          </artifact>
       </component>
+      <component group="org.codehaus.plexus" name="plexus-cipher" version="2.0">
+         <artifact name="plexus-cipher-2.0.jar">
+            <pgp value="6a814b1f869c2bbeab7cb7271a2a1c94bde89688"/>
+         </artifact>
+      </component>
+      <component group="org.codehaus.plexus" name="plexus-classworlds" version="2.7.0">
+         <artifact name="plexus-classworlds-2.7.0.jar">
+            <pgp value="b91ab7d2121dc6b0a61aa182d7742d58455ecc7c"/>
+         </artifact>
+      </component>
       <component group="org.codehaus.plexus" name="plexus-interpolation" version="1.26">
          <artifact name="plexus-interpolation-1.26.jar">
             <pgp value="f254b35617dc255d9344bcfa873a8e86b4372146"/>
+         </artifact>
+      </component>
+      <component group="org.codehaus.plexus" name="plexus-sec-dispatcher" version="2.0">
+         <artifact name="plexus-sec-dispatcher-2.0.jar">
+            <pgp value="f3d15b8ff9902805de4be6b18dc6f3d0abdbd017"/>
          </artifact>
       </component>
       <component group="org.codehaus.woodstox" name="stax2-api" version="4.2.1">

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/maven/PomProjectInitDescriptor.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/maven/PomProjectInitDescriptor.java
@@ -45,9 +45,9 @@ import java.util.Set;
 import java.util.TreeSet;
 
 public class PomProjectInitDescriptor implements BuildConverter {
-    private final static String MAVEN_VERSION = "3.6.3";
-    private final static String MAVEN_WAGON_VERSION = "3.4.2";
-    private final static String AETHER_VERSION = "1.1.0";
+    private final static String MAVEN_VERSION = "3.9.3";
+    private final static String MAVEN_WAGON_VERSION = "3.5.3";
+    private final static String MAVEN_RESOLVER_VERSION = "1.9.13";
 
     private final MavenSettingsProvider settingsProvider;
     private final DocumentationRegistry documentationRegistry;
@@ -100,8 +100,8 @@ public class PomProjectInitDescriptor implements BuildConverter {
             dependencies.create("org.apache.maven:maven-compat:" + MAVEN_VERSION),
             dependencies.create("org.apache.maven.wagon:wagon-http:" + MAVEN_WAGON_VERSION),
             dependencies.create("org.apache.maven.wagon:wagon-provider-api:" + MAVEN_WAGON_VERSION),
-            dependencies.create("org.eclipse.aether:aether-connector-basic:" + AETHER_VERSION),
-            dependencies.create("org.eclipse.aether:aether-transport-wagon:" + AETHER_VERSION)
+            dependencies.create("org.apache.maven.resolver:maven-resolver-connector-basic:" + MAVEN_RESOLVER_VERSION),
+            dependencies.create("org.apache.maven.resolver:maven-resolver-transport-wagon:" + MAVEN_RESOLVER_VERSION)
         );
         jvmPluginServices.configureAsRuntimeClasspath(config);
         detachedResolver.getRepositories().mavenCentral();

--- a/subprojects/build-init/src/main/java/org/gradleinternal/buildinit/plugins/internal/maven/MavenProjectsCreator.java
+++ b/subprojects/build-init/src/main/java/org/gradleinternal/buildinit/plugins/internal/maven/MavenProjectsCreator.java
@@ -50,6 +50,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 
+@SuppressWarnings("deprecation") // This Class uses a number of types deprecated in Maven
 public class MavenProjectsCreator {
 
     public Set<MavenProject> create(Settings mavenSettings, File pomFile) {
@@ -96,20 +97,17 @@ public class MavenProjectsCreator {
         //we should add coverage for nested multi-project builds with multiple parents.
         reactorProjects.add(mavenProject);
         List<ProjectBuildingResult> allProjects = builder.build(ImmutableList.of(pomFile), true, buildingRequest);
-        //noinspection NullableProblems
         CollectionUtils.collect(allProjects, reactorProjects, ProjectBuildingResult::getProject);
 
         MavenExecutionResult result = new DefaultMavenExecutionResult();
         result.setProject(mavenProject);
         RepositorySystemSession repoSession = new DefaultRepositorySystemSession();
-        @SuppressWarnings("deprecation")
         MavenSession session = new MavenSession(container, repoSession, executionRequest, result);
         session.setCurrentProject(mavenProject);
 
         return reactorProjects;
     }
 
-    @SuppressWarnings("deprecation")
     private void populateFromSettings(Settings settings, MavenExecutionRequest executionRequest, MavenExecutionRequestPopulator populator) throws MavenExecutionRequestPopulationException {
         populator.populateFromSettings(executionRequest, settings);
     }

--- a/subprojects/distributions-dependencies/build.gradle.kts
+++ b/subprojects/distributions-dependencies/build.gradle.kts
@@ -25,7 +25,7 @@ val bouncycastleVersion = "1.68"
 val jacksonVersion = "2.14.1"
 val jaxbVersion = "3.0.0"
 val junit5Version = "5.8.2"
-val mavenVersion = "3.6.3"
+val mavenVersion = "3.9.3"
 val nativePlatformVersion = "0.22-snapshot-20230807182135+0000"
 val slf4jVersion = "1.7.30"
 val spockVersion = if (isBundleGroovy4) "2.3-groovy-4.0" else "2.3-groovy-3.0"
@@ -136,10 +136,10 @@ dependencies {
         api(libs.nativePlatform)        { version { strictly(nativePlatformVersion) }}
         api(libs.nativePlatformFileEvents) { version { strictly(nativePlatformVersion) }}
         api(libs.objenesis)             { version { strictly("2.6") }}
-        api(libs.plexusCipher)          { version { strictly("1.7"); because("transitive dependency of Maven modules to process POM metadata") }}
+        api(libs.plexusCipher)          { version { strictly("2.0"); because("transitive dependency of Maven modules to process POM metadata") }}
         api(libs.plexusInterpolation)   { version { strictly("1.26"); because("transitive dependency of Maven modules to process POM metadata") }}
-        api(libs.plexusSecDispatcher)   { version { strictly("1.4"); because("transitive dependency of Maven modules to process POM metadata") }}
-        api(libs.plexusUtils)           { version { strictly("3.3.0"); because("transitive dependency of Maven modules to process POM metadata") }}
+        api(libs.plexusSecDispatcher)   { version { strictly("2.0"); because("transitive dependency of Maven modules to process POM metadata") }}
+        api(libs.plexusUtils)           { version { strictly("3.5.1"); because("transitive dependency of Maven modules to process POM metadata") }}
         api(libs.plist)                 { version { strictly("1.21") }}
         api(libs.servletApi)            { version { strictly("3.1.0") }}
         api(libs.slf4jApi)              { version { strictly(slf4jVersion) }}

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-demo-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-demo-1.0.pom
@@ -18,16 +18,16 @@
       <scope>runtime</scope>
       <exclusions>
         <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
           <artifactId>kotlin-stdlib-common</artifactId>
-          <groupId>org.jetbrains.kotlin</groupId>
         </exclusion>
         <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
           <artifactId>kotlin-test-common</artifactId>
-          <groupId>org.jetbrains.kotlin</groupId>
         </exclusion>
         <exclusion>
-          <artifactId>kotlin-test-annotations-common</artifactId>
           <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>kotlin-test-annotations-common</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -38,16 +38,16 @@
       <scope>runtime</scope>
       <exclusions>
         <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
           <artifactId>kotlin-stdlib-common</artifactId>
-          <groupId>org.jetbrains.kotlin</groupId>
         </exclusion>
         <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
           <artifactId>kotlin-test-common</artifactId>
-          <groupId>org.jetbrains.kotlin</groupId>
         </exclusion>
         <exclusion>
-          <artifactId>kotlin-test-annotations-common</artifactId>
           <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>kotlin-test-annotations-common</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-demo-debug-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-demo-debug-1.0.pom
@@ -18,16 +18,16 @@
       <scope>runtime</scope>
       <exclusions>
         <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
           <artifactId>kotlin-stdlib-common</artifactId>
-          <groupId>org.jetbrains.kotlin</groupId>
         </exclusion>
         <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
           <artifactId>kotlin-test-common</artifactId>
-          <groupId>org.jetbrains.kotlin</groupId>
         </exclusion>
         <exclusion>
-          <artifactId>kotlin-test-annotations-common</artifactId>
           <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>kotlin-test-annotations-common</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -38,16 +38,16 @@
       <scope>runtime</scope>
       <exclusions>
         <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
           <artifactId>kotlin-stdlib-common</artifactId>
-          <groupId>org.jetbrains.kotlin</groupId>
         </exclusion>
         <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
           <artifactId>kotlin-test-common</artifactId>
-          <groupId>org.jetbrains.kotlin</groupId>
         </exclusion>
         <exclusion>
-          <artifactId>kotlin-test-annotations-common</artifactId>
           <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>kotlin-test-annotations-common</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-full-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-full-1.0.pom
@@ -18,16 +18,16 @@
       <scope>runtime</scope>
       <exclusions>
         <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
           <artifactId>kotlin-stdlib-common</artifactId>
-          <groupId>org.jetbrains.kotlin</groupId>
         </exclusion>
         <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
           <artifactId>kotlin-test-common</artifactId>
-          <groupId>org.jetbrains.kotlin</groupId>
         </exclusion>
         <exclusion>
-          <artifactId>kotlin-test-annotations-common</artifactId>
           <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>kotlin-test-annotations-common</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -38,16 +38,16 @@
       <scope>runtime</scope>
       <exclusions>
         <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
           <artifactId>kotlin-stdlib-common</artifactId>
-          <groupId>org.jetbrains.kotlin</groupId>
         </exclusion>
         <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
           <artifactId>kotlin-test-common</artifactId>
-          <groupId>org.jetbrains.kotlin</groupId>
         </exclusion>
         <exclusion>
-          <artifactId>kotlin-test-annotations-common</artifactId>
           <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>kotlin-test-annotations-common</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-full-debug-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-full-debug-1.0.pom
@@ -18,16 +18,16 @@
       <scope>runtime</scope>
       <exclusions>
         <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
           <artifactId>kotlin-stdlib-common</artifactId>
-          <groupId>org.jetbrains.kotlin</groupId>
         </exclusion>
         <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
           <artifactId>kotlin-test-common</artifactId>
-          <groupId>org.jetbrains.kotlin</groupId>
         </exclusion>
         <exclusion>
-          <artifactId>kotlin-test-annotations-common</artifactId>
           <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>kotlin-test-annotations-common</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -38,16 +38,16 @@
       <scope>runtime</scope>
       <exclusions>
         <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
           <artifactId>kotlin-stdlib-common</artifactId>
-          <groupId>org.jetbrains.kotlin</groupId>
         </exclusion>
         <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
           <artifactId>kotlin-test-common</artifactId>
-          <groupId>org.jetbrains.kotlin</groupId>
         </exclusion>
         <exclusion>
-          <artifactId>kotlin-test-annotations-common</artifactId>
           <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>kotlin-test-annotations-common</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
Maven 3.6.1 brings in a dependency with a critical security vulnerability.
This version update should bring no behaviour change.

I'm not sure what I need to do to ensure the updates to verification-metadata are OK.
