### PR TITLE
Update wrapper to 8.4-20230821223421+0000

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.4-20230719142735+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.4-20230821223421+0000-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
So we can use a fix https://github.com/gradle/gradle/pull/26071 for test launcher