### PR TITLE
Attribute deprecation warnings to plugins

### DIFF
--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/code/DefaultUserCodeSource.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/code/DefaultUserCodeSource.java
@@ -18,19 +18,17 @@ package org.gradle.internal.code;
 
 import org.gradle.internal.DisplayName;
 
-import javax.annotation.Nullable;
-
 /**
  * Default implementation of {@link UserCodeSource}.
  */
 public class DefaultUserCodeSource implements UserCodeSource {
 
     private final DisplayName displayName;
-    private final String pluginId;
+    private final boolean isPlugin;
 
-    public DefaultUserCodeSource(DisplayName displayName, @Nullable String pluginId) {
+    public DefaultUserCodeSource(DisplayName displayName, boolean isPlugin) {
         this.displayName = displayName;
-        this.pluginId = pluginId;
+        this.isPlugin = isPlugin;
     }
 
     @Override
@@ -38,9 +36,8 @@ public class DefaultUserCodeSource implements UserCodeSource {
         return displayName;
     }
 
-    @Nullable
     @Override
-    public String getPluginId() {
-        return pluginId;
+    public boolean isPlugin() {
+        return isPlugin;
     }
 }

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/code/UserCodeSource.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/code/UserCodeSource.java
@@ -18,8 +18,6 @@ package org.gradle.internal.code;
 
 import org.gradle.internal.DisplayName;
 
-import javax.annotation.Nullable;
-
 /**
  * Describes the source of code being applied.
  */
@@ -30,8 +28,7 @@ public interface UserCodeSource {
     DisplayName getDisplayName();
 
     /**
-     * The ID of the plugin applying user code, if available.
+     * True if this source is a plugin. False if it is a script
      */
-    @Nullable
-    String getPluginId();
+    boolean isPlugin();
 }

--- a/platforms/ide/problems/src/main/java/org/gradle/problems/Location.java
+++ b/platforms/ide/problems/src/main/java/org/gradle/problems/Location.java
@@ -51,6 +51,6 @@ public class Location {
     }
 
     public String getFormatted() {
-        return sourceLongDisplayName.getCapitalizedDisplayName() + ": line " + lineNumber;
+        return sourceLongDisplayName.getDisplayName() + ": line " + lineNumber;
     }
 }

--- a/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/Reproducer.groovy
+++ b/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/Reproducer.groovy
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class Reproducer extends AbstractIntegrationSpec {
+    def "test"() {
+        given:
+        file("buildSrc/build.gradle") << """
+            plugins {
+                id("groovy-gradle-plugin")
+            }
+        """
+        file("buildSrc/src/main/groovy/MyExtension.java") << """
+            import org.gradle.api.plugins.JavaPluginExtension;
+            abstract class MyExtension {
+
+                private final JavaPluginExtension ext;
+
+                @javax.inject.Inject
+                public MyExtension(JavaPluginExtension ext) {
+                    this.ext = ext;
+                }
+
+                void doSomethingDeprecated() {
+                    ext.withSourcesJar();
+                }
+            }
+        """
+        file("buildSrc/src/main/groovy/my.plugin.gradle") << """
+            plugins {
+                id 'java-base'
+            }
+
+            sourceSets {
+                main
+            }
+            tasks.create("javadoc", Javadoc)
+
+            // 1
+            java {
+                withJavadocJar()
+            }
+
+            extensions.add(MyExtension, "myExtension", objects.newInstance(MyExtension, extensions.getByType(JavaPluginExtension)))
+        """
+        buildFile << """
+            plugins {
+                id 'my.plugin'
+            }
+
+            // 2
+            java {
+                consistentResolution {}
+            }
+
+            // 3
+            myExtension.doSomethingDeprecated()
+
+            // Attribute nothing if no plugin & no stack trace
+                // Be smarter about stack trace
+        """
+
+        expect:
+        succeeds "help"
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultPluginManager.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultPluginManager.java
@@ -165,7 +165,7 @@ public class DefaultPluginManager implements PluginManagerInternal {
             } else {
                 final Runnable adder = addPluginInternal(plugin);
                 if (adder != null) {
-                    UserCodeSource source = new DefaultUserCodeSource(plugin.getDisplayName(), pluginIdStr);
+                    UserCodeSource source = new DefaultUserCodeSource(plugin.getDisplayName(), true);
                     userCodeApplicationContext.apply(source, userCodeApplicationId ->
                         buildOperationExecutor.run(new AddPluginBuildOperation(adder, plugin, pluginIdStr, pluginClass, userCodeApplicationId)));
                 }

--- a/subprojects/core/src/main/java/org/gradle/configuration/BuildOperationScriptPlugin.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/BuildOperationScriptPlugin.java
@@ -61,7 +61,7 @@ public class BuildOperationScriptPlugin implements ScriptPlugin {
             //no operation, if there is no script code provided
             decorated.apply(target);
         } else {
-            UserCodeSource source = new DefaultUserCodeSource(getSource().getShortDisplayName(), null);
+            UserCodeSource source = new DefaultUserCodeSource(getSource().getShortDisplayName(), false);
             userCodeApplicationContext.apply(source, userCodeApplicationId -> buildOperationExecutor.run(new RunnableBuildOperation() {
                 @Override
                 public void run(BuildOperationContext context) {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractKotlinPluginAndroidSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractKotlinPluginAndroidSmokeTest.groovy
@@ -57,18 +57,27 @@ abstract class AbstractKotlinPluginAndroidSmokeTest extends AbstractSmokeTest im
                 .deprecations(KotlinAndroidDeprecations) {
                     expectKotlinConfigurationAsDependencyDeprecation(kotlinPluginVersionNumber)
                     expectAndroidOrKotlinWorkerSubmitDeprecation(androidPluginVersionNumber, parallelTasksInProject, kotlinPluginVersionNumber)
-                    expectReportDestinationPropertyDeprecation(androidPluginVersion)
+                    expectReportDestinationPropertyDeprecation(androidPluginVersion) {
+                        cause = "plugin 'com.android.internal.application'"
+                    }
                     expectKotlinCompileDestinationDirPropertyDeprecation(kotlinPluginVersionNumber)
                     if (GradleContextualExecuter.configCache || kotlinPluginVersionNumber >= VersionNumber.parse("1.8.0")) {
-                        expectBuildIdentifierIsCurrentBuildDeprecation(androidPluginVersion)
+                        expectBuildIdentifierIsCurrentBuildDeprecation(androidPluginVersion) {
+                            cause = "plugin 'com.android.internal.application'"
+                        }
                     }
-                    2.times {
-                        maybeExpectOrgGradleUtilGUtilDeprecation(androidPluginVersion)
+                    maybeExpectOrgGradleUtilGUtilDeprecation(androidPluginVersion) {
+                        cause = "plugin 'com.android.internal.application'"
                     }
                     if (GradleContextualExecuter.configCache) {
                         expectForUseAtConfigurationTimeDeprecation(kotlinPluginVersionNumber)
                     }
-                    expectBasePluginExtensionArchivesBaseNameDeprecation(kotlinPluginVersionNumber, androidPluginVersionNumber)
+                    expectBasePluginExtensionArchivesBaseNameDeprecation(kotlinPluginVersionNumber, androidPluginVersionNumber) {
+                        causes = [
+                            null,
+                            "plugin 'com.android.internal.application'"
+                        ]
+                    }
                 }.build()
 
         then:

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidGradleRecipesKotlinSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidGradleRecipesKotlinSmokeTest.groovy
@@ -199,14 +199,26 @@ class AndroidGradleRecipesKotlinSmokeTest extends AbstractSmokeTest {
             if (GradleContextualExecuter.configCache) {
                 expectForUseAtConfigurationTimeDeprecation(kotlinVersionNumber)
             }
-            expectOrgGradleUtilWrapUtilDeprecation(kotlinVersionNumber)
-            maybeExpectOrgGradleUtilGUtilDeprecation(agpVersion)
+            expectOrgGradleUtilWrapUtilDeprecation(kotlinVersionNumber) {
+                cause = "plugin 'org.jetbrains.kotlin.android'"
+            }
+            maybeExpectOrgGradleUtilGUtilDeprecation(agpVersion) {
+                cause = "plugin 'com.android.internal.application'"
+            }
             expectAndroidWorkerExecutionSubmitDeprecationWarning(agpVersion)
-            expectProjectConventionDeprecationWarning(agpVersion)
-            maybeExpectConventionTypeDeprecation(kotlinVersionNumber)
-            expectAndroidConventionTypeDeprecationWarning(agpVersion)
+            expectProjectConventionDeprecationWarning(agpVersion) {
+                cause = "plugin 'com.android.internal.application'"
+            }
+            maybeExpectConventionTypeDeprecation(kotlinVersionNumber) {
+                cause = "plugin 'org.jetbrains.kotlin.android'"
+            }
+            expectAndroidConventionTypeDeprecationWarning(agpVersion) {
+                cause = "plugin 'com.android.internal.application'"
+            }
             expectBasePluginConventionDeprecation(agpVersion)
-            expectBasePluginExtensionArchivesBaseNameDeprecation(kotlinVersionNumber, VersionNumber.parse(agpVersion))
+            expectBasePluginConventionDeprecation(kotlinVersionNumber, VersionNumber.parse(agpVersion)) {
+                cause = "plugin 'com.android.internal.application'"
+            }
         }
     }
 }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidGradleRecipesKotlinSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidGradleRecipesKotlinSmokeTest.groovy
@@ -216,7 +216,7 @@ class AndroidGradleRecipesKotlinSmokeTest extends AbstractSmokeTest {
                 cause = "plugin 'com.android.internal.application'"
             }
             expectBasePluginConventionDeprecation(agpVersion)
-            expectBasePluginConventionDeprecation(kotlinVersionNumber, VersionNumber.parse(agpVersion)) {
+            expectAndroidBasePluginConventionDeprecation(kotlinVersionNumber, VersionNumber.parse(agpVersion)) {
                 cause = "plugin 'com.android.internal.application'"
             }
         }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
@@ -66,10 +66,30 @@ class AndroidPluginsSmokeTest extends AbstractPluginValidatingSmokeTest implemen
         and:
         def runner = useAgpVersion(agpVersion, runner('sourceSets'))
         runner.deprecations(AndroidDeprecations) {
-            maybeExpectOrgGradleUtilGUtilDeprecation(agpVersion)
-            maybeExpectProjectConventionDeprecationWarning(agpVersion)
-            maybeExpectAndroidConventionTypeDeprecationWarning(agpVersion)
-            maybeExpectBasePluginConventionDeprecation(agpVersion)
+            maybeExpectOrgGradleUtilGUtilDeprecation(agpVersion) {
+                causes = [
+                    "plugin 'com.android.internal.application'",
+                    "plugin 'com.android.internal.library'"
+                ]
+            }
+            maybeExpectProjectConventionDeprecationWarning(agpVersion) {
+                causes = [
+                    "plugin 'com.android.internal.application'",
+                    "plugin 'com.android.internal.library'"
+                ]
+            }
+            maybeExpectAndroidConventionTypeDeprecationWarning(agpVersion) {
+                causes = [
+                    "plugin 'com.android.internal.application'",
+                    "plugin 'com.android.internal.library'"
+                ]
+            }
+            maybeExpectBasePluginConventionDeprecation(agpVersion) {
+                causes = [
+                    "plugin 'com.android.internal.application'",
+                    "plugin 'com.android.internal.library'"
+                ]
+            }
             expectAndroidBasePluginExtensionArchivesBaseNameDeprecation(VersionNumber.parse(agpVersion))
         }
 
@@ -108,13 +128,40 @@ class AndroidPluginsSmokeTest extends AbstractPluginValidatingSmokeTest implemen
         SantaTrackerConfigurationCacheWorkaround.beforeBuild(runner.projectDir, IntegrationTestBuildContext.INSTANCE.gradleUserHomeDir)
         def result = runner.deprecations(AbstractAndroidSantaTrackerSmokeTest.SantaTrackerDeprecations) {
             expectAndroidWorkerExecutionSubmitDeprecationWarning(agpVersion)
-            expectReportDestinationPropertyDeprecation(agpVersion)
-            expectProjectConventionDeprecationWarning(agpVersion)
-            expectAndroidConventionTypeDeprecationWarning(agpVersion)
-            expectBasePluginConventionDeprecation(agpVersion)
+            expectReportDestinationPropertyDeprecation(agpVersion) {
+                causes = [
+                    "plugin 'com.android.internal.application'",
+                    "plugin 'com.android.internal.library'"
+                ]
+            }
+            expectProjectConventionDeprecationWarning(agpVersion) {
+                causes = [
+                    "plugin 'com.android.internal.application'",
+                    "plugin 'com.android.internal.library'"
+                ]
+            }
+            expectAndroidConventionTypeDeprecationWarning(agpVersion) {
+                causes = [
+                    "plugin 'com.android.internal.application'",
+                    "plugin 'com.android.internal.library'"
+                ]
+            }
+            expectBasePluginConventionDeprecation(agpVersion) {
+                causes = [
+                    "plugin 'com.android.internal.application'",
+                    "plugin 'com.android.internal.library'"
+                ]
+            }
             expectBuildIdentifierNameDeprecation(agpVersion)
-            expectBuildIdentifierIsCurrentBuildDeprecation(agpVersion)
-            maybeExpectOrgGradleUtilGUtilDeprecation(agpVersion)
+            expectBuildIdentifierIsCurrentBuildDeprecation(agpVersion) {
+                causes = [
+                    "plugin 'com.android.internal.application'",
+                    "plugin 'com.android.internal.library'"
+                ]
+            }
+            maybeExpectOrgGradleUtilGUtilDeprecation(agpVersion) {
+                cause = "plugin 'com.android.internal.application'"
+            }
             expectAndroidBasePluginExtensionArchivesBaseNameDeprecation(agpVersionNumber)
         }.build()
 
@@ -133,11 +180,36 @@ class AndroidPluginsSmokeTest extends AbstractPluginValidatingSmokeTest implemen
         SantaTrackerConfigurationCacheWorkaround.beforeBuild(runner.projectDir, IntegrationTestBuildContext.INSTANCE.gradleUserHomeDir)
         result = runner.deprecations(AndroidDeprecations) {
             maybeExpectOrgGradleUtilGUtilDeprecation(agpVersion)
-            maybeExpectProjectConventionDeprecationWarning(agpVersion)
-            maybeExpectReportDestinationPropertyDeprecation(agpVersion)
-            maybeExpectAndroidConventionTypeDeprecationWarning(agpVersion)
-            maybeExpectBasePluginConventionDeprecation(agpVersion)
-            maybeExpectBuildIdentifierIsCurrentBuildDeprecation(agpVersion)
+            maybeExpectProjectConventionDeprecationWarning(agpVersion) {
+                causes = [
+                    "plugin 'com.android.internal.application'",
+                    "plugin 'com.android.internal.library'"
+                ]
+            }
+            maybeExpectReportDestinationPropertyDeprecation(agpVersion) {
+                causes = [
+                    "plugin 'com.android.internal.application'",
+                    "plugin 'com.android.internal.library'"
+                ]
+            }
+            maybeExpectAndroidConventionTypeDeprecationWarning(agpVersion) {
+                causes = [
+                    "plugin 'com.android.internal.application'",
+                    "plugin 'com.android.internal.library'"
+                ]
+            }
+            maybeExpectBasePluginConventionDeprecation(agpVersion) {
+                causes = [
+                    "plugin 'com.android.internal.application'",
+                    "plugin 'com.android.internal.library'"
+                ]
+            }
+            maybeExpectBuildIdentifierIsCurrentBuildDeprecation(agpVersion) {
+                causes = [
+                    "plugin 'com.android.internal.application'",
+                    "plugin 'com.android.internal.library'"
+                ]
+            }
             if (!GradleContextualExecuter.isConfigCache()) {
                 expectAndroidBasePluginExtensionArchivesBaseNameDeprecation(agpVersionNumber)
             }
@@ -159,11 +231,36 @@ class AndroidPluginsSmokeTest extends AbstractPluginValidatingSmokeTest implemen
             maybeExpectOrgGradleUtilGUtilDeprecation(agpVersion)
             expectAndroidWorkerExecutionSubmitDeprecationWarning(agpVersion)
             if (!GradleContextualExecuter.isConfigCache()) {
-                expectReportDestinationPropertyDeprecation(agpVersion)
-                expectProjectConventionDeprecationWarning(agpVersion)
-                expectAndroidConventionTypeDeprecationWarning(agpVersion)
-                expectBasePluginConventionDeprecation(agpVersion)
-                expectBuildIdentifierIsCurrentBuildDeprecation(agpVersion)
+                expectReportDestinationPropertyDeprecation(agpVersion) {
+                    causes = [
+                        "plugin 'com.android.internal.application'",
+                        "plugin 'com.android.internal.library'"
+                    ]
+                }
+                expectProjectConventionDeprecationWarning(agpVersion) {
+                    causes = [
+                        "plugin 'com.android.internal.application'",
+                        "plugin 'com.android.internal.library'"
+                    ]
+                }
+                expectAndroidConventionTypeDeprecationWarning(agpVersion) {
+                    causes = [
+                        "plugin 'com.android.internal.application'",
+                        "plugin 'com.android.internal.library'"
+                    ]
+                }
+                expectBasePluginConventionDeprecation(agpVersion) {
+                    causes = [
+                        "plugin 'com.android.internal.application'",
+                        "plugin 'com.android.internal.library'"
+                    ]
+                }
+                expectBuildIdentifierIsCurrentBuildDeprecation(agpVersion) {
+                    causes = [
+                        "plugin 'com.android.internal.application'",
+                        "plugin 'com.android.internal.library'"
+                    ]
+                }
                 expectAndroidBasePluginExtensionArchivesBaseNameDeprecation(agpVersionNumber)
             }
         }.build()
@@ -180,10 +277,30 @@ class AndroidPluginsSmokeTest extends AbstractPluginValidatingSmokeTest implemen
         when: 'clean re-build'
         def smokeTestRunner = this.runner('clean')
         useAgpVersion(agpVersion, smokeTestRunner).deprecations(AndroidDeprecations) {
-            maybeExpectOrgGradleUtilGUtilDeprecation(agpVersion)
-            expectProjectConventionDeprecationWarning(agpVersion)
-            expectAndroidConventionTypeDeprecationWarning(agpVersion)
-            expectBasePluginConventionDeprecation(agpVersion)
+            maybeExpectOrgGradleUtilGUtilDeprecation(agpVersion) {
+                causes = [
+                    "plugin 'com.android.internal.application'",
+                    "plugin 'com.android.internal.library'"
+                ]
+            }
+            expectProjectConventionDeprecationWarning(agpVersion) {
+                causes = [
+                    "plugin 'com.android.internal.application'",
+                    "plugin 'com.android.internal.library'"
+                ]
+            }
+            expectAndroidConventionTypeDeprecationWarning(agpVersion) {
+                causes = [
+                    "plugin 'com.android.internal.application'",
+                    "plugin 'com.android.internal.library'"
+                ]
+            }
+            expectBasePluginConventionDeprecation(agpVersion) {
+                causes = [
+                    "plugin 'com.android.internal.application'",
+                    "plugin 'com.android.internal.library'"
+                ]
+            }
             expectAndroidBasePluginExtensionArchivesBaseNameDeprecation(agpVersionNumber)
         }.build()
         SantaTrackerConfigurationCacheWorkaround.beforeBuild(runner.projectDir, IntegrationTestBuildContext.INSTANCE.gradleUserHomeDir)
@@ -192,11 +309,36 @@ class AndroidPluginsSmokeTest extends AbstractPluginValidatingSmokeTest implemen
             expectAndroidWorkerExecutionSubmitDeprecationWarning(agpVersion)
             expectBuildIdentifierNameDeprecation(agpVersion)
             if (!GradleContextualExecuter.isConfigCache()) {
-                expectReportDestinationPropertyDeprecation(agpVersion)
-                expectProjectConventionDeprecationWarning(agpVersion)
-                expectAndroidConventionTypeDeprecationWarning(agpVersion)
-                expectBasePluginConventionDeprecation(agpVersion)
-                expectBuildIdentifierIsCurrentBuildDeprecation(agpVersion)
+                expectReportDestinationPropertyDeprecation(agpVersion) {
+                    causes = [
+                        "plugin 'com.android.internal.application'",
+                        "plugin 'com.android.internal.library'"
+                    ]
+                }
+                expectProjectConventionDeprecationWarning(agpVersion) {
+                    causes = [
+                        "plugin 'com.android.internal.application'",
+                        "plugin 'com.android.internal.library'"
+                    ]
+                }
+                expectAndroidConventionTypeDeprecationWarning(agpVersion) {
+                    causes = [
+                        "plugin 'com.android.internal.application'",
+                        "plugin 'com.android.internal.library'"
+                    ]
+                }
+                expectBasePluginConventionDeprecation(agpVersion) {
+                    causes = [
+                        "plugin 'com.android.internal.application'",
+                        "plugin 'com.android.internal.library'"
+                    ]
+                }
+                expectBuildIdentifierIsCurrentBuildDeprecation(agpVersion) {
+                    causes = [
+                        "plugin 'com.android.internal.application'",
+                        "plugin 'com.android.internal.library'"
+                    ]
+                }
                 expectAndroidBasePluginExtensionArchivesBaseNameDeprecation(agpVersionNumber)
             }
         }.build()
@@ -211,7 +353,7 @@ class AndroidPluginsSmokeTest extends AbstractPluginValidatingSmokeTest implemen
 
         where:
         [agpVersion, ide] << [
-            TestedVersions.androidGradle.toList(),
+            TestedVersions.androidGradle.versions,
             [false]
         ].combinations()
     }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AsciidoctorPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AsciidoctorPluginSmokeTest.groovy
@@ -99,7 +99,9 @@ class AsciidoctorPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
                 VersionNumber.parse(asciidoctorVersion).major >= 4,
                 FOR_USE_AT_CONFIGURATION_TIME_DEPRECATION,
                 "Seems to be fixed in main branch, but no releases with a fix"
-            )
+            ) {
+                cause = "plugin class 'org.asciidoctor.gradle.base.AsciidoctorBasePlugin'"
+            }
         }
     }
 }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BNDSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BNDSmokeTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.smoketests
 
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.test.fixtures.archive.JarTestFixture
-import org.gradle.util.GradleVersion
 import spock.lang.Issue
 
 /**
@@ -32,7 +31,7 @@ pluginManagement {
         id "biz.aQute.bnd.builder" version "${TestedVersions.bnd}"
     }
 }
-    
+
 rootProject.name = 'bnd-smoke-test'
 """
     }
@@ -72,11 +71,11 @@ public class Example {
         when:
         runner("jar")
             .forwardOutput()
-            .expectLegacyDeprecationWarning(
-                "The AbstractTask.getConvention() method has been deprecated. " +
-                "This is scheduled to be removed in Gradle 9.0. " +
-                "Consult the upgrading guide for further information: " +
-                "https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#deprecated_access_to_conventions")
+            .deprecations {
+                expectAbstractTaskConventionDeprecationWarning {
+                    cause = "plugin 'biz.aQute.bnd.builder'"
+                }
+            }
             .build()
 
         then: "version numbers exist in the manifest"
@@ -159,11 +158,11 @@ public class MyUtil {
         when:
         runner(":jar")
             .forwardOutput()
-            .expectLegacyDeprecationWarning(
-                "The AbstractTask.getConvention() method has been deprecated. " +
-                "This is scheduled to be removed in Gradle 9.0. " +
-                "Consult the upgrading guide for further information: " +
-                "https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#deprecated_access_to_conventions")
+            .deprecations {
+                expectAbstractTaskConventionDeprecationWarning {
+                    cause = "plugin 'biz.aQute.bnd.builder'"
+                }
+            }
             .build()
 
         then: "version numbers exist in the manifest"
@@ -353,13 +352,13 @@ public class MyUtil {
 
         expect:
         runner(":resolve")
-                .forwardOutput()
-                .expectLegacyDeprecationWarning(
-                        "The AbstractTask.getConvention() method has been deprecated. " +
-                                "This is scheduled to be removed in Gradle 9.0. " +
-                                "Consult the upgrading guide for further information: " +
-                                "https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#deprecated_access_to_conventions")
-                .build()
+            .forwardOutput()
+            .deprecations {
+                expectAbstractTaskConventionDeprecationWarning {
+                    causes = [null, "plugin 'biz.aQute.bnd.builder'"]
+                }
+            }
+            .build()
     }
 
     @ToBeFixedForConfigurationCache(because = "Bndrun task does not support configuration cache")
@@ -432,13 +431,13 @@ Bundle-Activator: com.example.Activator
 
         expect:
         def result = runner(":run")
-                .forwardOutput()
-                .expectLegacyDeprecationWarning(
-                        "The AbstractTask.getConvention() method has been deprecated. " +
-                                "This is scheduled to be removed in Gradle 9.0. " +
-                                "Consult the upgrading guide for further information: " +
-                                "https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#deprecated_access_to_conventions")
-                .build()
+            .forwardOutput()
+            .deprecations {
+                expectAbstractTaskConventionDeprecationWarning {
+                    causes = [null, "plugin 'biz.aQute.bnd.builder'"]
+                }
+            }
+            .build()
 
         assert result.getOutput().contains("Example project ran.")
     }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BaseDeprecations.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BaseDeprecations.groovy
@@ -73,4 +73,14 @@ class BaseDeprecations {
     BaseDeprecations(SmokeTestGradleRunner runner) {
         this.runner = runner
     }
+
+    void expectAbstractTaskConventionDeprecationWarning(@DelegatesTo(SmokeTestGradleRunner.DeprecationOptions) Closure<?> action = null) {
+        runner.expectLegacyDeprecationWarning(
+            "The AbstractTask.getConvention() method has been deprecated. " +
+            "This is scheduled to be removed in Gradle 9.0. " +
+            "Consult the upgrading guide for further information: " +
+            DOCUMENTATION_REGISTRY.getDocumentationFor("upgrading_version_8", "deprecated_access_to_conventions"),
+            action
+        )
+    }
 }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
@@ -174,7 +174,9 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
                 "Gradle Enterprise plugin $version has been deprecated. " +
                     "Starting with Gradle 9.0, only Gradle Enterprise plugin 3.13.1 or newer is supported. " +
                     "Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#unsupported_ge_plugin_3.13"
-            )
+            ) {
+                cause = "plugin 'com.gradle.enterprise'"
+            }
             .expectLegacyDeprecationWarningIf(versionNumber < FIRST_VERSION_CALLING_BUILD_PATH,
                 "The BuildIdentifier.getName() method has been deprecated. " +
                     "This is scheduled to be removed in Gradle 9.0. " +
@@ -201,7 +203,9 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
                 "Gradle Enterprise plugin $version has been deprecated. " +
                     "Starting with Gradle 9.0, only Gradle Enterprise plugin 3.13.1 or newer is supported. " +
                     "Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#unsupported_ge_plugin_3.13"
-            )
+            ) {
+                cause = "plugin 'com.gradle.enterprise'"
+            }
             .expectLegacyDeprecationWarningIf(versionNumber < FIRST_VERSION_CALLING_BUILD_PATH,
                 "The BuildIdentifier.getName() method has been deprecated. " +
                     "This is scheduled to be removed in Gradle 9.0. " +
@@ -227,7 +231,9 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
                 "Gradle Enterprise plugin $version has been deprecated. " +
                     "Starting with Gradle 9.0, only Gradle Enterprise plugin 3.13.1 or newer is supported. " +
                     "Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#unsupported_ge_plugin_3.13"
-            )
+            ) {
+                cause = "plugin 'com.gradle.enterprise'"
+            }
             .expectLegacyDeprecationWarningIf(versionNumber < FIRST_VERSION_CALLING_BUILD_PATH,
                 "The BuildIdentifier.getName() method has been deprecated. " +
                     "This is scheduled to be removed in Gradle 9.0. " +
@@ -306,7 +312,9 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
                 "Gradle Enterprise plugin $pluginVersion has been deprecated. " +
                     "Starting with Gradle 9.0, only Gradle Enterprise plugin 3.13.1 or newer is supported. " +
                     "Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#unsupported_ge_plugin_3.13"
-            )
+            ) {
+                cause = "plugin class 'com.gradle.enterprise.gradleplugin.GradleEnterprisePlugin'"
+            }
             .expectLegacyDeprecationWarningIf(versionNumber < FIRST_VERSION_CALLING_BUILD_PATH,
                 "The BuildIdentifier.getName() method has been deprecated. " +
                     "This is scheduled to be removed in Gradle 9.0. " +

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GrettySmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GrettySmokeTest.groovy
@@ -90,7 +90,7 @@ class GrettySmokeTest extends AbstractPluginValidatingSmokeTest {
     @Override
     Map<String, Versions> getPluginsToValidate() {
         [
-            'org.gretty': Versions.of(grettyConfigForCurrentJavaVersion().collect { it.version } as String[])
+            'org.gretty': Versions.ofAll(grettyConfigForCurrentJavaVersion().collect { it.version } as List<String>)
         ]
     }
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GrettySmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GrettySmokeTest.groovy
@@ -64,13 +64,20 @@ class GrettySmokeTest extends AbstractPluginValidatingSmokeTest {
         def result = runner('checkContainerUp')
             .expectDeprecationWarning(
                 "The org.gradle.api.plugins.WarPluginConvention type has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#war_convention_deprecation",
-                "https://github.com/gretty-gradle-plugin/gretty/issues/266")
+                "https://github.com/gretty-gradle-plugin/gretty/issues/266"
+            ) {
+                causes = [null, "plugin 'org.gretty'"]
+            }
             .expectDeprecationWarningIf(
                 grettyVersion < VersionNumber.parse("4.1.0"),
                 "The org.gradle.util.VersionNumber type has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#org_gradle_util_reports_deprecations",
                 "https://github.com/gretty-gradle-plugin/gretty/issues/297"
-            )
-            .expectLegacyDeprecationWarning(BaseDeprecations.CONVENTION_TYPE_DEPRECATION)
+            ) {
+                causes = [null, "plugin 'org.gretty'"]
+            }
+            .expectLegacyDeprecationWarning(BaseDeprecations.CONVENTION_TYPE_DEPRECATION) {
+                causes = [null, "plugin 'org.gretty'"]
+            }
             .build()
 
         then:

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinAndroidDeprecations.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinAndroidDeprecations.groovy
@@ -44,14 +44,15 @@ class KotlinAndroidDeprecations extends BaseDeprecations implements WithKotlinDe
         runner.expectLegacyDeprecationWarningIf(androidPluginUsesOldWorkerApi(androidPluginVersionNumber.toString()) || (parallelTasksInProject.isPropertyPresent() && kotlinPluginUsesOldWorkerApi(kotlinPluginVersionNumber)), WORKER_SUBMIT_DEPRECATION)
     }
 
-    void expectBasePluginExtensionArchivesBaseNameDeprecation(VersionNumber kotlinVersionNumber, VersionNumber androidVersionNumber) {
-        expectKotlinBasePluginExtensionArchivesBaseNameDeprecation(kotlinVersionNumber)
+    void expectBasePluginExtensionArchivesBaseNameDeprecation(VersionNumber kotlinVersionNumber, VersionNumber androidVersionNumber, @DelegatesTo(SmokeTestGradleRunner.DeprecationOptions) Closure<?> action = null) {
+        expectKotlinBasePluginExtensionArchivesBaseNameDeprecation(kotlinVersionNumber, action)
         runner.expectLegacyDeprecationWarningIf(
             kotlinVersionNumber >= VersionNumber.parse('1.7.0') && androidVersionNumber < VersionNumber.parse('7.4.0'),
             "The BasePluginExtension.archivesBaseName property has been deprecated. " +
                 "This is scheduled to be removed in Gradle 9.0. " +
                 "Please use the archivesName property instead. " +
-                "For more information, please refer to https://docs.gradle.org/${GradleVersion.current().version}/dsl/org.gradle.api.plugins.BasePluginExtension.html#org.gradle.api.plugins.BasePluginExtension:archivesName in the Gradle documentation."
+                "For more information, please refer to https://docs.gradle.org/${GradleVersion.current().version}/dsl/org.gradle.api.plugins.BasePluginExtension.html#org.gradle.api.plugins.BasePluginExtension:archivesName in the Gradle documentation.",
+            action
         )
     }
 }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinMultiplatformPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinMultiplatformPluginSmokeTest.groovy
@@ -133,15 +133,45 @@ class KotlinMultiplatformPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
         // This project is a Kotlin JVM project that consumes a Kotlin Multiplatform JVM project, so can't just use default KMP deprecations
         testRunner.deprecations(KotlinDeprecations) {
             expectAbstractCompileDestinationDirDeprecation(kotlinVersionNumber)
-            expectConventionTypeDeprecation(kotlinVersionNumber)
-            2.times { expectProjectConventionDeprecation(kotlinVersionNumber) }
-            expectOrgGradleUtilWrapUtilDeprecation(kotlinVersionNumber)
+            expectProjectConventionDeprecation(kotlinVersionNumber)  {
+                causes = [
+                    null,
+                    null,
+                    "plugin 'org.jetbrains.kotlin.jvm'",
+                    "plugin class 'org.jetbrains.kotlin.gradle.scripting.internal.ScriptingGradleSubplugin'"
+                ]
+            }
+            expectOrgGradleUtilWrapUtilDeprecation(kotlinVersionNumber) {
+                causes = [
+                    null,
+                    "plugin 'org.jetbrains.kotlin.jvm'",
+                    "plugin 'org.jetbrains.kotlin.multiplatform'"
+                ]
+            }
             expectConfigureUtilDeprecation(kotlinVersionNumber)
-            expectConventionTypeDeprecation(kotlinVersionNumber)
-            2.times { expectJavaPluginConventionDeprecation(kotlinVersionNumber) }
-            expectBuildIdentifierNameDeprecation(kotlinVersionNumber)
+            expectConventionTypeDeprecation(kotlinVersionNumber) {
+                causes = [
+                    null,
+                    null,
+                    "plugin 'org.jetbrains.kotlin.jvm'",
+                    "plugin class 'org.jetbrains.kotlin.gradle.scripting.internal.ScriptingGradleSubplugin'"
+                ]
+            }
+            expectJavaPluginConventionDeprecation(kotlinVersionNumber) {
+                causes = [
+                    null,
+                    null,
+                    "plugin 'org.jetbrains.kotlin.jvm'",
+                    "plugin class 'org.jetbrains.kotlin.gradle.scripting.internal.ScriptingGradleSubplugin'"
+                ]
+            }
+            expectBuildIdentifierNameDeprecation(kotlinVersionNumber) {
+                cause = "plugin 'org.jetbrains.kotlin.multiplatform'"
+            }
             if (GradleContextualExecuter.configCache || kotlinVersionNumber == VersionNumber.parse("1.7.22")) {
-                expectForUseAtConfigurationTimeDeprecation(kotlinVersionNumber)
+                expectForUseAtConfigurationTimeDeprecation(kotlinVersionNumber) {
+                    cause = "plugin 'org.jetbrains.kotlin.multiplatform'"
+                }
             }
         }
         testRunner.expectLegacyDeprecationWarningIf(

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
@@ -65,6 +65,8 @@ class KotlinPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
                     ]
                 }
                 if (GradleContextualExecuter.isConfigCache()) {
+                    expectProjectConventionDeprecation(versionNumber)
+                    expectConventionTypeDeprecation(versionNumber)
                     expectBasePluginConventionDeprecation(versionNumber)
                     expectKotlinBasePluginExtensionArchivesBaseNameDeprecation(versionNumber)
                     expectForUseAtConfigurationTimeDeprecation(versionNumber)
@@ -131,30 +133,28 @@ class KotlinPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
                 expectKotlinParallelTasksDeprecation(versionNumber, parallelTasksInProject)
                 expectKotlin2JsPluginDeprecation(versionNumber)
                 expectKotlinCompileDestinationDirPropertyDeprecation(versionNumber)
-                expectKotlinCompileDestinationDirPropertyDeprecation(versionNumber) { // TODO: This one does not occur for 1.6.21
+                maybeExpectKotlinCompileDestinationDirPropertyDeprecation(versionNumber) {
                     cause = "plugin 'kotlin2js'"
                 }
                 expectKotlinArchiveNameDeprecation(versionNumber)
                 expectOrgGradleUtilWrapUtilDeprecation(versionNumber) {
                     cause = "plugin 'kotlin2js'"
                 }
-                expectProjectConventionDeprecation(versionNumber)
                 expectProjectConventionDeprecation(versionNumber) {
-                    cause = "plugin 'kotlin2js'"
+                    causes = [null, "plugin 'kotlin2js'"]
                 }
-                expectConventionTypeDeprecation(versionNumber)
                 expectConventionTypeDeprecation(versionNumber) {
-                    cause = "plugin 'kotlin2js'"
+                    causes = [null, "plugin 'kotlin2js'"]
                 }
-                expectJavaPluginConventionDeprecation(versionNumber)
                 expectJavaPluginConventionDeprecation(versionNumber) {
-                    cause = "plugin 'kotlin2js'"
+                    causes = [null, "plugin 'kotlin2js'"]
                 }
-                expectBasePluginConventionDeprecation(versionNumber)
                 expectBasePluginConventionDeprecation(versionNumber) {
-                    cause = "plugin 'kotlin2js'"
+                    causes = [null, "plugin 'kotlin2js'"]
                 }
-                expectKotlinBasePluginExtensionArchivesBaseNameDeprecation(versionNumber)
+                expectKotlinBasePluginExtensionArchivesBaseNameDeprecation(versionNumber) {
+                    causes = [null, "plugin 'kotlin2js'"]
+                }
                 if (GradleContextualExecuter.isConfigCache()) {
                     expectForUseAtConfigurationTimeDeprecation(versionNumber)
                 }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
@@ -43,10 +43,27 @@ class KotlinPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
                 expectKotlinParallelTasksDeprecation(versionNumber, parallelTasksInProject)
                 expectKotlinArchiveNameDeprecation(versionNumber)
                 expectAbstractCompileDestinationDirDeprecation(versionNumber)
-                expectOrgGradleUtilWrapUtilDeprecation(versionNumber)
-                expectProjectConventionDeprecation(versionNumber)
-                expectConventionTypeDeprecation(versionNumber)
-                expectJavaPluginConventionDeprecation(versionNumber)
+                expectOrgGradleUtilWrapUtilDeprecation(versionNumber) {
+                    cause = "plugin 'kotlin'"
+                }
+                expectProjectConventionDeprecation(versionNumber) {
+                    causes = [
+                        "plugin 'kotlin'",
+                        "plugin class 'org.jetbrains.kotlin.gradle.scripting.internal.ScriptingGradleSubplugin'"
+                    ]
+                }
+                expectConventionTypeDeprecation(versionNumber) {
+                    causes = [
+                        "plugin 'kotlin'",
+                        "plugin class 'org.jetbrains.kotlin.gradle.scripting.internal.ScriptingGradleSubplugin'"
+                    ]
+                }
+                expectJavaPluginConventionDeprecation(versionNumber) {
+                    causes = [
+                        "plugin 'kotlin'",
+                        "plugin class 'org.jetbrains.kotlin.gradle.scripting.internal.ScriptingGradleSubplugin'"
+                    ]
+                }
                 if (GradleContextualExecuter.isConfigCache()) {
                     expectBasePluginConventionDeprecation(versionNumber)
                     expectKotlinBasePluginExtensionArchivesBaseNameDeprecation(versionNumber)
@@ -62,10 +79,27 @@ class KotlinPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
         result = runner(parallelTasksInProject, versionNumber, 'run')
             .deprecations(KotlinDeprecations) {
                 if (GradleContextualExecuter.isNotConfigCache()) {
-                    expectOrgGradleUtilWrapUtilDeprecation(versionNumber)
-                    expectProjectConventionDeprecation(versionNumber)
-                    expectConventionTypeDeprecation(versionNumber)
-                    expectJavaPluginConventionDeprecation(versionNumber)
+                    expectOrgGradleUtilWrapUtilDeprecation(versionNumber) {
+                        cause = "plugin 'kotlin'"
+                    }
+                    expectProjectConventionDeprecation(versionNumber) {
+                        causes = [
+                            "plugin 'kotlin'",
+                            "plugin class 'org.jetbrains.kotlin.gradle.scripting.internal.ScriptingGradleSubplugin'"
+                        ]
+                    }
+                    expectConventionTypeDeprecation(versionNumber) {
+                        causes = [
+                            "plugin 'kotlin'",
+                            "plugin class 'org.jetbrains.kotlin.gradle.scripting.internal.ScriptingGradleSubplugin'"
+                        ]
+                    }
+                    expectJavaPluginConventionDeprecation(versionNumber) {
+                        causes = [
+                            "plugin 'kotlin'",
+                            "plugin class 'org.jetbrains.kotlin.gradle.scripting.internal.ScriptingGradleSubplugin'"
+                        ]
+                    }
                 }
             }.build()
 
@@ -97,12 +131,29 @@ class KotlinPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
                 expectKotlinParallelTasksDeprecation(versionNumber, parallelTasksInProject)
                 expectKotlin2JsPluginDeprecation(versionNumber)
                 expectKotlinCompileDestinationDirPropertyDeprecation(versionNumber)
+                expectKotlinCompileDestinationDirPropertyDeprecation(versionNumber) { // TODO: This one does not occur for 1.6.21
+                    cause = "plugin 'kotlin2js'"
+                }
                 expectKotlinArchiveNameDeprecation(versionNumber)
-                expectOrgGradleUtilWrapUtilDeprecation(versionNumber)
+                expectOrgGradleUtilWrapUtilDeprecation(versionNumber) {
+                    cause = "plugin 'kotlin2js'"
+                }
                 expectProjectConventionDeprecation(versionNumber)
+                expectProjectConventionDeprecation(versionNumber) {
+                    cause = "plugin 'kotlin2js'"
+                }
                 expectConventionTypeDeprecation(versionNumber)
+                expectConventionTypeDeprecation(versionNumber) {
+                    cause = "plugin 'kotlin2js'"
+                }
                 expectJavaPluginConventionDeprecation(versionNumber)
+                expectJavaPluginConventionDeprecation(versionNumber) {
+                    cause = "plugin 'kotlin2js'"
+                }
                 expectBasePluginConventionDeprecation(versionNumber)
+                expectBasePluginConventionDeprecation(versionNumber) {
+                    cause = "plugin 'kotlin2js'"
+                }
                 expectKotlinBasePluginExtensionArchivesBaseNameDeprecation(versionNumber)
                 if (GradleContextualExecuter.isConfigCache()) {
                     expectForUseAtConfigurationTimeDeprecation(versionNumber)
@@ -158,10 +209,27 @@ class KotlinPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
                 expectKotlinParallelTasksDeprecation(versionNumber, parallelTasksInProject)
                 expectKotlinArchiveNameDeprecation(versionNumber)
                 expectAbstractCompileDestinationDirDeprecation(versionNumber)
-                expectOrgGradleUtilWrapUtilDeprecation(versionNumber)
-                expectProjectConventionDeprecation(versionNumber)
-                expectConventionTypeDeprecation(versionNumber)
-                expectJavaPluginConventionDeprecation(versionNumber)
+                expectOrgGradleUtilWrapUtilDeprecation(versionNumber) {
+                    cause = "plugin 'org.jetbrains.kotlin.jvm'"
+                }
+                expectProjectConventionDeprecation(versionNumber) {
+                    causes = [
+                        "plugin 'org.jetbrains.kotlin.jvm'",
+                        "plugin class 'org.jetbrains.kotlin.gradle.scripting.internal.ScriptingGradleSubplugin'"
+                    ]
+                }
+                expectConventionTypeDeprecation(versionNumber) {
+                    causes = [
+                        "plugin 'org.jetbrains.kotlin.jvm'",
+                        "plugin class 'org.jetbrains.kotlin.gradle.scripting.internal.ScriptingGradleSubplugin'"
+                    ]
+                }
+                expectJavaPluginConventionDeprecation(versionNumber) {
+                    causes = [
+                        "plugin 'org.jetbrains.kotlin.jvm'",
+                        "plugin class 'org.jetbrains.kotlin.gradle.scripting.internal.ScriptingGradleSubplugin'"
+                    ]
+                }
                 if (GradleContextualExecuter.isConfigCache()) {
                     expectBasePluginConventionDeprecation(versionNumber)
                     expectKotlinBasePluginExtensionArchivesBaseNameDeprecation(versionNumber)
@@ -209,9 +277,24 @@ class KotlinPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
             .deprecations(KotlinDeprecations) {
                 expectAbstractCompileDestinationDirDeprecation(versionNumber)
                 expectOrgGradleUtilWrapUtilDeprecation(versionNumber)
-                expectProjectConventionDeprecation(versionNumber)
-                expectConventionTypeDeprecation(versionNumber)
-                expectJavaPluginConventionDeprecation(versionNumber)
+                expectProjectConventionDeprecation(versionNumber) {
+                    causes = [
+                        "plugin 'kotlin'",
+                        "plugin class 'org.jetbrains.kotlin.gradle.scripting.internal.ScriptingGradleSubplugin'"
+                    ]
+                }
+                expectConventionTypeDeprecation(versionNumber) {
+                    causes = [
+                        "plugin 'kotlin'",
+                        "plugin class 'org.jetbrains.kotlin.gradle.scripting.internal.ScriptingGradleSubplugin'"
+                    ]
+                }
+                expectJavaPluginConventionDeprecation(versionNumber) {
+                    causes = [
+                        "plugin 'kotlin'",
+                        "plugin class 'org.jetbrains.kotlin.gradle.scripting.internal.ScriptingGradleSubplugin'"
+                    ]
+                }
                 if (GradleContextualExecuter.isConfigCache()) {
                     expectForUseAtConfigurationTimeDeprecation(versionNumber)
                 }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPrecompiledScriptPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPrecompiledScriptPluginsSmokeTest.groovy
@@ -95,7 +95,9 @@ class KotlinPrecompiledScriptPluginsSmokeTest extends AbstractSmokeTest {
                 VersionNumber.parse(pluginPublishGradleVersion) < VersionNumber.parse("6.0"),
                 "Applying a Kotlin DSL precompiled script plugin published with Gradle versions < 6.0. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Use a version of the plugin published with Gradle >= 6.0. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#kotlin_dsl_precompiled_gradle_lt_6",
                 "Remove testing of plugins published with Gradle < 6.0"
-            )
+            ) {
+                cause = "plugin 'com.example.undertest'"
+            }
             .forwardOutput()
             .build()
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinRunnerFactory.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinRunnerFactory.groovy
@@ -28,10 +28,28 @@ trait KotlinRunnerFactory {
     SmokeTestGradleRunner createRunner(ParallelTasksInProject parallelTasksInProject, VersionNumber kotlinVersionNumber, VersionNumber agpVersionNumber, String... tasks) {
         return runnerFor(this, parallelTasksInProject, kotlinVersionNumber, tasks)
                 .deprecations(KotlinPluginSmokeTest.KotlinDeprecations) {
-                    expectOrgGradleUtilWrapUtilDeprecation(kotlinVersionNumber)
-                    expectBasePluginConventionDeprecation(kotlinVersionNumber, agpVersionNumber)
-                    expectProjectConventionDeprecation(kotlinVersionNumber, agpVersionNumber)
-                    expectConventionTypeDeprecation(kotlinVersionNumber, agpVersionNumber)
+                    expectOrgGradleUtilWrapUtilDeprecation(kotlinVersionNumber) {
+                        cause = "plugin 'kotlin-android'"
+                    }
+                    expectAndroidBasePluginConventionDeprecation(kotlinVersionNumber, agpVersionNumber) {
+                        causes = [
+                            null,
+                            "plugin 'com.android.internal.application'"
+                        ]
+                    }
+                    expectAndroidProjectConventionDeprecation(kotlinVersionNumber, agpVersionNumber) {
+                        causes = [
+                            null,
+                            "plugin 'com.android.internal.application'"
+                        ]
+                    }
+                    expectAndroidConventionTypeDeprecation(kotlinVersionNumber, agpVersionNumber) {
+                        causes = [
+                            null,
+                            "plugin 'kotlin-android'",
+                            "plugin 'com.android.internal.application'",
+                        ]
+                    }
                 }
     }
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/PalantirConsistentVersionsPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/PalantirConsistentVersionsPluginSmokeTest.groovy
@@ -51,17 +51,39 @@ class PalantirConsistentVersionsPluginSmokeTest extends AbstractSmokeTest {
 
         when:
         runner('--write-locks', '--stacktrace')
-            .expectDeprecationWarning("The Project.getConvention() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#deprecated_access_to_conventions", issueUrl)
-            .expectDeprecationWarning("The org.gradle.api.plugins.Convention type has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#deprecated_access_to_conventions", issueUrl)
-            .expectDeprecationWarning("The org.gradle.api.plugins.JavaPluginConvention type has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#java_convention_deprecation", issueUrl)
-            .expectDeprecationWarning("The compileClasspathCopy configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 9.0. Please use another configuration instead. For more information, please refer to https://docs.gradle.org/${GradleVersion.current().version}/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.", issueUrl)
-            .expectDeprecationWarning("The runtimeClasspathCopy configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 9.0. Please use another configuration instead. For more information, please refer to https://docs.gradle.org/${GradleVersion.current().version}/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.", issueUrl)
-            .expectDeprecationWarning("The testCompileClasspathCopy configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 9.0. Please use another configuration instead. For more information, please refer to https://docs.gradle.org/${GradleVersion.current().version}/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.", issueUrl)
-            .expectDeprecationWarning("The testRuntimeClasspathCopy configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 9.0. Please use another configuration instead. For more information, please refer to https://docs.gradle.org/${GradleVersion.current().version}/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.", issueUrl)
-            .expectDeprecationWarning("The compileClasspathCopy configuration has been deprecated for consumption. This will fail with an error in Gradle 9.0. For more information, please refer to https://docs.gradle.org/${GradleVersion.current().version}/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.", issueUrl)
-            .expectDeprecationWarning("The runtimeClasspathCopy configuration has been deprecated for consumption. This will fail with an error in Gradle 9.0. For more information, please refer to https://docs.gradle.org/${GradleVersion.current().version}/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.", issueUrl)
-            .expectDeprecationWarning("The testCompileClasspathCopy configuration has been deprecated for consumption. This will fail with an error in Gradle 9.0. For more information, please refer to https://docs.gradle.org/${GradleVersion.current().version}/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.", issueUrl)
-            .expectDeprecationWarning("The testRuntimeClasspathCopy configuration has been deprecated for consumption. This will fail with an error in Gradle 9.0. For more information, please refer to https://docs.gradle.org/${GradleVersion.current().version}/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.", issueUrl)
+            .expectDeprecationWarning("The Project.getConvention() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#deprecated_access_to_conventions", issueUrl) {
+                cause = "plugin class 'com.palantir.gradle.versions.VersionsLockPlugin'"
+            }
+            .expectDeprecationWarning("The org.gradle.api.plugins.Convention type has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#deprecated_access_to_conventions", issueUrl) {
+                cause = "plugin class 'com.palantir.gradle.versions.VersionsLockPlugin'"
+            }
+            .expectDeprecationWarning("The org.gradle.api.plugins.JavaPluginConvention type has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#java_convention_deprecation", issueUrl) {
+                cause = "plugin class 'com.palantir.gradle.versions.VersionsLockPlugin'"
+            }
+            .expectDeprecationWarning("The compileClasspathCopy configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 9.0. Please use another configuration instead. For more information, please refer to https://docs.gradle.org/${GradleVersion.current().version}/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.", issueUrl) {
+                cause = "plugin class 'com.palantir.gradle.versions.VersionsLockPlugin'"
+            }
+            .expectDeprecationWarning("The runtimeClasspathCopy configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 9.0. Please use another configuration instead. For more information, please refer to https://docs.gradle.org/${GradleVersion.current().version}/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.", issueUrl) {
+                cause = "plugin class 'com.palantir.gradle.versions.VersionsLockPlugin'"
+            }
+            .expectDeprecationWarning("The testCompileClasspathCopy configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 9.0. Please use another configuration instead. For more information, please refer to https://docs.gradle.org/${GradleVersion.current().version}/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.", issueUrl) {
+                cause = "plugin class 'com.palantir.gradle.versions.VersionsLockPlugin'"
+            }
+            .expectDeprecationWarning("The testRuntimeClasspathCopy configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 9.0. Please use another configuration instead. For more information, please refer to https://docs.gradle.org/${GradleVersion.current().version}/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.", issueUrl) {
+                cause = "plugin class 'com.palantir.gradle.versions.VersionsLockPlugin'"
+            }
+            .expectDeprecationWarning("The compileClasspathCopy configuration has been deprecated for consumption. This will fail with an error in Gradle 9.0. For more information, please refer to https://docs.gradle.org/${GradleVersion.current().version}/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.", issueUrl) {
+                cause = "plugin class 'com.palantir.gradle.versions.VersionsLockPlugin'"
+            }
+            .expectDeprecationWarning("The runtimeClasspathCopy configuration has been deprecated for consumption. This will fail with an error in Gradle 9.0. For more information, please refer to https://docs.gradle.org/${GradleVersion.current().version}/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.", issueUrl) {
+                cause = "plugin class 'com.palantir.gradle.versions.VersionsLockPlugin'"
+            }
+            .expectDeprecationWarning("The testCompileClasspathCopy configuration has been deprecated for consumption. This will fail with an error in Gradle 9.0. For more information, please refer to https://docs.gradle.org/${GradleVersion.current().version}/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.", issueUrl) {
+                cause = "plugin class 'com.palantir.gradle.versions.VersionsLockPlugin'"
+            }
+            .expectDeprecationWarning("The testRuntimeClasspathCopy configuration has been deprecated for consumption. This will fail with an error in Gradle 9.0. For more information, please refer to https://docs.gradle.org/${GradleVersion.current().version}/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.", issueUrl) {
+                cause = "plugin class 'com.palantir.gradle.versions.VersionsLockPlugin'"
+            }
             .build()
 
         then:
@@ -69,13 +91,27 @@ class PalantirConsistentVersionsPluginSmokeTest extends AbstractSmokeTest {
 
         when:
         def runner = runner("other:dependencies")
-            .expectDeprecationWarning("The Project.getConvention() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#deprecated_access_to_conventions", issueUrl)
-            .expectDeprecationWarning("The org.gradle.api.plugins.Convention type has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#deprecated_access_to_conventions", issueUrl)
-            .expectDeprecationWarning("The org.gradle.api.plugins.JavaPluginConvention type has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#java_convention_deprecation", issueUrl)
-            .expectDeprecationWarning("The compileClasspathCopy configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 9.0. Please use another configuration instead. For more information, please refer to https://docs.gradle.org/${GradleVersion.current().version}/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.", issueUrl)
-            .expectDeprecationWarning("The runtimeClasspathCopy configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 9.0. Please use another configuration instead. For more information, please refer to https://docs.gradle.org/${GradleVersion.current().version}/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.", issueUrl)
-            .expectDeprecationWarning("The testCompileClasspathCopy configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 9.0. Please use another configuration instead. For more information, please refer to https://docs.gradle.org/${GradleVersion.current().version}/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.", issueUrl)
-            .expectDeprecationWarning("The testRuntimeClasspathCopy configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 9.0. Please use another configuration instead. For more information, please refer to https://docs.gradle.org/${GradleVersion.current().version}/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.", issueUrl)
+            .expectDeprecationWarning("The Project.getConvention() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#deprecated_access_to_conventions", issueUrl) {
+                cause = "plugin class 'com.palantir.gradle.versions.VersionsLockPlugin'"
+            }
+            .expectDeprecationWarning("The org.gradle.api.plugins.Convention type has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#deprecated_access_to_conventions", issueUrl) {
+                cause = "plugin class 'com.palantir.gradle.versions.VersionsLockPlugin'"
+            }
+            .expectDeprecationWarning("The org.gradle.api.plugins.JavaPluginConvention type has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#java_convention_deprecation", issueUrl) {
+                cause = "plugin class 'com.palantir.gradle.versions.VersionsLockPlugin'"
+            }
+            .expectDeprecationWarning("The compileClasspathCopy configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 9.0. Please use another configuration instead. For more information, please refer to https://docs.gradle.org/${GradleVersion.current().version}/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.", issueUrl) {
+                cause = "plugin class 'com.palantir.gradle.versions.VersionsLockPlugin'"
+            }
+            .expectDeprecationWarning("The runtimeClasspathCopy configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 9.0. Please use another configuration instead. For more information, please refer to https://docs.gradle.org/${GradleVersion.current().version}/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.", issueUrl) {
+                cause = "plugin class 'com.palantir.gradle.versions.VersionsLockPlugin'"
+            }
+            .expectDeprecationWarning("The testCompileClasspathCopy configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 9.0. Please use another configuration instead. For more information, please refer to https://docs.gradle.org/${GradleVersion.current().version}/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.", issueUrl) {
+                cause = "plugin class 'com.palantir.gradle.versions.VersionsLockPlugin'"
+            }
+            .expectDeprecationWarning("The testRuntimeClasspathCopy configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 9.0. Please use another configuration instead. For more information, please refer to https://docs.gradle.org/${GradleVersion.current().version}/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.", issueUrl) {
+                cause = "plugin class 'com.palantir.gradle.versions.VersionsLockPlugin'"
+            }
 
         def result = runner.build()
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/PlayPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/PlayPluginSmokeTest.groovy
@@ -53,13 +53,49 @@ class PlayPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
 
         when:
         def result = runner('build')
-            .expectLegacyDeprecationWarning(orgGradleUtilTypeDeprecation("VersionNumber", 7))
+            .expectLegacyDeprecationWarning(orgGradleUtilTypeDeprecation("VersionNumber", 7)) {
+                causes = [
+                    null,
+                    "plugin class 'org.gradle.playframework.plugins.PlayApplicationPlugin'",
+                    "plugin class 'org.gradle.playframework.plugins.PlayDistributionPlugin'"
+                ]
+            }
             .expectLegacyDeprecationWarning(orgGradleUtilTypeDeprecation("CollectionUtils", 7))
-            .expectLegacyDeprecationWarning(BaseDeprecations.ABSTRACT_ARCHIVE_TASK_ARCHIVE_PATH_DEPRECATION)
-            .expectLegacyDeprecationWarning(BaseDeprecations.PROJECT_CONVENTION_DEPRECATION)
-            .expectLegacyDeprecationWarning(BaseDeprecations.CONVENTION_TYPE_DEPRECATION)
-            .expectLegacyDeprecationWarning(BaseDeprecations.JAVA_PLUGIN_CONVENTION_DEPRECATION)
-            .expectLegacyDeprecationWarning(orgGradleUtilTypeDeprecation("VersionNumber", 8))
+            .expectLegacyDeprecationWarning(BaseDeprecations.ABSTRACT_ARCHIVE_TASK_ARCHIVE_PATH_DEPRECATION) {
+                cause = "plugin class 'org.gradle.playframework.plugins.PlayDistributionPlugin'"
+            }
+            .expectLegacyDeprecationWarning(BaseDeprecations.PROJECT_CONVENTION_DEPRECATION) {
+                causes = [
+                    "plugin class 'org.gradle.playframework.plugins.PlayTwirlPlugin'",
+                    "plugin class 'org.gradle.playframework.plugins.PlayRoutesPlugin'",
+                    "plugin class 'org.gradle.playframework.plugins.PlayApplicationPlugin'",
+                    "plugin class 'org.gradle.playframework.plugins.PlayJavaScriptPlugin'"
+                ]
+            }
+            .expectLegacyDeprecationWarning(BaseDeprecations.CONVENTION_TYPE_DEPRECATION) {
+                causes = [
+                    "plugin class 'org.gradle.playframework.plugins.PlayTwirlPlugin'",
+                    "plugin class 'org.gradle.playframework.plugins.PlayRoutesPlugin'",
+                    "plugin class 'org.gradle.playframework.plugins.PlayApplicationPlugin'",
+                    "plugin class 'org.gradle.playframework.plugins.PlayJavaScriptPlugin'"
+                ]
+            }
+            .expectLegacyDeprecationWarning(BaseDeprecations.JAVA_PLUGIN_CONVENTION_DEPRECATION) {
+                causes = [
+                    "plugin class 'org.gradle.playframework.plugins.PlayTwirlPlugin'",
+                    "plugin class 'org.gradle.playframework.plugins.PlayRoutesPlugin'",
+                    "plugin class 'org.gradle.playframework.plugins.PlayApplicationPlugin'",
+                    "plugin class 'org.gradle.playframework.plugins.PlayJavaScriptPlugin'"
+                ]
+            }
+            .expectLegacyDeprecationWarning(orgGradleUtilTypeDeprecation("VersionNumber", 8)) {
+                causes = [
+                    "plugin class 'org.gradle.playframework.plugins.PlayTwirlPlugin'",
+                    "plugin class 'org.gradle.playframework.plugins.PlayRoutesPlugin'",
+                    "plugin class 'org.gradle.playframework.plugins.PlayApplicationPlugin'",
+                    "plugin class 'org.gradle.playframework.plugins.PlayJavaScriptPlugin'"
+                ]
+            }
             .build()
 
         then:

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/SmokeTestGradleRunner.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/SmokeTestGradleRunner.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.smoketests
 
+import org.gradle.api.Action
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.InvalidPluginMetadataException
@@ -29,8 +30,8 @@ class SmokeTestGradleRunner extends GradleRunner {
     private static final LOGGER = LoggerFactory.getLogger(SmokeTestGradleRunner)
 
     private final DefaultGradleRunner delegate
-    private final List<String> expectedDeprecationWarnings = []
-    private final List<String> maybeExpectedDeprecationWarnings = []
+    private final List<DeprecationWarningDetails> expectedDeprecationWarnings = []
+    private final List<DeprecationWarningDetails> maybeExpectedDeprecationWarnings = []
     private boolean ignoreDeprecationWarnings
 
     SmokeTestGradleRunner(DefaultGradleRunner delegate) {
@@ -67,11 +68,11 @@ class SmokeTestGradleRunner extends GradleRunner {
      *      is ignored, the parameter is only present to remind us that a followup is necessary, and
      *      to record how it will happen.
      */
-    SmokeTestGradleRunner expectDeprecationWarning(String warning, String followup) {
+    SmokeTestGradleRunner expectDeprecationWarning(String warning, String followup, @DelegatesTo(DeprecationOptions) Closure<?> action = null) {
         if (followup == null || followup.isBlank()) {
             throw new IllegalArgumentException("Follow up is required! Did you mean to expect a legacy deprecation warning instead?")
         }
-        expectedDeprecationWarnings.add(warning)
+        expectLegacyDeprecationWarning(warning, action)
         return this
     }
 
@@ -85,9 +86,9 @@ class SmokeTestGradleRunner extends GradleRunner {
      *      is ignored, the parameter is only present to remind us that a followup is necessary, and
      *      to record how it will happen.
      */
-    SmokeTestGradleRunner expectDeprecationWarningIf(boolean condition, String warning, String followup) {
+    SmokeTestGradleRunner expectDeprecationWarningIf(boolean condition, String warning, String followup, @DelegatesTo(DeprecationOptions) Closure<?> action = null) {
         if (condition) {
-            expectDeprecationWarning(warning, followup)
+            expectDeprecationWarning(warning, followup, action)
         }
         return this
     }
@@ -99,9 +100,29 @@ class SmokeTestGradleRunner extends GradleRunner {
      *
      * @param warning the text of the warning to match.
      */
-    SmokeTestGradleRunner expectLegacyDeprecationWarning(String warning) {
-        expectedDeprecationWarnings.add(warning)
+    SmokeTestGradleRunner expectLegacyDeprecationWarning(String warning, @DelegatesTo(DeprecationOptions) Closure<?> action = null) {
+        if (action != null) {
+            visitDetailsFromDeprecationOptions(warning, action, expectedDeprecationWarnings::add)
+        } else {
+            expectedDeprecationWarnings.add(new DeprecationWarningDetails(warning))
+        }
         return this
+    }
+
+    void visitDetailsFromDeprecationOptions(String warning, @DelegatesTo(DeprecationOptions) Closure<?> action = null, Action<DeprecationWarningDetails> visitor) {
+        def delegate = new DeprecationOptions()
+        action.delegate = delegate
+        action.call(delegate)
+
+        List<String> causes = []
+        if (delegate.cause != null) {
+            causes.add(delegate.cause)
+        }
+        causes.addAll(delegate.causes)
+
+        causes.each {
+            visitor.execute(new DeprecationWarningDetails(warning, it))
+        }
     }
 
     /**
@@ -113,9 +134,9 @@ class SmokeTestGradleRunner extends GradleRunner {
      * @param condition only expect the warning to be produced when this condition is {@code true}.
      * @param warning the text of the warning to match.
      */
-    SmokeTestGradleRunner expectLegacyDeprecationWarningIf(boolean condition, String warning) {
+    SmokeTestGradleRunner expectLegacyDeprecationWarningIf(boolean condition, String warning, @DelegatesTo(DeprecationOptions) Closure<?> action = null) {
         if (condition) {
-            expectLegacyDeprecationWarning(warning)
+            expectLegacyDeprecationWarning(warning, action)
         }
         return this
     }
@@ -132,8 +153,12 @@ class SmokeTestGradleRunner extends GradleRunner {
      *
      * @param warning the text of the warning to match.
      */
-    SmokeTestGradleRunner maybeExpectLegacyDeprecationWarning(String warning) {
-        maybeExpectedDeprecationWarnings.add(warning)
+    SmokeTestGradleRunner maybeExpectLegacyDeprecationWarning(String warning, @DelegatesTo(DeprecationOptions) Closure<?> action = null) {
+        if (action != null) {
+            visitDetailsFromDeprecationOptions(warning, action, maybeExpectedDeprecationWarnings::add)
+        } else {
+            maybeExpectedDeprecationWarnings.add(new DeprecationWarningDetails(warning))
+        }
         return this
     }
 
@@ -151,12 +176,19 @@ class SmokeTestGradleRunner extends GradleRunner {
      * @param condition only expect the warning to be produced when this condition is {@code true}.
      * @param warning the text of the warning to match.
      */
-    SmokeTestGradleRunner maybeExpectLegacyDeprecationWarningIf(boolean condition, String warning) {
+    SmokeTestGradleRunner maybeExpectLegacyDeprecationWarningIf(boolean condition, String warning, @DelegatesTo(DeprecationOptions) Closure<?> action = null) {
         if (condition) {
-            maybeExpectLegacyDeprecationWarning(warning)
+            maybeExpectLegacyDeprecationWarning(warning, action)
         }
         return this
     }
+
+//    SmokeTestGradleRunner ignoreDeprecationWarningsIf(boolean condition, String reason) {
+//        if (condition) {
+//            ignoreDeprecationWarnings(reason)
+//        }
+//        return this
+//    }
 
     SmokeTestGradleRunner ignoreDeprecationWarnings(String reason) {
         LOGGER.warn("Ignoring deprecation warnings because: {}", reason)
@@ -188,18 +220,43 @@ class SmokeTestGradleRunner extends GradleRunner {
         }
         def lines = result.output.readLines()
         def remainingWarnings = new ArrayList<>(expectedDeprecationWarnings + maybeExpectedDeprecationWarnings)
+
         def totalExpectedDeprecations = remainingWarnings.size()
         int foundDeprecations = 0
+        Map<Integer, DeprecationWarningDetails> unmatchedDeprecations = [:]
         lines.eachWithIndex { String line, int lineIndex ->
-            if (remainingWarnings.remove(line)) {
-                foundDeprecations++
-                return
+            // Attributed deprecations are in the form:
+            // <message>
+            //     Caused by <cause>
+
+            String cause = null
+            if (lineIndex + 1 < lines.size() && lines[lineIndex + 1].startsWith("    Caused by ")) {
+                cause = lines[lineIndex + 1].substring("    Caused by ".length())
             }
-            assert !line.contains("has been deprecated"), "Found an unexpected deprecation warning on line ${lineIndex + 1}: $line"
+
+            def foundDeprecation = new DeprecationWarningDetails(line, cause)
+            if (remainingWarnings.remove(foundDeprecation)) {
+                foundDeprecations++
+            } else if (line.contains("has been deprecated")) {
+                unmatchedDeprecations.put(lineIndex + 1, foundDeprecation)
+            }
         }
         remainingWarnings.removeAll(maybeExpectedDeprecationWarnings)
-        assert remainingWarnings.empty, "Expected ${totalExpectedDeprecations} deprecation warnings, found ${foundDeprecations} deprecation warnings. Did not match the following:\n${remainingWarnings.collect { " - $it" }.join("\n")}"
+
+        List<String> errorMessages = []
+        if (!remainingWarnings.isEmpty()) {
+            errorMessages += "Expected ${totalExpectedDeprecations} deprecation warnings, found ${foundDeprecations} deprecation warnings. Did not match the following:\n${remainingWarnings.collect { " - $it" }.join("\n")}"
+        }
+        if (!unmatchedDeprecations.isEmpty()) {
+            errorMessages += "Found unmatched deprecation warnings:\n${unmatchedDeprecations.collect { " - Line ${it.key}: ${it.value}" }.join("\n")}"
+        }
+
+        if (!errorMessages.isEmpty()) {
+            throw new AssertionError((Object) errorMessages.join("\n"))
+        }
+
         expectedDeprecationWarnings.clear()
+        maybeExpectedDeprecationWarnings.clear()
     }
 
     @Override
@@ -324,5 +381,55 @@ class SmokeTestGradleRunner extends GradleRunner {
     SmokeTestGradleRunner withJvmArguments(String... jvmArguments) {
         delegate.withJvmArguments(Arrays.asList(jvmArguments))
         return this
+    }
+
+    class DeprecationOptions {
+        String cause = null
+        List<String> causes = []
+    }
+
+    private class DeprecationWarningDetails {
+        final String message
+        final @Nullable String cause
+
+        DeprecationWarningDetails(String message) {
+            this(message, null)
+        }
+
+        DeprecationWarningDetails(String message, @Nullable String cause) {
+            this.message = message
+            this.cause = cause
+        }
+
+        @Override
+        String toString() {
+            String result = ""
+            if (cause != null) {
+                result = "[$cause] "
+            }
+
+            result + message
+        }
+
+        @Override
+        boolean equals(o) {
+            if (this.is(o)) {
+                return true
+            }
+
+            if (o == null || getClass() != o.class) {
+                return false
+            }
+
+            DeprecationWarningDetails that = (DeprecationWarningDetails) o
+
+            return Objects.equals(message, that.message) &&
+                Objects.equals(cause, that.cause)
+        }
+
+        @Override
+        int hashCode() {
+            return Objects.hash(message, cause)
+        }
     }
 }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithAndroidDeprecations.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithAndroidDeprecations.groovy
@@ -44,28 +44,28 @@ trait WithAndroidDeprecations implements WithReportDeprecations {
         runner.expectLegacyDeprecationWarningIf(androidPluginUsesOldWorkerApi(agpVersion), WORKER_SUBMIT_DEPRECATION)
     }
 
-    void expectProjectConventionDeprecationWarning(String agpVersion) {
-        runner.expectLegacyDeprecationWarningIf(androidPluginUsesConventions(agpVersion), PROJECT_CONVENTION_DEPRECATION)
+    void expectProjectConventionDeprecationWarning(String agpVersion, @DelegatesTo(SmokeTestGradleRunner.DeprecationOptions) Closure<?> action = null) {
+        runner.expectLegacyDeprecationWarningIf(androidPluginUsesConventions(agpVersion), PROJECT_CONVENTION_DEPRECATION, action)
     }
 
-    void maybeExpectProjectConventionDeprecationWarning(String agpVersion) {
-        runner.maybeExpectLegacyDeprecationWarningIf(androidPluginUsesConventions(agpVersion), PROJECT_CONVENTION_DEPRECATION)
+    void maybeExpectProjectConventionDeprecationWarning(String agpVersion, @DelegatesTo(SmokeTestGradleRunner.DeprecationOptions) Closure<?> action = null) {
+        runner.maybeExpectLegacyDeprecationWarningIf(androidPluginUsesConventions(agpVersion), PROJECT_CONVENTION_DEPRECATION, action)
     }
 
-    void expectAndroidConventionTypeDeprecationWarning(String agpVersion) {
-        runner.expectLegacyDeprecationWarningIf(androidPluginUsesConventions(agpVersion), CONVENTION_TYPE_DEPRECATION)
+    void expectAndroidConventionTypeDeprecationWarning(String agpVersion, @DelegatesTo(SmokeTestGradleRunner.DeprecationOptions) Closure<?> action = null) {
+        runner.expectLegacyDeprecationWarningIf(androidPluginUsesConventions(agpVersion), CONVENTION_TYPE_DEPRECATION, action)
     }
 
-    void maybeExpectAndroidConventionTypeDeprecationWarning(String agpVersion) {
-        runner.maybeExpectLegacyDeprecationWarningIf(androidPluginUsesConventions(agpVersion), CONVENTION_TYPE_DEPRECATION)
+    void maybeExpectAndroidConventionTypeDeprecationWarning(String agpVersion, @DelegatesTo(SmokeTestGradleRunner.DeprecationOptions) Closure<?> action = null) {
+        runner.maybeExpectLegacyDeprecationWarningIf(androidPluginUsesConventions(agpVersion), CONVENTION_TYPE_DEPRECATION, action)
     }
 
-    void maybeExpectBasePluginConventionDeprecation(String agpVersion) {
-        runner.maybeExpectLegacyDeprecationWarningIf(androidPluginUsesConventions(agpVersion), BASE_PLUGIN_CONVENTION_DEPRECATION)
+    void maybeExpectBasePluginConventionDeprecation(String agpVersion, @DelegatesTo(SmokeTestGradleRunner.DeprecationOptions) Closure<?> action = null) {
+        runner.maybeExpectLegacyDeprecationWarningIf(androidPluginUsesConventions(agpVersion), BASE_PLUGIN_CONVENTION_DEPRECATION, action)
     }
 
-    void expectBasePluginConventionDeprecation(String agpVersion) {
-        runner.expectLegacyDeprecationWarningIf(androidPluginUsesConventions(agpVersion), BASE_PLUGIN_CONVENTION_DEPRECATION)
+    void expectBasePluginConventionDeprecation(String agpVersion, @DelegatesTo(SmokeTestGradleRunner.DeprecationOptions) Closure<?> action = null) {
+        runner.expectLegacyDeprecationWarningIf(androidPluginUsesConventions(agpVersion), BASE_PLUGIN_CONVENTION_DEPRECATION, action)
     }
 
     void expectConfigUtilDeprecationWarning(String agpVersion) {
@@ -85,19 +85,25 @@ trait WithAndroidDeprecations implements WithReportDeprecations {
             "Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation"
     }
 
-    void maybeExpectBuildIdentifierIsCurrentBuildDeprecation(String agpVersion) {
+    void maybeExpectBuildIdentifierIsCurrentBuildDeprecation(String agpVersion, @DelegatesTo(SmokeTestGradleRunner.DeprecationOptions) Closure<?> action = null) {
         VersionNumber agpVersionNumber = VersionNumber.parse(agpVersion)
         runner.maybeExpectLegacyDeprecationWarningIf(
             agpVersionNumber < VersionNumber.parse("8.0.0-rc01"),
-            getBuildIdentifierIsCurrentBuildDeprecationMessage()
+            getBuildIdentifierIsCurrentBuildDeprecationMessage(),
+            action
         )
     }
 
-    void expectBuildIdentifierIsCurrentBuildDeprecation(String agpVersion, String fixedVersion = '8.0.0') {
+    void expectBuildIdentifierIsCurrentBuildDeprecation(String agpVersion, @DelegatesTo(SmokeTestGradleRunner.DeprecationOptions) Closure<?> action = null) {
+        expectBuildIdentifierIsCurrentBuildDeprecation(agpVersion, "8.0.0", action)
+    }
+
+    void expectBuildIdentifierIsCurrentBuildDeprecation(String agpVersion, String fixedVersion, @DelegatesTo(SmokeTestGradleRunner.DeprecationOptions) Closure<?> action = null) {
         VersionNumber agpVersionNumber = VersionNumber.parse(agpVersion)
         runner.expectLegacyDeprecationWarningIf(
             agpVersionNumber.baseVersion < VersionNumber.parse(fixedVersion),
-            getBuildIdentifierIsCurrentBuildDeprecationMessage()
+            getBuildIdentifierIsCurrentBuildDeprecationMessage(),
+            action
         )
     }
 
@@ -113,10 +119,11 @@ trait WithAndroidDeprecations implements WithReportDeprecations {
         )
     }
 
-    void maybeExpectOrgGradleUtilGUtilDeprecation(String agpVersion) {
+    void maybeExpectOrgGradleUtilGUtilDeprecation(String agpVersion, @DelegatesTo(SmokeTestGradleRunner.DeprecationOptions) Closure<?> action = null) {
         runner.maybeExpectLegacyDeprecationWarningIf(
             VersionNumber.parse(agpVersion) < VersionNumber.parse("7.5"),
-            GUTIL_DEPRECATION
+            GUTIL_DEPRECATION,
+            action
         )
     }
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithKotlinDeprecations.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithKotlinDeprecations.groovy
@@ -50,6 +50,14 @@ trait WithKotlinDeprecations extends WithReportDeprecations {
         )
     }
 
+    void maybeExpectKotlinCompileDestinationDirPropertyDeprecation(VersionNumber versionNumber, @DelegatesTo(SmokeTestGradleRunner.DeprecationOptions) Closure<?> action = null) {
+        runner.maybeExpectLegacyDeprecationWarningIf(
+            versionNumber >= VersionNumber.parse('1.5.20') && versionNumber <= VersionNumber.parse('1.6.21'),
+            ABSTRACT_COMPILE_DESTINATION_DIR_DEPRECATION,
+            action
+        )
+    }
+
     void expectKotlinArchiveNameDeprecation(VersionNumber versionNumber) {
         runner.expectLegacyDeprecationWarningIf(versionNumber.minor == 3, ARCHIVE_NAME_DEPRECATION)
     }
@@ -124,7 +132,7 @@ trait WithKotlinDeprecations extends WithReportDeprecations {
         )
     }
 
-    void expectBasePluginConventionDeprecation(VersionNumber kotlinVersionNumber, VersionNumber agpVersionNumber, @DelegatesTo(SmokeTestGradleRunner.DeprecationOptions) Closure<?> action = null) {
+    void expectAndroidBasePluginConventionDeprecation(VersionNumber kotlinVersionNumber, VersionNumber agpVersionNumber, @DelegatesTo(SmokeTestGradleRunner.DeprecationOptions) Closure<?> action = null) {
         runner.expectLegacyDeprecationWarningIf(
             agpVersionNumber < VersionNumber.parse("7.4.0") || kotlinVersionNumber < VersionNumber.parse("1.7.0"),
             BASE_PLUGIN_CONVENTION_DEPRECATION,
@@ -140,10 +148,11 @@ trait WithKotlinDeprecations extends WithReportDeprecations {
         )
     }
 
-    void expectProjectConventionDeprecation(VersionNumber kotlinVersionNumber, VersionNumber agpVersionNumber) {
+    void expectAndroidProjectConventionDeprecation(VersionNumber kotlinVersionNumber, VersionNumber agpVersionNumber, @DelegatesTo(SmokeTestGradleRunner.DeprecationOptions) Closure<?> action = null) {
         runner.expectLegacyDeprecationWarningIf(
             agpVersionNumber < VersionNumber.parse("7.4.0") || (agpVersionNumber >= VersionNumber.parse("7.4.0") && kotlinVersionNumber < VersionNumber.parse("1.7.0")),
-            PROJECT_CONVENTION_DEPRECATION
+            PROJECT_CONVENTION_DEPRECATION,
+            action
         )
     }
 
@@ -167,10 +176,11 @@ trait WithKotlinDeprecations extends WithReportDeprecations {
         versionNumber < VersionNumber.parse("1.7.22")
     }
 
-    void expectConventionTypeDeprecation(VersionNumber kotlinVersionNumber, VersionNumber agpVersionNumber) {
+    void expectAndroidConventionTypeDeprecation(VersionNumber kotlinVersionNumber, VersionNumber agpVersionNumber, @DelegatesTo(SmokeTestGradleRunner.DeprecationOptions) Closure<?> action = null) {
         runner.expectLegacyDeprecationWarningIf(
             agpVersionNumber < VersionNumber.parse("7.4.0") || (agpVersionNumber >= VersionNumber.parse("7.4.0") && kotlinVersionNumber < VersionNumber.parse("1.7.22")),
-            CONVENTION_TYPE_DEPRECATION
+            CONVENTION_TYPE_DEPRECATION,
+            action
         )
     }
 
@@ -184,19 +194,29 @@ trait WithKotlinDeprecations extends WithReportDeprecations {
         )
     }
 
-    void expectForUseAtConfigurationTimeDeprecation(VersionNumber versionNumber) {
+    void expectForUseAtConfigurationTimeDeprecation(VersionNumber versionNumber, @DelegatesTo(SmokeTestGradleRunner.DeprecationOptions) Closure<?> action = null) {
         runner.expectLegacyDeprecationWarningIf(
             versionNumber < VersionNumber.parse("1.8.0"),
-            FOR_USE_AT_CONFIGURATION_TIME_DEPRECATION
+            FOR_USE_AT_CONFIGURATION_TIME_DEPRECATION,
+            action
         )
     }
 
-    void expectBuildIdentifierNameDeprecation(VersionNumber versionNumber) {
+    void maybeExpectForUseAtConfigurationTimeDeprecation(VersionNumber versionNumber, @DelegatesTo(SmokeTestGradleRunner.DeprecationOptions) Closure<?> action = null) {
+        runner.maybeExpectLegacyDeprecationWarningIf(
+            versionNumber < VersionNumber.parse("1.8.0"),
+            FOR_USE_AT_CONFIGURATION_TIME_DEPRECATION,
+            action
+        )
+    }
+
+    void expectBuildIdentifierNameDeprecation(VersionNumber versionNumber, @DelegatesTo(SmokeTestGradleRunner.DeprecationOptions) Closure<?> action = null) {
         runner.expectLegacyDeprecationWarningIf(versionNumber >= VersionNumber.parse("1.8.20") && versionNumber.baseVersion < VersionNumber.parse('1.9.20'),
             "The BuildIdentifier.getName() method has been deprecated. " +
                 "This is scheduled to be removed in Gradle 9.0. " +
                 "Use getBuildPath() to get a unique identifier for the build. " +
-                "Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation"
+                "Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#build_identifier_name_and_current_deprecation",
+            action
         )
     }
 
@@ -206,7 +226,7 @@ trait WithKotlinDeprecations extends WithReportDeprecations {
             expectAbstractCompileDestinationDirDeprecation(versionNumber)
         }
         expectOrgGradleUtilWrapUtilDeprecation(versionNumber) {
-            cause = "plugin 'org.jetbrains.kotlin.multiplatform'"
+            causes = [null, "plugin 'org.jetbrains.kotlin.multiplatform'"]
         }
         expectConventionTypeDeprecation(versionNumber) {
             cause = "plugin class 'org.jetbrains.kotlin.gradle.scripting.internal.ScriptingGradleSubplugin'"
@@ -219,19 +239,24 @@ trait WithKotlinDeprecations extends WithReportDeprecations {
         }
         expectTestReportReportOnDeprecation(versionNumber)
         expectTestReportDestinationDirOnDeprecation(versionNumber)
-        expectBuildIdentifierNameDeprecation(versionNumber)
+        expectBuildIdentifierNameDeprecation(versionNumber) {
+            cause = "plugin 'org.jetbrains.kotlin.multiplatform'"
+        }
         if (GradleContextualExecuter.configCache || versionNumber == VersionNumber.parse("1.7.22")) {
-            expectForUseAtConfigurationTimeDeprecation(versionNumber)
+            maybeExpectForUseAtConfigurationTimeDeprecation(versionNumber) {
+                causes = [null, "plugin 'org.jetbrains.kotlin.multiplatform'"]
+            }
         }
     }
 
-    void expectKotlinBasePluginExtensionArchivesBaseNameDeprecation(VersionNumber versionNumber) {
+    void expectKotlinBasePluginExtensionArchivesBaseNameDeprecation(VersionNumber versionNumber, @DelegatesTo(SmokeTestGradleRunner.DeprecationOptions) Closure<?> action = null) {
         runner.expectLegacyDeprecationWarningIf(
             versionNumber < VersionNumber.parse('1.7.0'),
             "The BasePluginExtension.archivesBaseName property has been deprecated. " +
                 "This is scheduled to be removed in Gradle 9.0. " +
                 "Please use the archivesName property instead. " +
-                "For more information, please refer to https://docs.gradle.org/${GradleVersion.current().version}/dsl/org.gradle.api.plugins.BasePluginExtension.html#org.gradle.api.plugins.BasePluginExtension:archivesName in the Gradle documentation."
+                "For more information, please refer to https://docs.gradle.org/${GradleVersion.current().version}/dsl/org.gradle.api.plugins.BasePluginExtension.html#org.gradle.api.plugins.BasePluginExtension:archivesName in the Gradle documentation.",
+            action
         )
     }
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithKotlinDeprecations.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithKotlinDeprecations.groovy
@@ -42,10 +42,11 @@ trait WithKotlinDeprecations extends WithReportDeprecations {
         versionNumber >= KOTLIN_VERSION_USING_NEW_WORKERS_API && versionNumber <= KOTLIN_VERSION_WITH_OLD_WORKERS_API_REMOVED
     }
 
-    void expectKotlinCompileDestinationDirPropertyDeprecation(VersionNumber versionNumber) {
+    void expectKotlinCompileDestinationDirPropertyDeprecation(VersionNumber versionNumber, @DelegatesTo(SmokeTestGradleRunner.DeprecationOptions) Closure<?> action = null) {
         runner.expectLegacyDeprecationWarningIf(
             versionNumber >= VersionNumber.parse('1.5.20') && versionNumber <= VersionNumber.parse('1.6.21'),
-            ABSTRACT_COMPILE_DESTINATION_DIR_DEPRECATION
+            ABSTRACT_COMPILE_DESTINATION_DIR_DEPRECATION,
+            action
         )
     }
 
@@ -76,13 +77,14 @@ trait WithKotlinDeprecations extends WithReportDeprecations {
         )
     }
 
-    void expectOrgGradleUtilWrapUtilDeprecation(VersionNumber versionNumber) {
+    void expectOrgGradleUtilWrapUtilDeprecation(VersionNumber versionNumber, @DelegatesTo(SmokeTestGradleRunner.DeprecationOptions) Closure<?> action = null) {
         runner.expectLegacyDeprecationWarningIf(
             versionNumber < VersionNumber.parse("1.7.20"),
             "The org.gradle.util.WrapUtil type has been deprecated. " +
                 "This is scheduled to be removed in Gradle 9.0. " +
                 "Consult the upgrading guide for further information: " +
-                "${DOCUMENTATION_REGISTRY.getDocumentationFor("upgrading_version_7", "org_gradle_util_reports_deprecations")}"
+                "${DOCUMENTATION_REGISTRY.getDocumentationFor("upgrading_version_7", "org_gradle_util_reports_deprecations")}",
+            action
         )
     }
 
@@ -106,31 +108,35 @@ trait WithKotlinDeprecations extends WithReportDeprecations {
         )
     }
 
-    void expectProjectConventionDeprecation(VersionNumber versionNumber) {
+    void expectProjectConventionDeprecation(VersionNumber versionNumber, @DelegatesTo(SmokeTestGradleRunner.DeprecationOptions) Closure<?> action = null) {
         runner.expectLegacyDeprecationWarningIf(
             versionNumber < VersionNumber.parse("1.7.22"),
-            PROJECT_CONVENTION_DEPRECATION
+            PROJECT_CONVENTION_DEPRECATION,
+            action
         )
     }
 
-    void expectBasePluginConventionDeprecation(VersionNumber versionNumber) {
+    void expectBasePluginConventionDeprecation(VersionNumber versionNumber, @DelegatesTo(SmokeTestGradleRunner.DeprecationOptions) Closure<?> action = null) {
         runner.expectLegacyDeprecationWarningIf(
             versionNumber < VersionNumber.parse("1.7.0"),
-            BASE_PLUGIN_CONVENTION_DEPRECATION
+            BASE_PLUGIN_CONVENTION_DEPRECATION,
+            action
         )
     }
 
-    void expectBasePluginConventionDeprecation(VersionNumber kotlinVersionNumber, VersionNumber agpVersionNumber) {
+    void expectBasePluginConventionDeprecation(VersionNumber kotlinVersionNumber, VersionNumber agpVersionNumber, @DelegatesTo(SmokeTestGradleRunner.DeprecationOptions) Closure<?> action = null) {
         runner.expectLegacyDeprecationWarningIf(
             agpVersionNumber < VersionNumber.parse("7.4.0") || kotlinVersionNumber < VersionNumber.parse("1.7.0"),
-            BASE_PLUGIN_CONVENTION_DEPRECATION
+            BASE_PLUGIN_CONVENTION_DEPRECATION,
+            action
         )
     }
 
-    void expectJavaPluginConventionDeprecation(VersionNumber versionNumber) {
+    void expectJavaPluginConventionDeprecation(VersionNumber versionNumber, @DelegatesTo(SmokeTestGradleRunner.DeprecationOptions) Closure<?> action = null) {
         runner.expectLegacyDeprecationWarningIf(
             versionNumber < VersionNumber.parse("1.7.22"),
-            JAVA_PLUGIN_CONVENTION_DEPRECATION
+            JAVA_PLUGIN_CONVENTION_DEPRECATION,
+            action
         )
     }
 
@@ -141,17 +147,19 @@ trait WithKotlinDeprecations extends WithReportDeprecations {
         )
     }
 
-    void expectConventionTypeDeprecation(VersionNumber versionNumber) {
+    void expectConventionTypeDeprecation(VersionNumber versionNumber, @DelegatesTo(SmokeTestGradleRunner.DeprecationOptions) Closure<?> action = null) {
         runner.expectLegacyDeprecationWarningIf(
             shouldExpectConventionTypeDeprecation(versionNumber),
-            CONVENTION_TYPE_DEPRECATION
+            CONVENTION_TYPE_DEPRECATION,
+            action
         )
     }
 
-    void maybeExpectConventionTypeDeprecation(VersionNumber versionNumber) {
+    void maybeExpectConventionTypeDeprecation(VersionNumber versionNumber, @DelegatesTo(SmokeTestGradleRunner.DeprecationOptions) Closure<?> action = null) {
         runner.maybeExpectLegacyDeprecationWarningIf(
             shouldExpectConventionTypeDeprecation(versionNumber),
-            CONVENTION_TYPE_DEPRECATION
+            CONVENTION_TYPE_DEPRECATION,
+            action
         )
     }
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithKotlinDeprecations.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithKotlinDeprecations.groovy
@@ -205,10 +205,18 @@ trait WithKotlinDeprecations extends WithReportDeprecations {
         if (projectTypes.contains(ProjectTypes.JS)) {
             expectAbstractCompileDestinationDirDeprecation(versionNumber)
         }
-        expectOrgGradleUtilWrapUtilDeprecation(versionNumber)
-        expectConventionTypeDeprecation(versionNumber)
-        expectJavaPluginConventionDeprecation(versionNumber)
-        expectProjectConventionDeprecation(versionNumber)
+        expectOrgGradleUtilWrapUtilDeprecation(versionNumber) {
+            cause = "plugin 'org.jetbrains.kotlin.multiplatform'"
+        }
+        expectConventionTypeDeprecation(versionNumber) {
+            cause = "plugin class 'org.jetbrains.kotlin.gradle.scripting.internal.ScriptingGradleSubplugin'"
+        }
+        expectJavaPluginConventionDeprecation(versionNumber) {
+            cause = "plugin class 'org.jetbrains.kotlin.gradle.scripting.internal.ScriptingGradleSubplugin'"
+        }
+        expectProjectConventionDeprecation(versionNumber) {
+            cause = "plugin class 'org.jetbrains.kotlin.gradle.scripting.internal.ScriptingGradleSubplugin'"
+        }
         expectTestReportReportOnDeprecation(versionNumber)
         expectTestReportDestinationDirOnDeprecation(versionNumber)
         expectBuildIdentifierNameDeprecation(versionNumber)

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithReportDeprecations.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithReportDeprecations.groovy
@@ -29,18 +29,20 @@ trait WithReportDeprecations {
         "Please use the outputLocation property instead. " +
         String.format(RECOMMENDATION, "information", new DocumentationRegistry().getDslRefForProperty("org.gradle.api.reporting.Report", "destination"))
 
-    void expectReportDestinationPropertyDeprecation(String agpVersion) {
+    void expectReportDestinationPropertyDeprecation(String agpVersion, @DelegatesTo(SmokeTestGradleRunner.DeprecationOptions) Closure<?> action = null) {
         runner.expectDeprecationWarningIf(
             VersionNumber.parse(agpVersion).baseVersion < VersionNumber.parse("7.4.1"),
             REPORT_DESTINATION_DEPRECATION,
-            "https://github.com/gradle/gradle/issues/21533"
+            "https://github.com/gradle/gradle/issues/21533",
+            action
         )
     }
 
-    void maybeExpectReportDestinationPropertyDeprecation(String agpVersion) {
+    void maybeExpectReportDestinationPropertyDeprecation(String agpVersion, @DelegatesTo(SmokeTestGradleRunner.DeprecationOptions) Closure<?> action = null) {
         runner.maybeExpectLegacyDeprecationWarningIf(
             VersionNumber.parse(agpVersion).baseVersion < VersionNumber.parse("7.4.1"),
-            REPORT_DESTINATION_DEPRECATION
+            REPORT_DESTINATION_DEPRECATION,
+            action
         )
     }
 }


### PR DESCRIPTION
If we know the plugin ID of the at-fault plugin while building a deprecation, include that ID.
