### PR TITLE
Replace configureEach + casting with withType

### DIFF
--- a/platforms/documentation/docs/src/snippets/testing/test-suite-multi-configure-each/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/testing/test-suite-multi-configure-each/kotlin/build.gradle.kts
@@ -28,12 +28,10 @@ repositories {
 // tag::multi-configure[]
 testing {
     suites {
-        configureEach { // <1>
-            if (this is JvmTestSuite) {
-                useJUnitJupiter()
-                dependencies { // <2>
-                    implementation("org.mockito:mockito-junit-jupiter:4.6.1")
-                }
+        withType<JvmTestSuite> { // <1>
+            useJUnitJupiter()
+            dependencies { // <2>
+                implementation("org.mockito:mockito-junit-jupiter:4.6.1")
             }
         }
         // <3>


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context

Using configureEach with explicit casting looks like anti-pattern when withType<T> that does casting automatically is available.

<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
