### PR TITLE
Simplify test task state to make it CC-friendly

### DIFF
--- a/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
@@ -236,18 +236,6 @@ public abstract class AbstractTestTask extends ConventionTask implements Verific
      */
     protected abstract TestExecutionSpec createTestExecutionSpec();
 
-    @Internal
-    @VisibleForTesting
-    ListenerBroadcast<TestListener> getTestListenerBroadcaster() {
-        return testListenerSubscriptions.get();
-    }
-
-    @Internal
-    @VisibleForTesting
-    ListenerBroadcast<TestOutputListener> getTestOutputListenerBroadcaster() {
-        return testOutputListenerSubscriptions.get();
-    }
-
     @VisibleForTesting
     void setTestReporter(TestReporter testReporter) {
         this.testReporter = testReporter;
@@ -506,7 +494,7 @@ public abstract class AbstractTestTask extends ConventionTask implements Verific
         addTestListener(testCountLogger);
 
         ListenerBroadcast<TestListenerInternal> testListenerInternalBroadcaster = getListenerManager().createAnonymousBroadcaster(TestListenerInternal.class);
-        testListenerInternalBroadcaster.add(new TestListenerAdapter(getTestListenerBroadcaster().getSource(), getTestOutputListenerBroadcaster().getSource()));
+        testListenerInternalBroadcaster.add(new TestListenerAdapter(testListenerSubscriptions.get().getSource(), testOutputListenerSubscriptions.get().getSource()));
 
         ProgressLogger parentProgressLogger = getProgressLoggerFactory().newOperation(AbstractTestTask.class);
         parentProgressLogger.setDescription("Test Execution");


### PR DESCRIPTION
ListenerBroadcast and friends are complex structures(with lots of lazy init'ing) and pose challenges for correctly storing/restoring their state to/from disk (as required by CC).

This changeset simplifies the configuration-time state kept by AbstractTestTask so it only collects references to TestListener and TestOutputListener instances, without instantiating any ListenerBroadcasts.

Issue: #25855
