### PR TITLE
Implement EAR Deployment Descriptors for JAVA EE / Jakarta EE

### DIFF
--- a/platforms/jvm/ear/src/main/java/org/gradle/plugins/ear/descriptor/DeploymentDescriptor.java
+++ b/platforms/jvm/ear/src/main/java/org/gradle/plugins/ear/descriptor/DeploymentDescriptor.java
@@ -38,7 +38,7 @@ public interface DeploymentDescriptor {
     void setFileName(String fileName);
 
     /**
-     * The version of application.xml. Required. Valid versions are "1.3", "1.4", "5" and "6". Defaults to "6".
+     * The version of application.xml. Required. Valid versions are "1.3", "1.4", "5", "6", "7", "8", "9" and "10". Defaults to "6".
      */
     String getVersion();
 

--- a/platforms/jvm/ear/src/main/java/org/gradle/plugins/ear/descriptor/internal/DefaultDeploymentDescriptor.java
+++ b/platforms/jvm/ear/src/main/java/org/gradle/plugins/ear/descriptor/internal/DefaultDeploymentDescriptor.java
@@ -382,8 +382,10 @@ public class DefaultDeploymentDescriptor implements DeploymentDescriptor {
             rootAttributes.put("xsi:schemaLocation", "http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/application_1_4.xsd");
         } else if ("5".equals(version) || "6".equals(version)) {
             rootAttributes.put("xsi:schemaLocation", "http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_" + version + ".xsd");
-        } else if ("7".equals(version)) {
+        } else if ("7".equals(version) || "8".equals(version)) {
             rootAttributes.put("xsi:schemaLocation", "http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/application_" + version + ".xsd");
+        } else if ("9".equals(version) || "10".equals(version)) {
+            rootAttributes.put("xsi:schemaLocation", "https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_" + version + ".xsd");
         }
         if (applicationName != null) {
             new Node(root, nodeNameFor("application-name"), applicationName);
@@ -436,8 +438,10 @@ public class DefaultDeploymentDescriptor implements DeploymentDescriptor {
             return new QName("http://java.sun.com/xml/ns/j2ee", name);
         } else if ("5".equals(version) || "6".equals(version)) {
             return new QName("http://java.sun.com/xml/ns/javaee", name);
-        } else if ("7".equals(version)) {
+        } else if ("7".equals(version) || "8".equals(version)) {
             return new QName("http://xmlns.jcp.org/xml/ns/javaee", name);
+        } else if ("9".equals(version) || "10".equals(version)) {
+            return new QName("https://jakarta.ee/xml/ns/jakartaee", name);
         } else {
             return new QName(name);
         }

--- a/platforms/jvm/ear/src/test/groovy/org/gradle/plugins/ear/descriptor/internal/DefaultDeploymentDescriptorTest.groovy
+++ b/platforms/jvm/ear/src/test/groovy/org/gradle/plugins/ear/descriptor/internal/DefaultDeploymentDescriptorTest.groovy
@@ -69,6 +69,9 @@ class DefaultDeploymentDescriptorTest extends Specification {
         '5'     | _
         '6'     | _
         '7'     | _
+        '8'     | _
+        '9'     | _
+        '10'    | _
         acceptableDescriptors = defaultDescriptorForVersion(version)
     }
 
@@ -109,10 +112,21 @@ class DefaultDeploymentDescriptorTest extends Specification {
                 return attributesPermutations('<?xml version="1.0"?>\n<application ##ATTRIBUTES##/>\n', attributes).collect { String descriptor ->
                     toPlatformLineSeparators(descriptor)
                 }
-            default:
+            case '7':
+            case '8':
                 def attributes = [
                     'xmlns="http://xmlns.jcp.org/xml/ns/javaee"',
                     "xsi:schemaLocation=\"http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/application_${version}.xsd\"",
+                    'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"',
+                    "version=\"${version}\""
+                ]
+                return attributesPermutations('<?xml version="1.0"?>\n<application ##ATTRIBUTES##/>\n', attributes).collect { String descriptor ->
+                    toPlatformLineSeparators(descriptor)
+                }
+            default:
+                def attributes = [
+                    'xmlns="https://jakarta.ee/xml/ns/jakartaee"',
+                    "xsi:schemaLocation=\"https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_${version}.xsd\"",
                     'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"',
                     "version=\"${version}\""
                 ]
@@ -197,6 +211,12 @@ class DefaultDeploymentDescriptorTest extends Specification {
         '6'     | 'asElement'        | { it.asElement() }
         '7'     | 'asNode'           | { it.asNode() }
         '7'     | 'asElement'        | { it.asElement() }
+        '8'     | 'asNode'           | { it.asNode() }
+        '8'     | 'asElement'        | { it.asElement() }
+        '9'     | 'asNode'           | { it.asNode() }
+        '9'     | 'asElement'        | { it.asElement() }
+        '10'    | 'asNode'           | { it.asNode() }
+        '10'    | 'asElement'        | { it.asElement() }
         acceptableDescriptors = defaultDescriptorForVersion(version)
     }
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -9,6 +9,7 @@ Include only their name, impactful features should be called out separately belo
  THiS LIST SHOULD BE ALPHABETIZED BY [PERSON NAME] - the docs:updateContributorsInReleaseNotes task will enforce this ordering, which is case-insensitive.
 -->
 We would like to thank the following community members for their contributions to this release of Gradle:
+[Philipp Schneider](https://github.com/p-schneider),
 
 ## Upgrade instructions
 
@@ -50,6 +51,19 @@ Example:
 ADD RELEASE FEATURES BELOW
 vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv -->
 
+<a name="ear-plugin"></a>
+### Ear Plugin
+
+It is now possible to generate valid deployment descriptors for Java EE 8, Jakarta EE 9 and Jakarta EE 10
+by specifying the corresponding version in the `deploymentDescriptor` instead of having to use a custom descriptor file.
+
+```kotlin
+tasks.ear {
+    deploymentDescriptor {  // custom entries for application.xml:
+        version = "10"
+    }
+}
+```
 
 
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Support JAVA EE 8, Jakarta EE 9 and Jakarta EE 10 in ear Descriptor by correctly handling Values "8", "9", "10" in property `ear.deploymentDescriptor.version`.

<!--- The issue this PR addresses -->
<!--- Fixes #26438 -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
See #26438

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
