### PR TITLE
De-duplicate results for resolved variant dependencies in resolution …

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolutionResultApiIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolutionResultApiIntegrationTest.groovy
@@ -739,6 +739,63 @@ testRuntimeClasspath
 """
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/26334")
+    def "resolution result does not report duplicate variants for the same module reachable through different paths"() {
+        settingsFile << """
+            include "producer", "transitive"
+        """
+        file("producer/build.gradle") << """
+            configurations {
+                dependencyScope("runtimeOnly")
+                dependencyScope("implementation")
+                consumable("runtimeElements") {
+                    attributes.attribute(Attribute.of("attr1", Named), objects.named(Named,"value"))
+                    extendsFrom(runtimeOnly, implementation)
+                }
+            }
+            dependencies {
+              runtimeOnly(project(":transitive"))
+              implementation(project(":transitive"))
+            }
+        """
+        file("transitive/build.gradle") << """
+            configurations {
+                consumable("runtimeElements") {
+                    attributes.attribute(Attribute.of("attr1", Named), objects.named(Named,"value"))
+                }
+            }
+        """
+        buildFile << """
+            configurations {
+                dependencyScope("implementation")
+                resolvable("runtimeClasspath") {
+                    attributes.attribute(Attribute.of("attr1", Named), objects.named(Named,"value"))
+                    extendsFrom(implementation)
+                }
+            }
+            dependencies {
+                implementation project(':producer')
+            }
+
+            task resolve {
+                def rootComponent = configurations.runtimeClasspath.incoming.resolutionResult.rootComponent
+                doLast {
+                    def root = rootComponent.get()
+                    assert root.dependencies.size() == 1
+                    def producer = root.dependencies[0]
+                    def producerDependencies = producer.selected.dependencies
+                    def producerDependenciesForVariant = producer.selected.getDependenciesForVariant(producer.resolvedVariant)
+                    assert producerDependencies.size() == 1 // producer has only one variant dependency on transitive
+                    assert producerDependencies.size() == producerDependenciesForVariant.size()
+                    assert producerDependencies.containsAll(producerDependenciesForVariant)
+                }
+            }
+        """
+
+        expect:
+        succeeds("resolve")
+
+    }
     def "resolution result does not realize artifact tasks"() {
         settingsFile << "include 'producer'"
         file("producer/build.gradle") << """

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedComponentResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedComponentResult.java
@@ -16,8 +16,8 @@
 
 package org.gradle.api.internal.artifacts.result;
 
-import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
 import org.gradle.api.Action;
 import org.gradle.api.InvalidUserCodeException;
@@ -47,7 +47,7 @@ public class DefaultResolvedComponentResult implements ResolvedComponentResultIn
     private final Map<Long, ResolvedVariantResult> selectedVariantsById;
     private final List<ResolvedVariantResult> allVariants;
     private final String repositoryName;
-    private final Multimap<ResolvedVariantResult, DependencyResult> variantDependencies = ArrayListMultimap.create();
+    private final Multimap<ResolvedVariantResult, DependencyResult> variantDependencies = LinkedHashMultimap.create();
 
     public DefaultResolvedComponentResult(
         ModuleVersionIdentifier moduleVersion, ComponentSelectionReason selectionReason, ComponentIdentifier componentId,

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/result/DefaultResolvedComponentResultTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/result/DefaultResolvedComponentResultTest.groovy
@@ -60,4 +60,20 @@ class DefaultResolvedComponentResultTest extends Specification {
         then:
         module.dependencies == [dependency, unresolved] as Set
     }
+
+    def "associating the same result to a variant multiple times does not cause duplicate results"() {
+        given:
+        def module = newModule()
+        def dependency = newDependency()
+        def variant = module.getVariant(1)
+
+        when:
+        module.addDependency(dependency)
+
+        module.associateDependencyToVariant(dependency, variant)
+        module.associateDependencyToVariant(dependency, variant)
+
+        then:
+        module.getDependenciesForVariant(variant) == [dependency]
+    }
 }

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/result/ResolutionResultDataBuilder.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/result/ResolutionResultDataBuilder.groovy
@@ -45,7 +45,7 @@ class ResolutionResultDataBuilder {
     }
 
     static DefaultResolvedComponentResult newModule(String group='a', String module='a', String version='1', ComponentSelectionReason selectionReason = ComponentSelectionReasons.requested(), ResolvedVariantResult variant = newVariant(), String repoId = null) {
-        new DefaultResolvedComponentResult(newId(group, module, version), selectionReason, new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId(group, module), version), [1: variant], [variant], repoId)
+        new DefaultResolvedComponentResult(newId(group, module, version), selectionReason, new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId(group, module), version), [1L: variant], [variant], repoId)
     }
 
     static DefaultResolvedDependencyResult newDependency(ComponentSelector componentSelector, String group='a', String module='a', String selectedVersion='1') {


### PR DESCRIPTION
…result

At some point, this used a MultiMap with HashSet values. This caused order
of elements out of getDependenciesForVariant to be non-deterministic.

The MultiMap was switched to use ArrayList values. This fixed the inconsistent
ordering problem, but introduced a new problem.

With Set-like values, duplicate dependency results were filtered out.
With List-like values, duplicate dependency results are kept.

This commit changes the MultiMap's values to a LinkedHashSet. This
will have a stable (insertion) ordering and de-duplicate dependency
results.

fixes #26334

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
