### PR TITLE
Unify all "configuration-cache.inputs.unsafe.ignore*" property names

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
@@ -531,7 +531,7 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
 
     public static class ConfigurationCacheIgnoreInputsInTaskGraphSerialization extends BooleanBuildOption<StartParameterInternal> {
 
-        public static final String PROPERTY_NAME = "org.gradle.configuration-cache.inputs.unsafe.ignore-in-serialization";
+        public static final String PROPERTY_NAME = "org.gradle.configuration-cache.inputs.unsafe.ignore.in-serialization";
 
         public ConfigurationCacheIgnoreInputsInTaskGraphSerialization() {
             super(PROPERTY_NAME);

--- a/subprojects/docs/src/docs/userguide/optimizing-performance/configuration_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/optimizing-performance/configuration_cache.adoc
@@ -606,7 +606,7 @@ org.gradle.configuration-cache.inputs.unsafe.ignore.file-system-checks=\
 However, their changes would not invalidate the configuration cache afterward.
 Starting with Gradle 8.3, such undeclared configuration inputs are correctly tracked.
 +
-To temporarily revert to the earlier behavior, set the Gradle property `org.gradle.configuration-cache.inputs.unsafe.ignore-in-serialization` to `true`.
+To temporarily revert to the earlier behavior, set the Gradle property `org.gradle.configuration-cache.inputs.unsafe.ignore.in-serialization` to `true`.
 
 Ignore configuration inputs sparingly, and only if they do not affect the tasks produced by the configuration logic.
 The support for these options will be removed in future releases.

--- a/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
@@ -191,7 +191,7 @@ Used to exclude file system checks on the specified path from configuration cach
 +
 _Default is `null`._
 
-`org.gradle.configuration-cache.inputs.unsafe.ignore-in-serialization=(true,false)`::
+`org.gradle.configuration-cache.inputs.unsafe.ignore.in-serialization=(true,false)`::
 Used to ignore inputs in task graph serialization.
 +
 _Default is `false`._


### PR DESCRIPTION
Having a dedicated namespace for all potential ignores looks a bit nicer.

`*.ignore-in-serialization` becomes `*.ignore.in-serialization` to match existing `*.ignore.file-system-checks`.
