### PR TITLE
Remove location information from Problem data structures

### DIFF
--- a/subprojects/build-events/src/main/java/org/gradle/internal/build/event/types/DefaultProblemEvent.java
+++ b/subprojects/build-events/src/main/java/org/gradle/internal/build/event/types/DefaultProblemEvent.java
@@ -34,9 +34,6 @@ public class DefaultProblemEvent extends AbstractProgressEvent<InternalProblemDe
     private String description;
     private List<String> solutions;
     private Throwable cause;
-    private Integer line;
-    private Integer column;
-    private String path;
     private String problemType;
     private Map<String, String> additionalData;
 
@@ -45,9 +42,6 @@ public class DefaultProblemEvent extends AbstractProgressEvent<InternalProblemDe
         String problemId,
         String message,
         String severity,
-        @Nullable String path,
-        @Nullable Integer line,
-        @Nullable Integer column,
         @Nullable String docLink,
         @Nullable String description,
         List<String> solutions,
@@ -59,9 +53,6 @@ public class DefaultProblemEvent extends AbstractProgressEvent<InternalProblemDe
         this.problemId = problemId;
         this.message = message;
         this.severity = severity;
-        this.path = path;
-        this.line = line;
-        this.column = column;
         this.docLink = docLink;
         this.description = description;
         this.solutions = solutions;
@@ -89,24 +80,6 @@ public class DefaultProblemEvent extends AbstractProgressEvent<InternalProblemDe
     @Override
     public String getSeverity() {
         return severity;
-    }
-
-    @Nullable
-    @Override
-    public String getPath() {
-        return path;
-    }
-
-    @Nullable
-    @Override
-    public Integer getLine() {
-        return line;
-    }
-
-    @Nullable
-    @Override
-    public Integer getColumn() {
-        return column;
     }
 
     @Nullable

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ProblemsProgressEventConsumer.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ProblemsProgressEventConsumer.java
@@ -21,7 +21,6 @@ import com.google.common.collect.HashBiMap;
 import org.gradle.api.NonNullApi;
 import org.gradle.api.problems.interfaces.DocLink;
 import org.gradle.api.problems.interfaces.Problem;
-import org.gradle.api.problems.interfaces.ProblemLocation;
 import org.gradle.internal.build.event.types.DefaultProblemDescriptor;
 import org.gradle.internal.build.event.types.DefaultProblemEvent;
 import org.gradle.internal.operations.BuildOperationDescriptor;
@@ -57,15 +56,11 @@ public class ProblemsProgressEventConsumer extends ClientForwardingBuildOperatio
             seenProblems.put(problemCause, buildOperationId);
 
             DefaultProblemDescriptor descriptor = new DefaultProblemDescriptor(new OperationIdentifier(idFactory.nextId()), buildOperationId);
-            ProblemLocation where = problem.getWhere();
             DefaultProblemEvent event = new DefaultProblemEvent(
                 descriptor,
                 problem.getProblemGroup().toString(),
                 problem.getMessage(),
                 problem.getSeverity().toString(),
-                where == null ? null : where.getPath(),
-                where == null ? null : where.getLine(),
-                where == null ? null : where.getColumn(),
                 getDocumentationFor(problem),
                 problem.getDescription(),
                 problem.getSolutions(),

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r83/ProblemProgressEventCrossVersionTest.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r83/ProblemProgressEventCrossVersionTest.groovy
@@ -41,7 +41,7 @@ class ProblemProgressEventCrossVersionTest extends ToolingApiSpecification {
         }
     }
 
