### PR TITLE
Check if multi-release JARs are properly instrumented when loading classes

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/classanalysis/AsmConstants.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classanalysis/AsmConstants.java
@@ -20,6 +20,12 @@ import org.objectweb.asm.Opcodes;
 
 public class AsmConstants {
     public static final int ASM_LEVEL = Opcodes.ASM9;
+
+    /**
+     * The minimal version of Java for which ASM understands the bytecodes.
+     */
+    public static final int MIN_SUPPORTED_JAVA_VERSION = 1;
+
     /**
      * The latest version of Java for which ASM understands the bytecodes.
      *

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/JarCompat.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/JarCompat.java
@@ -29,7 +29,7 @@ import java.util.jar.JarFile;
 abstract class JarCompat implements Closeable {
     public static final boolean JAVA_9_COMPATIBLE = JavaVersion.current().isJava9Compatible();
 
-    private final JarFile jarFile;
+    protected final JarFile jarFile;
 
     private JarCompat(JarFile jarFile) {
         this.jarFile = jarFile;
@@ -38,6 +38,8 @@ abstract class JarCompat implements Closeable {
     public final JarFile getJarFile() {
         return jarFile;
     }
+
+    public abstract boolean isMultiRelease();
 
     @Override
     public final void close() throws IOException {
@@ -57,6 +59,12 @@ abstract class JarCompat implements Closeable {
         public LegacyJar(File jarFile) throws IOException {
             super(new JarFile(jarFile));
         }
+
+        @Override
+        public boolean isMultiRelease() {
+            // Pre-Java 9 platforms do not support multi-release JARs.
+            return false;
+        }
     }
 
     @SuppressWarnings("Since15")
@@ -64,6 +72,11 @@ abstract class JarCompat implements Closeable {
         MultiReleaseSupportingJar(File jarFile) throws IOException {
             // Set up the MR-JAR properly when running on Java 9+.
             super(new JarFile(jarFile, true, JarFile.OPEN_READ, JarFile.runtimeVersion()));
+        }
+
+        @Override
+        public boolean isMultiRelease() {
+            return jarFile.isMultiRelease();
         }
     }
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/JarCompat.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/JarCompat.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.classloader;
+
+import org.gradle.api.JavaVersion;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.util.jar.JarFile;
+
+/**
+ * Compatibility wrapper for multi-release JARs that can be used on Java 8 too.
+ */
+abstract class JarCompat implements Closeable {
+    public static final boolean JAVA_9_COMPATIBLE = JavaVersion.current().isJava9Compatible();
+
+    private final JarFile jarFile;
+
+    private JarCompat(JarFile jarFile) {
+        this.jarFile = jarFile;
+    }
+
+    public final JarFile getJarFile() {
+        return jarFile;
+    }
+
+    @Override
+    public final void close() throws IOException {
+        jarFile.close();
+    }
+
+    public static JarCompat open(File jarFile) throws IOException {
+        if (JAVA_9_COMPATIBLE) {
+            return new MultiReleaseSupportingJar(jarFile);
+        }
+        // Running on Java 8, fall back to the old ways.
+        return new LegacyJar(jarFile);
+    }
+
+
+    private static class LegacyJar extends JarCompat {
+        public LegacyJar(File jarFile) throws IOException {
+            super(new JarFile(jarFile));
+        }
+    }
+
+    @SuppressWarnings("Since15")
+    private static class MultiReleaseSupportingJar extends JarCompat {
+        MultiReleaseSupportingJar(File jarFile) throws IOException {
+            // Set up the MR-JAR properly when running on Java 9+.
+            super(new JarFile(jarFile, true, JarFile.OPEN_READ, JarFile.runtimeVersion()));
+        }
+    }
+}

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/JarCompat.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/JarCompat.java
@@ -41,6 +41,8 @@ abstract class JarCompat implements Closeable {
 
     public abstract boolean isMultiRelease();
 
+    public abstract int javaRuntimeVersionUsed();
+
     @Override
     public final void close() throws IOException {
         jarFile.close();
@@ -65,6 +67,11 @@ abstract class JarCompat implements Closeable {
             // Pre-Java 9 platforms do not support multi-release JARs.
             return false;
         }
+
+        @Override
+        public int javaRuntimeVersionUsed() {
+            throw new UnsupportedOperationException("Cannot get runtime version used when running on Java <9");
+        }
     }
 
     @SuppressWarnings("Since15")
@@ -77,6 +84,13 @@ abstract class JarCompat implements Closeable {
         @Override
         public boolean isMultiRelease() {
             return jarFile.isMultiRelease();
+        }
+
+        @Override
+        @SuppressWarnings("deprecation")
+        public int javaRuntimeVersionUsed() {
+            // Deprecated major() is used to keep Java 9 compatibility.
+            return JarFile.runtimeVersion().major();
         }
     }
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/TransformReplacer.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/TransformReplacer.java
@@ -20,6 +20,7 @@ import org.gradle.api.GradleException;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.internal.IoActions;
 import org.gradle.internal.agents.InstrumentingClassLoader;
+import org.gradle.internal.classanalysis.AsmConstants;
 import org.gradle.internal.classpath.TransformedClassPath;
 import org.gradle.internal.io.StreamByteBuffer;
 
@@ -200,10 +201,11 @@ public class TransformReplacer implements Closeable {
             if (jarFile == null) {
                 jarFile = JarCompat.open(jarFilePath);
                 if (jarFile.isMultiRelease() && !isTransformed(jarFile.getJarFile())) {
-                    throw new GradleException(
-                        "Cannot load multi-release JAR '"
-                            + originalJarFilePath.getAbsolutePath()
-                            + "' because it cannot be fully instrumented by this version of Gradle.");
+                    throw new GradleException(String.format(
+                        "Cannot load multi-release JAR '%s' because it cannot be fully instrumented for Java %d by this version of Gradle. Please use a supported Java version (<=%d).",
+                        originalJarFilePath.getAbsolutePath(),
+                        jarFile.javaRuntimeVersionUsed(),
+                        AsmConstants.MAX_SUPPORTED_JAVA_VERSION));
                 }
             }
             return jarFile.getJarFile();

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/classloader/TransformReplacerTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/classloader/TransformReplacerTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.internal.classloader
 
 import org.gradle.api.GradleException
 import org.gradle.api.JavaVersion
+import org.gradle.internal.classloader.TransformReplacer.MarkerResource
 import org.gradle.internal.classpath.TransformedClassPath
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.test.precondition.Requires
@@ -97,7 +98,7 @@ class TransformReplacerTest extends Specification {
             }
 
             entry("Foo.class", INSTRUMENTED_CLASS)
-            entry(TransformReplacer.MARKER_RESOURCE_NAME, "true")
+            entry(MarkerResource.RESOURCE_NAME, MarkerResource.TRANSFORMED.asBytes())
         }
 
         TransformedClassPath cp = classPath((original): transformed)
@@ -124,7 +125,7 @@ class TransformReplacerTest extends Specification {
             }
 
             entry("Foo.class", INSTRUMENTED_CLASS)
-            entry(TransformReplacer.MARKER_RESOURCE_NAME, "true")
+            entry(MarkerResource.RESOURCE_NAME, MarkerResource.TRANSFORMED.asBytes())
 
             versionedEntry(currentJvmMajor, "Foo.class", INSTRUMENTED_VERSIONED_CLASS)
         }
@@ -153,10 +154,10 @@ class TransformReplacerTest extends Specification {
             }
 
             entry("Foo.class", INSTRUMENTED_CLASS)
-            entry(TransformReplacer.MARKER_RESOURCE_NAME, "true")
+            entry(MarkerResource.RESOURCE_NAME, MarkerResource.TRANSFORMED.asBytes())
 
             versionedEntry(currentJvmMajor, "Foo.class", INSTRUMENTED_VERSIONED_CLASS)
-            versionedEntry(currentJvmMajor + 1, TransformReplacer.MARKER_RESOURCE_NAME, "false")
+            versionedEntry(currentJvmMajor + 1, MarkerResource.RESOURCE_NAME, MarkerResource.NOT_TRANSFORMED.asBytes())
         }
 
         TransformedClassPath cp = classPath((original): transformed)
