### PR TITLE
Add integration test simulating GE plugin's cross-build service ref access

### DIFF
--- a/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginCheckInFixture.groovy
+++ b/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginCheckInFixture.groovy
@@ -92,7 +92,7 @@ class GradleEnterprisePluginCheckInFixture {
                 void apply($Settings.name settings) {
                     println "gradleEnterprisePlugin.apply.runtimeVersion = $runtimeVersion"
 
-                    if (!$doCheckIn) {
+                    if (!$doCheckIn || settings.gradle.parent != null) {
                         return
                     }
 

--- a/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginConfigurationCachingIntegrationTest.groovy
+++ b/platforms/enterprise/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginConfigurationCachingIntegrationTest.groovy
@@ -59,23 +59,46 @@ class GradleEnterprisePluginConfigurationCachingIntegrationTest extends Abstract
 
     def "returned service ref refers to service for that build"() {
         given:
-        buildFile << """
-            def serviceRef = gradle.extensions.serviceRef
-            task p {
-                doLast {
-                    println "extension-buildInvocationId=" + serviceRef.get()._buildState.buildInvocationId
-                }
-            }
-        """
+        def taskName = "printInvocationId"
+        buildFile << taskPrintBuildInvocationId(taskName)
 
         when:
-        succeeds "p", "--configuration-cache"
+        succeeds taskName, "--configuration-cache"
         def firstInvocationId = output.find(~/(?<=extension-buildInvocationId=).+(?=\n)/)
-        succeeds "p", "--configuration-cache"
+        succeeds taskName, "--configuration-cache"
         def secondInvocationId = output.find(~/(?<=extension-buildInvocationId=).+(?=\n)/)
 
         then:
         firstInvocationId != secondInvocationId
+    }
+
+    def "returned service ref for included build refers to service for the root build"() {
+        given:
+        def rootTaskName = "printInvocationId"
+        def includedTaskName = "includedPrintInvocationId"
+
+        and:
+        buildTestFixture.withBuildInSubDir()
+        singleProjectBuild("included") {
+            settingsFile.prepend(plugin.plugins())
+            settingsFile.prepend(plugin.pluginManagement())
+            buildFile << taskPrintRootBuildInvocationId(includedTaskName)
+        }
+
+        and:
+        settingsFile << "includeBuild('included')"
+        buildFile << taskPrintBuildInvocationId(rootTaskName) << """
+            tasks.$rootTaskName {
+                dependsOn(gradle.includedBuild("included").task(":$includedTaskName"))
+            }
+        """
+
+        when:
+        succeeds rootTaskName, "--configuration-cache"
+        def invocationIds = output.findAll(~/(?<=extension-buildInvocationId=).+(?=\n)/)
+
+        then:
+        invocationIds[0] == invocationIds[1]
     }
 
     def "--scan does not auto apply plugin for build from cache"() {
@@ -172,5 +195,35 @@ class GradleEnterprisePluginConfigurationCachingIntegrationTest extends Abstract
 
         then:
         output.contains("offline: true")
+    }
+
+    private String taskPrintBuildInvocationId(String taskName) {
+        """
+            def serviceRef = gradle.extensions.serviceRef
+            task $taskName {
+                doLast {
+                    println "extension-buildInvocationId=" + serviceRef.get()._buildState.buildInvocationId
+                }
+            }
+        """
+    }
+
+    private String taskPrintRootBuildInvocationId(String taskName) {
+        """
+            def rootServiceRef() {
+                def rootGradle = gradle
+                while (rootGradle.parent != null) {
+                    rootGradle = gradle.parent
+                }
+                rootGradle.extensions.serviceRef
+            }
+
+            def serviceRef = rootServiceRef()
+            task $taskName {
+                doLast {
+                    println "extension-buildInvocationId=" + serviceRef.get()._buildState.buildInvocationId
+                }
+            }
+        """
     }
 }


### PR DESCRIPTION
## Summary

This PR adds an integration test for https://github.com/gradle/gradle/pull/26082. It updates the `GradleEnterprisePluginCheckInFixture` to better mimic the behavior of the GE plugin for included builds: the plugin does not perform the check-in in that case. It also creates a similar build setup that was problematic prior to the fix: a task in the included build attempts to access the service ref of the root build.

The test fails on `release` with the following error message, which is similar to what we observed in production: the plugin service ref was not recreated when loading from configuration cache

```
Build file '/Users/pshevche/dev/gradle/subprojects/enterprise/build/tmp/teŝt files/GradleEnter.Test/9wr1x/included/build.gradle' line: 16
Execution failed for task ':included:includedPrintInvocationId'.
org.gradle.internal.exceptions.LocationAwareException: Build file '/Users/pshevche/dev/gradle/subprojects/enterprise/build/tmp/teŝt files/GradleEnter.Test/9wr1x/included/build.gradle' line: 16
Execution failed for task ':included:includedPrintInvocationId'.
	at org.gradle.initialization.exception.DefaultExceptionAnalyser.transform(DefaultExceptionAnalyser.java:93)
	...
Caused by: org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':included:includedPrintInvocationId'.
	at app//org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.lambda$executeIfValid$1(ExecuteActionsTaskExecuter.java:149)
	...
Caused by: java.lang.NullPointerException: Cannot get property '_buildState' on null object
	at build_3vu9xjxpe4uj3yphqjl5tilen.run_closure1$_closure2(/Users/pshevche/dev/gradle/subprojects/enterprise/build/tmp/teŝt files/GradleEnter.Test/9wr1x/included/build.gradle:16)
	...
```

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
