### PR TITLE
Beanify `DocLink`, so Kotlin/Groovy would use property accessors

### DIFF
--- a/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/DefaultPrecompiledScriptPluginsSupport.kt
+++ b/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/DefaultPrecompiledScriptPluginsSupport.kt
@@ -486,7 +486,7 @@ fun Project.validateScriptPlugin(scriptPlugin: PrecompiledScriptPlugin) {
                 DefaultPluginManager.CORE_PLUGIN_NAMESPACE, DefaultPluginManager.CORE_PLUGIN_NAMESPACE
             ),
             null,
-            PRECOMPILED_SCRIPT_MANUAL.consultDocumentationMessage()
+            PRECOMPILED_SCRIPT_MANUAL.getConsultDocumentationMessage()
         )
     }
     val existingPlugin = plugins.findPlugin(scriptPlugin.id)
@@ -498,7 +498,7 @@ fun Project.validateScriptPlugin(scriptPlugin: PrecompiledScriptPlugin) {
                 scriptPlugin.id
             ),
             null,
-            PRECOMPILED_SCRIPT_MANUAL.consultDocumentationMessage()
+            PRECOMPILED_SCRIPT_MANUAL.getConsultDocumentationMessage()
         )
     }
 }

--- a/platforms/jvm/toolchains-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainQueryService.java
+++ b/platforms/jvm/toolchains-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainQueryService.java
@@ -165,7 +165,7 @@ public class JavaToolchainQueryService {
             DeprecationLogger.warnOfChangedBehaviour(
                     "Using a toolchain installed via auto-provisioning, but having no toolchain repositories configured",
                     "Consider defining toolchain download repositories, otherwise the build might fail in clean environments; " +
-                        "see " + Documentation.userManual("toolchains", "sub:download_repositories").url()
+                        "see " + Documentation.userManual("toolchains", "sub:download_repositories").getUrl()
                 )
                 .withUserManual("toolchains", "sub:download_repositories") //has no effect due to bug in DeprecationLogger.warnOfChangedBehaviour
                 .nagUser();

--- a/platforms/jvm/toolchains-jvm/src/main/java/org/gradle/jvm/toolchain/internal/install/DefaultJavaToolchainProvisioningService.java
+++ b/platforms/jvm/toolchains-jvm/src/main/java/org/gradle/jvm/toolchain/internal/install/DefaultJavaToolchainProvisioningService.java
@@ -100,14 +100,14 @@ public class DefaultJavaToolchainProvisioningService implements JavaToolchainPro
     public File tryInstall(JavaToolchainSpec spec) {
         if (!isAutoDownloadEnabled()) {
             throw new ToolchainDownloadFailedException("No locally installed toolchains match and toolchain auto-provisioning is not enabled.",
-                "Learn more about toolchain auto-detection at " + Documentation.userManual("toolchains", "sec:auto_detection").url() + ".");
+                "Learn more about toolchain auto-detection at " + Documentation.userManual("toolchains", "sec:auto_detection").getUrl() + ".");
         }
 
         List<? extends RealizedJavaToolchainRepository> repositories = toolchainResolverRegistry.requestedRepositories();
         if (repositories.isEmpty()) {
             throw new ToolchainDownloadFailedException("No locally installed toolchains match and toolchain download repositories have not been configured.",
-                "Learn more about toolchain auto-detection at " + Documentation.userManual("toolchains", "sec:auto_detection").url() + ".",
-                "Learn more about toolchain repositories at " + Documentation.userManual("toolchains", "sub:download_repositories").url() + ".");
+                "Learn more about toolchain auto-detection at " + Documentation.userManual("toolchains", "sec:auto_detection").getUrl() + ".",
+                "Learn more about toolchain repositories at " + Documentation.userManual("toolchains", "sub:download_repositories").getUrl() + ".");
         }
 
         for (RealizedJavaToolchainRepository request : repositories) {
@@ -119,8 +119,8 @@ public class DefaultJavaToolchainProvisioningService implements JavaToolchainPro
         }
 
         throw new ToolchainDownloadFailedException("No locally installed toolchains match and the configured toolchain download repositories aren't able to provide a match either.",
-            "Learn more about toolchain auto-detection at " + Documentation.userManual("toolchains", "sec:auto_detection").url() + ".",
-            "Learn more about toolchain repositories at " + Documentation.userManual("toolchains", "sub:download_repositories").url() + ".");
+            "Learn more about toolchain auto-detection at " + Documentation.userManual("toolchains", "sec:auto_detection").getUrl() + ".",
+            "Learn more about toolchain repositories at " + Documentation.userManual("toolchains", "sub:download_repositories").getUrl() + ".");
     }
 
     private File provisionInstallation(JavaToolchainSpec spec, URI uri, Collection<Authentication> authentications) {

--- a/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceIntegrationTest.groovy
+++ b/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceIntegrationTest.groovy
@@ -276,7 +276,7 @@ class HttpBuildCacheServiceIntegrationTest extends HttpBuildCacheFixture {
         withBuildCache().fails("jar")
             .assertHasCause("Using insecure protocols with remote build cache, without explicit opt-in, is unsupported.")
             .assertHasResolution("Switch remote build cache to a secure protocol (like HTTPS) or allow insecure protocols.")
-            .assertHasResolution(Documentation.dslReference(HttpBuildCache, "allowInsecureProtocol").consultDocumentationMessage())
+            .assertHasResolution(Documentation.dslReference(HttpBuildCache, "allowInsecureProtocol").getConsultDocumentationMessage())
     }
 
     def "ssl certificate is validated"() {

--- a/subprojects/build-cache-http/src/main/java/org/gradle/caching/http/internal/DefaultHttpBuildCacheServiceFactory.java
+++ b/subprojects/build-cache-http/src/main/java/org/gradle/caching/http/internal/DefaultHttpBuildCacheServiceFactory.java
@@ -125,7 +125,7 @@ public class DefaultHttpBuildCacheServiceFactory implements BuildCacheServiceFac
                     throw new InsecureProtocolException(
                         "Using insecure protocols with remote build cache, without explicit opt-in, is unsupported.",
                         "Switch remote build cache to a secure protocol (like HTTPS) or allow insecure protocols.",
-                        Documentation.dslReference(HttpBuildCache.class, "allowInsecureProtocol").consultDocumentationMessage()
+                        Documentation.dslReference(HttpBuildCache.class, "allowInsecureProtocol").getConsultDocumentationMessage()
                     );
                 },
                 redirect -> {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/HttpScriptPluginIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/HttpScriptPluginIntegrationSpec.groovy
@@ -67,7 +67,7 @@ class HttpScriptPluginIntegrationSpec extends AbstractHttpScriptPluginIntegratio
         fails(":help")
             .assertHasCause("Applying script plugins from insecure URIs, without explicit opt-in, is unsupported. The provided URI '${server.uri("/external.gradle")}' uses an insecure protocol (HTTP).")
             .assertHasResolution("Use '${GUtil.toSecureUrl(server.uri("/external.gradle"))}' instead or try 'apply from: resources.text.fromInsecureUri(\"${server.uri("/external.gradle")}\")'.")
-            .assertHasResolution(Documentation.dslReference(TextResourceFactory.class, "fromInsecureUri(java.lang.Object)").consultDocumentationMessage())
+            .assertHasResolution(Documentation.dslReference(TextResourceFactory.class, "fromInsecureUri(java.lang.Object)").getConsultDocumentationMessage())
     }
 
     def "does not complain when applying script plugin via http using text resource"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/resource/TextResourceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/resource/TextResourceIntegrationTest.groovy
@@ -127,7 +127,7 @@ class TextResourceIntegrationTest extends AbstractIntegrationSpec {
         fails("uriText")
             .assertHasCause("Loading a TextResource from an insecure URI, without explicit opt-in, is unsupported. The provided URI '${server.uri}/myConfig-${uuid}.txt' uses an insecure protocol (HTTP).")
             .assertHasResolution("Switch the URI to '${GUtil.toSecureUrl(server.uri)}/myConfig-${uuid}.txt' or try 'resources.text.fromInsecureUri(\"${server.uri}/myConfig-${uuid}.txt\")' to silence the warning.")
-            .assertHasResolution(Documentation.dslReference(TextResourceFactory, "fromInsecureUri(java.lang.Object)").consultDocumentationMessage())
+            .assertHasResolution(Documentation.dslReference(TextResourceFactory, "fromInsecureUri(java.lang.Object)").getConsultDocumentationMessage())
     }
 
     def "uri backed text resource over https"() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultObjectConfigurationAction.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultObjectConfigurationAction.java
@@ -120,14 +120,14 @@ public class DefaultObjectConfigurationAction implements ObjectConfigurationActi
                 throw new InsecureProtocolException(
                     String.format("Applying script plugins from insecure URIs, without explicit opt-in, is unsupported. The provided URI '%s' uses an insecure protocol (HTTP). ", scriptUri),
                     String.format("Use '%s' instead or try 'apply from: resources.text.fromInsecureUri(\"%s\")'. ", GUtil.toSecureUrl(scriptUri), scriptUri),
-                    Documentation.dslReference(TextResourceFactory.class, "fromInsecureUri(java.lang.Object)").consultDocumentationMessage()
+                    Documentation.dslReference(TextResourceFactory.class, "fromInsecureUri(java.lang.Object)").getConsultDocumentationMessage()
                 );
             },
             redirect -> {
                 throw new InsecureProtocolException(
                     String.format("Applying script plugins from an insecure redirect, without explicit opt-in, is unsupported. '%s' redirects to insecure '%s'. ", scriptUri, redirect),
                     "Switch to HTTPS or use TextResourceFactory.fromInsecureUri(Object).",
-                    Documentation.dslReference(TextResourceFactory.class, "fromInsecureUri(java.lang.Object)").consultDocumentationMessage()
+                    Documentation.dslReference(TextResourceFactory.class, "fromInsecureUri(java.lang.Object)").getConsultDocumentationMessage()
                 );
             }
         );

