### PR TITLE
docs: Fix Deprecated keyword in getting started

### DIFF
--- a/subprojects/docs/src/docs/userguide/getting-started/tutorial/part4_gradle_plugins.adoc
+++ b/subprojects/docs/src/docs/userguide/getting-started/tutorial/part4_gradle_plugins.adoc
@@ -119,7 +119,7 @@ Add the publishing information to your `build.gradle.kts` file:
 ----
 publishing {
     publications {
-        create<MavenPublication>("maven") {
+        mavenJava(MavenPublication)("maven") {
             groupId = "org.gradle.tutorial"
             artifactId = "tutorial"
             version = "1.0"


### PR DESCRIPTION
Page "part4_gradle_plugins.html" section "step_3_add_the_publishing_block" has a deprecated keyword "create<MavenPublication>("maven")". It does not work at gradle 8.2. Replace "create<MavenPublication>("maven")" to "mavenJava(MavenPublication)" according to gradle 8.2 docs

- getting started docs : https://docs.gradle.org/current/userguide/part4_gradle_plugins.html#step_3_add_the_publishing_block
- maven publish plugins docs : https://docs.gradle.org/current/userguide/publishing_maven.html#sec:modifying_the_generated_pom

<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
