### PR TITLE
Rename a few elements of the Kotlin DSL Reference docs

### DIFF
--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleKotlinDslReferencePlugin.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleKotlinDslReferencePlugin.java
@@ -77,7 +77,7 @@ public class GradleKotlinDslReferencePlugin implements Plugin<Project> {
      * The name of the module must match the first header of {@code kotlin/Module.md} file.
      */
     private static void renameModule(Project project) {
-        getDokkatooExtension(project).getModuleName().set("gradle");
+        getDokkatooExtension(project).getModuleName().set("Kotlin DSL Reference for Gradle");
     }
 
     private static void wireInArtificialSourceSet(Project project, GradleDocumentationExtension extension) {
@@ -89,7 +89,7 @@ public class GradleKotlinDslReferencePlugin implements Plugin<Project> {
 
         NamedDomainObjectContainer<DokkaSourceSetSpec> kotlinSourceSet = getDokkatooExtension(project).getDokkatooSourceSets();
         kotlinSourceSet.register("kotlin_dsl", spec -> {
-            spec.getDisplayName().set("Kotlin DSL");
+            spec.getDisplayName().set("DSL");
             spec.getSourceRoots().from(extension.getKotlinDslSource());
             spec.getSourceRoots().from(runtimeExtensions.flatMap(GradleKotlinDslRuntimeGeneratedSources::getGeneratedSources));
             spec.getClasspath().from(extension.getClasspath());
@@ -100,7 +100,7 @@ public class GradleKotlinDslReferencePlugin implements Plugin<Project> {
 
         NamedDomainObjectContainer<DokkaSourceSetSpec> javaSourceSet = getDokkatooExtension(project).getDokkatooSourceSets();
         javaSourceSet.register("java_api", spec -> {
-            spec.getDisplayName().set("Java API");
+            spec.getDisplayName().set("API");
             spec.getSourceRoots().from(extension.getDocumentedSource());
             spec.getClasspath().from(extension.getClasspath());
             spec.getIncludes().from(extension.getSourceRoot().file("kotlin/Module.md"));

--- a/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/DocsDistributionIntegrationSpec.groovy
+++ b/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/DocsDistributionIntegrationSpec.groovy
@@ -32,7 +32,7 @@ class DocsDistributionIntegrationSpec extends DistributionIntegrationSpec {
 
     @Override
     int getMaxDistributionSizeBytes() {
-        return 75 * 1024 * 1024
+        return 76 * 1024 * 1024
     }
 
     @Override

--- a/subprojects/docs/src/docs/kotlin/Module.md
+++ b/subprojects/docs/src/docs/kotlin/Module.md
@@ -1,6 +1,6 @@
-# Module gradle
+# Module Kotlin DSL Reference for Gradle
 
-# Gradle Kotlin DSL Reference
+# Kotlin DSL Reference for Gradle
 
 Gradle’s Kotlin DSL provides an enhanced editing experience in supported IDEs, with superior content assist, refactoring, documentation, and more.
 For an introduction see the <a href="../userguide/kotlin_dsl.html">Kotlin DSL Primer</a>.


### PR DESCRIPTION
Fixes #26359