### PR TITLE
Document and test building for older Kotlin language versions

### DIFF
--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc
@@ -93,6 +93,9 @@ The embedded Kotlin has been updated from 1.8.20 to link:https://github.com/JetB
 The Kotlin language and API levels for the Kotlin DSL are still set to 1.8 for backwards compatibility.
 See the release notes for link:https://github.com/JetBrains/kotlin/releases/tag/v1.8.22[Kotlin 1.8.22] and link:https://github.com/JetBrains/kotlin/releases/tag/v1.8.21[Kotlin 1.8.21].
 
+Kotlin 1.9 dropped support for Kotlin language and API level 1.3.
+If you build Gradle plugins written in Kotlin with this version of Gradle and need to support Gradle <7.0 you need to stick to using the Kotlin Gradle Plugin <1.9.0 and configure the Kotlin language and API levels to 1.3.
+See the <<compatibility.adoc#compatibility, Compatibility Matrix>> for details about other versions.
 
 === Deprecations
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/versions/KotlinGradlePluginVersions.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/versions/KotlinGradlePluginVersions.groovy
@@ -16,8 +16,11 @@
 
 package org.gradle.integtests.fixtures.versions
 
+import org.gradle.api.JavaVersion
 import org.gradle.internal.Factory
 import org.gradle.util.internal.VersionNumber
