### PR TITLE
Avoid side effect of evaluating Provider values in an attribute container causing the container to become inconsistent

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultMutableAttributeContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultMutableAttributeContainer.java
@@ -27,8 +27,8 @@ import org.gradle.internal.Cast;
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -190,7 +190,7 @@ class DefaultMutableAttributeContainer extends AbstractAttributeContainer implem
     private void realizeAllLazyAttributes() {
         if (!lazyAttributes.isEmpty()) {
             // As doInsertion will remove an item from lazyAttributes, we can't iterate that collection directly here, or else we'll get ConcurrentModificationException
-            final Set<Attribute<?>> savedKeys = new HashSet<>(lazyAttributes.keySet());
+            final Set<Attribute<?>> savedKeys = new LinkedHashSet<>(lazyAttributes.keySet());
             savedKeys.forEach(key -> doInsertion(Cast.uncheckedNonnullCast(key), lazyAttributes.get(key).get()));
         }
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultMutableAttributeContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultMutableAttributeContainerTest.groovy
@@ -43,7 +43,7 @@ class DefaultMutableAttributeContainerTest extends Specification {
             })
         }
         expect:
-        container.asImmutable()
+        container.asImmutable().keySet().size() == 100
         actual == expected
     }
 
@@ -60,7 +60,7 @@ class DefaultMutableAttributeContainerTest extends Specification {
         container.attributeProvider(secondAttribute, Providers.of("second"))
 
         expect:
-        container.asImmutable()
+        container.asImmutable().keySet() == [secondAttribute, firstAttribute] as Set
     }
 
     def "realizing the value of lazy attributes cannot add new attributes to the container"() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultMutableAttributeContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultMutableAttributeContainerTest.groovy
@@ -63,6 +63,38 @@ class DefaultMutableAttributeContainerTest extends Specification {
         container.asImmutable()
     }
 
