### PR TITLE
Improve how imports are added to plugin definitions for PropertyUpgradesBinaryCompatibilityCrossVersionSpec

### DIFF
--- a/subprojects/integ-test/build.gradle.kts
+++ b/subprojects/integ-test/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     crossVersionTestImplementation(project(":ide"))
     crossVersionTestImplementation(project(":code-quality"))
     crossVersionTestImplementation(project(":signing"))
+    crossVersionTestImplementation(project(":functional"))
 
     integTestImplementation(testFixtures(project(":core")))
     integTestImplementation(testFixtures(project(":diagnostics")))

--- a/subprojects/integ-test/src/crossVersionTest/groovy/org/gradle/integtests/AbstractPropertyUpgradesBinaryCompatibilityCrossVersionSpec.groovy
+++ b/subprojects/integ-test/src/crossVersionTest/groovy/org/gradle/integtests/AbstractPropertyUpgradesBinaryCompatibilityCrossVersionSpec.groovy
@@ -37,23 +37,11 @@ abstract class AbstractPropertyUpgradesBinaryCompatibilityCrossVersionSpec exten
     ]
 
     /**
-     * We won't upgrade these, so we don't need dependency on these packages.
+     * These packages are not available with the version we are building a plugin with and will cause plugin compilation to fail.
      */
     private static final List<String> BLACKLISTED_PACKAGES = [
-        "org.gradle.language.assembler",
-        "org.gradle.language.c",
-        "org.gradle.language.cpp",
-        "org.gradle.language.nativeplatform",
-        "org.gradle.language.objectivec",
-        "org.gradle.language.objectivecpp",
-        "org.gradle.language.rc",
-        "org.gradle.language.swift",
-        "org.gradle.nativeplatform",
-        "org.gradle.plugins.ide",
         "org.gradle.testkit",
         "org.gradle.api.flow",
-        "org.gradle.ide",
-        "org.gradle.swiftpm"
     ]
 
     private static final Supplier<List<String>> DEFAULT_GRADLE_IMPORTS = Lazy.unsafe().of {

--- a/subprojects/integ-test/src/crossVersionTest/groovy/org/gradle/integtests/AbstractPropertyUpgradesBinaryCompatibilityCrossVersionSpec.groovy
+++ b/subprojects/integ-test/src/crossVersionTest/groovy/org/gradle/integtests/AbstractPropertyUpgradesBinaryCompatibilityCrossVersionSpec.groovy
@@ -40,7 +40,9 @@ abstract class AbstractPropertyUpgradesBinaryCompatibilityCrossVersionSpec exten
      * These packages are not available with the version we are building a plugin with and will cause plugin compilation to fail.
      */
     private static final List<String> BLACKLISTED_PACKAGES = [
+        // Testkit is not available on compile classpath for plugin
         "org.gradle.testkit",
+        // Flow API is not available in Gradle 8.0.2 that we use to produce a plugin
         "org.gradle.api.flow",
     ]
 

--- a/subprojects/integ-test/src/crossVersionTest/groovy/org/gradle/integtests/PropertyUpgradesBinaryCompatibilityCrossVersionSpec.groovy
+++ b/subprojects/integ-test/src/crossVersionTest/groovy/org/gradle/integtests/PropertyUpgradesBinaryCompatibilityCrossVersionSpec.groovy
@@ -15,24 +15,17 @@
  */
 package org.gradle.integtests
 
-import org.gradle.api.plugins.quality.Checkstyle
 import org.gradle.integtests.fixtures.TargetVersions
 
 @TargetVersions("8.0.2")
 class PropertyUpgradesBinaryCompatibilityCrossVersionSpec extends AbstractPropertyUpgradesBinaryCompatibilityCrossVersionSpec {
-
-    @Override
-    protected List<Class<?>> importClasses() {
-        return [Checkstyle]
-    }
 
     def "can use upgraded Checkstyle in a Groovy plugin compiled with a previous Gradle version"() {
         given:
         prepareGroovyPluginTest """
             project.tasks.register("myCheckstyle", Checkstyle) {
                 maxErrors = 1
-                // int currentMaxErrors = maxErrors doesn't work yet
-                int currentMaxErrors = it.maxErrors
+                int currentMaxErrors = maxErrors
                 assert currentMaxErrors == 1
             }
         """


### PR DESCRIPTION
To simplify tests in PropertyUpgradesBinaryCompatibilityCrossVersionSpec. 