### PR TITLE
Clean up performance build directory on Windows

### DIFF
--- a/.teamcity/src/main/kotlin/common/performance-test-extensions.kt
+++ b/.teamcity/src/main/kotlin/common/performance-test-extensions.kt
@@ -92,6 +92,17 @@ fun BuildSteps.substDirOnWindows(os: Os) {
     }
 }
 
+fun BuildSteps.cleanUpPerformanceBuildDir(os: Os) {
+    if (os == Os.WINDOWS) {
+        script {
+            name = "CLEAN_UP_PERFORMANCE_BUILD_DIR"
+            executionMode = BuildStep.ExecutionMode.ALWAYS
+            scriptContent = """rmdir /s /q p:\subprojects\performance\build\santaTrackerAndroidBuild && (echo Directory removed) || (echo Directory not found) """
+            skipConditionally()
+        }
+    }
+}
+
 fun BuildSteps.removeSubstDirOnWindows(os: Os) {
     if (os == Os.WINDOWS) {
         script {

--- a/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
@@ -20,6 +20,7 @@ import common.Os
 import common.applyPerformanceTestSettings
 import common.buildToolGradleParameters
 import common.checkCleanM2AndAndroidUserHome
+import common.cleanUpPerformanceBuildDir
 import common.gradleWrapper
 import common.individualPerformanceTestArtifactRules
 import common.killGradleProcessesStep
@@ -99,6 +100,7 @@ class PerformanceTest(
                             ).joinToString(separator = " ")
                     }
                 }
+                cleanUpPerformanceBuildDir(os)
                 removeSubstDirOnWindows(os)
                 checkCleanM2AndAndroidUserHome(os)
             }


### PR DESCRIPTION
This is a workaround of https://github.com/gradle/gradle-private/issues/3961 Because some read-only files are created in `performance/build/santaTrackerAndroidBuild`, we have to clean them up at the end of performance tests, otherwise it breaks the subsequent builds.
