### PR TITLE
Do not emit build operation for non-planned transform step

### DIFF
--- a/subprojects/architecture-test/src/changes/archunit_store/internal-api-nullability.txt
+++ b/subprojects/architecture-test/src/changes/archunit_store/internal-api-nullability.txt
@@ -2705,6 +2705,7 @@ Class <org.gradle.internal.model.CalculatedModelValue> is not annotated (directl
 Class <org.gradle.internal.model.CalculatedValue> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (CalculatedValue.java:0)
 Class <org.gradle.internal.model.CalculatedValueContainer$CalculationState> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (CalculatedValueContainer.java:0)
 Class <org.gradle.internal.model.CalculatedValueContainer> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (CalculatedValueContainer.java:0)
+Class <org.gradle.internal.model.CalculatedValueContainerFactory$1> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (CalculatedValueContainerFactory.java:0)
 Class <org.gradle.internal.model.CalculatedValueContainerFactory$SupplierBackedCalculator> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (CalculatedValueContainerFactory.java:0)
 Class <org.gradle.internal.model.CalculatedValueContainerFactory> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (CalculatedValueContainerFactory.java:0)
 Class <org.gradle.internal.model.ModelContainer> is not annotated (directly or via its package) with @org.gradle.api.NonNullApi in (ModelContainer.java:0)

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/WorkNodeCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/WorkNodeCodec.kt
@@ -180,6 +180,7 @@ class WorkNodeCodec(
                     override fun <T : Any> getService(type: Class<T>): T {
                         return ownerService(type)
                     }
+                    override fun isGlobal() = true
                 })
                 successors = successors + setupNode.postExecutionNodes
             }

