### PR TITLE
DefaultGradleEnterprisePluginAdapter is not a service

### DIFF
--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginAdapter.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginAdapter.java
@@ -29,6 +29,7 @@ import javax.annotation.Nullable;
 
 public class DefaultGradleEnterprisePluginAdapter implements GradleEnterprisePluginAdapter {
 
+    private final GradleEnterprisePluginServiceFactory pluginServiceFactory;
     private final GradleEnterprisePluginConfig config;
     private final DefaultGradleEnterprisePluginRequiredServices requiredServices;
     private final GradleEnterprisePluginBuildState buildState;
@@ -36,27 +37,27 @@ public class DefaultGradleEnterprisePluginAdapter implements GradleEnterprisePlu
 
     private final BuildOperationNotificationListenerRegistrar buildOperationNotificationListenerRegistrar;
 
-    private GradleEnterprisePluginServiceFactory pluginServiceFactory;
-
     private transient GradleEnterprisePluginService pluginService;
 
     public DefaultGradleEnterprisePluginAdapter(
+        GradleEnterprisePluginServiceFactory pluginServiceFactory,
         GradleEnterprisePluginConfig config,
         DefaultGradleEnterprisePluginRequiredServices requiredServices,
         GradleEnterprisePluginBuildState buildState,
         DefaultGradleEnterprisePluginServiceRef pluginServiceRef,
         BuildOperationNotificationListenerRegistrar buildOperationNotificationListenerRegistrar
     ) {
+        this.pluginServiceFactory = pluginServiceFactory;
         this.config = config;
         this.requiredServices = requiredServices;
         this.buildState = buildState;
         this.pluginServiceRef = pluginServiceRef;
         this.buildOperationNotificationListenerRegistrar = buildOperationNotificationListenerRegistrar;
+
+        createPluginService();
     }
 
-    public GradleEnterprisePluginServiceRef register(GradleEnterprisePluginServiceFactory pluginServiceFactory) {
-        this.pluginServiceFactory = pluginServiceFactory;
-        createPluginService();
+    public GradleEnterprisePluginServiceRef getPluginServiceRef() {
         return pluginServiceRef;
     }
 

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginAdapterFactory.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginAdapterFactory.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.enterprise.impl;
+
+import org.gradle.internal.enterprise.GradleEnterprisePluginBuildState;
+import org.gradle.internal.enterprise.GradleEnterprisePluginConfig;
+import org.gradle.internal.enterprise.GradleEnterprisePluginServiceFactory;
+import org.gradle.internal.operations.notify.BuildOperationNotificationListenerRegistrar;
+import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.ServiceScope;
+
+@ServiceScope(Scopes.Gradle.class)
+public class DefaultGradleEnterprisePluginAdapterFactory {
+
+    private final GradleEnterprisePluginConfig config;
+    private final DefaultGradleEnterprisePluginRequiredServices requiredServices;
+    private final GradleEnterprisePluginBuildState buildState;
+    private final DefaultGradleEnterprisePluginServiceRef pluginServiceRef;
+    private final BuildOperationNotificationListenerRegistrar buildOperationNotificationListenerRegistrar;
+
+    public DefaultGradleEnterprisePluginAdapterFactory(
+        GradleEnterprisePluginConfig config,
+        DefaultGradleEnterprisePluginRequiredServices requiredServices,
+        GradleEnterprisePluginBuildState buildState,
+        DefaultGradleEnterprisePluginServiceRef pluginServiceRef,
+        BuildOperationNotificationListenerRegistrar buildOperationNotificationListenerRegistrar
+    ) {
+        this.config = config;
+        this.requiredServices = requiredServices;
+        this.buildState = buildState;
+        this.pluginServiceRef = pluginServiceRef;
+        this.buildOperationNotificationListenerRegistrar = buildOperationNotificationListenerRegistrar;
+    }
+
+    public DefaultGradleEnterprisePluginAdapter create(GradleEnterprisePluginServiceFactory pluginServiceFactory) {
+        return new DefaultGradleEnterprisePluginAdapter(
+            pluginServiceFactory,
+            config,
+            requiredServices,
+            buildState,
+            pluginServiceRef,
+            buildOperationNotificationListenerRegistrar
+        );
+    }
+}

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginCheckInService.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginCheckInService.java
@@ -31,17 +31,17 @@ import java.util.function.Supplier;
 public class DefaultGradleEnterprisePluginCheckInService implements GradleEnterprisePluginCheckInService {
 
     private final GradleEnterprisePluginManager manager;
-    private final DefaultGradleEnterprisePluginAdapter adapter;
+    private final DefaultGradleEnterprisePluginAdapterFactory pluginAdapterFactory;
     private final boolean isConfigurationCacheEnabled;
     private final boolean isIsolatedProjectsEnabled;
 
     public DefaultGradleEnterprisePluginCheckInService(
         BuildModelParameters buildModelParameters,
         GradleEnterprisePluginManager manager,
-        DefaultGradleEnterprisePluginAdapter adapter
+        DefaultGradleEnterprisePluginAdapterFactory pluginAdapterFactory
     ) {
         this.manager = manager;
-        this.adapter = adapter;
+        this.pluginAdapterFactory = pluginAdapterFactory;
         this.isConfigurationCacheEnabled = buildModelParameters.isConfigurationCache();
         this.isIsolatedProjectsEnabled = buildModelParameters.isIsolatedProjects();
     }
@@ -90,7 +90,8 @@ public class DefaultGradleEnterprisePluginCheckInService implements GradleEnterp
             nagAboutDeprecatedPluginVersion(pluginVersion);
         }
 
-        GradleEnterprisePluginServiceRef ref = adapter.register(serviceFactory);
+        DefaultGradleEnterprisePluginAdapter adapter = pluginAdapterFactory.create(serviceFactory);
+        GradleEnterprisePluginServiceRef ref = adapter.getPluginServiceRef();
         manager.registerAdapter(adapter);
         return checkInResult(null, () -> ref);
     }

--- a/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/GradleEnterprisePluginServices.java
+++ b/platforms/enterprise/enterprise/src/main/java/org/gradle/internal/enterprise/impl/GradleEnterprisePluginServices.java
@@ -43,7 +43,7 @@ public class GradleEnterprisePluginServices extends AbstractPluginServiceRegistr
 
     @Override
     public void registerGradleServices(ServiceRegistration registration) {
-        registration.add(DefaultGradleEnterprisePluginAdapter.class);
+        registration.add(DefaultGradleEnterprisePluginAdapterFactory.class);
         registration.add(DefaultGradleEnterprisePluginBackgroundJobExecutors.class);
         registration.add(DefaultGradleEnterprisePluginBuildState.class);
         registration.add(DefaultGradleEnterprisePluginConfig.class);


### PR DESCRIPTION
The adapter carries state and is referenced by the manager. It is not a service in the sense that it can be re-created in a stateless way when firing up the remaining services.

The configuration cache would not use serialization to restore a service, but use the existing service since it assumes the service is stateless.

This change allows to annotate all the Gradle enterprise services with the correct service scope.