### PR TITLE
Attach resolution failures to ResolutionResult

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheUnsupportedTypesIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheUnsupportedTypesIntegrationTest.groovy
@@ -58,7 +58,6 @@ import org.gradle.api.internal.artifacts.DefaultResolvedDependency
 import org.gradle.api.internal.artifacts.PreResolvedResolvableArtifact
 import org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.ConfigurationResolvableDependencies
 import org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.ConfigurationResolvableDependencies.ConfigurationArtifactView
-import org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.ConfigurationResolvableDependencies.LenientResolutionResult
 import org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer
 import org.gradle.api.internal.artifacts.configurations.DefaultResolvableConfiguration
 import org.gradle.api.internal.artifacts.configurations.DefaultUnlockedConfiguration
@@ -75,6 +74,7 @@ import org.gradle.api.internal.artifacts.query.DefaultArtifactResolutionQuery
 import org.gradle.api.internal.artifacts.repositories.DefaultMavenArtifactRepository
 import org.gradle.api.internal.artifacts.result.DefaultArtifactResolutionResult
 import org.gradle.api.internal.artifacts.result.DefaultComponentArtifactsResult
+import org.gradle.api.internal.artifacts.result.DefaultResolutionResult
 import org.gradle.api.internal.artifacts.result.DefaultResolvedArtifactResult
 import org.gradle.api.internal.artifacts.result.DefaultUnresolvedComponentResult
 import org.gradle.api.internal.artifacts.type.DefaultArtifactTypeContainer
@@ -280,7 +280,7 @@ class ConfigurationCacheUnsupportedTypesIntegrationTest extends AbstractConfigur
         ErrorHandlingResolvedConfiguration    | ResolvedConfiguration          | "project.configurations.maybeCreate('some').resolvedConfiguration"
         ErrorHandlingLenientConfiguration     | LenientConfiguration           | "project.configurations.maybeCreate('some').resolvedConfiguration.lenientConfiguration"
         ConfigurationResolvableDependencies   | ResolvableDependencies         | "project.configurations.maybeCreate('some').incoming"
-        LenientResolutionResult               | ResolutionResult               | "project.configurations.maybeCreate('some').incoming.resolutionResult"
+        DefaultResolutionResult               | ResolutionResult               | "project.configurations.maybeCreate('some').incoming.resolutionResult"
         DefaultDependencyConstraintSet        | DependencyConstraintSet        | "project.configurations.maybeCreate('some').dependencyConstraints"
         DefaultRepositoryHandler              | RepositoryHandler              | "project.repositories"
         DefaultMavenArtifactRepository        | ArtifactRepository             | "project.repositories.mavenCentral()"

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultResolverResults.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultResolverResults.java
@@ -16,63 +16,47 @@
 
 package org.gradle.api.internal.artifacts;
 
-import org.gradle.api.artifacts.Dependency;
-import org.gradle.api.artifacts.LenientConfiguration;
 import org.gradle.api.artifacts.ResolveException;
-import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedConfiguration;
-import org.gradle.api.artifacts.ResolvedDependency;
-import org.gradle.api.artifacts.component.ComponentIdentifier;
-import org.gradle.api.artifacts.result.ResolutionResult;
 import org.gradle.api.internal.artifacts.ivyservice.ArtifactResolveState;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.SelectedArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.VisitedArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.projectresult.ResolvedLocalComponentsResult;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.GraphValidationException;
-import org.gradle.api.internal.attributes.AttributeContainerInternal;
-import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
-import org.gradle.api.specs.Spec;
+import org.gradle.api.internal.artifacts.result.MinimalResolutionResult;
 
 import javax.annotation.Nullable;
