### PR TITLE
Remove exception from Javadoc on getAlltasks() in TaskExecutionGraph

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/execution/TaskExecutionGraph.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/execution/TaskExecutionGraph.java
@@ -155,7 +155,6 @@ public interface TaskExecutionGraph {
      * </p>
      *
      * @return The tasks. Returns an empty list if no tasks are to be executed.
-     * @throws IllegalStateException When this graph has not been populated.
      */
     List<Task> getAllTasks();
 


### PR DESCRIPTION
### Details
This is a Documentation change ONLY.

### Context
- Fix https://github.com/gradle/gradle/issues/25651
- Update Javadoc for [getAllTasks](https://docs.gradle.org/current/javadoc/org/gradle/api/execution/TaskExecutionGraph.html#getAllTasks--)() since it is an empty list by default and cannot throw an error.

### Reviewers
I was not able to get it to throw since it defaults to an empty list. Let me know if I am missing something here. This is a follow up from an old community filed issue (listed above).
