### PR TITLE
Clean up performance build directory at the beginning

### DIFF
--- a/.teamcity/src/main/kotlin/common/performance-test-extensions.kt
+++ b/.teamcity/src/main/kotlin/common/performance-test-extensions.kt
@@ -92,13 +92,15 @@ fun BuildSteps.substDirOnWindows(os: Os) {
     }
 }
 
-fun BuildSteps.cleanUpPerformanceBuildDir(os: Os) {
+fun BuildType.cleanUpPerformanceBuildDir(os: Os) {
     if (os == Os.WINDOWS) {
-        script {
-            name = "CLEAN_UP_PERFORMANCE_BUILD_DIR"
-            executionMode = BuildStep.ExecutionMode.ALWAYS
-            scriptContent = """rmdir /s /q p:\subprojects\performance\build\santaTrackerAndroidBuild && (echo Directory removed) || (echo Directory not found) """
-            skipConditionally()
+        steps {
+            script {
+                name = "CLEAN_UP_PERFORMANCE_BUILD_DIR"
+                executionMode = BuildStep.ExecutionMode.ALWAYS
+                scriptContent = """rmdir /s /q %teamcity.build.checkoutDir%\subprojects\performance\build && (echo Directory removed) || (echo Directory not found) """
+                skipConditionally()
+            }
         }
     }
 }

--- a/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
+++ b/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
@@ -8,6 +8,7 @@ import common.VersionedSettingsBranch
 import common.applyDefaultSettings
 import common.buildToolGradleParameters
 import common.checkCleanM2AndAndroidUserHome
+import common.cleanUpPerformanceBuildDir
 import common.compileAllDependency
 import common.dependsOn
 import common.functionalTestParameters
@@ -125,6 +126,7 @@ fun applyDefaults(
     buildType.applyDefaultSettings(os, timeout = timeout)
 
     buildType.killProcessStep("KILL_LEAKED_PROCESSES_FROM_PREVIOUS_BUILDS", os)
+    buildType.cleanUpPerformanceBuildDir(os)
     buildType.gradleRunnerStep(model, gradleTasks, os, extraParameters, daemon)
 
     buildType.steps {
@@ -157,9 +159,8 @@ fun applyTestDefaults(
     }
 
     buildType.killProcessStep("KILL_LEAKED_PROCESSES_FROM_PREVIOUS_BUILDS", os, arch)
-
+    buildType.cleanUpPerformanceBuildDir(os)
     buildType.gradleRunnerStep(model, gradleTasks, os, extraParameters, daemon, maxParallelForks = maxParallelForks)
-
     buildType.killProcessStep("KILL_PROCESSES_STARTED_BY_GRADLE", os, arch)
 
     buildType.steps {

--- a/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
@@ -20,7 +20,6 @@ import common.Os
 import common.applyPerformanceTestSettings
 import common.buildToolGradleParameters
 import common.checkCleanM2AndAndroidUserHome
-import common.cleanUpPerformanceBuildDir
 import common.gradleWrapper
 import common.individualPerformanceTestArtifactRules
 import common.killGradleProcessesStep
@@ -100,7 +99,6 @@ class PerformanceTest(
                             ).joinToString(separator = " ")
                     }
                 }
-                cleanUpPerformanceBuildDir(os)
                 removeSubstDirOnWindows(os)
                 checkCleanM2AndAndroidUserHome(os)
             }

--- a/.teamcity/src/main/kotlin/util/RerunFlakyTest.kt
+++ b/.teamcity/src/main/kotlin/util/RerunFlakyTest.kt
@@ -24,6 +24,7 @@ import common.Os
 import common.applyDefaultSettings
 import common.buildToolGradleParameters
 import common.checkCleanM2AndAndroidUserHome
+import common.cleanUpPerformanceBuildDir
 import common.compileAllDependency
 import common.functionalTestExtraParameters
 import common.functionalTestParameters
@@ -58,6 +59,8 @@ class RerunFlakyTest(os: Os, arch: Arch = Arch.AMD64) : BuildType({
         ).joinToString(separator = " ")
 
     killProcessStep("KILL_LEAKED_PROCESSES_FROM_PREVIOUS_BUILDS", os, arch)
+    cleanUpPerformanceBuildDir(os)
+
     (1..10).forEach { idx ->
         steps {
             gradleWrapper {

--- a/.teamcity/src/test/kotlin/ApplyDefaultConfigurationTest.kt
+++ b/.teamcity/src/test/kotlin/ApplyDefaultConfigurationTest.kt
@@ -119,6 +119,7 @@ class ApplyDefaultConfigurationTest {
         assertEquals(
             listOf(
                 "KILL_LEAKED_PROCESSES_FROM_PREVIOUS_BUILDS",
+                "CLEAN_UP_PERFORMANCE_BUILD_DIR",
                 "GRADLE_RUNNER",
                 "KILL_PROCESSES_STARTED_BY_GRADLE",
                 "CHECK_CLEAN_M2_ANDROID_USER_HOME"


### PR DESCRIPTION
Following https://github.com/gradle/gradle-private/issues/3961, we made an attempt to workaround this issue by removing the directory at the end of performance builds. However, if the performance builds are cancelled. the leftover directories would still break subsequent builds. Now let's clean up the directory at the beginning.