### PR TITLE
Add option to suppress 'dependencies-without-versions' validation error

### DIFF
--- a/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/metadata/InvalidPublicationChecker.java
+++ b/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/metadata/InvalidPublicationChecker.java
@@ -31,12 +31,16 @@ import org.gradle.internal.logging.text.TreeFormatter;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 @NotThreadSafe
 public class InvalidPublicationChecker {
+
+    private static final String DEPENDENCIES_WITHOUT_VERSION_SUPPRESSION = "dependencies-without-versions";;
 
     private static final DocumentationRegistry DOCUMENTATION_REGISTRY = new DocumentationRegistry();
 
@@ -45,12 +49,14 @@ public class InvalidPublicationChecker {
     private final BiMap<String, VariantIdentity> variants = HashBiMap.create();
     private final List<String> errors = new ArrayList<>();
     private final Set<String> explanations = new LinkedHashSet<>();
+    private final Set<String> suppressedValidationErrors;
     private boolean publicationHasVersion = false;
     private boolean publicationHasDependencyOrConstraint = false;
 
-    public InvalidPublicationChecker(String publicationName, String taskPath) {
+    public InvalidPublicationChecker(String publicationName, String taskPath, Set<String> suppressedValidationErrors) {
         this.publicationName = publicationName;
         this.taskPath = taskPath;
+        this.suppressedValidationErrors = suppressedValidationErrors;
     }
 
     public void checkComponent(SoftwareComponent component) {
@@ -77,11 +83,19 @@ public class InvalidPublicationChecker {
     }
 
     private void checkVariantDependencyVersions() {
-        if (publicationHasDependencyOrConstraint && !publicationHasVersion) {
+        if (!suppressedValidationErrors.contains(DEPENDENCIES_WITHOUT_VERSION_SUPPRESSION) && publicationHasDependencyOrConstraint && !publicationHasVersion) {
             // Previous variant did not declare any version
             failWith("Publication only contains dependencies and/or constraints without a version. " +
-                "You need to add minimal version information, publish resolved versions (" + DOCUMENTATION_REGISTRY.getDocumentationRecommendationFor("on this", "publishing_maven", "publishing_maven:resolved_dependencies") + ") or " +
-                "reference a platform (" + DOCUMENTATION_REGISTRY.getDocumentationRecommendationFor("platforms", "platforms") + ")");
+                "You should add minimal version information, publish resolved versions (" + DOCUMENTATION_REGISTRY.getDocumentationRecommendationFor("on this", "publishing_maven", "publishing_maven:resolved_dependencies") + ") or " +
+                "reference a platform (" + DOCUMENTATION_REGISTRY.getDocumentationRecommendationFor("platforms", "platforms") + "). " +
+                "Disable this check by adding 'dependencies-without-versions' to the suppressed validations of the " + taskPath + " task.");
+        }
+    }
+
+    public void validateAttributes(String variant, String group, String name, AttributeContainer attributes) {
+        for (DependencyAttributesValidator validator : dependencyAttributeValidators()) {
+            Optional<String> error = validator.validationErrorFor(group, name, attributes);
+            error.ifPresent(s -> addDependencyValidationError(variant, s, validator.getExplanation(), validator.getSuppressor()));
         }
     }
 
@@ -103,6 +117,15 @@ public class InvalidPublicationChecker {
             }
             throw new InvalidUserCodeException(formatter.toString());
         }
+    }
+
+    private List<DependencyAttributesValidator> dependencyAttributeValidators() {
+        // Currently limited to a single validator
+        EnforcedPlatformPublicationValidator validator = new EnforcedPlatformPublicationValidator();
+        if (suppressedValidationErrors.contains(validator.getSuppressor())) {
+            return Collections.emptyList();
+        }
+        return Collections.singletonList(validator);
     }
 
     private void failWith(String message) {

--- a/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/metadata/ModuleMetadataSpecBuilder.java
+++ b/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/metadata/ModuleMetadataSpecBuilder.java
@@ -57,7 +57,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 
@@ -81,14 +80,12 @@ public class ModuleMetadataSpecBuilder {
     private final Map<SoftwareComponent, ComponentData> componentCoordinates = new HashMap<>();
     private final DependencyCoordinateResolverFactory dependencyCoordinateResolverFactory;
     private final InvalidPublicationChecker checker;
-    private final List<DependencyAttributesValidator> dependencyAttributeValidators;
 
     public ModuleMetadataSpecBuilder(
         PublicationInternal<?> publication,
         Collection<? extends PublicationInternal<?>> publications,
         InvalidPublicationChecker checker,
-        DependencyCoordinateResolverFactory dependencyCoordinateResolverFactory,
-        List<DependencyAttributesValidator> dependencyAttributeValidators
+        DependencyCoordinateResolverFactory dependencyCoordinateResolverFactory
     ) {
         this.component = publication.getComponent();
         this.publicationCoordinates = publication.getCoordinates();
@@ -96,7 +93,6 @@ public class ModuleMetadataSpecBuilder {
         this.publications = publications;
         this.checker = checker;
         this.dependencyCoordinateResolverFactory = dependencyCoordinateResolverFactory;
-        this.dependencyAttributeValidators = dependencyAttributeValidators;
         // Collect a map from component to coordinates. This might be better to move to the component or some publications model
         collectCoordinates(componentCoordinates);
     }
@@ -336,10 +332,7 @@ public class ModuleMetadataSpecBuilder {
     }
 
     private List<ModuleMetadataSpec.Attribute> dependencyAttributesFor(String variant, String group, String name, AttributeContainer attributes) {
-        for (DependencyAttributesValidator validator : dependencyAttributeValidators) {
-            Optional<String> error = validator.validationErrorFor(group, name, attributes);
-            error.ifPresent(s -> checker.addDependencyValidationError(variant, s, validator.getExplanation(), validator.getSuppressor()));
-        }
+        checker.validateAttributes(variant, group, name, attributes);
         return attributesFor(attributes);
     }
 

--- a/platforms/software/publish/src/test/groovy/org/gradle/api/publish/internal/metadata/GradleModuleMetadataWriterTest.groovy
+++ b/platforms/software/publish/src/test/groovy/org/gradle/api/publish/internal/metadata/GradleModuleMetadataWriterTest.groovy
@@ -81,13 +81,12 @@ class GradleModuleMetadataWriterTest extends Specification {
     def resolverFactory = new TestDependencyCoordinateResolverFactory()
 
     private writeTo(Writer writer, PublicationInternal publication, List<PublicationInternal> publications) {
-        InvalidPublicationChecker checker = new InvalidPublicationChecker(publication.getName(), ':task')
+        InvalidPublicationChecker checker = new InvalidPublicationChecker(publication.getName(), ':task', [] as Set)
         ModuleMetadataSpec spec = new ModuleMetadataSpecBuilder(
             publication,
             publications,
             checker,
-            resolverFactory,
-            []
+            resolverFactory
         ).build().get()
         checker.validate()
 


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Resolves #23030

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

See #23030

I was considering to add somethings to the docs as well. But the error message informs directly about the new option now. And in the docs it already says:

> Gradle performs validation of generated module metadata. In some cases, validation can fail, indicating that you most likely have an error to fix, but you may have done something intentionally. If this is the case, Gradle will indicate the name of the validation error you can disable on the GenerateModuleMetadata tasks:

https://docs.gradle.org/current/userguide/publishing_setup.html#sec:suppressing_validation_errors

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- ~[ ] Provide unit tests (under `<subproject>/src/test`) to verify logic~
- ~[ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes~
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