--- a/subprojects/core/src/main/java/org/gradle/execution/ProjectExecutionServiceRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/ProjectExecutionServiceRegistry.java
@@ -44,7 +44,17 @@ public class ProjectExecutionServiceRegistry implements AutoCloseable {
         });
 
     public ProjectExecutionServiceRegistry(ServiceRegistry globalServices) {
-        global = globalServices::get;
+        global = new NodeExecutionContext() {
+            @Override
+            public <T> T getService(Class<T> type) throws ServiceLookupException {
+                return globalServices.get(type);
+            }
+
+            @Override
+            public boolean isGlobal() {
+                return true;
+            }
+        };
     }
 
     public NodeExecutionContext forProject(@Nullable ProjectInternal project) {
@@ -69,6 +79,11 @@ public class ProjectExecutionServiceRegistry implements AutoCloseable {
         @Override
         public <T> T getService(Class<T> type) throws ServiceLookupException {
             return services.get(type);
+        }
+
+        @Override
+        public boolean isGlobal() {
+            return false;
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/model/CalculatedValueContainerFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/model/CalculatedValueContainerFactory.java
@@ -19,6 +19,7 @@ package org.gradle.internal.model;
 import org.gradle.api.internal.tasks.NodeExecutionContext;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.resources.ProjectLeaseRegistry;
+import org.gradle.internal.service.ServiceLookupException;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
@@ -32,7 +33,17 @@ public class CalculatedValueContainerFactory {
 
     public CalculatedValueContainerFactory(ProjectLeaseRegistry projectLeaseRegistry, ServiceRegistry buildScopeServices) {
         this.projectLeaseRegistry = projectLeaseRegistry;
-        this.globalContext = buildScopeServices::get;
+        this.globalContext = new NodeExecutionContext() {
+            @Override
+            public <T> T getService(Class<T> type) throws ServiceLookupException {
+                return buildScopeServices.get(type);
+            }
+
+            @Override
+            public boolean isGlobal() {
+                return true;
+            }
+        };
     }
 
     /**

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformStepNode.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformStepNode.java
@@ -244,7 +244,7 @@ public abstract class TransformStepNode extends CreationOrderedNode implements S
 
             @Override
             public TransformStepSubject calculateValue(NodeExecutionContext context) {
-                return buildOperationExecutor.call(new TransformStepBuildOperation() {
+                TransformStepBuildOperation buildOperation = new TransformStepBuildOperation() {
                     @Override
                     protected TransformStepSubject transform() {
                         TransformStepSubject initialSubject;
@@ -266,7 +266,12 @@ public abstract class TransformStepNode extends CreationOrderedNode implements S
                     protected String describeSubject() {
                         return artifact.getId().getDisplayName();
                     }
-                });
+                };
+                if (context.isGlobal()) {
+                    return buildOperation.transform();
+                } else {
+                    return buildOperationExecutor.call(buildOperation);
+                }
             }
         }
     }
@@ -322,7 +327,7 @@ public abstract class TransformStepNode extends CreationOrderedNode implements S
 
             @Override
             public TransformStepSubject calculateValue(NodeExecutionContext context) {
-                return buildOperationExecutor.call(new TransformStepBuildOperation() {
+                TransformStepBuildOperation buildOperation = new TransformStepBuildOperation(){
                     @Override
                     protected TransformStepSubject transform() {
                         return previousTransformStepNode.getTransformedSubject()
@@ -338,7 +343,12 @@ public abstract class TransformStepNode extends CreationOrderedNode implements S
                             .map(Describable::getDisplayName)
                             .getOrMapFailure(Throwable::getMessage);
                     }
-                });
+                };
+                if (context.isGlobal()) {
+                    return buildOperation.transform();
+                } else {
+                    return buildOperationExecutor.call(buildOperation);
+                }
             }
         }
     }

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformTestFixture.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformTestFixture.groovy
@@ -71,7 +71,7 @@ allprojects {
         implementation producer.output
     }
 
-    task resolve (type: ShowFileCollection) {
+    task resolve(type: ShowFileCollection) {
         def view = configurations.resolver.incoming.artifactView {
             attributes.attribute(color, 'green')
         }.files

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/AbstractConsoleBuildPhaseFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/AbstractConsoleBuildPhaseFunctionalTest.groovy
@@ -119,7 +119,7 @@ abstract class AbstractConsoleBuildPhaseFunctionalTest extends AbstractConsoleGr
         buildFinished.releaseAll()
 
         and:
-        gradle.waitForFinish()
+        waitForFinish()
     }
 
     @ToBeFixedForConfigurationCache(because = "build listener", skip = ToBeFixedForConfigurationCache.Skip.FAILS_TO_CLEANUP)
@@ -203,7 +203,7 @@ abstract class AbstractConsoleBuildPhaseFunctionalTest extends AbstractConsoleGr
         rootBuildFinished.releaseAll()
 
         and:
-        gradle.waitForFinish()
+        waitForFinish()
     }
 
     @ToBeFixedForConfigurationCache(because = "Gradle.buildFinished", skip = ToBeFixedForConfigurationCache.Skip.LONG_TIMEOUT)
@@ -285,12 +285,94 @@ abstract class AbstractConsoleBuildPhaseFunctionalTest extends AbstractConsoleGr
         rootBuildFinished.releaseAll()
 
         and:
-        gradle.waitForFinish()
+        waitForFinish()
     }
 
     @ToBeFixedForConfigurationCache(because = "Gradle.buildFinished", skip = ToBeFixedForConfigurationCache.Skip.LONG_TIMEOUT)
     def "shows progress bar and percent phase completion with artifact transforms"() {
         given:
+        setupTransformBuild()
+        def jar = server.expectAndBlock('jar')
+        def doubleTransform = server.expectAndBlock('double-transform')
+        def sizeTransform = server.expectAndBlock('size-transform')
+        def resolveTask = server.expectAndBlock('resolve-task')
+        def buildFinished = server.expectAndBlock('build-finished')
+
+        when:
+        gradle = executer.withTasks(":util:resolve").start()
+
+        then:
+        jar.waitForAllPendingCalls()
+        assertHasBuildPhase("0% EXECUTING")
+        jar.releaseAll()
+
+        and:
+        doubleTransform.waitForAllPendingCalls()
+        assertHasBuildPhase("25% EXECUTING")
+        doubleTransform.releaseAll()
+
+        and:
+        sizeTransform.waitForAllPendingCalls()
+        assertHasBuildPhase("50% EXECUTING")
+        sizeTransform.releaseAll()
+
+        and:
+        resolveTask.waitForAllPendingCalls()
+        assertHasBuildPhase("75% EXECUTING")
+        resolveTask.releaseAll()
+
+        and:
+        buildFinished.waitForAllPendingCalls()
+        assertHasBuildPhase("100% EXECUTING")
+        buildFinished.releaseAll()
+
+        and:
+        waitForFinish()
+    }
+
+    @ToBeFixedForConfigurationCache(because = "Gradle.buildFinished", skip = ToBeFixedForConfigurationCache.Skip.LONG_TIMEOUT)
+    def "shows progress bar and percent phase completion with non-planned planned artifact transforms"() {
+        given:
+        setupTransformBuild()
+        def jar = server.expectAndBlock('jar')
+        def resolveTask = server.expectAndBlock('resolve-task')
+        def doubleTransform = server.expectAndBlock('double-transform')
+        def sizeTransform = server.expectAndBlock('size-transform')
+        def buildFinished = server.expectAndBlock('build-finished')
+
+        when:
+        gradle = executer.withTasks(":util:resolveWithoutDependencies").start()
+
+        then:
+        jar.waitForAllPendingCalls()
+        assertHasBuildPhase("0% EXECUTING")
+        jar.releaseAll()
+
+        and:
+        resolveTask.waitForAllPendingCalls()
+        assertHasBuildPhase("50% EXECUTING")
+        resolveTask.releaseAll()
+
+        and:
+        doubleTransform.waitForAllPendingCalls()
+        assertHasBuildPhase("50% EXECUTING")
+        doubleTransform.releaseAll()
+
+        and:
+        sizeTransform.waitForAllPendingCalls()
+        assertHasBuildPhase("50% EXECUTING")
+        sizeTransform.releaseAll()
+
+        and:
+        buildFinished.waitForAllPendingCalls()
+        assertHasBuildPhase("100% EXECUTING")
+        buildFinished.releaseAll()
+
+        and:
+        waitForFinish()
+    }
+
+    def setupTransformBuild() {
         settingsFile << """
             include 'lib'
             include 'util'
@@ -386,48 +468,24 @@ abstract class AbstractConsoleBuildPhaseFunctionalTest extends AbstractConsoleGr
                         size.artifactFiles.files.each { println it }
                     }
                 }
+                task resolveWithoutDependencies {
+                    def size = configurations.compile.incoming.artifactView {
+                        attributes { it.attribute(artifactType, 'size') }
+                    }.artifacts
+
+                    dependsOn(":lib:jar")
+
+                    doLast {
+                        ${server.callFromBuild('resolve-task')}
+                        size.artifactFiles.files.each { println it }
+                    }
+                }
             }
 
             gradle.buildFinished {
                 ${server.callFromBuild('build-finished')}
             }
         """
-        def jar = server.expectAndBlock('jar')
-        def doubleTransform = server.expectAndBlock('double-transform')
-        def sizeTransform = server.expectAndBlock('size-transform')
-        def resolveTask = server.expectAndBlock('resolve-task')
-        def buildFinished = server.expectAndBlock('build-finished')
-
-        when:
-        gradle = executer.withTasks(":util:resolve").start()
-
-        then:
-        jar.waitForAllPendingCalls()
-        assertHasBuildPhase("0% EXECUTING")
-        jar.releaseAll()
-
-        and:
-        doubleTransform.waitForAllPendingCalls()
-        assertHasBuildPhase("25% EXECUTING")
-        doubleTransform.releaseAll()
-
-        and:
-        sizeTransform.waitForAllPendingCalls()
-        assertHasBuildPhase("50% EXECUTING")
-        sizeTransform.releaseAll()
-
-        and:
-        resolveTask.waitForAllPendingCalls()
-        assertHasBuildPhase("75% EXECUTING")
-        resolveTask.releaseAll()
-
-        and:
-        buildFinished.waitForAllPendingCalls()
-        assertHasBuildPhase("100% EXECUTING")
-        buildFinished.releaseAll()
-
-        and:
-        gradle.waitForFinish()
     }
 
     void assertHasBuildPhase(String message) {
@@ -438,5 +496,10 @@ abstract class AbstractConsoleBuildPhaseFunctionalTest extends AbstractConsoleGr
 
     String regexFor(String message) {
         /<.*> $message \[[\dms ]+]/
+    }
+
+    void waitForFinish() {
+        result = gradle.waitForFinish()
+        outputDoesNotContain("More progress was logged than there should be")
     }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/tasks/NodeExecutionContext.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/tasks/NodeExecutionContext.java
@@ -25,4 +25,6 @@ public interface NodeExecutionContext {
      * Locates the given execution service.
      */
     <T> T getService(Class<T> type) throws ServiceLookupException;
+
+    boolean isGlobal();
 }


### PR DESCRIPTION
There are some situations when planned transform steps are executed in
a non-planned way:
- The project classpath depends on a transformed variant of an included build
- A task uses an artifact view that requires project transform, though doesn't declare the artifact view as an input

In those cases we don't want to emit the build operation, since the planned step is not really planned.

If Gradle emits the build operation the progress bar is broken and shows too much progress.

Fixes #24370
Fixes #26035