### PR TITLE
Add build-level retry

### DIFF
--- a/.teamcity/src/main/kotlin/common/extensions.kt
+++ b/.teamcity/src/main/kotlin/common/extensions.kt
@@ -16,6 +16,7 @@
 
 package common
 
+import common.KillProcessMode.KILL_ALL_GRADLE_PROCESSES
 import configurations.CompileAll
 import configurations.branchesFilterExcluding
 import configurations.buildScanCustomValue
@@ -191,6 +192,12 @@ fun BuildSteps.checkCleanM2AndAndroidUserHome(os: Os = Os.LINUX, buildType: Buil
     }
 }
 
+fun BuildStep.onlyRunOnPreTestedCommitBuildBranch() {
+    conditions {
+        contains("teamcity.build.branch", "pre-test/")
+    }
+}
+
 fun BuildStep.skipConditionally(buildType: BuildType? = null) {
     // we need to run CompileALl unconditionally because of artifact dependency
     if (buildType !is CompileAll) {
@@ -263,13 +270,25 @@ fun functionalTestParameters(os: Os): List<String> {
 fun promotionBuildParameters(dependencyBuildId: RelativeId, extraParameters: String, gitUserName: String, gitUserEmail: String) =
     """-PcommitId=%dep.$dependencyBuildId.build.vcs.number% $extraParameters "-PgitUserName=$gitUserName" "-PgitUserEmail=$gitUserEmail" $pluginPortalUrlOverride %additional.gradle.parameters%"""
 
-fun BuildType.killProcessStep(stepName: String, os: Os, arch: Arch = Arch.AMD64) {
+/**
+ * Align with build-logic/cleanup/src/main/java/gradlebuild/cleanup/services/KillLeakingJavaProcesses.java
+ */
+enum class KillProcessMode {
+    KILL_LEAKED_PROCESSES_FROM_PREVIOUS_BUILDS,
+    KILL_PROCESSES_STARTED_BY_GRADLE,
+    KILL_ALL_GRADLE_PROCESSES
+}
+
+fun BuildType.killProcessStep(mode: KillProcessMode, os: Os, arch: Arch = Arch.AMD64, executionMode: BuildStep.ExecutionMode = BuildStep.ExecutionMode.ALWAYS) {
     steps {
         script {
-            name = stepName
-            executionMode = BuildStep.ExecutionMode.ALWAYS
-            scriptContent = "\"${javaHome(BuildToolBuildJvm, os, arch)}/bin/java\" build-logic/cleanup/src/main/java/gradlebuild/cleanup/services/KillLeakingJavaProcesses.java $stepName"
+            name = mode.toString()
+            this.executionMode = executionMode
+            scriptContent = "\"${javaHome(BuildToolBuildJvm, os, arch)}/bin/java\" build-logic/cleanup/src/main/java/gradlebuild/cleanup/services/KillLeakingJavaProcesses.java $mode"
             skipConditionally(this@killProcessStep)
+            if (mode == KILL_ALL_GRADLE_PROCESSES) {
+                onlyRunOnPreTestedCommitBuildBranch()
+            }
         }
     }
 }

--- a/.teamcity/src/main/kotlin/common/performance-test-extensions.kt
+++ b/.teamcity/src/main/kotlin/common/performance-test-extensions.kt
@@ -92,6 +92,18 @@ fun BuildSteps.substDirOnWindows(os: Os) {
     }
 }
 
+fun BuildType.cleanUpGitUntrackedFilesAndDirectories() {
+    steps {
+        script {
+            name = "CLEAN_UP_GIT_UNTRACKED_FILES_AND_DIRECTORIES"
+            executionMode = BuildStep.ExecutionMode.RUN_ONLY_ON_FAILURE
+            scriptContent = "git clean -fdx -e \"test-splits/\""
+            skipConditionally()
+            onlyRunOnPreTestedCommitBuildBranch()
+        }
+    }
+}
+
 fun BuildType.cleanUpPerformanceBuildDir(os: Os) {
     if (os == Os.WINDOWS) {
         steps {

--- a/.teamcity/src/main/kotlin/configurations/FlakyTestQuarantine.kt
+++ b/.teamcity/src/main/kotlin/configurations/FlakyTestQuarantine.kt
@@ -2,6 +2,7 @@ package configurations
 
 import common.Arch
 import common.BuildToolBuildJvm
+import common.KillProcessMode.KILL_PROCESSES_STARTED_BY_GRADLE
 import common.Os
 import common.applyDefaultSettings
 import common.buildToolGradleParameters
@@ -68,7 +69,7 @@ class FlakyTestQuarantine(model: CIBuildModel, stage: Stage, os: Os, arch: Arch 
                 executionMode = BuildStep.ExecutionMode.ALWAYS
             }
         }
-        killProcessStep("KILL_PROCESSES_STARTED_BY_GRADLE", os, arch)
+        killProcessStep(KILL_PROCESSES_STARTED_BY_GRADLE, os, arch)
     }
 
     steps {

--- a/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
+++ b/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
@@ -3,18 +3,24 @@ package configurations
 import common.Arch
 import common.BuildToolBuildJvm
 import common.Jvm
+import common.KillProcessMode.KILL_ALL_GRADLE_PROCESSES
+import common.KillProcessMode.KILL_LEAKED_PROCESSES_FROM_PREVIOUS_BUILDS
+import common.KillProcessMode.KILL_PROCESSES_STARTED_BY_GRADLE
 import common.Os
 import common.VersionedSettingsBranch
 import common.applyDefaultSettings
 import common.buildToolGradleParameters
 import common.checkCleanM2AndAndroidUserHome
+import common.cleanUpGitUntrackedFilesAndDirectories
 import common.cleanUpPerformanceBuildDir
 import common.compileAllDependency
 import common.dependsOn
 import common.functionalTestParameters
 import common.gradleWrapper
 import common.killProcessStep
+import common.onlyRunOnPreTestedCommitBuildBranch
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildFeatures
+import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep.ExecutionMode
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 import jetbrains.buildServer.configs.kotlin.v2019_2.ProjectFeatures
@@ -93,9 +99,14 @@ fun BaseGradleBuildType.gradleRunnerStep(
     os: Os = Os.LINUX,
     extraParameters: String = "",
     daemon: Boolean = true,
-    maxParallelForks: String = "%maxParallelForks%"
+    maxParallelForks: String = "%maxParallelForks%",
+    isRetry: Boolean = false,
 ) {
-    val buildScanTags = model.buildScanTags + listOfNotNull(stage?.id)
+    val stepName: String = if (isRetry) "GRADLE_RETRY_RUNNER" else "GRADLE_RUNNER"
+    val stepExecutionMode: ExecutionMode = if (isRetry) ExecutionMode.RUN_ONLY_ON_FAILURE else ExecutionMode.DEFAULT
+    val extraBuildScanTags: List<String> = if (isRetry) listOf("RetriedBuild") else emptyList()
+
+    val buildScanTags = model.buildScanTags + listOfNotNull(stage?.id) + extraBuildScanTags
     val parameters = (
         buildToolGradleParameters(daemon, maxParallelForks = maxParallelForks) +
             listOf(extraParameters) +
@@ -105,9 +116,13 @@ fun BaseGradleBuildType.gradleRunnerStep(
 
     steps {
         gradleWrapper(this@gradleRunnerStep) {
-            name = "GRADLE_RUNNER"
+            name = stepName
             tasks = "clean $gradleTasks"
             gradleParams = parameters
+            executionMode = stepExecutionMode
+            if (isRetry) {
+                onlyRunOnPreTestedCommitBuildBranch()
+            }
         }
     }
 }
@@ -125,7 +140,7 @@ fun applyDefaults(
 ) {
     buildType.applyDefaultSettings(os, timeout = timeout)
 
-    buildType.killProcessStep("KILL_LEAKED_PROCESSES_FROM_PREVIOUS_BUILDS", os)
+    buildType.killProcessStep(KILL_LEAKED_PROCESSES_FROM_PREVIOUS_BUILDS, os)
     buildType.cleanUpPerformanceBuildDir(os)
     buildType.gradleRunnerStep(model, gradleTasks, os, extraParameters, daemon)
 
@@ -135,6 +150,20 @@ fun applyDefaults(
     }
 
     applyDefaultDependencies(model, buildType, dependsOnQuickFeedbackLinux)
+}
+
+private fun BaseGradleBuildType.addRetrySteps(
+    model: CIBuildModel,
+    gradleTasks: String,
+    os: Os = Os.LINUX,
+    arch: Arch = Arch.AMD64,
+    extraParameters: String = "",
+    maxParallelForks: String = "%maxParallelForks%",
+    daemon: Boolean = true,
+) {
+    killProcessStep(KILL_ALL_GRADLE_PROCESSES, os, arch, executionMode = ExecutionMode.RUN_ONLY_ON_FAILURE)
+    cleanUpGitUntrackedFilesAndDirectories()
+    gradleRunnerStep(model, gradleTasks, os, extraParameters, daemon, maxParallelForks = maxParallelForks, isRetry = true)
 }
 
 fun applyTestDefaults(
@@ -158,10 +187,11 @@ fun applyTestDefaults(
         preSteps()
     }
 
-    buildType.killProcessStep("KILL_LEAKED_PROCESSES_FROM_PREVIOUS_BUILDS", os, arch)
+    buildType.killProcessStep(KILL_LEAKED_PROCESSES_FROM_PREVIOUS_BUILDS, os, arch)
     buildType.cleanUpPerformanceBuildDir(os)
     buildType.gradleRunnerStep(model, gradleTasks, os, extraParameters, daemon, maxParallelForks = maxParallelForks)
-    buildType.killProcessStep("KILL_PROCESSES_STARTED_BY_GRADLE", os, arch)
+    buildType.addRetrySteps(model, gradleTasks, os, arch, extraParameters)
+    buildType.killProcessStep(KILL_PROCESSES_STARTED_BY_GRADLE, os, arch)
 
     buildType.steps {
         extraSteps()

--- a/.teamcity/src/main/kotlin/util/RerunFlakyTest.kt
+++ b/.teamcity/src/main/kotlin/util/RerunFlakyTest.kt
@@ -20,6 +20,8 @@ import common.Arch
 import common.BuildToolBuildJvm
 import common.JvmVendor
 import common.JvmVersion
+import common.KillProcessMode.KILL_LEAKED_PROCESSES_FROM_PREVIOUS_BUILDS
+import common.KillProcessMode.KILL_PROCESSES_STARTED_BY_GRADLE
 import common.Os
 import common.applyDefaultSettings
 import common.buildToolGradleParameters
@@ -58,7 +60,7 @@ class RerunFlakyTest(os: Os, arch: Arch = Arch.AMD64) : BuildType({
             functionalTestParameters(os)
         ).joinToString(separator = " ")
 
-    killProcessStep("KILL_LEAKED_PROCESSES_FROM_PREVIOUS_BUILDS", os, arch)
+    killProcessStep(KILL_LEAKED_PROCESSES_FROM_PREVIOUS_BUILDS, os, arch)
     cleanUpPerformanceBuildDir(os)
 
     (1..10).forEach { idx ->
@@ -70,7 +72,7 @@ class RerunFlakyTest(os: Os, arch: Arch = Arch.AMD64) : BuildType({
                 executionMode = BuildStep.ExecutionMode.ALWAYS
             }
         }
-        killProcessStep("KILL_PROCESSES_STARTED_BY_GRADLE", os, arch)
+        killProcessStep(KILL_PROCESSES_STARTED_BY_GRADLE, os, arch)
     }
 
     steps {

--- a/.teamcity/src/test/kotlin/ApplyDefaultConfigurationTest.kt
+++ b/.teamcity/src/test/kotlin/ApplyDefaultConfigurationTest.kt
@@ -96,6 +96,9 @@ class ApplyDefaultConfigurationTest {
             listOf(
                 "KILL_LEAKED_PROCESSES_FROM_PREVIOUS_BUILDS",
                 "GRADLE_RUNNER",
+                "KILL_ALL_GRADLE_PROCESSES",
+                "CLEAN_UP_GIT_UNTRACKED_FILES_AND_DIRECTORIES",
+                "GRADLE_RETRY_RUNNER",
                 "KILL_PROCESSES_STARTED_BY_GRADLE",
                 "CHECK_CLEAN_M2_ANDROID_USER_HOME"
             ),
@@ -121,6 +124,9 @@ class ApplyDefaultConfigurationTest {
                 "KILL_LEAKED_PROCESSES_FROM_PREVIOUS_BUILDS",
                 "CLEAN_UP_PERFORMANCE_BUILD_DIR",
                 "GRADLE_RUNNER",
+                "KILL_ALL_GRADLE_PROCESSES",
+                "CLEAN_UP_GIT_UNTRACKED_FILES_AND_DIRECTORIES",
+                "GRADLE_RETRY_RUNNER",
                 "KILL_PROCESSES_STARTED_BY_GRADLE",
                 "CHECK_CLEAN_M2_ANDROID_USER_HOME"
             ),
@@ -142,8 +148,10 @@ class ApplyDefaultConfigurationTest {
 
     private
     fun expectedRunnerParam(daemon: String = "--daemon", extraParameters: String = "", os: Os = Os.LINUX): String {
-        val linuxPaths = "-Porg.gradle.java.installations.paths=%linux.java8.oracle.64bit%,%linux.java11.openjdk.64bit%,%linux.java17.openjdk.64bit%,%linux.java20.openjdk.64bit%,%linux.java8.openjdk.64bit%"
-        val windowsPaths = "-Porg.gradle.java.installations.paths=%windows.java8.oracle.64bit%,%windows.java11.openjdk.64bit%,%windows.java17.openjdk.64bit%,%windows.java20.openjdk.64bit%,%windows.java8.openjdk.64bit%"
+        val linuxPaths =
+            "-Porg.gradle.java.installations.paths=%linux.java8.oracle.64bit%,%linux.java11.openjdk.64bit%,%linux.java17.openjdk.64bit%,%linux.java20.openjdk.64bit%,%linux.java8.openjdk.64bit%"
+        val windowsPaths =
+            "-Porg.gradle.java.installations.paths=%windows.java8.oracle.64bit%,%windows.java11.openjdk.64bit%,%windows.java17.openjdk.64bit%,%windows.java20.openjdk.64bit%,%windows.java8.openjdk.64bit%"
         val expectedInstallationPaths = if (os == Os.WINDOWS) windowsPaths else linuxPaths
         return "-Dorg.gradle.workers.max=%maxParallelForks% -PmaxParallelForks=%maxParallelForks% $pluginPortalUrlOverride -s --no-configuration-cache %additional.gradle.parameters% $daemon --continue $extraParameters \"-Dscan.tag.Check\" \"-Dscan.tag.\" -PteamCityBuildId=%teamcity.build.id% \"$expectedInstallationPaths\" -Porg.gradle.java.installations.auto-download=false"
     }

--- a/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.cache-miss-monitor.gradle.kts
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.cache-miss-monitor.gradle.kts
@@ -18,7 +18,6 @@
 
 import gradlebuild.AbstractBuildScanInfoCollectingService
 import gradlebuild.registerBuildScanInfoCollectingService
-import org.gradle.internal.os.OperatingSystem
 import org.gradle.tooling.events.task.TaskOperationResult
 import org.gradle.tooling.events.task.TaskSuccessResult
 import java.io.Serializable

--- a/build-logic/cleanup/src/main/java/gradlebuild/cleanup/services/KillLeakingJavaProcesses.java
+++ b/build-logic/cleanup/src/main/java/gradlebuild/cleanup/services/KillLeakingJavaProcesses.java
@@ -42,42 +42,87 @@ import java.util.stream.Stream;
  * Usage: java build-logic/cleanup/src/main/java/gradlebuild/cleanup/services/KillLeakingJavaProcesses.java
  */
 public class KillLeakingJavaProcesses {
+    enum ExecutionMode {
+        /**
+         * Run at the beginning of each build. Kill potentially leaked processes in previous builds.
+         * Only kill local Gradle processes (classpath in checkout directory).
+         * Not clean up global Gradle processes (i.e. classpath in ~/.gradle/...).
+         */
+        KILL_LEAKED_PROCESSES_FROM_PREVIOUS_BUILDS,
+        /**
+         * Run at the end of each build. Kill potentially leaked processes in the current build.
+         * Only kill local Gradle processes (classpath in checkout directory).
+         * Not clean up global Gradle processes (i.e. classpath in ~/.gradle/...).
+         * Because the step is not guaranteed to run (e.g. build timeout), we need `KILL_LEAKED_PROCESSES_FROM_PREVIOUS_BUILDS` mode.
+         */
+        KILL_PROCESSES_STARTED_BY_GRADLE,
+        /**
+         * Run when we want to retry the build. Kill all Gradle processes, regardless of they're global or local.
+         */
+        KILL_ALL_GRADLE_PROCESSES
+    }
+
     private static final Pattern UNIX_PID_PATTERN = Pattern.compile("([0-9]+)");
     private static final Pattern WINDOWS_PID_PATTERN = Pattern.compile("([0-9]+)\\s*$");
     private static final String MY_PID = String.valueOf(ProcessHandle.current().pid());
+    private static final String JAVA_EXECUTABLE_PATTERN_STR = "java(?:\\.exe)?";
+    private static final String GRADLE_MAIN_CLASS_PATTERN_STR = "(org\\.gradle\\.[a-zA-Z]+)";
+    private static final String PLAY_SERVER_PATTERN_STR = "(play\\.core\\.server\\.NettyServer)";
+    private static final String JAVA_PROCESS_STACK_TRACES_MONITOR_PATTERN_STR = "(JavaProcessStackTracesMonitor\\.java)";
+    private static ExecutionMode executionMode;
+
+    static String generateAllGradleProcessPattern() {
+        return "(?i)[/\\\\]" + JAVA_EXECUTABLE_PATTERN_STR + ".+("
+            + GRADLE_MAIN_CLASS_PATTERN_STR + "|"
+            + PLAY_SERVER_PATTERN_STR + "|"
+            + JAVA_PROCESS_STACK_TRACES_MONITOR_PATTERN_STR
+            + ").*";
+    }
 
     static String generateLeakingProcessKillPattern(String rootProjectDir) {
-        String javaExecutable = "java(?:\\.exe)?";
         String kotlinCompilerDaemonPattern = "(?:" + Pattern.quote("-Dkotlin.environment.keepalive org.jetbrains.kotlin.daemon.KotlinCompileDaemon") + ")";
         String quotedRootProjectDir = Pattern.quote(rootProjectDir);
-        String mainClassPattern = "(org\\.gradle\\.|[a-zA-Z]+)";
-        String playServerPattern = "(play\\.core\\.server\\.NettyServer)";
-        String javaProcessStackTracesMonitorPattern = "(JavaProcessStackTracesMonitor\\.java)";
-        String classPathPattern1 = "(?:-cp.+" + "(" + quotedRootProjectDir + "|build\\\\tmp\\\\performance-test-files)" + ".+?" + mainClassPattern + ")";
-        String classPathPattern2 = "(?:-classpath.+" + quotedRootProjectDir + ".+?" + Pattern.quote("\\build\\") + ".+?" + mainClassPattern + ")";
-        String classPathPattern3 = "(?:-classpath.+" + quotedRootProjectDir + ".+?" + playServerPattern + ")";
-        return "(?i)[/\\\\]" + "(" + javaExecutable + ".+?" + "(?:" +
-            classPathPattern1 + "|" +
-            classPathPattern2 + "|" +
-            classPathPattern3 + "|" +
-            kotlinCompilerDaemonPattern + "|" +
-            javaProcessStackTracesMonitorPattern +
-            ").+)";
+        String perfTestClasspathPattern = "(?:-cp.+\\\\build\\\\tmp\\\\performance-test-files.+?" + GRADLE_MAIN_CLASS_PATTERN_STR + ")";
+        String buildDirClasspathPattern = "(?:-classpath.+" + quotedRootProjectDir + ".+?" + Pattern.quote("\\build\\") + ".+?" + GRADLE_MAIN_CLASS_PATTERN_STR + ")";
+        String playServerPattern = "(?:-classpath.+" + quotedRootProjectDir + ".+?" + PLAY_SERVER_PATTERN_STR + ")";
+        return "(?i)[/\\\\]" + "(" + JAVA_EXECUTABLE_PATTERN_STR + ".+?" + "(?:"
+            + perfTestClasspathPattern + "|"
+            + buildDirClasspathPattern + "|"
+            + playServerPattern + "|"
+            + kotlinCompilerDaemonPattern + "|"
+            + JAVA_PROCESS_STACK_TRACES_MONITOR_PATTERN_STR + ").+)";
     }
 
     public static void main(String[] args) {
+        initExecutionMode(args);
+
         File rootProjectDir = new File(System.getProperty("user.dir"));
 
-        cleanPsOutputFilesFromPreviousRun(rootProjectDir, args);
+        cleanPsOutputFilesFromPreviousRun(rootProjectDir);
 
         List<String> psOutput = ps(rootProjectDir);
 
         writePsOutputToFile(rootProjectDir, psOutput);
 
-        forEachLeakingJavaProcess(psOutput, rootProjectDir, pid -> {
-            System.out.println("A process wasn't shutdown properly in a previous Gradle run. Killing process with PID " + pid);
-            pkill(pid);
-        });
+        if (executionMode == ExecutionMode.KILL_ALL_GRADLE_PROCESSES) {
+            Pattern commandLineArgsPattern = Pattern.compile(generateAllGradleProcessPattern());
+            forEachJavaProcess(psOutput, commandLineArgsPattern, pid -> {
+                System.out.println("Killing Gradle process with PID " + pid);
+                pkill(pid);
+            });
+        } else {
+            forEachLeakingJavaProcess(rootProjectDir, pid -> {
+                System.out.println("A process wasn't shutdown properly in a previous Gradle run. Killing process with PID " + pid);
+                pkill(pid);
+            });
+        }
+    }
+
+    private static void initExecutionMode(String[] args) {
+        if (args.length != 1) {
+            throw new IllegalArgumentException("Requires 1 param: " + Stream.of(ExecutionMode.values()).map(ExecutionMode::toString).collect(Collectors.joining("/")));
+        }
+        executionMode = ExecutionMode.valueOf(args[0]);
     }
 
     private static void writePsOutputToFile(File rootProjectDir, List<String> psOutput) {
@@ -91,8 +136,8 @@ public class KillLeakingJavaProcesses {
         }
     }
 
-    private static void cleanPsOutputFilesFromPreviousRun(File rootProjectDir, String[] args) {
-        if (args.length > 0 && "KILL_LEAKED_PROCESSES_FROM_PREVIOUS_BUILDS".equals(args[0])) {
+    private static void cleanPsOutputFilesFromPreviousRun(File rootProjectDir) {
+        if (executionMode == ExecutionMode.KILL_LEAKED_PROCESSES_FROM_PREVIOUS_BUILDS) {
             File[] psOutputs = rootProjectDir.listFiles((__, name) -> name.endsWith(".psoutput"));
             if (psOutputs != null) {
                 Stream.of(psOutputs).forEach(File::delete);
@@ -108,11 +153,11 @@ public class KillLeakingJavaProcesses {
     }
 
     static void forEachLeakingJavaProcess(File rootProjectDir, Consumer<String> action) {
-        forEachLeakingJavaProcess(ps(rootProjectDir), rootProjectDir, action);
+        Pattern commandLineArgsPattern = Pattern.compile(generateLeakingProcessKillPattern(rootProjectDir.getPath()));
+        forEachJavaProcess(ps(rootProjectDir), commandLineArgsPattern, action);
     }
 
-    private static void forEachLeakingJavaProcess(List<String> psOutput, File rootProjectDir, Consumer<String> action) {
-        Pattern commandLineArgsPattern = Pattern.compile(generateLeakingProcessKillPattern(rootProjectDir.getPath()));
+    private static void forEachJavaProcess(List<String> psOutput, Pattern commandLineArgsPattern, Consumer<String> action) {
         Pattern pidPattern = isWindows() ? WINDOWS_PID_PATTERN : UNIX_PID_PATTERN;
 
         psOutput.forEach(line -> {
@@ -164,11 +209,7 @@ public class KillLeakingJavaProcesses {
 
         @Override
         public String toString() {
-            return "ExecResult{" +
-                "code=" + code +
-                "\n stdout='" + stdout + '\'' +
-                "\n stderr='" + stderr + '\'' +
-                '}';
+            return "ExecResult{" + "code=" + code + "\n stdout='" + stdout + '\'' + "\n stderr='" + stderr + '\'' + '}';
         }
 
         ExecResult assertZeroExit() {

--- a/build-logic/cleanup/src/test/groovy/gradlebuild/cleanup/services/LeakingProcessKillPatternTest.groovy
+++ b/build-logic/cleanup/src/test/groovy/gradlebuild/cleanup/services/LeakingProcessKillPatternTest.groovy
@@ -52,4 +52,18 @@ class LeakingProcessKillPatternTest extends Specification {
         expect:
         (line =~ KillLeakingJavaProcesses.generateLeakingProcessKillPattern(projectDir)).find()
     }
+
+    def "matches GradleDaemon on linux"() {
+        def line = 'tcagent1 3976365  8.4 12.7 17555200 8376108 ?    Ssl  02:50  14:27 /opt/files/jdk-linux/OpenJDK17U-jdk_x64_linux_hotspot_17.0.6_10.tar.gz/bin/java -XX:MaxMetaspaceSize=2G -XX:+UseParallelGC -XX:+HeapDumpOnOutOfMemoryError --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.prefs/java.util.prefs=ALL-UNNAMED --add-opens=java.base/java.nio.charset=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED -Xms1536m -Xmx6g -Dfile.encoding=UTF-8 -Djava.io.tmpdir=/home/tcagent1/agent/temp/buildTmp -Duser.country=US -Duser.language=en -Duser.variant -cp /home/tcagent1/.gradle/wrapper/dists/gradle-8.4-20230818222751+0000-bin/89h6cjxiw2m9bic290x647cni/gradle-8.4-20230818222751+0000/lib/gradle-launcher-8.4.jar -javaagent:/home/tcagent1/.gradle/wrapper/dists/gradle-8.4-20230818222751+0000-bin/89h6cjxiw2m9bic290x647cni/gradle-8.4-20230818222751+0000/lib/agents/gradle-instrumentation-agent-8.4.jar org.gradle.launcher.daemon.bootstrap.GradleDaemon 8.4-20230818222751+0000'
+
+        expect:
+        (line =~ KillLeakingJavaProcesses.generateAllGradleProcessPattern()).find()
+    }
+
+    def "not matches TC agent JVM"() {
+        def line = 'tcagent1  213966  0.0  0.1 3160628 102456 ?      Sl   Sep17   0:37 /opt/jdk/open-jdk-11/bin/java -ea -Xms16m -Xmx64m -cp ../launcher/lib/launcher.jar jetbrains.buildServer.agent.Launcher -ea -XX:+DisableAttachMechanism --add-opens=java.base/java.lang=ALL-UNNAMED -XX:+IgnoreUnrecognizedVMOptions -Xmx384m -Dteamcity_logs=../logs/ -Dlog4j2.configurationFile=file:../conf/teamcity-agent-log4j2.xml jetbrains.buildServer.agent.AgentMain -file ../conf/buildAgent.properties'
+
+        expect:
+        !(line =~ KillLeakingJavaProcesses.generateAllGradleProcessPattern()).find()
+    }
 }

--- a/build-logic/profiling/src/main/kotlin/gradlebuild.buildscan.gradle.kts
+++ b/build-logic/profiling/src/main/kotlin/gradlebuild.buildscan.gradle.kts
@@ -111,6 +111,11 @@ fun Project.extractCiData() {
             buildScanPublished {
                 println("##teamcity[buildStatus text='{build.status.text}: ${this.buildScanUri}']")
             }
+            buildFinished {
+                if (failure == null) {
+                    println("##teamcity[buildStatus status='SUCCESS' text='Retried build succeeds']")
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
### Context 

We've been annoyed by non-test flakiness for a long time. This PRs adds the build level retry support for CI builds. For functional tests, if `GRADLE_RUNNER` step fails, there will be 3 extra steps running:

- KILL_ALL_GRADLE_PROCESSES: kill all Gradle JVMs on the build agent, including all daemons.
- CLEAN_UP_GIT_UNTRACKED_FILES_AND_DIRECTORIES: remove all on tracked files in the checkout directory.
- GRADLE_RETRY_RUNNER: rerun the failed builds.

In short, we retry the build step in a fresh checkout directory with a fresh environment. We hope this could fix most flakiness on CI. For now, this is only enabled for pre-tested commit builds.