### PR TITLE
Ignore failures while shutting down daemon connection

### DIFF
--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/DefaultIncomingConnectionHandler.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/DefaultIncomingConnectionHandler.java
@@ -167,7 +167,11 @@ public class DefaultIncomingConnectionHandler implements IncomingConnectionHandl
             }
 
             Object finished = daemonConnection.receive(60, TimeUnit.SECONDS);
-            LOGGER.debug("Received finished message: {}", finished);
+            if (finished != null) {
+                LOGGER.debug("Received finished message: {}", finished);
+            } else {
+                LOGGER.warn(String.format("Timed out waiting for finished message from client %s. Discarding connection.", connection));
+            }
         }
     }
 }


### PR DESCRIPTION
Once the daemon client has received the build result from the daemon, it tries to send a "finished" message to the daemon to initiate shutdown of the connection.  If the daemon has already shut the connection down from its side, the client should not care since it's preparing to shutdown its side of the connection anyways.  If the daemon is actually waiting, but does not receive the message for some reason, it will just timeout and close the connection.  

This changes the client to ignore any errors while sending the "finished" message so that this scenario does not cause a failure in the client on a potentially successful build.    

Fixes #25905 
