### PR TITLE
Move configuration metadata logic to builder

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalConfigurationMetadataBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalConfigurationMetadataBuilder.java
@@ -89,7 +89,7 @@ public class DefaultLocalConfigurationMetadataBuilder implements LocalConfigurat
         ModelContainer<?> model,
         CalculatedValueContainerFactory calculatedValueContainerFactory
     ) {
-        String name = configuration.getName();
+        String configurationName = configuration.getName();
         String description = configuration.getDescription();
         ComponentIdentifier componentId = parent.getId();
         ComponentConfigurationIdentifier configurationIdentifier = new ComponentConfigurationIdentifier(componentId, configuration.getName());
@@ -106,13 +106,13 @@ public class DefaultLocalConfigurationMetadataBuilder implements LocalConfigurat
             @Override
             public void visitOwnVariant(DisplayName displayName, ImmutableAttributes attributes, Collection<? extends Capability> capabilities, Collection<? extends PublishArtifact> artifacts) {
                 CalculatedValue<ImmutableList<LocalComponentArtifactMetadata>> variantArtifacts = getVariantArtifacts(componentId, displayName, artifacts, model, calculatedValueContainerFactory);
-                variantsBuilder.add(new LocalVariantMetadata(configuration.getName(), configurationIdentifier, displayName, attributes, ImmutableCapabilities.of(capabilities), variantArtifacts));
+                variantsBuilder.add(new LocalVariantMetadata(configurationName, configurationIdentifier, displayName, attributes, ImmutableCapabilities.of(capabilities), variantArtifacts));
             }
 
             @Override
             public void visitChildVariant(String name, DisplayName displayName, ImmutableAttributes attributes, Collection<? extends Capability> capabilities, Collection<? extends PublishArtifact> artifacts) {
                 CalculatedValue<ImmutableList<LocalComponentArtifactMetadata>> variantArtifacts = getVariantArtifacts(componentId, displayName, artifacts, model, calculatedValueContainerFactory);
-                variantsBuilder.add(new LocalVariantMetadata(configuration.getName() + "-" + name, new NestedVariantIdentifier(configurationIdentifier, name), displayName, attributes, ImmutableCapabilities.of(capabilities), variantArtifacts));
+                variantsBuilder.add(new LocalVariantMetadata(configurationName + "-" + name, new NestedVariantIdentifier(configurationIdentifier, name), displayName, attributes, ImmutableCapabilities.of(capabilities), variantArtifacts));
             }
         });
 
@@ -134,10 +134,10 @@ public class DefaultLocalConfigurationMetadataBuilder implements LocalConfigurat
 
         List<PublishArtifact> sourceArtifacts = artifactBuilder.build();
         CalculatedValue<ImmutableList<LocalComponentArtifactMetadata>> artifacts =
