### PR TITLE
Use build tree scoped cache for immutable artifact transform

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -30,7 +30,6 @@ import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
-import org.gradle.util.GradleVersion
 import org.junit.Rule
 import spock.lang.Issue
 
@@ -2254,7 +2253,7 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
     }
 
     Set<TestFile> gradleTreeScopeOutputDirs(String from, String to, Closure<String> stream = { output }) {
-        def parts = [Pattern.quote(temporaryFolder.getTestDirectory().absolutePath) + ".*", ".gradle", ".*", CacheLayout.TRANSFORMS.getKey(), "\\w+", "transformed"]
+        def parts = [Pattern.quote(temporaryFolder.getTestDirectory().absolutePath) + ".*", ".gradle", CacheLayout.TRANSFORMS.getKey(), "\\w+", "transformed"]
         outputDirs(from, to, parts.join(quotedFileSeparator), stream)
     }
 
@@ -2277,7 +2276,7 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
     }
 
     TestFile getCacheDir() {
-        return temporaryFolder.getTestDirectory().file(".gradle/${GradleVersion.current().version}/${CacheLayout.TRANSFORMS.getKey()}")
+        return temporaryFolder.getTestDirectory().file(".gradle/${CacheLayout.TRANSFORMS.getKey()}")
     }
 
     void writeLastTransformationAccessTimeToJournal(TestFile workspaceDir, long millis) {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -30,6 +30,7 @@ import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
+import org.gradle.util.GradleVersion
 import org.junit.Rule
 import spock.lang.Issue
 
@@ -2240,11 +2241,11 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
     }
 
     TestFile gradleUserHomeOutputDir(String from, String to, Closure<String> stream = { output }) {
-        outputDir(from, to, this.&gradleUserHomeOutputDirs, stream)
+        outputDir(from, to, this.&gradleTreeScopeOutputDirs, stream)
     }
 
     Set<TestFile> allOutputDirs(String from, String to, Closure<String> stream = { output }) {
-        return projectOutputDirs(from, to, stream) + gradleUserHomeOutputDirs(from, to, stream)
+        return projectOutputDirs(from, to, stream) + gradleTreeScopeOutputDirs(from, to, stream)
     }
 
     Set<TestFile> projectOutputDirs(String from, String to, Closure<String> stream = { output }) {
@@ -2252,8 +2253,8 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
         return outputDirs(from, to, parts.join(quotedFileSeparator), stream)
     }
 
-    Set<TestFile> gradleUserHomeOutputDirs(String from, String to, Closure<String> stream = { output }) {
-        def parts = [Pattern.quote(temporaryFolder.getTestDirectory().absolutePath) + ".*", ".gradle", ".*", "transformed", "\\w+", "transformed"]
+    Set<TestFile> gradleTreeScopeOutputDirs(String from, String to, Closure<String> stream = { output }) {
+        def parts = [Pattern.quote(temporaryFolder.getTestDirectory().absolutePath) + ".*", ".gradle", ".*", CacheLayout.TRANSFORMS.getKey(), "\\w+", "transformed"]
         outputDirs(from, to, parts.join(quotedFileSeparator), stream)
     }
 
@@ -2276,7 +2277,7 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
     }
 
     TestFile getCacheDir() {
-        return getUserHomeCacheDir().file(CacheLayout.TRANSFORMS.getKey())
+        return temporaryFolder.getTestDirectory().file(".gradle/${GradleVersion.current().version}/${CacheLayout.TRANSFORMS.getKey()}")
     }
 
     void writeLastTransformationAccessTimeToJournal(TestFile workspaceDir, long millis) {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -2221,7 +2221,7 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
     }
 
     Set<TestFile> gradleUserHomeOutputDirs(String from, String to, Closure<String> stream = { output }) {
-        def parts = [Pattern.quote(cacheDir.absolutePath), "\\w+", "transformed"]
+        def parts = [Pattern.quote(temporaryFolder.getTestDirectory().absolutePath) + ".*", ".gradle", ".*", "transformed", "\\w+", "transformed"]
         outputDirs(from, to, parts.join(quotedFileSeparator), stream)
     }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformParallelIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformParallelIntegrationTest.groovy
