### PR TITLE
Do not require Project instance to configure Project

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/configuration/DefaultProjectsPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/DefaultProjectsPreparer.java
@@ -39,7 +39,7 @@ public class DefaultProjectsPreparer implements ProjectsPreparer {
     @Override
     public void prepareProjects(GradleInternal gradle) {
         if (!buildModelParameters.isConfigureOnDemand() || !gradle.isRootBuild()) {
-            projectConfigurer.configureHierarchy(gradle.getRootProject());
+            projectConfigurer.configureHierarchy(gradle.getRootProject().getOwner());
             new ProjectsEvaluatedNotifier(buildOperationExecutor).notify(gradle);
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/execution/DefaultTaskSelector.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/DefaultTaskSelector.java
@@ -42,7 +42,7 @@ public class DefaultTaskSelector implements TaskSelector {
     public Spec<Task> getFilter(SelectionContext context, ProjectState project, String taskName, boolean includeSubprojects) {
         if (includeSubprojects) {
             // Try to delay configuring all the subprojects
-            configurer.configure(project.getMutableModel());
+            project.ensureConfigured();
             if (taskNameResolver.tryFindUnqualifiedTaskCheaply(taskName, project.getMutableModel())) {
                 // An exact match in the target project - can just filter tasks by path to avoid configuring subprojects at this point
                 return new TaskPathSpec(project.getMutableModel(), taskName);
@@ -56,9 +56,9 @@ public class DefaultTaskSelector implements TaskSelector {
     @Override
     public TaskSelection getSelection(SelectionContext context, ProjectState targetProject, String taskName, boolean includeSubprojects) {
         if (!includeSubprojects) {
-            configurer.configure(targetProject.getMutableModel());
+            targetProject.ensureConfigured();
         } else {
-            configurer.configureHierarchy(targetProject.getMutableModel());
+            configurer.configureHierarchy(targetProject);
         }
 
         TaskSelectionResult tasks = taskNameResolver.selectWithName(taskName, targetProject.getMutableModel(), includeSubprojects);

--- a/subprojects/core/src/main/java/org/gradle/execution/DefaultTasksBuildTaskScheduler.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/DefaultTasksBuildTaskScheduler.java
@@ -34,12 +34,10 @@ import java.util.List;
  */
 public class DefaultTasksBuildTaskScheduler implements BuildTaskScheduler {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultTasksBuildTaskScheduler.class);
-    private final ProjectConfigurer projectConfigurer;
     private final List<BuiltInCommand> builtInCommands;
     private final BuildTaskScheduler delegate;
 
-    public DefaultTasksBuildTaskScheduler(ProjectConfigurer projectConfigurer, List<BuiltInCommand> builtInCommands, BuildTaskScheduler delegate) {
-        this.projectConfigurer = projectConfigurer;
+    public DefaultTasksBuildTaskScheduler(List<BuiltInCommand> builtInCommands, BuildTaskScheduler delegate) {
         this.builtInCommands = builtInCommands;
         this.delegate = delegate;
     }
@@ -53,7 +51,7 @@ public class DefaultTasksBuildTaskScheduler implements BuildTaskScheduler {
             ProjectInternal project = gradle.getDefaultProject();
 
             //so that we don't miss out default tasks
-            projectConfigurer.configure(project);
+            project.getOwner().ensureConfigured();
 
             List<String> defaultTasks = project.getDefaultTasks();
             if (defaultTasks.size() == 0) {

--- a/subprojects/core/src/main/java/org/gradle/execution/ProjectConfigurer.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/ProjectConfigurer.java
@@ -16,26 +16,21 @@
 
 package org.gradle.execution;
 
-import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectState;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
 @ServiceScope(Scopes.BuildTree.class)
 public interface ProjectConfigurer {
-    /**
-     * Configures the given project.
-     */
-    void configure(ProjectInternal project);
 
     /**
-     * Configures the owned project, discovers tasks and binds model rules.
+     * Configures the project, discovers tasks and binds model rules.
      */
     void configureFully(ProjectState projectState);
 
     /**
      * Configures the given project and all its sub-projects.
      */
-    void configureHierarchy(ProjectInternal project);
+    void configureHierarchy(ProjectState projectState);
 
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
@@ -42,7 +42,6 @@ import org.gradle.execution.BuildTaskScheduler;
 import org.gradle.execution.BuildWorkExecutor;
 import org.gradle.execution.DefaultTasksBuildTaskScheduler;
 import org.gradle.execution.DryRunBuildExecutionAction;
-import org.gradle.execution.ProjectConfigurer;
 import org.gradle.execution.SelectedTaskExecutionAction;
 import org.gradle.execution.TaskNameResolvingBuildTaskScheduler;
 import org.gradle.execution.commandline.CommandLineTaskConfigurer;
@@ -104,8 +103,8 @@ public class GradleScopeServices extends DefaultServiceRegistry {
             buildOperationExecutor);
     }
 
-    BuildTaskScheduler createBuildTaskScheduler(CommandLineTaskParser commandLineTaskParser, ProjectConfigurer projectConfigurer, BuildTaskSelector.BuildSpecificSelector selector, List<BuiltInCommand> builtInCommands) {
-        return new DefaultTasksBuildTaskScheduler(projectConfigurer, builtInCommands, new TaskNameResolvingBuildTaskScheduler(commandLineTaskParser, selector));
+    BuildTaskScheduler createBuildTaskScheduler(CommandLineTaskParser commandLineTaskParser, BuildTaskSelector.BuildSpecificSelector selector, List<BuiltInCommand> builtInCommands) {
+        return new DefaultTasksBuildTaskScheduler(builtInCommands, new TaskNameResolvingBuildTaskScheduler(commandLineTaskParser, selector));
     }
 
     TaskExecutionPreparer createTaskExecutionPreparer(BuildTaskScheduler buildTaskScheduler, BuildOperationExecutor buildOperationExecutor, BuildModelParameters buildModelParameters) {

--- a/subprojects/core/src/test/groovy/org/gradle/configuration/DefaultProjectsPreparerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/configuration/DefaultProjectsPreparerTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.configuration
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.StartParameterInternal
 import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.api.internal.project.ProjectState
 import org.gradle.execution.ProjectConfigurer
 import org.gradle.internal.buildtree.BuildModelParameters
 import org.gradle.internal.operations.BuildOperationExecutor
@@ -26,7 +27,9 @@ import spock.lang.Specification
 class DefaultProjectsPreparerTest extends Specification {
     def startParameter = Mock(StartParameterInternal)
     def gradle = Mock(GradleInternal)
-    def rootProject = Mock(ProjectInternal)
+    def rootProject = Mock(ProjectInternal) {
+        getOwner() >> Stub(ProjectState)
+    }
     def projectConfigurer = Mock(ProjectConfigurer)
     def modelParameters = Mock(BuildModelParameters)
     def buildOperationExecutor = Mock(BuildOperationExecutor)
@@ -42,7 +45,7 @@ class DefaultProjectsPreparerTest extends Specification {
         configurer.prepareProjects(gradle)
 
         then:
-        1 * projectConfigurer.configureHierarchy(rootProject)
+        1 * projectConfigurer.configureHierarchy(rootProject.owner)
     }
 
     def "configures root build for on demand mode"() {
@@ -61,6 +64,6 @@ class DefaultProjectsPreparerTest extends Specification {
         then:
         gradle.rootBuild >> false
         modelParameters.configureOnDemand >> true
-        1 * projectConfigurer.configureHierarchy(rootProject)
+        1 * projectConfigurer.configureHierarchy(rootProject.owner)
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/execution/DefaultTasksBuildTaskSchedulerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/DefaultTasksBuildTaskSchedulerTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.execution
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.StartParameterInternal
 import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.api.internal.project.ProjectState
 import org.gradle.configuration.project.BuiltInCommand
 import org.gradle.execution.plan.ExecutionPlan
 import org.gradle.internal.DefaultTaskExecutionRequest
@@ -26,12 +27,13 @@ import org.gradle.internal.RunDefaultTasksExecutionRequest
 import spock.lang.Specification
 
 class DefaultTasksBuildTaskSchedulerTest extends Specification {
-    final projectConfigurer = Mock(ProjectConfigurer)
     final buildInCommand = Mock(BuiltInCommand)
     final delegate = Mock(BuildTaskScheduler)
-    final action = new DefaultTasksBuildTaskScheduler(projectConfigurer, [buildInCommand], delegate)
+    final action = new DefaultTasksBuildTaskScheduler([buildInCommand], delegate)
     final startParameter = Mock(StartParameterInternal)
-    final defaultProject = Mock(ProjectInternal)
+    final defaultProject = Mock(ProjectInternal) {
+        getOwner() >> Stub(ProjectState)
+    }
     final gradle = Mock(GradleInternal)
     final selector = Mock(EntryTaskSelector)
     final plan = Mock(ExecutionPlan)


### PR DESCRIPTION
The ProjectConfigurer interface requires entire Project instances, however the implementation only requires the projects owner ProjectState instances. We update the interface to remove this restriction and update any usages to only pass in the ProjectState.
