### PR TITLE
providing actionable guidance in MissingLockStateException

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/MissingLockStateException.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/MissingLockStateException.java
@@ -18,6 +18,7 @@ package org.gradle.internal.locking;
 
 public class MissingLockStateException extends RuntimeException {
     public MissingLockStateException(String configurationName) {
-        super("Locking strict mode: Configuration '" + configurationName + "' is locked but does not have lock state.");
+        super("Locking strict mode: Configuration '" + configurationName + "' is locked but does not have lock state. " +
+        "To create the lock state, run a task that will resolve that configuration and add --write-locks");
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingProviderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingProviderTest.groovy
@@ -222,7 +222,7 @@ empty=
         then:
         def ex = thrown(MissingLockStateException)
         1 * context.identityPath('conf') >> Path.path(':conf')
-        ex.message == 'Locking strict mode: Configuration \':conf\' is locked but does not have lock state.'
+        ex.message == 'Locking strict mode: Configuration \':conf\' is locked but does not have lock state. To create the lock state, run a task that will resolve that configuration and add --write-locks'
 
         where:
         unique << [true, false]


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #25756 -->

### Context
This change offers more clarity for Users: The updated exception message offers actionable guidance to users encountering the specific scenario where a locked configuration lacks a lock state. This will help users understand the issue better and know exactly what action to take to resolve it.

Fixes #25756

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
