### PR TITLE
Update dependency versions to address security alerts

### DIFF
--- a/build-logic/build-platform/build.gradle.kts
+++ b/build-logic/build-platform/build.gradle.kts
@@ -22,6 +22,7 @@ val kotlinVersion = providers.gradleProperty("buildKotlinVersion")
 dependencies {
     constraints {
         api("org.gradle.guides:gradle-guides-plugin:0.22")
+        api("org.apache.ant:ant:1.10.12") // Bump the version brought in transitively by gradle-guides-plugin
         api("com.gradle:gradle-enterprise-gradle-plugin:3.14") // Sync with `settings.gradle.kts`
         api("com.gradle.publish:plugin-publish-plugin:1.1.0")
         api("gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext:1.0.1")

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -629,18 +629,8 @@
             <pgp value="31bae2e51d95e0f8ad9b7bcc40a3c4432bd7308c"/>
          </artifact>
       </component>
-      <component group="com.h2database" name="h2" version="1.4.192">
-         <artifact name="h2-1.4.192.jar">
-            <pgp value="0cfa413799e2464c7d7e26220a4b343f2a55fdae"/>
-         </artifact>
-      </component>
-      <component group="com.h2database" name="h2" version="1.4.196">
-         <artifact name="h2-1.4.196.jar">
-            <pgp value="0cfa413799e2464c7d7e26220a4b343f2a55fdae"/>
-         </artifact>
-      </component>
-      <component group="com.h2database" name="h2" version="2.1.214">
-         <artifact name="h2-2.1.214.jar">
+      <component group="com.h2database" name="h2" version="2.2.220">
+         <artifact name="h2-2.2.220.jar">
             <pgp value="0cfa413799e2464c7d7e26220a4b343f2a55fdae"/>
          </artifact>
       </component>

--- a/subprojects/distributions-dependencies/build.gradle.kts
+++ b/subprojects/distributions-dependencies/build.gradle.kts
@@ -92,7 +92,7 @@ dependencies {
         api(libs.groovyTest)            { version { strictly(libs.groovyVersion) }}
         api(libs.groovyXml)             { version { strictly(libs.groovyVersion) }}
         api(libs.gson)                  { version { strictly("2.8.9") }}
-        api(libs.h2Database)            { version { strictly("2.1.214") }}
+        api(libs.h2Database)            { version { strictly("2.2.220") }}
         api(libs.hamcrest)              { version { strictly("1.3"); because("2.x changes the API") }}
         api(libs.hikariCP)              { version { strictly("4.0.3"); because("5.x requires Java 11+") }}
         api(libs.httpcore)              { version { strictly("4.4.14") }}


### PR DESCRIPTION
Updates 2 dependency versions which result in high-severity security alerts:
- `com.h2database:h2` -> 2.2.220
- `org.apache.ant:ant` -> 1.10.12 (constrain transitive dependency of `gradle-guides-plugin`)