@@ -212,9 +213,9 @@ class TransformReplacerTest extends Specification {
             }
 
             entry("Foo.class", INSTRUMENTED_CLASS)
-            entry(TransformReplacer.MARKER_RESOURCE_NAME, "true")
+            entry(MarkerResource.RESOURCE_NAME, MarkerResource.TRANSFORMED.asBytes())
 
-            versionedEntry(currentJvmMajor, TransformReplacer.MARKER_RESOURCE_NAME, "false")
+            versionedEntry(currentJvmMajor, MarkerResource.RESOURCE_NAME, MarkerResource.NOT_TRANSFORMED.asBytes())
         }
 
         TransformedClassPath cp = classPath((original): transformed)

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/classloader/TransformReplacerTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/classloader/TransformReplacerTest.groovy
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.classloader
+
+import org.gradle.api.GradleException
+import org.gradle.api.JavaVersion
+import org.gradle.internal.classpath.TransformedClassPath
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.UnitTestPreconditions
+import org.junit.Rule
+import spock.lang.Specification
+
+import java.security.CodeSigner
+import java.security.CodeSource
+import java.security.ProtectionDomain
+
+import static org.gradle.util.JarUtils.jar
+
+class TransformReplacerTest extends Specification {
+    @Rule
+    TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider(getClass())
+    def testDir = testDirectoryProvider.testDirectory
+
+    private static final byte[] ORIGINAL_CLASS = new byte[]{1}
+    private static final byte[] ORIGINAL_VERSIONED_CLASS = new byte[]{10}
+    private static final byte[] INSTRUMENTED_CLASS = new byte[]{2}
+    private static final byte[] INSTRUMENTED_VERSIONED_CLASS = new byte[]{20}
+
+    def "replaces original class with transformed in non-multi-release JAR"() {
+        given:
+        def original = jar(testDir.file("original.jar")) {
+            manifest {}
+
+            entry("Foo.class", ORIGINAL_CLASS)
+        }
+
+        def transformed = jar(testDir.file("transformed.jar")) {
+            manifest {}
+
+            entry("Foo.class", INSTRUMENTED_CLASS)
+        }
+
+        TransformedClassPath cp = classPath((original): transformed)
+
+        expect:
+        INSTRUMENTED_CLASS == loadTransformedClass(cp, "Foo", original)
+    }
+
+    def "replaces original class with transformed in JAR without manifest"() {
+        given:
+        def original = jar(testDir.file("original.jar")) {
+            manifest {}
+
+            entry("Foo.class", ORIGINAL_CLASS)
+        }
+
+        def transformed = jar(testDir.file("transformed.jar")) {
+            withoutManifest()
+
+            entry("Foo.class", INSTRUMENTED_CLASS)
+        }
+
+        TransformedClassPath cp = classPath((original): transformed)
+
+        expect:
+        INSTRUMENTED_CLASS == loadTransformedClass(cp, "Foo", original)
+    }
+
+    def "replaces original class with transformed in multi-release JAR"() {
+        given:
+        def original = jar(testDir.file("original.jar")) {
+            manifest {
+                multiRelease()
+            }
+
+            entry("Foo.class", ORIGINAL_CLASS)
+        }
+
+        def transformed = jar(testDir.file("transformed.jar")) {
+            manifest {
+                multiRelease()
+            }
+
+            entry("Foo.class", INSTRUMENTED_CLASS)
+            entry(TransformReplacer.MARKER_RESOURCE_NAME, "true")
+        }
+
+        TransformedClassPath cp = classPath((original): transformed)
+
+        expect:
+        INSTRUMENTED_CLASS == loadTransformedClass(cp, "Foo", original)
+    }
+
+    @Requires(UnitTestPreconditions.Jdk9OrLater)
+    def "replaces original class with transformed from versioned directory in multi-release JAR"() {
+        given:
+        def original = jar(testDir.file("original.jar")) {
+            manifest {
+                multiRelease()
+            }
+
+            entry("Foo.class", ORIGINAL_CLASS)
+            versionedEntry(currentJvmMajor, "Foo.class", ORIGINAL_VERSIONED_CLASS)
+        }
+
+        def transformed = jar(testDir.file("transformed.jar")) {
+            manifest {
+                multiRelease()
+            }
+
+            entry("Foo.class", INSTRUMENTED_CLASS)
+            entry(TransformReplacer.MARKER_RESOURCE_NAME, "true")
+
+            versionedEntry(currentJvmMajor, "Foo.class", INSTRUMENTED_VERSIONED_CLASS)
+        }
+
+        TransformedClassPath cp = classPath((original): transformed)
+
+        expect:
+        INSTRUMENTED_VERSIONED_CLASS == loadTransformedClass(cp, "Foo", original)
+    }
+
+    @Requires(UnitTestPreconditions.Jdk9OrLater)
+    def "replaces original class with transformed from versioned directory in multi-release JAR if next version is not supported"() {
+        given:
+        def original = jar(testDir.file("original.jar")) {
+            manifest {
+                multiRelease()
+            }
+
+            entry("Foo.class", ORIGINAL_CLASS)
+            versionedEntry(currentJvmMajor, "Foo.class", ORIGINAL_VERSIONED_CLASS)
+        }
+
+        def transformed = jar(testDir.file("transformed.jar")) {
+            manifest {
+                multiRelease()
+            }
+
+            entry("Foo.class", INSTRUMENTED_CLASS)
+            entry(TransformReplacer.MARKER_RESOURCE_NAME, "true")
+
+            versionedEntry(currentJvmMajor, "Foo.class", INSTRUMENTED_VERSIONED_CLASS)
+            versionedEntry(currentJvmMajor + 1, TransformReplacer.MARKER_RESOURCE_NAME, "false")
+        }
+
+        TransformedClassPath cp = classPath((original): transformed)
+
+        expect:
+        INSTRUMENTED_VERSIONED_CLASS == loadTransformedClass(cp, "Foo", original)
+    }
+
+    @Requires(UnitTestPreconditions.Jdk9OrLater)
+    def "fails loading if transformed multi-release jar has no marker resource"() {
+        given:
+        def original = jar(testDir.file("original.jar")) {
+            manifest {
+                multiRelease()
+            }
+
+            entry("Foo.class", ORIGINAL_CLASS)
+        }
+
+        def transformed = jar(testDir.file("transformed.jar")) {
+            manifest {
+                multiRelease()
+            }
+
+            entry("Foo.class", INSTRUMENTED_CLASS)
+        }
+
+        TransformedClassPath cp = classPath((original): transformed)
+
+        when:
+        loadTransformedClass(cp, "Foo", original)
+
+        then:
+        thrown(GradleException)
+    }
+
+    @Requires(UnitTestPreconditions.Jdk9OrLater)
+    def "fails loading if transformed multi-release jar does not instrument current JVM"() {
+        given:
+        def original = jar(testDir.file("original.jar")) {
+            manifest {
+                multiRelease()
+            }
+
+            entry("Foo.class", ORIGINAL_CLASS)
+            versionedEntry(currentJvmMajor, "Foo.class", ORIGINAL_VERSIONED_CLASS)
+        }
+
+        def transformed = jar(testDir.file("transformed.jar")) {
+            manifest {
+                multiRelease()
+            }
+
+            entry("Foo.class", INSTRUMENTED_CLASS)
+            entry(TransformReplacer.MARKER_RESOURCE_NAME, "true")
+
+            versionedEntry(currentJvmMajor, TransformReplacer.MARKER_RESOURCE_NAME, "false")
+        }
+
+        TransformedClassPath cp = classPath((original): transformed)
+
+        when:
+        loadTransformedClass(cp, "Foo", original)
+
+        then:
+        thrown(GradleException)
+    }
+
+    private static final byte[] loadTransformedClass(TransformedClassPath cp, String className, File originalJar) {
+        try (TransformReplacer replacer = new TransformReplacer(cp)) {
+            return replacer.getInstrumentedClass(className, protectionDomain(originalJar))
+        }
+    }
+
+    private static TransformedClassPath classPath(Map<File, File> originalToTransformed) {
+        def builder = TransformedClassPath.builderWithExactSize(originalToTransformed.size())
+        originalToTransformed.forEach(builder::add)
+        return builder.build()
+    }
+
+    private static int getCurrentJvmMajor() {
+        return JavaVersion.current().majorVersion.toInteger()
+    }
+
+    private static ProtectionDomain protectionDomain(File jarFile) {
+        def cs = new CodeSource(jarFile.toURI().toURL(), null as CodeSigner[])
+        return new ProtectionDomain(cs, null)
+    }
+}

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/classloader/TransformReplacerTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/classloader/TransformReplacerTest.groovy
@@ -190,7 +190,8 @@ class TransformReplacerTest extends Specification {
         loadTransformedClass(cp, "Foo", original)
 
         then:
-        thrown(GradleException)
+        def e = thrown(GradleException)
+        e.message.contains("cannot be fully instrumented for Java ${JavaVersion.current().majorVersion}")
     }
 
     @Requires(UnitTestPreconditions.Jdk9OrLater)
