### PR TITLE
Fingerprint mrjars based on available versions

### DIFF
--- a/subprojects/base-services/build.gradle.kts
+++ b/subprojects/base-services/build.gradle.kts
@@ -52,6 +52,8 @@ dependencies {
 packageCycles {
     // Needed for the factory methods in the base class
     excludePatterns.add("org/gradle/util/GradleVersion**")
+    // JavaVersion provides public API to the internal version parser implementation
+    excludePatterns.add("org/gradle/api/JavaVersion*")
 }
 
 jmh.includes = listOf("HashingAlgorithmsBenchmark")

--- a/subprojects/base-services/src/main/java/org/gradle/api/JavaVersion.java
+++ b/subprojects/base-services/src/main/java/org/gradle/api/JavaVersion.java
@@ -16,9 +16,7 @@
 package org.gradle.api;
 
 import com.google.common.annotations.VisibleForTesting;
-
-import java.util.ArrayList;
-import java.util.List;
+import org.gradle.api.internal.JavaVersionParser;
 
 /**
  * An enumeration of Java versions.
@@ -167,19 +165,7 @@ public enum JavaVersion {
             return getVersionForMajor((Integer) value);
         }
 
-        String name = value.toString();
-
-        int firstNonVersionCharIndex = findFirstNonVersionCharIndex(name);
-
-        String[] versionStrings = name.substring(0, firstNonVersionCharIndex).split("\\.");
-        List<Integer> versions = convertToNumber(name, versionStrings);
-
-        if (isLegacyVersion(versions)) {
-            assertTrue(name, versions.get(1) > 0);
-            return getVersionForMajor(versions.get(1));
-        } else {
-            return getVersionForMajor(versions.get(0));
-        }
+        return getVersionForMajor(JavaVersionParser.getMajorFromVersionString(value.toString()));
     }
 
     /**
@@ -319,50 +305,5 @@ public enum JavaVersion {
 
     private static JavaVersion getVersionForMajor(int major) {
         return major >= values().length ? JavaVersion.VERSION_HIGHER : values()[major - 1];
-    }
-
-    private static void assertTrue(String value, boolean condition) {
-        if (!condition) {
-            throw new IllegalArgumentException("Could not determine java version from '" + value + "'.");
-        }
-    }
-
-    private static boolean isLegacyVersion(List<Integer> versions) {
-        return 1 == versions.get(0) && versions.size() > 1;
-    }
-
-    private static List<Integer> convertToNumber(String value, String[] versionStrs) {
-        List<Integer> result = new ArrayList<Integer>();
-        for (String s : versionStrs) {
-            assertTrue(value, !isNumberStartingWithZero(s));
-            try {
-                result.add(Integer.parseInt(s));
-            } catch (NumberFormatException e) {
-                assertTrue(value, false);
-            }
-        }
-        assertTrue(value, !result.isEmpty() && result.get(0) > 0);
-        return result;
-    }
-
-    private static boolean isNumberStartingWithZero(String number) {
-        return number.length() > 1 && number.startsWith("0");
-    }
-
-    private static int findFirstNonVersionCharIndex(String s) {
-        assertTrue(s, s.length() != 0);
-
-        for (int i = 0; i < s.length(); ++i) {
-            if (!isDigitOrPeriod(s.charAt(i))) {
-                assertTrue(s, i != 0);
-                return i;
-            }
-        }
-
-        return s.length();
-    }
-
-    private static boolean isDigitOrPeriod(char c) {
-        return (c >= '0' && c <= '9') || c == '.';
     }
 }

--- a/subprojects/base-services/src/main/java/org/gradle/api/internal/JavaVersionParser.java
+++ b/subprojects/base-services/src/main/java/org/gradle/api/internal/JavaVersionParser.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal;
+
+import org.gradle.api.NonNullApi;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A helper to parse {@code System.getProperty("java.version")}.
+ */
+@NonNullApi
+public final class JavaVersionParser {
+    private JavaVersionParser() {}
+
+    /**
+     * Converts the version string into a "major" number. Major is the first version component for modern Java version (9, 10, etc.).
+     * For pre-9 versions that have version string starting with {@code "1."} (e.g. "1.8", "1.5") the second component is returned.
+     * For example, parsing {@code "1.8"} yields 8.
+     * <p>
+     * This method recognizes modern "majors" in the legacy format too, so {@code "1.9"} yields 9.
+     * <p>
+     * Only versions starting from "1.1" are supported.
+     *
+     * @param version the version string to parse
+     * @return the major as an integer
+     */
+    public static int getMajorFromVersionString(String version) {
+        int firstNonVersionCharIndex = findFirstNonVersionCharIndex(version);
+
+        String[] versionComponents = version.substring(0, firstNonVersionCharIndex).split("\\.");
+        List<Integer> versions = convertToNumber(version, versionComponents);
+
+        if (isLegacyVersion(versions)) {
+            assertTrue(version, versions.get(1) > 0);
+            return versions.get(1);
+        } else {
+            return versions.get(0);
+        }
+    }
+
+    private static void assertTrue(String value, boolean condition) {
+        if (!condition) {
+            unparseable(value);
+        }
+    }
+
+    private static boolean isLegacyVersion(List<Integer> versions) {
+        return 1 == versions.get(0) && versions.size() > 1;
+    }
+
+    private static List<Integer> convertToNumber(String version, String[] versionComponents) {
+        List<Integer> result = new ArrayList<Integer>();
+        for (String s : versionComponents) {
+            assertTrue(version, !isNumberStartingWithZero(s));
+            try {
+                result.add(Integer.parseInt(s));
+            } catch (NumberFormatException e) {
+                unparseable(version);
+            }
+        }
+        assertTrue(version, !result.isEmpty() && result.get(0) > 0);
+        return result;
+    }
+
+    private static boolean isNumberStartingWithZero(String number) {
+        return number.length() > 1 && number.startsWith("0");
+    }
+
+    private static int findFirstNonVersionCharIndex(String s) {
+        assertTrue(s, s.length() != 0);
+
+        for (int i = 0; i < s.length(); ++i) {
+            if (!isDigitOrPeriod(s.charAt(i))) {
+                assertTrue(s, i != 0);
+                return i;
+            }
+        }
+
+        return s.length();
+    }
+
+    private static boolean isDigitOrPeriod(char c) {
+        return (c >= '0' && c <= '9') || c == '.';
+    }
+
+    private static void unparseable(String version) {
+        throw new IllegalArgumentException("Could not determine java version from '" + version + "'.");
+    }
+}

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/classpath/BuildScriptClasspathIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/classpath/BuildScriptClasspathIntegrationSpec.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.classpath
 
-
 import org.gradle.api.internal.cache.CacheConfigurationsInternal
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AvailableJavaHomes
@@ -26,10 +25,13 @@ import org.gradle.integtests.fixtures.executer.ArtifactBuilder
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.server.http.HttpServer
 import org.gradle.test.fixtures.server.http.MavenHttpRepository
+import org.gradle.util.internal.TextUtil
 import org.junit.Rule
 import spock.lang.IgnoreIf
 import spock.lang.Issue
 import spock.lang.Unroll
+
+import java.util.stream.Collectors
 
 class BuildScriptClasspathIntegrationSpec extends AbstractIntegrationSpec implements FileAccessTimeJournalFixture {
     static final int MAX_CACHE_AGE_IN_DAYS = CacheConfigurationsInternal.DEFAULT_MAX_AGE_IN_DAYS_FOR_CREATED_CACHE_ENTRIES
@@ -459,6 +461,48 @@ class BuildScriptClasspathIntegrationSpec extends AbstractIntegrationSpec implem
         3200        || 3
     }
 
+    def "transformation normalizes input jars before fingerprinting"() {
+        requireOwnGradleUserHomeDir() // inspects cached content
+
+        given:
+        def buildClassSource = '''
+            package org.gradle.test;
+            public class BuildClass {
+                public String message() { return "hello world"; }
+            }
+        '''
+        def reproducibleJar = file("reproducible/testClasses.jar")
+        def currentTimestampJar = file("current/testClasses.jar")
+        artifactBuilder().tap {
+            preserveTimestamps(false)
+            sourceFile("org/gradle/test/BuildClass.java").text = buildClassSource
+            buildJar(reproducibleJar)
+        }
+        artifactBuilder().tap {
+            preserveTimestamps(true)
+            sourceFile("org/gradle/test/BuildClass.java").text = buildClassSource
+            buildJar(currentTimestampJar)
+        }
+
+        Closure<String> subprojectSource = {File jarPath -> """
+            buildscript { dependencies { classpath files("${TextUtil.normaliseFileSeparators(jarPath.absolutePath)}") } }
+
+            tasks.register("printMessage") { doLast { println (new org.gradle.test.BuildClass().message()) } }
+        """}
+
+        settingsScript("""
+            include "reproducible", "current"
+        """)
+
+        file("reproducible/build.gradle").text = subprojectSource(reproducibleJar)
+        file("current/build.gradle").text = subprojectSource(currentTimestampJar)
+
+        expect:
+        succeeds("printMessage")
+
+        getCachedTransformedJarsByName("testClasses.jar").size() == 1
+    }
+
     void notInJarCache(String filename) {
         inJarCache(filename, false)
     }
@@ -477,5 +521,18 @@ class BuildScriptClasspathIntegrationSpec extends AbstractIntegrationSpec implem
         return userHomeCacheDir.file(DefaultClasspathTransformerCacheFactory.CACHE_KEY)
     }
 
