### PR TITLE
Do not provide guidance on license of projects using start scripts

### DIFF
--- a/subprojects/docs/src/docs/userguide/jvm/application_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/application_plugin.adoc
@@ -173,9 +173,9 @@ include::sample[dir="snippets/java/application/groovy",files="build.gradle[tags=
 ====
 
 [[sec:application_licensing]]
-== Licensing
+== License of start scripts
 
-The Gradle start scripts that are bundled with your application are licensed under the https://www.apache.org/licenses/LICENSE-2.0[Apache 2.0 Software License]. This does not affect your application, which you can license as you choose.
+The start scripts generated for the application are licensed under the https://www.apache.org/licenses/LICENSE-2.0[Apache 2.0 Software License]. 
 
 [[sec:application_convention_properties]]
 == Convention properties (deprecated)


### PR DESCRIPTION
The start scripts are definitely licensed Apache 2.0

The rules for including the start scripts in any particular project requires a broader analysis.

It may be misleading to say that there is no impact on including Apache 2.0 licensed files in a project.

fixes #16697 

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
