### PR TITLE
Fix repeated dynamic invocations not intercepted in Groovy

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentedClosuresTracker.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentedClosuresTracker.java
@@ -24,8 +24,8 @@ import org.gradle.api.NonNullApi;
  * right before it leaves the call stack. <p>
  *
  * {@link InstrumentedClosuresTracker#hitInstrumentedDynamicCall} is invoked by the instrumentation infrastructure on every invocation that is dynamically dispatched
- * to the current closures chain. The implementation must ensure that all the closures in the scope are processed in a way that ensures call interception if a call
- * is dispatched to them.
+ * to the current closures chain and can potentially be intercepted. The implementation must ensure that all the closures in the scope are processed in a way that
+ * ensures call interception if a call is dispatched to them.
  */
 @NonNullApi
 public interface InstrumentedClosuresTracker {


### PR DESCRIPTION
The default Groovy implementation that decorated call sites would delegate to replaces the call site array entries, thus removing the intercepting call sites from the code path.

Fix this by writing the decorated call site references back to the call site array.

<!--- The issue this PR addresses -->
Fixes https://github.com/gradle/gradle/issues/26053
