### PR TITLE
Fix scheduling of finalizers after last finalized task

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/FinalizerTaskIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/FinalizerTaskIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.util.internal.ToBeImplemented
 import spock.lang.Ignore
 import spock.lang.Issue
@@ -855,7 +856,7 @@ class FinalizerTaskIntegrationTest extends AbstractIntegrationSpec {
         }
     }
 
-    @ToBeImplemented("https://github.com/gradle/gradle/issues/10549")
+    @Issue("https://github.com/gradle/gradle/issues/10549")
     def "mustRunAfter is respected for finalizer without direct dependency"() {
         settingsFile << """
             include 'a'
@@ -891,9 +892,7 @@ class FinalizerTaskIntegrationTest extends AbstractIntegrationSpec {
         expect:
         2.times {
             run("work", "--parallel")
-            // TODO: Should be:
-            // result.assertTaskOrder(":a:work", ":a:finalizer", ":b:work")
-            result.assertTaskOrder(any(exact(":a:work", ":a:finalizer"), ":b:work"))
+            result.assertTaskOrder(":a:work", ":a:finalizer", ":b:work")
         }
 
         and: "Apply workaround"
@@ -905,6 +904,49 @@ class FinalizerTaskIntegrationTest extends AbstractIntegrationSpec {
         2.times {
             run("work", "--parallel")
             result.assertTaskOrder(":a:work", ":a:finalizer", ":b:work")
+        }
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/25951")
+    def "finalizer is run after last finalized task"() {
+        buildFile """
+            def finalizer = tasks.register("finalizer") {
+            }
+
+            def test = tasks.register("test") {
+              finalizedBy finalizer
+            }
+
+            def cleanZip = tasks.register("cleanZip", Delete) {
+              delete layout.buildDirectory.file("zip.txt")
+            }
+
+            def zip = tasks.register("zip") {
+              def zipFile = layout.buildDirectory.file("zip.txt")
+              outputs.file zipFile
+              doLast { zipFile.get().asFile.text = "bar" }
+              dependsOn cleanZip
+            }
+
+            def integTest = tasks.register("integTest") {
+              finalizedBy finalizer
+            }
+
+            tasks.register("publish") {
+              inputs.files zip
+            }
+        """
+
+        expect:
+        2.times {
+            run(":test",  ":publish", ":integTest")
+            if (GradleContextualExecuter.isConfigCache()) {
+                // With configuration cache tasks can run in parallel
+                result.assertTaskOrder(exact(any(":test", ":integTest"), ":finalizer"))
+                result.assertTaskOrder(exact(":cleanZip", ":zip", ":publish"))
+            } else {
+                result.assertTaskOrder(":test", ":cleanZip", ":zip", ":publish", ":integTest", ":finalizer")
+            }
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/Node.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/Node.java
@@ -171,6 +171,11 @@ public abstract class Node {
         }
     }
 
+    /**
+     * Maybe update the group for this node when its dependencies are in groups with higher ordinal.
+     *
+     * That way we can ensure that the node is executed after all its dependencies, and we get rid of potential cycles.
+     */
     public void maybeUpdateOrdinalGroup() {
         OrdinalGroup ordinal = getGroup().asOrdinal();
         OrdinalGroup newOrdinal = ordinal;

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/Node.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/Node.java
@@ -176,7 +176,7 @@ public abstract class Node {
         OrdinalGroup newOrdinal = ordinal;
         for (Node successor : getHardSuccessors()) {
             OrdinalGroup successorOrdinal = successor.getGroup().asOrdinal();
-            if (successorOrdinal != null && (ordinal == null || successorOrdinal.getOrdinal() > ordinal.getOrdinal())) {
+            if (successorOrdinal != null && (newOrdinal == null || successorOrdinal.getOrdinal() > newOrdinal.getOrdinal())) {
                 newOrdinal = successorOrdinal;
             }
         }


### PR DESCRIPTION
We now update ordinal group for nodes to highest instead to latest. With that we correctly schedule finalizers later if necessary.

Fixes https://github.com/gradle/gradle/issues/25951

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
