### PR TITLE
Fix closure control flow tracking when closure calls throw exceptions

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/CallInterceptionClosureInstrumentingClassVisitor.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/CallInterceptionClosureInstrumentingClassVisitor.java
@@ -115,7 +115,7 @@ public class CallInterceptionClosureInstrumentingClassVisitor extends ClassVisit
                          * enterInstrumentedClosure(this);
                          * try {
                          *     return doCall$original(<args>);
-                         * } finally { // but with inlining the handler
+                         * } finally { // similar to what javac produces, this block is inlined at the normal return and catch+rethrow exit points;
                          *     leaveInstrumentedClosure(this);
                          * }
                          */
@@ -139,7 +139,7 @@ public class CallInterceptionClosureInstrumentingClassVisitor extends ClassVisit
                         _INVOKESPECIAL(clazz.className, methodNameToVisit, methodData.descriptor, false);
                         mv.visitLabel(tryBlockEnd);
 
-                        // finally:
+                        // finally block inlined before normal return:
                         _ALOAD(0);
                         _INVOKESTATIC(Type.getType(InstrumentedClosuresHelper.class).getInternalName(), "leaveInstrumentedClosure", enterLeaveDescriptor, false);
                         // and return:
@@ -151,7 +151,7 @@ public class CallInterceptionClosureInstrumentingClassVisitor extends ClassVisit
                         // Must use an F_NEW frame, as we may encounter class versions <= V1_5, see ASM MethodWriter
                         mv.visitFrame(Opcodes.F_NEW, 1, locals, 1, new Object[]{"java/lang/Throwable"});
 
-                        // finally:
+                        // finally block inlined before rethrowing a caught exception:
                         _ALOAD(0);
                         _INVOKESTATIC(Type.getType(InstrumentedClosuresHelper.class).getInternalName(), "leaveInstrumentedClosure", enterLeaveDescriptor, false);
                         // and rethrow:

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/CallInterceptionClosureInstrumentingClassVisitor.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/CallInterceptionClosureInstrumentingClassVisitor.java
@@ -20,6 +20,7 @@ import groovy.lang.Closure;
 import org.gradle.api.NonNullApi;
 import org.gradle.model.internal.asm.MethodVisitorScope;
 import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
@@ -112,13 +113,23 @@ public class CallInterceptionClosureInstrumentingClassVisitor extends ClassVisit
                     public void visitCode() {
                         /*
                          * enterInstrumentedClosure(this);
-                         * doCall$original(<args>);
-                         * leaveInstrumentedClosure(this);
+                         * try {
+                         *     return doCall$original(<args>);
+                         * } finally { // but with inlining the handler
+                         *     leaveInstrumentedClosure(this);
+                         * }
                          */
                         _ALOAD(0);
                         String enterLeaveDescriptor = Type.getMethodDescriptor(Type.VOID_TYPE, getType(InstrumentableClosure.class));
                         _INVOKESTATIC(Type.getType(InstrumentedClosuresHelper.class).getInternalName(), "enterInstrumentedClosure", enterLeaveDescriptor, false);
 
+                        Label tryBlockStart = new Label();
+                        Label tryBlockEnd = new Label();
+                        Label catchBlockStart = new Label();
+
+                        mv.visitTryCatchBlock(tryBlockStart, tryBlockEnd, catchBlockStart, "java/lang/Throwable");
+
+                        mv.visitLabel(tryBlockStart);
                         _ALOAD(0); // receiver reference to this
                         // Invoke the original method:
                         Type[] argumentTypes = Type.getArgumentTypes(methodData.descriptor);
@@ -126,11 +137,26 @@ public class CallInterceptionClosureInstrumentingClassVisitor extends ClassVisit
                             visitVarInsn(argumentTypes[argIndex - 1].getOpcode(Opcodes.ILOAD), argIndex);
                         }
                         _INVOKESPECIAL(clazz.className, methodNameToVisit, methodData.descriptor, false);
+                        mv.visitLabel(tryBlockEnd);
 
+                        // finally:
                         _ALOAD(0);
                         _INVOKESTATIC(Type.getType(InstrumentedClosuresHelper.class).getInternalName(), "leaveInstrumentedClosure", enterLeaveDescriptor, false);
-
+                        // and return:
                         visitInsn(Type.getReturnType(methodData.descriptor).getOpcode(IRETURN));
+
+                        // start exception handler:
+                        mv.visitLabel(catchBlockStart);
+                        Object[] locals = new Object[]{clazz.className.replaceAll("\\.", "/")};
+                        // Must use an F_NEW frame, as we may encounter class versions <= V1_5, see ASM MethodWriter
+                        mv.visitFrame(Opcodes.F_NEW, 1, locals, 1, new Object[]{"java/lang/Throwable"});
+
+                        // finally:
+                        _ALOAD(0);
+                        _INVOKESTATIC(Type.getType(InstrumentedClosuresHelper.class).getInternalName(), "leaveInstrumentedClosure", enterLeaveDescriptor, false);
+                        // and rethrow:
+                        mv.visitInsn(Opcodes.ATHROW);
+
                         visitMaxs(argumentTypes.length * 2 + 1, argumentTypes.length + 1);
                     }
                 }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/GroovyDynamicDispatchingInterceptingTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/GroovyDynamicDispatchingInterceptingTest.groovy
@@ -149,11 +149,13 @@ class GroovyDynamicDispatchingInterceptingTest extends AbstractCallInterceptionT
         }
         transformedInterceptedClosure.delegate = new FalseInterceptorTestReceiver()
 
-        when: 'a closure throwing an exception is called, then a closure that hits an instrumented call is called'
-        try {
-            transformedThrowingClosure()
-            // this calls throws an exception, but we expect the closure to be still correctly removed from control flow tracking
-        } catch (RuntimeException ignored) {}
+        when: 'a closure throwing an exception is called'
+        transformedThrowingClosure()
+
+        then: 'the exception is thrown, but despite that, the closure must have been removed from the closure control flow tracker, which is checked below'
+        thrown(RuntimeException)
+
+        when: 'another closure is called that makes a potentially intercepted call, which should turn all closures "on the stack" into effectively instrumented ones'
         transformedInterceptedClosure()
 
         then: 'the closure that threw an exception should not have become effectively instrumented'


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/26271.

Initially, the code in an instrumented closure's `doCall` was equivalent to:

```java
enterInstrumentedClosure(this);
Object result = doCall$original(<args>);
leaveInstrumentedCall(this);
return result;
```

This would lead to the closure reference leaking in the tracker if it throws an exception. Fix this by making the code equivalent to:

```java
enterInstrumentedClosure(this);
try {
    return doCall$original(<args>);
} finally {
    leaveInstrumentedClosure(this);
}
```

<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
