### PR TITLE
Introduce JetBrains as a known JVM vendor.

### DIFF
--- a/platforms/jvm/toolchains-jvm/src/main/java/org/gradle/jvm/toolchain/JvmVendorSpec.java
+++ b/platforms/jvm/toolchains-jvm/src/main/java/org/gradle/jvm/toolchain/JvmVendorSpec.java
@@ -65,6 +65,13 @@ public abstract class JvmVendorSpec {
     public static final JvmVendorSpec IBM_SEMERU = IBM;
 
     /**
+     * A constant for using <a href="https://www.jetbrains.com/jetbrains-runtime">JetBrains Runtime</a> as the JVM vendor.
+     *
+     * @since 8.3
+     */
+    public static final JvmVendorSpec JETBRAINS = matching(KnownJvmVendor.JETBRAINS);
+
+    /**
      * A constant for using <a href="https://www.microsoft.com/openjdk">Microsoft OpenJDK</a> as the JVM vendor.
      *
      * @since 7.3

--- a/platforms/jvm/toolchains-jvm/src/main/java/org/gradle/jvm/toolchain/JvmVendorSpec.java
+++ b/platforms/jvm/toolchains-jvm/src/main/java/org/gradle/jvm/toolchain/JvmVendorSpec.java
@@ -67,8 +67,9 @@ public abstract class JvmVendorSpec {
     /**
      * A constant for using <a href="https://www.jetbrains.com/jetbrains-runtime">JetBrains Runtime</a> as the JVM vendor.
      *
-     * @since 8.3
+     * @since 8.4
      */
+    @Incubating
     public static final JvmVendorSpec JETBRAINS = matching(KnownJvmVendor.JETBRAINS);
 
     /**

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -50,7 +50,18 @@ Example:
 ADD RELEASE FEATURES BELOW
 vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv -->
 
+### Introduce JetBrains as a known JVM vendor
 
+It is now possible to use JetBrains as a known JVM vendor when referring to [JetBrains Runtime](https://www.jetbrains.com/jetbrains-runtime) when using [Toolchains](https://docs.gradle.org/@version@/userguide/toolchains.html:
+
+```kotlin
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+        vendor.set(JvmVendorSpec.JETBRAINS)
+    }
+}
+```
 
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ADD RELEASE FEATURES ABOVE

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -52,7 +52,7 @@ vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv -->
 
 ### Introduce JetBrains as a known JVM vendor
 
-It is now possible to use JetBrains as a known JVM vendor when referring to [JetBrains Runtime](https://www.jetbrains.com/jetbrains-runtime) when using [Toolchains](https://docs.gradle.org/@version@/userguide/toolchains.html:
+It is now possible to use JetBrains as a known JVM vendor when referring to [JetBrains Runtime](https://www.jetbrains.com/jetbrains-runtime) when using [Toolchains](userguide/toolchains.html):
 
 ```kotlin
 java {

--- a/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
@@ -375,6 +375,7 @@ Sorting is done based on the following rules:
 .. GRAAL_VM
 .. HEWLETT_PACKARD
 .. IBM
+.. JETBRAINS
 .. MICROSOFT
 .. ORACLE
 .. SAP

--- a/subprojects/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/JvmVendor.java
+++ b/subprojects/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/JvmVendor.java
@@ -30,6 +30,7 @@ public interface JvmVendor {
         GRAAL_VM("graalvm community", "GraalVM Community"),
         HEWLETT_PACKARD("hewlett-packard", "HP-UX"),
         IBM("ibm", "ibm|international business machines corporation", "IBM"),
+        JETBRAINS("jetbrains", "JetBrains s.r.o"),
         MICROSOFT("microsoft", "Microsoft"),
         ORACLE("oracle", "Oracle"),
         SAP("sap se", "SAP SapMachine"),


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
It is possible to use JetBrains Runtime in JVM Toolchain with:

```
kotlin {
    jvmToolchain {
        languageVersion = JavaLanguageVersion.of(17)
        vendor = JvmVendorSpec.matching("JetBrains s.r.o")
    }
}
```

Introducing JetBrains as a known vendor would help pick up JBR in a more convenient way:

```
kotlin {
    jvmToolchain {
        languageVersion = JavaLanguageVersion.of(17)
        vendor = JvmVendorSpec.JETBRAINS
    }
}
```

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [X] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [X] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [X] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
