### PR TITLE
Make TestNG filtering compatible with CC

### DIFF
--- a/subprojects/testing-jvm/build.gradle.kts
+++ b/subprojects/testing-jvm/build.gradle.kts
@@ -11,6 +11,7 @@ dependency for any projects working directly with Test tasks.
 """
 
 dependencies {
+    implementation(project(":functional"))
     implementation(project(":base-services"))
     implementation(project(":messaging"))
     implementation(project(":logging"))

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/AbstractTestNGFilteringIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/AbstractTestNGFilteringIntegrationTest.groovy
@@ -18,7 +18,6 @@
 package org.gradle.testing.testng
 
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.testing.AbstractTestFilteringIntegrationTest
 import spock.lang.Issue
 
@@ -66,7 +65,6 @@ abstract class AbstractTestNGFilteringIntegrationTest extends AbstractTestFilter
     }
 
     @Issue("GRADLE-3112")
-    @ToBeFixedForConfigurationCache(because = "No tests found for given includes: [*AwesomeSuite*](--tests filter)")
     def "suites can be filtered from the command-line"() {
         given:
         theUsualFiles()
@@ -85,7 +83,6 @@ abstract class AbstractTestNGFilteringIntegrationTest extends AbstractTestFilter
     }
 
     @Issue("GRADLE-3112")
-    @ToBeFixedForConfigurationCache(because = "No tests found for given includes: [*AwesomeSuite*](filter.includeTestsMatching)")
     def "suites can be filtered from the build file"() {
         given:
         theUsualFiles()

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/SampleTestNGIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/SampleTestNGIntegrationTest.groovy
@@ -19,7 +19,6 @@ import org.gradle.integtests.fixtures.AbstractIntegrationTest
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import org.gradle.integtests.fixtures.Sample
 import org.gradle.integtests.fixtures.TestNGExecutionResult
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.UsesSample
 import org.junit.Before
 import org.junit.Rule
@@ -35,7 +34,6 @@ class SampleTestNGIntegrationTest extends AbstractIntegrationTest {
         executer.withRepositoryMirrors()
     }
 
-    @ToBeFixedForConfigurationCache(because = "load-after-store")
     @Test
     @UsesSample('testing/testng-suitexmlbuilder')
     void suiteXmlBuilder() {

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFilteringIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFilteringIntegrationTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.testing.testng
 
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import org.gradle.integtests.fixtures.TargetCoverage
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.testing.AbstractTestFilteringIntegrationTest
 import org.gradle.testing.fixture.TestNGCoverage
 import spock.lang.Issue
@@ -68,7 +67,6 @@ class TestNGFilteringIntegrationTest extends AbstractTestFilteringIntegrationTes
         """
     }
 
-    @ToBeFixedForConfigurationCache(because = "load-after-store")
     @Issue("GRADLE-3112")
     def "suites can be filtered from the command-line"() {
         given:
@@ -87,7 +85,6 @@ class TestNGFilteringIntegrationTest extends AbstractTestFilteringIntegrationTes
         result.testClass('BarTest').assertTestsExecuted('pass')
     }
 
-    @ToBeFixedForConfigurationCache(because = "load-after-store")
     @Issue("GRADLE-3112")
     def "suites can be filtered from the build file"() {
         given:

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGUpToDateCheckIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGUpToDateCheckIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.testing.testng
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.testing.fixture.TestNGCoverage
 import spock.lang.Issue
 
@@ -114,7 +113,6 @@ class TestNGUpToDateCheckIntegrationTest extends AbstractIntegrationSpec {
         'groupByInstances'    | '= true'
     }
 
-    @ToBeFixedForConfigurationCache(because = "load-after-store")
     @Issue('https://github.com/gradle/gradle/issues/4924')
     def "re-executes test when #property is changed"() {
         given:


### PR DESCRIPTION
TestNG supports filtering via \<suite\>...\</suite\>  [XML markup](https://testng.org/doc/documentation-main.html#testng-xml). To make this CC-compatible, we are now generating and caching the markup at serialization time, so it remains available during execution (as the objects required to build it - the markup writer and builder - are not persistable).

Fixes: #25859
