### PR TITLE
(minor) Fix Gradle version in CC docs mentioning an inputs tracking change

### DIFF
--- a/subprojects/docs/src/docs/userguide/optimizing-performance/configuration_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/optimizing-performance/configuration_cache.adoc
@@ -602,9 +602,9 @@ org.gradle.configuration-cache.inputs.unsafe.ignore.file-system-checks=\
     build/analytics.json
 ----
 
-* Before Gradle 8.3, some undeclared configuration inputs that were never used in the configuration logic could still be read when the task graph was serialized by the configuration cache.
+* Before Gradle 8.4, some undeclared configuration inputs that were never used in the configuration logic could still be read when the task graph was serialized by the configuration cache.
 However, their changes would not invalidate the configuration cache afterward.
-Starting with Gradle 8.3, such undeclared configuration inputs are correctly tracked.
+Starting with Gradle 8.4, such undeclared configuration inputs are correctly tracked.
 +
 To temporarily revert to the earlier behavior, set the Gradle property `org.gradle.configuration-cache.inputs.unsafe.ignore.in-serialization` to `true`.
 


### PR DESCRIPTION
The fix for https://github.com/gradle/gradle/issues/23249 got delayed to 8.4, so it should be 8.4 and not 8.3.