### PR TITLE
Remove inaccurate composite build requirement from docs

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/structuring/composite_builds.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/structuring/composite_builds.adoc
@@ -135,11 +135,33 @@ include::sample[dir="snippets/developingPlugins/testingPlugins/groovy/include-pl
 Most builds can be included in a composite, including other composite builds.
 There are some restrictions.
 
-Every included build:
+In a regular build, Gradle ensures that each project has a unique _project path_.
+It makes projects identifiable and addressable without conflicts.
 
-* Must not have a `rootProject.name` the same as another included build.
-* Must not have a `rootProject.name` the same as a top-level project of the composite build.
-* Must not have a `rootProject.name` the same as the composite build `rootProject.name`.
+In a composite build, Gradle adds additional qualification to each project from an included build to avoid project path conflicts.
+The full path to identify a project in a composite build is called a _build-tree path_.
+It consists of a _build path_ of an included build and a _project path_ of the project.
+
+By default, build paths and project paths are derived from directory names and structure on disk.
+Since included builds can be located anywhere on disk, their build path is determined by the name of the containing directory.
+This can sometimes lead to conflicts.
+
+To summarize, the included builds must fulfill these requirements:
+
+* Each included build must have a unique build path.
+* Each included build path must not conflict with any project path of the main build.
+
+These conditions guarantee that each project can be uniquely identified even in a composite build.
+
+If conflicts arise, the way to resolve them is by changing the _build name_ of an included build:
+
+.settings.gradle.kts
+[source,kotlin]
+----
+includeBuild("some-included-build") {
+    name = "other-name"
+}
+----
 
 [NOTE]
 ====


### PR DESCRIPTION
Some [requirements](https://docs.gradle.org/8.5/userguide/composite_builds.html#included_builds) for included builds listed in the Composite Builds docs are either inaccurate or unclear.

This PR updates the docs and gives users guidance on changing their build to satisfy the existing requirements.

There are currently two main places where we check for conflicts of name:

Here we check that the *build path* of the to-be-added included build does not conflict with an existing included build *build path*.
https://github.com/gradle/gradle/blob/65c5675a006f8a87b906450ee497e8ce555e10c2/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java#L252

Here we check that the *build path* of the to-be-added included build does not conflict with an existing *identity path* of a project in the main build. Since the main build always has a root `:` build path, it's the same as checking the regular *path* of the root subprojects.

https://github.com/gradle/gradle/blob/65c5675a006f8a87b906450ee497e8ce555e10c2/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildRegistry.java#L288

Both cases effectively ensure that each project in the composite build can be addressed via a unique *build-tree path* (aka *identity path*) without conflicts.


