### PR TITLE
Provide request attributes during selection

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/LocalFileDependencyBackedArtifactSetCodec.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/LocalFileDependencyBackedArtifactSetCodec.kt
@@ -179,6 +179,9 @@ class LocalFileDependencyBackedArtifactSetCodec(
 }
 
 
+// Deserialized counterpart of DefaultLocalFileDependencyBackedArtifactSet.
+// Stores less state than the original, since we perform selection for each possible extension at serialization time
+// This data is encoded in the variantSelector, meaning we no longer need to store the request attributes
 private
 class DeserializedLocalFileDependencyArtifactSet(
     dependencyMetadata: LocalFileDependencyMetadata,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -78,6 +78,7 @@ import org.gradle.api.internal.artifacts.dependencies.DependencyConstraintIntern
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingState;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.RootComponentMetadataBuilder;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactSelectionSpec;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.SelectedArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.VisitedArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.projectresult.ResolvedProjectConfiguration;
@@ -1682,12 +1683,14 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
 
         @Override
         public SelectedArtifactSet getTaskDependencyValue() {
-            return resultProvider.getTaskDependencyValue().select(dependencySpec, viewAttributes.asImmutable(), componentSpec, allowNoMatchingVariants, selectFromAllVariants);
+            ArtifactSelectionSpec artifactSpec = new ArtifactSelectionSpec(viewAttributes.asImmutable(), componentSpec, selectFromAllVariants, allowNoMatchingVariants);
+            return resultProvider.getTaskDependencyValue().select(dependencySpec, artifactSpec);
         }
 
         @Override
         public SelectedArtifactSet getValue() {
-            return resultProvider.getValue().select(dependencySpec, viewAttributes.asImmutable(), componentSpec, allowNoMatchingVariants, selectFromAllVariants);
+            ArtifactSelectionSpec artifactSpec = new ArtifactSelectionSpec(viewAttributes.asImmutable(), componentSpec, selectFromAllVariants, allowNoMatchingVariants);
+            return resultProvider.getValue().select(dependencySpec, artifactSpec);
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
@@ -110,7 +110,8 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
 
     private SelectedArtifactResults getSelectedArtifacts() {
         if (artifactsForThisConfiguration == null) {
-            artifactsForThisConfiguration = artifactResults.selectLenient(Specs.satisfyAll(), variantSelectorFactory.create(implicitAttributes, false, resolveContext.getDependenciesResolverFactory()), false);
+            ArtifactVariantSelector selector = variantSelectorFactory.create(resolveContext.getDependenciesResolverFactory());
+            artifactsForThisConfiguration = artifactResults.selectLenient(Specs.satisfyAll(), selector, false, false, implicitAttributes.asImmutable());
         }
         return artifactsForThisConfiguration;
     }
@@ -125,8 +126,8 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
 
     @Override
     public SelectedArtifactSet select(final Spec<? super Dependency> dependencySpec, final AttributeContainerInternal requestedAttributes, final Spec<? super ComponentIdentifier> componentSpec, boolean allowNoMatchingVariants, boolean selectFromAllVariants) {
-        ArtifactVariantSelector selector = variantSelectorFactory.create(requestedAttributes, allowNoMatchingVariants, resolveContext.getDependenciesResolverFactory());
-        SelectedArtifactResults artifactResults = this.artifactResults.selectLenient(componentSpec, selector, selectFromAllVariants);
+        ArtifactVariantSelector selector = variantSelectorFactory.create(resolveContext.getDependenciesResolverFactory());
+        SelectedArtifactResults artifactResults = this.artifactResults.selectLenient(componentSpec, selector, selectFromAllVariants, allowNoMatchingVariants, requestedAttributes.asImmutable());
 
         return new SelectedArtifactSet() {
             @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
@@ -23,13 +23,13 @@ import org.gradle.api.artifacts.ResolveException;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedDependency;
 import org.gradle.api.artifacts.UnresolvedDependency;
-import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.DependencyGraphNodeResult;
 import org.gradle.api.internal.artifacts.ResolveArtifactsBuildOperationType;
 import org.gradle.api.internal.artifacts.ResolveContext;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.DependencyVerificationOverride;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactSelectionSpec;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.CompositeResolvedArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.LocalDependencyFiles;
@@ -44,7 +44,6 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.Visit
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult.TransientConfigurationResults;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult.TransientConfigurationResultsLoader;
 import org.gradle.api.internal.artifacts.transform.ArtifactVariantSelector;
-import org.gradle.api.internal.artifacts.transform.VariantSelectorFactory;
 import org.gradle.api.internal.artifacts.verification.exceptions.DependencyVerificationException;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.file.FileCollectionInternal;
@@ -84,17 +83,17 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
     private final VisitedArtifactsResults artifactResults;
     private final VisitedFileDependencyResults fileDependencyResults;
     private final TransientConfigurationResultsLoader transientConfigurationResultsFactory;
-    private final VariantSelectorFactory variantSelectorFactory;
     private final AttributeContainerInternal implicitAttributes;
     private final BuildOperationExecutor buildOperationExecutor;
     private final DependencyVerificationOverride dependencyVerificationOverride;
     private final WorkerLeaseService workerLeaseService;
+    private final ArtifactVariantSelector artifactVariantSelector;
 
     // Selected for the configuration
     private SelectedArtifactResults artifactsForThisConfiguration;
     private DependencyVerificationException dependencyVerificationException;
 
-    public DefaultLenientConfiguration(ResolveContext resolveContext, Set<UnresolvedDependency> unresolvedDependencies, @Nullable ResolveException extraFailure, VisitedArtifactsResults artifactResults, VisitedFileDependencyResults fileDependencyResults, TransientConfigurationResultsLoader transientConfigurationResultsLoader, VariantSelectorFactory variantSelectorFactory, BuildOperationExecutor buildOperationExecutor, DependencyVerificationOverride dependencyVerificationOverride, WorkerLeaseService workerLeaseService) {
+    public DefaultLenientConfiguration(ResolveContext resolveContext, Set<UnresolvedDependency> unresolvedDependencies, @Nullable ResolveException extraFailure, VisitedArtifactsResults artifactResults, VisitedFileDependencyResults fileDependencyResults, TransientConfigurationResultsLoader transientConfigurationResultsLoader, BuildOperationExecutor buildOperationExecutor, DependencyVerificationOverride dependencyVerificationOverride, WorkerLeaseService workerLeaseService, ArtifactVariantSelector artifactVariantSelector) {
         this.resolveContext = resolveContext;
         this.implicitAttributes = resolveContext.getAttributes().asImmutable();
         this.unresolvedDependencies = unresolvedDependencies;
@@ -102,32 +101,34 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
         this.artifactResults = artifactResults;
         this.fileDependencyResults = fileDependencyResults;
         this.transientConfigurationResultsFactory = transientConfigurationResultsLoader;
-        this.variantSelectorFactory = variantSelectorFactory;
         this.buildOperationExecutor = buildOperationExecutor;
         this.dependencyVerificationOverride = dependencyVerificationOverride;
         this.workerLeaseService = workerLeaseService;
+        this.artifactVariantSelector = artifactVariantSelector;
     }
 
     private SelectedArtifactResults getSelectedArtifacts() {
         if (artifactsForThisConfiguration == null) {
-            ArtifactVariantSelector selector = variantSelectorFactory.create(resolveContext.getDependenciesResolverFactory());
-            artifactsForThisConfiguration = artifactResults.selectLenient(Specs.satisfyAll(), selector, false, false, implicitAttributes.asImmutable());
+            artifactsForThisConfiguration = artifactResults.selectLenient(artifactVariantSelector, getImplicitSelectionSpec());
         }
         return artifactsForThisConfiguration;
     }
 
     public SelectedArtifactSet select() {
-        return select(Specs.satisfyAll(), implicitAttributes, Specs.satisfyAll(), false, false);
+        return select(Specs.satisfyAll(), getImplicitSelectionSpec());
     }
 
     public SelectedArtifactSet select(final Spec<? super Dependency> dependencySpec) {
-        return select(dependencySpec, implicitAttributes, Specs.satisfyAll(), false, false);
+        return select(dependencySpec, getImplicitSelectionSpec());
+    }
+
+    private ArtifactSelectionSpec getImplicitSelectionSpec() {
+        return new ArtifactSelectionSpec(implicitAttributes.asImmutable(), Specs.satisfyAll(), false, false);
     }
 
     @Override
-    public SelectedArtifactSet select(final Spec<? super Dependency> dependencySpec, final AttributeContainerInternal requestedAttributes, final Spec<? super ComponentIdentifier> componentSpec, boolean allowNoMatchingVariants, boolean selectFromAllVariants) {
-        ArtifactVariantSelector selector = variantSelectorFactory.create(resolveContext.getDependenciesResolverFactory());
-        SelectedArtifactResults artifactResults = this.artifactResults.selectLenient(componentSpec, selector, selectFromAllVariants, allowNoMatchingVariants, requestedAttributes.asImmutable());
+    public SelectedArtifactSet select(final Spec<? super Dependency> dependencySpec, ArtifactSelectionSpec spec) {
+        SelectedArtifactResults artifactResults = this.artifactResults.selectLenient(artifactVariantSelector, spec);
 
         return new SelectedArtifactSet() {
             @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolver.java
@@ -34,6 +34,7 @@ import org.gradle.api.internal.artifacts.ResolverResults;
 import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingState;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactSelectionSpec;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.SelectedArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.VisitedArtifactSet;
@@ -42,7 +43,6 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.projectresult.
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.DefaultResolutionResultBuilder;
 import org.gradle.api.internal.artifacts.repositories.ResolutionAwareRepository;
 import org.gradle.api.internal.artifacts.result.MinimalResolutionResult;
-import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.specs.Spec;
 
@@ -120,7 +120,7 @@ public class ShortCircuitEmptyConfigurationResolver implements ConfigurationReso
         private static final EmptyResults INSTANCE = new EmptyResults();
 
         @Override
-        public SelectedArtifactSet select(Spec<? super Dependency> dependencySpec, AttributeContainerInternal requestedAttributes, Spec<? super ComponentIdentifier> componentSpec, boolean allowNoMatchingVariant, boolean selectFromAllVariants) {
+        public SelectedArtifactSet select(Spec<? super Dependency> dependencySpec, ArtifactSelectionSpec spec) {
             return this;
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactSelectionSpec.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactSelectionSpec.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
+
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.api.specs.Spec;
+
+/**
+ * A set of parameters governing the selection of artifacts from a dependency graph.
+ */
+public class ArtifactSelectionSpec {
+
+    private final ImmutableAttributes requestAttributes;
+    private final Spec<? super ComponentIdentifier> componentFilter;
+    private final boolean selectFromAllVariants;
+    private final boolean allowNoMatchingVariants;
+
+    public ArtifactSelectionSpec(
+        ImmutableAttributes requestAttributes,
+        Spec<? super ComponentIdentifier> componentFilter,
+        boolean selectFromAllVariants,
+        boolean allowNoMatchingVariants
+    ) {
+        this.requestAttributes = requestAttributes;
+        this.componentFilter = componentFilter;
+        this.selectFromAllVariants = selectFromAllVariants;
+        this.allowNoMatchingVariants = allowNoMatchingVariants;
+    }
+
+    /**
+     * The request attributes used to determine which variant of each graph node to select.
+     */
+    public ImmutableAttributes getRequestAttributes() {
+        return requestAttributes;
+    }
+
+    /**
+     * Filters the selected artifacts to only contain those which originated from a component matching this filter.
+     */
+    public Spec<? super ComponentIdentifier> getComponentFilter() {
+        return componentFilter;
+    }
+
+    /**
+     * If false, selection is restricted only to the artifacts exposed a selected node in the graph.
+     * If true, selection is expanded to include artifacts from any variant exposed by the component that a given node belongs to.
+     */
+    public boolean getSelectFromAllVariants() {
+        return selectFromAllVariants;
+    }
+
+    /**
+     * If false, selection will fail if no matching artifact variants are found for a given graph node.
+     */
+    public boolean getAllowNoMatchingVariants() {
+        return allowNoMatchingVariants;
+    }
+
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactSet.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.artifacts.transform.ArtifactVariantSelector;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.specs.Spec;
 
 /**
@@ -29,5 +30,11 @@ public interface ArtifactSet {
     /**
      * Selects the artifacts of this set that meet the given criteria. Implementation should be eager where possible, so that selection happens immediately, but may be lazy.
      */
-    ResolvedArtifactSet select(Spec<? super ComponentIdentifier> componentFilter, ArtifactVariantSelector variantSelector, boolean selectFromAllVariants);
+    ResolvedArtifactSet select(
+        Spec<? super ComponentIdentifier> componentFilter,
+        ArtifactVariantSelector variantSelector,
+        boolean selectFromAllVariants,
+        boolean allowNoMatchingVariants,
+        ImmutableAttributes requestAttributes
+    );
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactSet.java
@@ -16,10 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
-import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.artifacts.transform.ArtifactVariantSelector;
-import org.gradle.api.internal.attributes.ImmutableAttributes;
-import org.gradle.api.specs.Spec;
 
 /**
  * Represents a container of artifacts, possibly made up of several different variants.
@@ -30,11 +27,5 @@ public interface ArtifactSet {
     /**
      * Selects the artifacts of this set that meet the given criteria. Implementation should be eager where possible, so that selection happens immediately, but may be lazy.
      */
-    ResolvedArtifactSet select(
-        Spec<? super ComponentIdentifier> componentFilter,
-        ArtifactVariantSelector variantSelector,
-        boolean selectFromAllVariants,
-        boolean allowNoMatchingVariants,
-        ImmutableAttributes requestAttributes
-    );
+    ResolvedArtifactSet select(ArtifactVariantSelector variantSelector, ArtifactSelectionSpec spec);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/BuildDependenciesOnlyVisitedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/BuildDependenciesOnlyVisitedArtifactSet.java
@@ -48,8 +48,8 @@ public class BuildDependenciesOnlyVisitedArtifactSet implements VisitedArtifactS
 
     @Override
     public SelectedArtifactSet select(Spec<? super Dependency> dependencySpec, AttributeContainerInternal requestedAttributes, Spec<? super ComponentIdentifier> componentSpec, boolean allowNoMatchingVariant, boolean selectFromAllVariants) {
-        ArtifactVariantSelector variantSelector = variantSelectorFactory.create(requestedAttributes, allowNoMatchingVariant, dependenciesResolverFactory);
-        ResolvedArtifactSet selectedArtifacts = artifactsResults.select(componentSpec, variantSelector, selectFromAllVariants).getArtifacts();
+        ArtifactVariantSelector variantSelector = variantSelectorFactory.create(dependenciesResolverFactory);
+        ResolvedArtifactSet selectedArtifacts = artifactsResults.select(componentSpec, variantSelector, selectFromAllVariants, allowNoMatchingVariant, requestedAttributes.asImmutable()).getArtifacts();
         return new BuildDependenciesOnlySelectedArtifactSet(unresolvedDependencies, selectedArtifacts);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/BuildDependenciesOnlyVisitedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/BuildDependenciesOnlyVisitedArtifactSet.java
@@ -18,11 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.UnresolvedDependency;
-import org.gradle.api.artifacts.component.ComponentIdentifier;
-import org.gradle.api.internal.artifacts.transform.TransformUpstreamDependenciesResolverFactory;
 import org.gradle.api.internal.artifacts.transform.ArtifactVariantSelector;
-import org.gradle.api.internal.artifacts.transform.VariantSelectorFactory;
-import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.specs.Spec;
 
@@ -31,25 +27,21 @@ import java.util.Set;
 public class BuildDependenciesOnlyVisitedArtifactSet implements VisitedArtifactSet {
     private final Set<UnresolvedDependency> unresolvedDependencies;
     private final VisitedArtifactsResults artifactsResults;
-    private final VariantSelectorFactory variantSelectorFactory;
-    private final TransformUpstreamDependenciesResolverFactory dependenciesResolverFactory;
+    ArtifactVariantSelector artifactVariantSelector;
 
     public BuildDependenciesOnlyVisitedArtifactSet(
         Set<UnresolvedDependency> unresolvedDependencies,
         VisitedArtifactsResults artifactsResults,
-        VariantSelectorFactory variantSelectorFactory,
-        TransformUpstreamDependenciesResolverFactory dependenciesResolverFactory
+        ArtifactVariantSelector artifactVariantSelector
     ) {
         this.unresolvedDependencies = unresolvedDependencies;
         this.artifactsResults = artifactsResults;
-        this.variantSelectorFactory = variantSelectorFactory;
-        this.dependenciesResolverFactory = dependenciesResolverFactory;
+        this.artifactVariantSelector = artifactVariantSelector;
     }
 
     @Override
-    public SelectedArtifactSet select(Spec<? super Dependency> dependencySpec, AttributeContainerInternal requestedAttributes, Spec<? super ComponentIdentifier> componentSpec, boolean allowNoMatchingVariant, boolean selectFromAllVariants) {
-        ArtifactVariantSelector variantSelector = variantSelectorFactory.create(dependenciesResolverFactory);
-        ResolvedArtifactSet selectedArtifacts = artifactsResults.select(componentSpec, variantSelector, selectFromAllVariants, allowNoMatchingVariant, requestedAttributes.asImmutable()).getArtifacts();
+    public SelectedArtifactSet select(Spec<? super Dependency> dependencySpec, ArtifactSelectionSpec spec) {
+        ResolvedArtifactSet selectedArtifacts = artifactsResults.select(artifactVariantSelector, spec).getArtifacts();
         return new BuildDependenciesOnlySelectedArtifactSet(unresolvedDependencies, selectedArtifacts);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultLocalFileDependencyBackedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultLocalFileDependencyBackedArtifactSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,35 +24,35 @@ import org.gradle.api.specs.Spec;
 import org.gradle.internal.component.local.model.LocalFileDependencyMetadata;
 import org.gradle.internal.model.CalculatedValueContainerFactory;
 
-public class FileDependencyArtifactSet implements ArtifactSet {
-    private final LocalFileDependencyMetadata fileDependency;
-    private final ArtifactTypeRegistry artifactTypeRegistry;
-    private final CalculatedValueContainerFactory calculatedValueContainerFactory;
+/**
+ * Default implementation of {@link LocalFileDependencyBackedArtifactSet}.
+ */
+public class DefaultLocalFileDependencyBackedArtifactSet extends LocalFileDependencyBackedArtifactSet {
 
-    public FileDependencyArtifactSet(LocalFileDependencyMetadata fileDependency, ArtifactTypeRegistry artifactTypeRegistry, CalculatedValueContainerFactory calculatedValueContainerFactory) {
-        this.fileDependency = fileDependency;
-        this.artifactTypeRegistry = artifactTypeRegistry;
-        this.calculatedValueContainerFactory = calculatedValueContainerFactory;
-    }
+    private final ImmutableAttributes requestAttributes;
 
-    @Override
-    public ResolvedArtifactSet select(
+    public DefaultLocalFileDependencyBackedArtifactSet(
+        LocalFileDependencyMetadata dependencyMetadata,
         Spec<? super ComponentIdentifier> componentFilter,
         ArtifactVariantSelector variantSelector,
-        boolean selectFromAllVariants,
-        boolean allowNoMatchingVariants,
-        ImmutableAttributes requestAttributes
+        ArtifactTypeRegistry artifactTypeRegistry,
+        CalculatedValueContainerFactory calculatedValueContainerFactory,
+        ImmutableAttributes requestAttributes,
+        boolean allowNoMatchingVariants
     ) {
-        // Select the artifacts later, as this is a function of the file names and these may not be known yet because the producing tasks have not yet executed
-        return new DefaultLocalFileDependencyBackedArtifactSet(
-            fileDependency,
+        super(
+            dependencyMetadata,
             componentFilter,
             variantSelector,
             artifactTypeRegistry,
             calculatedValueContainerFactory,
-            requestAttributes,
             allowNoMatchingVariants
         );
+        this.requestAttributes = requestAttributes;
     }
 
+    @Override
+    public ImmutableAttributes getRequestAttributes() {
+        return requestAttributes;
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultVisitedArtifactResults.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultVisitedArtifactResults.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.ResolutionStrategy;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.artifacts.transform.ArtifactVariantSelector;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.specs.Spec;
 
 import java.util.ArrayList;
@@ -47,14 +48,14 @@ public class DefaultVisitedArtifactResults implements VisitedArtifactsResults {
         this.artifactsById = artifactsById;
     }
 
-    private SelectedArtifactResults select(Spec<? super ComponentIdentifier> componentFilter, ArtifactVariantSelector variantSelector, Function<ResolvedArtifactSet, ResolvedArtifactSet> artifactSetHandler, boolean selectFromAllVariants) {
+    private SelectedArtifactResults select(Spec<? super ComponentIdentifier> componentFilter, ArtifactVariantSelector variantSelector, Function<ResolvedArtifactSet, ResolvedArtifactSet> artifactSetHandler, boolean selectFromAllVariants, boolean allowNoMatchingVariants, ImmutableAttributes requestAttributes) {
         if (artifactsById.isEmpty()) {
             return NoArtifactResults.INSTANCE;
         }
 
         List<ResolvedArtifactSet> resolvedArtifactSets = new ArrayList<>(artifactsById.size());
         for (ArtifactSet artifactSet : artifactsById) {
-            ResolvedArtifactSet resolvedArtifacts = artifactSet.select(componentFilter, variantSelector, selectFromAllVariants);
+            ResolvedArtifactSet resolvedArtifacts = artifactSet.select(componentFilter, variantSelector, selectFromAllVariants, allowNoMatchingVariants, requestAttributes);
             resolvedArtifactSets.add(artifactSetHandler.apply(resolvedArtifacts));
         }
 
@@ -67,13 +68,13 @@ public class DefaultVisitedArtifactResults implements VisitedArtifactsResults {
     }
 
     @Override
-    public SelectedArtifactResults select(Spec<? super ComponentIdentifier> componentFilter, ArtifactVariantSelector variantSelector, boolean selectFromAllVariants) {
-        return select(componentFilter, variantSelector, DO_NOTHING, selectFromAllVariants);
+    public SelectedArtifactResults select(Spec<? super ComponentIdentifier> componentFilter, ArtifactVariantSelector variantSelector, boolean selectFromAllVariants, boolean allowNoMatchingVariants, ImmutableAttributes requestAttributes) {
+        return select(componentFilter, variantSelector, DO_NOTHING, selectFromAllVariants, allowNoMatchingVariants, requestAttributes);
     }
 
     @Override
-    public SelectedArtifactResults selectLenient(Spec<? super ComponentIdentifier> componentFilter, ArtifactVariantSelector variantSelector, boolean selectFromAllVariants) {
-        return select(componentFilter, variantSelector, ALLOW_UNAVAILABLE, selectFromAllVariants);
+    public SelectedArtifactResults selectLenient(Spec<? super ComponentIdentifier> componentFilter, ArtifactVariantSelector variantSelector, boolean selectFromAllVariants, boolean allowNoMatchingVariants, ImmutableAttributes requestAttributes) {
+        return select(componentFilter, variantSelector, ALLOW_UNAVAILABLE, selectFromAllVariants, allowNoMatchingVariants, requestAttributes);
     }
 
     private static class NoArtifactResults implements SelectedArtifactResults {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultVisitedArtifactResults.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultVisitedArtifactResults.java
@@ -18,10 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
 import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.ResolutionStrategy;
-import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.artifacts.transform.ArtifactVariantSelector;
-import org.gradle.api.internal.attributes.ImmutableAttributes;
-import org.gradle.api.specs.Spec;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -48,14 +45,14 @@ public class DefaultVisitedArtifactResults implements VisitedArtifactsResults {
         this.artifactsById = artifactsById;
     }
 
-    private SelectedArtifactResults select(Spec<? super ComponentIdentifier> componentFilter, ArtifactVariantSelector variantSelector, Function<ResolvedArtifactSet, ResolvedArtifactSet> artifactSetHandler, boolean selectFromAllVariants, boolean allowNoMatchingVariants, ImmutableAttributes requestAttributes) {
+    private SelectedArtifactResults select(ArtifactVariantSelector variantSelector, Function<ResolvedArtifactSet, ResolvedArtifactSet> artifactSetHandler, ArtifactSelectionSpec spec) {
         if (artifactsById.isEmpty()) {
             return NoArtifactResults.INSTANCE;
         }
 
         List<ResolvedArtifactSet> resolvedArtifactSets = new ArrayList<>(artifactsById.size());
         for (ArtifactSet artifactSet : artifactsById) {
-            ResolvedArtifactSet resolvedArtifacts = artifactSet.select(componentFilter, variantSelector, selectFromAllVariants, allowNoMatchingVariants, requestAttributes);
+            ResolvedArtifactSet resolvedArtifacts = artifactSet.select(variantSelector, spec);
             resolvedArtifactSets.add(artifactSetHandler.apply(resolvedArtifacts));
         }
 
@@ -68,13 +65,13 @@ public class DefaultVisitedArtifactResults implements VisitedArtifactsResults {
     }
 
     @Override
-    public SelectedArtifactResults select(Spec<? super ComponentIdentifier> componentFilter, ArtifactVariantSelector variantSelector, boolean selectFromAllVariants, boolean allowNoMatchingVariants, ImmutableAttributes requestAttributes) {
-        return select(componentFilter, variantSelector, DO_NOTHING, selectFromAllVariants, allowNoMatchingVariants, requestAttributes);
+    public SelectedArtifactResults select(ArtifactVariantSelector variantSelector, ArtifactSelectionSpec spec) {
+        return select(variantSelector, DO_NOTHING, spec);
     }
 
     @Override
-    public SelectedArtifactResults selectLenient(Spec<? super ComponentIdentifier> componentFilter, ArtifactVariantSelector variantSelector, boolean selectFromAllVariants, boolean allowNoMatchingVariants, ImmutableAttributes requestAttributes) {
-        return select(componentFilter, variantSelector, ALLOW_UNAVAILABLE, selectFromAllVariants, allowNoMatchingVariants, requestAttributes);
+    public SelectedArtifactResults selectLenient(ArtifactVariantSelector variantSelector, ArtifactSelectionSpec spec) {
+        return select(variantSelector, ALLOW_UNAVAILABLE, spec);
     }
 
     private static class NoArtifactResults implements SelectedArtifactResults {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/FileDependencyArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/FileDependencyArtifactSet.java
@@ -16,11 +16,8 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
-import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.artifacts.transform.ArtifactVariantSelector;
 import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry;
-import org.gradle.api.internal.attributes.ImmutableAttributes;
-import org.gradle.api.specs.Spec;
 import org.gradle.internal.component.local.model.LocalFileDependencyMetadata;
 import org.gradle.internal.model.CalculatedValueContainerFactory;
 
@@ -37,21 +34,18 @@ public class FileDependencyArtifactSet implements ArtifactSet {
 
     @Override
     public ResolvedArtifactSet select(
-        Spec<? super ComponentIdentifier> componentFilter,
         ArtifactVariantSelector variantSelector,
-        boolean selectFromAllVariants,
-        boolean allowNoMatchingVariants,
-        ImmutableAttributes requestAttributes
+        ArtifactSelectionSpec spec
     ) {
         // Select the artifacts later, as this is a function of the file names and these may not be known yet because the producing tasks have not yet executed
         return new DefaultLocalFileDependencyBackedArtifactSet(
             fileDependency,
-            componentFilter,
+            spec.getComponentFilter(),
             variantSelector,
             artifactTypeRegistry,
             calculatedValueContainerFactory,
-            requestAttributes,
-            allowNoMatchingVariants
+            spec.getRequestAttributes(),
+            spec.getAllowNoMatchingVariants()
         );
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
@@ -54,6 +54,27 @@ import java.io.File;
 import java.util.Collections;
 import java.util.Set;
 
+/**
+ * Abstract file dependency implementation. The two {@code default} and {@code deserialized} subtypes
+ * represent the artifact set before and after configuration cache serialization. The deserialized
+ * type only stores a subset of the information originally stored by the default type.
+ *
+ * <p>This is required since the files in a given file dependency artifact set are unknown until
+ * dependencies are executed. For this reason, we delay artifact selection until after this artifact
+ * set is restored from the configuration cache. This differs from normal artifact variant selection
+ * where we can perform selection before serialization.</p>
+ *
+ * <p>The tricky part that due to the artifactType registry, artifact variant selection depends on the
+ * file names of the artifacts exposed by a variant. Normal variants have access to these file names
+ * before the dependencies are executed, but file dependencies do not.</p>
+ *
+ * <p>We should do one of these things to fix the current mess here:</p>
+ * <ul>
+ *     <li>Kill file dependencies</li>
+ *     <li>Enhance file dependencies to know what files they produce</li>
+ *     <li>Kill artifactType registry</li>
+ * </ul>
+ */
 public abstract class LocalFileDependencyBackedArtifactSet implements TransformedArtifactSet, LocalDependencyFiles, ArtifactVariantSelector.ResolvedArtifactTransformer {
     private static final DisplayName LOCAL_FILE = Describables.of("local file");
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/NoBuildDependenciesArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/NoBuildDependenciesArtifactSet.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.artifacts.transform.ArtifactVariantSelector;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.specs.Spec;
 
@@ -30,8 +31,8 @@ public class NoBuildDependenciesArtifactSet implements ArtifactSet {
     }
 
     @Override
-    public ResolvedArtifactSet select(Spec<? super ComponentIdentifier> componentFilter, ArtifactVariantSelector variantSelector, boolean selectFromAllVariants) {
-        final ResolvedArtifactSet selectedArtifacts = set.select(componentFilter, variantSelector, selectFromAllVariants);
+    public ResolvedArtifactSet select(Spec<? super ComponentIdentifier> componentFilter, ArtifactVariantSelector variantSelector, boolean selectFromAllVariants, boolean allowNoMatchingVariants, ImmutableAttributes requestAttributes) {
+        final ResolvedArtifactSet selectedArtifacts = set.select(componentFilter, variantSelector, selectFromAllVariants, allowNoMatchingVariants, requestAttributes);
         if (selectedArtifacts == ResolvedArtifactSet.EMPTY) {
             return selectedArtifacts;
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/NoBuildDependenciesArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/NoBuildDependenciesArtifactSet.java
@@ -17,11 +17,8 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
 import org.gradle.api.Action;
-import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.artifacts.transform.ArtifactVariantSelector;
-import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
-import org.gradle.api.specs.Spec;
 
 public class NoBuildDependenciesArtifactSet implements ArtifactSet {
     private final ArtifactSet set;
@@ -31,8 +28,8 @@ public class NoBuildDependenciesArtifactSet implements ArtifactSet {
     }
 
     @Override
-    public ResolvedArtifactSet select(Spec<? super ComponentIdentifier> componentFilter, ArtifactVariantSelector variantSelector, boolean selectFromAllVariants, boolean allowNoMatchingVariants, ImmutableAttributes requestAttributes) {
-        final ResolvedArtifactSet selectedArtifacts = set.select(componentFilter, variantSelector, selectFromAllVariants, allowNoMatchingVariants, requestAttributes);
+    public ResolvedArtifactSet select(ArtifactVariantSelector variantSelector, ArtifactSelectionSpec spec) {
+        final ResolvedArtifactSet selectedArtifacts = set.select(variantSelector, spec);
         if (selectedArtifacts == ResolvedArtifactSet.EMPTY) {
             return selectedArtifacts;
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/VariantResolvingArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/VariantResolvingArtifactSet.java
@@ -75,7 +75,13 @@ public class VariantResolvingArtifactSet implements ArtifactSet, ArtifactVariant
     }
 
     @Override
-    public ResolvedArtifactSet select(Spec<? super ComponentIdentifier> componentFilter, ArtifactVariantSelector variantSelector, boolean selectFromAllVariants) {
+    public ResolvedArtifactSet select(
+        Spec<? super ComponentIdentifier> componentFilter,
+        ArtifactVariantSelector variantSelector,
+        boolean selectFromAllVariants,
+        boolean allowNoMatchingVariants,
+        ImmutableAttributes requestAttributes
+    ) {
         if (!componentFilter.isSatisfiedBy(componentId)) {
             return ResolvedArtifactSet.EMPTY;
         } else {
@@ -92,7 +98,8 @@ public class VariantResolvingArtifactSet implements ArtifactSet, ArtifactVariant
             } catch (Exception e) {
                 return new BrokenResolvedArtifactSet(e);
             }
-            return variantSelector.select(variants, this);
+
+            return variantSelector.select(variants, requestAttributes, allowNoMatchingVariants, this);
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/VariantResolvingArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/VariantResolvingArtifactSet.java
@@ -27,7 +27,6 @@ import org.gradle.api.internal.artifacts.transform.TransformedVariantFactory;
 import org.gradle.api.internal.artifacts.transform.VariantDefinition;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
-import org.gradle.api.specs.Spec;
 import org.gradle.internal.component.model.ComponentArtifactResolveMetadata;
 import org.gradle.internal.component.model.ComponentArtifactResolveState;
 import org.gradle.internal.component.model.ComponentGraphResolveState;
@@ -76,17 +75,14 @@ public class VariantResolvingArtifactSet implements ArtifactSet, ArtifactVariant
 
     @Override
     public ResolvedArtifactSet select(
-        Spec<? super ComponentIdentifier> componentFilter,
         ArtifactVariantSelector variantSelector,
-        boolean selectFromAllVariants,
-        boolean allowNoMatchingVariants,
-        ImmutableAttributes requestAttributes
+        ArtifactSelectionSpec spec
     ) {
-        if (!componentFilter.isSatisfiedBy(componentId)) {
+        if (!spec.getComponentFilter().isSatisfiedBy(componentId)) {
             return ResolvedArtifactSet.EMPTY;
         } else {
 
-            if (selectFromAllVariants && !artifacts.isEmpty()) {
+            if (spec.getSelectFromAllVariants() && !artifacts.isEmpty()) {
                 // Variants with overridden artifacts cannot be reselected since
                 // we do not know the "true" attributes of the requested artifact.
                 return ResolvedArtifactSet.EMPTY;
@@ -94,12 +90,12 @@ public class VariantResolvingArtifactSet implements ArtifactSet, ArtifactVariant
 
             ResolvedVariantSet variants;
             try {
-                variants = getVariants(selectFromAllVariants);
+                variants = getVariants(spec.getSelectFromAllVariants());
             } catch (Exception e) {
                 return new BrokenResolvedArtifactSet(e);
             }
 
-            return variantSelector.select(variants, requestAttributes, allowNoMatchingVariants, this);
+            return variantSelector.select(variants, spec.getRequestAttributes(), spec.getAllowNoMatchingVariants(), this);
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/VisitedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/VisitedArtifactSet.java
@@ -17,8 +17,6 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
 import org.gradle.api.artifacts.Dependency;
-import org.gradle.api.artifacts.component.ComponentIdentifier;
-import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.specs.Spec;
 
 /**
@@ -31,9 +29,7 @@ public interface VisitedArtifactSet {
      * Not every query is available on the value returned from this method. Details are progressively refined during resolution and more queries become available.
      *
      * @param dependencySpec Select only those artifacts reachable from first level dependencies that match the given spec.
-     * @param requestedAttributes Select only those artifacts that match the provided attributes.
-     * @param componentSpec Select only those artifacts source from components matching the given spec.
-     * @param allowNoMatchingVariant When true, ignore those components which have no matching variants. When false, fail when any component has no matching variant.
+     * @param spec Parameters controlling the artifact selection process
      */
-    SelectedArtifactSet select(Spec<? super Dependency> dependencySpec, AttributeContainerInternal requestedAttributes, Spec<? super ComponentIdentifier> componentSpec, boolean allowNoMatchingVariant, boolean selectFromAllVariants);
+    SelectedArtifactSet select(Spec<? super Dependency> dependencySpec, ArtifactSelectionSpec spec);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/VisitedArtifactsResults.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/VisitedArtifactsResults.java
@@ -16,19 +16,16 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
-import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.artifacts.transform.ArtifactVariantSelector;
-import org.gradle.api.internal.attributes.ImmutableAttributes;
-import org.gradle.api.specs.Spec;
 
 public interface VisitedArtifactsResults {
     /**
      * Selects the artifacts for the matching variant of each node seen during traversal. The implementation should attempt to select artifacts eagerly, but may be lazy where the selection cannot happen until the results are queried.
      */
-    SelectedArtifactResults select(Spec<? super ComponentIdentifier> componentFilter, ArtifactVariantSelector variantSelector, boolean selectFromAllVariants, boolean allowNoMatchingVariants, ImmutableAttributes requestAttributes);
+    SelectedArtifactResults select(ArtifactVariantSelector variantSelector, ArtifactSelectionSpec spec);
 
     /**
      * Selects the artifacts for the matching variant of each node seen during traversal, ignoring artifacts that are resolved, but unavailable. The implementation should attempt to select artifacts eagerly, but may be lazy where the selection cannot happen until the results are queried.
      */
-    SelectedArtifactResults selectLenient(Spec<? super ComponentIdentifier> componentFilter, ArtifactVariantSelector variantSelector, boolean selectFromAllVariants, boolean allowNoMatchingVariants, ImmutableAttributes requestAttributes);
+    SelectedArtifactResults selectLenient(ArtifactVariantSelector variantSelector, ArtifactSelectionSpec spec);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/VisitedArtifactsResults.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/VisitedArtifactsResults.java
@@ -18,16 +18,17 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.artifacts.transform.ArtifactVariantSelector;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.specs.Spec;
 
 public interface VisitedArtifactsResults {
     /**
      * Selects the artifacts for the matching variant of each node seen during traversal. The implementation should attempt to select artifacts eagerly, but may be lazy where the selection cannot happen until the results are queried.
      */
-    SelectedArtifactResults select(Spec<? super ComponentIdentifier> componentFilter, ArtifactVariantSelector variantSelector, boolean selectFromAllVariants);
+    SelectedArtifactResults select(Spec<? super ComponentIdentifier> componentFilter, ArtifactVariantSelector variantSelector, boolean selectFromAllVariants, boolean allowNoMatchingVariants, ImmutableAttributes requestAttributes);
 
     /**
      * Selects the artifacts for the matching variant of each node seen during traversal, ignoring artifacts that are resolved, but unavailable. The implementation should attempt to select artifacts eagerly, but may be lazy where the selection cannot happen until the results are queried.
      */
-    SelectedArtifactResults selectLenient(Spec<? super ComponentIdentifier> componentFilter, ArtifactVariantSelector variantSelector, boolean selectFromAllVariants);
+    SelectedArtifactResults selectLenient(Spec<? super ComponentIdentifier> componentFilter, ArtifactVariantSelector variantSelector, boolean selectFromAllVariants, boolean allowNoMatchingVariants, ImmutableAttributes requestAttributes);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ArtifactVariantSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ArtifactVariantSelector.java
@@ -39,16 +39,7 @@ public interface ArtifactVariantSelector {
      *
      * On failure, returns a set that forwards the failure to the {@link org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor}.
      */
-    ResolvedArtifactSet select(ResolvedVariantSet candidates, ResolvedArtifactTransformer resolvedArtifactTransformer);
-
-    /**
-     * As per {@link #select(ResolvedVariantSet, ResolvedArtifactTransformer)} but ignores no matching variants.
-     */
-    default ResolvedArtifactSet maybeSelect(ResolvedVariantSet candidates, ResolvedArtifactTransformer resolvedArtifactTransformer) {
-        return select(candidates, resolvedArtifactTransformer);
-    }
-
-    ImmutableAttributes getRequestedAttributes();
+    ResolvedArtifactSet select(ResolvedVariantSet candidates, ImmutableAttributes requestAttributes, boolean allowNoMatchingVariants, ResolvedArtifactTransformer resolvedArtifactTransformer);
 
     interface ResolvedArtifactTransformer {
         ResolvedArtifactSet asTransformed(

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AttributeMatchingArtifactVariantSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AttributeMatchingArtifactVariantSelector.java
@@ -54,8 +54,6 @@ public class AttributeMatchingArtifactVariantSelector implements ArtifactVariant
     private final AttributesSchemaInternal schema;
     private final ImmutableAttributesFactory attributesFactory;
     private final TransformedVariantFactory transformedVariantFactory;
-    private final ImmutableAttributes requested;
-    private final boolean ignoreWhenNoMatches;
     private final TransformUpstreamDependenciesResolverFactory dependenciesResolverFactory;
     private final SelectionFailureHandler failureProcessor;
 
@@ -64,8 +62,6 @@ public class AttributeMatchingArtifactVariantSelector implements ArtifactVariant
         AttributesSchemaInternal schema,
         ImmutableAttributesFactory attributesFactory,
         TransformedVariantFactory transformedVariantFactory,
-        ImmutableAttributes requested,
-        boolean ignoreWhenNoMatches,
         TransformUpstreamDependenciesResolverFactory dependenciesResolverFactory,
         SelectionFailureHandler failureProcessor
     ) {
@@ -73,35 +69,14 @@ public class AttributeMatchingArtifactVariantSelector implements ArtifactVariant
         this.schema = schema;
         this.attributesFactory = attributesFactory;
         this.transformedVariantFactory = transformedVariantFactory;
-        this.requested = requested;
-        this.ignoreWhenNoMatches = ignoreWhenNoMatches;
         this.dependenciesResolverFactory = dependenciesResolverFactory;
         this.failureProcessor = failureProcessor;
     }
 
     @Override
-    public String toString() {
-        return "Variant selector for " + requested;
-    }
-
-    @Override
-    public ImmutableAttributes getRequestedAttributes() {
-        return requested;
-    }
-
-    @Override
-    public ResolvedArtifactSet select(ResolvedVariantSet producer, ResolvedArtifactTransformer resolvedArtifactTransformer) {
-        return selectAndWrapFailures(producer, ignoreWhenNoMatches, resolvedArtifactTransformer);
-    }
-
-    @Override
-    public ResolvedArtifactSet maybeSelect(ResolvedVariantSet candidates, ResolvedArtifactTransformer resolvedArtifactTransformer) {
-        return selectAndWrapFailures(candidates, true, resolvedArtifactTransformer);
-    }
-
-    private ResolvedArtifactSet selectAndWrapFailures(ResolvedVariantSet producer, boolean ignoreWhenNoMatches, ResolvedArtifactTransformer resolvedArtifactTransformer) {
+    public ResolvedArtifactSet select(ResolvedVariantSet producer, ImmutableAttributes requestAttributes, boolean allowNoMatchingVariants, ResolvedArtifactTransformer resolvedArtifactTransformer) {
         try {
-            return doSelect(producer, ignoreWhenNoMatches, resolvedArtifactTransformer, AttributeMatchingExplanationBuilder.logging());
+            return doSelect(producer, allowNoMatchingVariants, resolvedArtifactTransformer, AttributeMatchingExplanationBuilder.logging(), requestAttributes);
         } catch (ArtifactVariantSelectionException t) {
             return failureProcessor.unknownArtifactVariantSelectionFailure(schema, t);
         } catch (Exception t) {
@@ -109,9 +84,9 @@ public class AttributeMatchingArtifactVariantSelector implements ArtifactVariant
         }
     }
 
-    private ResolvedArtifactSet doSelect(ResolvedVariantSet producer, boolean ignoreWhenNoMatches, ResolvedArtifactTransformer resolvedArtifactTransformer, AttributeMatchingExplanationBuilder explanationBuilder) {
+    private ResolvedArtifactSet doSelect(ResolvedVariantSet producer, boolean allowNoMatchingVariants, ResolvedArtifactTransformer resolvedArtifactTransformer, AttributeMatchingExplanationBuilder explanationBuilder, ImmutableAttributes requestAttributes) {
         AttributeMatcher matcher = schema.withProducer(producer.getSchema());
-        ImmutableAttributes componentRequested = attributesFactory.concat(requested, producer.getOverriddenAttributes());
+        ImmutableAttributes componentRequested = attributesFactory.concat(requestAttributes, producer.getOverriddenAttributes());
         final List<ResolvedVariant> variants = ImmutableList.copyOf(producer.getVariants());
 
         List<? extends ResolvedVariant> matches = matcher.matches(variants, componentRequested, explanationBuilder);
@@ -144,7 +119,7 @@ public class AttributeMatchingArtifactVariantSelector implements ArtifactVariant
             throw failureProcessor.ambiguousArtifactTransformationFailure(schema, producer.asDescribable().getDisplayName(), componentRequested, transformedVariants);
         }
 
-        if (ignoreWhenNoMatches) {
+        if (allowNoMatchingVariants) {
             return ResolvedArtifactSet.EMPTY;
         }
 
@@ -156,7 +131,7 @@ public class AttributeMatchingArtifactVariantSelector implements ArtifactVariant
      * If that does not produce a single result, then a subset of the results of attribute matching is returned, where the candidates which have
      * incompatible attributes values with the <strong>last</strong> candidate are included.
      */
-    private List<TransformedVariant> tryDisambiguate(
+    private static List<TransformedVariant> tryDisambiguate(
         AttributeMatcher matcher,
         List<TransformedVariant> candidates,
         ImmutableAttributes componentRequested,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultVariantSelectorFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultVariantSelectorFactory.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.artifacts.transform;
 
-import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.component.SelectionFailureHandler;
@@ -43,7 +42,7 @@ public class DefaultVariantSelectorFactory implements VariantSelectorFactory {
     }
 
     @Override
-    public ArtifactVariantSelector create(AttributeContainerInternal consumerAttributes, boolean allowNoMatchingVariants, TransformUpstreamDependenciesResolverFactory dependenciesResolverFactory) {
-        return new AttributeMatchingArtifactVariantSelector(consumerProvidedVariantFinder, schema, attributesFactory, transformedVariantFactory, consumerAttributes.asImmutable(), allowNoMatchingVariants, dependenciesResolverFactory, failureProcessor);
+    public ArtifactVariantSelector create(TransformUpstreamDependenciesResolverFactory dependenciesResolverFactory) {
+        return new AttributeMatchingArtifactVariantSelector(consumerProvidedVariantFinder, schema, attributesFactory, transformedVariantFactory, dependenciesResolverFactory, failureProcessor);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/VariantSelectorFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/VariantSelectorFactory.java
@@ -16,15 +16,9 @@
 
 package org.gradle.api.internal.artifacts.transform;
 
-import org.gradle.api.internal.attributes.AttributeContainerInternal;
-
 public interface VariantSelectorFactory {
     /**
-     * Returns a selector that selects the variant matching the supplied attributes, or which can be transformed to match.
+     * Returns a selector that selects using variant aware attribute matching.
      */
-    ArtifactVariantSelector create(
-        AttributeContainerInternal consumerAttributes,
-        boolean allowNoMatchingVariants,
-        TransformUpstreamDependenciesResolverFactory dependenciesResolverFactory
-    );
+    ArtifactVariantSelector create(TransformUpstreamDependenciesResolverFactory dependenciesResolverFactory);
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -488,7 +488,7 @@ class DefaultConfigurationSpec extends Specification implements InspectableConfi
         def localComponentsResult = Stub(ResolvedLocalComponentsResult)
         def visitedArtifactSet = Stub(VisitedArtifactSet)
 
-        _ * visitedArtifactSet.select(_, _, _, _, _) >> Stub(SelectedArtifactSet) {
+        _ * visitedArtifactSet.select(_, _) >> Stub(SelectedArtifactSet) {
             visitFiles(_, _) >> { ResolvedFileVisitor visitor, boolean l ->
                 files.each {
                     visitor.visitFile(it)
@@ -512,7 +512,7 @@ class DefaultConfigurationSpec extends Specification implements InspectableConfi
         def visitedArtifactSet = Stub(VisitedArtifactSet)
         def resolvedConfiguration = Stub(ResolvedConfiguration)
 
-        _ * visitedArtifactSet.select(_, _, _, _, _) >> Stub(SelectedArtifactSet) {
+        _ * visitedArtifactSet.select(_, _) >> Stub(SelectedArtifactSet) {
             visitFiles(_, _) >> { ResolvedFileVisitor v, boolean l -> v.visitFailure(failure) }
         }
         _ * resolvedConfiguration.hasError() >> true
@@ -579,7 +579,7 @@ class DefaultConfigurationSpec extends Specification implements InspectableConfi
         def selectedArtifactSet = Mock(SelectedArtifactSet)
 
         given:
-        _ * visitedArtifactSet.select(_, _, _, _, _) >> selectedArtifactSet
+        _ * visitedArtifactSet.select(_, _) >> selectedArtifactSet
         _ * selectedArtifactSet.visitDependencies(_) >> { TaskDependencyResolveContext visitor -> visitor.add(artifactTaskDependencies) }
         _ * artifactTaskDependencies.getDependencies(_) >> requiredTasks
 
@@ -1110,7 +1110,7 @@ class DefaultConfigurationSpec extends Specification implements InspectableConfi
         localComponentsResult.resolvedProjectConfigurations >> []
         def visitedArtifactSet = Mock(VisitedArtifactSet)
 
-        _ * visitedArtifactSet.select(_, _, _, _, _) >> Stub(SelectedArtifactSet) {
+        _ * visitedArtifactSet.select(_, _) >> Stub(SelectedArtifactSet) {
             collectFiles(_) >> { return it[0] }
         }
 
@@ -1878,7 +1878,7 @@ All Artifacts:
     private visitedArtifacts() {
         def visitedArtifactSet = Stub(VisitedArtifactSet)
         def selectedArtifactSet = Stub(SelectedArtifactSet)
-        _ * visitedArtifactSet.select(_, _, _, _) >> selectedArtifactSet
+        _ * visitedArtifactSet.select(_, _) >> selectedArtifactSet
         _ * selectedArtifactSet.visitDependencies(_) >> { Collection<Object> deps -> deps }
         visitedArtifactSet
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfigurationTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfigurationTest.groovy
@@ -28,7 +28,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.Visit
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.VisitedFileDependencyResults
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult.TransientConfigurationResults
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult.TransientConfigurationResultsLoader
-import org.gradle.api.internal.artifacts.transform.VariantSelectorFactory
+import org.gradle.api.internal.artifacts.transform.ArtifactVariantSelector
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.specs.Spec
 import org.gradle.internal.operations.BuildOperationExecutor
@@ -36,7 +36,6 @@ import org.gradle.test.fixtures.work.TestWorkerLeaseService
 import spock.lang.Specification
 
 class DefaultLenientConfigurationTest extends Specification {
-    def transforms = Stub(VariantSelectorFactory)
     def transientConfigurationResults = Mock(TransientConfigurationResults)
     def resultsLoader = Mock(TransientConfigurationResultsLoader)
     def artifactsResults = Stub(VisitedArtifactsResults)
@@ -119,7 +118,7 @@ class DefaultLenientConfigurationTest extends Specification {
     }
 
     private DefaultLenientConfiguration newConfiguration() {
-        new DefaultLenientConfiguration(configuration, null, null, artifactsResults, fileDependencyResults, resultsLoader, transforms, buildOperationExecutor, dependencyVerificationOverride, new TestWorkerLeaseService())
+        new DefaultLenientConfiguration(configuration, null, null, artifactsResults, fileDependencyResults, resultsLoader, buildOperationExecutor, dependencyVerificationOverride, new TestWorkerLeaseService(), Mock(ArtifactVariantSelector))
     }
 
     def generateDependenciesWithChildren(Map treeStructure) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolverSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolverSpec.groovy
@@ -20,12 +20,13 @@ import org.gradle.api.artifacts.component.BuildIdentifier
 import org.gradle.api.internal.artifacts.ConfigurationResolver
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
-import org.gradle.api.internal.artifacts.ResolverResults
 import org.gradle.api.internal.artifacts.ResolveContext
+import org.gradle.api.internal.artifacts.ResolverResults
 import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory
 import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingState
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactSelectionSpec
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext
 import org.gradle.api.specs.Specs
@@ -56,7 +57,7 @@ class ShortCircuitEmptyConfigurationResolverSpec extends Specification {
         localComponentsResult.resolvedProjectConfigurations as List == []
 
         def visitedArtifacts = results.visitedArtifacts
-        def artifactSet = visitedArtifacts.select(Specs.satisfyAll(), null, Specs.satisfyAll(), true, false)
+        def artifactSet = visitedArtifacts.select(Specs.satisfyAll(), Mock(ArtifactSelectionSpec))
         artifactSet.visitDependencies(depVisitor)
         artifactSet.visitArtifacts(artifactVisitor, true)
 
@@ -84,7 +85,7 @@ class ShortCircuitEmptyConfigurationResolverSpec extends Specification {
         localComponentsResult.resolvedProjectConfigurations as List == []
 
         def visitedArtifacts = results.visitedArtifacts
-        def artifactSet = visitedArtifacts.select(Specs.satisfyAll(), null, Specs.satisfyAll(), true, false)
+        def artifactSet = visitedArtifacts.select(Specs.satisfyAll(), Mock(ArtifactSelectionSpec))
         artifactSet.visitDependencies(depVisitor)
         artifactSet.visitArtifacts(artifactVisitor, true)
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultVisitedArtifactResultsTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultVisitedArtifactResultsTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact
 
 import org.gradle.api.artifacts.ResolutionStrategy
 import org.gradle.api.internal.artifacts.transform.ArtifactVariantSelector
+import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.specs.Spec
 import spock.lang.Specification
 
@@ -32,11 +33,11 @@ class DefaultVisitedArtifactResultsTest extends Specification {
         def spec = Stub(Spec)
 
         given:
-        artifacts1.select(spec, selector, selectFromAllVariants) >> variant1Artifacts
-        artifacts2.select(spec, selector, selectFromAllVariants) >> variant2Artifacts
+        artifacts1.select(spec, selector, selectFromAllVariants, false, ImmutableAttributes.EMPTY) >> variant1Artifacts
+        artifacts2.select(spec, selector, selectFromAllVariants, false, ImmutableAttributes.EMPTY) >> variant2Artifacts
 
         def results = new DefaultVisitedArtifactResults(ResolutionStrategy.SortOrder.CONSUMER_FIRST, [artifacts1, artifacts2])
-        def selected = results.select(spec, selector, selectFromAllVariants)
+        def selected = results.select(spec, selector, selectFromAllVariants, false, ImmutableAttributes.EMPTY)
 
         expect:
         selected.getArtifacts() instanceof CompositeResolvedArtifactSet
@@ -59,11 +60,11 @@ class DefaultVisitedArtifactResultsTest extends Specification {
         def spec = Stub(Spec)
 
         given:
-        artifacts1.select(spec, selector, selectFromAllVariants) >> variant1Artifacts
-        artifacts2.select(spec, selector, selectFromAllVariants) >> variant2Artifacts
+        artifacts1.select(spec, selector, selectFromAllVariants, false, ImmutableAttributes.EMPTY) >> variant1Artifacts
+        artifacts2.select(spec, selector, selectFromAllVariants, false, ImmutableAttributes.EMPTY) >> variant2Artifacts
 
         def results = new DefaultVisitedArtifactResults(ResolutionStrategy.SortOrder.CONSUMER_FIRST, [artifacts1, artifacts2])
-        def selected = results.select(spec, selector, selectFromAllVariants)
+        def selected = results.select(spec, selector, selectFromAllVariants, false, ImmutableAttributes.EMPTY)
 
         expect:
         selected.getArtifacts() instanceof CompositeResolvedArtifactSet
@@ -86,11 +87,11 @@ class DefaultVisitedArtifactResultsTest extends Specification {
         def spec = Stub(Spec)
 
         given:
-        artifacts1.select(spec, selector, selectFromAllVariants) >> variant1Artifacts
-        artifacts2.select(spec, selector, selectFromAllVariants) >> variant2Artifacts
+        artifacts1.select(spec, selector, selectFromAllVariants, false, ImmutableAttributes.EMPTY) >> variant1Artifacts
+        artifacts2.select(spec, selector, selectFromAllVariants, false, ImmutableAttributes.EMPTY) >> variant2Artifacts
 
         def results = new DefaultVisitedArtifactResults(ResolutionStrategy.SortOrder.CONSUMER_FIRST, [artifacts1, artifacts2])
-        def selected = results.selectLenient(spec, selector, selectFromAllVariants)
+        def selected = results.selectLenient(spec, selector, selectFromAllVariants, false, ImmutableAttributes.EMPTY)
 
         expect:
         selected.getArtifacts() instanceof CompositeResolvedArtifactSet
@@ -113,11 +114,11 @@ class DefaultVisitedArtifactResultsTest extends Specification {
         def spec = Stub(Spec)
 
         given:
-        artifacts1.select(spec, selector, selectFromAllVariants) >> variant1Artifacts
-        artifacts2.select(spec, selector, selectFromAllVariants) >> variant2Artifacts
+        artifacts1.select(spec, selector, selectFromAllVariants, false, ImmutableAttributes.EMPTY) >> variant1Artifacts
+        artifacts2.select(spec, selector, selectFromAllVariants, false, ImmutableAttributes.EMPTY) >> variant2Artifacts
 
         def results = new DefaultVisitedArtifactResults(ResolutionStrategy.SortOrder.CONSUMER_FIRST, [artifacts1, artifacts2])
-        def selected = results.selectLenient(spec, selector, selectFromAllVariants)
+        def selected = results.selectLenient(spec, selector, selectFromAllVariants, false, ImmutableAttributes.EMPTY)
 
         expect:
         selected.getArtifacts() == variant2Artifacts
@@ -136,11 +137,11 @@ class DefaultVisitedArtifactResultsTest extends Specification {
         def spec = Stub(Spec)
 
         given:
-        artifacts1.select(spec, selector, selectFromAllVariants) >> variant1Artifacts
-        artifacts2.select(spec, selector, selectFromAllVariants) >> variant2Artifacts
+        artifacts1.select(spec, selector, selectFromAllVariants, false, ImmutableAttributes.EMPTY) >> variant1Artifacts
+        artifacts2.select(spec, selector, selectFromAllVariants, false, ImmutableAttributes.EMPTY) >> variant2Artifacts
 
         def results = new DefaultVisitedArtifactResults(ResolutionStrategy.SortOrder.CONSUMER_FIRST, [artifacts1, artifacts2])
-        def selected = results.selectLenient(spec, selector, selectFromAllVariants)
+        def selected = results.selectLenient(spec, selector, selectFromAllVariants, false, ImmutableAttributes.EMPTY)
 
         expect:
         selected.getArtifacts() instanceof CompositeResolvedArtifactSet

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultVisitedArtifactResultsTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultVisitedArtifactResultsTest.groovy
@@ -18,8 +18,6 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact
 
 import org.gradle.api.artifacts.ResolutionStrategy
 import org.gradle.api.internal.artifacts.transform.ArtifactVariantSelector
-import org.gradle.api.internal.attributes.ImmutableAttributes
-import org.gradle.api.specs.Spec
 import spock.lang.Specification
 
 class DefaultVisitedArtifactResultsTest extends Specification {
@@ -30,14 +28,13 @@ class DefaultVisitedArtifactResultsTest extends Specification {
         def variant2Artifacts = Stub(ResolvedArtifactSet)
 
         def selector = Stub(ArtifactVariantSelector)
-        def spec = Stub(Spec)
 
         given:
-        artifacts1.select(spec, selector, selectFromAllVariants, false, ImmutableAttributes.EMPTY) >> variant1Artifacts
-        artifacts2.select(spec, selector, selectFromAllVariants, false, ImmutableAttributes.EMPTY) >> variant2Artifacts
+        artifacts1.select(selector, _) >> variant1Artifacts
+        artifacts2.select(selector, _) >> variant2Artifacts
 
         def results = new DefaultVisitedArtifactResults(ResolutionStrategy.SortOrder.CONSUMER_FIRST, [artifacts1, artifacts2])
-        def selected = results.select(spec, selector, selectFromAllVariants, false, ImmutableAttributes.EMPTY)
+        def selected = results.select(selector, Mock(ArtifactSelectionSpec))
 
         expect:
         selected.getArtifacts() instanceof CompositeResolvedArtifactSet
@@ -45,9 +42,6 @@ class DefaultVisitedArtifactResultsTest extends Specification {
 
         selected.getArtifactsWithId(0) == variant1Artifacts
         selected.getArtifactsWithId(1) == variant2Artifacts
-
-        where:
-        selectFromAllVariants << [false, true]
     }
 
     def "strict selection includes all failed artifacts"() {
@@ -57,14 +51,13 @@ class DefaultVisitedArtifactResultsTest extends Specification {
         def variant2Artifacts = new UnavailableResolvedArtifactSet(new Exception())
 
         def selector = Stub(ArtifactVariantSelector)
-        def spec = Stub(Spec)
 
         given:
-        artifacts1.select(spec, selector, selectFromAllVariants, false, ImmutableAttributes.EMPTY) >> variant1Artifacts
-        artifacts2.select(spec, selector, selectFromAllVariants, false, ImmutableAttributes.EMPTY) >> variant2Artifacts
+        artifacts1.select(selector, _) >> variant1Artifacts
+        artifacts2.select(selector, _) >> variant2Artifacts
 
         def results = new DefaultVisitedArtifactResults(ResolutionStrategy.SortOrder.CONSUMER_FIRST, [artifacts1, artifacts2])
-        def selected = results.select(spec, selector, selectFromAllVariants, false, ImmutableAttributes.EMPTY)
+        def selected = results.select(selector, Mock(ArtifactSelectionSpec))
 
         expect:
         selected.getArtifacts() instanceof CompositeResolvedArtifactSet
@@ -72,9 +65,6 @@ class DefaultVisitedArtifactResultsTest extends Specification {
 
         selected.getArtifactsWithId(0) == variant1Artifacts
         selected.getArtifactsWithId(1) == variant2Artifacts
-
-        where:
-        selectFromAllVariants << [false, true]
     }
 
     def "lenient selection includes selected variant of each node"() {
@@ -84,14 +74,13 @@ class DefaultVisitedArtifactResultsTest extends Specification {
         def variant2Artifacts = Stub(ResolvedArtifactSet)
 
         def selector = Stub(ArtifactVariantSelector)
-        def spec = Stub(Spec)
 
         given:
-        artifacts1.select(spec, selector, selectFromAllVariants, false, ImmutableAttributes.EMPTY) >> variant1Artifacts
-        artifacts2.select(spec, selector, selectFromAllVariants, false, ImmutableAttributes.EMPTY) >> variant2Artifacts
+        artifacts1.select(selector, _) >> variant1Artifacts
+        artifacts2.select(selector, _) >> variant2Artifacts
 
         def results = new DefaultVisitedArtifactResults(ResolutionStrategy.SortOrder.CONSUMER_FIRST, [artifacts1, artifacts2])
-        def selected = results.selectLenient(spec, selector, selectFromAllVariants, false, ImmutableAttributes.EMPTY)
+        def selected = results.selectLenient(selector, Mock(ArtifactSelectionSpec))
 
         expect:
         selected.getArtifacts() instanceof CompositeResolvedArtifactSet
@@ -99,9 +88,6 @@ class DefaultVisitedArtifactResultsTest extends Specification {
 
         selected.getArtifactsWithId(0) == variant1Artifacts
         selected.getArtifactsWithId(1) == variant2Artifacts
-
-        where:
-        selectFromAllVariants << [false, true]
     }
 
     def "lenient selection does not include unavailable selected variant"() {
@@ -111,20 +97,16 @@ class DefaultVisitedArtifactResultsTest extends Specification {
         def variant2Artifacts = Stub(ResolvedArtifactSet)
 
         def selector = Stub(ArtifactVariantSelector)
-        def spec = Stub(Spec)
 
         given:
-        artifacts1.select(spec, selector, selectFromAllVariants, false, ImmutableAttributes.EMPTY) >> variant1Artifacts
-        artifacts2.select(spec, selector, selectFromAllVariants, false, ImmutableAttributes.EMPTY) >> variant2Artifacts
+        artifacts1.select(selector, _) >> variant1Artifacts
+        artifacts2.select(selector, _) >> variant2Artifacts
 
         def results = new DefaultVisitedArtifactResults(ResolutionStrategy.SortOrder.CONSUMER_FIRST, [artifacts1, artifacts2])
-        def selected = results.selectLenient(spec, selector, selectFromAllVariants, false, ImmutableAttributes.EMPTY)
+        def selected = results.selectLenient(selector, Mock(ArtifactSelectionSpec))
 
         expect:
         selected.getArtifacts() == variant2Artifacts
-
-        where:
-        selectFromAllVariants << [false, true]
     }
 
     def "lenient selection includes broken artifacts"() {
@@ -134,14 +116,13 @@ class DefaultVisitedArtifactResultsTest extends Specification {
         def variant2Artifacts = Stub(ResolvedArtifactSet)
 
         def selector = Stub(ArtifactVariantSelector)
-        def spec = Stub(Spec)
 
         given:
-        artifacts1.select(spec, selector, selectFromAllVariants, false, ImmutableAttributes.EMPTY) >> variant1Artifacts
-        artifacts2.select(spec, selector, selectFromAllVariants, false, ImmutableAttributes.EMPTY) >> variant2Artifacts
+        artifacts1.select(selector, _) >> variant1Artifacts
+        artifacts2.select(selector, _) >> variant2Artifacts
 
         def results = new DefaultVisitedArtifactResults(ResolutionStrategy.SortOrder.CONSUMER_FIRST, [artifacts1, artifacts2])
-        def selected = results.selectLenient(spec, selector, selectFromAllVariants, false, ImmutableAttributes.EMPTY)
+        def selected = results.selectLenient(selector, Mock(ArtifactSelectionSpec))
 
         expect:
         selected.getArtifacts() instanceof CompositeResolvedArtifactSet
@@ -149,8 +130,5 @@ class DefaultVisitedArtifactResultsTest extends Specification {
 
         selected.getArtifactsWithId(0) == variant1Artifacts
         selected.getArtifactsWithId(1) == variant2Artifacts
-
-        where:
-        selectFromAllVariants << [false, true]
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSetTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSetTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.attributes.AttributeContainer
 import org.gradle.api.capabilities.Capability
 import org.gradle.api.internal.artifacts.transform.ArtifactVariantSelector
 import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry
+import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.file.FileCollectionInternal
 import org.gradle.api.internal.file.FileCollectionStructureVisitor
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext
@@ -41,7 +42,7 @@ class LocalFileDependencyBackedArtifactSetTest extends Specification {
     def filter = Mock(Spec)
     def selector = Mock(ArtifactVariantSelector)
     def artifactTypeRegistry = Mock(ArtifactTypeRegistry)
-    def set = new LocalFileDependencyBackedArtifactSet(dep, filter, selector, artifactTypeRegistry, TestUtil.calculatedValueContainerFactory())
+    def set = new DefaultLocalFileDependencyBackedArtifactSet(dep, filter, selector, artifactTypeRegistry, TestUtil.calculatedValueContainerFactory(), ImmutableAttributes.EMPTY, false)
 
     def "has build dependencies"() {
         def fileBuildDependencies = Stub(TaskDependency)
@@ -129,7 +130,7 @@ class LocalFileDependencyBackedArtifactSetTest extends Specification {
         _ * visitor.prepareForVisit(_) >> FileCollectionStructureVisitor.VisitType.Visit
         _ * filter.isSatisfiedBy(_) >> true
         1 * files.files >> ([f1, f2] as Set)
-        2 * selector.select(_, _) >> { ResolvedVariantSet variants, f -> variants.variants.first() }
+        2 * selector.select(_, _, _, _) >> { ResolvedVariantSet variants, r, a, f -> variants.variants.first() }
         1 * artifactTypeRegistry.mapAttributesFor(f1) >> attrs1
         1 * artifactTypeRegistry.mapAttributesFor(f2) >> attrs2
 
@@ -171,7 +172,7 @@ class LocalFileDependencyBackedArtifactSetTest extends Specification {
         1 * artifactTypeRegistry.mapAttributesFor(f1) >> attrs1
         1 * artifactTypeRegistry.mapAttributesFor(f2) >> attrs2
         1 * files.files >> ([f1, f2] as Set)
-        2 * selector.select(_, _) >> { ResolvedVariantSet variants, f -> variants.variants.first() }
+        2 * selector.select(_, _, _, _) >> { ResolvedVariantSet variants, r, a, f -> variants.variants.first() }
         2 * visitor.visitArtifacts(_) >> { ResolvedArtifactSet.Artifacts artifacts -> artifacts.visit(artifactVisitor) }
         1 * artifactVisitor.visitArtifact(_, attrs1, [], { it.file == f1 }) >> { DisplayName displayName, AttributeContainer attrs, List<? extends Capability> capabilities, ResolvableArtifact artifact ->
             assert displayName.displayName == 'local file'

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/NoBuildDependenciesArtifactSetTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/NoBuildDependenciesArtifactSetTest.groovy
@@ -16,47 +16,36 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact
 
-
 import org.gradle.api.internal.artifacts.transform.ArtifactVariantSelector
-import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext
-import org.gradle.api.specs.Spec
 import spock.lang.Specification
 
 class NoBuildDependenciesArtifactSetTest extends Specification {
     def "returns original selected artifacts when they are empty"() {
         def target = Stub(ArtifactSet)
-        def spec = Stub(Spec)
         def selector = Stub(ArtifactVariantSelector)
 
         when:
-        target.select(_, _, _, _, _) >> ResolvedArtifactSet.EMPTY
+        target.select(_, _) >> ResolvedArtifactSet.EMPTY
 
         then:
-        new NoBuildDependenciesArtifactSet(target).select(spec, selector, selectFromAllVariants, false, ImmutableAttributes.EMPTY) == ResolvedArtifactSet.EMPTY
-
-        where:
-        selectFromAllVariants << [false, true]
+        new NoBuildDependenciesArtifactSet(target).select(selector, Mock(ArtifactSelectionSpec)) == ResolvedArtifactSet.EMPTY
     }
 
     def "creates wrapper for non-empty set of selected artifacts"() {
         def target = Stub(ArtifactSet)
-        def spec = Stub(Spec)
         def selector = Stub(ArtifactVariantSelector)
         def selected = Stub(ResolvedArtifactSet)
         def visitor = Mock(TaskDependencyResolveContext)
 
         given:
-        target.select(_, _, _, _, _) >> selected
+        target.select(_, _) >> selected
 
         when:
-        def wrapper = new NoBuildDependenciesArtifactSet(target).select(spec, selector, selectFromAllVariants, false, ImmutableAttributes.EMPTY)
+        def wrapper = new NoBuildDependenciesArtifactSet(target).select(selector, Mock(ArtifactSelectionSpec))
         wrapper.visitDependencies(visitor)
 
         then:
         0 * visitor._
-
-        where:
-        selectFromAllVariants << [false, true]
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/NoBuildDependenciesArtifactSetTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/NoBuildDependenciesArtifactSetTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact
 
 
 import org.gradle.api.internal.artifacts.transform.ArtifactVariantSelector
+import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext
 import org.gradle.api.specs.Spec
 import spock.lang.Specification
@@ -28,11 +29,11 @@ class NoBuildDependenciesArtifactSetTest extends Specification {
         def spec = Stub(Spec)
         def selector = Stub(ArtifactVariantSelector)
 
-        given:
-        target.select(_, _, _) >> ResolvedArtifactSet.EMPTY
+        when:
+        target.select(_, _, _, _, _) >> ResolvedArtifactSet.EMPTY
 
-        expect:
-        new NoBuildDependenciesArtifactSet(target).select(spec, selector, selectFromAllVariants) == ResolvedArtifactSet.EMPTY
+        then:
+        new NoBuildDependenciesArtifactSet(target).select(spec, selector, selectFromAllVariants, false, ImmutableAttributes.EMPTY) == ResolvedArtifactSet.EMPTY
 
         where:
         selectFromAllVariants << [false, true]
@@ -46,10 +47,10 @@ class NoBuildDependenciesArtifactSetTest extends Specification {
         def visitor = Mock(TaskDependencyResolveContext)
 
         given:
-        target.select(_, _, _) >> selected
+        target.select(_, _, _, _, _) >> selected
 
         when:
-        def wrapper = new NoBuildDependenciesArtifactSet(target).select(spec,selector, selectFromAllVariants)
+        def wrapper = new NoBuildDependenciesArtifactSet(target).select(spec, selector, selectFromAllVariants, false, ImmutableAttributes.EMPTY)
         wrapper.visitDependencies(visitor)
 
         then:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/VariantResolvingArtifactSetTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/VariantResolvingArtifactSetTest.groovy
@@ -57,7 +57,8 @@ class VariantResolvingArtifactSetTest extends Specification {
     def "returns empty set when component id does not match spec"() {
         when:
         def artifactSet = new VariantResolvingArtifactSet(variantResolver, component, variant, dependency)
-        def selected = artifactSet.select({ false }, selector, selectFromAll, false, ImmutableAttributes.EMPTY)
+        def spec = new ArtifactSelectionSpec(ImmutableAttributes.EMPTY, { false }, selectFromAll, false)
+        def selected = artifactSet.select(selector, spec)
 
         then:
         0 * selector.select(_, _, _, _)
@@ -87,15 +88,16 @@ class VariantResolvingArtifactSetTest extends Specification {
         }
 
         when:
+        def spec = new ArtifactSelectionSpec(ImmutableAttributes.EMPTY, { true }, false, false)
         def artifactSet = new VariantResolvingArtifactSet(variantResolver, component, variant, dependency)
-        artifactSet.select({ true }, new ArtifactVariantSelector() {
+        artifactSet.select(new ArtifactVariantSelector() {
             @Override
             ResolvedArtifactSet select(ResolvedVariantSet candidates, ImmutableAttributes requestAttributes, boolean allowNoMatchingVariants, ArtifactVariantSelector.ResolvedArtifactTransformer factory) {
                 assert candidates.variants.size() == 2
                 // select the first variant
                 return candidates.variants[0].artifacts
             }
-        }, false, false, ImmutableAttributes.EMPTY)
+        }, spec)
 
         then:
         1 * variantResolver.resolveVariant(_, subvariant1) >> Mock(ResolvedVariant)
@@ -120,7 +122,8 @@ class VariantResolvingArtifactSetTest extends Specification {
         def artifactSet = new VariantResolvingArtifactSet(variantResolver, component, variant, dependency)
 
         when:
-        def selected = artifactSet.select({ true }, selector, selectFromAll, false, ImmutableAttributes.EMPTY)
+        def spec = new ArtifactSelectionSpec(ImmutableAttributes.EMPTY, { true }, false, false)
+        def selected = artifactSet.select(selector, spec)
 
         then:
         1 * selector.select(_, _, _, _) >> artifacts

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/VariantResolvingArtifactSetTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/VariantResolvingArtifactSetTest.groovy
@@ -57,10 +57,10 @@ class VariantResolvingArtifactSetTest extends Specification {
     def "returns empty set when component id does not match spec"() {
         when:
         def artifactSet = new VariantResolvingArtifactSet(variantResolver, component, variant, dependency)
-        def selected = artifactSet.select({ false }, selector, selectFromAll)
+        def selected = artifactSet.select({ false }, selector, selectFromAll, false, ImmutableAttributes.EMPTY)
 
         then:
-        0 * selector.select(_, _)
+        0 * selector.select(_, _, _, _)
         selected == ResolvedArtifactSet.EMPTY
 
         where:
@@ -90,17 +90,12 @@ class VariantResolvingArtifactSetTest extends Specification {
         def artifactSet = new VariantResolvingArtifactSet(variantResolver, component, variant, dependency)
         artifactSet.select({ true }, new ArtifactVariantSelector() {
             @Override
-            ResolvedArtifactSet select(ResolvedVariantSet candidates, ArtifactVariantSelector.ResolvedArtifactTransformer factory) {
+            ResolvedArtifactSet select(ResolvedVariantSet candidates, ImmutableAttributes requestAttributes, boolean allowNoMatchingVariants, ArtifactVariantSelector.ResolvedArtifactTransformer factory) {
                 assert candidates.variants.size() == 2
                 // select the first variant
                 return candidates.variants[0].artifacts
             }
-
-            @Override
-            ImmutableAttributes getRequestedAttributes() {
-                return ImmutableAttributes.EMPTY
-            }
-        }, false)
+        }, false, false, ImmutableAttributes.EMPTY)
 
         then:
         1 * variantResolver.resolveVariant(_, subvariant1) >> Mock(ResolvedVariant)
@@ -125,10 +120,10 @@ class VariantResolvingArtifactSetTest extends Specification {
         def artifactSet = new VariantResolvingArtifactSet(variantResolver, component, variant, dependency)
 
         when:
-        def selected = artifactSet.select({ true }, selector, selectFromAll)
+        def selected = artifactSet.select({ true }, selector, selectFromAll, false, ImmutableAttributes.EMPTY)
 
         then:
-        1 * selector.select(_, _) >> artifacts
+        1 * selector.select(_, _, _, _) >> artifacts
         _ * variantResolver.resolveVariant(_, _) >> Mock(ResolvedVariant)
         selected == artifacts
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/AttributeMatchingArtifactVariantSelectorSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/AttributeMatchingArtifactVariantSelectorSpec.groovy
@@ -64,10 +64,10 @@ class AttributeMatchingArtifactVariantSelectorSpec extends Specification {
         given:
         def resolvedArtifactSet = Mock(ResolvedArtifactSet)
         def variants = [variant]
-        def selector = new AttributeMatchingArtifactVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, transformedVariantFactory, requestedAttributes, false, dependenciesResolverFactory, failureProcessor)
+        def selector = new AttributeMatchingArtifactVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, transformedVariantFactory, dependenciesResolverFactory, failureProcessor)
 
         when:
-        def result = selector.select(variantSetOf(variants), factory)
+        def result = selector.select(variantSetOf(variants), requestedAttributes, false, factory)
 
         then:
         result == resolvedArtifactSet
@@ -79,10 +79,10 @@ class AttributeMatchingArtifactVariantSelectorSpec extends Specification {
     def 'multiple match on variant results in ambiguous exception'() {
         given:
         def variantSet = variantSetOf([variant, otherVariant])
-        def selector = new AttributeMatchingArtifactVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, transformedVariantFactory, requestedAttributes, false, dependenciesResolverFactory, failureProcessor)
+        def selector = new AttributeMatchingArtifactVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, transformedVariantFactory, dependenciesResolverFactory, failureProcessor)
 
         when:
-        def result = selector.select(variantSet, factory)
+        def result = selector.select(variantSet, requestedAttributes, false, factory)
 
         then:
         result instanceof BrokenResolvedArtifactSet
@@ -100,10 +100,10 @@ class AttributeMatchingArtifactVariantSelectorSpec extends Specification {
         def transformed = Mock(ResolvedArtifactSet)
         def variants = [variant]
         def transformedVariants = transformedVariants(variants)
-        def selector = new AttributeMatchingArtifactVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, transformedVariantFactory, requestedAttributes, false, dependenciesResolverFactory, failureProcessor)
+        def selector = new AttributeMatchingArtifactVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, transformedVariantFactory, dependenciesResolverFactory, failureProcessor)
 
         when:
-        def result = selector.select(variantSetOf(variants), factory)
+        def result = selector.select(variantSetOf(variants), requestedAttributes, false, factory)
 
         then:
         result == transformed
@@ -119,10 +119,10 @@ class AttributeMatchingArtifactVariantSelectorSpec extends Specification {
         def transformed = Mock(ResolvedArtifactSet)
         def variants = [variant, otherVariant, yetAnotherVariant]
         def transformedVariants = transformedVariants(variants)
-        def selector = new AttributeMatchingArtifactVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, transformedVariantFactory, requestedAttributes, false, dependenciesResolverFactory, failureProcessor)
+        def selector = new AttributeMatchingArtifactVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, transformedVariantFactory, dependenciesResolverFactory, failureProcessor)
 
         when:
-        def result = selector.select(variantSetOf(variants), factory)
+        def result = selector.select(variantSetOf(variants), requestedAttributes, false, factory)
 
         then:
         result == transformed
@@ -140,10 +140,10 @@ class AttributeMatchingArtifactVariantSelectorSpec extends Specification {
         given:
         def variants = [variant, otherVariant]
         def transformedVariants = transformedVariants(variants)
-        def selector = new AttributeMatchingArtifactVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, transformedVariantFactory, requestedAttributes, false, dependenciesResolverFactory, failureProcessor)
+        def selector = new AttributeMatchingArtifactVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, transformedVariantFactory, dependenciesResolverFactory, failureProcessor)
 
         when:
-        def result = selector.select(variantSetOf(variants), factory)
+        def result = selector.select(variantSetOf(variants), requestedAttributes, false, factory)
 
         then:
         result instanceof BrokenResolvedArtifactSet

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactVariantSelectorFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactVariantSelectorFactoryTest.groovy
@@ -69,7 +69,7 @@ class DefaultArtifactVariantSelectorFactoryTest extends Specification {
         attributeMatcher.matches(_ as Collection, typeAttributes("classes"), _ as AttributeMatchingExplanationBuilder) >> [variant1]
 
         expect:
-        def result = variantSelectorFactory.create(typeAttributes("classes"), true, dependenciesResolverFactory).select(set, factory)
+        def result = variantSelectorFactory.create(dependenciesResolverFactory).select(set, typeAttributes("classes"), false, factory)
         result == variant1Artifacts
     }
 
@@ -93,7 +93,7 @@ class DefaultArtifactVariantSelectorFactoryTest extends Specification {
         attributeMatcher.isMatching(_, _, _) >> true
 
         when:
-        def result = variantSelectorFactory.create(typeAttributes("classes"), true, dependenciesResolverFactory).select(set, factory)
+        def result = variantSelectorFactory.create(dependenciesResolverFactory).select(set, typeAttributes("classes"), false, factory)
         visit(result)
 
         then:
@@ -125,10 +125,10 @@ class DefaultArtifactVariantSelectorFactoryTest extends Specification {
         attributeMatcher.matches(transformedVariants, _, _) >> transformedVariants
         matchingCache.findTransformedVariants(_, _) >> transformedVariants
 
-        def selector = variantSelectorFactory.create(requested, true, dependenciesResolverFactory)
+        def selector = variantSelectorFactory.create(dependenciesResolverFactory)
 
         when:
-        def result = selector.select(set, factory)
+        def result = selector.select(set, requested, false, factory)
         visit(result)
 
         then:
@@ -146,7 +146,7 @@ Found the following transforms:
           - Transform '' producing attributes: artifactType 'dll'""")
     }
 
-    def "returns empty variant when no variants match and ignore no matching enabled"() {
+    def "returns no matching variant artifact set when no variants match and ignore no matching enabled"() {
         def variant1 = resolvedVariant()
         def variant2 = resolvedVariant()
         def set = resolvedVariantSet()
@@ -164,7 +164,7 @@ Found the following transforms:
         matchingCache.findTransformedVariants(_, _) >> []
 
         expect:
-        def result = variantSelectorFactory.create(typeAttributes("dll"), true, dependenciesResolverFactory).select(set, factory)
+        def result = variantSelectorFactory.create(dependenciesResolverFactory).select(set, typeAttributes("dll"), true, factory)
         result == ResolvedArtifactSet.EMPTY
     }
 
@@ -189,7 +189,7 @@ Found the following transforms:
         matchingCache.findTransformedVariants(_, _) >> []
 
         when:
-        def result = variantSelectorFactory.create(typeAttributes("dll"), false, dependenciesResolverFactory).select(set, factory)
+        def result = variantSelectorFactory.create(dependenciesResolverFactory).select(set, typeAttributes("dll"), false, factory)
         visit(result)
 
         then:


### PR DESCRIPTION
Provide request attributes and 'allowNoMatchingVariants' to variant selector at time of selection.
Previously, these parameters were passed to the selector at time of construction.
By wiring these parameters through at time of selection, we can access them, most importantly the
request attributes, during other parts of the selection chain.
Accessing the request attributes is needed by the VariantResolvingArtifactSet so that it
can eventually perform proper variant selection during variant reselection