### PR TITLE
Fix model building for tasks

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/fixtures/ToolingApiSpec.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/fixtures/ToolingApiSpec.groovy
@@ -164,8 +164,7 @@ trait ToolingApiSpec {
             }
         """
     }
-
-    def <T> T fetchModel(Class<T> type = SomeToolingModel.class) {
+    def <T> T fetchModel(Class<T> type = SomeToolingModel.class, String... tasks = null) {
         def model = null
         result = toolingApiExecutor.runBuildWithToolingConnection { connection ->
             def output = new ByteArrayOutputStream()
@@ -174,6 +173,7 @@ trait ToolingApiSpec {
             args.remove("--no-daemon")
 
             model = connection.model(type)
+                .forTasks(tasks)
                 .withArguments(args)
                 .setStandardOutput(new TeeOutputStream(output, System.out))
                 .setStandardError(new TeeOutputStream(error, System.err))

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiIModelQueryIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiIModelQueryIntegrationTest.groovy
@@ -94,6 +94,47 @@ class IsolatedProjectsToolingApiIModelQueryIntegrationTest extends AbstractIsola
         fixture.assertStateLoaded()
     }
 
+    def "can cache models for tasks"() {
+        given:
+        withSomeToolingModelBuilderPluginInBuildSrc()
+        settingsFile << """
+            include("a")
+            include("b")
+        """
+        buildFile << """
+            plugins.apply(my.MyPlugin)
+
+            tasks.register("dummyTask") {
+                println("Configuration of dummyTask")
+                doLast {
+                    println("Execution of dummyTask")
+                }
+            }
+        """
+
+        when:
+        executer.withArguments(ENABLE_CLI)
+        fetchModel(SomeToolingModel, ":dummyTask")
+
+        then:
+        fixture.assertStateStored {
+            projectsConfigured(":buildSrc", ":")
+            modelsCreated(":")
+        }
+        outputContains("Configuration of dummyTask")
+        outputContains("Execution of dummyTask")
+
+        when:
+        executer.withArguments(ENABLE_CLI)
+        fetchModel(SomeToolingModel, ":dummyTask")
+
+        then:
+        fixture.assertStateLoaded()
+        outputDoesNotContain("Configuration of dummyTask")
+        outputDoesNotContain("creating model")
+        outputContains("Execution of dummyTask")
+    }
+
     def "can ignore problems and cache custom model"() {
         given:
         settingsFile << """

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiModelQueryIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiModelQueryIntegrationTest.groovy
@@ -20,7 +20,7 @@ import org.gradle.configurationcache.fixtures.SomeToolingModel
 import org.gradle.tooling.model.GradleProject
 import org.gradle.tooling.model.gradle.GradleBuild
 
