### PR TITLE
Rebaseline performance tests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -29,4 +29,4 @@ systemProp.gradle.internal.testdistribution.writeTraceFile=true
 systemProp.gradle.internal.testdistribution.queryResponseTimeout=PT20S
 
 # Default performance baseline
-defaultPerformanceBaselines=8.4-commit-dc89352570f
+defaultPerformanceBaselines=8.4-commit-26296024f25


### PR DESCRIPTION
Re-baseline to the commit where windows java compiler daemons were made no longer persistent.