-    def "Test failure context"() {
+    def "test failure context"() {
         setup:
         buildFile << """
             plugins {
@@ -70,33 +70,8 @@ class ProblemProgressEventCrossVersionTest extends ToolingApiSpecification {
         def problems = listener.allProblems
         problems.size() == 2
         problems[0].message.contains('The RepositoryHandler.jcenter() method has been deprecated.')
-//        (problems[0].rawAttributes['doc'] as String).contains('https://docs.gradle.org/')
         problems[0].severity == Severity.WARNING.toString()
         problems[1].message.contains("Cannot locate tasks that match ':ba' as task 'ba' is ambiguous in root project")
         problems[1].severity == Severity.ERROR.toString()
-    }
-
-    def "Test line number"() {
-        setup:
-        buildFile << """
-            plugins {
-                repositories.mavenCentral()
-            }
-        """
-
-
-        when:
-        def listener = new MyProgressListener()
-        withConnection { connection ->
-            connection.newBuild().forTasks(":help").addProgressListener(listener).run()
-        }
-
-        then:
-        thrown(BuildException)
-        def problems = listener.allProblems
-        problems[0].message.contains('Could not compile build file')
-        problems[0].severity == Severity.ERROR.toString()
-        problems[0].path.endsWith('build.gradle')
-        problems[0].line == 3
     }
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/problems/ProblemDescriptor.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/problems/ProblemDescriptor.java
@@ -37,15 +37,6 @@ public interface ProblemDescriptor extends OperationDescriptor {
     String getSeverity();
 
     @Nullable
-    String getPath();
-
-    @Nullable
-    Integer getLine();
-
-    @Nullable
-    Integer getColumn();
-
-    @Nullable
     String getDocumentationLink();
 
     @Nullable

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/problems/internal/DefaultProblemsOperationDescriptor.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/problems/internal/DefaultProblemsOperationDescriptor.java
@@ -33,12 +33,6 @@ public class DefaultProblemsOperationDescriptor extends DefaultOperationDescript
     private final String message;
     private final String description;
     private final List<String> solutions;
-    @Nullable
-    private final String path;
-    @Nullable
-    private final Integer line;
-    @Nullable
-    private final Integer column;
     private final String documentationLink;
     private final Throwable cause;
     private final String problemType;
@@ -52,9 +46,6 @@ public class DefaultProblemsOperationDescriptor extends DefaultOperationDescript
         String message,
         @Nullable String description,
         List<String> solutions,
-        @Nullable String path,
-        @Nullable Integer line,
-        @Nullable Integer column,
         @Nullable String documentationLink,
         @Nullable Throwable cause,
         String problemType,
@@ -66,9 +57,6 @@ public class DefaultProblemsOperationDescriptor extends DefaultOperationDescript
         this.message = message;
         this.description = description;
         this.solutions = solutions;
-        this.path = path;
-        this.line = line;
-        this.column = column;
         this.documentationLink = documentationLink;
         this.cause = cause;
         this.problemType = problemType;
@@ -116,24 +104,6 @@ public class DefaultProblemsOperationDescriptor extends DefaultOperationDescript
     @Override
     public String getProblemType() {
         return problemType;
-    }
-
-    @Nullable
-    @Override
-    public Integer getLine() {
-        return line;
-    }
-
-    @Nullable
-    @Override
-    public Integer getColumn() {
-        return column;
-    }
-
-    @Nullable
-    @Override
-    public String getPath() {
-        return path;
     }
 
     @Override

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/parameters/BuildProgressListenerAdapter.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/parameters/BuildProgressListenerAdapter.java
@@ -680,9 +680,19 @@ public class BuildProgressListenerAdapter implements InternalBuildProgressListen
 
     private ProblemDescriptor toProblemDescriptor(InternalProblemEvent progressEvent, InternalProblemDescriptor descriptor) {
         OperationDescriptor parent = getParentDescriptor(descriptor.getParentId());
-        return new DefaultProblemsOperationDescriptor(descriptor, parent, progressEvent.getProblemGroup(), progressEvent.getSeverity(),
-            progressEvent.getMessage(), progressEvent.getDescription(), progressEvent.getSolutions(), progressEvent.getPath(),
-            progressEvent.getLine(), progressEvent.getColumn(), progressEvent.getDocumentationLink(), progressEvent.getCause(), progressEvent.getProblemType(), progressEvent.getAdditionalData());
+        return new DefaultProblemsOperationDescriptor(
+            descriptor,
+            parent,
+            progressEvent.getProblemGroup(),
+            progressEvent.getSeverity(),
+            progressEvent.getMessage(),
+            progressEvent.getDescription(),
+            progressEvent.getSolutions(),
+            progressEvent.getDocumentationLink(),
+            progressEvent.getCause(),
+            progressEvent.getProblemType(),
+            progressEvent.getAdditionalData()
+        );
     }
 
     private Set<OperationDescriptor> collectDescriptors(Set<? extends InternalOperationDescriptor> dependencies) {

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/InternalProblemEvent.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/InternalProblemEvent.java
@@ -37,15 +37,6 @@ public interface InternalProblemEvent extends InternalProgressEvent {
     String getSeverity();
 
     @Nullable
-    String getPath();
-
-    @Nullable
-    Integer getLine();
-
-    @Nullable
-    Integer getColumn();
-
-    @Nullable
     String getDocumentationLink();
 
     @Nullable


### PR DESCRIPTION
As discussed, we should remove the problem location from the TAPI.
I've cut deeper than the TAPI, as it's apparent that we will have to rethink this from the start.

The only place, where I've still decided to keep the location is the builder, as we would need to:
 - Delete all the references
 - And with that, loose all the already passed data references