### PR TITLE
Fix failing kotlin-dsl-tooling-builder

### DIFF
--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r54/KotlinBuildScriptModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r54/KotlinBuildScriptModelCrossVersionSpec.groovy
@@ -21,6 +21,7 @@ import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.kotlin.dsl.tooling.builders.AbstractKotlinScriptModelCrossVersionTest
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.test.fixtures.Flaky
+import org.gradle.util.GradleVersion
 import org.hamcrest.Matcher
 
 import static org.hamcrest.CoreMatchers.allOf
@@ -530,11 +531,19 @@ class KotlinBuildScriptModelCrossVersionSpec extends AbstractKotlinScriptModelCr
         )
     }
 
+    private String getKotlinSourcesJarName() {
+        if (targetVersion > GradleVersion.version("8.3")) {
+            return "kotlin-stdlib-${targetKotlinVersion}-sources.jar".toString()
+        } else {
+            return "kotlin-stdlib-jdk8-${targetKotlinVersion}-sources.jar".toString()
+        }
+    }
+
     private void assertSourcePathIncludesKotlinStdlibSourcesGiven(String rootProjectScript, String subProjectScript) {
         assertSourcePathGiven(
             rootProjectScript,
             subProjectScript,
-            hasItems("kotlin-stdlib-${targetKotlinVersion}-sources.jar".toString())
+            hasItems(getKotlinSourcesJarName())
         )
     }
 


### PR DESCRIPTION
After https://github.com/gradle/gradle/pull/26140, a lot of tests fail with

```


java.lang.AssertionError: |  
-- | --
  | Expected: (a collection containing "kotlin-stdlib-1.3.72-sources.jar") |  
  | but: a collection containing "kotlin-stdlib-1.3.72-sources.jar" was "gradle-kotlin-dsl-extensions-6.5.1.jar", was "gradle-kotlin-dsl-6.5.1.jar", was "gradle-kotlin-dsl-tooling-models-6.5.1.jar", was "antlr", was "base-annotations", was "base-services", was "base-services-groovy", was "bootstrap", was "build-cache", was "build-cache-base", was "build-cache-http", was "build-cache-packaging", was "build-events", was "build-init", was "build-option", was "build-profile", was "cli", was "code-quality", was "composite-builds", was "core", was "core-api", was "dependency-management", was "diagnostics", was "docs", was "ear", was "execution", was "file-collections", was "file-watching", was "files", was "hashing", was "ide", was "ide-native", was "ide-play", was "installation-beacon", was "instant-execution", was "instant-execution-report", was "internal-android-performance-testing", was "internal-integ-testing", was "internal-performance-testing", was "internal-testing", was "ivy", was "jacoco", was "java-compiler-plugin", was "javascript", was "jvm-services", was "kotlin-dsl", was "kotlin-dsl-plugins", was "kotlin-dsl-provider-plugins", was "kotlin-dsl-test-fixtures", was "kotlin-dsl-tooling-builders", was "kotlin-dsl-tooling-models", was "language-groovy", was "language-java", was "language-jvm", was "language-native", was "language-scala", was "launcher", was "logging", was "maven", was "messaging", was "model-core", was "model-groovy", was "native", was "normalization-java", was "persistent-cache", was "platform-base", was "platform-jvm", was "platform-native", was "platform-play", was "plugin-development", was "plugin-use", was "plugins", was "process-services", was "publish", was "reporting", was "resources", was "resources-gcs", was "resources-http", was "resources-s3", was "resources-sftp", was "scala", was "security", was "signing", was "snapshots", was "test-kit", was "testing-base", was "testing-junit-platform", was "testing-jvm", was "testing-native", was "tooling-api", was "tooling-api-builders", was "tooling-native", was "version-control", was "worker-processes", was "workers", was "wrapper", was "kotlin-reflect-1.3.72-sources.jar", was "kotlin-stdlib-jdk8-1.3.72-sources.jar", was "src" |  
  | at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20) |  
  | at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:8) |  
  | at org.gradle.kotlin.dsl.tooling.builders.r54.KotlinBuildScriptModelCrossVersionSpec.assertSourcePathGiven(KotlinBuildScriptModelCrossVersionSpec.groovy:573) |  
  | at org.gradle.kotlin.dsl.tooling.builders.r54.KotlinBuildScriptModelCrossVersionSpec.assertSourcePathIncludesKotlinStdlibSourcesGiven(KotlinBuildScriptModelCrossVersionSpec.groovy:537) |  
  | at org.gradle.kotlin.dsl.tooling.builders.r54.KotlinBuildScriptModelCrossVersionSpec.$spock_feature_2_17(KotlinBuildScriptModelCrossVersionSpec.groovy:441)
```

It seems like we need to select the result kotlin sources jar based on target Gradle version, i.e. for older version of Gradle, we would get `kotlin-stdlib-jdk8`; for newer version, we would get `kotlin-stdlib`.

