### PR TITLE
Fixed typo in the docs

### DIFF
--- a/subprojects/docs/src/docs/userguide/authoring-builds/working_with_files.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/working_with_files.adoc
@@ -657,7 +657,7 @@ Using empty configuration blocks for file or directory permissions still sets th
 In fact everything that's inside one of these configurations blocks is relative to the default values.
 Default permissions differ for files and directories:
 
- * *file*: read & write for *owner*, read for *group*, read for *other* (*0644*, *r-wr--r--*)
+ * *file*: read & write for *owner*, read for *group*, read for *other* (*0644*, *rw-r--r--*)
  * *directory*: read, write & execute for *owner*, read & execute for *group*, read & execute for *other* (*0755*, *rwxr-xr-x*)
 
 [[sec:using_the_copyspec_class]]


### PR DESCRIPTION
Fixes #25830 

### Context

Typo in the docs. Changed `r-wr—​r--` to `rw-r--r--`.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`