-
+    /**
+     * Finds all cached transformed JARs named {@code jarName}.
+     * @param jarName the name of the JAR to look
+     * @return the list of transformed JARs in the cache
+     */
+    List<File> getCachedTransformedJarsByName(String jarName) {
+        Arrays.stream(cacheDir.listFiles()).filter {
+            File cacheChild -> !cacheChild.name.startsWith("o_") && cacheChild.isDirectory()
+        }.map {
+            File cacheChild -> new File(cacheChild, jarName)
+        }.filter {
+            it.exists()
+        }.collect(Collectors.toList())
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/CachingJavaVersionProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/CachingJavaVersionProvider.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.classpath;
+
+import org.gradle.api.NonNullApi;
+import org.gradle.api.internal.JavaVersionParser;
+import org.gradle.internal.SystemProperties;
+
+@NonNullApi
+public class CachingJavaVersionProvider implements CurrentJavaVersionProvider {
+    private final int currentJavaVersion = JavaVersionParser.getMajorFromVersionString(SystemProperties.getInstance().getJavaVersion());
+
+    @Override
+    public int getJavaVersion() {
+        return currentJavaVersion;
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathFileHasher.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathFileHasher.java
@@ -21,6 +21,7 @@ import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 
 @NonNullApi
+@FunctionalInterface
 public interface ClasspathFileHasher {
     HashCode hashOf(FileSystemLocationSnapshot sourceSnapshot);
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/CurrentJavaVersionProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/CurrentJavaVersionProvider.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.classpath;
+
+import org.gradle.api.NonNullApi;
+
+/**
+ * Provides the Java version of the JVM this Gradle process runs in.
+ */
+@NonNullApi
+public interface CurrentJavaVersionProvider {
+    /**
+     * Returns the major Java version of the current JVM.
+     *
+     * @return the version
+     */
+    int getJavaVersion();
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultCachedClasspathTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultCachedClasspathTransformer.java
@@ -24,6 +24,7 @@ import org.gradle.cache.PersistentCache;
 import org.gradle.cache.scopes.GlobalScopedCacheBuilderFactory;
 import org.gradle.internal.Either;
 import org.gradle.internal.agents.AgentStatus;
+import org.gradle.internal.classpath.fingerprint.InstrumentedClasspathFingerprinter;
 import org.gradle.internal.classpath.types.DefaultInstrumentingTypeRegistryFactory;
 import org.gradle.internal.classpath.types.GradleCoreInstrumentingTypeRegistry;
 import org.gradle.internal.classpath.types.InstrumentingTypeRegistry;
@@ -34,7 +35,6 @@ import org.gradle.internal.concurrent.ManagedExecutor;
 import org.gradle.internal.file.FileAccessTimeJournal;
 import org.gradle.internal.file.FileAccessTracker;
 import org.gradle.internal.file.FileType;
-import org.gradle.internal.fingerprint.classpath.ClasspathFingerprinter;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 import org.gradle.internal.vfs.FileSystemAccess;
@@ -62,7 +62,7 @@ public class DefaultCachedClasspathTransformer implements CachedClasspathTransfo
     private final FileAccessTracker fileAccessTracker;
     private final ClasspathWalker classpathWalker;
     private final ClasspathBuilder classpathBuilder;
-    private final ClasspathFingerprinter classpathFingerprinter;
+    private final InstrumentedClasspathFingerprinter classpathFingerprinter;
     private final FileSystemAccess fileSystemAccess;
     private final GlobalCacheLocations globalCacheLocations;
     private final FileLockManager fileLockManager;
@@ -78,7 +78,7 @@ public class DefaultCachedClasspathTransformer implements CachedClasspathTransfo
         FileAccessTimeJournal fileAccessTimeJournal,
         ClasspathWalker classpathWalker,
         ClasspathBuilder classpathBuilder,
-        ClasspathFingerprinter classpathFingerprinter,
+        InstrumentedClasspathFingerprinter classpathFingerprinter,
         FileSystemAccess fileSystemAccess,
         ExecutorFactory executorFactory,
         GlobalCacheLocations globalCacheLocations,

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultCachedClasspathTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultCachedClasspathTransformer.java
@@ -71,6 +71,7 @@ public class DefaultCachedClasspathTransformer implements CachedClasspathTransfo
     private final ParallelTransformExecutor parallelTransformExecutor;
     private final InstrumentingTypeRegistryFactory typeRegistryFactory;
     private final GradleCoreInstrumentingTypeRegistry gradleCoreInstrumentingRegistry;
+    private final CurrentJavaVersionProvider currentJavaVersionProvider;
 
     public DefaultCachedClasspathTransformer(
         GlobalScopedCacheBuilderFactory cacheBuilderFactory,
@@ -99,6 +100,7 @@ public class DefaultCachedClasspathTransformer implements CachedClasspathTransfo
         this.parallelTransformExecutor = new ParallelTransformExecutor(cache, executor);
         this.gradleCoreInstrumentingRegistry = gradleCoreInstrumentingRegistry;
         this.typeRegistryFactory = new DefaultInstrumentingTypeRegistryFactory(gradleCoreInstrumentingRegistry, cache, parallelTransformExecutor, classpathWalker, fileSystemAccess);
+        this.currentJavaVersionProvider = new CachingJavaVersionProvider();
     }
 
     @Override
@@ -222,7 +224,8 @@ public class DefaultCachedClasspathTransformer implements CachedClasspathTransfo
             locationSnapshot -> classpathFingerprinter.fingerprint(locationSnapshot, null).getHash(),
             policy,
             transform,
-            gradleCoreInstrumentingRegistry);
+            gradleCoreInstrumentingRegistry,
+            currentJavaVersionProvider);
     }
 
     private Optional<Either<URL, Callable<URL>>> cachedURL(URL original, ClasspathFileTransformer transformer, Set<HashCode> seen, InstrumentingTypeRegistry typeRegistry) {

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultCachedClasspathTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultCachedClasspathTransformer.java
@@ -211,7 +211,7 @@ public class DefaultCachedClasspathTransformer implements CachedClasspathTransfo
     }
 
     private InstrumentingClasspathFileTransformer instrumentingClasspathFileTransformerFor(InstrumentingClasspathFileTransformer.Policy policy, Transform transform) {
-        return new InstrumentingClasspathFileTransformer(fileLockManager, classpathWalker, classpathBuilder, policy, transform, gradleCoreInstrumentingRegistry);
+        return new InstrumentingClasspathFileTransformer(fileLockManager, classpathWalker, classpathBuilder, FileSystemLocationSnapshot::getHash, policy, transform, gradleCoreInstrumentingRegistry);
     }
 
     private Optional<Either<URL, Callable<URL>>> cachedURL(URL original, ClasspathFileTransformer transformer, Set<HashCode> seen, InstrumentingTypeRegistry typeRegistry) {

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingClasspathFileTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingClasspathFileTransformer.java
@@ -35,22 +35,19 @@ import org.gradle.internal.hash.Hasher;
 import org.gradle.internal.hash.Hashing;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 import org.gradle.util.internal.GFileUtils;
+import org.gradle.util.internal.JarUtil;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.util.OptionalInt;
 import java.util.jar.Attributes;
-import java.util.jar.JarFile;
 import java.util.jar.Manifest;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static java.lang.String.format;
 import static org.gradle.cache.internal.filelock.LockOptionsBuilder.mode;
@@ -60,13 +57,6 @@ public class InstrumentingClasspathFileTransformer implements ClasspathFileTrans
     private static final Logger LOGGER = LoggerFactory.getLogger(InstrumentingClasspathFileTransformer.class);
     private static final int CACHE_FORMAT = 6;
     private static final int AGENT_INSTRUMENTATION_VERSION = 2;
-
-    // We cannot use Attributes.Name.MULTI_RELEASE as it is only available since Java 9;
-    private static final String MULTI_RELEASE_ATTRIBUTE = "Multi-Release";
-
-    // Pattern for JAR entries in the versioned directories.
-    // See https://docs.oracle.com/en/java/javase/20/docs/specs/jar/jar.html#multi-release-jar-files
-    private static final Pattern VERSIONED_JAR_ENTRY_PATH = Pattern.compile("^META-INF/versions/(\\d+)/.+$");
 
     private final FileLockManager fileLockManager;
     private final ClasspathWalker classpathWalker;
@@ -304,7 +294,7 @@ public class InstrumentingClasspathFileTransformer implements ClasspathFileTrans
         }
 
         private boolean isManifest(ClasspathEntryVisitor.Entry entry) {
-            return isManifestName(entry.getName());
+            return JarUtil.isManifestName(entry.getName());
         }
     }
 
@@ -330,8 +320,8 @@ public class InstrumentingClasspathFileTransformer implements ClasspathFileTrans
                                 // This policy doesn't transform signed JARs so no further checks are necessary.
                                 return new SkipTransformation(source);
                             }
