### PR TITLE
docs: View and Debug Dependencies: add a note about `buildEnvironment`

### DIFF
--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/viewing_debugging_dependencies.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/viewing_debugging_dependencies.adoc
@@ -22,6 +22,12 @@ It also displays information about dependency conflict resolution.
 The `dependencies` task can be especially helpful for issues related to transitive dependencies.
 Your build file lists direct dependencies, but the `dependencies` task can help you understand which transitive dependencies resolve during your build.
 
+[NOTE]
+====
+Graph of dependencies <<tutorial_using_tasks.adoc#sec:build_script_external_dependencies, declared in the `buildscript` `classpath` configuration>>
+can be rendered using <<command_line_interface.adoc#sec:listing_project_dependencies, task `buildEnvironment`>>.
+====
+
 === Output Annotations
 
 The `dependencies` task marks dependency trees with the following annotations:

--- a/subprojects/docs/src/docs/userguide/reference/command_line_interface.adoc
+++ b/subprojects/docs/src/docs/userguide/reference/command_line_interface.adoc
@@ -330,6 +330,7 @@ image::gradle-core-test-build-scan-dependencies.png[Build Scan dependencies repo
 
 Learn more in <<viewing_debugging_dependencies.adoc#sec:debugging-build-scans,Viewing and debugging dependencies>>.
 
+[[sec:listing_project_dependencies]]
 === Listing project dependencies
 
 Running `gradle dependencies` gives you a list of the dependencies of the selected project, broken down by configuration. For each configuration, the direct and transitive dependencies of that configuration are shown in a tree. Below is an example of this report:


### PR DESCRIPTION
Small addition to section "List Project Dependencies" of page "View and Debug Dependencies".