-            getConfigurationArtifacts(parent, model, calculatedValueContainerFactory, name, description, hierarchy, sourceArtifacts);
+            getConfigurationArtifacts(parent, model, calculatedValueContainerFactory, configurationName, description, hierarchy, sourceArtifacts);
 
         return new DefaultLocalConfigurationMetadata(
-            name,
+            configurationName,
             description,
             componentId,
             configuration.isVisible(),

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalConfigurationMetadataBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalConfigurationMetadataBuilder.java
@@ -40,10 +40,12 @@ import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.component.local.model.DefaultLocalConfigurationMetadata;
+import org.gradle.internal.component.local.model.LocalComponentArtifactMetadata;
 import org.gradle.internal.component.local.model.LocalComponentMetadata;
 import org.gradle.internal.component.local.model.LocalConfigurationMetadata;
 import org.gradle.internal.component.local.model.LocalFileDependencyMetadata;
 import org.gradle.internal.component.local.model.LocalVariantMetadata;
+import org.gradle.internal.component.local.model.PublishArtifactLocalArtifactMetadata;
 import org.gradle.internal.component.model.ComponentConfigurationIdentifier;
 import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.LocalOriginDependencyMetadata;
@@ -56,6 +58,8 @@ import javax.annotation.Nullable;
 import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Queue;
 import java.util.Set;
 
@@ -85,6 +89,8 @@ public class DefaultLocalConfigurationMetadataBuilder implements LocalConfigurat
         ModelContainer<?> model,
         CalculatedValueContainerFactory calculatedValueContainerFactory
     ) {
+        String name = configuration.getName();
+        String description = configuration.getDescription();
         ComponentIdentifier componentId = parent.getId();
         ComponentConfigurationIdentifier configurationIdentifier = new ComponentConfigurationIdentifier(componentId, configuration.getName());
 
@@ -99,12 +105,14 @@ public class DefaultLocalConfigurationMetadataBuilder implements LocalConfigurat
 
             @Override
             public void visitOwnVariant(DisplayName displayName, ImmutableAttributes attributes, Collection<? extends Capability> capabilities, Collection<? extends PublishArtifact> artifacts) {
-                variantsBuilder.add(new LocalVariantMetadata(configuration.getName(), configurationIdentifier, componentId, displayName, attributes, artifacts, ImmutableCapabilities.of(capabilities), model, calculatedValueContainerFactory));
+                CalculatedValue<ImmutableList<LocalComponentArtifactMetadata>> variantArtifacts = getVariantArtifacts(componentId, displayName, artifacts, model, calculatedValueContainerFactory);
+                variantsBuilder.add(new LocalVariantMetadata(configuration.getName(), configurationIdentifier, displayName, attributes, ImmutableCapabilities.of(capabilities), variantArtifacts));
             }
 
             @Override
             public void visitChildVariant(String name, DisplayName displayName, ImmutableAttributes attributes, Collection<? extends Capability> capabilities, Collection<? extends PublishArtifact> artifacts) {
-                variantsBuilder.add(new LocalVariantMetadata(configuration.getName() + "-" + name, new NestedVariantIdentifier(configurationIdentifier, name), componentId, displayName, attributes, artifacts, ImmutableCapabilities.of(capabilities), model, calculatedValueContainerFactory));
+                CalculatedValue<ImmutableList<LocalComponentArtifactMetadata>> variantArtifacts = getVariantArtifacts(componentId, displayName, artifacts, model, calculatedValueContainerFactory);
+                variantsBuilder.add(new LocalVariantMetadata(configuration.getName() + "-" + name, new NestedVariantIdentifier(configurationIdentifier, name), displayName, attributes, ImmutableCapabilities.of(capabilities), variantArtifacts));
             }
         });
 
@@ -116,7 +124,7 @@ public class DefaultLocalConfigurationMetadataBuilder implements LocalConfigurat
         ImmutableSet<String> hierarchy = Configurations.getNames(configuration.getHierarchy());
 
         CalculatedValue<DefaultLocalConfigurationMetadata.ConfigurationDependencyMetadata> dependencies =
