### PR TITLE
Cache default PgpSignatory when in-memory signing is used

### DIFF
--- a/subprojects/security/build.gradle.kts
+++ b/subprojects/security/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
     api(project(":core-api"))
     api(project(":resources"))
     implementation(project(":base-services"))
+    implementation(project(":functional"))
     implementation(project(":logging"))
     implementation(project(":process-services"))
     implementation(project(":resources-http"))


### PR DESCRIPTION
Computing a PGPSecretKey from armored text representation is suprisingly expensive. If in-memory PGP key is used, `getDefaultSignatory` gets called a lot when deducing task dependencies, fingerprinting task inputs, and storing the configuration cache, so caching is a good improvement.

This commit improves signing performance of the reproducer project with 5 signing tasks and about a dozen artifacts from 68s to 5s.

Fixes #26154.