### PR TITLE
Fix hashing of upgraded properties metadata files

### DIFF
--- a/build-logic/packaging/src/main/kotlin/gradlebuild/instrumentation/tasks/InstrumentedSuperTypesMergeTask.kt
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild/instrumentation/tasks/InstrumentedSuperTypesMergeTask.kt
@@ -27,7 +27,6 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
-import java.io.File
 import java.util.ArrayDeque
 import java.util.Properties
 import java.util.Queue
@@ -53,7 +52,7 @@ abstract class InstrumentedSuperTypesMergeTask : DefaultTask() {
     fun mergeInstrumentedSuperTypes() {
         val instrumentedClasses = findInstrumentedClasses()
         if (instrumentedClasses.isEmpty()) {
-            instrumentedSuperTypes.asFile.get().toEmptyFile()
+            instrumentedSuperTypes.asFile.get().delete()
             return
         }
 
@@ -127,8 +126,8 @@ abstract class InstrumentedSuperTypesMergeTask : DefaultTask() {
     fun writeSuperTypes(onlyInstrumentedSuperTypes: Map<String, Set<String>>) {
         val outputFile = instrumentedSuperTypes.asFile.get()
         if (onlyInstrumentedSuperTypes.isEmpty()) {
-            // If there is no instrumented types just create an empty file
-            outputFile.toEmptyFile()
+            // If there is no instrumented types just don't output any file
+            outputFile.delete()
         } else {
             outputFile.writer().use {
                 onlyInstrumentedSuperTypes.toSortedMap().forEach { (className, superTypes) ->
@@ -136,11 +135,5 @@ abstract class InstrumentedSuperTypesMergeTask : DefaultTask() {
                 }
             }
         }
-    }
-
-    private
-    fun File.toEmptyFile() {
-        this.delete()
-        this.createNewFile()
     }
 }

--- a/build-logic/packaging/src/main/kotlin/gradlebuild/instrumentation/tasks/UpgradedPropertiesMergeTask.kt
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild/instrumentation/tasks/UpgradedPropertiesMergeTask.kt
@@ -29,7 +29,6 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
-import java.io.File
 import java.io.FileReader
 
 
@@ -54,7 +53,7 @@ abstract class UpgradedPropertiesMergeTask : DefaultTask() {
     fun mergeUpgradedProperties() {
         val mergedUpgradedProperties = mergeProperties()
         if (mergedUpgradedProperties.isEmpty) {
-            upgradedProperties.asFile.get().toEmptyFile()
+            upgradedProperties.asFile.get().delete()
         } else {
             upgradedProperties.asFile.get().writer().use { Gson().toJson(mergedUpgradedProperties, it) }
         }
@@ -70,11 +69,5 @@ abstract class UpgradedPropertiesMergeTask : DefaultTask() {
             .map { JsonParser.parseReader(FileReader(it)).asJsonArray }
             .forEach { merged.addAll(it) }
         return merged
-    }
-
-    private
-    fun File.toEmptyFile() {
-        this.delete()
-        this.createNewFile()
     }
 }

--- a/build-logic/packaging/src/test/kotlin/gradlebuild/instrumentation/InstrumentationMetadataPluginTest.kt
+++ b/build-logic/packaging/src/test/kotlin/gradlebuild/instrumentation/InstrumentationMetadataPluginTest.kt
@@ -69,7 +69,7 @@ class InstrumentationMetadataPluginTest {
     }
 
     @Test
-    fun `should output empty instrumentation files if none of types is instrumented`() {
+    fun `should not output files if none of types is instrumented`() {
         // Given
         // Override the build.gradle files to not write instrumented-classes.txt or upgraded-properties.json file
         File(projectRoot, "core/build.gradle").writeText("""
@@ -92,17 +92,14 @@ class InstrumentationMetadataPluginTest {
         // Then
         val instrumentedSuperTypes = File(projectRoot, "distribution/build/instrumentation/instrumented-super-types.properties")
         val upgradedProperties = File(projectRoot, "distribution/build/instrumentation/upgraded-properties.json")
-        instrumentedSuperTypes.assertExistsAndIsEmpty()
-        upgradedProperties.assertExistsAndIsEmpty()
+        instrumentedSuperTypes.assertDoesNotExist()
+        upgradedProperties.assertDoesNotExist()
     }
 
     private
-    fun File.assertExistsAndIsEmpty() {
-        assert(this.exists()) {
-            "Expected ${this.name} to exist, but it didn't"
-        }
-        assert(this.length() == 0L) {
-            "Expected ${this.name} to be empty but had length ${this.length()}"
+    fun File.assertDoesNotExist() {
+        assert(!this.exists()) {
+            "Expected ${this.name} to not exist, but it did"
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/types/GradleCoreInstrumentingTypeRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/types/GradleCoreInstrumentingTypeRegistry.java
@@ -18,8 +18,9 @@ package org.gradle.internal.classpath.types;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import org.apache.commons.io.IOUtils;
+import org.gradle.internal.hash.DefaultStreamHasher;
 import org.gradle.internal.hash.HashCode;
+import org.gradle.internal.hash.StreamHasher;
 import org.gradle.internal.lazy.Lazy;
 
 import java.io.IOException;
@@ -70,6 +71,9 @@ public class GradleCoreInstrumentingTypeRegistry implements InstrumentingTypeReg
 
     private static Map<String, Set<String>> loadInstrumentedSuperTypes() {
         try (InputStream stream = GradleCoreInstrumentingTypeRegistry.class.getResourceAsStream(INSTRUMENTED_SUPER_TYPES_FILE)) {
+            if (stream == null) {
+                return Collections.emptyMap();
+            }
             Properties properties = new Properties();
             properties.load(stream);
             ImmutableMap.Builder<String, Set<String>> builder = ImmutableMap.builder();
@@ -90,11 +94,11 @@ public class GradleCoreInstrumentingTypeRegistry implements InstrumentingTypeReg
 
     private static Optional<HashCode> loadHashCodeFromResource(String resourceFile) {
         try (InputStream stream = GradleCoreInstrumentingTypeRegistry.class.getResourceAsStream(resourceFile)) {
-            byte[] bytes = IOUtils.toByteArray(stream);
-            if (bytes.length == 0) {
+            if (stream == null) {
                 return Optional.empty();
             }
-            return Optional.of(HashCode.fromBytes(bytes));
+            StreamHasher streamHasher = new DefaultStreamHasher();
+            return Optional.of(streamHasher.hash(stream));
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
@@ -83,6 +83,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
     }
     def gradleCoreInstrumenting = Stub(GradleCoreInstrumentingTypeRegistry) {
         getInstrumentedTypesHash() >> Optional.empty()
+        getUpgradedPropertiesHash() >> Optional.empty()
     }
     def classpathFingerprinter = Stub(ClasspathFingerprinter) {
         fingerprint(_, _) >> { FileSystemSnapshot snapshot, FileCollectionFingerprint previous ->


### PR DESCRIPTION
We now use `StreamHasher` instead of manually reading resource bytes when hashing metadata files.

Additionally, before we always wrote an empty file out, and that empty file was then part of the distribution (even if there were no property upgrades). That is all fine, but then we need to check the content of a file -> if it's empty we don't want to include hash of a file in the instrumentation caching hash.
So now we don't output any resource file if no property is upgraded. And with that it's a bit easier to handle that case.

Fixes https://github.com/gradle/gradle/issues/26426

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
