### PR TITLE
Add @Nullable annotation to ResolvedDependencyResult.resolvedVariant

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedDependencyResult.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedDependencyResult.java
@@ -21,6 +21,8 @@ import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.artifacts.result.ResolvedDependencyResult;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
 
+import javax.annotation.Nullable;
+
 public class DefaultResolvedDependencyResult extends AbstractDependencyResult implements ResolvedDependencyResult {
     private final ResolvedComponentResult selectedComponent;
     private final ResolvedVariantResult selectedVariant;
@@ -40,6 +42,7 @@ public class DefaultResolvedDependencyResult extends AbstractDependencyResult im
         return selectedComponent;
     }
 
+    @Nullable
     public ResolvedVariantResult getResolvedVariant() {
         return selectedVariant;
     }

--- a/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
+++ b/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
@@ -1,3 +1,12 @@
 {
-    "acceptedApiChanges": []
+    "acceptedApiChanges": [
+        {
+            "type": "org.gradle.api.artifacts.result.ResolvedDependencyResult",
+            "member": "Method org.gradle.api.artifacts.result.ResolvedDependencyResult.getResolvedVariant()",
+            "acceptation": "Corrected nullability annotation",
+            "changes": [
+                "From non-null returning to null returning breaking change"
+            ]
+        }
+    ]
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ResolvedDependencyResult.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ResolvedDependencyResult.java
@@ -18,6 +18,8 @@ package org.gradle.api.artifacts.result;
 
 import org.gradle.internal.scan.UsedByScanPlugin;
 
+import javax.annotation.Nullable;
+
 /**
  * A dependency that was resolved successfully.
  */
@@ -34,5 +36,6 @@ public interface ResolvedDependencyResult extends DependencyResult {
      *
      * @since 5.6
      */
+    @Nullable
     ResolvedVariantResult getResolvedVariant();
 }


### PR DESCRIPTION

### Context
Apparently the `ResolvedDependencyResult.getResolvedVariant()` can be null as the code [here](https://github.com/jjohannes/gradle/blob/1bdc8353b9cc66fcf722982541e1bbfa30c15ff7/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/CachingDependencyResultFactory.java#L53-L59) (which gives a warning in the IDE) suggests. This screenshot from a debugging session shows that it is possible: https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/913#issuecomment-1638716592

(Conceptually, I don't know how a resolution can be successful without a selected variant)

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- ~[ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective~
- ~[ ] Provide unit tests (under `<subproject>/src/test`) to verify logic~
- ~[ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes~
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