-                            if (isMultiReleaseJar == null && isManifestName(entryName)) {
-                                isMultiReleaseJar = isMultiReleaseJarManifest(readManifest(entry.getContent()));
+                            if (isMultiReleaseJar == null && JarUtil.isManifestName(entryName)) {
+                                isMultiReleaseJar = JarUtil.isMultiReleaseJarManifest(JarUtil.readManifest(entry.getContent()));
                             }
                         }
                     } catch (FileException e) {
@@ -429,8 +419,8 @@ public class InstrumentingClasspathFileTransformer implements ClasspathFileTrans
         @Override
         protected void processManifest(ClasspathBuilder.EntryBuilder builder, ClasspathEntryVisitor.Entry manifestEntry) throws IOException {
             try {
-                Manifest parsedManifest = readManifest(manifestEntry.getContent());
-                if (!isMultiReleaseJarManifest(parsedManifest)) {
+                Manifest parsedManifest = JarUtil.readManifest(manifestEntry.getContent());
+                if (!JarUtil.isMultiReleaseJarManifest(parsedManifest)) {
                     // If the original JAR is not multi-release, we don't need the manifest in the transformed JAR at all.
                     return;
                 }
@@ -441,7 +431,7 @@ public class InstrumentingClasspathFileTransformer implements ClasspathFileTrans
                 // For everything else (classpath, sealed, etc.) classloader will check the original JAR, so no need to copy it.
                 Manifest processedManifest = new Manifest();
                 copyManifestMainAttribute(parsedManifest, processedManifest, Attributes.Name.MANIFEST_VERSION);
-                setManifestMainAttribute(processedManifest, MULTI_RELEASE_ATTRIBUTE, "true");
+                setManifestMainAttribute(processedManifest, JarUtil.MULTI_RELEASE_ATTRIBUTE, "true");
 
                 builder.put(manifestEntry.getName(), toByteArray(processedManifest), manifestEntry.getCompressionMethod());
             } catch (IOException e) {
@@ -470,23 +460,6 @@ public class InstrumentingClasspathFileTransformer implements ClasspathFileTrans
         }
     }
 
-    private static boolean isManifestName(String name) {
-        return name.equals(JarFile.MANIFEST_NAME);
-    }
-
-    private static Manifest readManifest(byte[] content) throws IOException {
-        return new Manifest(new ByteArrayInputStream(content));
-    }
-
-    private static boolean isMultiReleaseJarManifest(Manifest manifest) {
-        return Boolean.parseBoolean(getManifestMainAttribute(manifest, MULTI_RELEASE_ATTRIBUTE));
-    }
-
-    @Nullable
-    private static String getManifestMainAttribute(Manifest manifest, String name) {
-        return manifest.getMainAttributes().getValue(name);
-    }
-
     @NonNullApi
     public static class MrJarUtils {
         /**
@@ -498,18 +471,10 @@ public class InstrumentingClasspathFileTransformer implements ClasspathFileTrans
          * @see <a href="https://docs.oracle.com/en/java/javase/20/docs/specs/jar/jar.html#multi-release-jar-files">MR JAR specification</a>
          */
         public static boolean isInUnsupportedMrJarVersionedDirectory(ClasspathEntryVisitor.Entry entry) {
-            Matcher match = VERSIONED_JAR_ENTRY_PATH.matcher(entry.getName());
-            if (match.matches()) {
-                try {
-                    int version = Integer.parseInt(match.group(1));
-                    return version > AsmConstants.MAX_SUPPORTED_JAVA_VERSION;
-                } catch (NumberFormatException ignored) {
-                    // Even though the pattern ensures that the version name is all digits, it fails to parse, probably because it is too big.
-                    // Technically it may be a valid MR JAR for Java >Integer.MAX_VALUE, but we are too far away from this.
-                    // We assume that JAR author didn't intend it to be a versioned directory and keep it.
-                }
+            OptionalInt version = JarUtil.getVersionedDirectoryMajorVersion(entry.getName());
+            if (version.isPresent()) {
+                return version.getAsInt() > AsmConstants.MAX_SUPPORTED_JAVA_VERSION;
             }
-
             // The entry is not in the versioned directory at all.
             return false;
         }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/UnsupportedBytecodeVersionException.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/UnsupportedBytecodeVersionException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.classpath;
+
+import org.gradle.api.GradleException;
+import org.gradle.api.NonNullApi;
+
+@NonNullApi
+public class UnsupportedBytecodeVersionException extends GradleException {
+    public UnsupportedBytecodeVersionException(String message) {
+        super(message);
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/fingerprint/InstrumentedClasspathFingerprinter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/fingerprint/InstrumentedClasspathFingerprinter.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.classpath.fingerprint;
+
+import org.gradle.api.internal.cache.StringInterner;
+import org.gradle.api.internal.changedetection.state.PropertiesFileFilter;
+import org.gradle.api.internal.changedetection.state.ResourceEntryFilter;
+import org.gradle.api.internal.changedetection.state.ResourceFilter;
+import org.gradle.api.internal.changedetection.state.ResourceSnapshotterCacheService;
+import org.gradle.api.internal.changedetection.state.RuntimeClasspathResourceHasher;
+import org.gradle.internal.execution.FileCollectionSnapshotter;
+import org.gradle.internal.execution.model.InputNormalizer;
+import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
+import org.gradle.internal.fingerprint.FileCollectionFingerprint;
+import org.gradle.internal.fingerprint.FileNormalizer;
+import org.gradle.internal.fingerprint.LineEndingSensitivity;
+import org.gradle.internal.fingerprint.classpath.impl.ClasspathFingerprintingStrategy;
+import org.gradle.internal.fingerprint.hashing.ResourceHasher;
+import org.gradle.internal.fingerprint.impl.AbstractFileCollectionFingerprinter;
+import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.ServiceScope;
+import org.gradle.internal.snapshot.FileSystemSnapshot;
+
+import javax.annotation.Nullable;
+
+/**
+ * Custom implementation of a runtime classpath fingerprinter to use with instrumented build script classpath JARs.
+ * It takes into account how the instrumentation works when computing the JAR fingerprint.
+ */
+@ServiceScope(Scopes.UserHome.class)
+public class InstrumentedClasspathFingerprinter extends AbstractFileCollectionFingerprinter {
+    public InstrumentedClasspathFingerprinter(ResourceSnapshotterCacheService cacheService, FileCollectionSnapshotter fileCollectionSnapshotter, StringInterner stringInterner) {
+        super(fingerprintingStrategy(cacheService, stringInterner), fileCollectionSnapshotter);
+    }
+
+    @Override
+    public CurrentFileCollectionFingerprint fingerprint(FileSystemSnapshot snapshot, @Nullable FileCollectionFingerprint previousFingerprint) {
+        return super.fingerprint(snapshot, previousFingerprint);
+    }
+
+    @Override
+    public FileNormalizer getNormalizer() {
+        return InputNormalizer.RUNTIME_CLASSPATH;
+    }
+
+    private static ClasspathFingerprintingStrategy fingerprintingStrategy(ResourceSnapshotterCacheService cacheService, StringInterner stringInterner) {
+        ResourceHasher resourceHasher = ClasspathFingerprintingStrategy.runtimeClasspathResourceHasher(
+            new RuntimeClasspathResourceHasher(),
+            LineEndingSensitivity.DEFAULT,
+            PropertiesFileFilter.FILTER_NOTHING,
+            ResourceEntryFilter.FILTER_NOTHING,
+            ResourceFilter.FILTER_NOTHING
+        );
+
+        return ClasspathFingerprintingStrategy.runtimeClassPathWithSpecialJarHandling(new JarVisitor(resourceHasher), resourceHasher, cacheService, stringInterner);
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/fingerprint/JarVisitor.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/fingerprint/JarVisitor.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.classpath.fingerprint;
+
+import org.gradle.api.internal.changedetection.state.ZipHasher;
+import org.gradle.internal.fingerprint.hashing.ResourceHasher;
+import org.gradle.internal.fingerprint.hashing.ZipEntryContext;
+import org.gradle.internal.hash.HashCode;
+import org.gradle.internal.hash.Hasher;
+import org.gradle.internal.io.IoFunction;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+
+/**
+ * Hashes JARs of the buildscript classpath.
+ */
+class JarVisitor implements ZipHasher.ArchiveVisitor {
+    private final ResourceHasher resourceHasher;
+
+    public JarVisitor(ResourceHasher resourceHasher) {
+        this.resourceHasher = resourceHasher;
+    }
+
+    @Nullable
+    @Override
+    public HashCode visitArchive(IoFunction<ZipHasher.EntryVisitor, Hasher> visitAction) throws IOException {
+        CollectingEntryVisitor entryVisitor = new CollectingEntryVisitor(resourceHasher);
+        @Nullable Hasher hasher = visitAction.apply(entryVisitor);
+        return hasher != null ? hasher.hash() : null;
+    }
+
+    @Override
+    public void appendConfigurationToHasher(Hasher hasher) {
+        resourceHasher.appendConfigurationToHasher(hasher);
+    }
+
+    private static class CollectingEntryVisitor implements ZipHasher.EntryVisitor {
+        private final ResourceHasher resourceHasher;
+
+        public CollectingEntryVisitor(ResourceHasher resourceHasher) {
+            this.resourceHasher = resourceHasher;
+        }
+
+        @Nullable
+        @Override
+        public HashCode visitEntry(ZipEntryContext zipEntryContext) throws IOException {
+            return resourceHasher.hash(zipEntryContext);
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/fingerprint/package-info.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/fingerprint/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Utilities to compute fingerprints of the instrumenting transformation inputs.
+ */
+@NonNullApi
+package org.gradle.internal.classpath.fingerprint;
+
+import org.gradle.api.NonNullApi;

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
@@ -48,6 +48,7 @@ import org.gradle.internal.buildoption.IntegerInternalOption;
 import org.gradle.internal.buildoption.InternalFlag;
 import org.gradle.internal.buildoption.InternalOptions;
 import org.gradle.internal.classloader.ClasspathHasher;
+import org.gradle.internal.classpath.fingerprint.InstrumentedClasspathFingerprinter;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.execution.FileCollectionFingerprinterRegistry;
 import org.gradle.internal.execution.FileCollectionSnapshotter;
@@ -293,6 +294,14 @@ public class VirtualFileSystemServices extends AbstractPluginServiceRegistry {
 
         FileChangeListeners createFileChangeListeners(ListenerManager listenerManager) {
             return new DefaultFileChangeListeners(listenerManager);
+        }
+
+        InstrumentedClasspathFingerprinter createInstrumentedClassPathFingerprinter(
+            ResourceSnapshotterCacheService resourceSnapshotterCacheService,
+            FileCollectionSnapshotter fileCollectionSnapshotter,
+            StringInterner stringInterner
+        ) {
+            return new InstrumentedClasspathFingerprinter(resourceSnapshotterCacheService, fileCollectionSnapshotter, stringInterner);
         }
 
     }

--- a/subprojects/core/src/main/java/org/gradle/util/internal/JarUtil.java
+++ b/subprojects/core/src/main/java/org/gradle/util/internal/JarUtil.java
@@ -19,11 +19,28 @@ package org.gradle.util.internal;
 import org.apache.commons.io.IOUtils;
 import org.gradle.internal.IoActions;
 
-import java.io.*;
+import javax.annotation.Nullable;
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.OptionalInt;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 public class JarUtil {
+    // We cannot use Attributes.Name.MULTI_RELEASE as it is only available since Java 9;
+    public static final String MULTI_RELEASE_ATTRIBUTE = "Multi-Release";
+    // Pattern for JAR entries in the versioned directories.
+    // See https://docs.oracle.com/en/java/javase/20/docs/specs/jar/jar.html#multi-release-jar-files
+    private static final Pattern VERSIONED_JAR_ENTRY_PATH = Pattern.compile("^META-INF/versions/(\\d+)/.+$");
+
     public static boolean extractZipEntry(File jarFile, String entryName, File extractToFile) throws IOException {
         boolean entryExtracted = false;
 
@@ -54,5 +71,65 @@ public class JarUtil {
         }
 
         return entryExtracted;
+    }
+
+    /**
+     * Checks if the {@code jarEntryName} is the name of the JAR manifest entry.
+     *
+     * @param jarEntryName the name of the entry
+     * @return {@code true} if the entry is the JAR manifest
+     */
+    public static boolean isManifestName(String jarEntryName) {
+        return jarEntryName.equals(JarFile.MANIFEST_NAME);
+    }
+
+    /**
+     * Parses Manifest from a byte array.
+     * @param content the bytes of the manifest
+     * @return the Manifest
+     * @throws IOException if the manifest cannot be parsed
+     */
+    public static Manifest readManifest(byte[] content) throws IOException {
+        return new Manifest(new ByteArrayInputStream(content));
+    }
+
+    /**
+     * Checks if the manifest declares JAR to be multi-release.
+     *
+     * @param manifest the manifest
+     * @return {@code true} if the manifest declares the multi-release JAR
+     */
+    public static boolean isMultiReleaseJarManifest(Manifest manifest) {
+        return Boolean.parseBoolean(getManifestMainAttribute(manifest, MULTI_RELEASE_ATTRIBUTE));
+    }
+
+    @Nullable
+    private static String getManifestMainAttribute(Manifest manifest, String name) {
+        return manifest.getMainAttributes().getValue(name);
+    }
+
+    /**
+     * Checks if the entry path is inside a versioned directory and returns the corresponding major version of Java platform.
+     * Returns empty Optional if this entry isn't inside a versioned directory.
+     *
+     * @param entryPath the full path to the entry inside the JAR
+     * @return major version of Java platform for which this entry is intended if it is in the versioned directory or empty Optional
+     *
+     * @see <a href="https://docs.oracle.com/en/java/javase/20/docs/specs/jar/jar.html#multi-release-jar-files">MR JAR specification</a>
+     */
+    public static OptionalInt getVersionedDirectoryMajorVersion(String entryPath) {
+        Matcher match = VERSIONED_JAR_ENTRY_PATH.matcher(entryPath);
+        if (match.matches()) {
+            try {
+                int version = Integer.parseInt(match.group(1));
+                return OptionalInt.of(version);
+            } catch (NumberFormatException ignored) {
+                // Even though the pattern ensures that the version name is all digits, it fails to parse, probably because it is too big.
+                // Technically it may be a valid MR JAR for Java >Integer.MAX_VALUE, but we are too far away from this.
+                // We assume that JAR author didn't intend it to be a versioned directory.
+            }
+        }
+        // The entry is not in the versioned directory.
+        return OptionalInt.empty();
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
@@ -28,11 +28,11 @@ import org.gradle.cache.scopes.GlobalScopedCacheBuilderFactory
 import org.gradle.internal.Pair
 import org.gradle.internal.agents.AgentStatus
 import org.gradle.internal.classloader.FilteringClassLoader
+import org.gradle.internal.classpath.fingerprint.InstrumentedClasspathFingerprinter
 import org.gradle.internal.classpath.types.GradleCoreInstrumentingTypeRegistry
 import org.gradle.internal.file.FileAccessTimeJournal
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint
 import org.gradle.internal.fingerprint.FileCollectionFingerprint
-import org.gradle.internal.fingerprint.classpath.ClasspathFingerprinter
 import org.gradle.internal.hash.Hasher
 import org.gradle.internal.io.ClassLoaderObjectInputStream
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot
@@ -84,7 +84,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
     def gradleCoreInstrumenting = Stub(GradleCoreInstrumentingTypeRegistry) {
         getInstrumentedFileHash() >> Optional.empty()
     }
-    def classpathFingerprinter = Stub(ClasspathFingerprinter) {
+    def classpathFingerprinter = Stub(InstrumentedClasspathFingerprinter) {
         fingerprint(_, _) >> { FileSystemSnapshot snapshot, FileCollectionFingerprint previous ->
             Stub(CurrentFileCollectionFingerprint) {
                 getHash() >> (snapshot as FileSystemLocationSnapshot).hash

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
@@ -30,8 +30,13 @@ import org.gradle.internal.agents.AgentStatus
 import org.gradle.internal.classloader.FilteringClassLoader
 import org.gradle.internal.classpath.types.GradleCoreInstrumentingTypeRegistry
 import org.gradle.internal.file.FileAccessTimeJournal
+import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint
+import org.gradle.internal.fingerprint.FileCollectionFingerprint
+import org.gradle.internal.fingerprint.classpath.ClasspathFingerprinter
 import org.gradle.internal.hash.Hasher
 import org.gradle.internal.io.ClassLoaderObjectInputStream
+import org.gradle.internal.snapshot.FileSystemLocationSnapshot
+import org.gradle.internal.snapshot.FileSystemSnapshot
 import org.gradle.test.fixtures.archive.ZipTestFixture
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
 import org.gradle.test.fixtures.file.TestFile
@@ -79,6 +84,14 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
     def gradleCoreInstrumenting = Stub(GradleCoreInstrumentingTypeRegistry) {
         getInstrumentedFileHash() >> Optional.empty()
     }
+    def classpathFingerprinter = Stub(ClasspathFingerprinter) {
+        fingerprint(_, _) >> { FileSystemSnapshot snapshot, FileCollectionFingerprint previous ->
+            Stub(CurrentFileCollectionFingerprint) {
+                getHash() >> (snapshot as FileSystemLocationSnapshot).hash
+            }
+        }
+    }
+
     URLClassLoader testClassLoader = null
 
     @Subject
@@ -88,6 +101,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         fileAccessTimeJournal,
         classpathWalker,
         classpathBuilder,
+        classpathFingerprinter,
         fileSystemAccess,
         executorFactory,
         globalCacheLocations,

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/InstrumentingClasspathFileTransformerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/InstrumentingClasspathFileTransformerTest.groovy
@@ -32,13 +32,11 @@ import org.junit.Rule
 import org.objectweb.asm.ClassVisitor
 import spock.lang.Specification
 
-import java.nio.charset.StandardCharsets
-import java.util.jar.Attributes
 import java.util.jar.JarFile
-import java.util.jar.Manifest
 
 import static org.gradle.internal.classpath.InstrumentingClasspathFileTransformer.instrumentForLoadingWithAgent
 import static org.gradle.internal.classpath.InstrumentingClasspathFileTransformer.instrumentForLoadingWithClassLoader
+import static org.gradle.util.JarUtils.jar
 
 class InstrumentingClasspathFileTransformerTest extends Specification {
     @Rule
@@ -241,59 +239,5 @@ class InstrumentingClasspathFileTransformerTest extends Specification {
 
     private JarTestFixture jarFixture(File transformedJar, boolean expectManifest = true) {
         return new JarTestFixture(transformedJar, 'UTF-8', null, expectManifest)
-    }
-
-    private File jar(File jarFile, @DelegatesTo(JarBuilder) Closure<?> closure) {
-        classpathBuilder.jar(jarFile) {
-            closure.setDelegate(new JarBuilder(it))
-            closure.setResolveStrategy(Closure.DELEGATE_FIRST)
-            closure()
-        }
-
-        jarFile
-    }
-
-    static class JarBuilder {
-        private final ClasspathBuilder.EntryBuilder builder
-        private boolean hasManifest
-
-        JarBuilder(ClasspathBuilder.EntryBuilder builder) {
-            this.builder = builder
-        }
-
-        def manifest(@DelegatesTo(value = Manifest, strategy = Closure.DELEGATE_FIRST) Closure<?> closure) {
-            def man = new Manifest()
-            man.mainAttributes.put(Attributes.Name.MANIFEST_VERSION, "1.0")
-
-            closure.setDelegate(man)
-            closure()
-
-            def baos = new ByteArrayOutputStream()
-            man.write(baos)
-            builder.put(JarFile.MANIFEST_NAME, baos.toByteArray())
-            hasManifest = true
-            this
-        }
-
-        def versionedEntry(int version, String path, byte[] bytes) {
-            entry(JarTestFixture.toVersionedPath(version, path), bytes)
-        }
-
-        def versionedEntry(int version, String path, String body) {
-            entry(JarTestFixture.toVersionedPath(version, path), body)
-        }
-
-        def entry(String path, byte[] bytes) {
-            checkManifestWritten()
-            builder.put(path, bytes)
-        }
-
-        def entry(String path, String body) {
-            entry(path, body.getBytes(StandardCharsets.UTF_8))
-        }
-
-        private def checkManifestWritten() {
-            assert hasManifest : "Must have manifest before entries"
-        }
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/InstrumentingClasspathFileTransformerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/InstrumentingClasspathFileTransformerTest.groovy
@@ -25,6 +25,7 @@ import org.gradle.internal.classpath.InstrumentingClasspathFileTransformer.Polic
 import org.gradle.internal.classpath.types.GradleCoreInstrumentingTypeRegistry
 import org.gradle.internal.classpath.types.InstrumentingTypeRegistry
 import org.gradle.internal.hash.Hasher
+import org.gradle.internal.snapshot.FileSystemLocationSnapshot
 import org.gradle.test.fixtures.archive.JarTestFixture
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
@@ -53,6 +54,7 @@ class InstrumentingClasspathFileTransformerTest extends Specification {
         getInstrumentedFileHash() >> Optional.empty()
     }
     def typeRegistry = Stub(InstrumentingTypeRegistry)
+
 
     def "instrumentation with #policy preserves classes"() {
         given:
@@ -219,7 +221,7 @@ class InstrumentingClasspathFileTransformerTest extends Specification {
     }
 
     private InstrumentingClasspathFileTransformer transformerWithPolicy(Policy policy) {
-        return new InstrumentingClasspathFileTransformer(fileLockManager, classpathWalker, classpathBuilder, policy, new NoOpTransformer(), gradleCoreInstrumentingRegistry)
+        return new InstrumentingClasspathFileTransformer(fileLockManager, classpathWalker, classpathBuilder, FileSystemLocationSnapshot::getHash, policy, new NoOpTransformer(), gradleCoreInstrumentingRegistry)
     }
 
     private static class NoOpTransformer implements CachedClasspathTransformer.Transform {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/fingerprint/InstrumentedClasspathFingerprinterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/fingerprint/InstrumentedClasspathFingerprinterTest.groovy
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.classpath.fingerprint
+
+
+import org.gradle.api.internal.cache.StringInterner
+import org.gradle.api.internal.changedetection.state.DefaultResourceSnapshotterCacheService
+import org.gradle.api.internal.file.TestFiles
+import org.gradle.internal.classanalysis.AsmConstants
+import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint
+import org.gradle.internal.fingerprint.impl.DefaultFileCollectionSnapshotter
+import org.gradle.internal.hash.HashCode
+import org.gradle.internal.serialize.HashCodeSerializer
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.testfixtures.internal.TestInMemoryIndexedCache
+import org.junit.Rule
+import spock.lang.Specification
+
+import java.util.jar.Manifest
+
+import static org.gradle.util.JarUtils.jar
+
+class InstrumentedClasspathFingerprinterTest extends Specification {
+    @Rule
+    TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider(getClass())
+    def testDir = testDirectoryProvider.testDirectory
+
+    def stringInterner = Stub(StringInterner) {
+        intern(_) >> { String s -> s }
+    }
+    def fileSystemAccess = TestFiles.fileSystemAccess()
+    def fileCollectionSnapshotter = new DefaultFileCollectionSnapshotter(fileSystemAccess, TestFiles.fileSystem())
+    TestInMemoryIndexedCache<HashCode, HashCode> resourceHashesCache = new TestInMemoryIndexedCache<>(new HashCodeSerializer())
+    def cacheService = new DefaultResourceSnapshotterCacheService(resourceHashesCache)
+
+    private static final int FIRST_SUPPORTED_VERSION = 8
+    private static final int SOME_SUPPORTED_VERSION = AsmConstants.MAX_SUPPORTED_JAVA_VERSION - 1
+    private static final int LATEST_SUPPORTED_VERSION = AsmConstants.MAX_SUPPORTED_JAVA_VERSION
+    private static final int FIRST_UNSUPPORTED_VERSION = AsmConstants.MAX_SUPPORTED_JAVA_VERSION + 1
+    private static final int NEXT_UNSUPPORTED_VERSION = AsmConstants.MAX_SUPPORTED_JAVA_VERSION + 2
+
+    def "can fingerprint jar with manifest"() {
+        def jarFile = jar(testDir.file("boring.jar")) {
+            manifest {}
+
+            classEntry(Dummy)
+        }
+
+        expect:
+        fingerprint(jarFile) != null
+    }
+
+    def "can fingerprint jar without manifest"() {
+        def jarFile = jar(testDir.file("noManifest.jar")) {
+            withoutManifest()
+
+            classEntry(Dummy)
+        }
+
+        expect:
+        fingerprint(jarFile) != null
+    }
+
+    def "multi-release jar without unsupported versioned directories has same fingerprint on all jvms"() {
+        def jarFile = jar(testDir.file("mrjar.jar")) {
+            manifest(multiRelease())
+
+            classEntry(Dummy)
+            versionedClassEntry(supportedVersionInJar, Dummy)
+        }
+
+        when:
+        def fingerprintOnSupportedJvm = fingerprintOnJvm(jarFile, FIRST_SUPPORTED_VERSION)
+
+        then:
+        verifyAll {
+            fingerprintOnSupportedJvm.hash == fingerprintOnJvm(jarFile, SOME_SUPPORTED_VERSION).hash
+            fingerprintOnSupportedJvm.hash == fingerprintOnJvm(jarFile, LATEST_SUPPORTED_VERSION).hash
+            fingerprintOnSupportedJvm.hash == fingerprintOnJvm(jarFile, FIRST_UNSUPPORTED_VERSION).hash
+            fingerprintOnSupportedJvm.hash == fingerprintOnJvm(jarFile, NEXT_UNSUPPORTED_VERSION).hash
+        }
+
+        where:
+        supportedVersionInJar << [SOME_SUPPORTED_VERSION, LATEST_SUPPORTED_VERSION]
+    }
+
+    def "non multi-release jar with unsupported versioned directories has same fingerprint on all jvms"() {
+        def jarFile = jar(testDir.file("mrjar.jar")) {
+            manifest {}
+
+            classEntry(Dummy)
+            versionedClassEntry(LATEST_SUPPORTED_VERSION, Dummy)
+            versionedClassEntry(FIRST_UNSUPPORTED_VERSION, Dummy)
+        }
+
+        when:
+        def fingerprintOnSupportedJvm = fingerprintOnJvm(jarFile, FIRST_SUPPORTED_VERSION)
+
+        then:
+        verifyAll {
+            fingerprintOnSupportedJvm.hash == fingerprintOnJvm(jarFile, SOME_SUPPORTED_VERSION).hash
+            fingerprintOnSupportedJvm.hash == fingerprintOnJvm(jarFile, LATEST_SUPPORTED_VERSION).hash
+            fingerprintOnSupportedJvm.hash == fingerprintOnJvm(jarFile, FIRST_UNSUPPORTED_VERSION).hash
+            fingerprintOnSupportedJvm.hash == fingerprintOnJvm(jarFile, NEXT_UNSUPPORTED_VERSION).hash
+        }
+    }
+
+    def "multi-release jar with unsupported versioned directory has same fingerprint on supported jvm"() {
+        def jarFile = jar(testDir.file("mrjar.jar")) {
+            manifest(multiRelease())
+
+            classEntry(Dummy)
+            versionedClassEntry(FIRST_UNSUPPORTED_VERSION, Dummy)
+            versionedClassEntry(NEXT_UNSUPPORTED_VERSION, Dummy)
+        }
+
+        when:
+        def fingerprintOnSupportedJvm = fingerprintOnJvm(jarFile, FIRST_SUPPORTED_VERSION)
+
+        then:
+        verifyAll {
+            fingerprintOnSupportedJvm.hash == fingerprintOnJvm(jarFile, SOME_SUPPORTED_VERSION).hash
+            fingerprintOnSupportedJvm.hash == fingerprintOnJvm(jarFile, LATEST_SUPPORTED_VERSION).hash
+        }
+    }
+
+    def "multi-release jar with unsupported versioned directory has same fingerprint on unsupported jvms not loading from this directory"() {
+        def jarFile = jar(testDir.file("mrjar.jar")) {
+            manifest(multiRelease())
+
+            classEntry(Dummy)
+            versionedClassEntry(NEXT_UNSUPPORTED_VERSION, Dummy)
+        }
+
+        when:
+        def fingerprintOnSupportedJvm = fingerprintOnJvm(jarFile, FIRST_SUPPORTED_VERSION)
+
+        then:
+        fingerprintOnSupportedJvm.hash == fingerprintOnJvm(jarFile, FIRST_UNSUPPORTED_VERSION).hash
+    }
+
+    def "multi-release jar with unsupported versioned directory has different fingerprint on jvms loading from it"() {
+        def jarFile = jar(testDir.file("mrjar.jar")) {
+            manifest(multiRelease())
+
+            classEntry(Dummy)
+            versionedClassEntry(FIRST_UNSUPPORTED_VERSION, Dummy)
+        }
+
+        when:
+        def fingerprintOnSupportedJvm = fingerprintOnJvm(jarFile, FIRST_SUPPORTED_VERSION)
+
+        then:
+        verifyAll {
+            fingerprintOnSupportedJvm.hash != fingerprintOnJvm(jarFile, FIRST_UNSUPPORTED_VERSION).hash
+            fingerprintOnSupportedJvm.hash != fingerprintOnJvm(jarFile, NEXT_UNSUPPORTED_VERSION).hash
+        }
+    }
+
+    private CurrentFileCollectionFingerprint fingerprint(File jarFile) {
+        return new InstrumentedClasspathFingerprinter(cacheService, fileCollectionSnapshotter, stringInterner).fingerprint(fileSystemAccess.read(jarFile.absolutePath), null)
+    }
+
+    private CurrentFileCollectionFingerprint fingerprintOnJvm(File jarFile, int jvmMajor) {
+        return new InstrumentedClasspathFingerprinter(jvmMajor, cacheService, fileCollectionSnapshotter, stringInterner).fingerprint(fileSystemAccess.read(jarFile.absolutePath), null)
+    }
+
+    private static Closure<?> multiRelease() {
+        return {
+            (delegate as Manifest).mainAttributes.putValue("Multi-Release", "true")
+        }
+    }
+
+    private static class Dummy {}
+}

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/JarUtils.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/JarUtils.groovy
@@ -16,7 +16,17 @@
 
 package org.gradle.util
 
+
+import org.gradle.test.fixtures.archive.JarTestFixture
+
+import java.nio.charset.StandardCharsets
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.util.jar.Attributes
+import java.util.jar.JarEntry
+import java.util.jar.JarFile
 import java.util.jar.JarOutputStream
+import java.util.jar.Manifest
 import java.util.zip.ZipEntry
 
 class JarUtils {
@@ -34,5 +44,128 @@ class JarUtils {
             jarOut.close()
         }
         return out.toByteArray()
+    }
+
+    /**
+     * Builds a JAR file with a DSL. The JAR file uses deterministic timestamps. The Jar manifest must be configured explicitly, as a first step.
+     * <p>
+     * <pre>
+     *     jar("path/to/file.jar") {
+     *         manifest {  // can be withoutManifest()
+     *             mainAttributes.putValue("Multi-Release", "true")
+     *         }
+     *
+     *         entry("Foo.class", fooBytes)
+     *         versionedEntry(11, "Foo.class", fooBytesForJava11)
+     *     }
+     *
+     * </pre>
+     * @param jarFile the jar file to create
+     * @param closure the configuration of the JAR file
+     * @return the path to the created JAR file.
+     */
+    static File jar(File jarFile, @DelegatesTo(value = JarBuilder, strategy = Closure.DELEGATE_FIRST) Closure<?> closure) {
+        try (def out = jarFile.newOutputStream(); def jarOut = new JarOutputStream(out)) {
+            closure.setDelegate(new JarBuilder(jarOut))
+            closure()
+        }
+
+        jarFile
+    }
+
+    /**
+     * DSL helper to build the JAR file. Start building with configuring the manifest ({@link JarBuilder#manifest(groovy.lang.Closure)}
+     * or specifying the lack thereof ({@link JarBuilder#withoutManifest()}.
+     */
+    static class JarBuilder {
+        /**
+         * @see org.gradle.api.internal.file.archive.ZipCopyAction#CONSTANT_TIME_FOR_ZIP_ENTRIES
+         */
+        private static final long CONSTANT_TIME_FOR_ZIP_ENTRIES = LocalDateTime.parse("1980-02-01T00:00:00.00").atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+
+        private final JarOutputStream jarOut
+        private boolean hasConfiguredManifest
+
+        JarBuilder(JarOutputStream jarOut) {
+            this.jarOut = jarOut
+        }
+
+        /**
+         * Specifies that this JAR has no manifest.
+         */
+        void withoutManifest() {
+            assert !hasConfiguredManifest: "Already written the manifest"
+            hasConfiguredManifest = true
+        }
+
+        /**
+         * Configures the JAR manifest.
+         */
+        void manifest(@DelegatesTo(value = Manifest, strategy = Closure.DELEGATE_FIRST) Closure<?> closure) {
+            assert !hasConfiguredManifest: "Already written the manifest"
+
+            def man = new Manifest()
+            man.mainAttributes.put(Attributes.Name.MANIFEST_VERSION, "1.0")
+
+            closure.setDelegate(man)
+            closure()
+
+            jarOut.putNextEntry(newEntryWithFixedTime(JarFile.MANIFEST_NAME))
+            man.write(jarOut)
+
+            hasConfiguredManifest = true
+            this
+        }
+
+        private static JarEntry newEntryWithFixedTime(String path) {
+            return new JarEntry(path).tap {
+                // setTimeLocal() is better but it is Java 9+.
+                setTime(CONSTANT_TIME_FOR_ZIP_ENTRIES)
+            }
+        }
+
+        /**
+         * Writes a versioned flavor of a JAR entry. The {@code path} should be a non-versioned path, e.g. {@code path/to/Foo.class}.
+         * @param version the java version (9, 10, etc.), must be &gt;8
+         * @param path the path of the entry (non-versioned)
+         * @param bytes the body of the entry
+         */
+        void versionedEntry(int version, String path, byte[] bytes) {
+            entry(JarTestFixture.toVersionedPath(version, path), bytes)
+        }
+
+        /**
+         * Writes a versioned flavor of a JAR entry. The {@code path} should be a non-versioned path, e.g. {@code path/to/Foo.class}.
+         * @param version the java version (9, 10, etc.), must be &gt;8
+         * @param path the path of the entry (non-versioned)
+         * @param body the body of the entry which is encoded with UTF-8
+         */
+        void versionedEntry(int version, String path, String body) {
+            entry(JarTestFixture.toVersionedPath(version, path), body)
+        }
+
+        /**
+         * Writes a JAR entry.
+         * @param path the path of the entry
+         * @param bytes the body of the entry
+         */
+        void entry(String path, byte[] bytes) {
+            checkManifestWritten()
+            jarOut.putNextEntry(newEntryWithFixedTime(path))
+            jarOut.write(bytes)
+        }
+
+        /**
+         * Writes a JAR entry.
+         * @param path the path of the entry
+         * @param body the body of the entry which is encoded with UTF-8
+         */
+        void entry(String path, String body) {
+            entry(path, body.getBytes(StandardCharsets.UTF_8))
+        }
+
+        private void checkManifestWritten() {
+            assert hasConfiguredManifest: "Must have manifest before entries. Use withoutManifest() to skip it explicitly."
+        }
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ArtifactBuilder.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ArtifactBuilder.java
@@ -27,5 +27,7 @@ public interface ArtifactBuilder {
 
     void manifestAttributes(Map<String, String> attributes);
 
+    void preserveTimestamps(boolean preserveTimestamps);
+
     void buildJar(File jarFile);
 }

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/archive/JarTestFixture.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/archive/JarTestFixture.groovy
@@ -101,7 +101,7 @@ class JarTestFixture extends ZipTestFixture {
     }
 
     def assertIsMultiRelease() {
-        "true" == manifest.mainAttributes.getValue("Multi-Release")
+        assert "true" == manifest.mainAttributes.getValue("Multi-Release")
         this
     }
 
@@ -115,6 +115,7 @@ class JarTestFixture extends ZipTestFixture {
     }
 
     static String toVersionedPath(int version, String basePath) {
+        assert version > 8: "Java only supports versioned directories for versions >8, got $version"
         return "META-INF/versions/$version/$basePath"
     }
 }

--- a/subprojects/normalization-java/src/main/java/org/gradle/internal/fingerprint/classpath/impl/ClasspathFingerprintingStrategy.java
+++ b/subprojects/normalization-java/src/main/java/org/gradle/internal/fingerprint/classpath/impl/ClasspathFingerprintingStrategy.java
@@ -110,12 +110,12 @@ public class ClasspathFingerprintingStrategy extends AbstractFingerprintingStrat
         LineEndingSensitivity lineEndingSensitivity
     ) {
         ResourceHasher resourceHasher = runtimeClasspathResourceHasher(runtimeClasspathResourceHasher, lineEndingSensitivity, propertiesFileFilters, manifestAttributeResourceEntryFilter, classpathResourceFilter);
-        ZipHasher zipHasher = new ZipHasher(resourceHasher);
+        ZipHasher zipHasher = ZipHasher.withResourceHasher(resourceHasher);
         return new ClasspathFingerprintingStrategy(CLASSPATH_IDENTIFIER, USE_FILE_HASH, resourceHasher, zipHasher, cacheService, stringInterner);
     }
 
     public static ClasspathFingerprintingStrategy compileClasspath(ResourceHasher classpathResourceHasher, ResourceSnapshotterCacheService cacheService, Interner<String> stringInterner) {
-        ZipHasher zipHasher = new ZipHasher(classpathResourceHasher);
+        ZipHasher zipHasher = ZipHasher.withResourceHasher(classpathResourceHasher);
         return new ClasspathFingerprintingStrategy(COMPILE_CLASSPATH_IDENTIFIER, IGNORE, classpathResourceHasher, zipHasher, cacheService, stringInterner);
     }
 
@@ -126,8 +126,8 @@ public class ClasspathFingerprintingStrategy extends AbstractFingerprintingStrat
         Interner<String> stringInterner,
         ZipHasher.HashingExceptionReporter hashingExceptionReporter
     ) {
-        ZipHasher fallbackZipHasher = new ZipHasher(runtimeClasspathResourceHasher);
-        ZipHasher zipHasher = new ZipHasher(classpathResourceHasher, fallbackZipHasher, hashingExceptionReporter);
+        ZipHasher fallbackZipHasher = ZipHasher.withResourceHasher(runtimeClasspathResourceHasher);
+        ZipHasher zipHasher = ZipHasher.withResourceHasherAndFallback(classpathResourceHasher, fallbackZipHasher, hashingExceptionReporter);
         return new ClasspathFingerprintingStrategy(COMPILE_CLASSPATH_IDENTIFIER, IGNORE, classpathResourceHasher, zipHasher, cacheService, stringInterner);
     }
 

--- a/subprojects/normalization-java/src/main/java/org/gradle/internal/fingerprint/classpath/impl/ClasspathFingerprintingStrategy.java
+++ b/subprojects/normalization-java/src/main/java/org/gradle/internal/fingerprint/classpath/impl/ClasspathFingerprintingStrategy.java
@@ -110,12 +110,12 @@ public class ClasspathFingerprintingStrategy extends AbstractFingerprintingStrat
         LineEndingSensitivity lineEndingSensitivity
     ) {
         ResourceHasher resourceHasher = runtimeClasspathResourceHasher(runtimeClasspathResourceHasher, lineEndingSensitivity, propertiesFileFilters, manifestAttributeResourceEntryFilter, classpathResourceFilter);
-        ZipHasher zipHasher = ZipHasher.withResourceHasher(resourceHasher);
+        ZipHasher zipHasher = ZipHasher.withArchiveVisitor(ZipHasher.visitorFromResourceHasher(resourceHasher));
         return new ClasspathFingerprintingStrategy(CLASSPATH_IDENTIFIER, USE_FILE_HASH, resourceHasher, zipHasher, cacheService, stringInterner);
     }
 
     public static ClasspathFingerprintingStrategy compileClasspath(ResourceHasher classpathResourceHasher, ResourceSnapshotterCacheService cacheService, Interner<String> stringInterner) {
-        ZipHasher zipHasher = ZipHasher.withResourceHasher(classpathResourceHasher);
+        ZipHasher zipHasher = ZipHasher.withArchiveVisitor(ZipHasher.visitorFromResourceHasher(classpathResourceHasher));
         return new ClasspathFingerprintingStrategy(COMPILE_CLASSPATH_IDENTIFIER, IGNORE, classpathResourceHasher, zipHasher, cacheService, stringInterner);
     }
 
@@ -126,8 +126,8 @@ public class ClasspathFingerprintingStrategy extends AbstractFingerprintingStrat
         Interner<String> stringInterner,
         ZipHasher.HashingExceptionReporter hashingExceptionReporter
     ) {
-        ZipHasher fallbackZipHasher = ZipHasher.withResourceHasher(runtimeClasspathResourceHasher);
-        ZipHasher zipHasher = ZipHasher.withResourceHasherAndFallback(classpathResourceHasher, fallbackZipHasher, hashingExceptionReporter);
+        ZipHasher fallbackZipHasher = ZipHasher.withArchiveVisitor(ZipHasher.visitorFromResourceHasher(runtimeClasspathResourceHasher));
+        ZipHasher zipHasher = ZipHasher.withFallback(ZipHasher.visitorFromResourceHasher(classpathResourceHasher), fallbackZipHasher, hashingExceptionReporter);
         return new ClasspathFingerprintingStrategy(COMPILE_CLASSPATH_IDENTIFIER, IGNORE, classpathResourceHasher, zipHasher, cacheService, stringInterner);
     }
 

--- a/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/ZipHasherTest.groovy
+++ b/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/ZipHasherTest.groovy
@@ -40,13 +40,13 @@ class ZipHasherTest extends Specification {
 
     ResourceEntryFilter manifestResourceFilter = new IgnoringResourceEntryFilter(ImmutableSet.copyOf("created-by"))
     ResourceEntryFilter propertyResourceFilter = new IgnoringResourceEntryFilter(ImmutableSet.copyOf("created-by", "पशुपतिरपि"))
-    ZipHasher zipHasher = ZipHasher.withResourceHasher(resourceHasher(ResourceEntryFilter.FILTER_NOTHING, ResourceEntryFilter.FILTER_NOTHING))
-    ZipHasher ignoringZipHasher = ZipHasher.withResourceHasher(resourceHasher(manifestResourceFilter, propertyResourceFilter))
+    ZipHasher zipHasher = ZipHasher.withArchiveVisitor(resourceHasher(ResourceEntryFilter.FILTER_NOTHING, ResourceEntryFilter.FILTER_NOTHING))
+    ZipHasher ignoringZipHasher = ZipHasher.withArchiveVisitor(resourceHasher(manifestResourceFilter, propertyResourceFilter))
 
-    static ResourceHasher resourceHasher(ResourceEntryFilter manifestResourceFilter, ResourceEntryFilter propertyResourceFilter) {
+    static ZipHasher.ArchiveVisitor resourceHasher(ResourceEntryFilter manifestResourceFilter, ResourceEntryFilter propertyResourceFilter) {
         ResourceHasher hasher = new RuntimeClasspathResourceHasher()
         ResourceHasher propertiesFileHasher = new PropertiesFileAwareClasspathResourceHasher(hasher, ['**/*.properties': propertyResourceFilter])
-        return new MetaInfAwareClasspathResourceHasher(propertiesFileHasher, manifestResourceFilter)
+        return ZipHasher.visitorFromResourceHasher(new MetaInfAwareClasspathResourceHasher(propertiesFileHasher, manifestResourceFilter))
     }
 
     def "adding an empty jar inside another jar changes the hashcode"() {
@@ -176,6 +176,6 @@ class ZipHasherTest extends Specification {
     }
 
     private static RegularFileSnapshotContext snapshotContext(TestFile file) {
-        return new DefaultRegularFileSnapshotContext({ }, new RegularFileSnapshot(file.path, file.name, TestHashCodes.hashCodeFrom(0), DefaultFileMetadata.file(0, 0, AccessType.DIRECT)))
+        return new DefaultRegularFileSnapshotContext({}, new RegularFileSnapshot(file.path, file.name, TestHashCodes.hashCodeFrom(0), DefaultFileMetadata.file(0, 0, AccessType.DIRECT)))
     }
 }

--- a/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/ZipHasherTest.groovy
+++ b/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/ZipHasherTest.groovy
@@ -40,8 +40,8 @@ class ZipHasherTest extends Specification {
 
     ResourceEntryFilter manifestResourceFilter = new IgnoringResourceEntryFilter(ImmutableSet.copyOf("created-by"))
     ResourceEntryFilter propertyResourceFilter = new IgnoringResourceEntryFilter(ImmutableSet.copyOf("created-by", "पशुपतिरपि"))
-    ZipHasher zipHasher = new ZipHasher(resourceHasher(ResourceEntryFilter.FILTER_NOTHING, ResourceEntryFilter.FILTER_NOTHING))
-    ZipHasher ignoringZipHasher = new ZipHasher(resourceHasher(manifestResourceFilter, propertyResourceFilter))
+    ZipHasher zipHasher = ZipHasher.withResourceHasher(resourceHasher(ResourceEntryFilter.FILTER_NOTHING, ResourceEntryFilter.FILTER_NOTHING))
+    ZipHasher ignoringZipHasher = ZipHasher.withResourceHasher(resourceHasher(manifestResourceFilter, propertyResourceFilter))
 
     static ResourceHasher resourceHasher(ResourceEntryFilter manifestResourceFilter, ResourceEntryFilter propertyResourceFilter) {
         ResourceHasher hasher = new RuntimeClasspathResourceHasher()


### PR DESCRIPTION
This is an attempt to solve #25434, but it ended up too convoluted for production. 

The problem: we filter out unsupported directories from MR-JARs when instrumenting. However, because of the agent, classes are loaded first from the original. If Gradle runs on the unsupported JVM, it can load non-instrumented original versioned class for which there's no transformed bytecode available.

The idea:
1. Make the instrumentation fail if a multi-release JAR contains versioned directory loadable with the current JVM.
2. Make sure that MR-JARs with unsupported directories have different fingerprints if the current JVM is supported or not.

This approach seems odd because after fingerprinting we already know the JAR is not going to be instrumentable. Unfortunately, fingerprinting code cannot properly communicate the failure.