### PR TITLE
Only emit planned transform operation in project context

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformBuildOperationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformBuildOperationIntegrationTest.groovy
@@ -17,6 +17,14 @@
 package org.gradle.integtests.resolve.transform
 
 import groovy.transform.EqualsAndHashCode
+import org.gradle.api.artifacts.transform.InputArtifact
+import org.gradle.api.artifacts.transform.TransformAction
+import org.gradle.api.artifacts.transform.TransformOutputs
+import org.gradle.api.artifacts.transform.TransformParameters
+import org.gradle.api.file.FileSystemLocation
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
@@ -26,6 +34,9 @@ import org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType
 import org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType.PlannedNode
 import org.gradle.internal.taskgraph.NodeIdentity
 import org.gradle.operations.dependencies.transforms.ExecutePlannedTransformStepBuildOperationType
+import org.gradle.operations.dependencies.transforms.ExecuteTransformActionBuildOperationType
+import org.gradle.operations.dependencies.transforms.IdentifyTransformExecutionProgressDetails
+import org.gradle.operations.dependencies.transforms.SnapshotTransformInputsBuildOperationType
 import org.gradle.operations.execution.ExecuteWorkBuildOperationType
 import org.gradle.test.fixtures.file.TestFile
 
@@ -1258,6 +1269,149 @@ class ArtifactTransformBuildOperationIntegrationTest extends AbstractIntegration
         getExecutePlannedStepOperations(2).each {
             checkExecuteTransformWorkOperations(it, 1)
         }
+    }
+
+    def "planned transform steps from script plugin buildscript block are ignored"() {
+        setupProjectTransformInBuildScriptBlock(true)
+
+        when:
+        run "consumer:hello"
+        then:
+        executedAndNotSkipped(":consumer:hello")
+
+        outputContains("processing [nested-producer.jar]")
+        outputContains("processing [nested-producer.jar.red]")
+        outputContains("Task-only execution plan: [PlannedTask('Task :consumer:hello', deps=[])]")
+
+        getPlannedNodes(0)
+        getExecutePlannedStepOperations(0).empty
+
+        buildOperations.progress(IdentifyTransformExecutionProgressDetails).size() == 2
+        // The execution engine in DependencyManagementBuildScopeServices doesn't fire build operations
+        buildOperations.none(ExecuteWorkBuildOperationType)
+        buildOperations.none(SnapshotTransformInputsBuildOperationType)
+        buildOperations.all(ExecuteTransformActionBuildOperationType).size() == 2
+    }
+
+    def "planned transform steps from project buildscript context are captured"() {
+        setupProjectTransformInBuildScriptBlock(false)
+
+        when:
+        run "consumer:hello"
+        then:
+        executedAndNotSkipped(":consumer:hello")
+
+        result.groupedOutput.transform("MakeColor")
+            .assertOutputContains("processing [nested-producer.jar]")
+            .assertOutputContains("processing [nested-producer.jar.red]")
+
+
+        outputContains("Task-only execution plan: [PlannedTask('Task :consumer:hello', deps=[])]")
+
+        getPlannedNodes(0)
+        getExecutePlannedStepOperations(2)
+
+        buildOperations.progress(IdentifyTransformExecutionProgressDetails).size() == 2
+        // The execution engine in DependencyManagementBuildScopeServices doesn't fire build operations
+        buildOperations.all(ExecuteWorkBuildOperationType).size() == 0
+        buildOperations.all(SnapshotTransformInputsBuildOperationType).size() == 0
+        buildOperations.all(ExecuteTransformActionBuildOperationType).size() == 2
+    }
+
+    private void setupProjectTransformInBuildScriptBlock(boolean inExternalScript) {
+        setupBuildWithChainedColorTransform()
+
+        file("included/settings.gradle") << """
+            include 'nested-producer'
+        """
+        setupBuildWithColorAttributes(file("included/build.gradle"))
+
+        settingsFile << """
+            includeBuild("included") {
+                dependencySubstitution {
+                    substitute(module("test:test")).using(project(":nested-producer"))
+                }
+            }
+        """
+
+        settingsFile << """
+            include 'consumer'
+        """
+
+        // Can't define classes in buildscript block, so let's do it in buildSrc
+        file("buildSrc/src/main/groovy/TargetColor.groovy") << """
+            import ${TransformParameters.name}
+            import ${Property.name}
+            import ${Input.name}
+
+            interface TargetColor extends TransformParameters {
+                @Input
+                Property<String> getTargetColor()
+            }
+        """
+
+        file("buildSrc/src/main/groovy/MakeColor.groovy") << """
+            import ${TransformAction.name}
+            import ${TransformOutputs.name}
+            import ${Provider.name}
+            import ${FileSystemLocation.name}
+            import ${InputArtifact.name}
+
+            abstract class MakeColor implements TransformAction<TargetColor> {
+                @InputArtifact
+                abstract Provider<FileSystemLocation> getInputArtifact()
+
+                void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
+                    println "processing [\${input.name}]"
+                    def output = outputs.file(input.name + "." + parameters.targetColor.get())
+                    if (input.file) {
+                        output.text = input.text + "-" + parameters.targetColor.get()
+                    } else {
+                        output.text = "missing-" + parameters.targetColor.get()
+                    }
+                }
+            }
+        """
+
+        def consumerBuildFile = file('consumer/build.gradle')
+        def buildscriptDestination = inExternalScript
+            ? file('consumer/my-script.gradle')
+            : consumerBuildFile
+        buildscriptDestination << """
+            buildscript {
+                // Can't use color, since we need to use the configuration directly and
+                // can't go via an artifact view
+                def artifactType = Attribute.of('artifactType', String)
+                dependencies {
+                    classpath("test:test:1.0")
+
+                    registerTransform(MakeColor) {
+                        from.attribute(artifactType, 'jar')
+                        to.attribute(artifactType, 'red')
+                        parameters.targetColor.set('red')
+                    }
+                    registerTransform(MakeColor) {
+                        from.attribute(artifactType, 'red')
+                        to.attribute(artifactType, 'green')
+                        parameters.targetColor.set('green')
+                    }
+                }
+                configurations.classpath.attributes.attribute(artifactType, 'green')
+            }
+        """
+        if (inExternalScript) {
+            consumerBuildFile << """
+                apply from: 'my-script.gradle'
+            """
+        }
+        consumerBuildFile << """
+            task hello {
+                doLast {
+                    println "Hello"
+                }
+            }
+        """
     }
 
     void checkExecutionPlanMatchingDependencies(List<PlannedNode> plannedNodes, List<NodeMatcher> nodeMatchers) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformStepNode.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformStepNode.java
