### PR TITLE
Update CC docs so EAR shows as compatible

### DIFF
--- a/subprojects/docs/src/docs/userguide/optimizing-performance/configuration_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/optimizing-performance/configuration_cache.adoc
@@ -319,7 +319,7 @@ a|
 [horizontal]
 link:{gradle-issues}13463[[.green]#✓#]:: <<application_plugin.adoc#application_plugin,Application>>
 link:{gradle-issues}13466[[.green]#✓#]:: <<war_plugin.adoc#war_plugin,WAR>>
-link:{gradle-issues}13467[[.red]#✖#]:: <<ear_plugin.adoc#ear_plugin,EAR>>
+link:{gradle-issues}13467[[.green]#✓#]:: <<ear_plugin.adoc#ear_plugin,EAR>>
 link:{gradle-issues}24329[[.yellow]#⚠#]:: <<publishing_maven.adoc#publishing_maven,Maven Publish>>
 link:{gradle-issues}24328[[.yellow]#⚠#]:: <<publishing_ivy.adoc#publishing_ivy,Ivy Publish>>
 link:{gradle-issues}13464[[.green]#✓#]:: <<distribution_plugin.adoc#distribution_plugin,Distribution>>


### PR DESCRIPTION
The EAR plugin has been made compatible with the configuration cache since 8.2, but we failed to reflect that on the docs.

Issue: #26258, #13467