--- a/subprojects/core/src/main/java/org/gradle/api/internal/resources/DefaultTextResourceFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/resources/DefaultTextResourceFactory.java
@@ -95,7 +95,7 @@ public class DefaultTextResourceFactory implements TextResourceFactory {
         throw new InsecureProtocolException(
             "Loading a TextResource from an insecure URI, without explicit opt-in, is unsupported. " + String.format("The provided URI '%s' uses an insecure protocol (HTTP). ", rootUri),
             String.format("Switch the URI to '%s' or try 'resources.text.fromInsecureUri(\"%s\")' to silence the warning. ", GUtil.toSecureUrl(rootUri), rootUri),
-            Documentation.dslReference(TextResourceFactory.class, "fromInsecureUri(java.lang.Object)").consultDocumentationMessage()
+            Documentation.dslReference(TextResourceFactory.class, "fromInsecureUri(java.lang.Object)").getConsultDocumentationMessage()
         );
     }
 
@@ -103,7 +103,7 @@ public class DefaultTextResourceFactory implements TextResourceFactory {
         throw new InsecureProtocolException(
             "Loading a TextResource from an insecure redirect, without explicit opt-in, is unsupported. " + String.format("'%s' redirects to insecure '%s'.", uri, redirect),
             "Switch to HTTPS or use TextResourceFactory.fromInsecureUri(Object) to silence the warning.",
-            Documentation.dslReference(TextResourceFactory.class, "fromInsecureUri(java.lang.Object)").consultDocumentationMessage()
+            Documentation.dslReference(TextResourceFactory.class, "fromInsecureUri(java.lang.Object)").getConsultDocumentationMessage()
         );
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/HttpsToHttpRedirectResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/HttpsToHttpRedirectResolveIntegrationTest.groovy
@@ -57,6 +57,6 @@ class HttpsToHttpRedirectResolveIntegrationTest extends AbstractRedirectResolveI
         fails('listJars')
             .assertHasCause("Redirecting from secure protocol to insecure protocol, without explicit opt-in, is unsupported. '$frontServerBaseUrl/repo' is redirecting to '${backingServer.uri}/redirected/group/projectA/1.0/ivy-1.0.xml'.")
             .assertHasResolution("Switch Ivy repository 'ivy($frontServerBaseUrl/repo)' to redirect to a secure protocol (like HTTPS) or allow insecure protocols.")
-            .assertHasResolution(Documentation.dslReference(UrlArtifactRepository, "allowInsecureProtocol").consultDocumentationMessage())
+            .assertHasResolution(Documentation.dslReference(UrlArtifactRepository, "allowInsecureProtocol").getConsultDocumentationMessage())
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultUrlArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultUrlArtifactRepository.java
@@ -89,7 +89,7 @@ public class DefaultUrlArtifactRepository implements UrlArtifactRepository {
         throw new InsecureProtocolException(
             "Using insecure protocols with repositories, without explicit opt-in, is unsupported.",
             String.format("Switch %s repository '%s' to redirect to a secure protocol (like HTTPS) or allow insecure protocols.", repositoryType, displayNameSupplier.get()),
-            Documentation.dslReference(UrlArtifactRepository.class, "allowInsecureProtocol").consultDocumentationMessage()
+            Documentation.dslReference(UrlArtifactRepository.class, "allowInsecureProtocol").getConsultDocumentationMessage()
         );
     }
 
@@ -107,7 +107,7 @@ public class DefaultUrlArtifactRepository implements UrlArtifactRepository {
         throw new InsecureProtocolException(
             "Redirecting from secure protocol to insecure protocol, without explicit opt-in, is unsupported." + contextualAdvice,
             String.format("Switch %s repository '%s' to redirect to a secure protocol (like HTTPS) or allow insecure protocols. ", repositoryType, displayNameSupplier.get()),
-            Documentation.dslReference(UrlArtifactRepository.class, "allowInsecureProtocol").consultDocumentationMessage()
+            Documentation.dslReference(UrlArtifactRepository.class, "allowInsecureProtocol").getConsultDocumentationMessage()
         );
     }
 

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/client/NoUsableDaemonFoundException.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/client/NoUsableDaemonFoundException.java
@@ -25,7 +25,7 @@ import java.util.List;
 
 public class NoUsableDaemonFoundException extends DefaultMultiCauseException implements ResolutionProvider {
 
-    private static final List<String> RESOLUTION = Collections.singletonList(Documentation.userManual("troubleshooting", "network_connection").consultDocumentationMessage());
+    private static final List<String> RESOLUTION = Collections.singletonList(Documentation.userManual("troubleshooting", "network_connection").getConsultDocumentationMessage());
 
     public NoUsableDaemonFoundException(String message, Iterable<? extends Throwable> causes) {
         super(message, causes);

--- a/subprojects/logging/src/main/java/org/gradle/api/internal/DocumentationRegistry.java
+++ b/subprojects/logging/src/main/java/org/gradle/api/internal/DocumentationRegistry.java
@@ -79,7 +79,7 @@ public class DocumentationRegistry {
     }
 
     public String getDocumentationRecommendationFor(String topic, DocLink docLink) {
-        String url = docLink.url();
+        String url = docLink.getUrl();
         return getRecommendationString(topic, url == null ? "<N/A>" : url);
     }
 

--- a/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DeprecatedFeatureUsage.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DeprecatedFeatureUsage.java
@@ -143,7 +143,7 @@ public class DeprecatedFeatureUsage extends FeatureUsage {
         append(outputBuilder, removalDetails);
         append(outputBuilder, contextualAdvice);
         append(outputBuilder, advice);
-        append(outputBuilder, documentation.consultDocumentationMessage());
+        append(outputBuilder, documentation.getConsultDocumentationMessage());
         return outputBuilder.toString();
     }
 

--- a/subprojects/logging/src/main/java/org/gradle/internal/deprecation/Documentation.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/deprecation/Documentation.java
@@ -47,8 +47,8 @@ public abstract class Documentation implements DocLink {
     }
 
     @Nullable
-    public String consultDocumentationMessage() {
-        return String.format(RECOMMENDATION, "information", url());
+    public String getConsultDocumentationMessage() {
+        return String.format(RECOMMENDATION, "information", getUrl());
     }
 
     private static abstract class SerializerableDocumentation extends Documentation {
@@ -101,12 +101,12 @@ public abstract class Documentation implements DocLink {
         }
 
         @Override
-        public String url() {
+        public String getUrl() {
             return null;
         }
 
         @Override
-        public String consultDocumentationMessage() {
+        public String getConsultDocumentationMessage() {
             return null;
         }
 
@@ -135,7 +135,7 @@ public abstract class Documentation implements DocLink {
         }
 
         @Override
-        public String url() {
+        public String getUrl() {
             if (section == null) {
                 return DOCUMENTATION_REGISTRY.getDocumentationFor(page);
             }
@@ -164,8 +164,8 @@ public abstract class Documentation implements DocLink {
         }
 
         @Override
-        public String consultDocumentationMessage() {
-            return "Consult the upgrading guide for further information: " + url();
+        public String getConsultDocumentationMessage() {
+            return "Consult the upgrading guide for further information: " + getUrl();
         }
     }
 
@@ -179,7 +179,7 @@ public abstract class Documentation implements DocLink {
         }
 
         @Override
-        public String url() {
+        public String getUrl() {
             return DOCUMENTATION_REGISTRY.getDslRefForProperty(targetClass, property);
         }
 

--- a/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DocumentedFailure.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DocumentedFailure.java
@@ -65,7 +65,7 @@ public class DocumentedFailure {
             StringBuilder outputBuilder = new StringBuilder(summary);
             append(outputBuilder, contextualAdvice);
             append(outputBuilder, advice);
-            append(outputBuilder, documentation.consultDocumentationMessage());
+            append(outputBuilder, documentation.getConsultDocumentationMessage());
             return cause == null
                 ? new GradleException(outputBuilder.toString())
                 : new DocumentedExceptionWithCause(outputBuilder.toString(), cause);

--- a/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/DefaultDeprecatedUsageProgressDetails.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/DefaultDeprecatedUsageProgressDetails.java
@@ -60,7 +60,7 @@ public class DefaultDeprecatedUsageProgressDetails implements DeprecatedUsagePro
 
     @Override
     public String getDocumentationUrl() {
-        return featureUsage.getDocumentationUrl().url();
+        return featureUsage.getDocumentationUrl().getUrl();
     }
 
     @Override

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/deprecation/DeprecatedFeatureUsageTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/deprecation/DeprecatedFeatureUsageTest.groovy
@@ -42,7 +42,7 @@ class DeprecatedFeatureUsageTest extends Specification {
         def featureUsage = new DeprecatedFeatureUsage("summary", "removalDetails", "advice", "contextualAdvice", documentationReference, DeprecatedFeatureUsage.Type.USER_CODE_DIRECT, getClass())
 
         expect:
-        featureUsage.getDocumentationUrl().url() == expected
+        featureUsage.getDocumentationUrl().getUrl() == expected
 
         where:
         documentationReference                 | expected

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/deprecation/DocumentationTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/deprecation/DocumentationTest.groovy
@@ -28,8 +28,8 @@ class DocumentationTest extends Specification {
         def documentationReference = Documentation.NO_DOCUMENTATION
 
         then:
-        documentationReference.url() == null
-        documentationReference.consultDocumentationMessage() == null
+        documentationReference.getUrl() == null
+        documentationReference.getConsultDocumentationMessage() == null
     }
 
     def "formats message for documentation id #documentationId, section #documentationSection"() {
@@ -37,7 +37,7 @@ class DocumentationTest extends Specification {
         def documentationReference = Documentation.userManual(documentationId, documentationSection)
 
         expect:
-        documentationReference.consultDocumentationMessage() == expectedUrl
+        documentationReference.getConsultDocumentationMessage() == expectedUrl
 
         where:
         documentationId | documentationSection | expectedUrl
@@ -51,8 +51,8 @@ class DocumentationTest extends Specification {
 
         then:
         def expectedUrl = DOCUMENTATION_REGISTRY.getDocumentationFor("upgrading_version_11", "section")
-        documentationReference.url() == expectedUrl
-        documentationReference.consultDocumentationMessage() == "Consult the upgrading guide for further information: ${expectedUrl}"
+        documentationReference.getUrl() == expectedUrl
+        documentationReference.getConsultDocumentationMessage() == "Consult the upgrading guide for further information: ${expectedUrl}"
     }
 
     def "creates dsl reference for property"() {
@@ -61,8 +61,8 @@ class DocumentationTest extends Specification {
 
         then:
         def expectedUrl = DOCUMENTATION_REGISTRY.getDslRefForProperty(Documentation, "property")
-        documentationReference.url() == expectedUrl
-        documentationReference.consultDocumentationMessage() == "For more information, please refer to ${expectedUrl} in the Gradle documentation."
+        documentationReference.getUrl() == expectedUrl
+        documentationReference.getConsultDocumentationMessage() == "For more information, please refer to ${expectedUrl} in the Gradle documentation."
     }
 
 }

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/internal/precompiled/PrecompiledGroovyPluginsPlugin.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/internal/precompiled/PrecompiledGroovyPluginsPlugin.java
@@ -101,13 +101,13 @@ public abstract class PrecompiledGroovyPluginsPlugin implements Plugin<Project> 
         if (scriptPlugin.getId().equals(CORE_PLUGIN_NAMESPACE) || scriptPlugin.getId().startsWith(CORE_PLUGIN_PREFIX)) {
             throw new PrecompiledScriptException(
                 String.format("The precompiled plugin (%s) cannot start with '%s'.", project.relativePath(scriptPlugin.getFileName()), CORE_PLUGIN_NAMESPACE),
-                PRECOMPILED_SCRIPT_MANUAL.consultDocumentationMessage());
+                PRECOMPILED_SCRIPT_MANUAL.getConsultDocumentationMessage());
         }
         Plugin<?> existingPlugin = project.getPlugins().findPlugin(scriptPlugin.getId());
         if (existingPlugin != null && existingPlugin.getClass().getPackage().getName().startsWith(CORE_PLUGIN_PREFIX)) {
             throw new PrecompiledScriptException(
                 String.format("The precompiled plugin (%s) conflicts with the core plugin '%s'. Rename your plugin.", project.relativePath(scriptPlugin.getFileName()), scriptPlugin.getId()),
-                PRECOMPILED_SCRIPT_MANUAL.consultDocumentationMessage());
+                PRECOMPILED_SCRIPT_MANUAL.getConsultDocumentationMessage());
         }
     }
 

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/internal/ValidationProblemSerialization.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/internal/ValidationProblemSerialization.java
@@ -245,8 +245,8 @@ public class ValidationProblemSerialization {
             }
 
             out.beginObject();
-            out.name("url").value(value.url());
-            out.name("consultDocumentationMessage").value(value.consultDocumentationMessage());
+            out.name("url").value(value.getUrl());
+            out.name("consultDocumentationMessage").value(value.getConsultDocumentationMessage());
             out.endObject();
         }
 
@@ -276,12 +276,12 @@ public class ValidationProblemSerialization {
             final String finalConsultDocumentationMessage = consultDocumentationMessage;
             return new DocLink() {
                 @Override
-                public String url() {
+                public String getUrl() {
                     return finalUrl;
                 }
 
                 @Override
-                public String consultDocumentationMessage() {
+                public String getConsultDocumentationMessage() {
                     return finalConsultDocumentationMessage;
                 }
             };

--- a/subprojects/plugin-development/src/test/groovy/org/gradle/plugin/devel/tasks/internal/ValidationProblemSerializationTest.groovy
+++ b/subprojects/plugin-development/src/test/groovy/org/gradle/plugin/devel/tasks/internal/ValidationProblemSerializationTest.groovy
@@ -102,8 +102,8 @@ class ValidationProblemSerializationTest extends Specification {
         deserialized[0].where.path == "location"
         deserialized[0].where.line == 1
         deserialized[0].where.column == 1
-        deserialized[0].documentationLink.url() == "url"
-        deserialized[0].documentationLink.consultDocumentationMessage() == "consult"
+        deserialized[0].documentationLink.getUrl() == "url"
+        deserialized[0].documentationLink.getConsultDocumentationMessage() == "consult"
     }
 
     /**
@@ -113,12 +113,12 @@ class ValidationProblemSerializationTest extends Specification {
     class TestDocLink implements DocLink {
 
         @Override
-        String url() {
+        String getUrl() {
             return "url"
         }
 
         @Override
-        String consultDocumentationMessage() {
+        String getConsultDocumentationMessage() {
             return "consult"
         }
     }

--- a/subprojects/problems/src/integTest/groovy/org/gradle/api/problems/ProblemsServiceIntegrationTest.groovy
+++ b/subprojects/problems/src/integTest/groovy/org/gradle/api/problems/ProblemsServiceIntegrationTest.groovy
@@ -90,12 +90,11 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         this.collectedProblems.size() == 1
-        this.collectedProblems[0]["documentationLink"] == [
-            "properties": [
-                "page": "test-id",
-                "section": "test-section"
-            ]
-        ]
+        def link = this.collectedProblems[0]["documentationLink"]
+        link["properties"]["page"] == "test-id"
+        link["properties"]["section"] == "test-section"
+        link["url"].startsWith("https://docs.gradle.org")
+        link["consultDocumentationMessage"].startsWith("For more information, please refer to https://docs.gradle.org")
     }
 
     def "can emit a problem with upgrade-guide documentation"() {
@@ -128,12 +127,11 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         this.collectedProblems.size() == 1
-        this.collectedProblems[0]["documentationLink"] == [
-            "properties": [
-                "page": "upgrading_version_8",
-                "section": "test-section"
-            ]
-        ]
+        def link = this.collectedProblems[0]["documentationLink"]
+        link["properties"]["page"] == "upgrading_version_8"
+        link["properties"]["section"] == "test-section"
+        link["url"].startsWith("https://docs.gradle.org")
+        link["consultDocumentationMessage"].startsWith("Consult the upgrading guide for further information: https://docs.gradle.org")
     }
 
     def "can emit a problem with dsl-reference documentation"() {
@@ -166,12 +164,9 @@ class ProblemsServiceIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         this.collectedProblems.size() == 1
-        this.collectedProblems[0]["documentationLink"] == [
-            "properties": [
-                "targetClass": Problem.class.name,
-                "property": "label",
-            ]
-        ]
+        def link = this.collectedProblems[0]["documentationLink"]
+        link["properties"]["targetClass"] == Problem.class.name
+        link["properties"]["property"] == "label"
     }
 
     def "can emit a problem with partially specified location"() {

--- a/subprojects/problems/src/main/java/org/gradle/api/problems/DocLink.java
+++ b/subprojects/problems/src/main/java/org/gradle/api/problems/DocLink.java
@@ -35,12 +35,12 @@ public interface DocLink {
      * The URL to the documentation page.
      */
     @Nullable
-    String url();
+    String getUrl();
 
     /**
      * A message that tells the user to consult the documentation.
      * There are currently 2 different messages used for this, hence this method.
      */
     @Nullable
-    String consultDocumentationMessage();
+    String getConsultDocumentationMessage();
 }


### PR DESCRIPTION
Fixes #26174