### PR TITLE
Ignore test when using config cache

### DIFF
--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParallelBuildOperationsIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParallelBuildOperationsIntegrationTest.groovy
@@ -20,8 +20,9 @@ import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
-import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.IntegTestPreconditions
 import org.gradle.workers.fixtures.WorkerExecutorFixture
 import org.junit.Rule
 import spock.lang.IgnoreIf
@@ -103,7 +104,12 @@ class WorkerExecutorParallelBuildOperationsIntegrationTest extends AbstractWorke
         assert endTime(":workTask").isBefore(endTime(":slowTask"))
     }
 
-    @Flaky(because = "https://github.com/gradle/gradle-private/issues/3911")
+    @Requires(
+        value = IntegTestPreconditions.NotConfigCached,
+        reason = """Assumptions about project locking do not hold.
+With CC enabled, the project is immutable so tasks run in parallel.
+This means workTask and slowTask would be expected to run concurrently in this case."""
+    )
     def "worker-based task with further actions does not complete when work items finish (while another task is executing in parallel)"() {
         when:
         buildFile << """


### PR DESCRIPTION
This test explicitly checks that intra-project task parallelism is constrained again after a task finishes waiting on work items in between task actions.  With config cache, project mutability is not a concern and therefore intra-project task parallelism is allowed, so this test is not meaningful when config cache is enabled.
