### PR TITLE
Adjust smoke tests for AGP usage of deprecated GUtil once per Gradle daemon

### DIFF
--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractAndroidSantaTrackerSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractAndroidSantaTrackerSmokeTest.groovy
@@ -107,7 +107,6 @@ class AbstractAndroidSantaTrackerSmokeTest extends AbstractSmokeTest {
                 expectConfigUtilDeprecationWarning(agpVersion)
                 expectBuildIdentifierIsCurrentBuildDeprecation(agpVersion)
                 expectBuildIdentifierNameDeprecation()
-                maybeExpectOrgGradleUtilGUtilDeprecation(agpVersion)
             }.build()
     }
 
@@ -182,7 +181,9 @@ class AbstractAndroidSantaTrackerSmokeTest extends AbstractSmokeTest {
             def init = AGP_VERSIONS.createAgpNightlyRepositoryInitScript()
             runner.withArguments([runner.arguments, ['-I', init.canonicalPath]].flatten())
         }
-        return runner
+        return runner.deprecations(SantaTrackerDeprecations) {
+            maybeExpectOrgGradleUtilGUtilDeprecation(agpVersion)
+        }
     }
 
     protected static boolean verify(BuildResult result, Map<String, TaskOutcome> outcomes) {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
@@ -111,9 +111,7 @@ class AndroidPluginsSmokeTest extends AbstractPluginValidatingSmokeTest implemen
             expectBasePluginConventionDeprecation(agpVersion)
             expectBuildIdentifierNameDeprecation()
             expectBuildIdentifierIsCurrentBuildDeprecation(agpVersion)
-            if ((ide && !GradleContextualExecuter.configCache) || (!ide && GradleContextualExecuter.configCache)) {
-                maybeExpectOrgGradleUtilGUtilDeprecation(agpVersion)
-            }
+            maybeExpectOrgGradleUtilGUtilDeprecation(agpVersion)
         }.build()
 
         then:
@@ -130,7 +128,7 @@ class AndroidPluginsSmokeTest extends AbstractPluginValidatingSmokeTest implemen
         when: 'up-to-date build'
         SantaTrackerConfigurationCacheWorkaround.beforeBuild(runner.projectDir, IntegrationTestBuildContext.INSTANCE.gradleUserHomeDir)
         result = runner.deprecations(AndroidDeprecations) {
-            maybeExpectGUtilDeprecation()
+            maybeExpectOrgGradleUtilGUtilDeprecation(agpVersion)
             maybeExpectProjectConventionDeprecationWarning(agpVersion)
             maybeExpectReportDestinationPropertyDeprecation(agpVersion)
             maybeExpectAndroidConventionTypeDeprecationWarning(agpVersion)
@@ -151,6 +149,7 @@ class AndroidPluginsSmokeTest extends AbstractPluginValidatingSmokeTest implemen
         abiChange.run()
         SantaTrackerConfigurationCacheWorkaround.beforeBuild(runner.projectDir, IntegrationTestBuildContext.INSTANCE.gradleUserHomeDir)
         result = runner.deprecations(AndroidDeprecations) {
+            maybeExpectOrgGradleUtilGUtilDeprecation(agpVersion)
             expectAndroidWorkerExecutionSubmitDeprecationWarning(agpVersion)
             if (!GradleContextualExecuter.isConfigCache()) {
                 expectReportDestinationPropertyDeprecation(agpVersion)
@@ -173,12 +172,14 @@ class AndroidPluginsSmokeTest extends AbstractPluginValidatingSmokeTest implemen
         when: 'clean re-build'
         def smokeTestRunner = this.runner('clean')
         useAgpVersion(agpVersion, smokeTestRunner).deprecations(AndroidDeprecations) {
+            maybeExpectOrgGradleUtilGUtilDeprecation(agpVersion)
             expectProjectConventionDeprecationWarning(agpVersion)
             expectAndroidConventionTypeDeprecationWarning(agpVersion)
             expectBasePluginConventionDeprecation(agpVersion)
         }.build()
         SantaTrackerConfigurationCacheWorkaround.beforeBuild(runner.projectDir, IntegrationTestBuildContext.INSTANCE.gradleUserHomeDir)
         result = runner.deprecations(AndroidDeprecations) {
+            maybeExpectOrgGradleUtilGUtilDeprecation(agpVersion)
             expectAndroidWorkerExecutionSubmitDeprecationWarning(agpVersion)
             expectBuildIdentifierNameDeprecation()
             if (!GradleContextualExecuter.isConfigCache()) {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BaseDeprecations.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BaseDeprecations.groovy
@@ -55,7 +55,7 @@ class BaseDeprecations {
     public static final String GUTIL_DEPRECATION = "The org.gradle.util.GUtil type has been deprecated. " +
         "This is scheduled to be removed in Gradle 9.0. " +
         "Consult the upgrading guide for further information: " +
-        DOCUMENTATION_REGISTRY.getDocumentationFor("upgrading_version_8","base_convention_deprecation")
+        DOCUMENTATION_REGISTRY.getDocumentationFor("upgrading_version_7", "org_gradle_util_reports_deprecations")
 
     public static final String JAVA_PLUGIN_CONVENTION_DEPRECATION = "The org.gradle.api.plugins.JavaPluginConvention type has been deprecated. " +
         "This is scheduled to be removed in Gradle 9.0. " +

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithAndroidDeprecations.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithAndroidDeprecations.groovy
@@ -68,10 +68,6 @@ trait WithAndroidDeprecations implements WithReportDeprecations {
         runner.expectLegacyDeprecationWarningIf(androidPluginUsesConventions(agpVersion), BASE_PLUGIN_CONVENTION_DEPRECATION)
     }
 
-    void maybeExpectGUtilDeprecation() {
-        runner.maybeExpectLegacyDeprecationWarning(GUTIL_DEPRECATION)
-    }
-
     void expectConfigUtilDeprecationWarning(String agpVersion) {
         runner.expectLegacyDeprecationWarningIf(
             versionIsLower(agpVersion, AGP_VERSION_WITHOUT_CONFIG_UTIL),
@@ -125,10 +121,7 @@ trait WithAndroidDeprecations implements WithReportDeprecations {
     void maybeExpectOrgGradleUtilGUtilDeprecation(String agpVersion) {
         runner.maybeExpectLegacyDeprecationWarningIf(
             VersionNumber.parse(agpVersion) < VersionNumber.parse("7.5"),
-            "The org.gradle.util.GUtil type has been deprecated. " +
-                "This is scheduled to be removed in Gradle 9.0. " +
-                "Consult the upgrading guide for further information: " +
-                "${DOCUMENTATION_REGISTRY.getDocumentationFor("upgrading_version_7", "org_gradle_util_reports_deprecations")}"
+            GUTIL_DEPRECATION
         )
     }
 }


### PR DESCRIPTION
This created flakiness in a whack a mole fashion given we reuse Gradle daemons across tests.
This PR attempts to fix this exhaustively.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
