### PR TITLE
Fix flaky JavaCompileParallelIntegrationTest

### DIFF
--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileParallelIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileParallelIntegrationTest.groovy
@@ -35,7 +35,7 @@ class JavaCompileParallelIntegrationTest extends AbstractIntegrationSpec {
     static Map<JavaInfo, JavaVersion> availableJdksWithJavac() {
         AvailableJavaHomes.availableJdksWithVersion.findAll { jdk, version ->
             try {
-                if (jdk.javacExecutable) {
+                if (jdk.javacExecutable && version >= JavaVersion.VERSION_1_8) {
                     return true
                 }
             }


### PR DESCRIPTION
This is a really old test that uses JDK 6 for test in some cases. JDK 6 is sometimes broken on build agents (unfortunately we don't know why yet), so let's simply use JDK>8 because the test doesn't care which JDK version is used.

Failure history:

https://ge.gradle.org/scans/tests?search.relativeStartTime=P90D&search.timeZoneId=Asia/Shanghai&tests.container=org.gradle.api.tasks.compile.JavaCompileParallelIntegrationTest&tests.test=system%20property%20java.home%20is%20not%20modified%20across%20compile%20task%20boundaries