### PR TITLE
Replace LGPL licensed Checkstyle XSLT with Apache licensed version

### DIFF
--- a/platforms/jvm/code-quality/build.gradle.kts
+++ b/platforms/jvm/code-quality/build.gradle.kts
@@ -57,6 +57,9 @@ dependencies {
     integTestDistributionRuntimeOnly(project(":distributions-full"))
 
     integTestImplementation(testFixtures(project(":language-groovy")))
+    integTestImplementation(libs.jsoup) {
+        because("We need to validate generated HTML reports")
+    }
 }
 
 packageCycles {

--- a/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginHtmlReportIntegrationTest.groovy
+++ b/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginHtmlReportIntegrationTest.groovy
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.plugins.quality.checkstyle
+
+
+import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
+import org.gradle.integtests.fixtures.TargetCoverage
+import org.gradle.quality.integtest.fixtures.CheckstyleCoverage
+import org.gradle.util.internal.VersionNumber
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.nodes.Element
+
+@TargetCoverage({ CheckstyleCoverage.getSupportedVersionsByJdk() })
+class CheckstylePluginHtmlReportIntegrationTest extends MultiVersionIntegrationSpec {
+    def setup() {
+        file("build.gradle") << """
+plugins {
+    id 'java-library'
+    id 'checkstyle'
+}
+
+${mavenCentralRepository()}
+
+checkstyle {
+    toolVersion = '$version'
+}
+        """
+        def nameOfCheck = "JavadocMethod"
+        if (versionNumber >= VersionNumber.parse('8.21')) {
+            nameOfCheck = "MissingJavadocMethod"
+        }
+        file("config/checkstyle/checkstyle.xml") << """
+<!DOCTYPE module PUBLIC
+          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="$nameOfCheck"/>
+    </module>
+</module>
+        """
+    }
+
+    private void goodCode() {
+        file("src/main/java/com/example/Foo.java").java """
+            package com.example;
+
+            public class Foo {
+                /**
+                 * This returns a bar.
+                 *
+                 * @return return the bar
+                 */
+                public String getBar() {
+                    return "bar";
+                }
+            }
+        """
+        file("src/main/java/com/example/Bar.java").java """
+            package com.example;
+
+            public class Bar {
+                /**
+                 * This returns a bar.
+                 *
+                 * @return return the bar
+                 */
+                public String getBar() {
+                    return "bar";
+                }
+            }
+        """
+        file("src/main/java/com/example/Baz.java").java """
+            package com.example;
+
+            public class Baz {
+                /**
+                 * This returns a bar.
+                 *
+                 * @return return the bar
+                 */
+                public String getBar() {
+                    return "bar";
+                }
+            }
+        """
+    }
+
+    private void badCode() {
+        file("src/main/java/com/example/Foo.java").java """
+            package com.example;
+
+            public class Foo {
+                public String getBar() {
+                    return "bar";
+                }
+                public String getBar2() {
+                    return "bar";
+                }
+                public String getBar3() {
+                    return "bar";
+                }
+            }
+        """
+        file("src/main/java/com/example/Bar.java").java """
+            package com.example;
+
+            public class Bar {
+                public String getBar() {
+                    return "bar";
+                }
+            }
+        """
+        file("src/main/java/com/example/Baz.java").java """
+            package com.example;
+
+            public class Baz {
+                /**
+                 * This returns a bar.
+                 *
+                 * @return return the bar
+                 */
+                public String getBar() {
+                    return "bar";
+                }
+            }
+        """
+    }
+
+    def "generates HTML report with good code"() {
+        goodCode()
+        when:
+        succeeds("checkstyleMain")
+        then:
+        def html = parseReport()
+        def head = html.selectFirst("head")
+        // Title of report is Checkstyle Violations
+        head.select("title").text() == "Checkstyle Violations"
+        // Has some CSS styling
+        head.select("style").size() == 1
+        def body = html.selectFirst("body")
+        def summaryTable = parseTable(body.selectFirst(".summary"))
+        summaryTable[0] == ["Total files checked", "Total violations", "Files with violations"]
+        summaryTable[1] == ["3", "0", "0"]
+
+        // Good code produces no violations
+        body.select(".filelist").size() == 0
+        def violations = body.selectFirst(".violations")
+        violations.selectFirst("p").text() == "No violations were found."
+        violations.select(".file-violation").size() == 0
+    }
+
+    def "generates HTML report with bad code"() {
+        badCode()
+        when:
+        fails("checkstyleMain")
+        then:
+        def html = parseReport()
+        def body = html.selectFirst("body")
+        def summaryTable = parseTable(body.selectFirst(".summary"))
+        summaryTable[1] == ["3", "4", "2"]
+
+        // Bad code produces violations in Foo.java and Bar.java, but not Baz.java
+        def fileList = parseTable(body.selectFirst(".filelist"))
+        fileList[0] == ["File", "Total violations"]
+        fileList[1][0].endsWith("Foo.java")
+        fileList[1][1] == "3"
+        fileList[2][0].endsWith("Bar.java")
+        fileList[2][1] == "1"
+
+        def violations = body.selectFirst(".violations")
+        def fileViolations = violations.select(".file-violation")
+        fileViolations.size() == 2
+
+        // Bar.java violations
+        fileViolations[0].selectFirst("h3").text().endsWith("Bar.java")
+        def barViolations = parseTable(fileViolations[0].selectFirst(".violationlist"))
+        barViolations[0] == ["Severity", "Description", "Line Number"]
+        barViolations[1] == ["error", "Missing a Javadoc comment.", "5"]
+
+        // Foo.java violations
+        fileViolations[1].selectFirst("h3").text().endsWith("Foo.java")
+
+        def fooViolations = parseTable(fileViolations[1].selectFirst(".violationlist"))
+        fooViolations[0] == ["Severity", "Description", "Line Number"]
+        fooViolations[1] == ["error", "Missing a Javadoc comment.", "5"]
+        fooViolations[2] == ["error", "Missing a Javadoc comment.", "8"]
+        fooViolations[3] == ["error", "Missing a Javadoc comment.", "11"]
+
+        // Sanity check that the anchor link is correct
+        def fooAnchorLink = body.selectXpath('//table[@class="filelist"]//tr[2]/td/a').attr("href")
+        def fooAnchorName = "#" + fileViolations[1].selectFirst("a").attr("name")
+        fooAnchorName == fooAnchorLink
+    }
+
+    private Document parseReport() {
+        def htmlReport = file("build/reports/checkstyle/main.html")
+        htmlReport.assertExists()
+        return Jsoup.parse(htmlReport)
+    }
+
+    /**
+     * Parse a HTML table into a list of lists.
+     * @param table
+     * @return each element in the list represents a list of column values for a row.
+     */
+    private List<List<String>> parseTable(Element table) {
+        def result = []
+        def rows = table.select("tr")
+        rows.each {row ->
+            def rowResult = []
+            def cols = row.select("td")
+            if (cols.isEmpty()) {
+                cols = row.select("th")
+            }
+            cols.each {col ->
+                rowResult << col.text()
+            }
+            result << rowResult
+        }
+        return result
+    }
+}

--- a/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginMultiProjectTest.groovy
+++ b/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginMultiProjectTest.groovy
@@ -33,7 +33,7 @@ class CheckstylePluginMultiProjectTest extends AbstractIntegrationSpec {
 
         expect:
         succeeds('checkstyleMain')
-        checkStyleReportFile(testDirectory).text.contains('Dummy.java')
+        checkStyleReportFile(testDirectory).assertExists()
     }
 
     def "fails when root project does contain config in default location"() {
@@ -57,7 +57,7 @@ class CheckstylePluginMultiProjectTest extends AbstractIntegrationSpec {
 
         expect:
         succeeds(':child:grand:checkstyleMain')
-        checkStyleReportFile(file('child/grand')).text.contains('Dummy.java')
+        checkStyleReportFile(file('child/grand')).assertExists()
     }
 
     def "configures checkstyle extension to read config from root project in a deeply nested multi-project build"() {
@@ -69,7 +69,7 @@ class CheckstylePluginMultiProjectTest extends AbstractIntegrationSpec {
 
         expect:
         succeeds(':a:b:c:checkstyleMain')
-        checkStyleReportFile(file('a/b/c')).text.contains('Dummy.java')
+        checkStyleReportFile(file('a/b/c')).assertExists()
     }
 
     def "configures checkstyle extension to read config from root project in a multi-project build even if sub project config is available"() {
@@ -82,7 +82,7 @@ class CheckstylePluginMultiProjectTest extends AbstractIntegrationSpec {
 
         expect:
         succeeds(':child:grand:checkstyleMain')
-        checkStyleReportFile(file('child/grand')).text.contains('Dummy.java')
+        checkStyleReportFile(file('child/grand')).assertExists()
     }
 
     def "explicitly configures checkstyle extension to point to config directory"() {
@@ -99,7 +99,7 @@ class CheckstylePluginMultiProjectTest extends AbstractIntegrationSpec {
 
         expect:
         succeeds(':child:checkstyleMain')
-        checkStyleReportFile(file('child')).text.contains('Dummy.java')
+        checkStyleReportFile(file('child')).assertExists()
     }
 
     static String simpleCheckStyleConfig() {

--- a/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginToolchainsIntegrationTest.groovy
+++ b/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginToolchainsIntegrationTest.groovy
@@ -159,8 +159,7 @@ class CheckstylePluginToolchainsIntegrationTest extends MultiVersionIntegrationS
         file("build/reports/checkstyle/main.xml").assertContents(containsClass("org.gradle.Class1"))
         file("build/reports/checkstyle/main.xml").assertContents(containsClass("org.gradle.Class2"))
 
-        file("build/reports/checkstyle/main.html").assertContents(containsClass("org.gradle.Class1"))
-        file("build/reports/checkstyle/main.html").assertContents(containsClass("org.gradle.Class2"))
+        file("build/reports/checkstyle/main.html").assertExists()
     }
 
     def "analyze bad code with the toolchain JDK"() {

--- a/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginVersionIntegrationTest.groovy
+++ b/platforms/jvm/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginVersionIntegrationTest.groovy
@@ -31,6 +31,7 @@ import spock.lang.IgnoreIf
 import spock.lang.Issue
 
 import static org.gradle.util.Matchers.containsLine
+import static org.gradle.util.Matchers.containsText
 import static org.gradle.util.internal.TextUtil.normaliseFileSeparators
 import static org.hamcrest.CoreMatchers.containsString
 import static org.hamcrest.CoreMatchers.startsWith
@@ -57,10 +58,8 @@ class CheckstylePluginVersionIntegrationTest extends MultiVersionIntegrationSpec
         file("build/reports/checkstyle/test.xml").assertContents(containsClass("org.gradle.TestClass1"))
         file("build/reports/checkstyle/test.xml").assertContents(containsClass("org.gradle.TestClass2"))
 
-        file("build/reports/checkstyle/main.html").assertContents(containsClass("org.gradle.Class1"))
-        file("build/reports/checkstyle/main.html").assertContents(containsClass("org.gradle.Class2"))
-        file("build/reports/checkstyle/test.html").assertContents(containsClass("org.gradle.TestClass1"))
-        file("build/reports/checkstyle/test.html").assertContents(containsClass("org.gradle.TestClass2"))
+        file("build/reports/checkstyle/main.html").assertExists()
+        file("build/reports/checkstyle/main.html").assertContents(containsText("No violations were found."))
     }
 
     def "supports fallback when configDirectory does not exist"() {

--- a/platforms/jvm/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/CheckstyleInvoker.groovy
+++ b/platforms/jvm/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/CheckstyleInvoker.groovy
@@ -25,6 +25,7 @@ import org.gradle.api.internal.exceptions.MarkedVerificationException
 import org.gradle.api.internal.project.antbuilder.AntBuilderDelegate
 import org.gradle.api.plugins.quality.Checkstyle
 import org.gradle.internal.logging.ConsoleRenderer
+import org.gradle.util.GradleVersion
 import org.gradle.util.internal.GFileUtils
 import org.gradle.util.internal.VersionNumber
 import org.slf4j.Logger
@@ -119,6 +120,7 @@ class CheckstyleInvoker implements Action<AntBuilderDelegate> {
                 ? stylesheetString.get()
                 : Checkstyle.getClassLoader().getResourceAsStream('checkstyle-noframes-sorted.xsl').text
             ant.xslt(in: xmlOutputLocation, out: htmlOutputLocation) {
+                param(name: "gradleVersion", expression: GradleVersion.current().toString())
                 style {
                     string(value: stylesheet)
                 }

--- a/platforms/jvm/code-quality/src/main/resources/checkstyle-noframes-sorted.xsl
+++ b/platforms/jvm/code-quality/src/main/resources/checkstyle-noframes-sorted.xsl
@@ -104,7 +104,7 @@
                                     <xsl:for-each select="file[error]">
                                         <!-- sort by number of errors and then alphabetically -->
                                         <xsl:sort data-type="number" order="descending" select="count(descendant::error)"/>
-                                        <xsl:sort select="name"/>
+                                        <xsl:sort select="@name"/>
                                         <xsl:variable name="errors" select="count(descendant::error)"/>
                                         <tr>
                                             <td><a href="#{generate-id(@name)}"><xsl:value-of select="@name"/></a></td>
@@ -113,7 +113,10 @@
                                     </xsl:for-each>
                                 </table>
                                 <p/>
-                                <xsl:apply-templates/>
+                                <xsl:apply-templates>
+                                    <!-- sort entries by file name alphabetically -->
+                                    <xsl:sort select="@name"/>
+                                </xsl:apply-templates>
                                 <p/>
                             </xsl:when>
                             <xsl:otherwise>

--- a/platforms/jvm/code-quality/src/main/resources/checkstyle-noframes-sorted.xsl
+++ b/platforms/jvm/code-quality/src/main/resources/checkstyle-noframes-sorted.xsl
@@ -1,4 +1,4 @@
-<xsl:stylesheet	xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+<?xml version="1.0"?>
 <!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
@@ -15,179 +15,152 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 -->
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xl="http://www.w3.org/1999/XSL/Transform">
+    <xsl:output method="html" indent="yes"/>
+    <xsl:param name="gradleVersion"/>
 
-<xsl:output method="html" indent="yes"/>
-<xsl:decimal-format decimal-separator="." grouping-separator="," />
+    <xsl:decimal-format decimal-separator="." grouping-separator="," />
 
-<xsl:key name="files" match="file" use="@name" />
+    <xsl:template match="checkstyle">
+        <html>
+            <head>
+                <title>Checkstyle Violations</title>
+                <!-- vaguely adapted from Gradle's CSS -->
+                <style type="text/css">
+                    body {
+                        background-color: #fff;
+                        color: #02303A;
+                    }
 
-<!-- Checkstyle XML Style Sheet by Stephane Bailliez <sbailliez@apache.org>         -->
-<!-- Part of the Checkstyle distribution found at http://checkstyle.sourceforge.net -->
-<!-- UsageContext (generates checkstyle_report.html):                                      -->
-<!--    <checkstyle failonviolation="false" config="${check.config}">               -->
-<!--      <fileset dir="${src.dir}" includes="**/*.java"/>                          -->
-<!--      <formatter type="xml" toFile="${doc.dir}/checkstyle_report.xml"/>         -->
-<!--    </checkstyle>                                                               -->
-<!--    <style basedir="${doc.dir}" destdir="${doc.dir}"                            -->
-<!--            includes="checkstyle_report.xml"                                    -->
-<!--            style="${doc.dir}/checkstyle-noframes-sorted.xsl"/>                 -->
+                    a {
+                        color: #1DA2BD;
+                    }
+                    a.link {
+                        color: #02303A;
+                    }
 
-<xsl:template match="checkstyle">
-	<html>
-		<head>
-		<style type="text/css">
-    .bannercell {
-      border: 0px;
-      padding: 0px;
-    }
-    body {
-      margin-left: 10;
-      margin-right: 10;
-      font:normal 80% arial,helvetica,sanserif;
-      background-color:#FFFFFF;
-      color:#000000;
-    }
-    .a td {
-      background: #efefef;
-    }
-    .b td {
-      background: #fff;
-    }
-    th, td {
-      text-align: left;
-      vertical-align: top;
-    }
-    th {
-      font-weight:bold;
-      background: #ccc;
-      color: black;
-    }
-    table, th, td {
-      font-size:100%;
-      border: none
-    }
-    table.log tr td, tr th {
+                    p {
+                        font-size: 1rem;
+                    }
 
-    }
-    h2 {
-      font-weight:bold;
-      font-size:140%;
-      margin-bottom: 5;
-    }
-    h3 {
-      font-size:100%;
-      font-weight:bold;
-      background: #525D76;
-      color: white;
-      text-decoration: none;
-      padding: 5px;
-      margin-right: 2px;
-      margin-left: 2px;
-      margin-bottom: 0;
-    }
-		</style>
-		</head>
-		<body>
-			<a name="top"></a>
-      <!-- jakarta logo -->
-      <table border="0" cellpadding="0" cellspacing="0" width="100%">
-      <tr>
-        <td class="bannercell" rowspan="2">
-          <!--a href="http://jakarta.apache.org/">
-          <img src="http://jakarta.apache.org/images/jakarta-logo.gif" alt="http://jakarta.apache.org" align="left" border="0"/>
-          </a-->
-        </td>
-    		<td class="text-align:right"><h2>CheckStyle Audit</h2></td>
-    		</tr>
-    		<tr>
-    		<td class="text-align:right">Designed for use with <a href='http://checkstyle.sourceforge.net/'>CheckStyle</a> and <a href='http://jakarta.apache.org'>Ant</a>.</td>
-    		</tr>
-      </table>
-    	<hr size="1"/>
+                    h1 a[name] {
+                        margin: 0;
+                        padding: 0;
+                    }
 
-			<!-- Summary part -->
-			<xsl:apply-templates select="." mode="summary"/>
-			<hr size="1" width="100%" align="left"/>
+                    tr:nth-child(even) {
+                        background: white;
+                    }
 
-			<!-- Package List part -->
-			<xsl:apply-templates select="." mode="filelist"/>
-			<hr size="1" width="100%" align="left"/>
+                    th {
+                        font-weight:bold;
+                    }
+                    tr {
+                        background: #efefef;
+                    }
+                    table th, td, tr {
+                        font-size:100%;
+                        border: none;
+                        text-align: left;
+                        vertical-align: top;
+                    }
+                </style>
+            </head>
+            <body>
+                <p>
+                    <a name="top"><h1>Checkstyle Results</h1></a>
+                </p>
+                <hr align="left" width="95%" size="1"/>
+                <h2>Summary</h2>
+                <table class="summary" width="95%" >
+                    <tr>
+                        <th>Total files checked</th>
+                        <th>Total violations</th>
+                        <th>Files with violations</th>
+                    </tr>
+                    <tr>
+                        <td>
+                            <xsl:number level="any" value="count(descendant::file)"/>
+                        </td>
+                        <td>
+                            <xsl:number level="any" value="count(descendant::error)"/>
+                        </td>
+                        <td>
+                            <xsl:number level="any" value="count(descendant::file[error])"/>
+                        </td>
+                    </tr>
+                </table>
+                <hr align="left" width="95%" size="1"/>
+                <div class="violations">
+                    <h2>Violations</h2>
+                    <p>
+                        <xsl:choose>
+                            <xsl:when test="count(descendant::error) > 0">
+                                <table class="filelist" width="95%">
+                                    <tr>
+                                        <th>File</th>
+                                        <th>Total violations</th>
+                                    </tr>
+                                    <xsl:for-each select="file[error]">
+                                        <!-- sort by number of errors and then alphabetically -->
+                                        <xsl:sort data-type="number" order="descending" select="count(descendant::error)"/>
+                                        <xsl:sort select="name"/>
+                                        <xsl:variable name="errors" select="count(descendant::error)"/>
+                                        <tr>
+                                            <td><a href="#{generate-id(@name)}"><xsl:value-of select="@name"/></a></td>
+                                            <td><xsl:value-of select="$errors"/></td>
+                                        </tr>
+                                    </xsl:for-each>
+                                </table>
+                                <p/>
+                                <xsl:apply-templates/>
+                                <p/>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                No violations were found.
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </p>
+                </div>
+                <hr align="left" width="95%" size="1"/>
+                <p>Generated by <a href="https://gradle.org"><xsl:value-of select="$gradleVersion"/></a> with <a href="https://checkstyle.sourceforge.io/">Checkstyle <xsl:value-of select="@version"/></a>.</p>
+            </body>
+        </html>
+    </xsl:template>
 
-			<!-- For each package create its part -->
-            <xsl:apply-templates select="file[@name and generate-id(.) = generate-id(key('files', @name))]" />
+    <!-- A single file with violations -->
+    <xsl:template match="file[error]">
+        <div class="file-violation">
+            <h3>
+                <a class="link" name="{generate-id(@name)}"><xsl:value-of select="@name"/></a>
+            </h3>
+            <table class="violationlist" width="95%">
+                <tr>
+                    <th>Severity</th>
+                    <th>Description</th>
+                    <th>Line Number</th>
+                </tr>
+                <xsl:apply-templates select="error"/>
+            </table>
+            <p/>
+            <a href="#top">Back to top</a>
+            <p/>
+        </div>
+    </xsl:template>
 
-			<hr size="1" width="100%" align="left"/>
+    <!-- A single row in the list of violations -->
+    <xsl:template match="error">
+        <tr>
+            <td>
+                <xsl:value-of select="@severity"/>
+            </td>
+            <td>
+                <xsl:value-of select="@message"/>
+            </td>
+            <td>
+                <xsl:value-of select="@line"/>
+            </td>
+        </tr>
+    </xsl:template>
 
-
-		</body>
-	</html>
-</xsl:template>
-
-
-
-	<xsl:template match="checkstyle" mode="filelist">
-		<h3>Files</h3>
-		<table class="log" border="0" cellpadding="5" cellspacing="2" width="100%">
-      <tr>
-        <th>Name</th>
-        <th>Errors</th>
-      </tr>
-          <xsl:for-each select="file[@name and generate-id(.) = generate-id(key('files', @name))]">
-                <xsl:sort data-type="number" order="descending" select="count(key('files', @name)/error)"/>
-				<xsl:variable name="errorCount" select="count(error)"/>
-				<tr>
-          <xsl:call-template name="alternated-row"/>
-					<td><a href="#f-{@name}"><xsl:value-of select="@name"/></a></td>
-					<td><xsl:value-of select="$errorCount"/></td>
-				</tr>
-			</xsl:for-each>
-		</table>
-	</xsl:template>
-
-
-	<xsl:template match="file">
-    <a name="f-{@name}"></a>
-    <h3>File <xsl:value-of select="@name"/></h3>
-
-    <table class="log" border="0" cellpadding="5" cellspacing="2" width="100%">
-    	<tr>
-    	  <th>Error Description</th>
-    	  <th>Line</th>
-      </tr>
-        <xsl:for-each select="key('files', @name)/error">
-          <xsl:sort data-type="number" order="ascending" select="@line"/>
-    	<tr>
-        <xsl:call-template name="alternated-row"/>
-    	  <td><xsl:value-of select="@message"/></td>
-    	  <td><xsl:value-of select="@line"/></td>
-    	</tr>
-    	</xsl:for-each>
-    </table>
-    <a href="#top">Back to top</a>
-	</xsl:template>
-
-
-	<xsl:template match="checkstyle" mode="summary">
-		<h3>Summary</h3>
-        <xsl:variable name="fileCount" select="count(file[@name and generate-id(.) = generate-id(key('files', @name))])"/>
-		<xsl:variable name="errorCount" select="count(file/error)"/>
-		<table class="log" border="0" cellpadding="5" cellspacing="2" width="100%">
-		<tr>
-			<th>Files</th>
-			<th>Errors</th>
-		</tr>
-		<tr>
-		  <xsl:call-template name="alternated-row"/>
-			<td><xsl:value-of select="$fileCount"/></td>
-			<td><xsl:value-of select="$errorCount"/></td>
-		</tr>
-		</table>
-	</xsl:template>
-
-  <xsl:template name="alternated-row">
-    <xsl:attribute name="class">
-      <xsl:if test="position() mod 2 = 1">a</xsl:if>
-      <xsl:if test="position() mod 2 = 0">b</xsl:if>
-    </xsl:attribute>
-  </xsl:template>
 </xsl:stylesheet>

--- a/platforms/jvm/code-quality/src/testFixtures/groovy/org/gradle/quality/integtest/fixtures/CheckstyleCoverage.groovy
+++ b/platforms/jvm/code-quality/src/testFixtures/groovy/org/gradle/quality/integtest/fixtures/CheckstyleCoverage.groovy
@@ -21,7 +21,7 @@ import org.gradle.api.plugins.quality.CheckstylePlugin
 import org.gradle.util.internal.VersionNumber
 
 class CheckstyleCoverage {
-    private final static List<String> JDK8_SUPPORTED = ['7.0', '7.6', '8.0', '8.12', '8.17', '8.24', CheckstylePlugin.DEFAULT_CHECKSTYLE_VERSION].asImmutable()
+    private final static List<String> JDK8_SUPPORTED = [CheckstylePlugin.DEFAULT_CHECKSTYLE_VERSION, '7.0', '7.6', '8.0', '8.12', '8.17', '8.24'].asImmutable()
     private final static List<String> JDK11_REQUIRED = ['10.3.3'].asImmutable()
     private final static List<String> ALL = JDK8_SUPPORTED + JDK11_REQUIRED
 


### PR DESCRIPTION
This change replaces the XSLT supplied with Gradle with one created by me under the Apache license.

The existing XSLT was identified as an Apache licensed file when it was checked into the Gradle codebase, but the origin of this file is from the a LGPL licensed Checkstyle contribution repository.

The report retains the same features:
- A summary
- A clickable file listing sorted by total error count
- A list of violations for each file

The styling was changed to mimic the Gradle documentation styling.

This retains the same file name on the off chance that something outside of Gradle relies on that name.

Fixes #18818 

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
