### PR TITLE
Add `@LeaksFileHandles` to a few tests

### DIFF
--- a/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/NextGenBuildCacheHttpIntegrationTest.groovy
+++ b/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/NextGenBuildCacheHttpIntegrationTest.groovy
@@ -19,9 +19,11 @@ package org.gradle.caching
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
 import org.gradle.integtests.fixtures.TestBuildCache
+import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.test.fixtures.server.http.HttpBuildCacheServer
 import org.junit.Rule
 
+@LeaksFileHandles("https://github.com/gradle/gradle-private/issues/3916")
 class NextGenBuildCacheHttpIntegrationTest extends AbstractIntegrationSpec implements DirectoryBuildCacheFixture {
 
     @Rule

--- a/subprojects/build-cache/src/integTest/groovy/org/gradle/caching/NextGenBuildCacheIntegrationTest.groovy
+++ b/subprojects/build-cache/src/integTest/groovy/org/gradle/caching/NextGenBuildCacheIntegrationTest.groovy
@@ -18,9 +18,11 @@ package org.gradle.caching
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
+import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 
+@LeaksFileHandles("https://github.com/gradle/gradle-private/issues/3916")
 class NextGenBuildCacheIntegrationTest extends AbstractIntegrationSpec implements DirectoryBuildCacheFixture {
 
     def "compile task is loaded from cache"() {

--- a/subprojects/build-cache/src/integTest/groovy/org/gradle/caching/internal/NextGenBuildCacheBuildOperationsIntegrationTest.groovy
+++ b/subprojects/build-cache/src/integTest/groovy/org/gradle/caching/internal/NextGenBuildCacheBuildOperationsIntegrationTest.groovy
@@ -36,12 +36,14 @@ import org.gradle.internal.file.FileType
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.io.NullOutputStream
 import org.gradle.internal.time.Time
+import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.util.internal.TextUtil
 import spock.lang.Shared
 
 import java.nio.charset.StandardCharsets
 import java.util.zip.GZIPInputStream
 
+@LeaksFileHandles("https://github.com/gradle/gradle-private/issues/3916")
 class NextGenBuildCacheBuildOperationsIntegrationTest extends AbstractIntegrationSpec {
 
     @Shared

--- a/subprojects/build-cache/src/test/groovy/org/gradle/caching/internal/controller/NextGenBuildCacheControllerTest.groovy
+++ b/subprojects/build-cache/src/test/groovy/org/gradle/caching/internal/controller/NextGenBuildCacheControllerTest.groovy
@@ -33,12 +33,14 @@ import org.gradle.internal.snapshot.RelativePathTrackingFileSystemSnapshotHierar
 import org.gradle.internal.snapshot.SnapshotUtil
 import org.gradle.internal.snapshot.SnapshotVisitResult
 import org.gradle.internal.vfs.FileSystemAccess
+import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
 import org.slf4j.Logger
 import spock.lang.Specification
 
+@LeaksFileHandles("https://github.com/gradle/gradle-private/issues/3916")
 class NextGenBuildCacheControllerTest extends Specification {
 
     @Rule


### PR DESCRIPTION
Because we see some cases of file handle leaking:

```
Found non-empty test files dir: subprojects/build-cache/build/tmp/teŝt files/NextGenBuil.Test:
  3ez4f/.gradle/8.4-20230725085645+0000/gc.properties
  3ez4f/.gradle/8.4-20230725085645+0000/fileChanges/last-build.bin
```