### PR TITLE
Update tested AGP versions

### DIFF
--- a/gradle/dependency-management/agp-versions.properties
+++ b/gradle/dependency-management/agp-versions.properties
@@ -1,4 +1,4 @@
 # Generated - Update by running `./gradlew updateAgpVersions`
-latests=7.3.1,7.4.2,8.0.2,8.1.0,8.2.0-alpha15
-nightlyBuildId=10589238
-nightlyVersion=8.2.0-dev
+latests=7.3.1,7.4.2,8.0.2,8.1.1,8.2.0-beta02,8.3.0-alpha02
+nightlyBuildId=10767672
+nightlyVersion=8.3.0-dev


### PR DESCRIPTION
from 8.1.0 to 8.1.1
from 8.2.0-alpha15 to 8.2.0-beta02
introducing 8.3.0-alpha02
nightly is now 8.3.0-dev

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