@@ -222,7 +223,8 @@ class TransformReplacerTest extends Specification {
         loadTransformedClass(cp, "Foo", original)
 
         then:
-        thrown(GradleException)
+        def e = thrown(GradleException)
+        e.message.contains("cannot be fully instrumented for Java ${JavaVersion.current().majorVersion}")
     }
 
     private static final byte[] loadTransformedClass(TransformedClassPath cp, String className, File originalJar) {

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingClasspathFileTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingClasspathFileTransformer.java
@@ -26,7 +26,7 @@ import org.gradle.cache.FileLock;
 import org.gradle.cache.FileLockManager;
 import org.gradle.internal.Pair;
 import org.gradle.internal.classanalysis.AsmConstants;
-import org.gradle.internal.classloader.TransformReplacer;
+import org.gradle.internal.classloader.TransformReplacer.MarkerResource;
 import org.gradle.internal.classpath.types.GradleCoreInstrumentingTypeRegistry;
 import org.gradle.internal.classpath.types.InstrumentingTypeRegistry;
 import org.gradle.internal.file.FileException;
@@ -46,7 +46,6 @@ import org.slf4j.LoggerFactory;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.OptionalInt;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
@@ -470,10 +469,10 @@ public class InstrumentingClasspathFileTransformer implements ClasspathFileTrans
             if (isMultiReleaseJar) {
                 // Put marker resource into a multi-release JAR so the classloader can recognize that it tries to load non-instrumented classes.
                 // Root directory is always supported. Every Java version before lowestUnsupportedVersion should also load from root.
-                builder.put(TransformReplacer.MARKER_RESOURCE_NAME, "true".getBytes(StandardCharsets.UTF_8));
+                builder.put(MarkerResource.RESOURCE_NAME, MarkerResource.TRANSFORMED.asBytes());
                 if (hasUnsupportedVersionInJar()) {
                     // Every Java version starting from lowestUnsupportedVersion should see this jar as unsupported.
-                    builder.put(JarUtil.toVersionedPath(lowestUnsupportedVersionInJar, TransformReplacer.MARKER_RESOURCE_NAME), "false".getBytes(StandardCharsets.UTF_8));
+                    builder.put(JarUtil.toVersionedPath(lowestUnsupportedVersionInJar, MarkerResource.RESOURCE_NAME), MarkerResource.NOT_TRANSFORMED.asBytes());
                 }
             }
         }

