### PR TITLE
Make BuildLauncher and TestLauncher behavior more uniform

### DIFF
--- a/subprojects/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -61,6 +61,16 @@ With the deprecation of `Project.buildDir`, buildscripts that are compiled with 
 
 See <<#project_builddir, the deprecation entry>> for details.
 
+==== `TestLauncher` API no longer ignores build failures
+
+The `TestLauncher` interface is part of the Tooling API, specialized for running tests.
+It is a logical extension of the `BuildLauncher` that can only launch tasks.
+A discrepancy has been reported in their behavior: if the same failing test is executed, `BuildLauncher` will report a build failure but `TestLauncher` won't.
+Originally, this was a design decision in order to continue the execution and run the tests in all test tasks and not stop at the first failure.
+At the same time, this behavior can be confusing for users as they can experience a failing test in a successful build.
+To make the two APIs more uniform, we made `TestLauncher` also fail the build, which is a potential breaking change.
+To continue the test execution even if a test task failed, Tooling API clients should explicitly pass `--continue` to the build.
+
 [[legacy_attribute_snapshotting]]
 ==== Fixed variant selection behavior with `ArtifactView` and `ArtifactCollection`
 

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationAction.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationAction.java
@@ -88,7 +88,6 @@ class TestExecutionBuildConfigurationAction implements EntryTaskSelector {
     }
 
     private void configureTestTask(AbstractTestTask test) {
-        test.setIgnoreFailures(true);
         test.getFilter().setFailOnNoMatchingTests(false);
         test.getOutputs().upToDateWhen(Specs.SATISFIES_NONE);
         if (test instanceof Test) {

--- a/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/TestExecutionBuildTaskSchedulerTest.groovy
+++ b/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/TestExecutionBuildTaskSchedulerTest.groovy
@@ -122,7 +122,6 @@ class TestExecutionBuildTaskSchedulerTest extends Specification {
         then:
         1 * testFilter.includeTest(expectedClassFilter, expectedMethodFilter)
 
-        1 * testTask.setIgnoreFailures(true)
         1 * testFilter.setFailOnNoMatchingTests(false)
         1 * outputsInternal.upToDateWhen(Specs.SATISFIES_NONE)
 

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/TestLauncherSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/TestLauncherSpec.groovy
@@ -63,8 +63,12 @@ abstract class TestLauncherSpec extends ToolingApiSpecification implements WithO
     }
 
     void launchTests(Closure configurationClosure) {
+        launchTests(null, configurationClosure)
+    }
+
+    void launchTests(ResultHandler<Void> resultHandler, Closure configurationClosure) {
         withConnection { ProjectConnection connection ->
-            launchTests(connection, null, cancellationTokenSource.token(), configurationClosure)
+            launchTests(connection, resultHandler, cancellationTokenSource.token(), configurationClosure)
         }
     }
 


### PR DESCRIPTION
The TestLauncher calls AbstractTestTask.setIgnoreFailures(true) which makes the build pass even if the test failed. This is an unexpected behavior compared to the BuildLauncher as users do expect build failures.

The failures were ignored in order not to stop the execution when a test task failed. At the same time, the client can always run the build with the `--continue` flag and have the same behavior.

Fixes https://github.com/gradle/gradle/issues/26195

TODO
- [x] Mention this in the release notes as a potential breaking change
