### PR TITLE
Generate thread dump in project root directory

### DIFF
--- a/.teamcity/src/main/kotlin/common/extensions.kt
+++ b/.teamcity/src/main/kotlin/common/extensions.kt
@@ -102,7 +102,7 @@ const val hiddenArtifactDestination = ".teamcity/gradle-logs"
 fun BuildType.applyDefaultSettings(os: Os = Os.LINUX, arch: Arch = Arch.AMD64, buildJvm: Jvm = BuildToolBuildJvm, timeout: Int = 30) {
     artifactRules = """
         *.psoutput => $hiddenArtifactDestination
-        build/*.threaddump => $hiddenArtifactDestination
+        *.threaddump => $hiddenArtifactDestination
         build/report-* => $hiddenArtifactDestination
         build/tmp/teŝt files/** => $hiddenArtifactDestination/teŝt-files
         build/errorLogs/** => $hiddenArtifactDestination/errorLogs

--- a/build-logic/cleanup/src/main/java/gradlebuild/cleanup/services/KillLeakingJavaProcesses.java
+++ b/build-logic/cleanup/src/main/java/gradlebuild/cleanup/services/KillLeakingJavaProcesses.java
@@ -98,7 +98,7 @@ public class KillLeakingJavaProcesses {
 
         File rootProjectDir = new File(System.getProperty("user.dir"));
 
-        cleanPsOutputFilesFromPreviousRun(rootProjectDir);
+        cleanPsOutputAndThreaddumpFilesFromPreviousRun(rootProjectDir);
 
         List<String> psOutput = ps(rootProjectDir);
 
@@ -136,9 +136,9 @@ public class KillLeakingJavaProcesses {
         }
     }
 
-    private static void cleanPsOutputFilesFromPreviousRun(File rootProjectDir) {
+    private static void cleanPsOutputAndThreaddumpFilesFromPreviousRun(File rootProjectDir) {
         if (executionMode == ExecutionMode.KILL_LEAKED_PROCESSES_FROM_PREVIOUS_BUILDS) {
-            File[] psOutputs = rootProjectDir.listFiles((__, name) -> name.endsWith(".psoutput"));
+            File[] psOutputs = rootProjectDir.listFiles((__, name) -> name.endsWith(".psoutput") || name.endsWith(".threaddump"));
             if (psOutputs != null) {
                 Stream.of(psOutputs).forEach(File::delete);
             }

--- a/build-logic/lifecycle/src/main/kotlin/PrintStackTracesOnTimeoutBuildService.kt
+++ b/build-logic/lifecycle/src/main/kotlin/PrintStackTracesOnTimeoutBuildService.kt
@@ -19,7 +19,6 @@ import org.gradle.api.provider.Property
 import org.gradle.api.services.BuildService
 import org.gradle.api.services.BuildServiceParameters
 import org.gradle.process.ExecOperations
-import java.io.File
 import java.util.Timer
 import javax.inject.Inject
 import kotlin.concurrent.timerTask
@@ -39,7 +38,7 @@ abstract class PrintStackTracesOnTimeoutBuildService @Inject constructor(private
                     commandLine(
                         "${System.getProperty("java.home")}/bin/java",
                         parameters.projectDirectory.file("subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/timeout/JavaProcessStackTracesMonitor.java").get().asFile.absolutePath,
-                        File(parameters.projectDirectory.asFile.get(), "build").absolutePath
+                        parameters.projectDirectory.asFile.get().absolutePath
                     )
                 }
             },


### PR DESCRIPTION
We found an error complaining `build/` not exist:

```
Exception in thread "main" java.lang.RuntimeException: java.io.FileNotFoundException: C:\tcagent1\work\f63322e10dd6b396\build\2023-09-18-10-25-32.threaddump (The system cannot find the path specified)
10:25:32     at org.gradle.integtests.fixtures.timeout.JavaProcessStackTracesMonitor.<init>(JavaProcessStackTracesMonitor.java:70)
```

Let's generate thread dumps in root directory directly because ps output files are already there.
