### PR TITLE
Adapt Scala - Java compatibility

### DIFF
--- a/subprojects/scala/src/integTest/groovy/org/gradle/integtests/fixtures/ScalaCoverage.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/integtests/fixtures/ScalaCoverage.groovy
@@ -21,8 +21,8 @@ import org.gradle.api.JavaVersion
 class ScalaCoverage {
 
     private static final Map<String, JavaVersion> SCALA_2_VERSIONS = [
-        "2.11.12": JavaVersion.VERSION_1_9,
-        "2.12.18": JavaVersion.VERSION_20,
+        "2.11.12": JavaVersion.VERSION_1_8,
+        "2.12.18": JavaVersion.VERSION_1_8,
         "2.13.11": JavaVersion.VERSION_20,
     ]
     private static final Map<String, JavaVersion> SCALA_3_VERSIONS = [


### PR DESCRIPTION
Scala 2.12 really can't emit bytecode higher than Java 8 level. Aligning Scala 2.11 to that as well.
See #19456

Issue #23488