### PR TITLE
Tweak `no configuration cache is available` message

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheEncryptionIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheEncryptionIntegrationTest.groovy
@@ -148,7 +148,7 @@ class ConfigurationCacheEncryptionIntegrationTest extends AbstractConfigurationC
 
         then:
         configurationCache.assertStateStored()
-        outputContains("Calculating task graph as no configuration cache is available for tasks: help")
+        outputContains("Calculating task graph as no cached configuration is available for tasks: help")
     }
 
     def "new configuration cache entry if key is not found"() {
@@ -169,7 +169,7 @@ class ConfigurationCacheEncryptionIntegrationTest extends AbstractConfigurationC
 
         then:
         configurationCache.assertStateStored()
-        outputContains("Calculating task graph as no configuration cache is available for tasks: help")
+        outputContains("Calculating task graph as no cached configuration is available for tasks: help")
     }
 
     @Requires(UnitTestPreconditions.NotWindows)

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheIntegrationTest.groovy
@@ -41,7 +41,7 @@ class ConfigurationCacheIntegrationTest extends AbstractConfigurationCacheIntegr
         settingsFile.createFile()
         configurationCacheRun(task, *options)
         def firstRunOutput = removeVfsLogOutput(result.normalizedOutput)
-            .replaceAll(/Calculating task graph as no configuration cache is available for tasks: ${task}.*\n/, '')
+            .replaceAll(/Calculating task graph as no cached configuration is available for tasks: ${task}.*\n/, '')
             .replaceAll(/Configuration cache entry stored.\n/, '')
 
         when:
@@ -243,7 +243,7 @@ class ConfigurationCacheIntegrationTest extends AbstractConfigurationCacheIntegr
 
         then:
         configurationCache.assertStateStored()
-        outputContains("Calculating task graph as no configuration cache is available for tasks: a")
+        outputContains("Calculating task graph as no cached configuration is available for tasks: a")
         outputContains("running build script")
         outputContains("create task")
         outputContains("configure task")
@@ -265,7 +265,7 @@ class ConfigurationCacheIntegrationTest extends AbstractConfigurationCacheIntegr
 
         then:
         configurationCache.assertStateStored()
-        outputContains("Calculating task graph as no configuration cache is available for tasks: b")
+        outputContains("Calculating task graph as no cached configuration is available for tasks: b")
         outputContains("running build script")
         outputContains("create task")
         outputContains("configure task")

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheProjectReportIntegTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheProjectReportIntegTest.groovy
@@ -28,7 +28,7 @@ class ConfigurationCacheProjectReportIntegTest extends AbstractConfigurationCach
         given:
         configurationCacheRun(task, *options)
         def firstRunOutput = removeVfsLogOutput(result.normalizedOutput)