--- a/subprojects/core/src/main/java/org/gradle/util/internal/JarUtil.java
+++ b/subprojects/core/src/main/java/org/gradle/util/internal/JarUtil.java
@@ -19,11 +19,28 @@ package org.gradle.util.internal;
 import org.apache.commons.io.IOUtils;
 import org.gradle.internal.IoActions;
 
-import java.io.*;
+import javax.annotation.Nullable;
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.OptionalInt;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 public class JarUtil {
+    // We cannot use Attributes.Name.MULTI_RELEASE as it is only available since Java 9;
+    public static final String MULTI_RELEASE_ATTRIBUTE = "Multi-Release";
+    // Pattern for JAR entries in the versioned directories.
+    // See https://docs.oracle.com/en/java/javase/20/docs/specs/jar/jar.html#multi-release-jar-files
+    private static final Pattern VERSIONED_JAR_ENTRY_PATH = Pattern.compile("^META-INF/versions/(\\d+)/.+$");
+
     public static boolean extractZipEntry(File jarFile, String entryName, File extractToFile) throws IOException {
         boolean entryExtracted = false;
 
@@ -54,5 +71,65 @@ public class JarUtil {
         }
 
         return entryExtracted;
+    }
+
+    /**
+     * Checks if the {@code jarEntryName} is the name of the JAR manifest entry.
+     *
+     * @param jarEntryName the name of the entry
+     * @return {@code true} if the entry is the JAR manifest
+     */
+    public static boolean isManifestName(String jarEntryName) {
+        return jarEntryName.equals(JarFile.MANIFEST_NAME);
+    }
+
+    /**
+     * Parses Manifest from a byte array.
+     * @param content the bytes of the manifest
+     * @return the Manifest
+     * @throws IOException if the manifest cannot be parsed
+     */
+    public static Manifest readManifest(byte[] content) throws IOException {
+        return new Manifest(new ByteArrayInputStream(content));
+    }
+
+    /**
+     * Checks if the manifest declares JAR to be multi-release.
+     *
+     * @param manifest the manifest
+     * @return {@code true} if the manifest declares the multi-release JAR
+     */
+    public static boolean isMultiReleaseJarManifest(Manifest manifest) {
+        return Boolean.parseBoolean(getManifestMainAttribute(manifest, MULTI_RELEASE_ATTRIBUTE));
+    }
+
+    @Nullable
+    private static String getManifestMainAttribute(Manifest manifest, String name) {
+        return manifest.getMainAttributes().getValue(name);
+    }
+
+    /**
+     * Checks if the entry path is inside a versioned directory and returns the corresponding major version of Java platform.
+     * Returns empty Optional if this entry isn't inside a versioned directory.
+     *
+     * @param entryPath the full path to the entry inside the JAR
+     * @return major version of Java platform for which this entry is intended if it is in the versioned directory or empty Optional
+     *
+     * @see <a href="https://docs.oracle.com/en/java/javase/20/docs/specs/jar/jar.html#multi-release-jar-files">MR JAR specification</a>
+     */
+    public static OptionalInt getVersionedDirectoryMajorVersion(String entryPath) {
+        Matcher match = VERSIONED_JAR_ENTRY_PATH.matcher(entryPath);
+        if (match.matches()) {
+            try {
+                int version = Integer.parseInt(match.group(1));
+                return OptionalInt.of(version);
+            } catch (NumberFormatException ignored) {
+                // Even though the pattern ensures that the version name is all digits, it fails to parse, probably because it is too big.
+                // Technically it may be a valid MR JAR for Java >Integer.MAX_VALUE, but we are too far away from this.
+                // We assume that JAR author didn't intend it to be a versioned directory.
+            }
+        }
+        // The entry is not in the versioned directory.
+        return OptionalInt.empty();
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/util/internal/JarUtil.java
+++ b/subprojects/core/src/main/java/org/gradle/util/internal/JarUtil.java
@@ -132,4 +132,8 @@ public class JarUtil {
         // The entry is not in the versioned directory.
         return OptionalInt.empty();
     }
+
+    public static String toVersionedPath(int version, String basePath) {
+        return String.format("META-INF/versions/%d/%s", version, basePath);
+    }
 }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/JarUtils.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/JarUtils.groovy
@@ -18,6 +18,7 @@ package org.gradle.util
 
 
 import org.gradle.test.fixtures.archive.JarTestFixture
+import org.gradle.util.internal.JarUtil
 
 import java.nio.charset.StandardCharsets
 import java.time.LocalDateTime
@@ -101,10 +102,10 @@ class JarUtils {
         /**
          * Configures the JAR manifest.
          */
-        void manifest(@DelegatesTo(value = Manifest, strategy = Closure.DELEGATE_FIRST) Closure<?> closure) {
+        void manifest(@DelegatesTo(value = ManifestWithDsl, strategy = Closure.DELEGATE_FIRST) Closure<?> closure) {
             assert !hasConfiguredManifest: "Already written the manifest"
 
-            def man = new Manifest()
+            def man = new ManifestWithDsl()
             man.mainAttributes.put(Attributes.Name.MANIFEST_VERSION, "1.0")
 
             closure.setDelegate(man)
@@ -166,6 +167,18 @@ class JarUtils {
 
         private void checkManifestWritten() {
             assert hasConfiguredManifest: "Must have manifest before entries. Use withoutManifest() to skip it explicitly."
+        }
+    }
+
+    /**
+     * A Manifest with additional goodies to make its configuration more pleasant.
+     */
+    static class ManifestWithDsl extends Manifest {
+        /**
+         * Configures this Manifest to be Multi-Release.
+         */
+        void multiRelease() {
+            mainAttributes.putValue(JarUtil.MULTI_RELEASE_ATTRIBUTE, "true")
         }
     }
 }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/JarUtils.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/JarUtils.groovy
@@ -16,7 +16,17 @@
 
 package org.gradle.util
 
+
+import org.gradle.test.fixtures.archive.JarTestFixture
+
+import java.nio.charset.StandardCharsets
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.util.jar.Attributes
+import java.util.jar.JarEntry
+import java.util.jar.JarFile
 import java.util.jar.JarOutputStream
+import java.util.jar.Manifest
 import java.util.zip.ZipEntry
 
 class JarUtils {
@@ -34,5 +44,128 @@ class JarUtils {
             jarOut.close()
         }
         return out.toByteArray()
+    }
+
+    /**
+     * Builds a JAR file with a DSL. The JAR file uses deterministic timestamps. The Jar manifest must be configured explicitly, as a first step.
+     * <p>
+     * <pre>
+     *     jar("path/to/file.jar") {
+     *         manifest {  // can be withoutManifest()
+     *             mainAttributes.putValue("Multi-Release", "true")
+     *         }
+     *
+     *         entry("Foo.class", fooBytes)
+     *         versionedEntry(11, "Foo.class", fooBytesForJava11)
+     *     }
+     *
+     * </pre>
+     * @param jarFile the jar file to create
+     * @param closure the configuration of the JAR file
+     * @return the path to the created JAR file.
+     */
+    static File jar(File jarFile, @DelegatesTo(value = JarBuilder, strategy = Closure.DELEGATE_FIRST) Closure<?> closure) {
+        try (def out = jarFile.newOutputStream(); def jarOut = new JarOutputStream(out)) {
+            closure.setDelegate(new JarBuilder(jarOut))
+            closure()
+        }
+
+        jarFile
+    }
+
+    /**
+     * DSL helper to build the JAR file. Start building with configuring the manifest ({@link JarBuilder#manifest(groovy.lang.Closure)}
+     * or specifying the lack thereof ({@link JarBuilder#withoutManifest()}.
+     */
+    static class JarBuilder {
+        /**
+         * @see org.gradle.api.internal.file.archive.ZipCopyAction#CONSTANT_TIME_FOR_ZIP_ENTRIES
+         */
+        private static final long CONSTANT_TIME_FOR_ZIP_ENTRIES = LocalDateTime.parse("1980-02-01T00:00:00.00").atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+
+        private final JarOutputStream jarOut
+        private boolean hasConfiguredManifest
+
+        JarBuilder(JarOutputStream jarOut) {
+            this.jarOut = jarOut
+        }
+
+        /**
+         * Specifies that this JAR has no manifest.
+         */
+        void withoutManifest() {
+            assert !hasConfiguredManifest: "Already written the manifest"
+            hasConfiguredManifest = true
+        }
+
+        /**
+         * Configures the JAR manifest.
+         */
+        void manifest(@DelegatesTo(value = Manifest, strategy = Closure.DELEGATE_FIRST) Closure<?> closure) {
+            assert !hasConfiguredManifest: "Already written the manifest"
+
+            def man = new Manifest()
+            man.mainAttributes.put(Attributes.Name.MANIFEST_VERSION, "1.0")
+
+            closure.setDelegate(man)
+            closure()
+
+            jarOut.putNextEntry(newEntryWithFixedTime(JarFile.MANIFEST_NAME))
+            man.write(jarOut)
+
+            hasConfiguredManifest = true
+            this
+        }
+
+        private static JarEntry newEntryWithFixedTime(String path) {
+            return new JarEntry(path).tap {
+                // setTimeLocal() is better but it is Java 9+.
+                setTime(CONSTANT_TIME_FOR_ZIP_ENTRIES)
+            }
+        }
+
+        /**
+         * Writes a versioned flavor of a JAR entry. The {@code path} should be a non-versioned path, e.g. {@code path/to/Foo.class}.
+         * @param version the java version (9, 10, etc.), must be &gt;8
+         * @param path the path of the entry (non-versioned)
+         * @param bytes the body of the entry
+         */
+        void versionedEntry(int version, String path, byte[] bytes) {
+            entry(JarTestFixture.toVersionedPath(version, path), bytes)
+        }
+
+        /**
+         * Writes a versioned flavor of a JAR entry. The {@code path} should be a non-versioned path, e.g. {@code path/to/Foo.class}.
+         * @param version the java version (9, 10, etc.), must be &gt;8
+         * @param path the path of the entry (non-versioned)
+         * @param body the body of the entry which is encoded with UTF-8
+         */
+        void versionedEntry(int version, String path, String body) {
+            entry(JarTestFixture.toVersionedPath(version, path), body)
+        }
+
+        /**
+         * Writes a JAR entry.
+         * @param path the path of the entry
+         * @param bytes the body of the entry
+         */
+        void entry(String path, byte[] bytes) {
+            checkManifestWritten()
+            jarOut.putNextEntry(newEntryWithFixedTime(path))
+            jarOut.write(bytes)
+        }
+
+        /**
+         * Writes a JAR entry.
+         * @param path the path of the entry
+         * @param body the body of the entry which is encoded with UTF-8
+         */
+        void entry(String path, String body) {
+            entry(path, body.getBytes(StandardCharsets.UTF_8))
+        }
+
+        private void checkManifestWritten() {
+            assert hasConfiguredManifest: "Must have manifest before entries. Use withoutManifest() to skip it explicitly."
+        }
     }
 }

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/archive/JarTestFixture.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/archive/JarTestFixture.groovy
@@ -114,6 +114,10 @@ class JarTestFixture extends ZipTestFixture {
         assertNotContainsFile(toVersionedPath(version, basePath))
     }
 
+    def assertVersionedContent(int version, String basePath, String content) {
+        assertFileContent(toVersionedPath(version, basePath), content)
+    }
+
     static String toVersionedPath(int version, String basePath) {
         assert version > 8: "Java only supports versioned directories for versions >8, got $version"
         return "META-INF/versions/$version/$basePath"

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/archive/JarTestFixture.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/archive/JarTestFixture.groovy
@@ -101,7 +101,7 @@ class JarTestFixture extends ZipTestFixture {
     }
 
     def assertIsMultiRelease() {
-        "true" == manifest.mainAttributes.getValue("Multi-Release")
+        assert "true" == manifest.mainAttributes.getValue("Multi-Release")
         this
     }
 
@@ -115,6 +115,7 @@ class JarTestFixture extends ZipTestFixture {
     }
 
     static String toVersionedPath(int version, String basePath) {
+        assert version > 8: "Java only supports versioned directories for versions >8, got $version"
         return "META-INF/versions/$version/$basePath"
     }
 }


### PR DESCRIPTION
Gradle can only instrument bytecode up to the version ASM understands.
For multi-release JARs this means that versioned directories for the
unsupported JVM versions are not processed and instrumented JARs contain
no classes for these versions. However, due to the way agent-based
instrumentation works, classes are loaded first from the original JAR
and only then the agent replaces the bytecode with the instrumented
copy. Prior to this commit, it was possible that the non-instrumented
original class could be loaded when Gradle would run on the unsupported
JVM.

Now instrumentation puts a marker resource into processed multi-release
JARs which contains instrumentation status. Root directory always has
"instrumented" status. If there is an unsupported versioned directory
with class files, it gets a versioned resource with "not instrumented"
status.

The replacing class loader loads the resource and checks the status when
transformed classes are looked up in the JAR for the first time. If the
JVM is unsupported and there are versioned class for this JVM, the class
loader loads the "not instrumented" version of the resource and aborts
loading the class.

Fixes #25434