-import java.io.File;
-import java.util.Set;
-import java.util.function.Function;
 
 /**
- * Default implementation of {@link ResolverResults}.
+ * Default implementation of {@link ResolverResults} containing the results of a complete resolution.
  */
 public class DefaultResolverResults implements ResolverResults {
 
     private final ResolvedLocalComponentsResult resolvedLocalComponentsResult;
-    private final ResolutionResult resolutionResult;
-    private final ResolvedConfiguration resolvedConfiguration;
+    private final MinimalResolutionResult minimalResolutionResult;
     private final VisitedArtifactSet visitedArtifacts;
     private final ArtifactResolveState artifactResolveState;
-    private final ResolveException failure;
+    private final ResolvedConfiguration resolvedConfiguration;
 
     public DefaultResolverResults(
-        @Nullable ResolvedLocalComponentsResult resolvedLocalComponentsResult,
-        @Nullable ResolutionResult resolutionResult,
+        ResolvedLocalComponentsResult resolvedLocalComponentsResult,
+        MinimalResolutionResult minimalResolutionResult,
         VisitedArtifactSet visitedArtifacts,
-        @Nullable ResolvedConfiguration resolvedConfiguration,
         @Nullable ArtifactResolveState artifactResolveState,
-        @Nullable ResolveException failure
+        @Nullable ResolvedConfiguration resolvedConfiguration
     ) {
         this.resolvedLocalComponentsResult = resolvedLocalComponentsResult;
-        this.resolutionResult = resolutionResult;
+        this.minimalResolutionResult = minimalResolutionResult;
         this.visitedArtifacts = visitedArtifacts;
-        this.resolvedConfiguration = resolvedConfiguration;
         this.artifactResolveState = artifactResolveState;
-        this.failure = failure;
+        this.resolvedConfiguration = resolvedConfiguration;
     }
 
     @Override
     public boolean hasError() {
-        if (failure != null) {
+        if (resolvedConfiguration != null && resolvedConfiguration.hasError()) {
             return true;
         }
-        return resolvedConfiguration != null && resolvedConfiguration.hasError();
+
+        return minimalResolutionResult.getExtraFailure() != null;
     }
 
     @Override
@@ -84,85 +68,36 @@ public class DefaultResolverResults implements ResolverResults {
     }
 
     @Override
-    public ResolutionResult getResolutionResult() {
-        maybeRethrowFatalError();
-        return resolutionResult;
+    public MinimalResolutionResult getMinimalResolutionResult() {
+        return minimalResolutionResult;
     }
 
     @Override
     public ResolvedLocalComponentsResult getResolvedLocalComponents() {
-        maybeRethrowFatalError();
         return resolvedLocalComponentsResult;
     }
 
     @Override
     public ArtifactResolveState getArtifactResolveState() {
-        maybeRethrowAnyError();
         return artifactResolveState;
     }
 
     @Override
     public VisitedArtifactSet getVisitedArtifacts() {
-        maybeRethrowFatalError();
         return visitedArtifacts;
     }
 
-    public void maybeRethrowFatalError() {
-        if (failure != null && isFatalError(failure)) {
-            throw failure;
-        }
-    }
-
-    private static boolean isFatalError(ResolveException failure) {
-        boolean isNonFatal = failure.getCause() instanceof GraphValidationException;
-        return !isNonFatal;
-    }
-
-    private void maybeRethrowAnyError() {
-        if (failure != null) {
-            throw failure;
-        }
-    }
-
-    @Override
-    public Throwable getNonFatalFailure() {
-        return failure != null && !isFatalError(failure) ? failure : null;
-    }
-
+    @Nullable
     @Override
     public ResolveException getFailure() {
-        return failure;
-    }
-
-    @Override
-    public ResolverResults withFailure(ResolveException resolveException) {
-        return new DefaultResolverResults(
-            resolvedLocalComponentsResult,
-            resolutionResult,
-            visitedArtifacts,
-            resolvedConfiguration,
-            artifactResolveState,
-            resolveException
-        );
-    }
-
-    @Override
-    public ResolverResults updateResolutionResult(Function<ResolutionResult, ResolutionResult> updater) {
-        return new DefaultResolverResults(
-            resolvedLocalComponentsResult,
-            updater.apply(resolutionResult),
-            visitedArtifacts,
-            resolvedConfiguration,
-            artifactResolveState,
-            failure
-        );
+        return minimalResolutionResult.getExtraFailure();
     }
 
     /**
      * Create a new result representing the result of resolving build dependencies.
      */
     public static ResolverResults buildDependenciesResolved(
-        ResolutionResult resolutionResult,
+        MinimalResolutionResult resolutionResult,
         ResolvedLocalComponentsResult resolvedLocalComponentsResult,
         VisitedArtifactSet visitedArtifacts
     ) {
@@ -170,7 +105,6 @@ public class DefaultResolverResults implements ResolverResults {
             resolvedLocalComponentsResult,
             resolutionResult,
             visitedArtifacts,
-            null,
             null,
             null
         );
@@ -180,7 +114,7 @@ public class DefaultResolverResults implements ResolverResults {
      * Create a new result representing the result of resolving the dependency graph.
      */
     public static ResolverResults graphResolved(
-        ResolutionResult resolutionResult,
+        MinimalResolutionResult resolutionResult,
         ResolvedLocalComponentsResult resolvedLocalComponentsResult,
         VisitedArtifactSet visitedArtifacts,
         @Nullable ArtifactResolveState artifactResolveState
@@ -189,7 +123,6 @@ public class DefaultResolverResults implements ResolverResults {
             resolvedLocalComponentsResult,
             resolutionResult,
             visitedArtifacts,
-            null,
             artifactResolveState,
             null
         );
@@ -198,105 +131,13 @@ public class DefaultResolverResults implements ResolverResults {
     /**
      * Create a new result representing the result of resolving the artifacts.
      */
-    public static ResolverResults artifactsResolved(ResolutionResult resolutionResult, ResolvedLocalComponentsResult localComponentsResult, ResolvedConfiguration resolvedConfiguration, VisitedArtifactSet visitedArtifacts) {
+    public static ResolverResults artifactsResolved(MinimalResolutionResult resolutionResult, ResolvedLocalComponentsResult localComponentsResult, ResolvedConfiguration resolvedConfiguration, VisitedArtifactSet visitedArtifacts) {
         return new DefaultResolverResults(
             localComponentsResult,
             resolutionResult,
             visitedArtifacts,
-            resolvedConfiguration,
             null, // Do not need to keep the artifact resolve state around after artifact resolution
-            null
+            resolvedConfiguration
         );
-    }
-
-    /**
-     * Create a new result representing a failure to resolve the dependency graph.
-     */
-    public static ResolverResults failed(Exception failure, ResolveException contextualizedFailure) {
-        BrokenResolvedConfiguration broken = new BrokenResolvedConfiguration(failure, contextualizedFailure);
-        return new DefaultResolverResults(
-            null,
-            null,
-            broken,
-            broken,
-            null,
-            contextualizedFailure
-        );
-    }
-
-    /**
-     * Create a new result representing a failure to resolve the artifacts of a resolved dependency graph.
-     */
-    public static ResolverResults failed(ResolutionResult resolutionResult, ResolvedLocalComponentsResult localComponentsResult, Exception failure, ResolveException contextualizedFailure) {
-        BrokenResolvedConfiguration broken = new BrokenResolvedConfiguration(failure, contextualizedFailure);
-        return artifactsResolved(resolutionResult, localComponentsResult, broken, broken).withFailure(contextualizedFailure);
-    }
-
-    /**
-     * Allows resolution failures to be visited.
-     */
-    private static class BrokenResolvedConfiguration implements ResolvedConfiguration, VisitedArtifactSet, SelectedArtifactSet {
-        private final Throwable originalException;
-        private final ResolveException contextualizedException;
-
-        public BrokenResolvedConfiguration(Throwable originalException, ResolveException contextualizedException) {
-            this.originalException = originalException;
-            this.contextualizedException = contextualizedException;
-        }
-
-        @Override
-        public boolean hasError() {
-            return true;
-        }
-
-        @Override
-        public LenientConfiguration getLenientConfiguration() {
-            throw contextualizedException;
-        }
-
-        @Override
-        public void rethrowFailure() throws ResolveException {
-            throw contextualizedException;
-        }
-
-        @Override
-        public Set<File> getFiles() throws ResolveException {
-            throw contextualizedException;
-        }
-
-        @Override
-        public Set<File> getFiles(Spec<? super Dependency> dependencySpec) throws ResolveException {
-            throw contextualizedException;
-        }
-
-        @Override
-        public Set<ResolvedDependency> getFirstLevelModuleDependencies() throws ResolveException {
-            throw contextualizedException;
-        }
-
-        @Override
-        public Set<ResolvedDependency> getFirstLevelModuleDependencies(Spec<? super Dependency> dependencySpec) throws ResolveException {
-            throw contextualizedException;
-        }
-
-        @Override
-        public Set<ResolvedArtifact> getResolvedArtifacts() throws ResolveException {
-            throw contextualizedException;
-        }
-
-        @Override
-        public SelectedArtifactSet select(Spec<? super Dependency> dependencySpec, AttributeContainerInternal requestedAttributes, Spec<? super ComponentIdentifier> componentSpec, boolean allowNoMatchingVariant, boolean selectFromAllVariants) {
-            return this;
-        }
-
-        @Override
-        public void visitDependencies(TaskDependencyResolveContext context) {
-            context.visitFailure(originalException);
-        }
-
-        @Override
-        public void visitArtifacts(ArtifactVisitor visitor, boolean continueOnSelectionFailure) {
-            visitor.visitFailure(originalException);
-        }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolverResults.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolverResults.java
@@ -22,9 +22,9 @@ import org.gradle.api.artifacts.result.ResolutionResult;
 import org.gradle.api.internal.artifacts.ivyservice.ArtifactResolveState;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.VisitedArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.projectresult.ResolvedLocalComponentsResult;
+import org.gradle.api.internal.artifacts.result.MinimalResolutionResult;
 
 import javax.annotation.Nullable;
-import java.util.function.Function;
 
 /**
  * Immutable representation of the state of dependency resolution. Can represent intermediate resolution states after
@@ -54,13 +54,11 @@ public interface ResolverResults {
     /**
      * Returns the dependency graph resolve result.
      */
-    @Nullable
-    ResolutionResult getResolutionResult();
+    MinimalResolutionResult getMinimalResolutionResult();
 
     /**
      * Returns details of the local components in the resolved dependency graph.
      */
-    @Nullable
     ResolvedLocalComponentsResult getResolvedLocalComponents();
 
     /**
@@ -70,27 +68,8 @@ public interface ResolverResults {
     ArtifactResolveState getArtifactResolveState();
 
     /**
-     * Returns the non-fatal failure, if present.
-     */
-    @Nullable
-    Throwable getNonFatalFailure();
-
-    /**
-     * Returns the failure, fatal or non-fatal, or null if there's no failure. Used internally to
-     * set the failure on the resolution build operation result.
+     * Returns an attached failure, if any.
      */
     @Nullable
     ResolveException getFailure();
-
-    /**
-     * Return a new result with the provided {@code resolveException} attached.
-     */
-    ResolverResults withFailure(ResolveException failure);
-
-    /**
-     * Returns a new result with a resolution result equal to the value returned by the provided updater.
-     *
-     * @param updater a function that takes the current resolution result and returns a new resolution result
-     */
-    ResolverResults updateResolutionResult(Function<ResolutionResult, ResolutionResult> updater);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -45,12 +45,12 @@ import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.artifacts.PublishArtifactSet;
 import org.gradle.api.artifacts.ResolutionStrategy;
 import org.gradle.api.artifacts.ResolvableDependencies;
+import org.gradle.api.artifacts.ResolveException;
 import org.gradle.api.artifacts.ResolvedConfiguration;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
-import org.gradle.api.artifacts.result.DependencyResult;
 import org.gradle.api.artifacts.result.ResolutionResult;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.attributes.Attribute;
@@ -81,6 +81,8 @@ import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.RootComponen
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.SelectedArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.VisitedArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.projectresult.ResolvedProjectConfiguration;
+import org.gradle.api.internal.artifacts.result.DefaultResolutionResult;
+import org.gradle.api.internal.artifacts.result.MinimalResolutionResult;
 import org.gradle.api.internal.artifacts.result.ResolutionResultInternal;
 import org.gradle.api.internal.artifacts.transform.DefaultTransformUpstreamDependenciesResolverFactory;
 import org.gradle.api.internal.artifacts.transform.TransformUpstreamDependenciesResolverFactory;
@@ -96,10 +98,8 @@ import org.gradle.api.internal.initialization.ResettableConfiguration;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectState;
 import org.gradle.api.internal.project.ProjectStateRegistry;
-import org.gradle.api.internal.provider.DefaultProvider;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
-import org.gradle.api.provider.Provider;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
 import org.gradle.api.tasks.TaskDependency;
@@ -109,7 +109,6 @@ import org.gradle.internal.DisplayName;
 import org.gradle.internal.Factories;
 import org.gradle.internal.Factory;
 import org.gradle.internal.ImmutableActionSet;
-import org.gradle.internal.UncheckedException;
 import org.gradle.internal.code.UserCodeApplicationContext;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
 import org.gradle.internal.component.external.model.ProjectDerivedCapability;
@@ -149,6 +148,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -750,7 +750,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
                 // because:
                 // 1. the `failed` method will have been called with the user facing error
                 // 2. such an error may still lead to a valid dependency graph
-                ResolutionResult resolutionResult = results.getResolutionResult();
+                ResolutionResult resolutionResult = new DefaultResolutionResult(results.getMinimalResolutionResult());
                 context.setResult(ResolveConfigurationResolutionBuildOperationResult.create(resolutionResult, attributesFactory));
             }
 
@@ -1631,12 +1631,12 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
 
         @Override
         public ResolutionResult getTaskDependencyValue() {
-            return getResultsForBuildDependencies().getResolutionResult();
+            return new DefaultResolutionResult(getResultsForBuildDependencies().getMinimalResolutionResult());
         }
 
         @Override
         public ResolutionResult getValue() {
-            return getResultsForArtifacts().getResolutionResult();
+            return new DefaultResolutionResult(getResultsForArtifacts().getMinimalResolutionResult());
         }
     }
 
@@ -2113,7 +2113,7 @@ since users cannot create non-legacy configurations and there is no current publ
         @Override
         public ResolutionResult getResolutionResult() {
             assertIsResolvable();
-            return new LenientResolutionResult(false);
+            return new DefaultResolutionResult(new LazyMinimalResolutionResult(false));
         }
 
         @Override
@@ -2149,8 +2149,8 @@ since users cannot create non-legacy configurations and there is no current publ
         }
 
         @Override
-        public ResolutionResult getLenientResolutionResult() {
-            return new LenientResolutionResult(true);
+        public ResolutionResultInternal getLenientResolutionResult() {
+            return new DefaultResolutionResult(new LazyMinimalResolutionResult(true));
         }
 
         private class ConfigurationArtifactView implements ArtifactView {
@@ -2191,17 +2191,17 @@ since users cannot create non-legacy configurations and there is no current publ
         }
 
         /**
-         * A resolution result that lazily resolves the configuration. The laziness is needed to properly support {@link #getRootComponent}.
+         * A minimal resolution result that lazily resolves the configuration.
          */
-        private class LenientResolutionResult implements ResolutionResultInternal {
+        private class LazyMinimalResolutionResult implements MinimalResolutionResult {
+
             private final boolean lenient;
-            private volatile Throwable nonFatalFailure;
-            private volatile ResolutionResult delegate;
+            private volatile MinimalResolutionResult delegate;
 
             /**
-             * @param lenient If true, non-fatal failures will not be thrown during resolution.
+             * @param lenient If true, extra failures will not be thrown during resolution.
              */
-            private LenientResolutionResult(boolean lenient) {
+            public LazyMinimalResolutionResult(boolean lenient) {
                 this.lenient = lenient;
             }
 
@@ -2210,10 +2210,10 @@ since users cannot create non-legacy configurations and there is no current publ
                     synchronized (this) {
                         if (delegate == null) {
                             ResolveState currentState = resolveToStateOrLater(ARTIFACTS_RESOLVED);
-                            delegate = currentState.getCachedResolverResults().getResolutionResult();
-                            this.nonFatalFailure = currentState.getCachedResolverResults().getNonFatalFailure();
-                            if (nonFatalFailure != null && !lenient) {
-                                throw UncheckedException.throwAsUncheckedException(nonFatalFailure);
+                            delegate = currentState.getCachedResolverResults().getMinimalResolutionResult();
+                            ResolveException extraFailure = delegate.getExtraFailure();
+                            if (extraFailure != null && !lenient) {
+                                throw extraFailure;
                             }
                         }
                     }
@@ -2221,62 +2221,22 @@ since users cannot create non-legacy configurations and there is no current publ
             }
 
             @Override
-            public ResolvedComponentResult getRoot() {
+            public Supplier<ResolvedComponentResult> getRootSource() {
                 resolve();
-                return delegate.getRoot();
-            }
-
-            @Override
-            public Provider<ResolvedComponentResult> getRootComponent() {
-                return new DefaultProvider<>(this::getRoot);
-            }
-
-            public Provider<Throwable> getNonFatalFailure() {
-                return new DefaultProvider<>(() -> {
-                    resolve();
-                    return nonFatalFailure;
-                });
-            }
-
-            @Override
-            public Set<? extends DependencyResult> getAllDependencies() {
-                resolve();
-                return delegate.getAllDependencies();
-            }
-
-            @Override
-            public void allDependencies(Action<? super DependencyResult> action) {
-                resolve();
-                delegate.allDependencies(action);
-            }
-
-            @Override
-            public void allDependencies(Closure closure) {
-                resolve();
-                delegate.allDependencies(closure);
-            }
-
-            @Override
-            public Set<ResolvedComponentResult> getAllComponents() {
-                resolve();
-                return delegate.getAllComponents();
-            }
-
-            @Override
-            public void allComponents(Action<? super ResolvedComponentResult> action) {
-                resolve();
-                delegate.allComponents(action);
-            }
-
-            @Override
-            public void allComponents(Closure closure) {
-                resolve();
-                delegate.allComponents(closure);
+                return delegate.getRootSource();
             }
 
             @Override
             public AttributeContainer getRequestedAttributes() {
+                resolve();
                 return delegate.getRequestedAttributes();
+            }
+
+            @Nullable
+            @Override
+            public ResolveException getExtraFailure() {
+                resolve();
+                return delegate.getExtraFailure();
             }
 
             @Override
@@ -2287,16 +2247,11 @@ since users cannot create non-legacy configurations and there is no current publ
 
             @Override
             public boolean equals(Object obj) {
-                if (obj instanceof LenientResolutionResult) {
+                if (obj instanceof LazyMinimalResolutionResult) {
                     resolve();
-                    return delegate.equals(((LenientResolutionResult) obj).delegate);
+                    return delegate.equals(((LazyMinimalResolutionResult) obj).delegate);
                 }
                 return false;
-            }
-
-            @Override
-            public String toString() {
-                return "lenient resolution result for " + delegate;
             }
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolvableDependenciesInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolvableDependenciesInternal.java
@@ -16,8 +16,8 @@
 package org.gradle.api.internal.artifacts.configurations;
 
 import org.gradle.api.artifacts.ResolvableDependencies;
-import org.gradle.api.artifacts.result.ResolutionResult;
+import org.gradle.api.internal.artifacts.result.ResolutionResultInternal;
 
 public interface ResolvableDependenciesInternal extends ResolvableDependencies  {
-    ResolutionResult getLenientResolutionResult();
+    ResolutionResultInternal getLenientResolutionResult();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
@@ -62,6 +62,7 @@ import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.RunnableBuildOperation;
 import org.gradle.internal.work.WorkerLeaseService;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -79,6 +80,7 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
 
     private final ResolveContext resolveContext;
     private final Set<UnresolvedDependency> unresolvedDependencies;
+    private final ResolveException extraFailure;
     private final VisitedArtifactsResults artifactResults;
     private final VisitedFileDependencyResults fileDependencyResults;
     private final TransientConfigurationResultsLoader transientConfigurationResultsFactory;
@@ -92,10 +94,11 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
     private SelectedArtifactResults artifactsForThisConfiguration;
     private DependencyVerificationException dependencyVerificationException;
 
-    public DefaultLenientConfiguration(ResolveContext resolveContext, Set<UnresolvedDependency> unresolvedDependencies, VisitedArtifactsResults artifactResults, VisitedFileDependencyResults fileDependencyResults, TransientConfigurationResultsLoader transientConfigurationResultsLoader, VariantSelectorFactory variantSelectorFactory, BuildOperationExecutor buildOperationExecutor, DependencyVerificationOverride dependencyVerificationOverride, WorkerLeaseService workerLeaseService) {
+    public DefaultLenientConfiguration(ResolveContext resolveContext, Set<UnresolvedDependency> unresolvedDependencies, @Nullable ResolveException extraFailure, VisitedArtifactsResults artifactResults, VisitedFileDependencyResults fileDependencyResults, TransientConfigurationResultsLoader transientConfigurationResultsLoader, VariantSelectorFactory variantSelectorFactory, BuildOperationExecutor buildOperationExecutor, DependencyVerificationOverride dependencyVerificationOverride, WorkerLeaseService workerLeaseService) {
         this.resolveContext = resolveContext;
         this.implicitAttributes = resolveContext.getAttributes().asImmutable();
         this.unresolvedDependencies = unresolvedDependencies;
+        this.extraFailure = extraFailure;
         this.artifactResults = artifactResults;
         this.fileDependencyResults = fileDependencyResults;
         this.transientConfigurationResultsFactory = transientConfigurationResultsLoader;
@@ -131,6 +134,9 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
                 for (UnresolvedDependency unresolvedDependency : unresolvedDependencies) {
                     context.visitFailure(unresolvedDependency.getProblem());
                 }
+                if (extraFailure != null) {
+                    context.visitFailure(extraFailure);
+                }
                 context.add(artifactResults.getArtifacts());
             }
 
@@ -140,9 +146,12 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
                     for (UnresolvedDependency unresolvedDependency : unresolvedDependencies) {
                         visitor.visitFailure(unresolvedDependency.getProblem());
                     }
-                    if (!continueOnSelectionFailure) {
-                        return;
-                    }
+                }
+                if (extraFailure != null) {
+                    visitor.visitFailure(extraFailure);
+                }
+                if ((!unresolvedDependencies.isEmpty() || extraFailure != null) && !continueOnSelectionFailure) {
+                    return;
                 }
                 // This may be called from an unmanaged thread, so temporarily enlist the current thread as a worker if it is not already so that it can visit the results
                 // It would be better to instead to memoize the results on the first visit so that this is not required

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolver.java
@@ -25,7 +25,6 @@ import org.gradle.api.artifacts.ResolvedDependency;
 import org.gradle.api.artifacts.UnresolvedDependency;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
-import org.gradle.api.artifacts.result.ResolutionResult;
 import org.gradle.api.internal.artifacts.ConfigurationResolver;
 import org.gradle.api.internal.artifacts.DefaultResolverResults;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
@@ -42,6 +41,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.projectresult.
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.projectresult.ResolvedLocalComponentsResultGraphVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.DefaultResolutionResultBuilder;
 import org.gradle.api.internal.artifacts.repositories.ResolutionAwareRepository;
+import org.gradle.api.internal.artifacts.result.MinimalResolutionResult;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.specs.Spec;
@@ -101,7 +101,7 @@ public class ShortCircuitEmptyConfigurationResolver implements ConfigurationReso
         Module module = resolveContext.getModule();
         ModuleVersionIdentifier id = moduleIdentifierFactory.moduleWithVersion(module.getGroup(), module.getName(), module.getVersion());
         ComponentIdentifier componentIdentifier = componentIdentifierFactory.createComponentIdentifier(module);
-        ResolutionResult emptyResult = DefaultResolutionResultBuilder.empty(id, componentIdentifier, resolveContext.getAttributes());
+        MinimalResolutionResult emptyResult = DefaultResolutionResultBuilder.empty(id, componentIdentifier, resolveContext.getAttributes());
         ResolvedLocalComponentsResult emptyProjectResult = new ResolvedLocalComponentsResultGraphVisitor(thisBuild);
         return DefaultResolverResults.graphResolved(emptyResult, emptyProjectResult, EmptyResults.INSTANCE, null);
     }
@@ -109,7 +109,7 @@ public class ShortCircuitEmptyConfigurationResolver implements ConfigurationReso
     @Override
     public ResolverResults resolveArtifacts(ResolveContext resolveContext, ResolverResults graphResults) throws ResolveException {
         if (!resolveContext.hasDependencies() && graphResults.getVisitedArtifacts() == EmptyResults.INSTANCE) {
-            return DefaultResolverResults.artifactsResolved(graphResults.getResolutionResult(), graphResults.getResolvedLocalComponents(), new EmptyResolvedConfiguration(), EmptyResults.INSTANCE);
+            return DefaultResolverResults.artifactsResolved(graphResults.getMinimalResolutionResult(), graphResults.getResolvedLocalComponents(), new EmptyResolvedConfiguration(), EmptyResults.INSTANCE);
         } else {
             assert graphResults.getArtifactResolveState() != null;
             return delegate.resolveArtifacts(resolveContext, graphResults);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DefaultResolutionResultBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DefaultResolutionResultBuilder.java
@@ -28,16 +28,15 @@ import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.artifacts.result.ComponentSelectionCause;
 import org.gradle.api.artifacts.result.ComponentSelectionReason;
 import org.gradle.api.artifacts.result.DependencyResult;
-import org.gradle.api.artifacts.result.ResolutionResult;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.artifacts.result.ResolvedDependencyResult;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedGraphDependency;
-import org.gradle.api.internal.artifacts.result.DefaultResolutionResult;
+import org.gradle.api.internal.artifacts.result.DefaultMinimalResolutionResult;
 import org.gradle.api.internal.artifacts.result.DefaultResolvedComponentResult;
+import org.gradle.api.internal.artifacts.result.MinimalResolutionResult;
 import org.gradle.internal.Describables;
-import org.gradle.internal.Factory;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 
@@ -53,7 +52,6 @@ public class DefaultResolutionResultBuilder implements ResolvedComponentVisitor 
     private static final DefaultComponentSelectionDescriptor DEPENDENCY_LOCKING = new DefaultComponentSelectionDescriptor(ComponentSelectionCause.CONSTRAINT, Describables.of("Dependency locking"));
     private final Long2ObjectMap<DefaultResolvedComponentResult> components = new Long2ObjectOpenHashMap<>();
     private final CachingDependencyResultFactory dependencyResultFactory = new CachingDependencyResultFactory();
-    private AttributeContainer requestedAttributes;
     private long id;
     private ComponentSelectionReason selectionReason;
     private ComponentIdentifier componentId;
@@ -62,22 +60,18 @@ public class DefaultResolutionResultBuilder implements ResolvedComponentVisitor 
     private ImmutableList<ResolvedVariantResult> allVariants;
     private final Map<Long, ResolvedVariantResult> selectedVariants = new LinkedHashMap<>();
 
-    public static ResolutionResult empty(ModuleVersionIdentifier id, ComponentIdentifier componentIdentifier, AttributeContainer attributes) {
+    public static MinimalResolutionResult empty(ModuleVersionIdentifier id, ComponentIdentifier componentIdentifier, AttributeContainer attributes) {
         DefaultResolutionResultBuilder builder = new DefaultResolutionResultBuilder();
-        builder.setRequestedAttributes(attributes);
         builder.startVisitComponent(0L, ComponentSelectionReasons.root(), null);
         builder.visitComponentDetails(componentIdentifier, id);
         builder.visitComponentVariants(Collections.emptyList());
         builder.endVisitComponent();
-        return builder.complete(0L);
+        ResolvedComponentResult root = builder.getRoot(0L);
+        return new DefaultMinimalResolutionResult(() -> root, attributes, null);
     }
 
-    public void setRequestedAttributes(AttributeContainer attributes) {
-        requestedAttributes = attributes;
-    }
-
-    public ResolutionResult complete(long rootId) {
-        return new DefaultResolutionResult(new RootFactory(components.get(rootId)), requestedAttributes);
+    public ResolvedComponentResult getRoot(long rootId) {
+        return components.get(rootId);
     }
 
     @Override
@@ -147,7 +141,10 @@ public class DefaultResolutionResultBuilder implements ResolvedComponentVisitor 
         }
     }
 
-    public void addExtraFailures(long rootId, Set<UnresolvedDependency> extraFailures) {
+    // TODO: Dependency locking failures should be attached to the resolution result just like
+    // dependency verification failures are. Dependency locking failures are not unresolved dependencies
+    // and should not be modeled as one.
+    public void addDependencyLockingFailures(long rootId, Set<UnresolvedDependency> extraFailures) {
         DefaultResolvedComponentResult root = components.get(rootId);
         for (UnresolvedDependency failure : extraFailures) {
             ModuleVersionSelector failureSelector = failure.getSelector();
@@ -155,19 +152,6 @@ public class DefaultResolutionResultBuilder implements ResolvedComponentVisitor 
             root.addDependency(dependencyResultFactory.createUnresolvedDependency(failureComponentSelector, root, true,
                 ComponentSelectionReasons.of(DEPENDENCY_LOCKING),
                 new ModuleVersionResolveException(failureComponentSelector, () -> "Dependency lock state out of date", failure.getProblem())));
-        }
-    }
-
-    private static class RootFactory implements Factory<ResolvedComponentResult> {
-        private final DefaultResolvedComponentResult rootModule;
-
-        public RootFactory(DefaultResolvedComponentResult rootModule) {
-            this.rootModule = rootModule;
-        }
-
-        @Override
-        public ResolvedComponentResult create() {
-            return rootModule;
         }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultMinimalResolutionResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultMinimalResolutionResult.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.result;
+
+import org.gradle.api.artifacts.ResolveException;
+import org.gradle.api.artifacts.result.ResolvedComponentResult;
+import org.gradle.api.attributes.AttributeContainer;
+
+import javax.annotation.Nullable;
+import java.util.function.Supplier;
+
+/**
+ * Default implementation of {@link MinimalResolutionResult}.
+ */
+public class DefaultMinimalResolutionResult implements MinimalResolutionResult {
+
+    private final Supplier<ResolvedComponentResult> rootSource;
+    private final AttributeContainer requestedAttributes;
+    private final ResolveException extraFailure;
+
+    public DefaultMinimalResolutionResult(
+        Supplier<ResolvedComponentResult> rootSource,
+        AttributeContainer requestedAttributes,
+        @Nullable ResolveException extraFailure
+    ) {
+        this.rootSource = rootSource;
+        this.requestedAttributes = requestedAttributes;
+        this.extraFailure = extraFailure;
+    }
+
+    public Supplier<ResolvedComponentResult> getRootSource() {
+        return rootSource;
+    }
+
+    public AttributeContainer getRequestedAttributes() {
+        return requestedAttributes;
+    }
+
+    @Nullable
+    public ResolveException getExtraFailure() {
+        return extraFailure;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolutionResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolutionResult.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.result;
 
 import groovy.lang.Closure;
 import org.gradle.api.Action;
+import org.gradle.api.artifacts.ResolveException;
 import org.gradle.api.artifacts.result.DependencyResult;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.attributes.AttributeContainer;
@@ -25,11 +26,11 @@ import org.gradle.api.internal.provider.DefaultProvider;
 import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.Actions;
-import org.gradle.internal.Factory;
 import org.gradle.util.internal.ConfigureUtil;
 
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.Objects;
 import java.util.Set;
 
 import static org.gradle.api.internal.artifacts.result.DefaultResolvedComponentResult.eachElement;
@@ -37,28 +38,30 @@ import static org.gradle.api.internal.artifacts.result.DefaultResolvedComponentR
 @SuppressWarnings("rawtypes")
 public class DefaultResolutionResult implements ResolutionResultInternal {
 
-    private final Factory<ResolvedComponentResult> rootSource;
-    private final AttributeContainer requestedAttributes;
+    private final MinimalResolutionResult minimal;
 
-    public DefaultResolutionResult(Factory<ResolvedComponentResult> rootSource, AttributeContainer requestedAttributes) {
-        assert rootSource != null;
-        this.rootSource = rootSource;
-        this.requestedAttributes = requestedAttributes;
+    public DefaultResolutionResult(MinimalResolutionResult minimal) {
+        this.minimal = minimal;
     }
 
     @Override
     public ResolvedComponentResult getRoot() {
-        return rootSource.create();
+        return minimal.getRootSource().get();
     }
 
     @Override
     public Provider<ResolvedComponentResult> getRootComponent() {
-        return new DefaultProvider<>(this::getRoot);
+        return new DefaultProvider<>(() -> minimal.getRootSource().get());
     }
 
     @Override
-    public Provider<Throwable> getNonFatalFailure() {
-        return Providers.notDefined();
+    public Provider<ResolveException> getExtraFailure() {
+        return Providers.ofNullable(minimal.getExtraFailure());
+    }
+
+    @Override
+    public AttributeContainer getRequestedAttributes() {
+        return minimal.getRequestedAttributes();
     }
 
     @Override
@@ -96,8 +99,19 @@ public class DefaultResolutionResult implements ResolutionResultInternal {
     }
 
     @Override
-    public AttributeContainer getRequestedAttributes() {
-        return requestedAttributes;
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DefaultResolutionResult that = (DefaultResolutionResult) o;
+        return Objects.equals(minimal, that.minimal);
     }
 
+    @Override
+    public int hashCode() {
+        return Objects.hash(minimal);
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/MinimalResolutionResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/MinimalResolutionResult.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.result;
+
+import org.gradle.api.artifacts.ResolveException;
+import org.gradle.api.artifacts.result.ResolvedComponentResult;
+import org.gradle.api.attributes.AttributeContainer;
+
+import javax.annotation.Nullable;
+import java.util.function.Supplier;
+
+/**
+ * Contains the minimal data required to construct a complete {@link org.gradle.api.artifacts.result.ResolutionResult}.
+ */
+public interface MinimalResolutionResult {
+
+    /**
+     * A function which provides root of the dependency graph.
+     */
+    Supplier<ResolvedComponentResult> getRootSource();
+
+    /**
+     * The request attributes used to initially build the dependency graph.
+     */
+    AttributeContainer getRequestedAttributes();
+
+    /**
+     * An optional non-fatal failure emitted during graph resolution.
+     */
+    @Nullable
+    ResolveException getExtraFailure();
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/ResolutionResultInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/ResolutionResultInternal.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.result;
 
+import org.gradle.api.artifacts.ResolveException;
 import org.gradle.api.artifacts.result.ResolutionResult;
 import org.gradle.api.provider.Provider;
 
@@ -27,5 +28,5 @@ public interface ResolutionResultInternal extends ResolutionResult {
     /**
      * An optional non-fatal failure which may be attached to a resolution result.
      */
-    Provider<Throwable> getNonFatalFailure();
+    Provider<ResolveException> getExtraFailure();
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfigurationTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfigurationTest.groovy
@@ -119,7 +119,7 @@ class DefaultLenientConfigurationTest extends Specification {
     }
 
     private DefaultLenientConfiguration newConfiguration() {
-        new DefaultLenientConfiguration(configuration, null, artifactsResults, fileDependencyResults, resultsLoader, transforms, buildOperationExecutor, dependencyVerificationOverride, new TestWorkerLeaseService())
+        new DefaultLenientConfiguration(configuration, null, null, artifactsResults, fileDependencyResults, resultsLoader, transforms, buildOperationExecutor, dependencyVerificationOverride, new TestWorkerLeaseService())
     }
 
     def generateDependenciesWithChildren(Map treeStructure) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolverSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolverSpec.groovy
@@ -77,9 +77,7 @@ class ShortCircuitEmptyConfigurationResolverSpec extends Specification {
         def results = dependencyResolver.resolveGraph(resolveContext)
 
         then:
-        def result = results.resolutionResult
-        result.allComponents.size() == 1
-        result.allDependencies.empty
+        results.minimalResolutionResult.rootSource.get().dependencies.empty
 
         and:
         def localComponentsResult = results.resolvedLocalComponents

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentResultSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentResultSerializerTest.groovy
@@ -123,7 +123,7 @@ class ComponentResultSerializerTest extends Specification {
     private ResolvedComponentResult deserialize(byte[] serialized) {
         def builder = new DefaultResolutionResultBuilder()
         serializer.readInto(new KryoBackedDecoder(new ByteArrayInputStream(serialized)), builder)
-        return builder.complete(0).root
+        return builder.getRoot(0)
     }
 
     private Capability capability(String name) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DefaultResolutionResultBuilderSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DefaultResolutionResultBuilderSpec.groovy
@@ -60,10 +60,10 @@ class DefaultResolutionResultBuilderSpec extends Specification {
         resolvedConf("leaf4", [])
 
         when:
-        def result = builder.complete(id("root"))
+        def result = builder.getRoot(id("root"))
 
         then:
-        printGraph(result.root) == """x:root:1
+        printGraph(result) == """x:root:1
   x:mid1:1 [root]
     x:leaf1:1 [mid1]
     x:leaf2:1 [mid1]
@@ -87,10 +87,10 @@ class DefaultResolutionResultBuilderSpec extends Specification {
         resolvedConf("b3", [])
 
         when:
-        def result = builder.complete(id("a"))
+        def result = builder.getRoot(id("a"))
 
         then:
-        printGraph(result.root) == """x:a:1
+        printGraph(result) == """x:a:1
   x:b1:1 [a]
     x:b2:1 [a,b1]
       x:b3:1 [a,b1,b2]
@@ -110,10 +110,10 @@ class DefaultResolutionResultBuilderSpec extends Specification {
         resolvedConf("c", [dep("c", "a")])
 
         when:
-        def result = builder.complete(id("a"))
+        def result = builder.getRoot(id("a"))
 
         then:
-        printGraph(result.root) == """x:a:1
+        printGraph(result) == """x:a:1
   x:b:1 [a]
     x:c:1 [b]
       x:a:1 [c]
@@ -132,7 +132,7 @@ class DefaultResolutionResultBuilderSpec extends Specification {
         resolvedConf("d", [])
 
         when:
-        def deps = builder.complete(id("a")).root.dependencies
+        def deps = builder.getRoot(id("a")).dependencies
 
         then:
         def b = deps.find { it.selected.id.module == 'b' }
@@ -152,7 +152,7 @@ class DefaultResolutionResultBuilderSpec extends Specification {
         resolvedConf("c", [dep("c", "a")])
 
         when:
-        def a = builder.complete(id("a")).root
+        def a = builder.getRoot(id("a"))
 
         then:
         def b  = first(a.dependencies).selected
@@ -187,10 +187,10 @@ class DefaultResolutionResultBuilderSpec extends Specification {
         resolvedConf("leaf2", [])
 
         when:
-        def result = builder.complete(id("root"))
+        def result = builder.getRoot(id("root"))
 
         then:
-        printGraph(result.root) == """x:root:1
+        printGraph(result) == """x:root:1
   x:mid1:1 [root]
     x:leaf1:1 [mid1]
     x:leaf2:1 [mid1]
@@ -210,10 +210,10 @@ class DefaultResolutionResultBuilderSpec extends Specification {
         resolvedConf("mid1", [dep("mid1", "leaf2", new RuntimeException("baz!"))])
 
         when:
-        def result = builder.complete(id("root"))
+        def result = builder.getRoot(id("root"))
 
         then:
-        def mid1 = first(result.root.dependencies)
+        def mid1 = first(result.dependencies)
         mid1.selected.dependencies.size() == 2
         mid1.selected.dependencies*.requested.module == ['leaf1', 'leaf2']
     }
@@ -228,10 +228,10 @@ class DefaultResolutionResultBuilderSpec extends Specification {
         resolvedConf("c", [])
 
         when:
-        def result = builder.complete(id("a"))
+        def result = builder.getRoot(id("a"))
 
         then:
-        printGraph(result.root) == """x:a:1
+        printGraph(result) == """x:a:1
   x:b:1 [a]
   x:c:1 [a]
   x:U:1 -> x:U:1 - Could not resolve x:U:1.

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilderTest.groovy
@@ -39,7 +39,6 @@ import org.gradle.util.AttributeTestUtil
 import org.gradle.util.TestUtil
 import spock.lang.Specification
 
-import static java.util.Collections.emptySet
 import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasons.CONFLICT_RESOLUTION
 import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasons.of
 import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasons.requested
@@ -65,14 +64,14 @@ class StreamingResolutionResultBuilderTest extends Specification {
         builder.finish(rootNode)
 
         when:
-        def result = builder.complete(emptySet())
+        def result = builder.complete(null, [] as Set)
 
         then:
-        with(result) {
-            root.id == DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org", "root"), "1.0")
-            root.selectionReason == root()
+        with(result.rootSource.get()) {
+            id == DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org", "root"), "1.0")
+            selectionReason == root()
         }
-        printGraph(result.root) == """org:root:1.0
+        printGraph(result.rootSource.get()) == """org:root:1.0
 """
     }
 
@@ -97,10 +96,10 @@ class StreamingResolutionResultBuilderTest extends Specification {
         builder.finish(root)
 
         when:
-        def result = builder.complete(emptySet())
+        def result = builder.complete(null, [] as Set)
 
         then:
-        printGraph(result.root) == """org:root:1.0
+        printGraph(result.rootSource.get()) == """org:root:1.0
   org:dep1:2.0(C) [root]
   org:dep2:3.0 -> org:dep2:3.0 - Could not resolve org:dep2:3.0.
 """
@@ -126,10 +125,10 @@ class StreamingResolutionResultBuilderTest extends Specification {
         builder.finish(root)
 
         when:
-        def result = builder.complete(emptySet())
+        def result = builder.complete(null, [] as Set)
 
         then:
-        printGraph(result.root) == """org:root:1.0
+        printGraph(result.rootSource.get()) == """org:root:1.0
   org:dep1:2.0(C) [root]
 """
     }
@@ -166,10 +165,10 @@ class StreamingResolutionResultBuilderTest extends Specification {
         builder.finish(root)
 
         when:
-        def result = builder.complete(emptySet())
+        def result = builder.complete(null, [] as Set)
 
         then:
-        printGraph(result.root) == """org:root:1.0
+        printGraph(result.rootSource.get()) == """org:root:1.0
   org:dep1:1.0 [root]
     org:dep2:1.0 [dep1]
     org:dep3:1.0 [dep1]
@@ -205,10 +204,10 @@ class StreamingResolutionResultBuilderTest extends Specification {
         builder.finish(root)
 
         when:
-        def result = builder.complete(emptySet())
+        def result = builder.complete(null, [] as Set)
 
         then:
-        printGraph(result.root) == """org:root:1.0
+        printGraph(result.rootSource.get()) == """org:root:1.0
   org:dep1:1.0 -> org:dep1:1.0 - Could not resolve org:dep1:1.0.
   org:dep2:2.0 [root]
     org:dep1:5.0 -> org:dep1:5.0 - Could not resolve org:dep1:5.0.

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/result/DefaultResolutionResultTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/result/DefaultResolutionResultTest.groovy
@@ -27,7 +27,6 @@ import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.tasks.diagnostics.internal.graph.nodes.UnresolvedDependencyEdge
-import org.gradle.internal.Factory
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
 import org.gradle.internal.resolve.ModuleVersionNotFoundException
 import org.gradle.util.Path
@@ -152,7 +151,7 @@ class DefaultResolutionResultTest extends Specification {
     }
 
     private static ResolutionResult newResolutionResult(root) {
-        new DefaultResolutionResult({ root } as Factory, ImmutableAttributes.EMPTY)
+        new DefaultResolutionResult(new DefaultMinimalResolutionResult(() -> root, ImmutableAttributes.EMPTY, null))
     }
 
 }

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
@@ -159,8 +159,8 @@ public abstract class DependencyInsightReportTask extends DefaultTask {
             zConfigurationAttributes = getProject().provider(configuration::getAttributes);
 
             ResolvableDependenciesInternal incoming = (ResolvableDependenciesInternal) configuration.getIncoming();
-            ResolutionResultInternal result = (ResolutionResultInternal) incoming.getLenientResolutionResult();
-            errorHandler.addErrorProvider(result.getNonFatalFailure());
+            ResolutionResultInternal result = incoming.getLenientResolutionResult();
+            errorHandler.addErrorProvider(result.getExtraFailure());
             rootComponentProperty.set(result.getRootComponent());
         }
         return rootComponentProperty;

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/ResolutionErrorRenderer.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/ResolutionErrorRenderer.java
@@ -42,31 +42,22 @@ import static org.gradle.util.internal.TextUtil.getPluralEnding;
 class ResolutionErrorRenderer {
     private final Spec<DependencyResult> dependencySpec;
     private final List<Action<StyledTextOutput>> errorActions = new ArrayList<>(1);
-    private final List<Provider<Throwable>> errorProviders = new ArrayList<>(1);
+    private final List<Provider<ResolveException>> errorProviders = new ArrayList<>(1);
 
     public ResolutionErrorRenderer(@Nullable Spec<DependencyResult> dependencySpec) {
         this.dependencySpec = dependencySpec;
     }
 
-    public void addErrorProvider(Provider<Throwable> errorProvider) {
+    public void addErrorProvider(Provider<ResolveException> errorProvider) {
         errorProviders.add(errorProvider);
     }
 
     private void resolveErrorProviders() {
-        for (Provider<Throwable> errorProvider : errorProviders) {
-            Throwable error = errorProvider.getOrNull();
+        for (Provider<ResolveException> errorProvider : errorProviders) {
+            ResolveException error = errorProvider.getOrNull();
             if (error != null) {
-                handleError(error);
+                error.getCauses().forEach(this::handleResolutionError);
             }
-        }
-    }
-
-    public void handleError(Throwable throwable) {
-        if (throwable instanceof ResolveException) {
-            Throwable cause = throwable.getCause();
-            handleResolutionError(cause);
-        } else {
-            throw UncheckedException.throwAsUncheckedException(throwable);
         }
     }
 


### PR DESCRIPTION
Allow ResolutionResults to hold extra resolution failures Attach resolution failures previously held by ResolverResults onto ResolutionResult Avoid needing ErrorHandingResolutionResult since errors are better handled in general by ResolutionResults Move handling of fatal resolution exceptions to ErrorHandlingConfigurationResolver Simplify ResolverResults API
Create MinimalResolutionResult to avoid extra unnecessary implementation of ResolutionResult methods
