### PR TITLE
Fix regression in copy spec fileMode/dirMode mutation

### DIFF
--- a/subprojects/architecture-test/src/changes/archunit_store/internal-api-symmetrical-accessors-nullability.txt
+++ b/subprojects/architecture-test/src/changes/archunit_store/internal-api-symmetrical-accessors-nullability.txt
@@ -5,8 +5,6 @@ Accessors for org.gradle.api.internal.file.copy.DefaultCopySpec.dirMode don't us
 Accessors for org.gradle.api.internal.file.copy.DefaultCopySpec.fileMode don't use symmetrical @Nullable
 Accessors for org.gradle.api.internal.file.copy.DelegatingCopySpecInternal.dirMode don't use symmetrical @Nullable
 Accessors for org.gradle.api.internal.file.copy.DelegatingCopySpecInternal.fileMode don't use symmetrical @Nullable
-Accessors for org.gradle.api.internal.file.copy.SingleParentCopySpec.dirMode don't use symmetrical @Nullable
-Accessors for org.gradle.api.internal.file.copy.SingleParentCopySpec.fileMode don't use symmetrical @Nullable
 Accessors for org.gradle.api.internal.tasks.DefaultSourceSetOutput.resourcesDir don't use symmetrical @Nullable
 Accessors for org.gradle.api.internal.tasks.TaskStateInternal.outcome don't use symmetrical @Nullable
 Accessors for org.gradle.execution.plan.Node.executionFailure don't use symmetrical @Nullable

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyTaskChildSpecIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyTaskChildSpecIntegrationTest.groovy
@@ -44,4 +44,32 @@ class CopyTaskChildSpecIntegrationTest extends AbstractIntegrationSpec implement
         then:
         failure.assertHasCause("You cannot add child specs at execution time. Consider configuring this task during configuration time or using a separate task to do the configuration.")
     }
+
+    def "can query file and dir mode if set in the parent"() {
+        given:
+        file("root/root-file.txt") << 'root'
+        buildScript("""
+
+            def baseSpec = copySpec {
+                from("root") {
+                    println(fileMode)
+                    dirMode = 0755
+                    println(dirMode)
+                    dirMode = 0755
+                }
+            }
+
+            tasks.register("copy", Copy) {
+                println(fileMode)
+                dirMode = 0755
+                println(dirMode)
+                dirMode = 0755
+                into("build-output")
+                with baseSpec
+            }
+        """)
+
+        expect:
+        succeeds "copy"
+    }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyTaskChildSpecIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyTaskChildSpecIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.tasks
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
+import spock.lang.Issue
 
 class CopyTaskChildSpecIntegrationTest extends AbstractIntegrationSpec implements DirectoryBuildCacheFixture {
 
@@ -45,6 +46,7 @@ class CopyTaskChildSpecIntegrationTest extends AbstractIntegrationSpec implement
         failure.assertHasCause("You cannot add child specs at execution time. Consider configuring this task during configuration time or using a separate task to do the configuration.")
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/25924")
     def "can query file and dir mode if set in the parent"() {
         given:
         file("root/root-file.txt") << 'root'

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/CopySpecResolver.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/CopySpecResolver.java
@@ -17,6 +17,7 @@ package org.gradle.api.internal.file.copy;
 
 
 import org.gradle.api.Action;
+import org.gradle.api.file.ConfigurableFilePermissions;
 import org.gradle.api.file.DuplicatesStrategy;
 import org.gradle.api.file.FileCopyDetails;
 import org.gradle.api.file.FileTree;
@@ -37,7 +38,9 @@ public interface CopySpecResolver {
     Integer getFileMode();
     @Nullable
     Integer getDirMode();
+    Provider<ConfigurableFilePermissions> getFilePermissions();
     Provider<FilePermissions> getImmutableFilePermissions();
+    Provider<ConfigurableFilePermissions> getDirPermissions();
     Provider<FilePermissions> getImmutableDirPermissions();
     boolean getIncludeEmptyDirs();
     String getFilteringCharset();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/DefaultCopySpec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/DefaultCopySpec.java
@@ -467,12 +467,17 @@ public class DefaultCopySpec implements CopySpecInternal {
 
     @Override
     public Integer getDirMode() {
-        return buildRootResolver().getDirMode();
+        return getMode(buildRootResolver().getDirPermissions());
     }
 
     @Override
     public Integer getFileMode() {
-        return buildRootResolver().getFileMode();
+        return getMode(buildRootResolver().getFilePermissions());
+    }
+
+    @Nullable
+    private Integer getMode(Provider<ConfigurableFilePermissions> permissions) {
+        return permissions.map(FilePermissions::toUnixNumeric).getOrNull();
     }
 
     @Override
@@ -773,8 +778,18 @@ public class DefaultCopySpec implements CopySpecInternal {
         }
 
         @Override
+        public Provider<ConfigurableFilePermissions> getFilePermissions() {
+            return filePermissions;
+        }
+
+        @Override
         public Provider<FilePermissions> getImmutableFilePermissions() {
             return getPermissions(filePermissions, CopySpecResolver::getImmutableFilePermissions);
+        }
+
+        @Override
+        public Provider<ConfigurableFilePermissions> getDirPermissions() {
+            return dirPermissions;
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/SingleParentCopySpec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/SingleParentCopySpec.java
@@ -32,6 +32,8 @@ public class SingleParentCopySpec extends DefaultCopySpec {
         super(fileCollectionFactory, objectFactory, instantiator, patternSetFactory);
         this.parentResolver = parentResolver;
         this.objectFactory = objectFactory;
+        getFilePermissions().convention(parentResolver.getFilePermissions());
+        getDirPermissions().convention(parentResolver.getDirPermissions());
     }
 
     @Override
@@ -61,16 +63,6 @@ public class SingleParentCopySpec extends DefaultCopySpec {
     @Override
     public DuplicatesStrategy getDuplicatesStrategy() {
         return buildResolverRelativeToParent(parentResolver).getDuplicatesStrategy();
-    }
-
-    @Override
-    public Integer getDirMode() {
-        return buildResolverRelativeToParent(parentResolver).getDirMode();
-    }
-
-    @Override
-    public Integer getFileMode() {
-        return buildResolverRelativeToParent(parentResolver).getFileMode();
     }
 
     @Override


### PR DESCRIPTION
that were wrongly made throw if read before because the underlying property is finalized

* Fix for https://github.com/gradle/gradle/issues/25924

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
