### PR TITLE
Make TestLauncher test debugging compatible with configuration cache

### DIFF
--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationAction.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationAction.java
@@ -100,6 +100,11 @@ class TestExecutionBuildConfigurationAction implements EntryTaskSelector {
                     options.getServer().set(false);
                     options.getSuspend().set(false);
                 });
+            } else {
+                ((Test) test).debugOptions(javaDebugOptions -> {
+                    DefaultJavaDebugOptions options = (DefaultJavaDebugOptions) javaDebugOptions;
+                    options.getEnabled().set(false);
+                });
             }
         }
     }
@@ -109,6 +114,7 @@ class TestExecutionBuildConfigurationAction implements EntryTaskSelector {
         for (final Map.Entry<String, List<InternalJvmTestRequest>> entry : taskAndTests.entrySet()) {
             String testTaskPath = entry.getKey();
             for (AbstractTestTask testTask : queryTestTasks(context, testTaskPath)) {
+                configureTestTask(testTask);
                 for (InternalJvmTestRequest jvmTestRequest : entry.getValue()) {
                     final TestFilter filter = testTask.getFilter();
                     filter.includeTest(jvmTestRequest.getClassName(), jvmTestRequest.getMethodName());
@@ -150,6 +156,7 @@ class TestExecutionBuildConfigurationAction implements EntryTaskSelector {
         forEachTaskIn(plan, task -> {
             if (task instanceof AbstractTestTask) {
                 AbstractTestTask testTask = (AbstractTestTask) task;
+                configureTestTask(testTask);
                 for (InternalJvmTestRequest jvmTestRequest : internalJvmTestRequests) {
                     final TestFilter filter = testTask.getFilter();
                     filter.includeTest(jvmTestRequest.getClassName(), jvmTestRequest.getMethodName());
@@ -163,6 +170,7 @@ class TestExecutionBuildConfigurationAction implements EntryTaskSelector {
         for (final InternalTestDescriptor descriptor : testDescriptors) {
             final String testTaskPath = taskPathOf(descriptor);
             for (AbstractTestTask testTask : queryTestTasks(context, testTaskPath)) {
+                configureTestTask(testTask);
                 for (InternalTestDescriptor testDescriptor : testDescriptors) {
                     if (taskPathOf(testDescriptor).equals(testTaskPath)) {
                         includeTestMatching((InternalJvmTestDescriptor) testDescriptor, testTask);

--- a/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/TestExecutionBuildTaskSchedulerTest.groovy
+++ b/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/TestExecutionBuildTaskSchedulerTest.groovy
@@ -122,8 +122,8 @@ class TestExecutionBuildTaskSchedulerTest extends Specification {
         then:
         1 * testFilter.includeTest(expectedClassFilter, expectedMethodFilter)
 
-        1 * testFilter.setFailOnNoMatchingTests(false)
-        1 * outputsInternal.upToDateWhen(Specs.SATISFIES_NONE)
+        (1..2) * testFilter.setFailOnNoMatchingTests(false)
+        (1..2) * outputsInternal.upToDateWhen(Specs.SATISFIES_NONE)
 
         where:
         requestType        | descriptors        | internalJvmRequests                                 | expectedClassFilter | expectedMethodFilter | tasksAndTests

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r85/TestLauncherDebugCrossVersionTest.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r85/TestLauncherDebugCrossVersionTest.groovy
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r85
+
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.test.fixtures.file.TestFile
+import org.gradle.tooling.GradleConnectionException
+import org.gradle.tooling.ProjectConnection
+import org.gradle.tooling.ResultHandler
+import spock.lang.Issue
+
+@TargetGradleVersion('>=8.5')
+class TestLauncherDebugCrossVersionTest extends ToolingApiSpecification {
+
+    @Issue('https://github.com/gradle/gradle/issues/26366')
+    def "Run test twice (#scenarioName)"() {
+        setup:
+        sampleBuildWithTest()
+
+        when:
+        String output1 = runTaskAndTestClassUsing(firstDebug)
+        String output2 = runTaskAndTestClassUsing(secondDebug)
+
+        then:
+        assertTestDebugMode(output1, firstDebug)
+        assertTestDebugMode(output2, secondDebug)
+
+        where:
+        scenarioName                     | firstDebug | secondDebug
+        "first wo/debug, second w/debug" | false      | true
+        "first w/debug, second wo/debug" | true       | false
+    }
+
+    private def sampleBuildWithTest() {
+        settingsFile << "include('app')"
+        javaBuildWithTests(file('app'))
+    }
+
+    int retryCounter = 0
+
+    private String runTaskAndTestClassUsing(boolean debugMode) {
+        def stdout = new ByteArrayOutputStream()
+        withConnection { ProjectConnection connection ->
+            def testLauncher = connection.newTestLauncher()
+                .withTaskAndTestClasses(':app:test', Arrays.asList('TestClass1'))
+                .setStandardOutput(stdout)
+            if (debugMode) {
+                // JDWPUtil is flaky https://github.com/gradle/gradle/issues/26366
+                testLauncher.debugTestsOn(49052 + (retryCounter++))
+            }
+            testLauncher.run(resultHandlerFor(debugMode))
+        }
+        stdout.toString('utf-8')
+    }
+
+    private resultHandlerFor(final boolean debugMode) {
+        new ResultHandler<Void>() {
+
+            @Override
+            void onComplete(Void result) {
+                if (debugMode) {
+                    throw new Exception("Test task running in non-debug mode should pass")
+                }
+            }
+
+            @Override
+            void onFailure(GradleConnectionException failure) {
+                if (!debugMode) {
+                    throw new Exception("Test running in debug mode should fail if no debugger is present")
+                }
+            }
+        }
+    }
+
+    private void javaBuildWithTests(TestFile projectDir) {
+        propertiesFile << 'org.gradle.configuration-cache=true'
+        projectDir.file('settings.gradle') << ''
+        javaLibraryWithTests(projectDir)
+    }
+
+    private void javaLibraryWithTests(TestFile projectDir) {
+        projectDir.file('build.gradle') << '''
+            plugins {
+                id 'java-library'
+            }
+            repositories {
+                mavenCentral()
+            }
+            testing {
+                suites {
+                    test {
+                        useJUnitJupiter()
+                    }
+                }
+            }
+            tasks.named('test') {
+                testLogging {
+                    showStandardStreams = true
+                }
+                doFirst {
+                    System.out.println("Debug mode enabled: " + debugOptions.enabled.get())
+                }
+            }
+        '''
+        writeTestClass(projectDir, 'TestClass1')
+        writeTestClass(projectDir, 'TestClass2')
+    }
+
+    private TestFile writeTestClass(TestFile projectDir, String testClassName) {
+        projectDir.file("src/test/java/${testClassName}.java") << """
+            public class $testClassName {
+                @org.junit.jupiter.api.Test
+                void testMethod() {
+                    System.out.println("${testClassName}.testMethod");
+                }
+            }
+        """
+    }
+
+    private void assertTestDebugMode(String output, boolean debugMode) {
+        assert output.contains("Debug mode enabled: $debugMode")
+    }
+}


### PR DESCRIPTION
The debug configuration was ignored when the configuration cache entry was reused.

<!--- The issue this PR addresses -->
<!-- Fixes #? -->
Partially fixes https://github.com/gradle/gradle/issues/26366