@@ -422,7 +422,7 @@ class ArtifactTransformParallelIntegrationTest extends AbstractDependencyResolut
         handle.waitForFinish()
     }
 
-    def "only one process can run immutable transforms at the same time"() {
+    def "multiple processes can run immutable transforms at the same time"() {
         given:
         List<BuildTestFile> builds = (1..3).collect { idx ->
             def lib = mavenRepo.module("org.test.foo", "build${idx}").publish()
@@ -468,7 +468,7 @@ class ArtifactTransformParallelIntegrationTest extends AbstractDependencyResolut
 
         expect:
         server.expectConcurrent(buildNames.collect { "resolveStarted_" + it })
-        def transformations = server.expectConcurrentAndBlock(1, buildNames.collect { it + "-1.0.jar" } as String[])
+        def transformations = server.expectConcurrentAndBlock(3, buildNames.collect { it + "-1.0.jar" } as String[])
         def buildHandles = builds.collect {
             executer.inDirectory(it).withTasks("resolve").start()
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -232,7 +232,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
         ) {
             return new ImmutableTransformWorkspaceServices(
                 buildTreeScopedCacheBuilderFactory
-                    .createCacheBuilder("immutable-artifact-transforms")
+                    .createCacheBuilder("transformed")
                     .withCrossVersionCache(CacheBuilder.LockTarget.DefaultTarget)
                     .withDisplayName("Artifact transforms cache"),
                 fileAccessTimeJournal,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -96,7 +96,6 @@ import org.gradle.api.internal.attributes.AttributeDesugaring;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.DefaultAttributesSchema;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
-import org.gradle.api.internal.cache.CacheConfigurationsInternal;
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.component.ComponentTypeRegistry;
 import org.gradle.api.internal.file.FileCollectionFactory;
@@ -110,11 +109,7 @@ import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.problems.Problems;
 import org.gradle.api.provider.ProviderFactory;
-import org.gradle.cache.CacheBuilder;
-import org.gradle.cache.internal.CrossBuildInMemoryCacheFactory;
-import org.gradle.cache.scopes.BuildTreeScopedCacheBuilderFactory;
 import org.gradle.configuration.internal.UserCodeApplicationContext;
-import org.gradle.internal.Try;
 import org.gradle.internal.authentication.AuthenticationSchemeRegistry;
 import org.gradle.internal.build.BuildModelLifecycleListener;
 import org.gradle.internal.build.BuildState;
@@ -126,7 +121,6 @@ import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.execution.ExecutionEngine;
 import org.gradle.internal.execution.InputFingerprinter;
 import org.gradle.internal.execution.history.ExecutionHistoryStore;
-import org.gradle.internal.file.FileAccessTimeJournal;
 import org.gradle.internal.hash.ChecksumService;
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher;
 import org.gradle.internal.instantiation.InstantiatorFactory;
@@ -221,25 +215,6 @@ public class DefaultDependencyManagementServices implements DependencyManagement
 
         MutableTransformWorkspaceServices createMutableTransformWorkspaceServices(ProjectLayout projectLayout, ExecutionHistoryStore executionHistoryStore) {
             return new MutableTransformWorkspaceServices(projectLayout.getBuildDirectory().dir(".transforms"), executionHistoryStore);
-        }
-
-        ImmutableTransformWorkspaceServices createImmutableTransformWorkspaceServices(
-            BuildTreeScopedCacheBuilderFactory buildTreeScopedCacheBuilderFactory,
-            CrossBuildInMemoryCacheFactory crossBuildInMemoryCacheFactory,
-            FileAccessTimeJournal fileAccessTimeJournal,
-            ExecutionHistoryStore executionHistoryStore,
-            CacheConfigurationsInternal cacheConfigurations
-        ) {
-            return new ImmutableTransformWorkspaceServices(
-                buildTreeScopedCacheBuilderFactory
-                    .createCacheBuilder("transformed")
-                    .withCrossVersionCache(CacheBuilder.LockTarget.DefaultTarget)
-                    .withDisplayName("Artifact transforms cache"),
-                fileAccessTimeJournal,
-                executionHistoryStore,
-                crossBuildInMemoryCacheFactory.newCacheRetainingDataFromPreviousBuild(Try::isSuccessful),
-                cacheConfigurations
-            );
         }
 
         TransformInvocationFactory createTransformInvocationFactory(

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -96,6 +96,7 @@ import org.gradle.api.internal.attributes.AttributeDesugaring;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.DefaultAttributesSchema;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.api.internal.cache.CacheConfigurationsInternal;
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.component.ComponentTypeRegistry;
 import org.gradle.api.internal.file.FileCollectionFactory;
@@ -109,7 +110,11 @@ import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.problems.Problems;
 import org.gradle.api.provider.ProviderFactory;
+import org.gradle.cache.CacheBuilder;
+import org.gradle.cache.internal.CrossBuildInMemoryCacheFactory;
+import org.gradle.cache.scopes.BuildTreeScopedCacheBuilderFactory;
 import org.gradle.configuration.internal.UserCodeApplicationContext;
+import org.gradle.internal.Try;
 import org.gradle.internal.authentication.AuthenticationSchemeRegistry;
 import org.gradle.internal.build.BuildModelLifecycleListener;
 import org.gradle.internal.build.BuildState;
@@ -121,6 +126,7 @@ import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.execution.ExecutionEngine;
 import org.gradle.internal.execution.InputFingerprinter;
 import org.gradle.internal.execution.history.ExecutionHistoryStore;
+import org.gradle.internal.file.FileAccessTimeJournal;
 import org.gradle.internal.hash.ChecksumService;
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher;
 import org.gradle.internal.instantiation.InstantiatorFactory;
@@ -213,8 +219,27 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             return attributesSchema;
         }
 
-        MutableTransformWorkspaceServices createTransformWorkspaceServices(ProjectLayout projectLayout, ExecutionHistoryStore executionHistoryStore) {
+        MutableTransformWorkspaceServices createMutableTransformWorkspaceServices(ProjectLayout projectLayout, ExecutionHistoryStore executionHistoryStore) {
             return new MutableTransformWorkspaceServices(projectLayout.getBuildDirectory().dir(".transforms"), executionHistoryStore);
+        }
+
+        ImmutableTransformWorkspaceServices createImmutableTransformWorkspaceServices(
+            BuildTreeScopedCacheBuilderFactory buildTreeScopedCacheBuilderFactory,
+            CrossBuildInMemoryCacheFactory crossBuildInMemoryCacheFactory,
+            FileAccessTimeJournal fileAccessTimeJournal,
+            ExecutionHistoryStore executionHistoryStore,
+            CacheConfigurationsInternal cacheConfigurations
+        ) {
+            return new ImmutableTransformWorkspaceServices(
+                buildTreeScopedCacheBuilderFactory
+                    .createCacheBuilder("immutable-artifact-transforms")
+                    .withCrossVersionCache(CacheBuilder.LockTarget.DefaultTarget)
+                    .withDisplayName("Artifact transforms cache"),
+                fileAccessTimeJournal,
+                executionHistoryStore,
+                crossBuildInMemoryCacheFactory.newCacheRetainingDataFromPreviousBuild(Try::isSuccessful),
+                cacheConfigurations
+            );
         }
 
         TransformInvocationFactory createTransformInvocationFactory(

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildTreeScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildTreeScopeServices.java
@@ -21,6 +21,7 @@ import org.gradle.StartParameter;
 import org.gradle.api.internal.artifacts.ivyservice.ArtifactCacheLockingAccessCoordinator;
 import org.gradle.api.internal.artifacts.ivyservice.ArtifactCacheMetadata;
 import org.gradle.api.internal.artifacts.ivyservice.ArtifactCachesProvider;
+import org.gradle.api.internal.artifacts.ivyservice.CacheLayout;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ConnectionFailureRepositoryDisabler;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ModuleDescriptorHashCodec;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ModuleDescriptorHashModuleSource;
@@ -217,7 +218,7 @@ class DependencyManagementBuildTreeScopeServices {
     ) {
         return new ImmutableTransformWorkspaceServices(
             buildTreeScopedCacheBuilderFactory
-                .createCacheBuilder("transformed")
+                .createCacheBuilder(CacheLayout.TRANSFORMS.getKey())
                 .withCrossVersionCache(CacheBuilder.LockTarget.DefaultTarget)
                 .withDisplayName("Artifact transforms cache"),
             fileAccessTimeJournal,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildTreeScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildTreeScopeServices.java
@@ -218,7 +218,7 @@ class DependencyManagementBuildTreeScopeServices {
     ) {
         return new ImmutableTransformWorkspaceServices(
             buildTreeScopedCacheBuilderFactory
-                .createCacheBuilder(CacheLayout.TRANSFORMS.getKey())
+                .createCrossVersionCacheBuilder(CacheLayout.TRANSFORMS.getKey())
                 .withCrossVersionCache(CacheBuilder.LockTarget.DefaultTarget)
                 .withDisplayName("Artifact transforms cache"),
             fileAccessTimeJournal,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGradleUserHomeScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGradleUserHomeScopeServices.java
@@ -21,20 +21,15 @@ import org.gradle.BuildResult;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.artifacts.ivyservice.ArtifactCachesProvider;
 import org.gradle.api.internal.artifacts.ivyservice.DefaultArtifactCaches;
-import org.gradle.api.internal.artifacts.transform.ImmutableTransformWorkspaceServices;
 import org.gradle.api.internal.artifacts.transform.ToPlannedTransformStepConverter;
 import org.gradle.api.internal.cache.CacheConfigurationsInternal;
 import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.api.internal.changedetection.state.DefaultExecutionHistoryCacheAccess;
-import org.gradle.cache.CacheBuilder;
 import org.gradle.cache.UnscopedCacheBuilderFactory;
-import org.gradle.cache.internal.CrossBuildInMemoryCacheFactory;
 import org.gradle.cache.internal.InMemoryCacheDecoratorFactory;
 import org.gradle.cache.internal.UsedGradleVersions;
-import org.gradle.cache.scopes.BuildTreeScopedCacheBuilderFactory;
 import org.gradle.cache.scopes.GlobalScopedCacheBuilderFactory;
 import org.gradle.execution.plan.ToPlannedNodeConverter;
-import org.gradle.internal.Try;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.execution.history.ExecutionHistoryCacheAccess;
 import org.gradle.internal.execution.history.ExecutionHistoryStore;
@@ -98,26 +93,6 @@ public class DependencyManagementGradleUserHomeScopeServices {
             inMemoryCacheDecoratorFactory,
             stringInterner,
             classLoaderHasher
-        );
-    }
-
-    ImmutableTransformWorkspaceServices createTransformWorkspaceServices(
-        ArtifactCachesProvider artifactCaches,
-        BuildTreeScopedCacheBuilderFactory buildTreeScopedCacheBuilderFactory,
-        CrossBuildInMemoryCacheFactory crossBuildInMemoryCacheFactory,
-        FileAccessTimeJournal fileAccessTimeJournal,
-        ExecutionHistoryStore executionHistoryStore,
-        CacheConfigurationsInternal cacheConfigurations
-    ) {
-        return new ImmutableTransformWorkspaceServices(
-            buildTreeScopedCacheBuilderFactory
-                .createCacheBuilder("immutable-artifact-transforms")
-                .withCrossVersionCache(CacheBuilder.LockTarget.DefaultTarget)
-                .withDisplayName("Artifact transforms cache"),
-            fileAccessTimeJournal,
-            executionHistoryStore,
-            crossBuildInMemoryCacheFactory.newCacheRetainingDataFromPreviousBuild(Try::isSuccessful),
-            cacheConfigurations
         );
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGradleUserHomeScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGradleUserHomeScopeServices.java
@@ -31,6 +31,7 @@ import org.gradle.cache.UnscopedCacheBuilderFactory;
 import org.gradle.cache.internal.CrossBuildInMemoryCacheFactory;
 import org.gradle.cache.internal.InMemoryCacheDecoratorFactory;
 import org.gradle.cache.internal.UsedGradleVersions;
+import org.gradle.cache.scopes.BuildTreeScopedCacheBuilderFactory;
 import org.gradle.cache.scopes.GlobalScopedCacheBuilderFactory;
 import org.gradle.execution.plan.ToPlannedNodeConverter;
 import org.gradle.internal.Try;
@@ -102,15 +103,15 @@ public class DependencyManagementGradleUserHomeScopeServices {
 
     ImmutableTransformWorkspaceServices createTransformWorkspaceServices(
         ArtifactCachesProvider artifactCaches,
-        UnscopedCacheBuilderFactory unscopedCacheBuilderFactory,
+        BuildTreeScopedCacheBuilderFactory buildTreeScopedCacheBuilderFactory,
         CrossBuildInMemoryCacheFactory crossBuildInMemoryCacheFactory,
         FileAccessTimeJournal fileAccessTimeJournal,
         ExecutionHistoryStore executionHistoryStore,
         CacheConfigurationsInternal cacheConfigurations
     ) {
         return new ImmutableTransformWorkspaceServices(
-            unscopedCacheBuilderFactory
-                .cache(artifactCaches.getWritableCacheMetadata().getTransformsStoreDirectory())
+            buildTreeScopedCacheBuilderFactory
+                .createCacheBuilder("immutable-artifact-transforms")
                 .withCrossVersionCache(CacheBuilder.LockTarget.DefaultTarget)
                 .withDisplayName("Artifact transforms cache"),
             fileAccessTimeJournal,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ArtifactCacheMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ArtifactCacheMetadata.java
@@ -43,9 +43,4 @@ public interface ArtifactCacheMetadata {
      * @return Metadata store location
      */
     File getMetaDataStoreDirectory();
-
-    /**
-     * Returns the root directory for the transforms cache.
-     */
-    File getTransformsStoreDirectory();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultArtifactCacheMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultArtifactCacheMetadata.java
@@ -27,13 +27,11 @@ public class DefaultArtifactCacheMetadata implements ArtifactCacheMetadata, Glob
 
     public static final CacheVersion CACHE_LAYOUT_VERSION = CacheLayout.META_DATA.getVersion();
     private final File cacheDir;
-    private final File transformsDir;
     private final File baseDir;
 
     public DefaultArtifactCacheMetadata(GlobalScopedCacheBuilderFactory cacheBuilderFactory) {
         this.baseDir = cacheBuilderFactory.getRootDir();
         this.cacheDir = cacheBuilderFactory.baseDirForCrossVersionCache(CacheLayout.ROOT.getKey());
-        this.transformsDir = cacheBuilderFactory.baseDirForCrossVersionCache(CacheLayout.TRANSFORMS.getKey());
     }
 
     public DefaultArtifactCacheMetadata(GlobalScopedCacheBuilderFactory cacheBuilderFactory, File baseDir) {
@@ -43,11 +41,6 @@ public class DefaultArtifactCacheMetadata implements ArtifactCacheMetadata, Glob
     @Override
     public File getCacheDir() {
         return cacheDir;
-    }
-
-    @Override
-    public File getTransformsStoreDirectory() {
-        return transformsDir;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformInvocationFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformInvocationFactory.java
@@ -120,7 +120,7 @@ public class DefaultTransformInvocationFactory implements TransformInvocationFac
         if (producerProject == null) {
             return immutableWorkspaceProvider;
         }
-        return producerProject.getServices().get(TransformWorkspaceServices.class);
+        return producerProject.getServices().get(MutableTransformWorkspaceServices.class);
     }
 
     @Nullable

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformInvocationFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformInvocationFactoryTest.groovy
@@ -102,7 +102,7 @@ class DefaultTransformInvocationFactoryTest extends AbstractProjectBuilderSpec {
     def inputFingerprinter = new DefaultInputFingerprinter(fileCollectionSnapshotter, fileCollectionFingerprinterRegistry, valueSnapshotter)
 
     def projectServiceRegistry = Stub(ServiceRegistry) {
-        get(TransformWorkspaceServices) >> new TestTransformWorkspaceServices(mutableTransformsStoreDirectory, executionHistoryStore)
+        get(MutableTransformWorkspaceServices) >> new TestTransformWorkspaceServices(mutableTransformsStoreDirectory, executionHistoryStore)
     }
 
     def childProject = Stub(ProjectInternal) {


### PR DESCRIPTION
Instead of gradle user home scoped cache, to avoid contention when running multiple builds in parallel with artifact transform.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