-            .replaceAll(/Calculating task graph as no configuration cache is available for tasks: ${task}.*\n/, '')
+            .replaceAll(/Calculating task graph as no cached configuration is available for tasks: ${task}.*\n/, '')
             .replaceAll(/Configuration cache entry stored.\n/, '')
 
         when:

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
@@ -238,7 +238,7 @@ class DefaultConfigurationCache internal constructor(
             when (val checkedFingerprint = checkFingerprint()) {
                 is CheckedFingerprint.NotFound -> {
                     logBootstrapSummary(
-                        "{} as no configuration cache is available for {}",
+                        "{} as no cached configuration is available for {}",
                         buildActionModelRequirements.actionDisplayName.capitalizedDisplayName,
                         buildActionModelRequirements.configurationCacheKeyDisplayName.displayName
                     )

--- a/subprojects/docs/src/snippets/configurationCache/noProblem/tests/store.out
+++ b/subprojects/docs/src/snippets/configurationCache/noProblem/tests/store.out
@@ -1,1 +1,1 @@
-Calculating task graph as no configuration cache is available for tasks: help
+Calculating task graph as no cached configuration is available for tasks: help

--- a/subprojects/docs/src/snippets/configurationCache/problemsFixed/tests/store.out
+++ b/subprojects/docs/src/snippets/configurationCache/problemsFixed/tests/store.out
@@ -1,4 +1,4 @@
-Calculating task graph as no configuration cache is available for tasks: someTask
+Calculating task graph as no cached configuration is available for tasks: someTask
 > Task :someTask
 
 BUILD SUCCESSFUL in 0s

--- a/subprojects/docs/src/snippets/configurationCache/problemsFixedReuse/tests/store.out
+++ b/subprojects/docs/src/snippets/configurationCache/problemsFixedReuse/tests/store.out
@@ -1,4 +1,4 @@
-Calculating task graph as no configuration cache is available for tasks: someTask
+Calculating task graph as no cached configuration is available for tasks: someTask
 > Task :someTask
 
 BUILD SUCCESSFUL in 0s

--- a/subprojects/docs/src/snippets/configurationCache/problemsGroovy/tests/store.out
+++ b/subprojects/docs/src/snippets/configurationCache/problemsGroovy/tests/store.out
@@ -1,4 +1,4 @@
-Calculating task graph as no configuration cache is available for tasks: someTask
+Calculating task graph as no cached configuration is available for tasks: someTask
 > Task :someTask
 
 1 problem was found storing the configuration cache.

--- a/subprojects/docs/src/snippets/configurationCache/problemsKotlin/tests/store.out
+++ b/subprojects/docs/src/snippets/configurationCache/problemsKotlin/tests/store.out
@@ -1,4 +1,4 @@
-Calculating task graph as no configuration cache is available for tasks: someTask
+Calculating task graph as no cached configuration is available for tasks: someTask
 > Task :someTask
 
 1 problem was found storing the configuration cache.

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheFixture.groovy
@@ -256,9 +256,9 @@ class ConfigurationCacheFixture {
             return
         }
         if (details.runsTasks) {
-            spec.outputContains("Calculating task graph as no configuration cache is available for tasks:")
+            spec.outputContains("Calculating task graph as no cached configuration is available for tasks:")
         } else {
-            spec.outputContains("Creating tooling model as no configuration cache is available for the requested model")
+            spec.outputContains("Creating tooling model as no cached configuration is available for the requested model")
         }
     }
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaConfigurationCachePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaConfigurationCachePerformanceTest.groovy
@@ -25,6 +25,7 @@ import org.gradle.profiler.BuildMutator
 import org.gradle.profiler.InvocationSettings
 
 import java.nio.file.Files
+import java.util.regex.Pattern
 
 import static org.gradle.performance.annotations.ScenarioType.PER_COMMIT
 import static org.gradle.performance.annotations.ScenarioType.PER_DAY
@@ -95,12 +96,13 @@ class JavaConfigurationCachePerformanceTest extends AbstractCrossVersionPerforma
             void afterBuild(BuildContext context, Throwable error) {
                 if (context.iteration > 1) {
                     def tag = action == storing
-                        ? "Calculating task graph as no cached configuration is available"
+                        ? "Calculating task graph as no (cached configuration|configuration cache) is available"
                         : "Reusing configuration cache"
                     File buildLog = new File(invocationSettings.projectDir, "profile.log")
 
                     def found = Files.lines(buildLog.toPath()).withCloseable { lines ->
-                        lines.anyMatch { line -> line.contains(tag) }
+                        def pattern = Pattern.compile(tag)
+                        lines.anyMatch { line -> pattern.matcher(line).find() }
                     }
                     if (!found) {
                         assertTrue("Configuration cache log '$tag' not found in '$buildLog'\n\n$buildLog.text", found)

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaConfigurationCachePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaConfigurationCachePerformanceTest.groovy
@@ -95,7 +95,7 @@ class JavaConfigurationCachePerformanceTest extends AbstractCrossVersionPerforma
             void afterBuild(BuildContext context, Throwable error) {
                 if (context.iteration > 1) {
                     def tag = action == storing
-                        ? "Calculating task graph as no configuration cache is available"
+                        ? "Calculating task graph as no cached configuration is available"
                         : "Reusing configuration cache"
                     File buildLog = new File(invocationSettings.projectDir, "profile.log")
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractGradleBuildConfigurationCacheSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractGradleBuildConfigurationCacheSmokeTest.groovy
@@ -45,7 +45,7 @@ abstract class AbstractGradleBuildConfigurationCacheSmokeTest extends AbstractGr
 
     @Override
     protected void assertConfigurationCacheStateStored() {
-        assert result.output.count("Calculating task graph as no configuration cache is available") == 1
+        assert result.output.count("Calculating task graph as no cached configuration is available") == 1
     }
 
     @Override

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r84/TestLauncherCompositeBuildCrossVersionTest.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r84/TestLauncherCompositeBuildCrossVersionTest.groovy
@@ -339,6 +339,6 @@ class TestLauncherCompositeBuildCrossVersionTest extends ToolingApiSpecification
     }
 
     private boolean noConfigurationCacheAvailableIn(String output) {
-        output.contains('Calculating task graph as no configuration cache is available')
+        output.contains('Calculating task graph as no cached configuration is available')
     }
 }

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r84/TestLauncherCompositeBuildCrossVersionTest.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r84/TestLauncherCompositeBuildCrossVersionTest.groovy
@@ -25,6 +25,7 @@ import org.gradle.tooling.ProjectConnection
 import spock.lang.Issue
 
 import java.util.function.Function
+import java.util.regex.Pattern
 
 import static java.util.Arrays.asList
 
@@ -339,6 +340,11 @@ class TestLauncherCompositeBuildCrossVersionTest extends ToolingApiSpecification
     }
 
     private boolean noConfigurationCacheAvailableIn(String output) {
-        output.contains('Calculating task graph as no cached configuration is available')
+        noConfigCachePattern.matcher(output).find()
     }
+
+    static Pattern noConfigCachePattern = Pattern.compile(
+        'Calculating task graph as no (cached configuration|configuration cache) is available',
+        Pattern.MULTILINE
+    )
 }


### PR DESCRIPTION
Change it from:
> Calculating task graph as ~no configuration cache~ is available for tasks: …

to:

> Calculating task graph as *no cached configuration* is available for tasks: …

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
