### PR TITLE
Use IDE plugins to set GRADLE_LIBS_REPO_OVERRIDE url

### DIFF
--- a/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/idea/model/IdeaModule.java
+++ b/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/idea/model/IdeaModule.java
@@ -45,7 +45,7 @@ import static org.gradle.util.internal.ConfigureUtil.configure;
  * Enables fine-tuning module details (*.iml file) of the IDEA plugin.
  * <p>
  * Example of use with a blend of most possible properties.
- * Typically you don't have to configure this model directly because Gradle configures it for you.
+ * Typically, you don't have to configure this model directly because Gradle configures it for you.
  *
  * <pre class='autoTested'>
  * plugins {
@@ -109,6 +109,9 @@ import static org.gradle.util.internal.ConfigureUtil.configure;
  *
  *     //and hate reading sources :)
  *     downloadSources = false
+ *
+ *     //Override the default Gradle Libs repository default which is set to "https://repo.gradle.org/gradle/list/libs-releases
+ *     gradleLibsRepoOverride = "https://myorg.mavenreposiotory.org"
  *   }
  * }
  * </pre>
@@ -193,6 +196,8 @@ public abstract class IdeaModule {
     private PathFactory pathFactory;
     private boolean offline;
     private Map<String, Iterable<File>> singleEntryLibraries;
+    private String gradleLibsRepoOverride;
+
 
     @Inject
     public IdeaModule(Project project, IdeaModuleIml iml) {
@@ -211,7 +216,7 @@ public abstract class IdeaModule {
      * Configures module name, that is the name of the *.iml file.
      * <p>
      * It's <b>optional</b> because the task should configure it correctly for you.
-     * By default it will try to use the <b>project.name</b> or prefix it with a part of a <b>project.path</b> to make
+     * By default, it will try to use the <b>project.name</b> or prefix it with a part of a <b>project.path</b> to make
      * sure the module name is unique in the scope of a multi-module build.
      * The 'uniqueness' of a module name is required for correct import into IDEA and the task will make sure the name
      * is unique.
@@ -578,6 +583,14 @@ public abstract class IdeaModule {
         this.singleEntryLibraries = singleEntryLibraries;
     }
 
+    public String getGradleLibsRepoOverride() {
+        return gradleLibsRepoOverride;
+    }
+
+    public void setGradleLibsRepoOverride(String gradleLibsRepoOverride) {
+        this.gradleLibsRepoOverride = gradleLibsRepoOverride;
+    }
+
     /**
      * Enables advanced configuration like tinkering with the output XML or affecting the way existing *.iml content is merged with gradle build information.
      * <p>
@@ -623,7 +636,7 @@ public abstract class IdeaModule {
     public Set<Dependency> resolveDependencies() {
         ProjectInternal projectInternal = (ProjectInternal) project;
         IdeArtifactRegistry ideArtifactRegistry = projectInternal.getServices().get(IdeArtifactRegistry.class);
-        IdeaDependenciesProvider ideaDependenciesProvider = new IdeaDependenciesProvider(projectInternal, ideArtifactRegistry, new DefaultGradleApiSourcesResolver(projectInternal.newDetachedResolver()));
+        IdeaDependenciesProvider ideaDependenciesProvider = new IdeaDependenciesProvider(projectInternal, ideArtifactRegistry, new DefaultGradleApiSourcesResolver(projectInternal.newDetachedResolver(), gradleLibsRepoOverride));
         return ideaDependenciesProvider.provide(this);
     }
 

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/AbstractSourcesAndJavadocJarsIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/AbstractSourcesAndJavadocJarsIntegrationTest.groovy
@@ -394,6 +394,47 @@ dependencies {
 
     @ToBeFixedForConfigurationCache
     @Requires(UnitTestPreconditions.StableGroovy) // localGroovy() version cannot be swapped-out when a snapshot Groovy build is used
+    def "sources for localGroovy() are downloaded and attached from idea module's repo"() {
+        given:
+        def repo = givenGroovyExistsInGradleRepo()
+
+        buildScript """
+            apply plugin: "java"
+            apply plugin: "idea"
+            apply plugin: "eclipse"
+
+            idea {
+                module {
+                    gradleLibsRepoOverride = "$repo.uri/"
+                }
+            }
+
+            dependencies {
+                implementation localGroovy()
+            }
+            """
+
+        when:
+        succeeds ideTask
+
+        then:
+        ideFileContainsEntry("groovy-${groovyVersion}.jar", ["groovy-${groovyVersion}-sources.jar"], [])
+        ideFileContainsEntry("groovy-ant-${groovyVersion}.jar", ["groovy-ant-${groovyVersion}-sources.jar"], [])
+        ideFileContainsEntry("groovy-astbuilder-${groovyVersion}.jar", ["groovy-astbuilder-${groovyVersion}-sources.jar"], [])
+        ideFileContainsEntry("groovy-console-${groovyVersion}.jar", ["groovy-console-${groovyVersion}-sources.jar"], [])
+        ideFileContainsEntry("groovy-datetime-${groovyVersion}.jar", ["groovy-datetime-${groovyVersion}-sources.jar"], [])
+        ideFileContainsEntry("groovy-dateutil-${groovyVersion}.jar", ["groovy-dateutil-${groovyVersion}-sources.jar"], [])
+        ideFileContainsEntry("groovy-groovydoc-${groovyVersion}.jar", ["groovy-groovydoc-${groovyVersion}-sources.jar"], [])
+        ideFileContainsEntry("groovy-json-${groovyVersion}.jar", ["groovy-json-${groovyVersion}-sources.jar"], [])
+        ideFileContainsEntry("groovy-nio-${groovyVersion}.jar", ["groovy-nio-${groovyVersion}-sources.jar"], [])
+        ideFileContainsEntry("groovy-sql-${groovyVersion}.jar", ["groovy-sql-${groovyVersion}-sources.jar"], [])
+        ideFileContainsEntry("groovy-templates-${groovyVersion}.jar", ["groovy-templates-${groovyVersion}-sources.jar"], [])
+        ideFileContainsEntry("groovy-test-${groovyVersion}.jar", ["groovy-test-${groovyVersion}-sources.jar"], [])
+        ideFileContainsEntry("groovy-xml-${groovyVersion}.jar", ["groovy-xml-${groovyVersion}-sources.jar"], [])
+    }
+
+    @ToBeFixedForConfigurationCache
+    @Requires(UnitTestPreconditions.StableGroovy) // localGroovy() version cannot be swapped-out when a snapshot Groovy build is used
     def "sources for localGroovy() are downloaded and attached when using gradleApi()"() {
         given:
         def repo = givenGroovyExistsInGradleRepo()

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
@@ -94,6 +94,9 @@ import java.util.Set;
  *
  *     //customizing which dependencies should be marked as test on the project's classpath
  *     testConfigurations = [configurations.testCompileClasspath, configurations.testRuntimeClasspath]
+ *
+ *     //Override the default Gradle Libs repository default which is set to "https://repo.gradle.org/gradle/list/libs-releases
+ *     gradleLibsRepoOverride = "https://myorg.mavenreposiotory.org"
  *   }
  * }
  * </pre>
@@ -159,6 +162,8 @@ public abstract class EclipseClasspath {
     private boolean projectDependenciesOnly;
 
     private List<File> classFolders;
+
+    private String gradleLibsRepoOverride;
 
     private final org.gradle.api.Project project;
 
@@ -311,6 +316,14 @@ public abstract class EclipseClasspath {
         this.classFolders = classFolders;
     }
 
+    public String getGradleLibsRepoOverride() {
+        return gradleLibsRepoOverride;
+    }
+
+    public void setGradleLibsRepoOverride(String gradleLibsRepoOverride) {
+        this.gradleLibsRepoOverride = gradleLibsRepoOverride;
+    }
+
     public org.gradle.api.Project getProject() {
         return project;
     }
@@ -357,7 +370,7 @@ public abstract class EclipseClasspath {
     public List<ClasspathEntry> resolveDependencies() {
         ProjectInternal projectInternal = (ProjectInternal) this.project;
         IdeArtifactRegistry ideArtifactRegistry = projectInternal.getServices().get(IdeArtifactRegistry.class);
-        ClasspathFactory classpathFactory = new ClasspathFactory(this, ideArtifactRegistry, new DefaultGradleApiSourcesResolver(projectInternal.newDetachedResolver()), EclipseClassPathUtil.isInferModulePath(this.project));
+        ClasspathFactory classpathFactory = new ClasspathFactory(this, ideArtifactRegistry, new DefaultGradleApiSourcesResolver(projectInternal.newDetachedResolver(), gradleLibsRepoOverride), EclipseClassPathUtil.isInferModulePath(this.project));
         return classpathFactory.createEntries();
     }
 
@@ -423,4 +436,5 @@ public abstract class EclipseClasspath {
     public SetProperty<Configuration> getTestConfigurations() {
         return testConfigurations;
     }
+
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/DefaultGradleApiSourcesResolver.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/DefaultGradleApiSourcesResolver.java
@@ -40,9 +40,11 @@ public class DefaultGradleApiSourcesResolver implements GradleApiSourcesResolver
     private static final Pattern FILE_NAME_PATTERN = Pattern.compile("(groovy(-.+?)?)-(\\d.+?)\\.jar");
 
     private final DetachedResolver resolver;
+    private final String gradleLibsRepoOverride;
 
-    public DefaultGradleApiSourcesResolver(DetachedResolver resolver) {
+    public DefaultGradleApiSourcesResolver(DetachedResolver resolver, String gradleLibsRepoOverride) {
         this.resolver = resolver;
+        this.gradleLibsRepoOverride = gradleLibsRepoOverride;
         addGradleLibsRepository();
     }
 
@@ -80,8 +82,13 @@ public class DefaultGradleApiSourcesResolver implements GradleApiSourcesResolver
         });
     }
 
-    private static String gradleLibsRepoUrl() {
-        String repoOverride = System.getenv(GRADLE_LIBS_REPO_OVERRIDE_VAR);
-        return repoOverride != null ? repoOverride : GRADLE_LIBS_REPO_URL;
+    private String gradleLibsRepoUrl() {
+        if(gradleLibsRepoOverride != null) {
+            return gradleLibsRepoOverride;
+        } else {
+            String repoOverride = System.getenv(GRADLE_LIBS_REPO_OVERRIDE_VAR);
+            return repoOverride != null ? repoOverride : GRADLE_LIBS_REPO_URL;
+        }
+
     }
 }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #25840 , #18249

### Context

Currently IDEs downloads Gradle sources from a hardcoded repository https://repo.gradle.org/gradle/list/libs-releases. 

This url is blocked by our proxy. This results in a very poor developer experience when trying to import the project into the ide. Intellij keeps trying to download Gradle sources from this url for a lot of time and project import never finishes. The issue is also very confusing at first glance because developers think that something is wrong with maven repositories defined for the project. 

There is a workaround of adding an environment variable for this url; but quoting from #25840 

> This[workaround] is great for an individual but hard for teams. In an environment of hundreds or thousands of engineers we'd have to make a large announcement, hope they apply the workaround, etc. This is pretty expensive and results aren't very durable for new people joining a team, machine upgrades, etc

This PR allows a build author to specify a Gradle sources repository url using the `idea` or `eclipse` plugins.



### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
