### PR TITLE
Fix configuration cache debug log for space usage analysis

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheDebugLogIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheDebugLogIntegrationTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.execution.plan.LocalTaskNode
 import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheDebugOption
 
 import static org.gradle.configurationcache.fingerprint.ConfigurationCacheFingerprint.GradleEnvironment
+import static org.gradle.configurationcache.fingerprint.ProjectSpecificFingerprint.ProjectFingerprint
 
 class ConfigurationCacheDebugLogIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
 
@@ -54,8 +55,10 @@ class ConfigurationCacheDebugLogIntegrationTest extends AbstractConfigurationCac
 
         then: "fingerprint frame events are logged"
         def events = collectOutputEvents()
-        events.contains([profile: "fingerprint", type: "O", "frame": GradleEnvironment.name])
-        events.contains([profile: "fingerprint", type: "C", "frame": GradleEnvironment.name])
+        events.contains([profile: "build fingerprint", type: "O", "frame": GradleEnvironment.name])
+        events.contains([profile: "build fingerprint", type: "C", "frame": GradleEnvironment.name])
+        events.contains([profile: "project fingerprint", type: "O", "frame": ProjectFingerprint.name])
+        events.contains([profile: "project fingerprint", type: "C", "frame": ProjectFingerprint.name])
 
         and: "Gradle and Work Graph events are logged"
         events.contains([profile: "build ':' state", type: "O", frame: "Gradle"])

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheIO.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheIO.kt
@@ -182,9 +182,9 @@ class ConfigurationCacheIO internal constructor(
         stateFile: ConfigurationCacheStateFile,
         action: suspend DefaultWriteContext.(ConfigurationCacheState) -> T
     ): T {
-
-        val build = host.currentBuild
-        val (context, codecs) = writerContextFor(encryptionService.outputStream(stateFile.stateType, stateFile::outputStream), build.gradle.owner.displayName.displayName + " state")
+        val (context, codecs) = writerContextFor(encryptionService.outputStream(stateFile.stateType, stateFile::outputStream)) {
+            host.currentBuild.gradle.owner.displayName.displayName + " state"
+        }
         return context.useToRun {
             runWriteOperation {
                 action(ConfigurationCacheState(codecs, stateFile, eventEmitter, host))
@@ -210,8 +210,11 @@ class ConfigurationCacheIO internal constructor(
         }
     }
 
+    /**
+     * @param profile the unique name associated with the output stream for debugging space usage issues
+     */
     internal
-    fun writerContextFor(outputStream: OutputStream, profile: String): Pair<DefaultWriteContext, Codecs> =
+    fun writerContextFor(outputStream: OutputStream, profile: () -> String): Pair<DefaultWriteContext, Codecs> =
         KryoBackedEncoder(outputStream).let { encoder ->
             writeContextFor(
                 encoder,
@@ -221,9 +224,9 @@ class ConfigurationCacheIO internal constructor(
         }
 
     private
-    fun loggingTracerFor(profile: String, encoder: KryoBackedEncoder) =
+    fun loggingTracerFor(profile: () -> String, encoder: KryoBackedEncoder) =
         loggingTracerLogLevel()?.let { level ->
-            LoggingTracer(profile, encoder::getWritePosition, logger, level)
+            LoggingTracer(profile(), encoder::getWritePosition, logger, level)
         }
 
     private

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
@@ -23,6 +23,7 @@ import org.gradle.api.internal.provider.ValueSourceProviderFactory
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.logging.Logging
 import org.gradle.configurationcache.cacheentry.EntryDetails
+import org.gradle.configurationcache.extensions.toDefaultLowerCase
 import org.gradle.configurationcache.extensions.uncheckedCast
 import org.gradle.configurationcache.fingerprint.ConfigurationCacheFingerprintController
 import org.gradle.configurationcache.initialization.ConfigurationCacheStartParameter
@@ -420,14 +421,30 @@ class DefaultConfigurationCache internal constructor(
 
     private
     fun startCollectingCacheFingerprint() {
-        cacheFingerprintController.maybeStartCollectingFingerprint(store.assignSpoolFile(StateType.BuildFingerprint), store.assignSpoolFile(StateType.ProjectFingerprint)) {
-            cacheFingerprintWriterContextFor(encryptionService.outputStream(it.stateType, it.file::outputStream))
+        cacheFingerprintController.maybeStartCollectingFingerprint(
+            store.assignSpoolFile(StateType.BuildFingerprint),
+            store.assignSpoolFile(StateType.ProjectFingerprint)
+        ) { stateFile ->
+            cacheFingerprintWriterContextFor(
+                encryptionService.outputStream(
+                    stateFile.stateType,
+                    stateFile.file::outputStream
+                )
+            ) {
+                profileNameFor(stateFile)
+            }
         }
     }
 
     private
-    fun cacheFingerprintWriterContextFor(outputStream: OutputStream): DefaultWriteContext {
-        val (context, codecs) = cacheIO.writerContextFor(outputStream, "fingerprint")
+    fun profileNameFor(stateFile: ConfigurationCacheStateStore.StateFile) =
+        stateFile.stateType.name.replace(Regex("\\p{Upper}")) { match ->
+            " " + match.value.toDefaultLowerCase()
+        }.drop(1)
+
+    private
+    fun cacheFingerprintWriterContextFor(outputStream: OutputStream, profile: () -> String): DefaultWriteContext {
+        val (context, codecs) = cacheIO.writerContextFor(outputStream, profile)
         return context.apply {
             push(IsolateOwner.OwnerHost(host), codecs.fingerprintTypesCodec())
         }


### PR DESCRIPTION
The configuration cache debug log enables [space usage analysis via speedscope](https://github.com/gradle/gcc2speedscope#gradle-configuration-cache-log-to-speedscope).

This PR fixes the debug log output to honor the invariant that the pairs `(profile, sequenceNumber)` taken from the logged events are unique. 