+    def "realizing the value of lazy attributes cannot add new attributes to the container"() {
+        def container = new DefaultMutableAttributeContainer(attributesFactory)
+        def firstAttribute = Attribute.of("first", String)
+        def secondAttribute = Attribute.of("second", String)
+        container.attributeProvider(firstAttribute, Providers.<String>changing {
+            container.attribute(secondAttribute, "second" )
+            "first"
+        })
+
+        when:
+        container.asImmutable()
+        then:
+        def e = thrown(IllegalStateException)
+        e.message == "Cannot add new attribute 'second' while realizing all attributes of the container."
+    }
+
+    def "realizing the value of lazy attributes cannot add new lazy attributes to the container"() {
+        def container = new DefaultMutableAttributeContainer(attributesFactory)
+        def firstAttribute = Attribute.of("first", String)
+        def secondAttribute = Attribute.of("second", String)
+        container.attributeProvider(firstAttribute, Providers.<String>changing {
+            container.attributeProvider(secondAttribute, Providers.of("second"))
+            "first"
+        })
+
+        when:
+        container.asImmutable()
+        then:
+        def e = thrown(IllegalStateException)
+        e.message == "Cannot add new attribute 'second' while realizing all attributes of the container."
+    }
+
     def "adding mismatched attribute types fails fast"() {
         Property<Integer> testProperty = new DefaultProperty<>(Mock(PropertyHost), Integer).convention(1)
         def testAttribute = Attribute.of("test", String)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultMutableAttributeContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultMutableAttributeContainerTest.groovy
@@ -47,6 +47,22 @@ class DefaultMutableAttributeContainerTest extends Specification {
         actual == expected
     }
 
+    def "realizing the value of lazy attributes may cause other attributes to be realized"() {
+        def container = new DefaultMutableAttributeContainer(attributesFactory)
+        def firstAttribute = Attribute.of("first", String)
+        def secondAttribute = Attribute.of("second", String)
+        container.attributeProvider(firstAttribute, Providers.<String>changing {
+            // side effect is to evaluate the secondAttribute's value and prevent
+            // it from changing by removing it from the list of "lazy attributes"
+            container.getAttribute(secondAttribute)
+            "first"
+        })
+        container.attributeProvider(secondAttribute, Providers.of("second"))
+
+        expect:
+        container.asImmutable()
+    }
+
     def "adding mismatched attribute types fails fast"() {
         Property<Integer> testProperty = new DefaultProperty<>(Mock(PropertyHost), Integer).convention(1)
         def testAttribute = Attribute.of("test", String)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultMutableAttributeContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultMutableAttributeContainerTest.groovy
@@ -30,6 +30,23 @@ import spock.lang.Specification
 class DefaultMutableAttributeContainerTest extends Specification {
     def attributesFactory = AttributeTestUtil.attributesFactory()
 
+    def "lazy attributes are evaluated in insertion order"() {
+        def container = new DefaultMutableAttributeContainer(attributesFactory)
+        def actual = []
+        def expected = []
+        (1..100).each { idx ->
+            def testAttribute = Attribute.of("test"+idx, String)
+            expected << idx
+            container.attributeProvider(testAttribute, Providers.<String>changing {
+                actual << idx
+                "value " + idx
+            })
+        }
+        expect:
+        container.asImmutable()
+        actual == expected
+    }
+
     def "adding mismatched attribute types fails fast"() {
         Property<Integer> testProperty = new DefaultProperty<>(Mock(PropertyHost), Integer).convention(1)
         def testAttribute = Attribute.of("test", String)

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/AttributeContainerResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/AttributeContainerResolutionIntegrationTest.groovy
@@ -22,18 +22,6 @@ import spock.lang.Issue
 class AttributeContainerResolutionIntegrationTest extends AbstractIntegrationSpec {
     @Issue("https://github.com/gradle/gradle/issues/26298")
     def "lazy attributes provided to a Configuration do not fail resolution when they have side effects"() {
-        settingsFile << """
-            include "sub"
-        """
-        file("sub/build.gradle") << """
-            configurations {
-                consumable("conf") {
-                    attributes {
-                        attribute(Attribute.of("attr", Named), objects.named(Named, "value"))
-                    }
-                }
-            }
-        """
         buildFile << """
             configurations {
                 conf {
@@ -48,10 +36,6 @@ class AttributeContainerResolutionIntegrationTest extends AbstractIntegrationSpe
                         })
                     }
                 }
-            }
-
-            dependencies {
-                conf(project(":sub"))
             }
 
             task resolve {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/AttributeContainerResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/AttributeContainerResolutionIntegrationTest.groovy
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Issue
+
+class AttributeContainerResolutionIntegrationTest extends AbstractIntegrationSpec {
+    @Issue("https://github.com/gradle/gradle/issues/26298")
+    def "lazy attributes provided to a Configuration do not fail resolution when they have side effects"() {
+        settingsFile << """
+            include "sub"
+        """
+        file("sub/build.gradle") << """
+            configurations {
+                consumable("conf") {
+                    attributes {
+                        attribute(Attribute.of("attr", Named), objects.named(Named, "value"))
+                    }
+                }
+            }
+        """
+        buildFile << """
+            configurations {
+                conf {
+                    attributes {
+                        def otherAttribute = Attribute.of("zzz", Named)
+                        attributeProvider(Attribute.of("aaa", Named), provider {
+                            assert getAttribute(otherAttribute).name == "other"
+                            objects.named(Named, "value")
+                        })
+                        attributeProvider(otherAttribute, provider {
+                            objects.named(Named, "other")
+                        })
+                    }
+                }
+            }
+
+            dependencies {
+                conf(project(":sub"))
+            }
+
+            task resolve {
+                inputs.files(configurations.conf)
+            }
+        """
+        expect:
+        // When this has failed in the past, building the task graph hits a NPE from the attribute container
+        succeeds("resolve")
+    }
+}


### PR DESCRIPTION
refs #26298.

<!--- The issue this PR addresses -->

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