-class IsolatedProjectsToolingApiIModelQueryIntegrationTest extends AbstractIsolatedProjectsToolingApiIntegrationTest {
+class IsolatedProjectsToolingApiModelQueryIntegrationTest extends AbstractIsolatedProjectsToolingApiIntegrationTest {
     def setup() {
         settingsFile << """
             rootProject.name = 'root'

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiModelQueryIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiModelQueryIntegrationTest.groovy
@@ -94,7 +94,7 @@ class IsolatedProjectsToolingApiModelQueryIntegrationTest extends AbstractIsolat
         fixture.assertStateLoaded()
     }
 
-    def "can cache models for tasks"() {
+    def "can cache models with tasks"() {
         given:
         withSomeToolingModelBuilderPluginInBuildSrc()
         settingsFile << """

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/BuildTreeConfigurationCache.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/BuildTreeConfigurationCache.kt
@@ -34,9 +34,9 @@ interface BuildTreeConfigurationCache {
      * Loads the scheduled tasks from cache, if available, or else runs the given function to schedule the tasks and then
      * writes the result to the cache.
      *
-     * @param tasksOnly True if tasks execution only was requested. False if model building for tasks was requested.
+     * @param isModelBuildingRequested True if tasks scheduling was requested as a part of model building process. False if only tasks schedule was requested.
      */
-    fun loadOrScheduleRequestedTasks(graph: BuildTreeWorkGraph, graphBuilder: BuildTreeWorkGraphBuilder?, scheduler: (BuildTreeWorkGraph) -> BuildTreeWorkGraph.FinalizedGraph, tasksOnly: Boolean): WorkGraphResult
+    fun loadOrScheduleRequestedTasks(graph: BuildTreeWorkGraph, graphBuilder: BuildTreeWorkGraphBuilder?, scheduler: (BuildTreeWorkGraph) -> BuildTreeWorkGraph.FinalizedGraph, isModelBuildingRequested: Boolean): WorkGraphResult
 
     /**
      * Loads the scheduled tasks from cache.

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/BuildTreeConfigurationCache.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/BuildTreeConfigurationCache.kt
@@ -34,7 +34,7 @@ interface BuildTreeConfigurationCache {
      * Loads the scheduled tasks from cache, if available, or else runs the given function to schedule the tasks and then
      * writes the result to the cache.
      *
-     * @param isModelBuildingRequested True if tasks scheduling was requested as a part of model building process. False if only tasks schedule was requested.
+     * @param isModelBuildingRequested True if tasks scheduling was requested as a part of model building process.
      */
     fun loadOrScheduleRequestedTasks(graph: BuildTreeWorkGraph, graphBuilder: BuildTreeWorkGraphBuilder?, scheduler: (BuildTreeWorkGraph) -> BuildTreeWorkGraph.FinalizedGraph, isModelBuildingRequested: Boolean): WorkGraphResult
 

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/BuildTreeConfigurationCache.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/BuildTreeConfigurationCache.kt
@@ -33,8 +33,10 @@ interface BuildTreeConfigurationCache {
     /**
      * Loads the scheduled tasks from cache, if available, or else runs the given function to schedule the tasks and then
      * writes the result to the cache.
+     *
+     * @param tasksOnly True if tasks execution only was requested. False if model building for tasks was requested.
      */
-    fun loadOrScheduleRequestedTasks(graph: BuildTreeWorkGraph, graphBuilder: BuildTreeWorkGraphBuilder?, scheduler: (BuildTreeWorkGraph) -> BuildTreeWorkGraph.FinalizedGraph): WorkGraphResult
+    fun loadOrScheduleRequestedTasks(graph: BuildTreeWorkGraph, graphBuilder: BuildTreeWorkGraphBuilder?, scheduler: (BuildTreeWorkGraph) -> BuildTreeWorkGraph.FinalizedGraph, tasksOnly: Boolean): WorkGraphResult
 
     /**
      * Loads the scheduled tasks from cache.

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheAwareBuildTreeWorkController.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheAwareBuildTreeWorkController.kt
@@ -35,7 +35,7 @@ class ConfigurationCacheAwareBuildTreeWorkController(
     private val startParameter: ConfigurationCacheStartParameter,
 ) : BuildTreeWorkController {
 
-    override fun scheduleAndRunRequestedTasks(taskSelector: EntryTaskSelector?, tasksOnly: Boolean): ExecutionResult<Void> {
+    override fun scheduleAndRunRequestedTasks(taskSelector: EntryTaskSelector?, isModelBuildingRequested: Boolean): ExecutionResult<Void> {
         val scheduleTaskSelectorPostProcessing: BuildTreeWorkGraphBuilder? = taskSelector?.let { selector ->
             { rootBuildState ->
                 addFinalization(rootBuildState, selector::postProcessExecutionPlan)
@@ -46,7 +46,7 @@ class ConfigurationCacheAwareBuildTreeWorkController(
                 graph = graph,
                 scheduler = { workPreparer.scheduleRequestedTasks(graph, taskSelector) },
                 graphBuilder = scheduleTaskSelectorPostProcessing,
-                tasksOnly = tasksOnly
+                isModelBuildingRequested = isModelBuildingRequested
             )
             if (!result.wasLoadedFromCache && !result.entryDiscarded && startParameter.loadAfterStore) {
                 // Load the work graph from cache instead

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
@@ -330,7 +330,7 @@ class DefaultConfigurationCache internal constructor(
         saveToCache(
             stateType = StateType.Model,
             action = { stateFile -> cacheIO.writeModelTo(model, stateFile) },
-            onSaveFinish = { scopeRegistryListener.dispose() }
+            disposeResources = true
         )
     }
 
@@ -339,12 +339,12 @@ class DefaultConfigurationCache internal constructor(
         saveToCache(
             stateType = StateType.Work,
             action = { stateFile -> writeConfigurationCacheState(stateFile) },
-            onSaveFinish = { if (!isModelBuildingRequested) scopeRegistryListener.dispose() }
+            disposeResources = !isModelBuildingRequested,
         )
     }
 
     private
-    fun saveToCache(stateType: StateType, action: (ConfigurationCacheStateFile) -> Unit, onSaveFinish: () -> Unit) {
+    fun saveToCache(stateType: StateType, action: (ConfigurationCacheStateFile) -> Unit, disposeResources: Boolean) {
 
         cacheEntryRequiresCommit = true
 
@@ -361,7 +361,9 @@ class DefaultConfigurationCache internal constructor(
                     problems.failingBuildDueToSerializationError()
                     throw error
                 } finally {
-                    onSaveFinish()
+                    if (disposeResources) {
+                        scopeRegistryListener.dispose()
+                    }
                 }
             }
         }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
@@ -125,7 +125,12 @@ class DefaultConfigurationCache internal constructor(
         this.host = host
     }
 
-    override fun loadOrScheduleRequestedTasks(graph: BuildTreeWorkGraph, graphBuilder: BuildTreeWorkGraphBuilder?, scheduler: (BuildTreeWorkGraph) -> BuildTreeWorkGraph.FinalizedGraph): BuildTreeConfigurationCache.WorkGraphResult {
+    override fun loadOrScheduleRequestedTasks(
+        graph: BuildTreeWorkGraph,
+        graphBuilder: BuildTreeWorkGraphBuilder?,
+        scheduler: (BuildTreeWorkGraph) -> BuildTreeWorkGraph.FinalizedGraph,
+        tasksOnly: Boolean
+    ): BuildTreeConfigurationCache.WorkGraphResult {
         return if (isLoaded) {
             val finalizedGraph = loadWorkGraph(graph, graphBuilder, false)
             BuildTreeConfigurationCache.WorkGraphResult(
@@ -136,7 +141,7 @@ class DefaultConfigurationCache internal constructor(
         } else {
             runWorkThatContributesToCacheEntry {
                 val finalizedGraph = scheduler(graph)
-                saveWorkGraph()
+                saveWorkGraph(tasksOnly)
                 BuildTreeConfigurationCache.WorkGraphResult(
                     finalizedGraph,
                     wasLoadedFromCache = false,
@@ -322,18 +327,24 @@ class DefaultConfigurationCache internal constructor(
 
     private
     fun saveModel(model: Any) {
-        saveToCache(StateType.Model) { stateFile ->
-            cacheIO.writeModelTo(model, stateFile)
-        }
+        saveToCache(
+            stateType = StateType.Model,
+            action = { stateFile -> cacheIO.writeModelTo(model, stateFile) },
+            onSaveFinish = { scopeRegistryListener.dispose() }
+        )
     }
 
     private
-    fun saveWorkGraph() {
-        saveToCache(StateType.Work) { layout -> writeConfigurationCacheState(layout) }
+    fun saveWorkGraph(tasksOnly: Boolean) {
+        saveToCache(
+            stateType = StateType.Work,
+            action = { stateFile -> writeConfigurationCacheState(stateFile) },
+            onSaveFinish = { if (tasksOnly) scopeRegistryListener.dispose() }
+        )
     }
 
     private
-    fun saveToCache(stateType: StateType, action: (ConfigurationCacheStateFile) -> Unit) {
+    fun saveToCache(stateType: StateType, action: (ConfigurationCacheStateFile) -> Unit, onSaveFinish: () -> Unit) {
 
         cacheEntryRequiresCommit = true
 
@@ -350,7 +361,7 @@ class DefaultConfigurationCache internal constructor(
                     problems.failingBuildDueToSerializationError()
                     throw error
                 } finally {
-                    scopeRegistryListener.dispose()
+                    onSaveFinish()
                 }
             }
         }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
@@ -129,7 +129,7 @@ class DefaultConfigurationCache internal constructor(
         graph: BuildTreeWorkGraph,
         graphBuilder: BuildTreeWorkGraphBuilder?,
         scheduler: (BuildTreeWorkGraph) -> BuildTreeWorkGraph.FinalizedGraph,
-        tasksOnly: Boolean
+        isModelBuildingRequested: Boolean
     ): BuildTreeConfigurationCache.WorkGraphResult {
         return if (isLoaded) {
             val finalizedGraph = loadWorkGraph(graph, graphBuilder, false)
@@ -141,7 +141,7 @@ class DefaultConfigurationCache internal constructor(
         } else {
             runWorkThatContributesToCacheEntry {
                 val finalizedGraph = scheduler(graph)
-                saveWorkGraph(tasksOnly)
+                saveWorkGraph(isModelBuildingRequested)
                 BuildTreeConfigurationCache.WorkGraphResult(
                     finalizedGraph,
                     wasLoadedFromCache = false,
@@ -335,11 +335,11 @@ class DefaultConfigurationCache internal constructor(
     }
 
     private
-    fun saveWorkGraph(tasksOnly: Boolean) {
+    fun saveWorkGraph(isModelBuildingRequested: Boolean) {
         saveToCache(
             stateType = StateType.Work,
             action = { stateFile -> writeConfigurationCacheState(stateFile) },
-            onSaveFinish = { if (tasksOnly) scopeRegistryListener.dispose() }
+            onSaveFinish = { if (!isModelBuildingRequested) scopeRegistryListener.dispose() }
         )
     }
 

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/VintageBuildTreeWorkController.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/VintageBuildTreeWorkController.kt
@@ -31,7 +31,7 @@ class VintageBuildTreeWorkController(
     private val taskGraph: BuildTreeWorkGraphController
 ) : BuildTreeWorkController {
 
-    override fun scheduleAndRunRequestedTasks(taskSelector: EntryTaskSelector?, tasksOnly: Boolean): ExecutionResult<Void> {
+    override fun scheduleAndRunRequestedTasks(taskSelector: EntryTaskSelector?, isModelBuildingRequested: Boolean): ExecutionResult<Void> {
         return taskGraph.withNewWorkGraph { graph: BuildTreeWorkGraph ->
             val finalizedGraph: BuildTreeWorkGraph.FinalizedGraph = workPreparer.scheduleRequestedTasks(graph, taskSelector)
             workExecutor.execute(finalizedGraph)

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/VintageBuildTreeWorkController.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/VintageBuildTreeWorkController.kt
@@ -31,7 +31,7 @@ class VintageBuildTreeWorkController(
     private val taskGraph: BuildTreeWorkGraphController
 ) : BuildTreeWorkController {
 
-    override fun scheduleAndRunRequestedTasks(taskSelector: EntryTaskSelector?): ExecutionResult<Void> {
+    override fun scheduleAndRunRequestedTasks(taskSelector: EntryTaskSelector?, tasksOnly: Boolean): ExecutionResult<Void> {
         return taskGraph.withNewWorkGraph { graph: BuildTreeWorkGraph ->
             val finalizedGraph: BuildTreeWorkGraph.FinalizedGraph = workPreparer.scheduleRequestedTasks(graph, taskSelector)
             workExecutor.execute(finalizedGraph)

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeWorkController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeWorkController.java
@@ -29,7 +29,7 @@ public interface BuildTreeWorkController {
     /**
      * Schedules and runs requested tasks based on the provided {@code taskSelector}.
      *
-     * @param isModelBuildingRequested True if tasks run was requested as a part of model building process. False if only tasks run was requested.
+     * @param isModelBuildingRequested True if tasks run was requested as a part of model building process.
      * */
     ExecutionResult<Void> scheduleAndRunRequestedTasks(@Nullable EntryTaskSelector taskSelector, boolean isModelBuildingRequested);
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeWorkController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeWorkController.java
@@ -25,5 +25,11 @@ import javax.annotation.Nullable;
 
 @ServiceScope(Scopes.BuildTree.class)
 public interface BuildTreeWorkController {
-    ExecutionResult<Void> scheduleAndRunRequestedTasks(@Nullable EntryTaskSelector taskSelector);
+
+    /**
+     * Schedules and runs requested tasks based on the provided {@code taskSelector}.
+     *
+     * @param tasksOnly True if tasks execution only was requested. False if model building for tasks was requested.
+     * */
+    ExecutionResult<Void> scheduleAndRunRequestedTasks(@Nullable EntryTaskSelector taskSelector, boolean tasksOnly);
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeWorkController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeWorkController.java
@@ -29,7 +29,7 @@ public interface BuildTreeWorkController {
     /**
      * Schedules and runs requested tasks based on the provided {@code taskSelector}.
      *
-     * @param tasksOnly True if tasks execution only was requested. False if model building for tasks was requested.
+     * @param isModelBuildingRequested True if tasks run was requested as a part of model building process. False if only tasks run was requested.
      * */
-    ExecutionResult<Void> scheduleAndRunRequestedTasks(@Nullable EntryTaskSelector taskSelector, boolean tasksOnly);
+    ExecutionResult<Void> scheduleAndRunRequestedTasks(@Nullable EntryTaskSelector taskSelector, boolean isModelBuildingRequested);
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/DefaultBuildTreeLifecycleController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/DefaultBuildTreeLifecycleController.java
@@ -65,7 +65,7 @@ public class DefaultBuildTreeLifecycleController implements BuildTreeLifecycleCo
 
     @Override
     public void scheduleAndRunTasks(EntryTaskSelector selector) {
-        runBuild(() -> workController.scheduleAndRunRequestedTasks(selector));
+        runBuild(() -> workController.scheduleAndRunRequestedTasks(selector, true));
     }
 
     @Override
@@ -73,7 +73,7 @@ public class DefaultBuildTreeLifecycleController implements BuildTreeLifecycleCo
         return runBuild(() -> {
             modelCreator.beforeTasks(action);
             if (runTasks) {
-                ExecutionResult<Void> result = workController.scheduleAndRunRequestedTasks(null);
+                ExecutionResult<Void> result = workController.scheduleAndRunRequestedTasks(null, false);
                 if (!result.getFailures().isEmpty()) {
                     return result.asFailure();
                 }

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/DefaultBuildTreeLifecycleController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/DefaultBuildTreeLifecycleController.java
@@ -65,7 +65,7 @@ public class DefaultBuildTreeLifecycleController implements BuildTreeLifecycleCo
 
     @Override
     public void scheduleAndRunTasks(EntryTaskSelector selector) {
-        runBuild(() -> workController.scheduleAndRunRequestedTasks(selector, true));
+        runBuild(() -> workController.scheduleAndRunRequestedTasks(selector, false));
     }
 
     @Override
@@ -73,7 +73,7 @@ public class DefaultBuildTreeLifecycleController implements BuildTreeLifecycleCo
         return runBuild(() -> {
             modelCreator.beforeTasks(action);
             if (runTasks) {
-                ExecutionResult<Void> result = workController.scheduleAndRunRequestedTasks(null, false);
+                ExecutionResult<Void> result = workController.scheduleAndRunRequestedTasks(null, true);
                 if (!result.getFailures().isEmpty()) {
                     return result.asFailure();
                 }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/buildtree/DefaultBuildTreeLifecycleControllerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/buildtree/DefaultBuildTreeLifecycleControllerTest.groovy
@@ -42,7 +42,7 @@ class DefaultBuildTreeLifecycleControllerTest extends Specification {
         controller.scheduleAndRunTasks()
 
         then:
-        1 * workController.scheduleAndRunRequestedTasks(null, true) >> ExecutionResult.succeeded()
+        1 * workController.scheduleAndRunRequestedTasks(null, false) >> ExecutionResult.succeeded()
 
         and:
         1 * finishExecutor.finishBuildTree([]) >> null
@@ -59,7 +59,7 @@ class DefaultBuildTreeLifecycleControllerTest extends Specification {
         e == reportableFailure
 
         and:
-        1 * workController.scheduleAndRunRequestedTasks(null, true) >> ExecutionResult.failed(failure)
+        1 * workController.scheduleAndRunRequestedTasks(null, false) >> ExecutionResult.failed(failure)
 
         and:
         1 * finishExecutor.finishBuildTree([failure]) >> reportableFailure
@@ -74,7 +74,7 @@ class DefaultBuildTreeLifecycleControllerTest extends Specification {
         e == reportableFailure
 
         and:
-        1 * workController.scheduleAndRunRequestedTasks(null, true) >> ExecutionResult.succeeded()
+        1 * workController.scheduleAndRunRequestedTasks(null, false) >> ExecutionResult.succeeded()
 
         and:
         1 * finishExecutor.finishBuildTree([]) >> reportableFailure
@@ -90,7 +90,7 @@ class DefaultBuildTreeLifecycleControllerTest extends Specification {
         result == "result"
 
         and:
-        1 * workController.scheduleAndRunRequestedTasks(null, false) >> ExecutionResult.succeeded()
+        1 * workController.scheduleAndRunRequestedTasks(null, true) >> ExecutionResult.succeeded()
 
         and:
         1 * modelCreator.fromBuildModel(action) >> "result"
@@ -111,7 +111,7 @@ class DefaultBuildTreeLifecycleControllerTest extends Specification {
         e == reportableFailure
 
         and:
-        1 * workController.scheduleAndRunRequestedTasks(null, false) >> ExecutionResult.failed(failure)
+        1 * workController.scheduleAndRunRequestedTasks(null, true) >> ExecutionResult.failed(failure)
         0 * action._
 
         and:

--- a/subprojects/core/src/test/groovy/org/gradle/internal/buildtree/DefaultBuildTreeLifecycleControllerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/buildtree/DefaultBuildTreeLifecycleControllerTest.groovy
@@ -42,7 +42,7 @@ class DefaultBuildTreeLifecycleControllerTest extends Specification {
         controller.scheduleAndRunTasks()
 
         then:
-        1 * workController.scheduleAndRunRequestedTasks(null) >> ExecutionResult.succeeded()
+        1 * workController.scheduleAndRunRequestedTasks(null, true) >> ExecutionResult.succeeded()
 
         and:
         1 * finishExecutor.finishBuildTree([]) >> null
@@ -59,7 +59,7 @@ class DefaultBuildTreeLifecycleControllerTest extends Specification {
         e == reportableFailure
 
         and:
-        1 * workController.scheduleAndRunRequestedTasks(null) >> ExecutionResult.failed(failure)
+        1 * workController.scheduleAndRunRequestedTasks(null, true) >> ExecutionResult.failed(failure)
 
         and:
         1 * finishExecutor.finishBuildTree([failure]) >> reportableFailure
@@ -74,7 +74,7 @@ class DefaultBuildTreeLifecycleControllerTest extends Specification {
         e == reportableFailure
 
         and:
-        1 * workController.scheduleAndRunRequestedTasks(null) >> ExecutionResult.succeeded()
+        1 * workController.scheduleAndRunRequestedTasks(null, true) >> ExecutionResult.succeeded()
 
         and:
         1 * finishExecutor.finishBuildTree([]) >> reportableFailure
@@ -90,7 +90,7 @@ class DefaultBuildTreeLifecycleControllerTest extends Specification {
         result == "result"
 
         and:
-        1 * workController.scheduleAndRunRequestedTasks(null) >> ExecutionResult.succeeded()
+        1 * workController.scheduleAndRunRequestedTasks(null, false) >> ExecutionResult.succeeded()
 
         and:
         1 * modelCreator.fromBuildModel(action) >> "result"
@@ -111,7 +111,7 @@ class DefaultBuildTreeLifecycleControllerTest extends Specification {
         e == reportableFailure
 
         and:
-        1 * workController.scheduleAndRunRequestedTasks(null) >> ExecutionResult.failed(failure)
+        1 * workController.scheduleAndRunRequestedTasks(null, false) >> ExecutionResult.failed(failure)
         0 * action._
 
         and:


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/23889

The problem is that we disposing classloaders in ServiceScopeLookup after saving a work graph and after saving a models.
While we **only** running tasks or **only** building models everything working as expected. 
When we run tasks **and** building models (what is a sync scenario) we are saving models with ServiceScopeLookup was disposed on run tasks step. 

This PR is introducing `tasksOnly` flag for passing a knowledge "are we going only run tasks, or we are going to build a models as well"