### PR TITLE
Fix hanging `JavaProcessStackTracesMonitor` issue

### DIFF
--- a/build-logic/cleanup/src/main/java/gradlebuild/cleanup/services/KillLeakingJavaProcesses.java
+++ b/build-logic/cleanup/src/main/java/gradlebuild/cleanup/services/KillLeakingJavaProcesses.java
@@ -52,10 +52,17 @@ public class KillLeakingJavaProcesses {
         String quotedRootProjectDir = Pattern.quote(rootProjectDir);
         String mainClassPattern = "(org\\.gradle\\.|[a-zA-Z]+)";
         String playServerPattern = "(play\\.core\\.server\\.NettyServer)";
+        String javaProcessStackTracesMonitorPattern = "(JavaProcessStackTracesMonitor\\.java)";
         String classPathPattern1 = "(?:-cp.+" + "(" + quotedRootProjectDir + "|build\\\\tmp\\\\performance-test-files)" + ".+?" + mainClassPattern + ")";
         String classPathPattern2 = "(?:-classpath.+" + quotedRootProjectDir + ".+?" + Pattern.quote("\\build\\") + ".+?" + mainClassPattern + ")";
         String classPathPattern3 = "(?:-classpath.+" + quotedRootProjectDir + ".+?" + playServerPattern + ")";
-        return "(?i)[/\\\\]" + "(" + javaExecutable + ".+?" + "(?:" + classPathPattern1 + "|" + classPathPattern2 + "|" + classPathPattern3 + "|" + kotlinCompilerDaemonPattern + ").+)";
+        return "(?i)[/\\\\]" + "(" + javaExecutable + ".+?" + "(?:" +
+            classPathPattern1 + "|" +
+            classPathPattern2 + "|" +
+            classPathPattern3 + "|" +
+            kotlinCompilerDaemonPattern + "|" +
+            javaProcessStackTracesMonitorPattern +
+            ").+)";
     }
 
     public static void main(String[] args) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/timeout/JavaProcessStackTracesMonitor.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/timeout/JavaProcessStackTracesMonitor.java
@@ -250,7 +250,7 @@ public class JavaProcessStackTracesMonitor {
     private static ByteArrayOutputStream connectStream(InputStream forkedProcessOutput, CountDownLatch latch) {
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         PrintStream ps = new PrintStream(os, true);
-        new Thread(() -> {
+        Thread thread = new Thread(() -> {
             try {
                 BufferedReader reader = new BufferedReader(new InputStreamReader(forkedProcessOutput));
                 String line;
@@ -262,7 +262,9 @@ public class JavaProcessStackTracesMonitor {
             } finally {
                 latch.countDown();
             }
-        }).start();
+        });
+        thread.setDaemon(true);
+        thread.start();
         return os;
     }
 


### PR DESCRIPTION
See https://github.com/gradle/gradle-private/issues/3976

This commit makes two changes:

1. Make the threads daemon so they don't prevent the process exiting.
2. Add a pattern to `KillLeakingJavaProcesses` so the hanging processes be cleaned up by subsequent builds.