### PR TITLE
Fix nullability discrepancies in DependencyConstraintHandlerScope

### DIFF
--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyConstraintHandlerScope.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyConstraintHandlerScope.kt
@@ -50,7 +50,7 @@ private constructor(
      * @return The dependency constraint.
      * @see [DependencyConstraintHandler.add]
      */
-    operator fun String.invoke(dependencyConstraintNotation: Any): DependencyConstraint? =
+    operator fun String.invoke(dependencyConstraintNotation: Any): DependencyConstraint =
         constraints.add(this, dependencyConstraintNotation)
 
     /**
@@ -73,7 +73,7 @@ private constructor(
      * @since 8.3
      */
     @Incubating
-    operator fun NamedDomainObjectProvider<Configuration>.invoke(dependencyConstraintNotation: Any): DependencyConstraint? =
+    operator fun NamedDomainObjectProvider<Configuration>.invoke(dependencyConstraintNotation: Any): DependencyConstraint =
         constraints.add(name, dependencyConstraintNotation)
 
     /**
@@ -86,7 +86,7 @@ private constructor(
      * @since 8.3
      */
     @Incubating
-    operator fun NamedDomainObjectProvider<Configuration>.invoke(dependencyConstraintNotation: String, configuration: DependencyConstraint.() -> Unit): DependencyConstraint? =
+    operator fun NamedDomainObjectProvider<Configuration>.invoke(dependencyConstraintNotation: String, configuration: DependencyConstraint.() -> Unit): DependencyConstraint =
         constraints.add(name, dependencyConstraintNotation, configuration)
 
     /**
@@ -96,7 +96,7 @@ private constructor(
      * @return The dependency constraint.
      * @see [DependencyConstraintHandler.add]
      */
-    operator fun Configuration.invoke(dependencyConstraintNotation: Any): DependencyConstraint? =
+    operator fun Configuration.invoke(dependencyConstraintNotation: Any): DependencyConstraint =
         add(name, dependencyConstraintNotation)
 
     /**


### PR DESCRIPTION
`DependencyConstraintHandlerScope` wrongly returns nullables. The underlying `DependencyConstraintHandler` contract is to not return nullables. This PR fixes this discrepancy.

This is not a breaking change.

This is a follow up to
* https://github.com/gradle/gradle/pull/25005

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
