### PR TITLE
Print daemon log if it's not parse-able

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/daemon/AbstractDaemonFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/daemon/AbstractDaemonFixture.groovy
@@ -35,6 +35,7 @@ abstract class AbstractDaemonFixture implements DaemonFixture {
         this.context = DaemonContextParser.parseFromFile(daemonLog)
         if (!this.context) {
             println "Could not parse daemon log: \n$daemonLog.text"
+            throw new IllegalStateException("unable to parse DefaultDaemonContext from source: [${daemonLog.absolutePath}].");
         }
         if (this.context?.pid == null) {
             println "PID in daemon log ($daemonLog.absolutePath) is null."
@@ -60,7 +61,7 @@ abstract class AbstractDaemonFixture implements DaemonFixture {
     @Override
     boolean logContains(long fromLine, String searchString) {
         Files.lines(logFile.toPath()).withCloseable { lines ->
-            lines.skip(fromLine).anyMatch{ it.contains(searchString) }
+            lines.skip(fromLine).anyMatch { it.contains(searchString) }
         }
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/daemon/DaemonContextParser.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/daemon/DaemonContextParser.java
@@ -43,7 +43,7 @@ public class DaemonContextParser {
         } catch(IOException e) {
             throw new IllegalStateException("unable to parse DefaultDaemonContext from source: [" + file.getAbsolutePath() + "].", e);
         }
-        throw new IllegalStateException("unable to parse DefaultDaemonContext from source: [" + file.getAbsolutePath() + "].");
+        return null;
     }
 
     public static DaemonContext parseFromString(String source) {


### PR DESCRIPTION
Sometimes we see the exception like this:

```
Caused by: java.lang.IllegalStateException: unable to parse DefaultDaemonContext from source: [/home/tcagent1/agent/work/f63322e10dd6b396/intTestHomeDir/distributions-basics/test-kit-daemon/8.4-20230830082300+0000/daemon-706687.out.log].
  at app//org.gradle.integtests.fixtures.daemon.DaemonContextParser.parseFromFile(DaemonContextParser.java:46)
  at app//org.gradle.integtests.fixtures.daemon.AbstractDaemonFixture.<init>(AbstractDaemonFixture.groovy:35)
  at app//org.gradle.integtests.fixtures.daemon.TestableDaemon.<init>(TestableDaemon.groovy:29)
  at app//org.gradle.integtests.fixtures.daemon.DaemonLogsAnalyzer.daemonForLogFile(DaemonLogsAnalyzer.groovy:80)
  at org.gradle.integtests.fixtures.daemon.DaemonLogsAnalyzer.getAllDaemons_closure3(DaemonLogsAnalyzer.groovy:71)
```

According to `AbstractDaemonFixture`, the intention was actually returning `null` if the log is not parse-able.
