### PR TITLE
Use isolated daemons in AbstractCompilerContinuousIntegrationTest

### DIFF
--- a/platforms/jvm/language-jvm/src/testFixtures/groovy/org/gradle/api/tasks/compile/AbstractCompilerContinuousIntegrationTest.groovy
+++ b/platforms/jvm/language-jvm/src/testFixtures/groovy/org/gradle/api/tasks/compile/AbstractCompilerContinuousIntegrationTest.groovy
@@ -22,6 +22,7 @@ abstract class AbstractCompilerContinuousIntegrationTest extends AbstractContinu
 
     def setup() {
         executer.withWorkerDaemonsExpirationDisabled()
+        executer.requireIsolatedDaemons()
     }
 
     abstract String getCompileTaskName()


### PR DESCRIPTION
This is an attempt to fix https://github.com/gradle/gradle-private/issues/3973. Looking at the failures, seems like the problem is the shared daemons, i.e. another test was executed before `GroovyCompilerContinuousIntegrationTest`, leaving some leftover internal state in the shared daemon.

Let's try to isolated the daemon used for `GroovyCompilerContinuousIntegrationTest`.
