### PR TITLE
Disable another shellcheck related to `ulimit` command

### DIFF
--- a/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+++ b/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
@@ -180,7 +180,7 @@ if ! "\$cygwin" && ! "\$darwin" && ! "\$nonstop" ; then
     case \$MAX_FD in #(
       max*)
         # In POSIX sh, ulimit -H is undefined. That's why the result is checked to see if it worked.
-        # shellcheck disable=SC3045
+        # shellcheck disable=SC2039,SC3045
         MAX_FD=\$( ulimit -H -n ) ||
             warn "Could not query maximum file descriptor limit"
     esac
@@ -188,7 +188,7 @@ if ! "\$cygwin" && ! "\$darwin" && ! "\$nonstop" ; then
       '' | soft) :;; #(
       *)
         # In POSIX sh, ulimit -n is undefined. That's why the result is checked to see if it worked.
-        # shellcheck disable=SC3045
+        # shellcheck disable=SC2039,SC3045
         ulimit -n "\$MAX_FD" ||
             warn "Could not set maximum file descriptor limit to \$MAX_FD"
     esac


### PR DESCRIPTION
Fixes #26160

The newly disabled SC2039 check is very similar to an already disabled one SC3045, but InteliJ IDEA integration with Shellcheck still reports it.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
