### PR TITLE
Change flaky deprecation warnings to "maybe"

### DIFF
--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
@@ -131,13 +131,12 @@ class AndroidPluginsSmokeTest extends AbstractPluginValidatingSmokeTest implemen
         when: 'up-to-date build'
         SantaTrackerConfigurationCacheWorkaround.beforeBuild(runner.projectDir, IntegrationTestBuildContext.INSTANCE.gradleUserHomeDir)
         result = runner.deprecations(AndroidDeprecations) {
-            if (!GradleContextualExecuter.isConfigCache()) {
-                expectReportDestinationPropertyDeprecation(agpVersion)
-                expectProjectConventionDeprecationWarning(agpVersion)
-                expectAndroidConventionTypeDeprecationWarning(agpVersion)
-                expectBasePluginConventionDeprecation(agpVersion)
-                expectBuildIdentifierIsCurrentBuildDeprecation(agpVersion)
-            }
+            maybeExpectGUtilDeprecation()
+            maybeExpectProjectConventionDeprecationWarning(agpVersion)
+            maybeExpectReportDestinationPropertyDeprecation(agpVersion)
+            maybeExpectAndroidConventionTypeDeprecationWarning(agpVersion)
+            maybeExpectBasePluginConventionDeprecation(agpVersion)
+            maybeExpectBuildIdentifierIsCurrentBuildDeprecation(agpVersion)
         }.build()
 
         then:

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BaseDeprecations.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BaseDeprecations.groovy
@@ -52,6 +52,11 @@ class BaseDeprecations {
         "Consult the upgrading guide for further information: " +
         DOCUMENTATION_REGISTRY.getDocumentationFor("upgrading_version_8","base_convention_deprecation")
 
+    public static final String GUTIL_DEPRECATION = "The org.gradle.util.GUtil type has been deprecated. " +
+        "This is scheduled to be removed in Gradle 9.0. " +
+        "Consult the upgrading guide for further information: " +
+        DOCUMENTATION_REGISTRY.getDocumentationFor("upgrading_version_8","base_convention_deprecation")
+
     public static final String JAVA_PLUGIN_CONVENTION_DEPRECATION = "The org.gradle.api.plugins.JavaPluginConvention type has been deprecated. " +
         "This is scheduled to be removed in Gradle 9.0. " +
         "Consult the upgrading guide for further information: " +

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithAndroidDeprecations.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithAndroidDeprecations.groovy
@@ -48,12 +48,28 @@ trait WithAndroidDeprecations implements WithReportDeprecations {
         runner.expectLegacyDeprecationWarningIf(androidPluginUsesConventions(agpVersion), PROJECT_CONVENTION_DEPRECATION)
     }
 
+    void maybeExpectProjectConventionDeprecationWarning(String agpVersion) {
+        runner.maybeExpectLegacyDeprecationWarningIf(androidPluginUsesConventions(agpVersion), PROJECT_CONVENTION_DEPRECATION)
+    }
+
     void expectAndroidConventionTypeDeprecationWarning(String agpVersion) {
         runner.expectLegacyDeprecationWarningIf(androidPluginUsesConventions(agpVersion), CONVENTION_TYPE_DEPRECATION)
     }
 
+    void maybeExpectAndroidConventionTypeDeprecationWarning(String agpVersion) {
+        runner.maybeExpectLegacyDeprecationWarningIf(androidPluginUsesConventions(agpVersion), CONVENTION_TYPE_DEPRECATION)
+    }
+
+    void maybeExpectBasePluginConventionDeprecation(String agpVersion) {
+        runner.maybeExpectLegacyDeprecationWarningIf(androidPluginUsesConventions(agpVersion), BASE_PLUGIN_CONVENTION_DEPRECATION)
+    }
+
     void expectBasePluginConventionDeprecation(String agpVersion) {
         runner.expectLegacyDeprecationWarningIf(androidPluginUsesConventions(agpVersion), BASE_PLUGIN_CONVENTION_DEPRECATION)
+    }
+
+    void maybeExpectGUtilDeprecation() {
+        runner.maybeExpectLegacyDeprecationWarning(GUTIL_DEPRECATION)
     }
 
     void expectConfigUtilDeprecationWarning(String agpVersion) {
@@ -66,23 +82,32 @@ trait WithAndroidDeprecations implements WithReportDeprecations {
         )
     }
 
+    private static getBuildIdentifierIsCurrentBuildDeprecationMessage() {
+        return "The BuildIdentifier.isCurrentBuild() method has been deprecated. " +
+            "This is scheduled to be removed in Gradle 9.0. " +
+            "Use getBuildPath() to get a unique identifier for the build. " +
+            "Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation"
+    }
+
+    void maybeExpectBuildIdentifierIsCurrentBuildDeprecation(String agpVersion) {
+        VersionNumber agpVersionNumber = VersionNumber.parse(agpVersion)
+        runner.maybeExpectLegacyDeprecationWarningIf(
+            agpVersionNumber < VersionNumber.parse("8.0.0-rc01"),
+            getBuildIdentifierIsCurrentBuildDeprecationMessage()
+        )
+    }
+
     void expectBuildIdentifierIsCurrentBuildDeprecation(String agpVersion) {
         VersionNumber agpVersionNumber = VersionNumber.parse(agpVersion)
         runner.expectLegacyDeprecationWarningIf(
             agpVersionNumber < VersionNumber.parse("8.0.0-rc01"),
-            "The BuildIdentifier.isCurrentBuild() method has been deprecated. " +
-                "This is scheduled to be removed in Gradle 9.0. " +
-                "Use getBuildPath() to get a unique identifier for the build. " +
-                "Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation"
+            getBuildIdentifierIsCurrentBuildDeprecationMessage()
         )
     }
 
     void expectBuildIdentifierIsCurrentBuildDeprecation() {
         runner.expectDeprecationWarning(
-            "The BuildIdentifier.isCurrentBuild() method has been deprecated. " +
-                "This is scheduled to be removed in Gradle 9.0. " +
-                "Use getBuildPath() to get a unique identifier for the build. " +
-                "Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation",
+            getBuildIdentifierIsCurrentBuildDeprecationMessage(),
             "https://issuetracker.google.com/issues/279306626"
         )
     }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithReportDeprecations.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithReportDeprecations.groovy
@@ -25,15 +25,22 @@ import static org.gradle.api.internal.DocumentationRegistry.RECOMMENDATION
 @SelfType(BaseDeprecations)
 trait WithReportDeprecations {
     private static final String REPORT_DESTINATION_DEPRECATION = "The Report.destination property has been deprecated. " +
-            "This is scheduled to be removed in Gradle 9.0. " +
-            "Please use the outputLocation property instead. " +
-        String.format(RECOMMENDATION,"information",  new DocumentationRegistry().getDslRefForProperty("org.gradle.api.reporting.Report", "destination"))
+        "This is scheduled to be removed in Gradle 9.0. " +
+        "Please use the outputLocation property instead. " +
+        String.format(RECOMMENDATION, "information", new DocumentationRegistry().getDslRefForProperty("org.gradle.api.reporting.Report", "destination"))
 
     void expectReportDestinationPropertyDeprecation(String agpVersion) {
         runner.expectDeprecationWarningIf(
             VersionNumber.parse(agpVersion).baseVersion < VersionNumber.parse("7.4.1"),
             REPORT_DESTINATION_DEPRECATION,
             "https://github.com/gradle/gradle/issues/21533"
+        )
+    }
+
+    void maybeExpectReportDestinationPropertyDeprecation(String agpVersion) {
+        runner.maybeExpectLegacyDeprecationWarningIf(
+            VersionNumber.parse(agpVersion).baseVersion < VersionNumber.parse("7.4.1"),
+            REPORT_DESTINATION_DEPRECATION
         )
     }
 }


### PR DESCRIPTION
We've observed a lot of flakiness caused by deprecation messages in the test case. Now let's change them to "maybe".