+
+import static org.junit.Assume.assumeTrue
 
 /**
  * Kotlin Gradle Plugin Versions.
@@ -84,5 +87,33 @@ class KotlinGradlePluginVersions {
 
     String getLatestStableOrRC() {
         return latestsStableOrRC.last()
+    }
+
+    private static final VersionNumber KOTLIN_1_8_0 = VersionNumber.parse('1.8.0')
+    private static final VersionNumber KOTLIN_1_9_0 = VersionNumber.parse('1.9.0')
+
+    static void assumeCurrentJavaVersionIsSupportedBy(String kotlinVersion) {
+        VersionNumber kotlinVersionNumber = VersionNumber.parse(kotlinVersion)
+        JavaVersion current = JavaVersion.current()
+        JavaVersion mini = getMinimumJavaVersionFor(kotlinVersionNumber)
+        assumeTrue("KGP $kotlinVersion minimum supported Java version is $mini, current is $current", current >= mini)
+        JavaVersion maxi = getMaximumJavaVersionFor(kotlinVersionNumber)
+        if (maxi != null) {
+            assumeTrue("KGP $kotlinVersion maximum supported Java version is $maxi, current is $current", current <= maxi)
+        }
+    }
+
+    static JavaVersion getMinimumJavaVersionFor(VersionNumber kotlinVersion) {
+        return JavaVersion.VERSION_1_8
+    }
+
+    private static JavaVersion getMaximumJavaVersionFor(VersionNumber kotlinVersion) {
+        if (kotlinVersion.baseVersion < KOTLIN_1_8_0) {
+            return JavaVersion.VERSION_18
+        }
+        if (kotlinVersion.baseVersion < KOTLIN_1_9_0) {
+            return JavaVersion.VERSION_19
+        }
+        return null
     }
 }

--- a/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginCrossVersionSmokeTest.kt
+++ b/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginCrossVersionSmokeTest.kt
@@ -16,7 +16,9 @@
 
 package org.gradle.kotlin.dsl.plugins.dsl
 
+import org.gradle.integtests.fixtures.versions.KotlinGradlePluginVersions
 import org.gradle.kotlin.dsl.fixtures.AbstractKotlinIntegrationTest
+import org.gradle.kotlin.dsl.support.expectedKotlinDslPluginsVersion
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
@@ -27,17 +29,16 @@ import org.junit.Test
  */
 class KotlinDslPluginCrossVersionSmokeTest : AbstractKotlinIntegrationTest() {
 
+    // Previous versions depend on Kotlin that is not supported with Gradle >= 8.0
+    val oldestSupportedKotlinDslPluginVersion = "3.2.4"
+
     @Test
     fun `can run with first version of kotlin-dsl plugin supporting Gradle 8_0`() {
 
         assumeNonEmbeddedGradleExecuter()
 
-        // Previous versions depend on Kotlin that is not supported with Gradle >= 8.0
-        val testedVersion = "3.2.4"
-        val blessedVersion = org.gradle.kotlin.dsl.support.expectedKotlinDslPluginsVersion
-
         withDefaultSettingsIn("buildSrc")
-        withBuildScriptIn("buildSrc", scriptWithKotlinDslPlugin(testedVersion)).appendText(
+        withBuildScriptIn("buildSrc", scriptWithKotlinDslPlugin(oldestSupportedKotlinDslPluginVersion)).appendText(
             """
             tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
                 kotlinOptions.freeCompilerArgs += "-Xskip-metadata-version-check"
@@ -49,20 +50,14 @@ class KotlinDslPluginCrossVersionSmokeTest : AbstractKotlinIntegrationTest() {
         withDefaultSettings()
         withBuildScript("""plugins { id("some") }""")
 
-        executer.expectDocumentedDeprecationWarning("Using the `kotlin-dsl` plugin together with Kotlin Gradle Plugin < 1.8.0. This behavior has been deprecated. This will fail with an error in Gradle 9.0. Please let Gradle control the version of `kotlin-dsl` by removing any explicit `kotlin-dsl` version constraints from your build logic. Or use version $blessedVersion which is the expected version for this Gradle release. If you explicitly declare which version of the Kotlin Gradle Plugin to use for your build logic, update it to >= 1.8.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#kotlin_dsl_with_kgp_lt_1_8_0")
-        executer.expectDocumentedDeprecationWarning("The Project.getConvention() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_access_to_conventions")
-        executer.expectDocumentedDeprecationWarning(
-            "The org.gradle.api.plugins.Convention type has been deprecated. " +
-                "This is scheduled to be removed in Gradle 9.0. " +
-                "Consult the upgrading guide for further information: " +
-                "https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_access_to_conventions"
-        )
+        expectConventionDeprecations()
+        expectKotlinDslPluginDeprecation()
 
         build("help").apply {
 
             assertThat(
                 output,
-                containsString("This version of Gradle expects version '$blessedVersion' of the `kotlin-dsl` plugin but version '$testedVersion' has been applied to project ':buildSrc'. Let Gradle control the version of `kotlin-dsl` by removing any explicit `kotlin-dsl` version constraints from your build logic.")
+                containsString("This version of Gradle expects version '$expectedKotlinDslPluginsVersion' of the `kotlin-dsl` plugin but version '$oldestSupportedKotlinDslPluginVersion' has been applied to project ':buildSrc'. Let Gradle control the version of `kotlin-dsl` by removing any explicit `kotlin-dsl` version constraints from your build logic.")
             )
 
             assertThat(
@@ -70,5 +65,109 @@ class KotlinDslPluginCrossVersionSmokeTest : AbstractKotlinIntegrationTest() {
                 containsString("some!")
             )
         }
+    }
+
+    @Test
+    fun `can build plugin for oldest supported Kotlin language version`() {
+
+        // Kotlin version leaks on the classpath when running embedded
+        assumeNonEmbeddedGradleExecuter()
+
+        val oldestKotlinLanguageVersion = KotlinGradlePluginVersions.getLANGUAGE_VERSIONS().first()
+
+        withDefaultSettingsIn("producer")
+        withBuildScriptIn("producer", scriptWithKotlinDslPlugin()).appendText(
+            """
+            tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+                compilerOptions {
+                    languageVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion("$oldestKotlinLanguageVersion")
+                    apiVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion("$oldestKotlinLanguageVersion")
+                }
+            }
+            """
+        )
+        withFile("producer/src/main/kotlin/some.gradle.kts", """println("some!")""")
+
+        withDefaultSettings().appendText("""includeBuild("producer")""")
+        withBuildScript("""plugins { id("some") }""")
+
+        executer.expectDeprecationWarning("w: Language version $oldestKotlinLanguageVersion is deprecated and its support will be removed in a future version of Kotlin")
+
+        build("help").apply {
+            assertThat(output, containsString("some!"))
+        }
+    }
+
+    @Test
+    fun `can build plugin for previous unsupported Kotlin language version`() {
+
+        // Kotlin version leaks on the classpath when running embedded
+        assumeNonEmbeddedGradleExecuter()
+
+        val previousKotlinLanguageVersion = "1.2"
+
+        withDefaultSettingsIn("producer")
+        withBuildScriptIn("producer",
+            """
+            plugins {
+                `kotlin-dsl` version "$oldestSupportedKotlinDslPluginVersion"
+            }
+
+            $repositoriesBlock
+
+            tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+                // compilerOptions {
+                //     languageVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion("$previousKotlinLanguageVersion")
+                //     apiVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion("$previousKotlinLanguageVersion")
+                // }
+                kotlinOptions {
+                    languageVersion = "$previousKotlinLanguageVersion"
+                    apiVersion = "$previousKotlinLanguageVersion"
+                    freeCompilerArgs += "-Xskip-metadata-version-check"
+                }
+            }
+            """
+        )
+        withFile("producer/src/main/kotlin/some.gradle.kts", """println("some!")""")
+
+        withDefaultSettings().appendText("""includeBuild("producer")""")
+        withBuildScript("""plugins { id("some") }""")
+
+        expectConventionDeprecations()
+        expectKotlinDslPluginDeprecation()
+
+        build("help").apply {
+            assertThat(output, containsString("some!"))
+        }
+    }
+
+    private
+    fun expectConventionDeprecations() {
+        executer.expectDocumentedDeprecationWarning(
+            "The Project.getConvention() method has been deprecated. " +
+                "This is scheduled to be removed in Gradle 9.0. " +
+                "Consult the upgrading guide for further information: " +
+                "https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_access_to_conventions"
+        )
+        executer.expectDocumentedDeprecationWarning(
+            "The org.gradle.api.plugins.Convention type has been deprecated. " +
+                "This is scheduled to be removed in Gradle 9.0. " +
+                "Consult the upgrading guide for further information: " +
+                "https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_access_to_conventions"
+        )
+    }
+
+    private
+    fun expectKotlinDslPluginDeprecation() {
+        executer.expectDocumentedDeprecationWarning(
+            "Using the `kotlin-dsl` plugin together with Kotlin Gradle Plugin < 1.8.0. " +
+                "This behavior has been deprecated. " +
+                "This will fail with an error in Gradle 9.0. " +
+                "Please let Gradle control the version of `kotlin-dsl` by removing any explicit `kotlin-dsl` version constraints from your build logic. " +
+                "Or use version $expectedKotlinDslPluginsVersion which is the expected version for this Gradle release. " +
+                "If you explicitly declare which version of the Kotlin Gradle Plugin to use for your build logic, update it to >= 1.8.0. " +
+                "Consult the upgrading guide for further information: " +
+                "https://docs.gradle.org/current/userguide/upgrading_version_8.html#kotlin_dsl_with_kgp_lt_1_8_0"
+        )
     }
 }

--- a/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginGradlePluginCrossVersionSmokeTest.kt
+++ b/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginGradlePluginCrossVersionSmokeTest.kt
@@ -18,6 +18,7 @@ package org.gradle.kotlin.dsl.plugins.dsl
 
 import org.gradle.integtests.fixtures.RepoScriptBlockUtil
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.gradle.integtests.fixtures.versions.KotlinGradlePluginVersions
 import org.gradle.kotlin.dsl.*
 import org.gradle.kotlin.dsl.fixtures.AbstractPluginTest
 import org.gradle.test.fixtures.dsl.GradleDsl
@@ -43,11 +44,7 @@ class KotlinDslPluginGradlePluginCrossVersionSmokeTest(
 
         @Parameterized.Parameters(name = "{0}")
         @JvmStatic
-        fun testedKotlinVersions() = listOf(
-            embeddedKotlinVersion,
-            "1.7.0", "1.7.10", "1.7.22",
-            "1.6.21", "1.6.10",
-        )
+        fun testedKotlinVersions() = KotlinGradlePluginVersions().latestsStableOrRC
     }
 
     @Test

--- a/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginGradlePluginCrossVersionSmokeTest.kt
+++ b/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginGradlePluginCrossVersionSmokeTest.kt
@@ -53,6 +53,8 @@ class KotlinDslPluginGradlePluginCrossVersionSmokeTest(
 
         assumeNonEmbeddedGradleExecuter() // newer Kotlin version always leaks on the classpath when running embedded
 
+        KotlinGradlePluginVersions.assumeCurrentJavaVersionIsSupportedBy(kotlinVersion)
+
         withDefaultSettingsIn("buildSrc")
         withBuildScriptIn(
             "buildSrc",


### PR DESCRIPTION
### Context

* Fixes https://github.com/gradle/gradle/issues/25868 by documenting the limitation in the upgrading guide
* Adds integration tests setting support boundaries and demonstrating a workaround to build for previous Kotlin versions with the current Gradle.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