@@ -46,6 +46,7 @@ import org.gradle.operations.dependencies.variants.Capability;
 import org.gradle.operations.dependencies.variants.ComponentIdentifier;
 
 import javax.annotation.Nullable;
+import javax.annotation.OverridingMethodsMustInvokeSuper;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -228,23 +229,21 @@ public abstract class TransformStepNode extends CreationOrderedNode implements S
             return result;
         }
 
-        private class TransformInitialArtifact implements ValueCalculator<TransformStepSubject> {
-            private final BuildOperationExecutor buildOperationExecutor;
+        protected class TransformInitialArtifact extends AbstractTransformArtifacts {
 
             public TransformInitialArtifact(BuildOperationExecutor buildOperationExecutor) {
-                this.buildOperationExecutor = buildOperationExecutor;
+                super(buildOperationExecutor);
             }
 
             @Override
             public void visitDependencies(TaskDependencyResolveContext context) {
-                context.add(transformStep);
-                context.add(upstreamDependencies);
+                super.visitDependencies(context);
                 context.add(artifact);
             }
 
             @Override
-            public TransformStepSubject calculateValue(NodeExecutionContext context) {
-                return buildOperationExecutor.call(new TransformStepBuildOperation() {
+            protected TransformStepBuildOperation createBuildOperation(NodeExecutionContext context) {
+                return new TransformStepBuildOperation() {
                     @Override
                     protected TransformStepSubject transform() {
                         TransformStepSubject initialSubject;
@@ -266,7 +265,7 @@ public abstract class TransformStepNode extends CreationOrderedNode implements S
                     protected String describeSubject() {
                         return artifact.getId().getDisplayName();
                     }
-                });
+                };
             }
         }
     }
@@ -306,23 +305,21 @@ public abstract class TransformStepNode extends CreationOrderedNode implements S
             super.executeIfNotAlready();
         }
 
-        private class TransformPreviousArtifacts implements ValueCalculator<TransformStepSubject> {
-            private final BuildOperationExecutor buildOperationExecutor;
+        protected class TransformPreviousArtifacts extends AbstractTransformArtifacts {
 
             public TransformPreviousArtifacts(BuildOperationExecutor buildOperationExecutor) {
-                this.buildOperationExecutor = buildOperationExecutor;
+                super(buildOperationExecutor);
             }
 
             @Override
             public void visitDependencies(TaskDependencyResolveContext context) {
-                context.add(transformStep);
-                context.add(upstreamDependencies);
+                super.visitDependencies(context);
                 context.add(new DefaultTransformNodeDependency(Collections.singletonList(previousTransformStepNode)));
             }
 
             @Override
-            public TransformStepSubject calculateValue(NodeExecutionContext context) {
-                return buildOperationExecutor.call(new TransformStepBuildOperation() {
+            protected TransformStepBuildOperation createBuildOperation(NodeExecutionContext context) {
+                return new TransformStepBuildOperation() {
                     @Override
                     protected TransformStepSubject transform() {
                         return previousTransformStepNode.getTransformedSubject()
@@ -338,12 +335,35 @@ public abstract class TransformStepNode extends CreationOrderedNode implements S
                             .map(Describable::getDisplayName)
                             .getOrMapFailure(Throwable::getMessage);
                     }
-                });
+                };
             }
         }
     }
 
-    private abstract class TransformStepBuildOperation implements CallableBuildOperation<TransformStepSubject> {
+    protected abstract class AbstractTransformArtifacts implements ValueCalculator<TransformStepSubject> {
+        private final BuildOperationExecutor buildOperationExecutor;
+
+        protected AbstractTransformArtifacts(BuildOperationExecutor buildOperationExecutor) {
+            this.buildOperationExecutor = buildOperationExecutor;
+        }
+
+        @OverridingMethodsMustInvokeSuper
+        @Override
+        public void visitDependencies(TaskDependencyResolveContext context) {
+            context.add(transformStep);
+            context.add(upstreamDependencies);
+        }
+
+        @Override
+        public TransformStepSubject calculateValue(NodeExecutionContext context) {
+            TransformStepBuildOperation buildOperation = createBuildOperation(context);
+            return buildOperationExecutor.call(buildOperation);
+        }
+
+        protected abstract TransformStepBuildOperation createBuildOperation(NodeExecutionContext context);
+    }
+
+    protected abstract class TransformStepBuildOperation implements CallableBuildOperation<TransformStepSubject> {
 
         @UsedByScanPlugin("The string is used for filtering out artifact transform logs in Gradle Enterprise")
         private static final String TRANSFORMING_PROGRESS_PREFIX = "Transforming ";

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformStepNode.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformStepNode.java
@@ -357,7 +357,10 @@ public abstract class TransformStepNode extends CreationOrderedNode implements S
         @Override
         public TransformStepSubject calculateValue(NodeExecutionContext context) {
             TransformStepBuildOperation buildOperation = createBuildOperation(context);
-            return buildOperationExecutor.call(buildOperation);
+            ProjectInternal owningProject = transformStep.getOwningProject();
+            return owningProject == null
+                ? buildOperation.transform()
+                : buildOperationExecutor.call(buildOperation);
         }
 
         protected abstract TransformStepBuildOperation createBuildOperation(NodeExecutionContext context);

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformTestFixture.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformTestFixture.groovy
@@ -71,7 +71,7 @@ allprojects {
         implementation producer.output
     }
 
-    task resolve (type: ShowFileCollection) {
+    task resolve(type: ShowFileCollection) {
         def view = configurations.resolver.incoming.artifactView {
             attributes.attribute(color, 'green')
         }.files

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/AbstractConsoleBuildPhaseFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/AbstractConsoleBuildPhaseFunctionalTest.groovy
@@ -119,7 +119,7 @@ abstract class AbstractConsoleBuildPhaseFunctionalTest extends AbstractConsoleGr
         buildFinished.releaseAll()
 
         and:
-        gradle.waitForFinish()
+        waitForFinish()
     }
 
     @ToBeFixedForConfigurationCache(because = "build listener", skip = ToBeFixedForConfigurationCache.Skip.FAILS_TO_CLEANUP)
@@ -203,7 +203,7 @@ abstract class AbstractConsoleBuildPhaseFunctionalTest extends AbstractConsoleGr
         rootBuildFinished.releaseAll()
 
         and:
-        gradle.waitForFinish()
+        waitForFinish()
     }
 
     @ToBeFixedForConfigurationCache(because = "Gradle.buildFinished", skip = ToBeFixedForConfigurationCache.Skip.LONG_TIMEOUT)
@@ -285,12 +285,94 @@ abstract class AbstractConsoleBuildPhaseFunctionalTest extends AbstractConsoleGr
         rootBuildFinished.releaseAll()
 
         and:
-        gradle.waitForFinish()
+        waitForFinish()
     }
 
     @ToBeFixedForConfigurationCache(because = "Gradle.buildFinished", skip = ToBeFixedForConfigurationCache.Skip.LONG_TIMEOUT)
     def "shows progress bar and percent phase completion with artifact transforms"() {
         given:
+        setupTransformBuild()
+        def jar = server.expectAndBlock('jar')
+        def doubleTransform = server.expectAndBlock('double-transform')
+        def sizeTransform = server.expectAndBlock('size-transform')
+        def resolveTask = server.expectAndBlock('resolve-task')
+        def buildFinished = server.expectAndBlock('build-finished')
+
+        when:
+        gradle = executer.withTasks(":util:resolve").start()
+
+        then:
+        jar.waitForAllPendingCalls()
+        assertHasBuildPhase("0% EXECUTING")
+        jar.releaseAll()
+
+        and:
+        doubleTransform.waitForAllPendingCalls()
+        assertHasBuildPhase("25% EXECUTING")
+        doubleTransform.releaseAll()
+
+        and:
+        sizeTransform.waitForAllPendingCalls()
+        assertHasBuildPhase("50% EXECUTING")
+        sizeTransform.releaseAll()
+
+        and:
+        resolveTask.waitForAllPendingCalls()
+        assertHasBuildPhase("75% EXECUTING")
+        resolveTask.releaseAll()
+
+        and:
+        buildFinished.waitForAllPendingCalls()
+        assertHasBuildPhase("100% EXECUTING")
+        buildFinished.releaseAll()
+
+        and:
+        waitForFinish()
+    }
+
+    @ToBeFixedForConfigurationCache(because = "Gradle.buildFinished", skip = ToBeFixedForConfigurationCache.Skip.LONG_TIMEOUT)
+    def "shows progress bar and percent phase completion with non-planned planned artifact transforms"() {
+        given:
+        setupTransformBuild()
+        def jar = server.expectAndBlock('jar')
+        def resolveTask = server.expectAndBlock('resolve-task')
+        def doubleTransform = server.expectAndBlock('double-transform')
+        def sizeTransform = server.expectAndBlock('size-transform')
+        def buildFinished = server.expectAndBlock('build-finished')
+
+        when:
+        gradle = executer.withTasks(":util:resolveWithoutDependencies").start()
+
+        then:
+        jar.waitForAllPendingCalls()
+        assertHasBuildPhase("0% EXECUTING")
+        jar.releaseAll()
+
+        and:
+        resolveTask.waitForAllPendingCalls()
+        assertHasBuildPhase("50% EXECUTING")
+        resolveTask.releaseAll()
+
+        and:
+        doubleTransform.waitForAllPendingCalls()
+        assertHasBuildPhase("50% EXECUTING")
+        doubleTransform.releaseAll()
+
+        and:
+        sizeTransform.waitForAllPendingCalls()
+        assertHasBuildPhase("50% EXECUTING")
+        sizeTransform.releaseAll()
+
+        and:
+        buildFinished.waitForAllPendingCalls()
+        assertHasBuildPhase("100% EXECUTING")
+        buildFinished.releaseAll()
+
+        and:
+        waitForFinish()
+    }
+
+    def setupTransformBuild() {
         settingsFile << """
             include 'lib'
             include 'util'
@@ -386,48 +468,24 @@ abstract class AbstractConsoleBuildPhaseFunctionalTest extends AbstractConsoleGr
                         size.artifactFiles.files.each { println it }
                     }
                 }
+                task resolveWithoutDependencies {
+                    def size = configurations.compile.incoming.artifactView {
+                        attributes { it.attribute(artifactType, 'size') }
+                    }.artifacts
+
+                    dependsOn(":lib:jar")
+
+                    doLast {
+                        ${server.callFromBuild('resolve-task')}
+                        size.artifactFiles.files.each { println it }
+                    }
+                }
             }
 
             gradle.buildFinished {
                 ${server.callFromBuild('build-finished')}
             }
         """
-        def jar = server.expectAndBlock('jar')
-        def doubleTransform = server.expectAndBlock('double-transform')
-        def sizeTransform = server.expectAndBlock('size-transform')
-        def resolveTask = server.expectAndBlock('resolve-task')
-        def buildFinished = server.expectAndBlock('build-finished')
-
-        when:
-        gradle = executer.withTasks(":util:resolve").start()
-
-        then:
-        jar.waitForAllPendingCalls()
-        assertHasBuildPhase("0% EXECUTING")
-        jar.releaseAll()
-
-        and:
-        doubleTransform.waitForAllPendingCalls()
-        assertHasBuildPhase("25% EXECUTING")
-        doubleTransform.releaseAll()
-
-        and:
-        sizeTransform.waitForAllPendingCalls()
-        assertHasBuildPhase("50% EXECUTING")
-        sizeTransform.releaseAll()
-
-        and:
-        resolveTask.waitForAllPendingCalls()
-        assertHasBuildPhase("75% EXECUTING")
-        resolveTask.releaseAll()
-
-        and:
-        buildFinished.waitForAllPendingCalls()
-        assertHasBuildPhase("100% EXECUTING")
-        buildFinished.releaseAll()
-
-        and:
-        gradle.waitForFinish()
     }
 
     void assertHasBuildPhase(String message) {
@@ -438,5 +496,10 @@ abstract class AbstractConsoleBuildPhaseFunctionalTest extends AbstractConsoleGr
 
     String regexFor(String message) {
         /<.*> $message \[[\dms ]+]/
+    }
+
+    void waitForFinish() {
+        result = gradle.waitForFinish()
+        outputDoesNotContain("More progress was logged than there should be")
     }
 }

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/AbstractConsoleBuildPhaseFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/AbstractConsoleBuildPhaseFunctionalTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.integtests.fixtures.console.AbstractConsoleGroupedTaskFunction
 import org.gradle.integtests.fixtures.executer.GradleHandle
 import org.gradle.test.fixtures.ConcurrentTestUtil
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
+import org.gradle.util.internal.ToBeImplemented
 import org.junit.Rule
 
 abstract class AbstractConsoleBuildPhaseFunctionalTest extends AbstractConsoleGroupedTaskFunctionalTest {
@@ -319,6 +320,7 @@ abstract class AbstractConsoleBuildPhaseFunctionalTest extends AbstractConsoleGr
         waitForFinish()
     }
 
+    @ToBeImplemented("https://github.com/gradle/gradle/issues/24370")
     def "shows progress bar and percent phase completion with non-planned planned artifact transforms"() {
         given:
         setupTransformBuild()
@@ -348,16 +350,18 @@ abstract class AbstractConsoleBuildPhaseFunctionalTest extends AbstractConsoleGr
 
         and:
         sizeTransform.waitForAllPendingCalls()
-        assertHasBuildPhase("50% EXECUTING")
+        assertHasBuildPhase("100% EXECUTING")
         sizeTransform.releaseAll()
 
         and:
         buildFinished.waitForAllPendingCalls()
-        assertHasBuildPhase("100% EXECUTING")
+        assertHasBuildPhase("200% EXECUTING")
         buildFinished.releaseAll()
 
-        and:
-        waitForFinish()
+        when:
+        result = gradle.waitForFinish()
+        then:
+        outputContains("More progress was logged than there should be")
     }
 
     def setupTransformBuild() {


### PR DESCRIPTION
It is possible to register transforms in the context of a script, and those transforms might run on substituted included build dependencies.

Even though these transforms will never be part of any execution plan, calculating the node identity of them will currently fail, because they don't have an owning project.

This causes the Build Scan plugin to fail.

Therefore, this PR stops emitting the build operation in this case.