### PR TITLE
Do not store request details in local dependency metadata

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/metadata/ProjectMetadataController.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/metadata/ProjectMetadataController.kt
@@ -147,7 +147,7 @@ class ProjectMetadataController(
     suspend fun ReadContext.readConfiguration(componentId: ComponentIdentifier, factory: CalculatedValueContainerFactory): LocalConfigurationMetadata {
         val configurationName = readString()
         val configurationAttributes = readNonNull<ImmutableAttributes>()
-        val dependencies = readDependencies(componentId)
+        val dependencies = readDependencies()
         val variants = readVariants(factory).toSet()
 
         return DefaultLocalConfigurationMetadata(
@@ -158,15 +158,12 @@ class ProjectMetadataController(
     }
 
     private
-    suspend fun ReadContext.readDependencies(componentId: ComponentIdentifier): List<LocalComponentDependencyMetadata> {
+    suspend fun ReadContext.readDependencies(): List<LocalComponentDependencyMetadata> {
         return readList {
             val selector = readNonNull<ComponentSelector>()
             val constraint = readBoolean()
             LocalComponentDependencyMetadata(
-                componentId,
                 selector,
-                null,
-                null,
                 ImmutableAttributes.EMPTY,
                 null,
                 emptyList(),

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyModuleResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyModuleResolveIntegrationTest.groovy
@@ -106,7 +106,8 @@ task retrieve(type: Sync) {
 
         expect:
         fails 'retrieve'
-        failure.assertHasCause("Project : declares a dependency from configuration 'compile' to configuration 'x86_windows' which is not declared in the descriptor for test:target:1.0.")
+        failure.assertHasCause("Could not resolve test:target:1.0.\nRequired by:\n    project :")
+        failure.assertHasCause("A dependency was declared on configuration 'x86_windows' which is not declared in the descriptor for test:target:1.0.")
     }
 
     def "fails when ivy module references a configuration that does not exist"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenScopesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenScopesIntegrationTest.groovy
@@ -376,6 +376,7 @@ dependencies {
 """
         expect:
         fails 'checkDep'
-        failure.assertHasCause("Project : declares a dependency from configuration 'conf' to configuration 'x86_windows' which is not declared in the descriptor for test:target:1.0.")
+        failure.assertHasCause("Could not resolve test:target:1.0.\nRequired by:\n    project :")
+        failure.assertHasCause("A dependency was declared on configuration 'x86_windows' which is not declared in the descriptor for test:target:1.0.")
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -1397,8 +1397,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
                     : DefaultMutableVersionConstraint.withVersion(lockedVersion);
                 ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(lockedDependency.getGroup(), lockedDependency.getModule()), versionConstraint);
                 return new LocalComponentDependencyMetadata(
-                    componentIdentifier, selector, name, getAttributes(),
-                    ImmutableAttributes.EMPTY, null, Collections.emptyList(),  Collections.emptyList(),
+                    selector, ImmutableAttributes.EMPTY, null, Collections.emptyList(),  Collections.emptyList(),
                     false, false, false, true, false, true, getLockReason(strict, lockedVersion)
                 );
             });
@@ -1407,8 +1406,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
         Stream<LocalComponentDependencyMetadata> consistentResolutionConstraintMetadata = getConsistentResolutionConstraints().map(dc -> {
             ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(dc.getGroup(), dc.getName()), dc.getVersionConstraint());
             return new LocalComponentDependencyMetadata(
-                componentIdentifier, selector, name, getAttributes(),
-                ImmutableAttributes.EMPTY, null, Collections.emptyList(), Collections.emptyList(),
+                selector, ImmutableAttributes.EMPTY, null, Collections.emptyList(), Collections.emptyList(),
                 false, false, false, true, false, true, dc.getReason()
             );
         });

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/clientmodule/ClientModuleResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/clientmodule/ClientModuleResolver.java
@@ -75,7 +75,7 @@ public class ClientModuleResolver implements ComponentMetaDataResolver {
         org.gradle.api.artifacts.ClientModule clientModule = componentOverrideMetadata.getClientModule();
         if (clientModule != null) {
             ModuleComponentResolveMetadata originalMetadata = (ModuleComponentResolveMetadata) result.getState().getMetadata();
-            List<ModuleDependencyMetadata> clientModuleDependencies = createClientModuleDependencies(identifier, clientModule);
+            List<ModuleDependencyMetadata> clientModuleDependencies = createClientModuleDependencies(clientModule);
             ModuleComponentArtifactMetadata clientModuleArtifact = createClientModuleArtifact(originalMetadata);
             ClientModuleComponentResolveMetadata clientModuleMetaData = new ClientModuleComponentResolveMetadata(originalMetadata, clientModuleArtifact, clientModuleDependencies);
 
@@ -89,10 +89,10 @@ public class ClientModuleResolver implements ComponentMetaDataResolver {
     }
 
     @SuppressWarnings("deprecation")
-    private List<ModuleDependencyMetadata> createClientModuleDependencies(ComponentIdentifier identifier, org.gradle.api.artifacts.ClientModule clientModule) {
+    private List<ModuleDependencyMetadata> createClientModuleDependencies(org.gradle.api.artifacts.ClientModule clientModule) {
         List<ModuleDependencyMetadata> dependencies = Lists.newArrayList();
         for (ModuleDependency moduleDependency : clientModule.getDependencies()) {
-            ModuleDependencyMetadata dependencyMetadata = createDependencyMetadata(identifier, moduleDependency);
+            ModuleDependencyMetadata dependencyMetadata = createDependencyMetadata(moduleDependency);
             dependencies.add(dependencyMetadata);
         }
         return dependencies;
@@ -102,8 +102,8 @@ public class ClientModuleResolver implements ComponentMetaDataResolver {
         return metadata.artifact("jar", "jar", null);
     }
 
-    private ModuleDependencyMetadata createDependencyMetadata(ComponentIdentifier identifier, ModuleDependency moduleDependency) {
-        LocalOriginDependencyMetadata dependencyMetadata = dependencyMetadataFactory.createDependencyMetadata(identifier, moduleDependency.getTargetConfiguration(), null, moduleDependency);
+    private ModuleDependencyMetadata createDependencyMetadata(ModuleDependency moduleDependency) {
+        LocalOriginDependencyMetadata dependencyMetadata = dependencyMetadataFactory.createDependencyMetadata(moduleDependency);
         if (dependencyMetadata instanceof DslOriginDependencyMetadata) {
             return new ClientModuleDependencyMetadataWrapper((DslOriginDependencyMetadata) dependencyMetadata);
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultDependencyMetadataFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultDependencyMetadataFactory.java
@@ -20,9 +20,7 @@ import com.google.common.collect.ImmutableList;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.DependencyConstraint;
 import org.gradle.api.artifacts.ModuleDependency;
-import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ComponentSelector;
-import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.dependencies.DefaultProjectDependencyConstraint;
 import org.gradle.api.internal.artifacts.dependencies.DependencyConstraintInternal;
@@ -44,15 +42,15 @@ public class DefaultDependencyMetadataFactory implements DependencyMetadataFacto
     }
 
     @Override
-    public LocalOriginDependencyMetadata createDependencyMetadata(ComponentIdentifier componentId, @Nullable String clientConfiguration, @Nullable AttributeContainer attributes, ModuleDependency dependency) {
+    public LocalOriginDependencyMetadata createDependencyMetadata(ModuleDependency dependency) {
         DependencyMetadataConverter factoryInternal = findFactoryForDependency(dependency);
-        return factoryInternal.createDependencyMetadata(componentId, clientConfiguration, attributes, dependency);
+        return factoryInternal.createDependencyMetadata(dependency);
     }
 
     @Override
-    public LocalOriginDependencyMetadata createDependencyConstraintMetadata(ComponentIdentifier componentId, String clientConfiguration, AttributeContainer attributes, DependencyConstraint dependencyConstraint) {
+    public LocalOriginDependencyMetadata createDependencyConstraintMetadata(DependencyConstraint dependencyConstraint) {
         ComponentSelector selector = createSelector(dependencyConstraint);
-        return new LocalComponentDependencyMetadata(componentId, selector, clientConfiguration, attributes, dependencyConstraint.getAttributes(), null,
+        return new LocalComponentDependencyMetadata(selector, dependencyConstraint.getAttributes(), null,
                 Collections.emptyList(), Collections.emptyList(), ((DependencyConstraintInternal)dependencyConstraint).isForce(), false, false, true, false, dependencyConstraint.getReason());
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DependencyMetadataConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DependencyMetadataConverter.java
@@ -16,14 +16,10 @@
 package org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies;
 
 import org.gradle.api.artifacts.ModuleDependency;
-import org.gradle.api.artifacts.component.ComponentIdentifier;
-import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.internal.component.model.LocalOriginDependencyMetadata;
 
-import javax.annotation.Nullable;
-
 public interface DependencyMetadataConverter {
-    LocalOriginDependencyMetadata createDependencyMetadata(ComponentIdentifier componentId, @Nullable String clientConfiguration, @Nullable AttributeContainer attributes, ModuleDependency dependency);
+    LocalOriginDependencyMetadata createDependencyMetadata(ModuleDependency dependency);
 
     boolean canConvert(ModuleDependency dependency);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DependencyMetadataFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DependencyMetadataFactory.java
@@ -17,13 +17,9 @@ package org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencie
 
 import org.gradle.api.artifacts.DependencyConstraint;
 import org.gradle.api.artifacts.ModuleDependency;
-import org.gradle.api.artifacts.component.ComponentIdentifier;
-import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.internal.component.model.LocalOriginDependencyMetadata;
 
-import javax.annotation.Nullable;
-
 public interface DependencyMetadataFactory {
-    LocalOriginDependencyMetadata createDependencyMetadata(ComponentIdentifier componentId, @Nullable String clientConfiguration, @Nullable AttributeContainer attributes, ModuleDependency dependency);
-    LocalOriginDependencyMetadata createDependencyConstraintMetadata(ComponentIdentifier componentId, String clientConfiguration, AttributeContainer attributes, DependencyConstraint dependencyConstraint);
+    LocalOriginDependencyMetadata createDependencyMetadata(ModuleDependency dependency);
+    LocalOriginDependencyMetadata createDependencyConstraintMetadata(DependencyConstraint dependencyConstraint);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ExternalModuleDependencyMetadataConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ExternalModuleDependencyMetadataConverter.java
@@ -17,9 +17,7 @@ package org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencie
 
 import org.gradle.api.artifacts.ExternalModuleDependency;
 import org.gradle.api.artifacts.ModuleDependency;
-import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
-import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.VersionConstraintInternal;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
@@ -37,7 +35,7 @@ public class ExternalModuleDependencyMetadataConverter extends AbstractDependenc
     }
 
     @Override
-    public LocalOriginDependencyMetadata createDependencyMetadata(ComponentIdentifier componentId, @Nullable String clientConfiguration, @Nullable AttributeContainer clientAttributes, ModuleDependency dependency) {
+    public LocalOriginDependencyMetadata createDependencyMetadata(ModuleDependency dependency) {
         ExternalModuleDependency externalModuleDependency = (ExternalModuleDependency) dependency;
         boolean force = externalModuleDependency.isForce();
         boolean changing = externalModuleDependency.isChanging();
@@ -51,7 +49,7 @@ public class ExternalModuleDependencyMetadataConverter extends AbstractDependenc
 
         List<ExcludeMetadata> excludes = convertExcludeRules(dependency.getExcludeRules());
         LocalComponentDependencyMetadata dependencyMetaData = new LocalComponentDependencyMetadata(
-                componentId, selector, clientConfiguration, clientAttributes,
+                selector,
                 dependency.getAttributes(),
                 dependency.getTargetConfiguration(),
                 convertArtifacts(dependency.getArtifacts()),

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/LocalConfigurationMetadataBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/LocalConfigurationMetadataBuilder.java
@@ -17,7 +17,6 @@ package org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencie
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationsProvider;
 import org.gradle.internal.component.local.model.LocalComponentMetadata;
@@ -30,7 +29,7 @@ import org.gradle.internal.model.ModelContainer;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.BiFunction;
+import java.util.function.Function;
 
 /**
  * Builds {@link LocalConfigurationMetadata} instances from {@link ConfigurationInternal}s, while
@@ -62,12 +61,11 @@ public interface LocalConfigurationMetadataBuilder {
 
         public DefaultLocalConfigurationMetadataBuilder.DependencyState computeIfAbsent(
             ConfigurationInternal configuration,
-            ComponentIdentifier componentId,
-            BiFunction<ConfigurationInternal, ComponentIdentifier, DefaultLocalConfigurationMetadataBuilder.DependencyState> factory
+            Function<ConfigurationInternal, DependencyState> factory
         ) {
             DependencyState state = cache.get(configuration.getName());
             if (state == null) {
-                state = factory.apply(configuration, componentId);
+                state = factory.apply(configuration);
                 cache.put(configuration.getName(), state);
             }
             return state;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectDependencyMetadataConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectDependencyMetadataConverter.java
@@ -17,9 +17,7 @@ package org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencie
 
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.ProjectDependency;
-import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ComponentSelector;
-import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.dependencies.ProjectDependencyInternal;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.internal.component.local.model.DefaultProjectComponentSelector;
@@ -28,7 +26,6 @@ import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.LocalComponentDependencyMetadata;
 import org.gradle.internal.component.model.LocalOriginDependencyMetadata;
 
-import javax.annotation.Nullable;
 import java.util.List;
 
 public class ProjectDependencyMetadataConverter extends AbstractDependencyMetadataConverter {
@@ -38,7 +35,7 @@ public class ProjectDependencyMetadataConverter extends AbstractDependencyMetada
     }
 
     @Override
-    public LocalOriginDependencyMetadata createDependencyMetadata(ComponentIdentifier componentId, @Nullable String clientConfiguration, AttributeContainer clientAttributes, ModuleDependency dependency) {
+    public LocalOriginDependencyMetadata createDependencyMetadata(ModuleDependency dependency) {
         ProjectDependencyInternal projectDependency = (ProjectDependencyInternal) dependency;
         ComponentSelector selector = DefaultProjectComponentSelector.newSelector(projectDependency.getDependencyProject(),
                 ((AttributeContainerInternal)projectDependency.getAttributes()).asImmutable(),
@@ -46,10 +43,7 @@ public class ProjectDependencyMetadataConverter extends AbstractDependencyMetada
 
         List<ExcludeMetadata> excludes = convertExcludeRules(dependency.getExcludeRules());
         LocalComponentDependencyMetadata dependencyMetaData = new LocalComponentDependencyMetadata(
-            componentId,
             selector,
-            clientConfiguration,
-            clientAttributes,
             dependency.getAttributes(),
             projectDependency.getTargetConfiguration(),
             convertArtifacts(dependency.getArtifacts()),

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformDependencyMetadata.java
@@ -84,7 +84,7 @@ class LenientPlatformDependencyMetadata implements ModuleDependencyMetadata, For
             return new VariantSelectionResult(Collections.singletonList(variant), false);
         }
         // the target component exists, so we need to fallback to the traditional selection process
-        return new LocalComponentDependencyMetadata(componentId, cs, null, ImmutableAttributes.EMPTY, ImmutableAttributes.EMPTY, null, Collections.emptyList(), Collections.emptyList(), false, false, true, false, false, null).selectVariants(consumerAttributes, targetComponentState, consumerSchema, explicitRequestedCapabilities);
+        return new LocalComponentDependencyMetadata(cs, ImmutableAttributes.EMPTY, null, Collections.emptyList(), Collections.emptyList(), false, false, true, false, false, null).selectVariants(consumerAttributes, targetComponentState, consumerSchema, explicitRequestedCapabilities);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/IvyDependencyDescriptor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/IvyDependencyDescriptor.java
@@ -30,7 +30,7 @@ import org.gradle.internal.component.external.model.ExternalDependencyDescriptor
 import org.gradle.internal.component.model.ComponentGraphResolveState;
 import org.gradle.internal.component.model.ConfigurationGraphResolveState;
 import org.gradle.internal.component.model.ConfigurationMetadata;
-import org.gradle.internal.component.model.ConfigurationNotFoundException;
+import org.gradle.internal.component.model.ExternalConfigurationNotFoundException;
 import org.gradle.internal.component.model.Exclude;
 import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
@@ -204,7 +204,7 @@ public class IvyDependencyDescriptor extends ExternalDependencyDescriptor {
 
         ConfigurationGraphResolveState configuration = targetComponent.getConfiguration(targetPattern);
         if (configuration == null) {
-            throw new ConfigurationNotFoundException(fromComponent, fromConfiguration, targetPattern, targetComponent.getId());
+            throw new ExternalConfigurationNotFoundException(fromComponent, fromConfiguration, targetPattern, targetComponent.getId());
         }
         maybeAddConfiguration(targetConfigurations, configuration);
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/MavenDependencyDescriptor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/MavenDependencyDescriptor.java
@@ -25,7 +25,7 @@ import org.gradle.internal.component.external.model.ExternalDependencyDescriptor
 import org.gradle.internal.component.model.ComponentGraphResolveState;
 import org.gradle.internal.component.model.ConfigurationGraphResolveState;
 import org.gradle.internal.component.model.ConfigurationMetadata;
-import org.gradle.internal.component.model.ConfigurationNotFoundException;
+import org.gradle.internal.component.model.ExternalConfigurationNotFoundException;
 import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.component.model.VariantGraphResolveState;
@@ -110,7 +110,7 @@ public class MavenDependencyDescriptor extends ExternalDependencyDescriptor {
         if (configuration == null) {
             configuration = targetComponent.getConfiguration("default");
             if (configuration == null) {
-                throw new ConfigurationNotFoundException(fromComponentId, fromConfiguration.getName(), target, targetComponent.getId());
+                throw new ExternalConfigurationNotFoundException(fromComponentId, fromConfiguration.getName(), target, targetComponent.getId());
             }
         }
         return configuration;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DslOriginDependencyMetadataWrapper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DslOriginDependencyMetadataWrapper.java
@@ -54,11 +54,6 @@ public class DslOriginDependencyMetadataWrapper extends DelegatingDependencyMeta
     }
 
     @Override
-    public String getModuleConfiguration() {
-        return delegate.getModuleConfiguration();
-    }
-
-    @Override
     public String getDependencyConfiguration() {
         return delegate.getDependencyConfiguration();
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ExternalConfigurationNotFoundException.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ExternalConfigurationNotFoundException.java
@@ -16,10 +16,11 @@
 
 package org.gradle.internal.component.model;
 
+import org.apache.commons.lang.StringUtils;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 
-public class ConfigurationNotFoundException extends RuntimeException {
-    public ConfigurationNotFoundException(String toConfiguration, ComponentIdentifier toComponent) {
-        super(String.format("A dependency was declared on configuration '%s' which is not declared in the descriptor for %s.", toConfiguration, toComponent.getDisplayName()));
+public class ExternalConfigurationNotFoundException extends RuntimeException {
+    public ExternalConfigurationNotFoundException(ComponentIdentifier fromComponent, String fromConfiguration, String toConfiguration, ComponentIdentifier toComponent) {
+        super(String.format("%s declares a dependency from configuration '%s' to configuration '%s' which is not declared in the descriptor for %s.", StringUtils.capitalize(fromComponent.getDisplayName()), fromConfiguration, toConfiguration, toComponent.getDisplayName()));
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalOriginDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalOriginDependencyMetadata.java
@@ -18,7 +18,6 @@ package org.gradle.internal.component.model;
 
 import org.gradle.api.artifacts.component.ComponentSelector;
 
-import javax.annotation.Nullable;
 import java.util.List;
 
 /**
@@ -26,8 +25,6 @@ import java.util.List;
  * This has a simplified model of a dependency, that maps from a single module configuration to a single target configuration.
  */
 public interface LocalOriginDependencyMetadata extends ForcingDependencyMetadata {
-    @Nullable
-    String getModuleConfiguration();
 
     String getDependencyConfiguration();
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/AbstractDependencyDescriptorFactoryInternalSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/AbstractDependencyDescriptorFactoryInternalSpec.groovy
@@ -31,7 +31,6 @@ import org.gradle.util.internal.WrapUtil
 import spock.lang.Specification
 
 abstract class AbstractDependencyDescriptorFactoryInternalSpec extends Specification {
-    static final TEST_CONF = "conf"
     static final TEST_DEP_CONF = "depconf1"
 
     static final TEST_EXCLUDE_RULE = new org.gradle.api.internal.artifacts.DefaultExcludeRule("testOrg", null)
@@ -62,7 +61,6 @@ abstract class AbstractDependencyDescriptorFactoryInternalSpec extends Specifica
 
     protected static void assertDependencyDescriptorHasCommonFixtureValues(LocalOriginDependencyMetadata dependencyMetadata, boolean withArtifacts) {
         assert TEST_IVY_EXCLUDE_RULE == dependencyMetadata.getExcludes().get(0)
-        assert dependencyMetadata.getModuleConfiguration() == TEST_CONF
         if (!withArtifacts) {
             assert dependencyMetadata.getDependencyConfiguration() == TEST_DEP_CONF
         }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultDependencyMetadataFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultDependencyMetadataFactoryTest.groovy
@@ -17,21 +17,13 @@ package org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencie
 
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.artifacts.ProjectDependency
-import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.internal.artifacts.dependencies.DefaultDependencyConstraint
 import org.gradle.internal.component.model.LocalOriginDependencyMetadata
 import spock.lang.Specification
 
 class DefaultDependencyMetadataFactoryTest extends Specification {
-    def configurationName = "conf"
     def projectDependency = Stub(ProjectDependency)
-    def componentId = new ComponentIdentifier() {
-        @Override
-        String getDisplayName() {
-            return "example"
-        }
-    }
 
     def "delegates to internal factory"() {
         given:
@@ -41,7 +33,7 @@ class DefaultDependencyMetadataFactoryTest extends Specification {
 
         when:
         def dependencyDescriptorFactory = new DefaultDependencyMetadataFactory(converter1, converter2)
-        def created = dependencyDescriptorFactory.createDependencyMetadata(componentId, configurationName, null, projectDependency)
+        def created = dependencyDescriptorFactory.createDependencyMetadata(projectDependency)
 
         then:
         created == result
@@ -49,7 +41,7 @@ class DefaultDependencyMetadataFactoryTest extends Specification {
         and:
         1 * converter1.canConvert(projectDependency) >> false
         1 * converter2.canConvert(projectDependency) >> true
-        1 * converter2.createDependencyMetadata(componentId, configurationName, null, projectDependency) >> result
+        1 * converter2.createDependencyMetadata(projectDependency) >> result
     }
 
     def "fails where no internal factory can handle dependency type"() {
@@ -60,7 +52,7 @@ class DefaultDependencyMetadataFactoryTest extends Specification {
 
         and:
         def dependencyDescriptorFactory = new DefaultDependencyMetadataFactory(converter)
-        dependencyDescriptorFactory.createDependencyMetadata(componentId, configurationName, null, projectDependency)
+        dependencyDescriptorFactory.createDependencyMetadata(projectDependency)
 
         then:
         thrown InvalidUserDataException
@@ -72,7 +64,7 @@ class DefaultDependencyMetadataFactoryTest extends Specification {
 
         when:
         def dependencyDescriptorFactory = new DefaultDependencyMetadataFactory()
-        def created = dependencyDescriptorFactory.createDependencyConstraintMetadata(componentId, configurationName, null, dependencyConstraint)
+        def created = dependencyDescriptorFactory.createDependencyConstraintMetadata(dependencyConstraint)
         def selector = created.selector as ModuleComponentSelector
 
         then:
@@ -82,7 +74,6 @@ class DefaultDependencyMetadataFactoryTest extends Specification {
         selector.version == "1"
 
         and:
-        created.moduleConfiguration == configurationName
         created.artifacts.empty
         created.excludes.empty
         !created.force

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalConfigurationMetadataBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalConfigurationMetadataBuilderTest.groovy
@@ -102,8 +102,8 @@ class DefaultLocalConfigurationMetadataBuilderTest extends Specification {
 
         then:
         1 * dependencySet.iterator() >> [dependency1, dependency2].iterator()
-        1 * dependencyMetadataFactory.createDependencyMetadata(componentId, "config", _, dependency1) >> dependencyDescriptor1
-        1 * dependencyMetadataFactory.createDependencyMetadata(componentId, "config", _, dependency2) >> dependencyDescriptor2
+        1 * dependencyMetadataFactory.createDependencyMetadata(dependency1) >> dependencyDescriptor1
+        1 * dependencyMetadataFactory.createDependencyMetadata(dependency2) >> dependencyDescriptor2
         dependencies == [dependencyDescriptor1, dependencyDescriptor2]
     }
 
@@ -124,8 +124,8 @@ class DefaultLocalConfigurationMetadataBuilderTest extends Specification {
 
         then:
         1 * dependencyConstraintSet.iterator() >> [dependencyConstraint1, dependencyConstraint2].iterator()
-        1 * dependencyMetadataFactory.createDependencyConstraintMetadata(componentId, "config", _, dependencyConstraint1) >> dependencyDescriptor1
-        1 * dependencyMetadataFactory.createDependencyConstraintMetadata(componentId, "config", _, dependencyConstraint2) >> dependencyDescriptor2
+        1 * dependencyMetadataFactory.createDependencyConstraintMetadata(dependencyConstraint1) >> dependencyDescriptor1
+        1 * dependencyMetadataFactory.createDependencyConstraintMetadata(dependencyConstraint2) >> dependencyDescriptor2
         dependencies == [dependencyDescriptor1, dependencyDescriptor2]
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ExternalModuleDependencyMetadataConverterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ExternalModuleDependencyMetadataConverterTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencie
 import org.gradle.api.artifacts.ExternalModuleDependency
 import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.ProjectDependency
-import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.internal.artifacts.VersionConstraintInternal
 import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency
@@ -28,12 +27,6 @@ import org.gradle.internal.component.model.LocalOriginDependencyMetadata
 class ExternalModuleDependencyMetadataConverterTest extends AbstractDependencyDescriptorFactoryInternalSpec {
 
     ExternalModuleDependencyMetadataConverter converter = new ExternalModuleDependencyMetadataConverter(excludeRuleConverterStub)
-    private final ComponentIdentifier componentId = new ComponentIdentifier() {
-        @Override
-        String getDisplayName() {
-            return "example"
-        }
-    }
 
     def canConvert() {
         expect:
@@ -44,7 +37,7 @@ class ExternalModuleDependencyMetadataConverterTest extends AbstractDependencyDe
     def testAddWithNullGroupAndNullVersionShouldHaveEmptyStringModuleRevisionValues() {
         when:
         ModuleDependency dependency = new DefaultExternalModuleDependency(null, "gradle-core", null, TEST_DEP_CONF)
-        LocalOriginDependencyMetadata dependencyMetaData = converter.createDependencyMetadata(componentId, TEST_CONF, null, dependency)
+        LocalOriginDependencyMetadata dependencyMetaData = converter.createDependencyMetadata(dependency)
         ModuleComponentSelector selector = (ModuleComponentSelector) dependencyMetaData.getSelector()
 
         then:
@@ -60,7 +53,7 @@ class ExternalModuleDependencyMetadataConverterTest extends AbstractDependencyDe
         DefaultExternalModuleDependency moduleDependency = new DefaultExternalModuleDependency("org.gradle", "gradle-core", "1.0", configuration)
         setUpDependency(moduleDependency, withArtifacts)
 
-        LocalOriginDependencyMetadata dependencyMetaData = converter.createDependencyMetadata(componentId, TEST_CONF, null, moduleDependency)
+        LocalOriginDependencyMetadata dependencyMetaData = converter.createDependencyMetadata(moduleDependency)
 
         then:
         moduleDependency.changing == dependencyMetaData.changing

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectDependencyMetadataConverterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectDependencyMetadataConverterTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencie
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ExternalModuleDependency
 import org.gradle.api.artifacts.ProjectDependency
-import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultProjectDependency
 import org.gradle.api.internal.attributes.ImmutableAttributes
@@ -33,12 +32,6 @@ import org.junit.Rule
 class ProjectDependencyMetadataConverterTest extends AbstractDependencyDescriptorFactoryInternalSpec {
 
     private ProjectDependencyMetadataConverter converter = new ProjectDependencyMetadataConverter(excludeRuleConverterStub)
-    private final ComponentIdentifier componentId = new ComponentIdentifier() {
-        @Override
-        String getDisplayName() {
-            return "example"
-        }
-    }
 
     @Rule
     TestNameTestDirectoryProvider temporaryFolder = TestNameTestDirectoryProvider.newInstance(getClass())
@@ -54,7 +47,7 @@ class ProjectDependencyMetadataConverterTest extends AbstractDependencyDescripto
         def configuration = withArtifacts ? null : TEST_DEP_CONF
         ProjectDependency projectDependency = createProjectDependency(configuration)
         setUpDependency(projectDependency, withArtifacts)
-        LocalOriginDependencyMetadata dependencyMetaData = converter.createDependencyMetadata(componentId, TEST_CONF, null, projectDependency)
+        LocalOriginDependencyMetadata dependencyMetaData = converter.createDependencyMetadata(projectDependency)
 
         then:
         assertDependencyDescriptorHasCommonFixtureValues(dependencyMetaData, withArtifacts)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -1125,9 +1125,9 @@ class DependencyGraphBuilderTest extends Specification {
             ComponentResolveMetadata excluded = args.exclude
             excludeRules << new DefaultExclude(moduleIdentifierFactory.module(excluded.moduleVersionId.group, excluded.moduleVersionId.name))
         }
-        def dependencyMetaData = new LocalComponentDependencyMetadata(from.id, componentSelector,
-                "default", null, ImmutableAttributes.EMPTY, "default", [] as List<IvyArtifactName>,
-                excludeRules, force, false, transitive, false, false, null)
+        def dependencyMetaData = new LocalComponentDependencyMetadata(componentSelector,
+            ImmutableAttributes.EMPTY, "default", [] as List<IvyArtifactName>,
+            excludeRules, force, false, transitive, false, false, null)
         dependencyMetaData = new DslOriginDependencyMetadataWrapper(dependencyMetaData, Stub(ModuleDependency) {
             getAttributes() >> ImmutableAttributes.EMPTY
         })

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
@@ -155,7 +155,7 @@ class ComponentMetadataDetailsAdapterTest extends Specification {
         def componentIdentifier = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.test", "consumer"), "1.0")
         def consumerIdentifier = DefaultModuleVersionIdentifier.newId(componentIdentifier)
         def componentSelector = newSelector(DefaultModuleIdentifier.newId(consumerIdentifier.group, consumerIdentifier.name), new DefaultMutableVersionConstraint(consumerIdentifier.version))
-        def consumer = new LocalComponentDependencyMetadata(componentIdentifier, componentSelector, "default", attributes, ImmutableAttributes.EMPTY, null, [] as List, [], false, false, true, false, false, null)
+        def consumer = new LocalComponentDependencyMetadata(componentSelector, ImmutableAttributes.EMPTY, null, [] as List, [], false, false, true, false, false, null)
         def state = DependencyManagementTestUtil.modelGraphResolveFactory().stateFor(immutable)
 
         def variant = consumer.selectVariants(attributes, state, schema, [] as Set).variants[0]

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
@@ -279,7 +279,7 @@ abstract class AbstractDependencyMetadataRulesTest extends Specification {
         def componentIdentifier = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.test", "consumer"), "1.0")
         def consumerIdentifier = DefaultModuleVersionIdentifier.newId(componentIdentifier)
         def componentSelector = newSelector(consumerIdentifier.module, new DefaultMutableVersionConstraint(consumerIdentifier.version))
-        def consumer = new LocalComponentDependencyMetadata(componentIdentifier, componentSelector, "default", attributes, ImmutableAttributes.EMPTY, null, [] as List, [], false, false, true, false, false, null)
+        def consumer = new LocalComponentDependencyMetadata(componentSelector, ImmutableAttributes.EMPTY, null, [] as List, [], false, false, true, false, false, null)
         def state = DependencyManagementTestUtil.modelGraphResolveFactory().stateFor(immutable)
 
         return consumer.selectVariants(attributes, state, schema, [] as Set).variants[0].metadata

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/IvyDependencyDescriptorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/IvyDependencyDescriptorTest.groovy
@@ -34,7 +34,7 @@ import org.gradle.internal.component.model.ComponentGraphResolveState
 import org.gradle.internal.component.model.ConfigurationGraphResolveMetadata
 import org.gradle.internal.component.model.ConfigurationGraphResolveState
 import org.gradle.internal.component.model.ConfigurationMetadata
-import org.gradle.internal.component.model.ConfigurationNotFoundException
+import org.gradle.internal.component.model.ExternalConfigurationNotFoundException
 import org.gradle.internal.component.model.DefaultIvyArtifactName
 import org.gradle.internal.component.model.Exclude
 import org.gradle.internal.component.model.ModuleConfigurationMetadata
@@ -429,7 +429,7 @@ class IvyDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
         metadata.selectLegacyConfigurations(fromComponent, fromConfig, toComponent)
 
         then:
-        ConfigurationNotFoundException e = thrown()
+        ExternalConfigurationNotFoundException e = thrown()
         e.message == "Thing a declares a dependency from configuration 'from' to configuration 'to' which is not declared in the descriptor for thing b."
 
         where:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/MavenDependencyDescriptorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/MavenDependencyDescriptorTest.groovy
@@ -45,9 +45,9 @@ import org.gradle.internal.component.external.model.maven.MavenDependencyDescrip
 import org.gradle.internal.component.external.model.maven.MavenDependencyType
 import org.gradle.internal.component.model.ComponentGraphResolveState
 import org.gradle.internal.component.model.ConfigurationMetadata
-import org.gradle.internal.component.model.ConfigurationNotFoundException
 import org.gradle.internal.component.model.Exclude
 import org.gradle.internal.component.model.ExcludeMetadata
+import org.gradle.internal.component.model.ExternalConfigurationNotFoundException
 import org.gradle.internal.component.model.ModuleConfigurationMetadata
 
 class MavenDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
@@ -202,7 +202,7 @@ class MavenDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
         dep.selectLegacyConfigurations(fromComponent, fromCompile, toComponent)
 
         then:
-        thrown(ConfigurationNotFoundException)
+        thrown(ExternalConfigurationNotFoundException)
     }
 
     def "fails when runtime configuration is not defined in target component"() {
@@ -218,7 +218,7 @@ class MavenDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
         dep.selectLegacyConfigurations(fromComponent, fromRuntime, toComponent)
 
         then:
-        thrown(ConfigurationNotFoundException)
+        thrown(ExternalConfigurationNotFoundException)
     }
 
     private static MavenDependencyDescriptor mavenDependencyMetadata(MavenScope scope, ModuleComponentSelector selector, List<ExcludeMetadata> excludes) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultLocalComponentMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultLocalComponentMetadataTest.groovy
@@ -29,8 +29,6 @@ import org.gradle.api.artifacts.FileCollectionDependency
 import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.PublishArtifact
 import org.gradle.api.artifacts.PublishArtifactSet
-import org.gradle.api.artifacts.component.ComponentIdentifier
-import org.gradle.api.attributes.AttributeContainer
 import org.gradle.api.internal.artifacts.DefaultDependencySet
 import org.gradle.api.internal.artifacts.DefaultExcludeRule
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
@@ -444,12 +442,12 @@ class DefaultLocalComponentMetadataTest extends Specification {
 
     class TestDependencyMetadataFactory implements DependencyMetadataFactory {
         @Override
-        LocalOriginDependencyMetadata createDependencyMetadata(ComponentIdentifier componentId, String clientConfiguration, AttributeContainer attributes, ModuleDependency dependency) {
+        LocalOriginDependencyMetadata createDependencyMetadata(ModuleDependency dependency) {
             return dependencyMetadata(dependency)
         }
 
         @Override
-        LocalOriginDependencyMetadata createDependencyConstraintMetadata(ComponentIdentifier componentId, String clientConfiguration, AttributeContainer attributes, DependencyConstraint dependencyConstraint) {
+        LocalOriginDependencyMetadata createDependencyConstraintMetadata(DependencyConstraint dependencyConstraint) {
             throw new UnsupportedOperationException()
         }
     }

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -1534,7 +1534,7 @@ org:leaf:[1.5,2.0] FAILED
 project :A FAILED
    Failures:
       - Could not resolve project :A.
-          - Project : declares a dependency from configuration 'conf' to configuration 'default' which is not declared in the descriptor for project :A.
+          - A dependency was declared on configuration 'default' which is not declared in the descriptor for project :A.
 
 project :A FAILED
 \\--- conf
@@ -1548,7 +1548,7 @@ project :A FAILED
 project :C FAILED
    Failures:
       - Could not resolve project :C.
-          - Project :B declares a dependency from configuration 'default' to configuration 'default' which is not declared in the descriptor for project :C.
+          - A dependency was declared on configuration 'default' which is not declared in the descriptor for project :C.
 
 project :C FAILED
 \\--- project :B

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/dependencies/JavaConfigurationSetupIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/dependencies/JavaConfigurationSetupIntegrationTest.groovy
@@ -119,7 +119,7 @@ class JavaConfigurationSetupIntegrationTest extends AbstractIntegrationSpec {
         !deprecated(alternatives)   || output.contains("The $configuration configuration has been deprecated for consumption. This will fail with an error in Gradle 8.0. Please use attributes to consume the ${alternatives} configuration instead.")
         !valid(alternatives)        || output.contains("> Task :resolve\n\n")
         !forbidden(alternatives)    || errorOutput.contains("Selected configuration '$configuration' on 'project :sub' but it can't be used as a project dependency because it isn't intended for consumption by other components.")
-        !doesNotExist(alternatives) || errorOutput.contains("Project : declares a dependency from configuration 'root' to configuration '$configuration' which is not declared in the descriptor for project :sub.")
+        !doesNotExist(alternatives) || errorOutput.contains("A dependency was declared on configuration '$configuration' which is not declared in the descriptor for project :sub.")
 
         where:
         plugin         | configuration                  | alternatives


### PR DESCRIPTION
These three fields were virtually unused. The attributes were unused, and the componentId and client configuration was only used for the rare error message where the dependency declared a target configuration AND that target configuration was not found in the target component. This case is rare, since it only occurs when variant-aware dependency resolution is disabled. And, in no other places do we print the declared configuration. Furthermore, the componentId is already printed in error messages where it was printed via the now-removed message, so no loss of information is apparent for the user.
