### PR TITLE
Fix grouping per owner of method instruction for generated JvmBytecodeCallInterceptor

### DIFF
--- a/subprojects/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/model/CallableOwnerInfo.java
+++ b/subprojects/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/model/CallableOwnerInfo.java
@@ -18,6 +18,8 @@ package org.gradle.internal.instrumentation.model;
 
 import org.objectweb.asm.Type;
 
+import java.util.Objects;
+
 public class CallableOwnerInfo {
     private final Type type;
     private final boolean interceptSubtypes;
@@ -33,5 +35,22 @@ public class CallableOwnerInfo {
 
     public boolean isInterceptSubtypes() {
         return interceptSubtypes;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CallableOwnerInfo that = (CallableOwnerInfo) o;
+        return interceptSubtypes == that.interceptSubtypes && Objects.equals(type, that.type);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, interceptSubtypes);
     }
 }

--- a/subprojects/internal-instrumentation-processor/src/test/groovy/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeCodeGenTest.groovy
+++ b/subprojects/internal-instrumentation-processor/src/test/groovy/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeCodeGenTest.groovy
@@ -103,13 +103,11 @@ class PropertyUpgradeCodeGenTest extends InstrumentationCodeGenTest {
                              _INVOKESTATIC(TASK__ADAPTER_TYPE, "access_get_incremental", "(Lorg/gradle/test/Task;)Z");
                              return true;
                          }
-                     }
-                     if (metadata.isInstanceOf(owner, "org/gradle/test/Task")) {
-                      if (name.equals("setIncremental") && descriptor.equals("(Z)Lorg/gradle/test/Task;") && (opcode == Opcodes.INVOKEVIRTUAL || opcode == Opcodes.INVOKEINTERFACE)) {
+                        if (name.equals("setIncremental") && descriptor.equals("(Z)Lorg/gradle/test/Task;") && (opcode == Opcodes.INVOKEVIRTUAL || opcode == Opcodes.INVOKEINTERFACE)) {
                              _INVOKESTATIC(TASK__ADAPTER_TYPE, "access_set_incremental", "(Lorg/gradle/test/Task;Z)Lorg/gradle/test/Task;");
                              return true;
                          }
-                     }
+                    }
                     return false;
                 }
             }
@@ -228,9 +226,7 @@ class PropertyUpgradeCodeGenTest extends InstrumentationCodeGenTest {
                              _INVOKESTATIC(TASK__ADAPTER_TYPE, "access_get_targetCompatibility", "(Lorg/gradle/test/Task;)Ljava/lang/String;");
                              return true;
                          }
-                    }
-                    if (metadata.isInstanceOf(owner, "org/gradle/test/Task")) {
-                       if (name.equals("setTargetCompatibility") && descriptor.equals("(Ljava/lang/String;)V") && (opcode == Opcodes.INVOKEVIRTUAL || opcode == Opcodes.INVOKEINTERFACE)) {
+                         if (name.equals("setTargetCompatibility") && descriptor.equals("(Ljava/lang/String;)V") && (opcode == Opcodes.INVOKEVIRTUAL || opcode == Opcodes.INVOKEINTERFACE)) {
                            _INVOKESTATIC(TASK__ADAPTER_TYPE, "access_set_targetCompatibility", "(Lorg/gradle/test/Task;Ljava/lang/String;)V");
                            return true;
                        }


### PR DESCRIPTION
It seems I broke it at one point, when I introduced CallableOwnerInfo type