### PR TITLE
Update gitStream catagories to match CODEOWNERS as of today

### DIFF
--- a/.cm/change_categories.cm
+++ b/.cm/change_categories.cm
@@ -121,43 +121,9 @@ platforms:
       - 'subprojects/internal-instrumentation-processor/'
       - 'subprojects/model-core/'
       - 'subprojects/model-groovy/'
-  - core:
-    name: 'core'
+  - core_execution:
+    name: 'core_execution'
     subprojects:
-      - 'subprojects/base-services/'
-      - 'subprojects/bootstrap/'
-      - 'subprojects/build-option/'
-      - 'subprojects/cli/'
-      - 'subprojects/distributions-basics/'
-      - 'subprojects/distributions-core/'
-      - 'subprojects/file-temp/'
-      - 'subprojects/file-watching/'
-      - 'subprojects/files/'
-      - 'subprojects/hashing/'
-      - 'subprojects/installation-beacon/'
-      - 'subprojects/instrumentation-agent/'
-      - 'subprojects/launcher/'
-      - 'subprojects/logging/'
-      - 'subprojects/logging-api/'
-      - 'subprojects/messaging/'
-      - 'subprojects/persistent-cache/'
-      - 'subprojects/problems/'
-      - 'subprojects/process-services/'
-      - 'subprojects/snapshots/'
-      - 'subprojects/worker-services/'
-      - 'subprojects/wrapper/'
-      - 'subprojects/wrapper-shared/'
-  - documentation:
-    name: 'documentation'
-    subprojects:
-      - 'subprojects/docs/'
-      - 'subprojects/docs-asciidoctor-extensions/'
-      - 'subprojects/docs-asciidoctor-extensions-base/'
-      - 'subprojects/samples/'
-  - execution:
-    name: 'execution'
-    subprojects:
-      - 'subprojects/base-annotations/'
       - 'subprojects/build-cache/'
       - 'subprojects/build-cache-base/'
       - 'subprojects/build-cache-http/'
@@ -172,6 +138,17 @@ platforms:
       - 'subprojects/snapshots/'
       - 'subprojects/worker-processes/'
       - 'subprojects/workers/'
+  - core_execution:
+    name: 'core_runtime'
+    subprojects:
+      - 'subprojects/installation-beacon/'
+  - documentation:
+    name: 'documentation'
+    subprojects:
+      - 'subprojects/docs/'
+      - 'subprojects/docs-asciidoctor-extensions/'
+      - 'subprojects/docs-asciidoctor-extensions-base/'
+      - 'subprojects/samples/'
   - extensibility:
     name: 'extensibility'
     subprojects:
@@ -181,17 +158,12 @@ platforms:
   - gradle_enterprise:
     name: 'gradle_enterprise'
     subprojects:
-      - 'platforms/enterprise/enterprise/'
-      - 'platforms/enterprise/enterprise-logging/'
-      - 'platforms/enterprise/enterprise-operations/'
-      - 'platforms/enterprise/enterprise-plugin-performance/'
-      - 'platforms/enterprise/enterprise-workers/'
+      - 'platforms/enterprise/'
   - ide:
     name: 'ide'
     subprojects:
       - 'platforms/ide/'
       - 'subprojects/ide/'
-      - 'platforms/ide/ide-plugins/'
       - 'subprojects/tooling-api/'
       - 'subprojects/tooling-api-builders/'
   - jvm:
@@ -216,13 +188,9 @@ platforms:
   - kotlin_dsl:
     name: 'kotlin_dsl'
     subprojects:
+      - 'platforms/core-configuration/'
       - 'build-logic/kotlin-dsl/'
-      - 'platforms/core-configuration/kotlin-dsl/'
-      - 'platforms/core-configuration/kotlin-dsl-integ-tests/'
-      - 'platforms/core-configuration/kotlin-dsl-plugins/'
-      - 'platforms/core-configuration/kotlin-dsl-provider-plugins/'
-      - 'platforms/core-configuration/kotlin-dsl-tooling-builders/'
-      - 'platforms/core-configuration/kotlin-dsl-tooling-models/'
+      - 'subprojects/docs/src/snippets/kotlinDsl/'
   - release_coordination:
     name: 'release_coordination'
     subprojects:

--- a/.cm/change_categories.cm
+++ b/.cm/change_categories.cm
@@ -188,7 +188,12 @@ platforms:
   - kotlin_dsl:
     name: 'kotlin_dsl'
     subprojects:
-      - 'platforms/core-configuration/'
+      - 'platforms/core-configuration/kotlin-dsl/'
+      - 'platforms/core-configuration/kotlin-dsl-integ-tests/'
+      - 'platforms/core-configuration/kotlin-dsl-plugins/'
+      - 'platforms/core-configuration/kotlin-dsl-provider-plugins/'
+      - 'platforms/core-configuration/kotlin-dsl-tooling-builders/'
+      - 'platforms/core-configuration/kotlin-dsl-tooling-models/'
       - 'build-logic/kotlin-dsl/'
       - 'subprojects/docs/src/snippets/kotlinDsl/'
   - release_coordination:

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -51,13 +51,14 @@ platforms/core-configuration/kotlin-dsl-tooling-builders/   @gradle/bt-kotlin-ds
 platforms/core-configuration/kotlin-dsl-tooling-models/     @gradle/bt-kotlin-dsl-maintainers
 
 # Core automation platform (core/runtime)
-
 subprojects/installation-beacon             @gradle/bt-core-runtime-maintainers
 
 # Gradle Enterprise integration
-platforms/enterprise                        @gradle/bt-build-scan @gradle/ge-build-insights
-platforms/enterprise/enterprise/            @gradle/bt-build-scan @gradle/ge-testing @gradle/ge-build-insights @ldaley
-platforms/enterprise/enterprise-logging/    @gradle/bt-build-scan @gradle/ge-build-insights @gradle/ge-testing
+platforms/enterprise                                    @gradle/bt-build-scan @gradle/ge-build-insights
+platforms/enterprise/enterprise/                        @gradle/bt-build-scan @gradle/ge-testing @gradle/ge-build-insights @ldaley
+platforms/enterprise/enterprise-logging/                @gradle/bt-build-scan @gradle/ge-build-insights @gradle/ge-testing
+platforms/enterprise/enterprise-operations/             @gradle/bt-build-scan
+platforms/enterprise/enterprise-plugin-performance/     @gradle/bt-build-scan
 
 # JVM platform
 platforms/jvm/                              @gradle/bt-jvm

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -117,7 +117,7 @@ subprojects/internal-testing/               @gradle/bt-developer-productivity
 .github/workflows/gitstream.yml     @tresat
 
 # Architecture council
-.github/CODEOWNERS @gradle/bt-architecture-council
+.github/CODEOWNERS @gradle/bt-architecture-council @tresat
 
 # IDE Experience team
 platforms/ide/                    @gradle/bt-ide-experience


### PR DESCRIPTION
- Also add missing new enterprise projects to CODEOWNERS.
- Also remove deleted core projects.
- Also add and clean platform includes.

