### PR TITLE
Fix failing docs tests on Java 20

### DIFF
--- a/subprojects/docs/src/docsTest/java/org/gradle/docs/samples/BaseSamplesTest.java
+++ b/subprojects/docs/src/docsTest/java/org/gradle/docs/samples/BaseSamplesTest.java
@@ -30,6 +30,7 @@ import org.gradle.integtests.fixtures.logging.EmbeddedKotlinOutputNormalizer;
 import org.gradle.integtests.fixtures.logging.GradleWelcomeOutputNormalizer;
 import org.gradle.integtests.fixtures.logging.NativeComponentReportOutputNormalizer;
 import org.gradle.integtests.fixtures.logging.SampleOutputNormalizer;
+import org.gradle.integtests.fixtures.logging.SpringBootWebAppTestOutputNormalizer;
 import org.gradle.integtests.fixtures.logging.ToolchainDownloadOutputNormalizer;
 import org.gradle.integtests.fixtures.logging.ZincScalaCompilerOutputNormalizer;
 import org.gradle.integtests.fixtures.mirror.SetMirrorsSampleModifier;
@@ -47,7 +48,8 @@ import org.gradle.integtests.fixtures.mirror.SetMirrorsSampleModifier;
     ConfigurationCacheOutputNormalizer.class,
     EmbeddedKotlinOutputNormalizer.class,
     ZincScalaCompilerOutputNormalizer.class,
-    ToolchainDownloadOutputNormalizer.class
+    ToolchainDownloadOutputNormalizer.class,
+    SpringBootWebAppTestOutputNormalizer.class,
 })
 @SampleModifiers({
     SetMirrorsSampleModifier.class,

--- a/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/groovy/buildSrc/build.gradle
+++ b/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/groovy/buildSrc/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.github.spotbugs.snom:spotbugs-gradle-plugin:5.0.12'
+    implementation 'com.github.spotbugs.snom:spotbugs-gradle-plugin:5.0.14'
     testImplementation platform("org.spockframework:spock-bom:2.2-groovy-3.0")
     testImplementation 'org.spockframework:spock-core'
 }

--- a/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/kotlin/buildSrc/build.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/kotlin/buildSrc/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:5.0.12")
+    implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:5.0.14")
     testImplementation("junit:junit:4.13")
 }
 // end::repositories-and-dependencies[]

--- a/subprojects/docs/src/samples/build-organization/publishing-convention-plugins/groovy/convention-plugins/build.gradle
+++ b/subprojects/docs/src/samples/build-organization/publishing-convention-plugins/groovy/convention-plugins/build.gradle
@@ -32,7 +32,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.github.spotbugs.snom:spotbugs-gradle-plugin:5.0.12'
+    implementation 'com.github.spotbugs.snom:spotbugs-gradle-plugin:5.0.14'
     testImplementation platform("org.spockframework:spock-bom:2.2-groovy-3.0")
     testImplementation 'org.spockframework:spock-core'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/subprojects/docs/src/samples/build-organization/publishing-convention-plugins/kotlin/convention-plugins/build.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/publishing-convention-plugins/kotlin/convention-plugins/build.gradle.kts
@@ -31,7 +31,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:5.0.12")
+    implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:5.0.14")
     testImplementation("junit:junit:4.13")
 }
 // end::repositories-and-dependencies[]

--- a/subprojects/docs/src/samples/groovy/library-publishing/groovy/my-library/build.gradle
+++ b/subprojects/docs/src/samples/groovy/library-publishing/groovy/my-library/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.codehaus.groovy:groovy-all:3.0.13'
+    implementation 'org.codehaus.groovy:groovy-all:3.0.18'
 }
 
 publishing {

--- a/subprojects/docs/src/samples/groovy/library-publishing/kotlin/my-library/build.gradle.kts
+++ b/subprojects/docs/src/samples/groovy/library-publishing/kotlin/my-library/build.gradle.kts
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    implementation("org.codehaus.groovy:groovy-all:3.0.13")
+    implementation("org.codehaus.groovy:groovy-all:3.0.18")
 }
 
 publishing {

--- a/subprojects/docs/src/samples/incubating/build-organization/publishing-convention-plugins/groovy/convention-plugins/build.gradle
+++ b/subprojects/docs/src/samples/incubating/build-organization/publishing-convention-plugins/groovy/convention-plugins/build.gradle
@@ -41,6 +41,6 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.github.spotbugs.snom:spotbugs-gradle-plugin:5.0.12'
+    implementation 'com.github.spotbugs.snom:spotbugs-gradle-plugin:5.0.14'
 }
 // end::repositories-and-dependencies[]

--- a/subprojects/docs/src/samples/incubating/build-organization/publishing-convention-plugins/kotlin/convention-plugins/build.gradle.kts
+++ b/subprojects/docs/src/samples/incubating/build-organization/publishing-convention-plugins/kotlin/convention-plugins/build.gradle.kts
@@ -40,6 +40,6 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:5.0.12")
+    implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:5.0.14")
 }
 // end::repositories-and-dependencies[]

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/SpringBootWebAppTestOutputNormalizer.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/SpringBootWebAppTestOutputNormalizer.groovy
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures.logging
+
+import org.gradle.exemplar.executor.ExecutionMetadata
+import org.gradle.exemplar.test.normalizer.OutputNormalizer
+
+/**
+ * Removes extra empty lines from `spring-boot-web-application` sample output.
+ * Before:
+ * <pre>
+ > Task :app:compileJava
+
+ > Task :app:processResources
+ > Task :app:classes
+
+ > Task :app:compileTestJava
+
+ > Task :app:processTestResources NO-SOURCE
+ > Task :app:testClasses
+ > Task :app:test
+
+ BUILD SUCCESSFUL in 0s
+ 4 actionable tasks: 4 executed
+ </pre>
+ *
+ * After:
+ <pre>
+ > Task :app:compileJava
+ > Task :app:processResources
+ > Task :app:classes
+ > Task :app:compileTestJava
+ > Task :app:processTestResources NO-SOURCE
+ > Task :app:testClasses
+ > Task :app:test
+
+ BUILD SUCCESSFUL in 0s
+ 4 actionable tasks: 4 executed
+ </pre>
+ * */
+class SpringBootWebAppTestOutputNormalizer implements OutputNormalizer {
+
+    @Override
+    String normalize(String output, ExecutionMetadata executionMetadata) {
+        return executionMetadata.tempSampleProjectDir.name.contains('building-spring-boot-web-applications')
+            ? removeEmptyLinesBeforeBuildSuccessful(output)
+            : output
+    }
+
+    private static String removeEmptyLinesBeforeBuildSuccessful(String output) {
+        List<String> lines = output.readLines()
+        int buildSuccessfulLineIndex = lines.indexOf("BUILD SUCCESSFUL in 0s")
+        assert buildSuccessfulLineIndex != -1
+
+        List<String> normalized = lines.subList(0, buildSuccessfulLineIndex).grep { !it.isEmpty() } + "" + lines.subList(buildSuccessfulLineIndex, lines.size())
+        return normalized.join("\n")
+    }
+}


### PR DESCRIPTION
This PR fixes several problems in DocsTest on Java 20:

- Upgrade `spotbugs-gradle-plugin`.
- Upgrade `groovy-all`
- Somehow there're some empty lines in `building-spring-boot-web-applications` sample output. Add a new normalizer to fix.