### PR TITLE
Fix issue with logging test suite exceptions and improve test logging docs

### DIFF
--- a/subprojects/docs/src/docs/userguide/jvm/java_testing.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/java_testing.adoc
@@ -348,6 +348,32 @@ If `scanForTestClasses` is false and no include or exclude patterns are specifie
 With http://junit.org/junit5/docs/current/user-guide[JUnit Platform], only `includes` and `excludes` are used to filter test classes — `scanForTestClasses` has no effect.
 ====
 
+[[sec:test_logging]]
+== Test logging
+
+Gradle allows fine-tuned control over events that are logged to the console.  Logging is configurable on a per-log-level basis and by default, the following events are logged:
+
+[cols="1,1,1"]
+|===
+|When the log level is |Events that are logged | Additional configuration
+| `ERROR`, `QUIET` or `WARNING`
+| None
+| None
+| `LIFECYCLE`
+| link:{javadocPath}/org/gradle/api/tasks/testing/logging/TestLogEvent.html#FAILED[Test failures]
+| Exception format is link:{javadocPath}/org/gradle/api/tasks/testing/logging/TestExceptionFormat.html#SHORT[SHORT]
+| `INFO`
+| link:{javadocPath}/org/gradle/api/tasks/testing/logging/TestLogEvent.html#FAILED[Test failures], link:{javadocPath}/org/gradle/api/tasks/testing/logging/TestLogEvent.html#SKIPPED[skipped tests], link:{javadocPath}/org/gradle/api/tasks/testing/logging/TestLogEvent.html#STANDARD_OUT[test standard output] and link:{javadocPath}/org/gradle/api/tasks/testing/logging/TestLogEvent.html#STANDARD_ERROR[test standard error]
+| Stacktraces are truncated.
+| `DEBUG`
+| link:{javadocPath}/org/gradle/api/tasks/testing/logging/TestLogEvent.html[All events]
+| Full stacktraces are logged.
+|===
+
+Test logging can be modified on a per-log-level basis by adjusting the appropriate link:{javadocPath}/org/gradle/api/tasks/testing/logging/TestLogging.html[TestLogging] instances in the link:{javadocPath}/org/gradle/api/tasks/testing/AbstractTestTask.html#getTestLogging--[testLogging] property of the test task.
+For example, to adjust the `INFO` level test logging configuration, modify the
+link:{javadocPath}/org/gradle/api/tasks/testing/logging/TestLoggingContainer.html#getInfo--[TestLoggingContainer.getInfo()] property.
+
 [[test_grouping]]
 == Test grouping
 

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/ClassMethodNameStackTraceSpec.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/ClassMethodNameStackTraceSpec.java
@@ -41,7 +41,7 @@ public class ClassMethodNameStackTraceSpec implements Spec<StackTraceElement> {
     }
 
     private boolean classNameMatch(String targetClassName) {
-        if (!targetClassName.startsWith(className)) {
+        if (this.className == null || !targetClassName.startsWith(className)) {
             return false;
         }
 

--- a/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/logging/TestExceptionFormat.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/logging/TestExceptionFormat.java
@@ -21,7 +21,7 @@ package org.gradle.api.tasks.testing.logging;
  */
 public enum TestExceptionFormat {
     /**
-     * Short display of exceptions.
+     * Short display of exceptions.  Shows the exception types and locations as well as the hierarchy of causes, but not exception messages or full stack traces.
      */
     SHORT,
     /**

--- a/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/logging/TestLogging.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/logging/TestLogging.java
@@ -52,18 +52,24 @@ public interface TestLogging {
     void events(Object... events);
 
     /**
-     * Returns the minimum granularity of the events to be logged. Typically, 0 corresponds to the Gradle-generated test suite for the whole test run, 1 corresponds to the Gradle-generated test suite
-     * for a particular test JVM, 2 corresponds to a test class, and 3 corresponds to a test method. These values will vary if user-defined suites are executed. <p>-1 denotes the highest granularity
-     * and corresponds to an atomic test.
+     * Returns the minimum granularity of the events to be logged. Typically, 0 corresponds to events from the Gradle-generated test suite for the whole test run, 1 corresponds to the Gradle-generated test suite
+     * for a particular test JVM, 2 corresponds to a test class, and 3 corresponds to a test method. These values may extend higher if user-defined suites or parameterized test methods are executed.  Events
+     * from levels lower than the specified granularity will be ignored.
+     * <p>The default granularity is -1, which specifies that test events from only the most granular level should be logged.  In other words, if a test method is not parameterized, only events
+     * from the test method will be logged and events from the test class and lower will be ignored.  On the other hand, if a test method is parameterized, then events from the iterations of that test
+     * method will be logged and events from the test method and lower will be ignored.
      *
      * @return the minimum granularity of the events to be logged
      */
     int getMinGranularity();
 
     /**
-     * Sets the minimum granularity of the events to be logged. Typically, 0 corresponds to the Gradle-generated test suite for the whole test run, 1 corresponds to the Gradle-generated test suite for
-     * a particular test JVM, 2 corresponds to a test class, and 3 corresponds to a test method. These values will vary if user-defined suites are executed. <p>-1 denotes the highest granularity and
-     * corresponds to an atomic test.
+     * Sets the minimum granularity of the events to be logged. Typically, 0 corresponds to events from the Gradle-generated test suite for the whole test run, 1 corresponds to the Gradle-generated test suite
+     * for a particular test JVM, 2 corresponds to a test class, and 3 corresponds to a test method. These values may extend higher if user-defined suites or parameterized test methods are executed.  Events
+     * from levels lower than the specified granularity will be ignored.
+     * <p>The default granularity is -1, which specifies that test events from only the most granular level should be logged.  In other words, if a test method is not parameterized, only events
+     * from the test method will be logged and events from the test class and lower will be ignored.  On the other hand, if a test method is parameterized, then events from the iterations of that test
+     * method will be logged and events from the test method and lower will be ignored.
      *
      * @param granularity the minimum granularity of the events to be logged
      */
@@ -71,8 +77,11 @@ public interface TestLogging {
 
     /**
      * Returns the maximum granularity of the events to be logged. Typically, 0 corresponds to the Gradle-generated test suite for the whole test run, 1 corresponds to the Gradle-generated test suite
-     * for a particular test JVM, 2 corresponds to a test class, and 3 corresponds to a test method. These values will vary if user-defined suites are executed. <p>-1 denotes the highest granularity
-     * and corresponds to an atomic test.
+     * for a particular test JVM, 2 corresponds to a test class, and 3 corresponds to a test method. These values may extend higher if user-defined suites or parameterized test methods are executed.  Events
+     * from levels higher than the specified granularity will be ignored.
+     * <p>The default granularity is -1, which specifies that test events from only the most granular level should be logged.  Setting this value to something lower will cause events
+     * from a higher level to be ignored.  For example, setting the value to 3 will cause only events from the test method level to be logged and any events from iterations of a parameterized test method
+     * will be ignored.
      *
      * @return the maximum granularity of the events to be logged
      */
@@ -80,8 +89,13 @@ public interface TestLogging {
 
     /**
      * Returns the maximum granularity of the events to be logged. Typically, 0 corresponds to the Gradle-generated test suite for the whole test run, 1 corresponds to the Gradle-generated test suite
-     * for a particular test JVM, 2 corresponds to a test class, and 3 corresponds to a test method. These values will vary if user-defined suites are executed. <p>-1 denotes the highest granularity
-     * and corresponds to an atomic test.
+     * for a particular test JVM, 2 corresponds to a test class, and 3 corresponds to a test method. These values may extend higher if user-defined suites or parameterized test methods are executed.  Events
+     * from levels higher than the specified granularity will be ignored.
+     * <p>The default granularity is -1, which specifies that test events from only the most granular level should be logged.  Setting this value to something lower will cause events
+     * from a higher level to be ignored.  For example, setting the value to 3 will cause only events from the test method level to be logged and any events from iterations of a parameterized test method
+     * will be ignored.
+     *<p>Note that since the default value of {@link #getMinGranularity()} is -1 (the highest level of granularity) it only makes sense to configure the maximum granularity while also setting the
+     * minimum granularity to a value greater than -1.
      *
      * @param granularity the maximum granularity of the events to be logged
      */
@@ -105,56 +119,58 @@ public interface TestLogging {
     void setDisplayGranularity(int granularity);
 
     /**
-     * Tells whether exceptions that occur during test execution will be logged. Typically these exceptions coincide with a "failed" event.
+     * Tells whether exceptions that occur during test execution will be logged. Typically these exceptions coincide with a "failed" event.  Defaults to true.
      *
      * @return whether exceptions that occur during test execution will be logged
      */
     boolean getShowExceptions();
 
     /**
-     * Sets whether exceptions that occur during test execution will be logged.
+     * Sets whether exceptions that occur during test execution will be logged.  Defaults to true.
      *
      * @param flag whether exceptions that occur during test execution will be logged
      */
     void setShowExceptions(boolean flag);
 
     /**
-     * Tells whether causes of exceptions that occur during test execution will be logged. Only relevant if {@code showExceptions} is {@code true}.
+     * Tells whether causes of exceptions that occur during test execution will be logged. Only relevant if {@code showExceptions} is {@code true}.  Defaults to true.
      *
      * @return whether causes of exceptions that occur during test execution will be logged
      */
     boolean getShowCauses();
 
     /**
-     * Sets whether causes of exceptions that occur during test execution will be logged. Only relevant if {@code showExceptions} is {@code true}.
+     * Sets whether causes of exceptions that occur during test execution will be logged. Only relevant if {@code showExceptions} is {@code true}. Defaults to true.
      *
      * @param flag whether causes of exceptions that occur during test execution will be logged
      */
     void setShowCauses(boolean flag);
 
     /**
-     * Tells whether stack traces of exceptions that occur during test execution will be logged.
+     * Tells whether stack traces of exceptions that occur during test execution will be logged.  Defaults to true.
      *
      * @return whether stack traces of exceptions that occur during test execution will be logged
      */
     boolean getShowStackTraces();
 
     /**
-     * Sets whether stack traces of exceptions that occur during test execution will be logged.
+     * Sets whether stack traces of exceptions that occur during test execution will be logged.  Defaults to true.
      *
      * @param flag whether stack traces of exceptions that occur during test execution will be logged
      */
     void setShowStackTraces(boolean flag);
 
     /**
-     * Returns the format to be used for logging test exceptions. Only relevant if {@code showStackTraces} is {@code true}.
+     * Returns the format to be used for logging test exceptions. Only relevant if {@code showStackTraces} is {@code true}.  Defaults to {@link TestExceptionFormat#FULL} for
+     * the INFO and DEBUG log levels and {@link TestExceptionFormat#SHORT} for the LIFECYCLE log level.
      *
      * @return the format to be used for logging test exceptions
      */
     TestExceptionFormat getExceptionFormat();
 
     /**
-     * Sets the format to be used for logging test exceptions. Only relevant if {@code showStackTraces} is {@code true}.
+     * Sets the format to be used for logging test exceptions. Only relevant if {@code showStackTraces} is {@code true}.  Defaults to {@link TestExceptionFormat#FULL} for
+     * the INFO and DEBUG log levels and {@link TestExceptionFormat#SHORT} for the LIFECYCLE log level.
      *
      * @param exceptionFormat the format to be used for logging test exceptions
      * @since 4.0
@@ -162,7 +178,8 @@ public interface TestLogging {
     void setExceptionFormat(TestExceptionFormat exceptionFormat);
 
     /**
-     * Sets the format to be used for logging test exceptions. Only relevant if {@code showStackTraces} is {@code true}.
+     * Sets the format to be used for logging test exceptions. Only relevant if {@code showStackTraces} is {@code true}.  Defaults to {@link TestExceptionFormat#FULL} for
+     * the INFO and DEBUG log levels and {@link TestExceptionFormat#SHORT} for the LIFECYCLE log level.
      *
      * @param exceptionFormat the format to be used for logging test exceptions
      */

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/jupiter/JUnitJupiterConsoleLoggingIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/jupiter/JUnitJupiterConsoleLoggingIntegrationTest.groovy
@@ -27,4 +27,33 @@ class JUnitJupiterConsoleLoggingIntegrationTest extends AbstractJUnitConsoleLogg
     String getMaybePackagePrefix() {
         return ''
     }
+
+    def "failure during JUnit platform initialization is written to console when granularity is set"() {
+        buildFile.text = """
+            apply plugin: "groovy"
+
+            ${mavenCentralRepository()}
+
+            dependencies {
+                ${testFrameworkDependencies}
+            }
+
+            test {
+                ${configureTestFramework} {
+                    includeEngines 'does-not-exist'
+                }
+                testLogging {
+                    minGranularity = 1
+                    exceptionFormat = "FULL"
+                }
+            }
+        """
+
+        when:
+        executer.withStackTraceChecksDisabled()
+        fails "test"
+
+        then:
+        output.contains("org.junit.platform.commons.JUnitException: No TestEngine ID matched the following include EngineFilters: [does-not-exist]")
+    }
 }


### PR DESCRIPTION
This fixes an error where exceptions for test suite level exceptions would throw an NPE when being formatted for display.  It also improves some of the documentation around test logging and specifically test logging granularity to make it more comprehensible.

Fixes #25857 

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