-            calculatedValueContainerFactory.create(Describables.of("Dependency state for", configuration.getDescription()), context -> {
+            calculatedValueContainerFactory.create(Describables.of("Dependency state for", description), context -> {
                 // TODO: Do we need to acquire project lock from `model`? getState calls user code.
                 DependencyState state = getState(configurationsProvider, hierarchy, componentId, dependencyCache);
                 return new DefaultLocalConfigurationMetadata.ConfigurationDependencyMetadata(
@@ -124,9 +132,13 @@ public class DefaultLocalConfigurationMetadataBuilder implements LocalConfigurat
                 );
             });
 
+        List<PublishArtifact> sourceArtifacts = artifactBuilder.build();
+        CalculatedValue<ImmutableList<LocalComponentArtifactMetadata>> artifacts =
+            getConfigurationArtifacts(parent, model, calculatedValueContainerFactory, name, description, hierarchy, sourceArtifacts);
+
         return new DefaultLocalConfigurationMetadata(
-            configuration.getName(),
-            configuration.getDescription(),
+            name,
+            description,
             componentId,
             configuration.isVisible(),
             configuration.isTransitive(),
@@ -138,11 +150,57 @@ public class DefaultLocalConfigurationMetadataBuilder implements LocalConfigurat
             configuration.isCanBeResolved(),
             dependencies,
             variantsBuilder.build(),
-            artifactBuilder.build(),
-            model,
             calculatedValueContainerFactory,
-            parent
+            artifacts
         );
+    }
+
+    private static CalculatedValue<ImmutableList<LocalComponentArtifactMetadata>> getConfigurationArtifacts(
+        LocalComponentMetadata parent, ModelContainer<?> model, CalculatedValueContainerFactory calculatedValueContainerFactory,
+        String name, String description, ImmutableSet<String> hierarchy, List<PublishArtifact> sourceArtifacts
+    ) {
+        CalculatedValue<ImmutableList<LocalComponentArtifactMetadata>> artifacts =
+            calculatedValueContainerFactory.create(Describables.of(description, "artifacts"), context -> {
+                if (sourceArtifacts.isEmpty() && hierarchy.isEmpty()) {
+                    return ImmutableList.of();
+                } else {
+                    return model.fromMutableState(m -> {
+                        Set<LocalComponentArtifactMetadata> result = new LinkedHashSet<>(sourceArtifacts.size());
+                        for (PublishArtifact sourceArtifact : sourceArtifacts) {
+                            // The following line may realize tasks, so project lock must be held.
+                            result.add(new PublishArtifactLocalArtifactMetadata(parent.getId(), sourceArtifact));
+                        }
+                        for (String config : hierarchy) {
+                            if (config.equals(name)) {
+                                continue;
+                            }
+                            // TODO: Deprecate the behavior of inheriting artifacts from parent configurations.
+                            LocalConfigurationMetadata conf = parent.getConfiguration(config);
+                            result.addAll(conf.prepareToResolveArtifacts().getArtifacts());
+                        }
+                        return ImmutableList.copyOf(result);
+                    });
+                }
+            });
+        return artifacts;
+    }
+
+    private static CalculatedValue<ImmutableList<LocalComponentArtifactMetadata>> getVariantArtifacts(
+        ComponentIdentifier componentId, DisplayName displayName, Collection<? extends PublishArtifact> sourceArtifacts, ModelContainer<?> model, CalculatedValueContainerFactory calculatedValueContainerFactory
+    ) {
+        return calculatedValueContainerFactory.create(Describables.of(displayName, "artifacts"), context -> {
+            if (sourceArtifacts.isEmpty()) {
+                return ImmutableList.of();
+            } else {
+                return model.fromMutableState(m -> {
+                    ImmutableList.Builder<LocalComponentArtifactMetadata> result = ImmutableList.builderWithExpectedSize(sourceArtifacts.size());
+                    for (PublishArtifact sourceArtifact : sourceArtifacts) {
+                        result.add(new PublishArtifactLocalArtifactMetadata(componentId, sourceArtifact));
+                    }
+                    return result.build();
+                });
+            }
+        });
     }
 
     /**

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractConfigurationMetadata.java
@@ -135,11 +135,6 @@ public abstract class AbstractConfigurationMetadata implements ModuleConfigurati
     }
 
     @Override
-    public boolean isCanBeResolved() {
-        return false;
-    }
-
-    @Override
     public boolean isExternalVariant() {
         return externalVariant;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractVariantBackedConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractVariantBackedConfigurationMetadata.java
@@ -121,11 +121,6 @@ class AbstractVariantBackedConfigurationMetadata implements ModuleConfigurationM
     }
 
     @Override
-    public boolean isCanBeResolved() {
-        return false;
-    }
-
-    @Override
     public boolean isTransitive() {
         return true;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyRuleAwareWithBaseConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyRuleAwareWithBaseConfigurationMetadata.java
@@ -157,11 +157,6 @@ class LazyRuleAwareWithBaseConfigurationMetadata implements ModuleConfigurationM
     }
 
     @Override
-    public boolean isCanBeResolved() {
-        return false;
-    }
-
-    @Override
     public boolean isExternalVariant() {
         return externalVariant;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
@@ -174,7 +174,7 @@ public final class DefaultLocalComponentMetadata implements LocalComponentMetada
                 return null;
             }
             if (artifactTransformer != null) {
-                md = md.copy(artifactTransformer);
+                md = md.copyWithTransformedArtifacts(artifactTransformer);
             }
             allConfigurations.put(name, md);
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalConfigurationMetadata.java
@@ -95,7 +95,7 @@ public final class DefaultLocalConfigurationMetadata implements LocalConfigurati
     }
 
     @Override
-    public LocalConfigurationMetadata copy(Transformer<LocalComponentArtifactMetadata, LocalComponentArtifactMetadata> artifactTransformer) {
+    public LocalConfigurationMetadata copyWithTransformedArtifacts(Transformer<LocalComponentArtifactMetadata, LocalComponentArtifactMetadata> artifactTransformer) {
         ImmutableSet.Builder<LocalVariantMetadata> copiedVariants = ImmutableSet.builder();
         for (LocalVariantMetadata oldVariant : variants) {
             CalculatedValue<ImmutableList<LocalComponentArtifactMetadata>> newArtifacts =

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/LocalConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/LocalConfigurationMetadata.java
@@ -25,6 +25,13 @@ public interface LocalConfigurationMetadata extends ConfigurationMetadata, Local
     @Override
     ImmutableList<? extends LocalComponentArtifactMetadata> getArtifacts();
 
-    LocalConfigurationMetadata copy(Transformer<LocalComponentArtifactMetadata, LocalComponentArtifactMetadata> artifactTransformer);
+    /**
+     * Returns a copy of this configuration metadata, except with all artifacts transformed by the given transformer.
+     *
+     * @param artifactTransformer A transformer applied to all artifacts and sub-variant artifacts.
+     *
+     * @return A copy of this metadata, with the given transformer applied to all artifacts.
+     */
+    LocalConfigurationMetadata copyWithTransformedArtifacts(Transformer<LocalComponentArtifactMetadata, LocalComponentArtifactMetadata> artifactTransformer);
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/LocalVariantMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/LocalVariantMetadata.java
@@ -17,49 +17,21 @@
 package org.gradle.internal.component.local.model;
 
 import com.google.common.collect.ImmutableList;
-import org.gradle.api.artifacts.PublishArtifact;
-import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
-import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.component.model.DefaultVariantMetadata;
 import org.gradle.internal.component.model.VariantResolveMetadata;
-import org.gradle.internal.model.CalculatedValueContainer;
-import org.gradle.internal.model.CalculatedValueContainerFactory;
-import org.gradle.internal.model.ModelContainer;
-
-import java.util.Collection;
-import java.util.List;
+import org.gradle.internal.model.CalculatedValue;
 
 /**
  * Implementation of {@link VariantResolveMetadata} which allows variant artifacts to be calculated lazily
  * while holding a project lock.
  */
 public final class LocalVariantMetadata extends DefaultVariantMetadata {
-    private final CalculatedValueContainer<ImmutableList<LocalComponentArtifactMetadata>, ?> artifacts;
+    private final CalculatedValue<ImmutableList<LocalComponentArtifactMetadata>> artifacts;
 
-    public LocalVariantMetadata(String name, Identifier identifier, ComponentIdentifier componentId, DisplayName displayName, ImmutableAttributes attributes, Collection<? extends PublishArtifact> sourceArtifacts, ImmutableCapabilities capabilities, ModelContainer<?> model, CalculatedValueContainerFactory calculatedValueContainerFactory) {
-        this(name, identifier, displayName, attributes, capabilities, calculatedValueContainerFactory.create(Describables.of(displayName, "artifacts"), context -> {
-            if (sourceArtifacts.isEmpty()) {
-                return ImmutableList.of();
-            } else {
-                return model.fromMutableState(m -> {
-                    ImmutableList.Builder<LocalComponentArtifactMetadata> result = ImmutableList.builderWithExpectedSize(sourceArtifacts.size());
-                    for (PublishArtifact sourceArtifact : sourceArtifacts) {
-                        result.add(new PublishArtifactLocalArtifactMetadata(componentId, sourceArtifact));
-                    }
-                    return result.build();
-                });
-            }
-        }));
-    }
-
-    public LocalVariantMetadata(String name, Identifier identifier, DisplayName displayName, ImmutableAttributes attributes, ImmutableCapabilities capabilities, List<LocalComponentArtifactMetadata> artifacts, CalculatedValueContainerFactory calculatedValueContainerFactory) {
-        this(name, identifier, displayName, attributes, capabilities, calculatedValueContainerFactory.create(Describables.of(displayName, "artifacts"), ImmutableList.copyOf(artifacts)));
-    }
-
-    private LocalVariantMetadata(String name, Identifier identifier, DisplayName displayName, ImmutableAttributes attributes, ImmutableCapabilities capabilities, CalculatedValueContainer<ImmutableList<LocalComponentArtifactMetadata>, ?> artifacts) {
+    public LocalVariantMetadata(String name, Identifier identifier, DisplayName displayName, ImmutableAttributes attributes, ImmutableCapabilities capabilities, CalculatedValue<ImmutableList<LocalComponentArtifactMetadata>> artifacts) {
         super(name, identifier, displayName, attributes, ImmutableList.of(), capabilities);
         this.artifacts = artifacts;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ConfigurationMetadata.java
@@ -87,8 +87,6 @@ public interface ConfigurationMetadata extends VariantArtifactGraphResolveMetada
 
     boolean isCanBeConsumed();
 
-    boolean isCanBeResolved();
-
     /**
      * Find the component artifact with the given IvyArtifactName, creating a new one if none matches.
      *

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine
 
+import com.google.common.collect.ImmutableList
 import org.apache.ivy.core.module.id.ModuleRevisionId
 import org.gradle.api.Action
 import org.gradle.api.artifacts.ModuleDependency
@@ -49,12 +50,14 @@ import org.gradle.api.internal.attributes.AttributeDesugaring
 import org.gradle.api.internal.attributes.AttributesSchemaInternal
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.specs.Specs
+import org.gradle.internal.Describables
 import org.gradle.internal.component.external.descriptor.DefaultExclude
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.external.model.ImmutableCapabilities
 import org.gradle.internal.component.local.model.DefaultLocalComponentMetadata
 import org.gradle.internal.component.local.model.DefaultLocalConfigurationMetadata
 import org.gradle.internal.component.local.model.DslOriginDependencyMetadataWrapper
+import org.gradle.internal.component.local.model.LocalComponentArtifactMetadata
 import org.gradle.internal.component.local.model.LocalComponentGraphResolveStateFactory
 import org.gradle.internal.component.local.model.PublishArtifactLocalArtifactMetadata
 import org.gradle.internal.component.model.ComponentIdGenerator
@@ -65,6 +68,8 @@ import org.gradle.internal.component.model.DependencyMetadata
 import org.gradle.internal.component.model.ExcludeMetadata
 import org.gradle.internal.component.model.IvyArtifactName
 import org.gradle.internal.component.model.LocalComponentDependencyMetadata
+import org.gradle.internal.component.model.LocalOriginDependencyMetadata
+import org.gradle.internal.model.CalculatedValue
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.operations.BuildOperationQueue
 import org.gradle.internal.resolve.ModuleVersionNotFoundException
@@ -1028,11 +1033,7 @@ class DependencyGraphBuilderTest extends Specification {
         def componentId = DefaultModuleComponentIdentifier.newId(id)
 
         def artifacts = [new PublishArtifactLocalArtifactMetadata(componentId, new DefaultPublishArtifact("art1", "zip", "art", null, new Date(), new File("art1.zip")))]
-        def defaultConfiguration = new DefaultLocalConfigurationMetadata(
-            "default", "defaultConfig", componentId, true, true, ["default"] as Set, attributes, ImmutableCapabilities.EMPTY,
-            true, false, true, [], [] as Set, [],
-            [] as Set, TestUtil.calculatedValueContainerFactory(), artifacts
-        )
+        def defaultConfiguration = newConfiguration("default", componentId, [], [], artifacts)
 
         def configurations = new DefaultLocalComponentMetadata.ConfigurationsMapMetadataFactory(["default": defaultConfiguration])
         return new DefaultLocalComponentMetadata(id, componentId, "release", attributesSchema, configurations, null)
@@ -1043,20 +1044,30 @@ class DependencyGraphBuilderTest extends Specification {
         def componentId = newProjectId(":root")
 
         def artifacts = [new PublishArtifactLocalArtifactMetadata(componentId, new DefaultPublishArtifact("art1", "zip", "art", null, new Date(), new File("art1.zip")))]
-        def defaultConfiguration = new DefaultLocalConfigurationMetadata(
-            "default", "defaultConfig", componentId, true, true, ["default"] as Set, attributes, ImmutableCapabilities.EMPTY,
-            true, false, true, [], [] as Set, [],
-            [] as Set, TestUtil.calculatedValueContainerFactory(), artifacts
-        )
+        def defaultConfiguration = newConfiguration("default", componentId, [], [], artifacts)
 
-        def rootConfiguration = new DefaultLocalConfigurationMetadata(
-            "root", "rootConfig", componentId, true, true, ["default", "root"] as Set, attributes, ImmutableCapabilities.EMPTY,
-            true, false, true, defaultConfiguration.getDependencies(), [] as Set, [],
-            [] as Set, TestUtil.calculatedValueContainerFactory(), []
-        )
+        def rootConfiguration = newConfiguration("root", componentId, ["default"], defaultConfiguration.getDependencies(), [])
 
         def configurations = new DefaultLocalComponentMetadata.ConfigurationsMapMetadataFactory(["default": defaultConfiguration, "root": rootConfiguration])
         return new DefaultLocalComponentMetadata(newId("group", "root", "1.0"), componentId, "release", attributesSchema, configurations, null)
+    }
+
+    def newConfiguration(String name, ComponentIdentifier componentId, List<String> extendsFrom, List<LocalOriginDependencyMetadata> dependencies, List<LocalComponentArtifactMetadata> artifacts) {
+        CalculatedValue<DefaultLocalConfigurationMetadata.ConfigurationDependencyMetadata> dependencyMetadata =
+            TestUtil.calculatedValueContainerFactory().create(Describables.of(name, "dependencies"),
+                new DefaultLocalConfigurationMetadata.ConfigurationDependencyMetadata(dependencies, [] as Set, [])
+            )
+
+        CalculatedValue<ImmutableList<LocalComponentArtifactMetadata>> artifactMetadata =
+            TestUtil.calculatedValueContainerFactory().create(Describables.of(name, "artifacts"),
+                ImmutableList.copyOf(artifacts)
+            )
+
+        return new DefaultLocalConfigurationMetadata(
+            name, name, componentId, true, true, [name] + extendsFrom as Set, attributes, ImmutableCapabilities.EMPTY,
+            true, false, true, dependencyMetadata,
+            [] as Set, TestUtil.calculatedValueContainerFactory(), artifactMetadata
+        )
     }
 
     def traverses(Map<String, ?> args = [:], def from, ComponentResolveMetadata to) {


### PR DESCRIPTION
This moves logic required to build artifact metadata to the configuration metadata builder, thus allowing us to make the actual metadata types more 'dumb' while also removing extra unnecessary constructors
