### PR TITLE
Fixing JUnitJupiterCategoriesOrTagsCoverageIntegrationTest

### DIFF
--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/jupiter/JUnitJupiterCategoriesOrTagsCoverageIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/jupiter/JUnitJupiterCategoriesOrTagsCoverageIntegrationTest.groovy
@@ -172,7 +172,7 @@ class JUnitJupiterCategoriesOrTagsCoverageIntegrationTest extends AbstractJUnitC
                         return new TestTemplateInvocationContext() {
                             @Override
                             public String getDisplayName(int invocationIndex) {
-                                return locale.getDisplayName();
+                                return locale.getDisplayName(Locale.US);
                             }
 
                             @Override


### PR DESCRIPTION
Fixing JUnitJupiterCategoriesOrTagsCoverageIntegrationTest#'can combine tags with custom extension' for non-english environments

<!--- The issue this PR addresses -->
Fixes #25947

### Context
addressing langue failure in non-english environment for JUnitJupiterCategoriesOrTagsCoverageIntegrationTest

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
  - not applicable, it's fixing a Test
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
  - not applicable: no changes in src/main
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
  - not applicable: no changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
