### PR TITLE
Create VisitedGraphResults

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultResolverResults.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultResolverResults.java
@@ -16,12 +16,11 @@
 
 package org.gradle.api.internal.artifacts;
 
-import org.gradle.api.artifacts.ResolveException;
 import org.gradle.api.artifacts.ResolvedConfiguration;
 import org.gradle.api.internal.artifacts.ivyservice.ArtifactResolveState;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.VisitedArtifactSet;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results.VisitedGraphResults;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.projectresult.ResolvedLocalComponentsResult;
-import org.gradle.api.internal.artifacts.result.MinimalResolutionResult;
 
 import javax.annotation.Nullable;
 
@@ -31,32 +30,23 @@ import javax.annotation.Nullable;
 public class DefaultResolverResults implements ResolverResults {
 
     private final ResolvedLocalComponentsResult resolvedLocalComponentsResult;
-    private final MinimalResolutionResult minimalResolutionResult;
+    private final VisitedGraphResults graphResults;
     private final VisitedArtifactSet visitedArtifacts;
     private final ArtifactResolveState artifactResolveState;
     private final ResolvedConfiguration resolvedConfiguration;
 
     public DefaultResolverResults(
         ResolvedLocalComponentsResult resolvedLocalComponentsResult,
-        MinimalResolutionResult minimalResolutionResult,
+        VisitedGraphResults graphResults,
         VisitedArtifactSet visitedArtifacts,
         @Nullable ArtifactResolveState artifactResolveState,
         @Nullable ResolvedConfiguration resolvedConfiguration
     ) {
         this.resolvedLocalComponentsResult = resolvedLocalComponentsResult;
-        this.minimalResolutionResult = minimalResolutionResult;
+        this.graphResults = graphResults;
         this.visitedArtifacts = visitedArtifacts;
         this.artifactResolveState = artifactResolveState;
         this.resolvedConfiguration = resolvedConfiguration;
-    }
-
-    @Override
-    public boolean hasError() {
-        if (resolvedConfiguration != null && resolvedConfiguration.hasError()) {
-            return true;
-        }
-
-        return minimalResolutionResult.getExtraFailure() != null;
     }
 
     @Override
@@ -68,8 +58,8 @@ public class DefaultResolverResults implements ResolverResults {
     }
 
     @Override
-    public MinimalResolutionResult getMinimalResolutionResult() {
-        return minimalResolutionResult;
+    public VisitedGraphResults getVisitedGraph() {
+        return graphResults;
     }
 
     @Override
@@ -87,23 +77,17 @@ public class DefaultResolverResults implements ResolverResults {
         return visitedArtifacts;
     }
 
-    @Nullable
-    @Override
-    public ResolveException getFailure() {
-        return minimalResolutionResult.getExtraFailure();
-    }
-
     /**
      * Create a new result representing the result of resolving build dependencies.
      */
     public static ResolverResults buildDependenciesResolved(
-        MinimalResolutionResult resolutionResult,
+        VisitedGraphResults graphResults,
         ResolvedLocalComponentsResult resolvedLocalComponentsResult,
         VisitedArtifactSet visitedArtifacts
     ) {
         return new DefaultResolverResults(
             resolvedLocalComponentsResult,
-            resolutionResult,
+            graphResults,
             visitedArtifacts,
             null,
             null
@@ -114,14 +98,14 @@ public class DefaultResolverResults implements ResolverResults {
      * Create a new result representing the result of resolving the dependency graph.
      */
     public static ResolverResults graphResolved(
-        MinimalResolutionResult resolutionResult,
+        VisitedGraphResults graphResults,
         ResolvedLocalComponentsResult resolvedLocalComponentsResult,
         VisitedArtifactSet visitedArtifacts,
         @Nullable ArtifactResolveState artifactResolveState
     ) {
         return new DefaultResolverResults(
             resolvedLocalComponentsResult,
-            resolutionResult,
+            graphResults,
             visitedArtifacts,
             artifactResolveState,
             null
@@ -131,10 +115,10 @@ public class DefaultResolverResults implements ResolverResults {
     /**
      * Create a new result representing the result of resolving the artifacts.
      */
-    public static ResolverResults artifactsResolved(MinimalResolutionResult resolutionResult, ResolvedLocalComponentsResult localComponentsResult, ResolvedConfiguration resolvedConfiguration, VisitedArtifactSet visitedArtifacts) {
+    public static ResolverResults artifactsResolved(VisitedGraphResults graphResults, ResolvedLocalComponentsResult localComponentsResult, ResolvedConfiguration resolvedConfiguration, VisitedArtifactSet visitedArtifacts) {
         return new DefaultResolverResults(
             localComponentsResult,
-            resolutionResult,
+            graphResults,
             visitedArtifacts,
             null, // Do not need to keep the artifact resolve state around after artifact resolution
             resolvedConfiguration

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolveContext.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolveContext.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.artifacts;
 
+import org.gradle.api.Describable;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
 import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal;
@@ -32,6 +33,8 @@ import java.util.List;
 public interface ResolveContext extends DependencyMetaDataProvider {
 
     String getName();
+
+    Describable asDescribable();
 
     String getDisplayName();
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolverResults.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolverResults.java
@@ -16,13 +16,11 @@
 
 package org.gradle.api.internal.artifacts;
 
-import org.gradle.api.artifacts.ResolveException;
 import org.gradle.api.artifacts.ResolvedConfiguration;
-import org.gradle.api.artifacts.result.ResolutionResult;
 import org.gradle.api.internal.artifacts.ivyservice.ArtifactResolveState;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.VisitedArtifactSet;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results.VisitedGraphResults;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.projectresult.ResolvedLocalComponentsResult;
-import org.gradle.api.internal.artifacts.result.MinimalResolutionResult;
 
 import javax.annotation.Nullable;
 
@@ -37,24 +35,22 @@ import javax.annotation.Nullable;
 public interface ResolverResults {
 
     /**
-     * Returns true if there was a failure attached to this result.
-     */
-    boolean hasError();
-
-    /**
-     * Returns the old model, slowly being replaced by the new model represented by {@link ResolutionResult}. Requires artifacts to be resolved.
+     * Returns the old model, which has been replaced by {@link VisitedGraphResults} and {@link VisitedArtifactSet}.
+     * Using this model directly should be avoided.
+     * This method should only be used to implement existing public API methods.
      */
     ResolvedConfiguration getResolvedConfiguration();
+
+    /**
+     * Return the model representing the resolved graph. This model provides access
+     * to the root component as well as any failure that occurred while resolving the graph.
+     */
+    VisitedGraphResults getVisitedGraph();
 
     /**
      * Returns details of the artifacts visited during dependency graph resolution. This set is later refined during artifact resolution.
      */
     VisitedArtifactSet getVisitedArtifacts();
-
-    /**
-     * Returns the dependency graph resolve result.
-     */
-    MinimalResolutionResult getMinimalResolutionResult();
 
     /**
      * Returns details of the local components in the resolved dependency graph.
@@ -66,10 +62,4 @@ public interface ResolverResults {
      */
     @Nullable
     ArtifactResolveState getArtifactResolveState();
-
-    /**
-     * Returns an attached failure, if any.
-     */
-    @Nullable
-    ResolveException getFailure();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -81,10 +81,10 @@ import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.RootComponen
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactSelectionSpec;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.SelectedArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.VisitedArtifactSet;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results.VisitedGraphResults;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.projectresult.ResolvedProjectConfiguration;
 import org.gradle.api.internal.artifacts.result.DefaultResolutionResult;
 import org.gradle.api.internal.artifacts.result.MinimalResolutionResult;
-import org.gradle.api.internal.artifacts.result.ResolutionResultInternal;
 import org.gradle.api.internal.artifacts.transform.DefaultTransformUpstreamDependenciesResolverFactory;
 import org.gradle.api.internal.artifacts.transform.TransformUpstreamDependenciesResolverFactory;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
@@ -725,7 +725,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
                 markParentsObserved(requestedState);
                 markReferencedProjectConfigurationsObserved(requestedState, results);
 
-                if (!newState.hasError()) {
+                if (newState.getCachedResolverResults().getVisitedGraph().getAdditionalResolutionFailure() == null) {
                     dependencyResolutionListeners.getSource().afterResolve(incoming);
 
                     // Use the current state, which may have changed if the listener queried the result
@@ -743,15 +743,15 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
             }
 
             private void captureBuildOperationResult(BuildOperationContext context, ResolverResults results) {
-                Throwable failure = results.getFailure();
-                if (failure != null) {
-                    context.failed(failure);
+                ResolveException resolutionFailure = results.getVisitedGraph().getAdditionalResolutionFailure();
+                if (resolutionFailure != null) {
+                    context.failed(resolutionFailure);
                 }
                 // When dependency resolution has failed, we don't want the build operation listeners to fail as well
                 // because:
                 // 1. the `failed` method will have been called with the user facing error
                 // 2. such an error may still lead to a valid dependency graph
-                ResolutionResult resolutionResult = new DefaultResolutionResult(results.getMinimalResolutionResult());
+                ResolutionResult resolutionResult = new DefaultResolutionResult(results.getVisitedGraph().getResolutionResult());
                 context.setResult(ResolveConfigurationResolutionBuildOperationResult.create(resolutionResult, attributesFactory));
             }
 
@@ -1108,6 +1108,11 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
     @Override
     public String getUploadTaskName() {
         return Configurations.uploadTaskName(getName());
+    }
+
+    @Override
+    public Describable asDescribable() {
+        return displayName;
     }
 
     @Override
@@ -1632,12 +1637,12 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
 
         @Override
         public ResolutionResult getTaskDependencyValue() {
-            return new DefaultResolutionResult(getResultsForBuildDependencies().getMinimalResolutionResult());
+            return new DefaultResolutionResult(getResultsForBuildDependencies().getVisitedGraph().getResolutionResult());
         }
 
         @Override
         public ResolutionResult getValue() {
-            return new DefaultResolutionResult(getResultsForArtifacts().getMinimalResolutionResult());
+            return new DefaultResolutionResult(getResultsForArtifacts().getVisitedGraph().getResolutionResult());
         }
     }
 
@@ -2017,7 +2022,7 @@ since users cannot create non-legacy configurations and there is no current publ
 
         @Override
         boolean hasError() {
-            return cachedResolverResults.hasError();
+            return cachedResolverResults.getVisitedGraph().hasResolutionFailure();
         }
 
         @Override
@@ -2116,7 +2121,7 @@ since users cannot create non-legacy configurations and there is no current publ
         @Override
         public ResolutionResult getResolutionResult() {
             assertIsResolvable();
-            return new DefaultResolutionResult(new LazyMinimalResolutionResult(false));
+            return new DefaultResolutionResult(new ConfigurationResolvingMinimalResolutionResult());
         }
 
         @Override
@@ -2152,8 +2157,19 @@ since users cannot create non-legacy configurations and there is no current publ
         }
 
         @Override
-        public ResolutionResultInternal getLenientResolutionResult() {
-            return new DefaultResolutionResult(new LazyMinimalResolutionResult(true));
+        public ResolutionResultProvider<VisitedGraphResults> getGraphResultsProvider() {
+            assertIsResolvable();
+            return new ResolutionResultProvider<VisitedGraphResults>() {
+                @Override
+                public VisitedGraphResults getTaskDependencyValue() {
+                    return resolveGraphForBuildDependenciesIfRequired().getVisitedGraph();
+                }
+
+                @Override
+                public VisitedGraphResults getValue() {
+                    return resolveToStateOrLater(ARTIFACTS_RESOLVED).getCachedResolverResults().getVisitedGraph();
+                }
+            };
         }
 
         private class ConfigurationArtifactView implements ArtifactView {
@@ -2196,63 +2212,38 @@ since users cannot create non-legacy configurations and there is no current publ
         /**
          * A minimal resolution result that lazily resolves the configuration.
          */
-        private class LazyMinimalResolutionResult implements MinimalResolutionResult {
+        private class ConfigurationResolvingMinimalResolutionResult implements MinimalResolutionResult {
 
-            private final boolean lenient;
-            private volatile MinimalResolutionResult delegate;
+            private MinimalResolutionResult getDelegate() {
+                VisitedGraphResults graph = getGraphResultsProvider().getValue();
 
-            /**
-             * @param lenient If true, extra failures will not be thrown during resolution.
-             */
-            public LazyMinimalResolutionResult(boolean lenient) {
-                this.lenient = lenient;
-            }
-
-            private void resolve() {
-                if (delegate == null) {
-                    synchronized (this) {
-                        if (delegate == null) {
-                            ResolveState currentState = resolveToStateOrLater(ARTIFACTS_RESOLVED);
-                            delegate = currentState.getCachedResolverResults().getMinimalResolutionResult();
-                            ResolveException extraFailure = delegate.getExtraFailure();
-                            if (extraFailure != null && !lenient) {
-                                throw extraFailure;
-                            }
-                        }
-                    }
+                ResolveException failure = graph.getAdditionalResolutionFailure();
+                if (failure != null) {
+                    throw failure;
                 }
+
+                return graph.getResolutionResult();
             }
 
             @Override
             public Supplier<ResolvedComponentResult> getRootSource() {
-                resolve();
-                return delegate.getRootSource();
+                return getDelegate().getRootSource();
             }
 
             @Override
             public AttributeContainer getRequestedAttributes() {
-                resolve();
-                return delegate.getRequestedAttributes();
-            }
-
-            @Nullable
-            @Override
-            public ResolveException getExtraFailure() {
-                resolve();
-                return delegate.getExtraFailure();
+                return getDelegate().getRequestedAttributes();
             }
 
             @Override
             public int hashCode() {
-                resolve();
-                return delegate.hashCode();
+                return getDelegate().hashCode();
             }
 
             @Override
             public boolean equals(Object obj) {
-                if (obj instanceof LazyMinimalResolutionResult) {
-                    resolve();
-                    return delegate.equals(((LazyMinimalResolutionResult) obj).delegate);
+                if (obj instanceof ConfigurationResolvingMinimalResolutionResult) {
+                    return getDelegate().equals(((ConfigurationResolvingMinimalResolutionResult) obj).getDelegate());
                 }
                 return false;
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolvableDependenciesInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolvableDependenciesInternal.java
@@ -16,8 +16,8 @@
 package org.gradle.api.internal.artifacts.configurations;
 
 import org.gradle.api.artifacts.ResolvableDependencies;
-import org.gradle.api.internal.artifacts.result.ResolutionResultInternal;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results.VisitedGraphResults;
 
 public interface ResolvableDependenciesInternal extends ResolvableDependencies  {
-    ResolutionResultInternal getLenientResolutionResult();
+    ResolutionResultProvider<VisitedGraphResults> getGraphResultsProvider();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ArtifactResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ArtifactResolveState.java
@@ -16,29 +16,33 @@
 
 package org.gradle.api.internal.artifacts.ivyservice;
 
-import org.gradle.api.artifacts.UnresolvedDependency;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.VisitedArtifactsResults;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.VisitedFileDependencyResults;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results.VisitedGraphResults;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult.ResolvedGraphResults;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult.TransientConfigurationResultsBuilder;
-
-import java.util.Set;
 
 /**
  * Intermediate state saved between graph resolution and artifact resolution.
  */
 public class ArtifactResolveState {
-    final ResolvedGraphResults graphResults;
+    final VisitedGraphResults graphResults;
+    final ResolvedGraphResults legacyGraphResults;
     final VisitedArtifactsResults artifactsResults;
     final VisitedFileDependencyResults fileDependencyResults;
-    final Set<UnresolvedDependency> failures;
     final TransientConfigurationResultsBuilder transientConfigurationResultsBuilder;
 
-    ArtifactResolveState(ResolvedGraphResults graphResults, VisitedArtifactsResults artifactsResults, VisitedFileDependencyResults fileDependencyResults, Set<UnresolvedDependency> failures, TransientConfigurationResultsBuilder transientConfigurationResultsBuilder) {
+    ArtifactResolveState(
+        VisitedGraphResults graphResults,
+        ResolvedGraphResults legacyGraphResults,
+        VisitedArtifactsResults artifactsResults,
+        VisitedFileDependencyResults fileDependencyResults,
+        TransientConfigurationResultsBuilder transientConfigurationResultsBuilder
+    ) {
         this.graphResults = graphResults;
+        this.legacyGraphResults = legacyGraphResults;
         this.artifactsResults = artifactsResults;
         this.fileDependencyResults = fileDependencyResults;
-        this.failures = failures;
         this.transientConfigurationResultsBuilder = transientConfigurationResultsBuilder;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
@@ -46,6 +46,8 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.Composit
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.CompositeDependencyGraphVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.FailOnVersionConflictGraphVisitor;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results.DefaultVisitedGraphResults;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results.VisitedGraphResults;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult.DefaultResolvedConfigurationBuilder;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult.ResolutionFailureCollector;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult.ResolvedConfigurationDependencyGraphVisitor;
@@ -163,9 +165,12 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
         DefaultResolvedArtifactsBuilder artifactsVisitor = new DefaultResolvedArtifactsBuilder(buildProjectDependencies, resolutionStrategy.getSortOrder());
         resolver.resolve(resolveContext, ImmutableList.of(), metadataHandler, IS_LOCAL_EDGE, graphVisitor, artifactsVisitor, attributesSchema, artifactTypeRegistry, projectDependencyResolver, false);
 
+        Set<UnresolvedDependency> unresolvedDependencies = failureCollector.complete(Collections.emptySet());
+        VisitedGraphResults graphResults = new DefaultVisitedGraphResults(resolveContext.asDescribable(), resolutionResultBuilder.getResolutionResult(), unresolvedDependencies, null);
+
         ArtifactVariantSelector artifactVariantSelector = variantSelectorFactory.create(resolveContext.getDependenciesResolverFactory());
-        VisitedArtifactSet artifacts = new BuildDependenciesOnlyVisitedArtifactSet(failureCollector.complete(Collections.emptySet()), artifactsVisitor.complete(), artifactVariantSelector);
-        return DefaultResolverResults.buildDependenciesResolved(resolutionResultBuilder.getResolutionResult(), localComponentsVisitor, artifacts);
+        VisitedArtifactSet artifacts = new BuildDependenciesOnlyVisitedArtifactSet(graphResults, artifactsVisitor.complete(), artifactVariantSelector);
+        return DefaultResolverResults.buildDependenciesResolved(graphResults, localComponentsVisitor, artifacts);
     }
 
     @Override
@@ -221,33 +226,34 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
 
         VisitedArtifactsResults artifactsResults = artifactsBuilder.complete();
         VisitedFileDependencyResults fileDependencyResults = fileDependencyVisitor.complete();
-        ResolvedGraphResults graphResults = oldModelBuilder.complete();
+        ResolvedGraphResults legacyGraphResults = oldModelBuilder.complete();
 
-        // TODO: Failures from dependency locking should be included in the extraFailuresBuilder.
+        // TODO: Failures from dependency locking should be included in the additionalFailuresBuilder.
         Set<UnresolvedDependency> lockingFailures = Collections.emptySet();
-        ImmutableSet.Builder<Throwable> extraFailuresBuilder = ImmutableSet.builder();
+        ImmutableSet.Builder<Throwable> additionalFailuresBuilder = ImmutableSet.builder();
         if (lockingVisitor != null) {
             lockingFailures = lockingVisitor.collectLockingFailures();
         }
         if (versionConflictVisitor != null) {
             for (Throwable failure : versionConflictVisitor.collectConflictFailures()) {
-                extraFailuresBuilder.add(failure);
+                additionalFailuresBuilder.add(failure);
             }
         }
 
-        Set<Throwable> extraFailures = extraFailuresBuilder.build();
+        Set<Throwable> additionalFailures = additionalFailuresBuilder.build();
         Set<UnresolvedDependency> resolutionFailures = failureCollector.complete(lockingFailures);
 
-        ResolveException extraFailure = exceptionContextualizer.mapFailures(extraFailures, resolveContext.getDisplayName(), "dependencies");
-        MinimalResolutionResult resolutionResult = newModelBuilder.complete(extraFailure, lockingFailures);
+        MinimalResolutionResult resolutionResult = newModelBuilder.complete(lockingFailures);
+        ResolveException additionalFailure = exceptionContextualizer.mapFailures(additionalFailures, resolveContext.getDisplayName(), "dependencies");
+        VisitedGraphResults graphResults = new DefaultVisitedGraphResults(resolveContext.asDescribable(), resolutionResult, resolutionFailures, additionalFailure);
 
-        ArtifactResolveState artifactResolveState = new ArtifactResolveState(graphResults, artifactsResults, fileDependencyResults, resolutionFailures, oldTransientModelBuilder);
+        ArtifactResolveState artifactResolveState = new ArtifactResolveState(graphResults, legacyGraphResults, artifactsResults, fileDependencyResults, oldTransientModelBuilder);
         ArtifactVariantSelector selector = variantSelectorFactory.create(resolveContext.getDependenciesResolverFactory());
-        VisitedArtifactSet visitedArtifactSet = new BuildDependenciesOnlyVisitedArtifactSet(resolutionFailures, artifactsResults, selector);
-        ResolverResults results = DefaultResolverResults.graphResolved(resolutionResult, localComponentsVisitor, visitedArtifactSet, artifactResolveState);
+        VisitedArtifactSet visitedArtifactSet = new BuildDependenciesOnlyVisitedArtifactSet(graphResults, artifactsResults, selector);
+        ResolverResults results = DefaultResolverResults.graphResolved(graphResults, localComponentsVisitor, visitedArtifactSet, artifactResolveState);
 
         // Only write dependency locks if resolution completed without failure.
-        if (lockingVisitor != null && resolutionFailures.isEmpty() && extraFailures.isEmpty() && lockingFailures.isEmpty()) {
+        if (lockingVisitor != null && !graphResults.hasResolutionFailure()) {
             lockingVisitor.writeLocks();
         }
 
@@ -265,11 +271,21 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
         VisitedArtifactsResults artifactResults = resolveState.artifactsResults;
         TransientConfigurationResultsBuilder transientConfigurationResultsBuilder = resolveState.transientConfigurationResultsBuilder;
 
-        TransientConfigurationResultsLoader transientConfigurationResultsFactory = new TransientConfigurationResultsLoader(transientConfigurationResultsBuilder, resolveState.graphResults);
+        TransientConfigurationResultsLoader transientConfigurationResultsFactory = new TransientConfigurationResultsLoader(transientConfigurationResultsBuilder, resolveState.legacyGraphResults);
 
         ArtifactVariantSelector selector = variantSelectorFactory.create(resolveContext.getDependenciesResolverFactory());
-        DefaultLenientConfiguration result = new DefaultLenientConfiguration(resolveContext, resolveState.failures, graphResults.getMinimalResolutionResult().getExtraFailure(), artifactResults, resolveState.fileDependencyResults, transientConfigurationResultsFactory, buildOperationExecutor, dependencyVerificationOverride, workerLeaseService, selector);
+        DefaultLenientConfiguration result = new DefaultLenientConfiguration(
+            resolveContext,
+            resolveState.graphResults,
+            artifactResults,
+            resolveState.fileDependencyResults,
+            transientConfigurationResultsFactory,
+            buildOperationExecutor,
+            dependencyVerificationOverride,
+            workerLeaseService,
+            selector
+        );
 
-        return DefaultResolverResults.artifactsResolved(graphResults.getMinimalResolutionResult(), graphResults.getResolvedLocalComponents(), new DefaultResolvedConfiguration(result), result);
+        return DefaultResolverResults.artifactsResolved(graphResults.getVisitedGraph(), graphResults.getResolvedLocalComponents(), new DefaultResolvedConfiguration(result), result);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
@@ -105,7 +105,7 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
         ArtifactVariantSelector artifactVariantSelector
     ) {
         this.resolveContext = resolveContext;
-        this.implicitAttributes = graphResults.getResolutionResult().getRequestedAttributes();
+        this.implicitAttributes = resolveContext.getAttributes().asImmutable();
         this.graphResults = graphResults;
         this.artifactResults = artifactResults;
         this.fileDependencyResults = fileDependencyResults;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultResolvedConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultResolvedConfiguration.java
@@ -37,12 +37,15 @@ public class DefaultResolvedConfiguration implements ResolvedConfiguration {
 
     @Override
     public boolean hasError() {
-        return configuration.hasError();
+        return configuration.getGraphResults().hasResolutionFailure();
     }
 
     @Override
     public void rethrowFailure() throws ResolveException {
-        configuration.rethrowFailure();
+        ResolveException failure = configuration.getGraphResults().getResolutionFailure();
+        if (failure != null) {
+            throw failure;
+        }
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultResolvedConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultResolvedConfiguration.java
@@ -21,11 +21,14 @@ import org.gradle.api.artifacts.ResolveException;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedConfiguration;
 import org.gradle.api.artifacts.ResolvedDependency;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results.VisitedGraphResults;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 
 public class DefaultResolvedConfiguration implements ResolvedConfiguration {
@@ -37,15 +40,20 @@ public class DefaultResolvedConfiguration implements ResolvedConfiguration {
 
     @Override
     public boolean hasError() {
-        return configuration.getGraphResults().hasResolutionFailure();
+        return configuration.getGraphResults().hasAnyFailure();
     }
 
     @Override
     public void rethrowFailure() throws ResolveException {
-        ResolveException failure = configuration.getGraphResults().getResolutionFailure();
-        if (failure != null) {
-            throw failure;
+        VisitedGraphResults graphResults = configuration.getGraphResults();
+
+        if (!graphResults.hasAnyFailure()) {
+            return;
         }
+
+        List<Throwable> failures = new ArrayList<>();
+        graphResults.visitFailures(failures::add);
+        throw new ResolveException(configuration.getDisplayName().toString(), failures);
     }
 
     @Override
@@ -66,7 +74,7 @@ public class DefaultResolvedConfiguration implements ResolvedConfiguration {
         if (!failures.isEmpty()) {
             throw new DefaultLenientConfiguration.ArtifactResolveException(
                 "files",
-                configuration.getResolveContext().getDisplayName(),
+                configuration.getDisplayName().toString(),
                 failures
             );
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ErrorHandlingConfigurationResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ErrorHandlingConfigurationResolver.java
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.artifacts.ivyservice;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.gradle.api.Describable;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.LenientConfiguration;
 import org.gradle.api.artifacts.ResolveException;
@@ -23,20 +24,26 @@ import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedConfiguration;
 import org.gradle.api.artifacts.ResolvedDependency;
 import org.gradle.api.artifacts.UnresolvedDependency;
+import org.gradle.api.artifacts.result.ResolvedComponentResult;
+import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.ConfigurationResolver;
 import org.gradle.api.internal.artifacts.DefaultResolverResults;
 import org.gradle.api.internal.artifacts.ResolveContext;
 import org.gradle.api.internal.artifacts.ResolveExceptionContextualizer;
 import org.gradle.api.internal.artifacts.ResolverResults;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.VisitedArtifactSet;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results.DefaultVisitedGraphResults;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results.VisitedGraphResults;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.projectresult.ResolvedLocalComponentsResult;
 import org.gradle.api.internal.artifacts.repositories.ResolutionAwareRepository;
 import org.gradle.api.internal.artifacts.result.MinimalResolutionResult;
 import org.gradle.api.specs.Spec;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * Handles fatal and non-fatal exceptions thrown by a delegate resolver.
@@ -60,7 +67,7 @@ public class ErrorHandlingConfigurationResolver implements ConfigurationResolver
         try {
             return delegate.resolveBuildDependencies(resolveContext);
         } catch (Exception e) {
-            return new BrokenResolverResults(exceptionMapper.contextualize(e, resolveContext));
+            return new BrokenResolverResults(resolveContext.asDescribable(), exceptionMapper.contextualize(e, resolveContext));
         }
     }
 
@@ -69,7 +76,7 @@ public class ErrorHandlingConfigurationResolver implements ConfigurationResolver
         try {
             return delegate.resolveGraph(resolveContext);
         } catch (Exception e) {
-            return new BrokenResolverResults(exceptionMapper.contextualize(e, resolveContext));
+            return new BrokenResolverResults(resolveContext.asDescribable(), exceptionMapper.contextualize(e, resolveContext));
         }
     }
 
@@ -79,14 +86,14 @@ public class ErrorHandlingConfigurationResolver implements ConfigurationResolver
         try {
             artifactResults = delegate.resolveArtifacts(resolveContext, graphResults);
         } catch (Exception e) {
-            return new BrokenResolverResults(exceptionMapper.contextualize(e, resolveContext));
+            return new BrokenResolverResults(resolveContext.asDescribable(), exceptionMapper.contextualize(e, resolveContext));
         }
 
         // Handle non-fatal failures in old model (ResolvedConfiguration) with `ErrorHandling` wrappers.
         // The new model (ResolutionResult) handles non-fatal failure without needing wrappers.
         ResolvedConfiguration wrappedConfiguration = new ErrorHandlingResolvedConfiguration(artifactResults.getResolvedConfiguration(), resolveContext, exceptionMapper);
         return DefaultResolverResults.artifactsResolved(
-            graphResults.getMinimalResolutionResult(),
+            graphResults.getVisitedGraph(),
             graphResults.getResolvedLocalComponents(),
             wrappedConfiguration,
             artifactResults.getVisitedArtifacts()
@@ -268,20 +275,27 @@ public class ErrorHandlingConfigurationResolver implements ConfigurationResolver
     @VisibleForTesting
     public static class BrokenResolverResults implements ResolverResults {
 
+        private final Describable resolveContextDisplayName;
         private final ResolveException failure;
 
-        public BrokenResolverResults(ResolveException failure) {
+        public BrokenResolverResults(Describable resolveContextDisplayName, ResolveException failure) {
+            this.resolveContextDisplayName = resolveContextDisplayName;
             this.failure = failure;
-        }
-
-        @Override
-        public boolean hasError() {
-            return true;
         }
 
         @Override
         public ResolvedConfiguration getResolvedConfiguration() {
             return new BrokenResolvedConfiguration(failure);
+        }
+
+        @Override
+        public VisitedGraphResults getVisitedGraph() {
+            return new DefaultVisitedGraphResults(
+                resolveContextDisplayName,
+                new BrokenMinimalResolutionResult(failure),
+                Collections.emptySet(),
+                failure
+            );
         }
 
         @Override
@@ -298,14 +312,25 @@ public class ErrorHandlingConfigurationResolver implements ConfigurationResolver
         public ArtifactResolveState getArtifactResolveState() {
             throw failure;
         }
+    }
 
-        @Override
-        public ResolveException getFailure() {
-            return failure;
+    private static class BrokenMinimalResolutionResult implements MinimalResolutionResult {
+
+        private final ResolveException failure;
+
+        public BrokenMinimalResolutionResult(ResolveException failure) {
+            this.failure = failure;
         }
 
         @Override
-        public MinimalResolutionResult getMinimalResolutionResult() {
+        public Supplier<ResolvedComponentResult> getRootSource() {
+            return () -> {
+                throw failure;
+            };
+        }
+
+        @Override
+        public AttributeContainer getRequestedAttributes() {
             throw failure;
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/InMemoryResolutionResultBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/InMemoryResolutionResultBuilder.java
@@ -78,6 +78,6 @@ public class InMemoryResolutionResultBuilder implements DependencyGraphVisitor {
         if (requestAttributes == null) {
             throw new IllegalStateException("Resolution result not computed yet");
         }
-        return new DefaultMinimalResolutionResult(() -> root, requestAttributes, null);
+        return new DefaultMinimalResolutionResult(() -> root, requestAttributes);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolver.java
@@ -38,6 +38,8 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.Artif
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.SelectedArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.VisitedArtifactSet;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results.DefaultVisitedGraphResults;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results.VisitedGraphResults;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.projectresult.ResolvedLocalComponentsResult;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.projectresult.ResolvedLocalComponentsResultGraphVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.DefaultResolutionResultBuilder;
@@ -102,14 +104,15 @@ public class ShortCircuitEmptyConfigurationResolver implements ConfigurationReso
         ModuleVersionIdentifier id = moduleIdentifierFactory.moduleWithVersion(module.getGroup(), module.getName(), module.getVersion());
         ComponentIdentifier componentIdentifier = componentIdentifierFactory.createComponentIdentifier(module);
         MinimalResolutionResult emptyResult = DefaultResolutionResultBuilder.empty(id, componentIdentifier, resolveContext.getAttributes());
+        VisitedGraphResults graphResults = new DefaultVisitedGraphResults(resolveContext.asDescribable(), emptyResult, Collections.emptySet(), null);
         ResolvedLocalComponentsResult emptyProjectResult = new ResolvedLocalComponentsResultGraphVisitor(thisBuild);
-        return DefaultResolverResults.graphResolved(emptyResult, emptyProjectResult, EmptyResults.INSTANCE, null);
+        return DefaultResolverResults.graphResolved(graphResults, emptyProjectResult, EmptyResults.INSTANCE, null);
     }
 
     @Override
     public ResolverResults resolveArtifacts(ResolveContext resolveContext, ResolverResults graphResults) throws ResolveException {
         if (!resolveContext.hasDependencies() && graphResults.getVisitedArtifacts() == EmptyResults.INSTANCE) {
-            return DefaultResolverResults.artifactsResolved(graphResults.getMinimalResolutionResult(), graphResults.getResolvedLocalComponents(), new EmptyResolvedConfiguration(), EmptyResults.INSTANCE);
+            return DefaultResolverResults.artifactsResolved(graphResults.getVisitedGraph(), graphResults.getResolvedLocalComponents(), new EmptyResolvedConfiguration(), EmptyResults.INSTANCE);
         } else {
             assert graphResults.getArtifactResolveState() != null;
             return delegate.resolveArtifacts(resolveContext, graphResults);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolver.java
@@ -103,8 +103,8 @@ public class ShortCircuitEmptyConfigurationResolver implements ConfigurationReso
         Module module = resolveContext.getModule();
         ModuleVersionIdentifier id = moduleIdentifierFactory.moduleWithVersion(module.getGroup(), module.getName(), module.getVersion());
         ComponentIdentifier componentIdentifier = componentIdentifierFactory.createComponentIdentifier(module);
-        MinimalResolutionResult emptyResult = DefaultResolutionResultBuilder.empty(id, componentIdentifier, resolveContext.getAttributes());
-        VisitedGraphResults graphResults = new DefaultVisitedGraphResults(resolveContext.asDescribable(), emptyResult, Collections.emptySet(), null);
+        MinimalResolutionResult emptyResult = DefaultResolutionResultBuilder.empty(id, componentIdentifier, resolveContext.getAttributes().asImmutable());
+        VisitedGraphResults graphResults = new DefaultVisitedGraphResults(emptyResult, Collections.emptySet(), null);
         ResolvedLocalComponentsResult emptyProjectResult = new ResolvedLocalComponentsResultGraphVisitor(thisBuild);
         return DefaultResolverResults.graphResolved(graphResults, emptyProjectResult, EmptyResults.INSTANCE, null);
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/BuildDependenciesOnlyVisitedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/BuildDependenciesOnlyVisitedArtifactSet.java
@@ -54,7 +54,7 @@ public class BuildDependenciesOnlyVisitedArtifactSet implements VisitedArtifactS
 
         @Override
         public void visitDependencies(TaskDependencyResolveContext context) {
-            graphResults.visitResolutionFailures(context::visitFailure);
+            graphResults.visitFailures(context::visitFailure);
             context.add(selectedArtifacts);
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/results/DefaultVisitedGraphResults.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/results/DefaultVisitedGraphResults.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results;
+
+import org.gradle.api.Describable;
+import org.gradle.api.artifacts.ResolveException;
+import org.gradle.api.artifacts.UnresolvedDependency;
+import org.gradle.api.internal.artifacts.result.MinimalResolutionResult;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+
+/**
+ * Default implementation of {@link VisitedGraphResults}.
+ */
+public class DefaultVisitedGraphResults implements VisitedGraphResults {
+
+    private final Describable resolveContextDisplayName;
+    private final MinimalResolutionResult resolutionResult;
+    private final Set<UnresolvedDependency> unresolvedDependencies;
+    private final ResolveException additionalFailure;
+
+    public DefaultVisitedGraphResults(
+        Describable resolveContextDisplayName,
+        MinimalResolutionResult resolutionResult,
+        Set<UnresolvedDependency> unresolvedDependencies,
+        @Nullable ResolveException additionalFailure
+    ) {
+        this.resolveContextDisplayName = resolveContextDisplayName;
+        this.resolutionResult = resolutionResult;
+        this.unresolvedDependencies = unresolvedDependencies;
+        this.additionalFailure = additionalFailure;
+    }
+
+    @Override
+    public boolean hasResolutionFailure() {
+        return !unresolvedDependencies.isEmpty() || additionalFailure != null;
+    }
+
+    @Nullable
+    @Override
+    public ResolveException getResolutionFailure() {
+        if (!hasResolutionFailure()) {
+            return null;
+        }
+
+        List<Throwable> failures = new ArrayList<>();
+        visitResolutionFailures(failures::add);
+        return new ResolveException(resolveContextDisplayName.getDisplayName(), failures);
+    }
+
+    @Override
+    public void visitResolutionFailures(Consumer<Throwable> visitor) {
+        for (UnresolvedDependency unresolvedDependency : unresolvedDependencies) {
+            visitor.accept(unresolvedDependency.getProblem());
+        }
+        if (additionalFailure != null) {
+            visitor.accept(additionalFailure);
+        }
+    }
+
+    @Override
+    public MinimalResolutionResult getResolutionResult() {
+        return resolutionResult;
+    }
+
+    @Override
+    public Set<UnresolvedDependency> getUnresolvedDependencies() {
+        return unresolvedDependencies;
+    }
+
+    @Nullable
+    @Override
+    public ResolveException getAdditionalResolutionFailure() {
+        return additionalFailure;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/results/VisitedGraphResults.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/results/VisitedGraphResults.java
@@ -20,7 +20,7 @@ import org.gradle.api.artifacts.ResolveException;
 import org.gradle.api.artifacts.UnresolvedDependency;
 import org.gradle.api.internal.artifacts.result.MinimalResolutionResult;
 
-import javax.annotation.Nullable;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 
@@ -32,38 +32,28 @@ import java.util.function.Consumer;
 public interface VisitedGraphResults {
 
     /**
-     * Returns true if any resolution failures occurred while building these results.
+     * Returns true if any failures occurred while building these results.
      */
-    boolean hasResolutionFailure();
-
-    /**
-     * Returns an optional exception describing all resolution failures that occurred while building these results.
-     * This failure encapsulates all failures provided by {@link #getUnresolvedDependencies()} and
-     * {@link #getAdditionalResolutionFailure()}.
-     *
-     * @return null if {@link #hasResolutionFailure()} is false.
-     */
-    @Nullable
-    ResolveException getResolutionFailure();
+    boolean hasAnyFailure();
 
     /**
      * Visits all failures that occurred while resolving the graph.
+     *
+     * <p>No failures are visited if {@link #hasAnyFailure()} is false</p>
      */
-    void visitResolutionFailures(Consumer<Throwable> visitor);
+    void visitFailures(Consumer<Throwable> visitor);
 
     /**
-     * Returns all resolution failures.
+     * Returns all failures to resolve a dependency.
+     * These failures are also accessible via the resolution result.
      */
     Set<UnresolvedDependency> getUnresolvedDependencies();
 
     /**
-     * Returns an optional failure describing all failures encountered during
-     * resolution that are _not_ captured in the resolution result. Since the
-     * resolution result provides access to unresolved dependencies, this failure
-     * captures anything not provided by {@link #getUnresolvedDependencies()}.
+     * Returns an optional failure describing an error that occurred during resolution.
+     * This failure does not encompass unresolved dependencies and is _not_ captured in the resolution result.
      */
-    @Nullable
-    ResolveException getAdditionalResolutionFailure();
+    Optional<ResolveException> getResolutionFailure();
 
     /**
      * Returns the root of the dependency graph.

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/results/VisitedGraphResults.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/results/VisitedGraphResults.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results;
+
+import org.gradle.api.artifacts.ResolveException;
+import org.gradle.api.artifacts.UnresolvedDependency;
+import org.gradle.api.internal.artifacts.result.MinimalResolutionResult;
+
+import javax.annotation.Nullable;
+import java.util.Set;
+import java.util.function.Consumer;
+
+/**
+ * Models the result of resolving dependency graph. Provides access to the root
+ * of the dependency graph, as well as access to any failures that occurred while
+ * building the graph.
+ */
+public interface VisitedGraphResults {
+
+    /**
+     * Returns true if any resolution failures occurred while building these results.
+     */
+    boolean hasResolutionFailure();
+
+    /**
+     * Returns an optional exception describing all resolution failures that occurred while building these results.
+     * This failure encapsulates all failures provided by {@link #getUnresolvedDependencies()} and
+     * {@link #getAdditionalResolutionFailure()}.
+     *
+     * @return null if {@link #hasResolutionFailure()} is false.
+     */
+    @Nullable
+    ResolveException getResolutionFailure();
+
+    /**
+     * Visits all failures that occurred while resolving the graph.
+     */
+    void visitResolutionFailures(Consumer<Throwable> visitor);
+
+    /**
+     * Returns all resolution failures.
+     */
+    Set<UnresolvedDependency> getUnresolvedDependencies();
+
+    /**
+     * Returns an optional failure describing all failures encountered during
+     * resolution that are _not_ captured in the resolution result. Since the
+     * resolution result provides access to unresolved dependencies, this failure
+     * captures anything not provided by {@link #getUnresolvedDependencies()}.
+     */
+    @Nullable
+    ResolveException getAdditionalResolutionFailure();
+
+    /**
+     * Returns the root of the dependency graph.
+     */
+    MinimalResolutionResult getResolutionResult();
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/results/package-info.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/results/package-info.java
@@ -14,19 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.artifacts.result;
+@NonNullApi
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results;
 
-import org.gradle.api.artifacts.ResolveException;
-import org.gradle.api.artifacts.result.ResolutionResult;
-import org.gradle.api.provider.Provider;
-
-/**
- * Internal counterpart to {@link ResolutionResult}.
- */
-public interface ResolutionResultInternal extends ResolutionResult {
-
-    /**
-     * An optional non-fatal failure which may be attached to a resolution result.
-     */
-    Provider<ResolveException> getExtraFailure();
-}
+import org.gradle.api.NonNullApi;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DefaultResolutionResultBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DefaultResolutionResultBuilder.java
@@ -31,11 +31,11 @@ import org.gradle.api.artifacts.result.DependencyResult;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.artifacts.result.ResolvedDependencyResult;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
-import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedGraphDependency;
 import org.gradle.api.internal.artifacts.result.DefaultMinimalResolutionResult;
 import org.gradle.api.internal.artifacts.result.DefaultResolvedComponentResult;
 import org.gradle.api.internal.artifacts.result.MinimalResolutionResult;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.Describables;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
@@ -60,7 +60,7 @@ public class DefaultResolutionResultBuilder implements ResolvedComponentVisitor 
     private ImmutableList<ResolvedVariantResult> allVariants;
     private final Map<Long, ResolvedVariantResult> selectedVariants = new LinkedHashMap<>();
 
-    public static MinimalResolutionResult empty(ModuleVersionIdentifier id, ComponentIdentifier componentIdentifier, AttributeContainer attributes) {
+    public static MinimalResolutionResult empty(ModuleVersionIdentifier id, ComponentIdentifier componentIdentifier, ImmutableAttributes attributes) {
         DefaultResolutionResultBuilder builder = new DefaultResolutionResultBuilder();
         builder.startVisitComponent(0L, ComponentSelectionReasons.root(), null);
         builder.visitComponentDetails(componentIdentifier, id);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DefaultResolutionResultBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DefaultResolutionResultBuilder.java
@@ -67,7 +67,7 @@ public class DefaultResolutionResultBuilder implements ResolvedComponentVisitor 
         builder.visitComponentVariants(Collections.emptyList());
         builder.endVisitComponent();
         ResolvedComponentResult root = builder.getRoot(0L);
-        return new DefaultMinimalResolutionResult(() -> root, attributes, null);
+        return new DefaultMinimalResolutionResult(() -> root, attributes);
     }
 
     public ResolvedComponentResult getRoot(long rootId) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilder.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result;
 
 import com.google.common.collect.Lists;
-import org.gradle.api.artifacts.ResolveException;
 import org.gradle.api.artifacts.UnresolvedDependency;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
@@ -42,7 +41,6 @@ import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.time.Time;
 import org.gradle.internal.time.Timer;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
@@ -90,10 +88,10 @@ public class StreamingResolutionResultBuilder implements DependencyGraphVisitor 
         this.desugaring = desugaring;
     }
 
-    public MinimalResolutionResult complete(@Nullable ResolveException extraFailure, Set<UnresolvedDependency> dependencyLockingFailures) {
+    public MinimalResolutionResult complete(Set<UnresolvedDependency> dependencyLockingFailures) {
         BinaryStore.BinaryData data = store.done();
         RootFactory rootSource = new RootFactory(data, failures, cache, componentSelectorSerializer, dependencyResultSerializer, componentResultSerializer, dependencyLockingFailures);
-        return new DefaultMinimalResolutionResult(rootSource::create, rootAttributes, extraFailure);
+        return new DefaultMinimalResolutionResult(rootSource::create, rootAttributes);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilder.java
@@ -20,7 +20,6 @@ import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.UnresolvedDependency;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
-import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphComponent;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphEdge;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode;
@@ -31,6 +30,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.RootGrap
 import org.gradle.api.internal.artifacts.result.DefaultMinimalResolutionResult;
 import org.gradle.api.internal.artifacts.result.MinimalResolutionResult;
 import org.gradle.api.internal.attributes.AttributeDesugaring;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.cache.internal.BinaryStore;
@@ -67,7 +67,7 @@ public class StreamingResolutionResultBuilder implements DependencyGraphVisitor 
     private final Set<Long> visitedComponents = new HashSet<>();
     private final AttributeDesugaring desugaring;
 
-    private AttributeContainer rootAttributes;
+    private ImmutableAttributes rootAttributes;
     private boolean mayHaveVirtualPlatforms;
 
     public StreamingResolutionResultBuilder(

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultMinimalResolutionResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultMinimalResolutionResult.java
@@ -17,7 +17,7 @@
 package org.gradle.api.internal.artifacts.result;
 
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
-import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 
 import java.util.function.Supplier;
 
@@ -27,11 +27,11 @@ import java.util.function.Supplier;
 public class DefaultMinimalResolutionResult implements MinimalResolutionResult {
 
     private final Supplier<ResolvedComponentResult> rootSource;
-    private final AttributeContainer requestedAttributes;
+    private final ImmutableAttributes requestedAttributes;
 
     public DefaultMinimalResolutionResult(
         Supplier<ResolvedComponentResult> rootSource,
-        AttributeContainer requestedAttributes
+        ImmutableAttributes requestedAttributes
     ) {
         this.rootSource = rootSource;
         this.requestedAttributes = requestedAttributes;
@@ -43,7 +43,7 @@ public class DefaultMinimalResolutionResult implements MinimalResolutionResult {
     }
 
     @Override
-    public AttributeContainer getRequestedAttributes() {
+    public ImmutableAttributes getRequestedAttributes() {
         return requestedAttributes;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultMinimalResolutionResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultMinimalResolutionResult.java
@@ -16,11 +16,9 @@
 
 package org.gradle.api.internal.artifacts.result;
 
-import org.gradle.api.artifacts.ResolveException;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.attributes.AttributeContainer;
 
-import javax.annotation.Nullable;
 import java.util.function.Supplier;
 
 /**
@@ -30,28 +28,22 @@ public class DefaultMinimalResolutionResult implements MinimalResolutionResult {
 
     private final Supplier<ResolvedComponentResult> rootSource;
     private final AttributeContainer requestedAttributes;
-    private final ResolveException extraFailure;
 
     public DefaultMinimalResolutionResult(
         Supplier<ResolvedComponentResult> rootSource,
-        AttributeContainer requestedAttributes,
-        @Nullable ResolveException extraFailure
+        AttributeContainer requestedAttributes
     ) {
         this.rootSource = rootSource;
         this.requestedAttributes = requestedAttributes;
-        this.extraFailure = extraFailure;
     }
 
+    @Override
     public Supplier<ResolvedComponentResult> getRootSource() {
         return rootSource;
     }
 
+    @Override
     public AttributeContainer getRequestedAttributes() {
         return requestedAttributes;
-    }
-
-    @Nullable
-    public ResolveException getExtraFailure() {
-        return extraFailure;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolutionResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolutionResult.java
@@ -18,12 +18,11 @@ package org.gradle.api.internal.artifacts.result;
 
 import groovy.lang.Closure;
 import org.gradle.api.Action;
-import org.gradle.api.artifacts.ResolveException;
 import org.gradle.api.artifacts.result.DependencyResult;
+import org.gradle.api.artifacts.result.ResolutionResult;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.provider.DefaultProvider;
-import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.Actions;
 import org.gradle.util.internal.ConfigureUtil;
@@ -36,7 +35,7 @@ import java.util.Set;
 import static org.gradle.api.internal.artifacts.result.DefaultResolvedComponentResult.eachElement;
 
 @SuppressWarnings("rawtypes")
-public class DefaultResolutionResult implements ResolutionResultInternal {
+public class DefaultResolutionResult implements ResolutionResult {
 
     private final MinimalResolutionResult minimal;
 
@@ -52,11 +51,6 @@ public class DefaultResolutionResult implements ResolutionResultInternal {
     @Override
     public Provider<ResolvedComponentResult> getRootComponent() {
         return new DefaultProvider<>(() -> minimal.getRootSource().get());
-    }
-
-    @Override
-    public Provider<ResolveException> getExtraFailure() {
-        return Providers.ofNullable(minimal.getExtraFailure());
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/MinimalResolutionResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/MinimalResolutionResult.java
@@ -16,11 +16,9 @@
 
 package org.gradle.api.internal.artifacts.result;
 
-import org.gradle.api.artifacts.ResolveException;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.attributes.AttributeContainer;
 
-import javax.annotation.Nullable;
 import java.util.function.Supplier;
 
 /**
@@ -37,10 +35,4 @@ public interface MinimalResolutionResult {
      * The request attributes used to initially build the dependency graph.
      */
     AttributeContainer getRequestedAttributes();
-
-    /**
-     * An optional non-fatal failure emitted during graph resolution.
-     */
-    @Nullable
-    ResolveException getExtraFailure();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/MinimalResolutionResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/MinimalResolutionResult.java
@@ -17,7 +17,7 @@
 package org.gradle.api.internal.artifacts.result;
 
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
-import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 
 import java.util.function.Supplier;
 
@@ -34,5 +34,5 @@ public interface MinimalResolutionResult {
     /**
      * The request attributes used to initially build the dependency graph.
      */
-    AttributeContainer getRequestedAttributes();
+    ImmutableAttributes getRequestedAttributes();
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/DefaultResolverResultsSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/DefaultResolverResultsSpec.groovy
@@ -16,69 +16,48 @@
 
 package org.gradle.api.internal.artifacts
 
-import org.gradle.api.artifacts.ResolveException
+
 import org.gradle.api.artifacts.ResolvedConfiguration
 import org.gradle.api.internal.artifacts.ivyservice.ArtifactResolveState
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.VisitedArtifactSet
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results.VisitedGraphResults
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.projectresult.ResolvedLocalComponentsResult
-import org.gradle.api.internal.artifacts.result.MinimalResolutionResult
 import spock.lang.Specification
 
 class DefaultResolverResultsSpec extends Specification {
     private resolvedConfiguration = Mock(ResolvedConfiguration)
-    private minimalResolutionResult = Mock(MinimalResolutionResult)
+    private graphResults = Mock(VisitedGraphResults)
     private projectConfigurationResult = Mock(ResolvedLocalComponentsResult)
     private visitedArtifactsSet = Mock(VisitedArtifactSet)
     private artifactResolveState = Mock(ArtifactResolveState)
 
     def "provides build dependencies results"() {
         when:
-        def results = DefaultResolverResults.buildDependenciesResolved(minimalResolutionResult, projectConfigurationResult, visitedArtifactsSet)
+        def results = DefaultResolverResults.buildDependenciesResolved(graphResults, projectConfigurationResult, visitedArtifactsSet)
 
         then:
-        results.minimalResolutionResult == minimalResolutionResult
+        results.visitedGraph == graphResults
         results.resolvedLocalComponents == projectConfigurationResult
         results.visitedArtifacts == visitedArtifactsSet
     }
 
     def "provides resolve results"() {
         when:
-        def results = DefaultResolverResults.graphResolved(minimalResolutionResult, projectConfigurationResult, visitedArtifactsSet, artifactResolveState)
+        def results = DefaultResolverResults.graphResolved(graphResults, projectConfigurationResult, visitedArtifactsSet, artifactResolveState)
 
         then:
-        results.minimalResolutionResult == minimalResolutionResult
+        results.visitedGraph == graphResults
         results.resolvedLocalComponents == projectConfigurationResult
         results.visitedArtifacts == visitedArtifactsSet
         results.artifactResolveState == artifactResolveState
 
         when:
-        results = DefaultResolverResults.artifactsResolved(minimalResolutionResult, projectConfigurationResult, resolvedConfiguration, visitedArtifactsSet)
+        results = DefaultResolverResults.artifactsResolved(graphResults, projectConfigurationResult, resolvedConfiguration, visitedArtifactsSet)
 
         then:
-        results.minimalResolutionResult == minimalResolutionResult
+        results.visitedGraph == graphResults
         results.resolvedLocalComponents == projectConfigurationResult
         results.visitedArtifacts == visitedArtifactsSet
         results.resolvedConfiguration == resolvedConfiguration
-    }
-
-    def "resolution result failures are passed-through"() {
-        def failure = Mock(ResolveException)
-        def resolutionResult = Mock(MinimalResolutionResult) {
-            getExtraFailure() >> failure
-        }
-
-        def results = DefaultResolverResults.graphResolved(resolutionResult, Mock(ResolvedLocalComponentsResult), Mock(VisitedArtifactSet), Mock(ArtifactResolveState))
-
-        when:
-        def hasFailure = results.hasError()
-
-        then:
-        hasFailure
-
-        when:
-        def actual = results.getFailure()
-
-        then:
-        actual == failure
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -16,7 +16,6 @@
 package org.gradle.api.internal.artifacts.configurations
 
 import org.gradle.api.Action
-import org.gradle.api.Describable
 import org.gradle.api.GradleException
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Named
@@ -382,7 +381,7 @@ class DefaultConfigurationSpec extends Specification implements InspectableConfi
         def failure = new ResolveException("bad", new RuntimeException())
 
         and:
-        _ * resolver.resolveGraph(_) >> new ErrorHandlingConfigurationResolver.BrokenResolverResults(configuration.asDescribable(), failure)
+        _ * resolver.resolveGraph(_) >> new ErrorHandlingConfigurationResolver.BrokenResolverResults(failure)
         _ * resolutionStrategy.resolveGraphToDetermineTaskDependencies() >> true
 
         when:
@@ -487,7 +486,7 @@ class DefaultConfigurationSpec extends Specification implements InspectableConfi
 
     private void expectResolved(Set<File> files) {
         def resolutionResult = new DefaultMinimalResolutionResult(() -> Stub(ResolvedComponentResult), ImmutableAttributes.EMPTY)
-        def visitedGraphResults = new DefaultVisitedGraphResults(Mock(Describable), resolutionResult, [] as Set, null)
+        def visitedGraphResults = new DefaultVisitedGraphResults(resolutionResult, [] as Set, null)
         def localComponentsResult = Stub(ResolvedLocalComponentsResult)
         def visitedArtifactSet = Stub(VisitedArtifactSet)
 
@@ -509,7 +508,7 @@ class DefaultConfigurationSpec extends Specification implements InspectableConfi
 
     private void expectResolved(ResolveException failure) {
         def resolutionResult = new DefaultMinimalResolutionResult(() -> Stub(ResolvedComponentResult), ImmutableAttributes.EMPTY)
-        def visitedGraphResults = new DefaultVisitedGraphResults(Mock(Describable), resolutionResult, [] as Set, failure)
+        def visitedGraphResults = new DefaultVisitedGraphResults(resolutionResult, [] as Set, failure)
 
         def localComponentsResult = Stub(ResolvedLocalComponentsResult)
         def visitedArtifactSet = Stub(VisitedArtifactSet)
@@ -1117,7 +1116,7 @@ class DefaultConfigurationSpec extends Specification implements InspectableConfi
             collectFiles(_) >> { return it[0] }
         }
 
-        VisitedGraphResults visitedGraphResults = new DefaultVisitedGraphResults(config.asDescribable(), resolutionResult, [] as Set, null)
+        VisitedGraphResults visitedGraphResults = new DefaultVisitedGraphResults(resolutionResult, [] as Set, null)
 
         resolver.resolveGraph(config) >> DefaultResolverResults.graphResolved(visitedGraphResults, localComponentsResult, visitedArtifactSet, Mock(ArtifactResolveState))
         resolver.resolveArtifacts(config, _ as ResolverResults) >> { ResolveContext conf, ResolverResults res ->
@@ -1844,19 +1843,19 @@ All Artifacts:
 
     private ResolverResults buildDependenciesResolved(ConfigurationInternal conf) {
         def resolutionResult = new DefaultMinimalResolutionResult(() -> Stub(ResolvedComponentResult), ImmutableAttributes.EMPTY)
-        def visitedGraphResults = new DefaultVisitedGraphResults(conf.asDescribable(), resolutionResult, [] as Set, null)
+        def visitedGraphResults = new DefaultVisitedGraphResults(resolutionResult, [] as Set, null)
         DefaultResolverResults.buildDependenciesResolved(visitedGraphResults, Stub(ResolvedLocalComponentsResult), visitedArtifacts())
     }
 
     private ResolverResults graphResolved(ConfigurationInternal conf) {
         def resolutionResult = new DefaultMinimalResolutionResult(() -> Stub(ResolvedComponentResult), ImmutableAttributes.EMPTY)
-        def visitedGraphResults = new DefaultVisitedGraphResults(conf.asDescribable(), resolutionResult, [] as Set, null)
+        def visitedGraphResults = new DefaultVisitedGraphResults(resolutionResult, [] as Set, null)
         DefaultResolverResults.graphResolved(visitedGraphResults, Stub(ResolvedLocalComponentsResult), visitedArtifacts(), Mock(ArtifactResolveState))
     }
 
     private ResolverResults artifactsResolved(ConfigurationInternal conf) {
         def resolutionResult = new DefaultMinimalResolutionResult(() -> Stub(ResolvedComponentResult), ImmutableAttributes.EMPTY)
-        def visitedGraphResults = new DefaultVisitedGraphResults(conf.asDescribable(), resolutionResult, [] as Set, null)
+        def visitedGraphResults = new DefaultVisitedGraphResults(resolutionResult, [] as Set, null)
         DefaultResolverResults.artifactsResolved(visitedGraphResults, Stub(ResolvedLocalComponentsResult), Mock(ResolvedConfiguration), visitedArtifacts())
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.artifacts.configurations
 
 import org.gradle.api.Action
+import org.gradle.api.Describable
 import org.gradle.api.GradleException
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Named
@@ -54,12 +55,13 @@ import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDepen
 import org.gradle.api.internal.artifacts.dsl.PublishArtifactNotationParserFactory
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider
 import org.gradle.api.internal.artifacts.ivyservice.ArtifactResolveState
-import org.gradle.api.internal.artifacts.ivyservice.DefaultLenientConfiguration
 import org.gradle.api.internal.artifacts.ivyservice.ErrorHandlingConfigurationResolver
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.RootComponentMetadataBuilder
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedFileVisitor
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.SelectedArtifactSet
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.VisitedArtifactSet
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results.DefaultVisitedGraphResults
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results.VisitedGraphResults
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.projectresult.ResolvedLocalComponentsResult
 import org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact
 import org.gradle.api.internal.artifacts.result.DefaultMinimalResolutionResult
@@ -341,7 +343,7 @@ class DefaultConfigurationSpec extends Specification implements InspectableConfi
 
     def "get as path throws failure resolving"() {
         def configuration = conf()
-        def failure = new RuntimeException()
+        def failure = new ResolveException(configuration.getDisplayName(), [])
 
         given:
         expectResolved(failure)
@@ -359,8 +361,8 @@ class DefaultConfigurationSpec extends Specification implements InspectableConfi
         configuration.resolve()
 
         then:
-        def t = thrown(DefaultLenientConfiguration.ArtifactResolveException)
-        t.cause == failure
+        def t = thrown(ResolveException)
+        t == failure
     }
 
     def "build dependencies are resolved lazily"() {
@@ -380,7 +382,7 @@ class DefaultConfigurationSpec extends Specification implements InspectableConfi
         def failure = new ResolveException("bad", new RuntimeException())
 
         and:
-        _ * resolver.resolveGraph(_) >> new ErrorHandlingConfigurationResolver.BrokenResolverResults(failure)
+        _ * resolver.resolveGraph(_) >> new ErrorHandlingConfigurationResolver.BrokenResolverResults(configuration.asDescribable(), failure)
         _ * resolutionStrategy.resolveGraphToDetermineTaskDependencies() >> true
 
         when:
@@ -484,7 +486,8 @@ class DefaultConfigurationSpec extends Specification implements InspectableConfi
     }
 
     private void expectResolved(Set<File> files) {
-        def resolutionResults = new DefaultMinimalResolutionResult(() -> Stub(ResolvedComponentResult), ImmutableAttributes.EMPTY, null)
+        def resolutionResult = new DefaultMinimalResolutionResult(() -> Stub(ResolvedComponentResult), ImmutableAttributes.EMPTY)
+        def visitedGraphResults = new DefaultVisitedGraphResults(Mock(Describable), resolutionResult, [] as Set, null)
         def localComponentsResult = Stub(ResolvedLocalComponentsResult)
         def visitedArtifactSet = Stub(VisitedArtifactSet)
 
@@ -500,14 +503,14 @@ class DefaultConfigurationSpec extends Specification implements InspectableConfi
         _ * localComponentsResult.resolvedProjectConfigurations >> Collections.emptySet()
         _ * resolver.getRepositories() >> []
 
-        def graphResults = DefaultResolverResults.graphResolved(resolutionResults, localComponentsResult, visitedArtifactSet, Mock(ArtifactResolveState))
-        _ * resolver.resolveGraph(_) >> graphResults
-        _ * resolver.resolveArtifacts(_, _) >> DefaultResolverResults.artifactsResolved(resolutionResults, localComponentsResult, Stub(ResolvedConfiguration), visitedArtifactSet)
+        _ * resolver.resolveGraph(_) >> DefaultResolverResults.graphResolved(visitedGraphResults, localComponentsResult, visitedArtifactSet, Mock(ArtifactResolveState))
+        _ * resolver.resolveArtifacts(_, _) >> DefaultResolverResults.artifactsResolved(visitedGraphResults, localComponentsResult, Stub(ResolvedConfiguration), visitedArtifactSet)
     }
 
+    private void expectResolved(ResolveException failure) {
+        def resolutionResult = new DefaultMinimalResolutionResult(() -> Stub(ResolvedComponentResult), ImmutableAttributes.EMPTY)
+        def visitedGraphResults = new DefaultVisitedGraphResults(Mock(Describable), resolutionResult, [] as Set, failure)
 
-    private void expectResolved(Throwable failure) {
-        def resolutionResults = Mock(MinimalResolutionResult)
         def localComponentsResult = Stub(ResolvedLocalComponentsResult)
         def visitedArtifactSet = Stub(VisitedArtifactSet)
         def resolvedConfiguration = Stub(ResolvedConfiguration)
@@ -519,9 +522,8 @@ class DefaultConfigurationSpec extends Specification implements InspectableConfi
         _ * resolvedConfiguration.getLenientConfiguration() >> Stub(LenientConfiguration)
 
         _ * localComponentsResult.resolvedProjectConfigurations >> Collections.emptySet()
-        def graphResults = DefaultResolverResults.graphResolved(resolutionResults, localComponentsResult, visitedArtifactSet, Mock(ArtifactResolveState))
-        _ * resolver.resolveGraph(_) >> graphResults
-        _ * resolver.resolveArtifacts(_, _) >> DefaultResolverResults.artifactsResolved(resolutionResults, localComponentsResult, resolvedConfiguration, visitedArtifactSet)
+        _ * resolver.resolveGraph(_) >> DefaultResolverResults.graphResolved(visitedGraphResults, localComponentsResult, visitedArtifactSet, Mock(ArtifactResolveState))
+        _ * resolver.resolveArtifacts(_, _) >> DefaultResolverResults.artifactsResolved(visitedGraphResults, localComponentsResult, resolvedConfiguration, visitedArtifactSet)
     }
 
     def "artifacts have correct build dependencies"() {
@@ -584,7 +586,7 @@ class DefaultConfigurationSpec extends Specification implements InspectableConfi
         _ * artifactTaskDependencies.getDependencies(_) >> requiredTasks
 
         and:
-        _ * resolver.resolveBuildDependencies(_) >> DefaultResolverResults.buildDependenciesResolved(Mock(MinimalResolutionResult), Stub(ResolvedLocalComponentsResult), visitedArtifactSet)
+        _ * resolver.resolveBuildDependencies(_) >> DefaultResolverResults.buildDependenciesResolved(Mock(VisitedGraphResults), Stub(ResolvedLocalComponentsResult), visitedArtifactSet)
 
         expect:
         configuration.buildDependencies.getDependencies(targetTask) == requiredTasks
@@ -860,6 +862,7 @@ class DefaultConfigurationSpec extends Specification implements InspectableConfi
         Action<ResolvableDependencies> beforeResolveAction = Mock()
         Action<ResolvableDependencies> afterResolveAction = Mock()
         def config = conf("conf")
+        resolveConfig(config)
         def beforeResolveCalled = false
         def afterResolveCalled = false
 
@@ -1094,7 +1097,7 @@ class DefaultConfigurationSpec extends Specification implements InspectableConfi
         def config = conf("conf")
         def resolvedComponentResult = Mock(ResolvedComponentResult)
         Supplier<ResolvedComponentResult> rootSource = () -> resolvedComponentResult
-        def result = new DefaultMinimalResolutionResult(rootSource, ImmutableAttributes.EMPTY, null)
+        def result = new DefaultMinimalResolutionResult(rootSource, ImmutableAttributes.EMPTY)
 
         resolves(config, result, Mock(ResolvedConfiguration))
 
@@ -1114,9 +1117,11 @@ class DefaultConfigurationSpec extends Specification implements InspectableConfi
             collectFiles(_) >> { return it[0] }
         }
 
-        resolver.resolveGraph(config) >> DefaultResolverResults.graphResolved(resolutionResult, localComponentsResult, visitedArtifactSet, Mock(ArtifactResolveState))
+        VisitedGraphResults visitedGraphResults = new DefaultVisitedGraphResults(config.asDescribable(), resolutionResult, [] as Set, null)
+
+        resolver.resolveGraph(config) >> DefaultResolverResults.graphResolved(visitedGraphResults, localComponentsResult, visitedArtifactSet, Mock(ArtifactResolveState))
         resolver.resolveArtifacts(config, _ as ResolverResults) >> { ResolveContext conf, ResolverResults res ->
-            DefaultResolverResults.artifactsResolved(res.minimalResolutionResult, res.resolvedLocalComponents, resolvedConfiguration, visitedArtifactSet)
+            DefaultResolverResults.artifactsResolved(res.visitedGraph, res.resolvedLocalComponents, resolvedConfiguration, visitedArtifactSet)
         }
     }
 
@@ -1124,8 +1129,7 @@ class DefaultConfigurationSpec extends Specification implements InspectableConfi
         def parent = conf("parent", ":parent")
         def config = conf("conf")
         config.extendsFrom parent
-        def result = Mock(MinimalResolutionResult)
-        resolves(config, result, Mock(ResolvedConfiguration))
+        resolveConfig(config)
 
         when:
         config.resolve()
@@ -1141,10 +1145,7 @@ class DefaultConfigurationSpec extends Specification implements InspectableConfi
 
         when:
         config = conf("conf")
-        def result = Mock(MinimalResolutionResult) {
-            getRootSource() >> Mock(Supplier)
-        }
-        resolves(config, result, Mock(ResolvedConfiguration))
+        resolveConfig(config)
         config.incoming.getResolutionResult().root
 
         then:
@@ -1170,7 +1171,7 @@ class DefaultConfigurationSpec extends Specification implements InspectableConfi
         config.state == RESOLVED
 
         and:
-        1 * resolver.resolveGraph(config) >> DefaultResolverResults.graphResolved(Mock(MinimalResolutionResult), Stub(ResolvedLocalComponentsResult), visitedArtifacts(), Mock(ArtifactResolveState))
+        1 * resolver.resolveGraph(config) >> graphResolved(config)
         1 * resolver.getRepositories() >> []
         0 * resolver._
     }
@@ -1189,17 +1190,12 @@ class DefaultConfigurationSpec extends Specification implements InspectableConfi
         config.state == UNRESOLVED
 
         and:
-        1 * resolver.resolveBuildDependencies(config) >> DefaultResolverResults.buildDependenciesResolved(Mock(MinimalResolutionResult), Stub(ResolvedLocalComponentsResult), visitedArtifacts())
+        1 * resolver.resolveBuildDependencies(config) >> buildDependenciesResolved(config)
         0 * resolver._
     }
 
     def "resolving graph for task dependencies, and then resolving it for results does not re-resolve graph"() {
         def config = conf("conf")
-        def minimalResolutionResult = Mock(MinimalResolutionResult) {
-            getRootSource() >> Mock(Supplier)
-        }
-        def graphResults = DefaultResolverResults.graphResolved(minimalResolutionResult, Stub(ResolvedLocalComponentsResult), visitedArtifacts(), Mock(ArtifactResolveState))
-
         given:
         _ * resolutionStrategy.resolveGraphToDetermineTaskDependencies() >> true
 
@@ -1211,7 +1207,7 @@ class DefaultConfigurationSpec extends Specification implements InspectableConfi
         config.state == RESOLVED
 
         and:
-        1 * resolver.resolveGraph(config) >> graphResults
+        1 * resolver.resolveGraph(config) >> graphResolved(config)
         1 * resolver.getRepositories() >> []
         0 * resolver._
 
@@ -1223,16 +1219,12 @@ class DefaultConfigurationSpec extends Specification implements InspectableConfi
         config.state == RESOLVED
 
         and:
-        1 * resolver.resolveArtifacts(config, _) >> DefaultResolverResults.artifactsResolved(minimalResolutionResult, Stub(ResolvedLocalComponentsResult), Stub(ResolvedConfiguration), visitedArtifacts())
+        1 * resolver.resolveArtifacts(config, _) >> artifactsResolved(config)
         0 * resolver._
     }
 
     def "resolves graph when result requested after resolving task dependencies"() {
         def config = conf("conf")
-        def minimalResolutionResult = Mock(MinimalResolutionResult) {
-            getRootSource() >> Mock(Supplier)
-        }
-        def graphResults = DefaultResolverResults.graphResolved(minimalResolutionResult, Stub(ResolvedLocalComponentsResult), visitedArtifacts(), Mock(ArtifactResolveState))
 
         given:
         _ * resolutionStrategy.resolveGraphToDetermineTaskDependencies() >> false
@@ -1245,7 +1237,7 @@ class DefaultConfigurationSpec extends Specification implements InspectableConfi
         config.state == UNRESOLVED
 
         and:
-        1 * resolver.resolveBuildDependencies(config) >> graphResults
+        1 * resolver.resolveBuildDependencies(config) >> buildDependenciesResolved(config)
         0 * resolver._
 
         when:
@@ -1256,18 +1248,14 @@ class DefaultConfigurationSpec extends Specification implements InspectableConfi
         config.state == RESOLVED
 
         and:
-        1 * resolver.resolveGraph(config) >> DefaultResolverResults.graphResolved(minimalResolutionResult, Stub(ResolvedLocalComponentsResult), visitedArtifacts(), Mock(ArtifactResolveState))
-        1 * resolver.resolveArtifacts(config, _) >> DefaultResolverResults.artifactsResolved(minimalResolutionResult, Stub(ResolvedLocalComponentsResult), Stub(ResolvedConfiguration), visitedArtifacts())
+        1 * resolver.resolveGraph(config) >> graphResolved(config)
+        1 * resolver.resolveArtifacts(config, _) >> artifactsResolved(config)
         1 * resolver.getRepositories() >> []
         0 * resolver._
     }
 
     def "resolving configuration for results, and then resolving task dependencies required does not re-resolve graph"() {
         def config = conf("conf")
-        def minimalResolutionResult = Mock(MinimalResolutionResult) {
-            getRootSource() >> Mock(Supplier)
-        }
-        def graphResults = DefaultResolverResults.graphResolved(minimalResolutionResult, Stub(ResolvedLocalComponentsResult), visitedArtifacts(), Mock(ArtifactResolveState))
 
         given:
         _ * resolutionStrategy.resolveGraphToDetermineTaskDependencies() >> graphResolveRequired
@@ -1280,8 +1268,8 @@ class DefaultConfigurationSpec extends Specification implements InspectableConfi
         config.state == RESOLVED
 
         and:
-        1 * resolver.resolveGraph(config) >> graphResults
-        1 * resolver.resolveArtifacts(config, _) >> DefaultResolverResults.artifactsResolved(minimalResolutionResult, Stub(ResolvedLocalComponentsResult), Stub(ResolvedConfiguration), visitedArtifacts())
+        1 * resolver.resolveGraph(config) >> graphResolved(config)
+        1 * resolver.resolveArtifacts(config, _) >> artifactsResolved(config)
         1 * resolver.getRepositories() >> []
         0 * resolver._
 
@@ -1335,10 +1323,7 @@ class DefaultConfigurationSpec extends Specification implements InspectableConfi
 
     def "copied configuration is not resolved"() {
         def config = conf("conf")
-        def result = Mock(MinimalResolutionResult)
-
-        given:
-        resolves(config, result, Mock(ResolvedConfiguration))
+        resolveConfig(config)
 
         config.resolutionStrategy
         config.incoming.resolutionResult
@@ -1371,12 +1356,9 @@ class DefaultConfigurationSpec extends Specification implements InspectableConfi
 
     def "mutations are prohibited after resolution"() {
         def conf = conf("conf")
-        def result = Mock(MinimalResolutionResult) {
-            getRootSource() >> Mock(Supplier)
-        }
+        resolveConfig(conf)
 
         given:
-        resolves(conf, result, Mock(ResolvedConfiguration))
         conf.incoming.getResolutionResult().root
 
         when:
@@ -1860,6 +1842,25 @@ All Artifacts:
         "dependency was locked to version '1.1' (update/lenient mode)"  | false
     }
 
+    private ResolverResults buildDependenciesResolved(ConfigurationInternal conf) {
+        def resolutionResult = new DefaultMinimalResolutionResult(() -> Stub(ResolvedComponentResult), ImmutableAttributes.EMPTY)
+        def visitedGraphResults = new DefaultVisitedGraphResults(conf.asDescribable(), resolutionResult, [] as Set, null)
+        DefaultResolverResults.buildDependenciesResolved(visitedGraphResults, Stub(ResolvedLocalComponentsResult), visitedArtifacts())
+    }
+
+    private ResolverResults graphResolved(ConfigurationInternal conf) {
+        def resolutionResult = new DefaultMinimalResolutionResult(() -> Stub(ResolvedComponentResult), ImmutableAttributes.EMPTY)
+        def visitedGraphResults = new DefaultVisitedGraphResults(conf.asDescribable(), resolutionResult, [] as Set, null)
+        DefaultResolverResults.graphResolved(visitedGraphResults, Stub(ResolvedLocalComponentsResult), visitedArtifacts(), Mock(ArtifactResolveState))
+    }
+
+    private ResolverResults artifactsResolved(ConfigurationInternal conf) {
+        def resolutionResult = new DefaultMinimalResolutionResult(() -> Stub(ResolvedComponentResult), ImmutableAttributes.EMPTY)
+        def visitedGraphResults = new DefaultVisitedGraphResults(conf.asDescribable(), resolutionResult, [] as Set, null)
+        DefaultResolverResults.artifactsResolved(visitedGraphResults, Stub(ResolvedLocalComponentsResult), Mock(ResolvedConfiguration), visitedArtifacts())
+    }
+
+
     private DefaultConfiguration configurationWithExcludeRules(ExcludeRule... rules) {
         def config = conf()
         config.setExcludeRules(rules as LinkedHashSet)
@@ -1867,12 +1868,12 @@ All Artifacts:
     }
 
     // You need to wrap this in an interaction {} block when calling it
-    private ResolvedConfiguration resolveConfig(ConfigurationInternal config) {
-        def resolvedConfiguration = Mock(ResolvedConfiguration)
-        def resolutionResult = Mock(MinimalResolutionResult)
+    private void resolveConfig(config) {
+        def result = Mock(MinimalResolutionResult) {
+            getRootSource() >> Mock(Supplier)
+        }
 
-        resolves(config, resolutionResult, resolvedConfiguration)
-        resolvedConfiguration
+        resolves(config, result, Mock(ResolvedConfiguration))
     }
 
     private visitedArtifacts() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfigurationTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfigurationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice
 
+import org.gradle.api.Describable
 import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.ResolvedArtifact
 import org.gradle.api.artifacts.ResolvedDependency
@@ -26,8 +27,11 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.Depe
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.VisitedArtifactsResults
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.VisitedFileDependencyResults
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results.DefaultVisitedGraphResults
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results.VisitedGraphResults
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult.TransientConfigurationResults
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult.TransientConfigurationResultsLoader
+import org.gradle.api.internal.artifacts.result.MinimalResolutionResult
 import org.gradle.api.internal.artifacts.transform.ArtifactVariantSelector
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.specs.Spec
@@ -118,7 +122,8 @@ class DefaultLenientConfigurationTest extends Specification {
     }
 
     private DefaultLenientConfiguration newConfiguration() {
-        new DefaultLenientConfiguration(configuration, null, null, artifactsResults, fileDependencyResults, resultsLoader, buildOperationExecutor, dependencyVerificationOverride, new TestWorkerLeaseService(), Mock(ArtifactVariantSelector))
+        VisitedGraphResults visitedGraphResults = new DefaultVisitedGraphResults(Stub(Describable), Stub(MinimalResolutionResult), [] as Set, null)
+        new DefaultLenientConfiguration(configuration, visitedGraphResults, artifactsResults, fileDependencyResults, resultsLoader, transforms, buildOperationExecutor, dependencyVerificationOverride, new TestWorkerLeaseService(), Mock(ArtifactVariantSelector))
     }
 
     def generateDependenciesWithChildren(Map treeStructure) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfigurationTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfigurationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.artifacts.ivyservice
 
-import org.gradle.api.Describable
 import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.ResolvedArtifact
 import org.gradle.api.artifacts.ResolvedDependency
@@ -122,8 +121,8 @@ class DefaultLenientConfigurationTest extends Specification {
     }
 
     private DefaultLenientConfiguration newConfiguration() {
-        VisitedGraphResults visitedGraphResults = new DefaultVisitedGraphResults(Stub(Describable), Stub(MinimalResolutionResult), [] as Set, null)
-        new DefaultLenientConfiguration(configuration, visitedGraphResults, artifactsResults, fileDependencyResults, resultsLoader, transforms, buildOperationExecutor, dependencyVerificationOverride, new TestWorkerLeaseService(), Mock(ArtifactVariantSelector))
+        VisitedGraphResults visitedGraphResults = new DefaultVisitedGraphResults(Stub(MinimalResolutionResult), [] as Set, null)
+        new DefaultLenientConfiguration(configuration, visitedGraphResults, artifactsResults, fileDependencyResults, resultsLoader, buildOperationExecutor, dependencyVerificationOverride, new TestWorkerLeaseService(), Mock(ArtifactVariantSelector))
     }
 
     def generateDependenciesWithChildren(Map treeStructure) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ErrorHandlingConfigurationResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ErrorHandlingConfigurationResolverTest.groovy
@@ -26,8 +26,8 @@ import org.gradle.api.internal.artifacts.ResolveExceptionContextualizer
 import org.gradle.api.internal.artifacts.ResolverResults
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.VisitedArtifactSet
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results.VisitedGraphResults
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.projectresult.ResolvedLocalComponentsResult
-import org.gradle.api.internal.artifacts.result.MinimalResolutionResult
 import org.gradle.api.specs.Specs
 import spock.lang.Specification
 
@@ -36,7 +36,7 @@ import static org.junit.Assert.fail
 class ErrorHandlingConfigurationResolverTest extends Specification {
     private delegate = Mock(ConfigurationResolver)
     private resolvedConfiguration = Mock(ResolvedConfiguration)
-    private resolutionResult = Mock(MinimalResolutionResult)
+    private visitedGraphResults = Mock(VisitedGraphResults)
     private projectConfigResult = Mock(ResolvedLocalComponentsResult)
     private visitedArtifactSet = Mock(VisitedArtifactSet)
     private context = Mock(ConfigurationInternal)
@@ -172,7 +172,7 @@ class ErrorHandlingConfigurationResolverTest extends Specification {
         lenientConfiguration.getArtifacts(_) >> { throw failure }
         lenientConfiguration.getUnresolvedModuleDependencies() >> { throw failure }
 
-        delegate.resolveArtifacts(context, _) >> DefaultResolverResults.artifactsResolved(resolutionResult, projectConfigResult, resolvedConfiguration, visitedArtifactSet)
+        delegate.resolveArtifacts(context, _) >> DefaultResolverResults.artifactsResolved(visitedGraphResults, projectConfigResult, resolvedConfiguration, visitedArtifactSet)
 
         when:
         def results = resolver.resolveArtifacts(context, graphResults)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolverSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolverSpec.groovy
@@ -78,7 +78,7 @@ class ShortCircuitEmptyConfigurationResolverSpec extends Specification {
         def results = dependencyResolver.resolveGraph(resolveContext)
 
         then:
-        results.minimalResolutionResult.rootSource.get().dependencies.empty
+        results.visitedGraph.resolutionResult.rootSource.get().dependencies.empty
 
         and:
         def localComponentsResult = results.resolvedLocalComponents

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/results/DefaultVisitedGraphResultsTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/results/DefaultVisitedGraphResultsTest.groovy
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results
+
+import org.gradle.api.Describable
+import org.gradle.api.artifacts.ResolveException
+import org.gradle.api.artifacts.UnresolvedDependency
+import org.gradle.api.internal.artifacts.result.DefaultMinimalResolutionResult
+import org.gradle.api.internal.artifacts.result.MinimalResolutionResult
+import org.gradle.api.internal.attributes.ImmutableAttributes
+import org.gradle.internal.Describables
+import spock.lang.Specification
+
+import java.util.function.Supplier
+
+/**
+ * Tests {@link DefaultVisitedGraphResults}
+ */
+class DefaultVisitedGraphResultsTest extends Specification {
+
+    Describable name = Describables.of("Configuration", "conf")
+    MinimalResolutionResult resolutionResult = new DefaultMinimalResolutionResult(Mock(Supplier), ImmutableAttributes.EMPTY)
+
+    def "hasResolutionFailure returns true if there is a failure"() {
+        given:
+        def results1 = new DefaultVisitedGraphResults(name, resolutionResult, Collections.emptySet(), null)
+        def results2 = new DefaultVisitedGraphResults(name, resolutionResult, Collections.singleton(Mock(UnresolvedDependency)), null)
+        def results3 = new DefaultVisitedGraphResults(name, resolutionResult, Collections.emptySet(), Mock(ResolveException))
+
+        expect:
+        !results1.hasResolutionFailure()
+        results2.hasResolutionFailure()
+        results3.hasResolutionFailure()
+    }
+
+    def "provides resolution failure aggregating all failures"() {
+        given:
+        def throwable = Mock(Throwable)
+        def resolveEx = Mock(ResolveException)
+
+        def unresolved = Mock(UnresolvedDependency) {
+            getProblem() >> throwable
+        }
+
+        def results1 = new DefaultVisitedGraphResults(name, resolutionResult, Collections.emptySet(), null)
+        def results2 = new DefaultVisitedGraphResults(name, resolutionResult, Collections.singleton(unresolved), null)
+        def results3 = new DefaultVisitedGraphResults(name, resolutionResult, Collections.emptySet(), resolveEx)
+        def results4 = new DefaultVisitedGraphResults(name, resolutionResult, Collections.singleton(unresolved), resolveEx)
+
+        expect:
+        results1.resolutionFailure == null
+        results2.resolutionFailure.causes == [throwable]
+        results3.resolutionFailure.causes == [resolveEx]
+        results4.resolutionFailure.causes == [throwable, resolveEx]
+    }
+
+    def "visits all resolution failures"() {
+        given:
+        def throwable = Mock(Throwable)
+        def resolveEx = Mock(ResolveException)
+
+        def unresolved = Mock(UnresolvedDependency) {
+            getProblem() >> throwable
+        }
+
+        def results1 = new DefaultVisitedGraphResults(name, resolutionResult, Collections.emptySet(), null)
+        def results2 = new DefaultVisitedGraphResults(name, resolutionResult, Collections.singleton(unresolved), null)
+        def results3 = new DefaultVisitedGraphResults(name, resolutionResult, Collections.emptySet(), resolveEx)
+        def results4 = new DefaultVisitedGraphResults(name, resolutionResult, Collections.singleton(unresolved), resolveEx)
+
+        expect:
+        visitFailures(results1) == []
+        visitFailures(results2) == [throwable]
+        visitFailures(results3) == [resolveEx]
+        visitFailures(results4) == [throwable, resolveEx]
+    }
+
+    def "getters return the values passed to the constructor"() {
+        given:
+        def resolveEx = Mock(ResolveException)
+        def unresolved = Mock(UnresolvedDependency)
+        def results = new DefaultVisitedGraphResults(name, resolutionResult, Collections.singleton(unresolved), resolveEx)
+
+        expect:
+        results.resolutionResult == resolutionResult
+        results.unresolvedDependencies == ([unresolved] as Set)
+        results.additionalResolutionFailure == resolveEx
+    }
+
+    private List<Throwable> visitFailures(VisitedGraphResults results) {
+        List<Throwable> result = []
+        results.visitResolutionFailures { result.add(it) }
+        return result
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilderTest.groovy
@@ -64,7 +64,7 @@ class StreamingResolutionResultBuilderTest extends Specification {
         builder.finish(rootNode)
 
         when:
-        def result = builder.complete(null, [] as Set)
+        def result = builder.complete([] as Set)
 
         then:
         with(result.rootSource.get()) {
@@ -96,7 +96,7 @@ class StreamingResolutionResultBuilderTest extends Specification {
         builder.finish(root)
 
         when:
-        def result = builder.complete(null, [] as Set)
+        def result = builder.complete([] as Set)
 
         then:
         printGraph(result.rootSource.get()) == """org:root:1.0
@@ -125,7 +125,7 @@ class StreamingResolutionResultBuilderTest extends Specification {
         builder.finish(root)
 
         when:
-        def result = builder.complete(null, [] as Set)
+        def result = builder.complete([] as Set)
 
         then:
         printGraph(result.rootSource.get()) == """org:root:1.0
@@ -165,7 +165,7 @@ class StreamingResolutionResultBuilderTest extends Specification {
         builder.finish(root)
 
         when:
-        def result = builder.complete(null, [] as Set)
+        def result = builder.complete([] as Set)
 
         then:
         printGraph(result.rootSource.get()) == """org:root:1.0
@@ -204,7 +204,7 @@ class StreamingResolutionResultBuilderTest extends Specification {
         builder.finish(root)
 
         when:
-        def result = builder.complete(null, [] as Set)
+        def result = builder.complete([] as Set)
 
         then:
         printGraph(result.rootSource.get()) == """org:root:1.0

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/result/DefaultResolutionResultTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/result/DefaultResolutionResultTest.groovy
@@ -151,7 +151,7 @@ class DefaultResolutionResultTest extends Specification {
     }
 
     private static ResolutionResult newResolutionResult(root) {
-        new DefaultResolutionResult(new DefaultMinimalResolutionResult(() -> root, ImmutableAttributes.EMPTY, null))
+        new DefaultResolutionResult(new DefaultMinimalResolutionResult(() -> root, ImmutableAttributes.EMPTY))
     }
 
 }

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
@@ -164,13 +164,11 @@ public abstract class DependencyInsightReportTask extends DefaultTask {
             ProviderFactory providerFactory = getProject().getProviders();
             ResolutionResultProvider<VisitedGraphResults> graphResultsProvider =
                 ((ResolvableDependenciesInternal) configuration.getIncoming()).getGraphResultsProvider();
-            errorHandler.addErrorSource(providerFactory.provider(() -> {
-                Throwable failure = graphResultsProvider.getValue().getAdditionalResolutionFailure();
-                if (failure != null) {
-                    return Collections.singletonList(failure);
-                }
-                return Collections.emptyList();
-            }));
+            errorHandler.addErrorSource(providerFactory.provider(() ->
+                graphResultsProvider.getValue().getResolutionFailure()
+                    .map(Collections::singletonList)
+                    .orElse(Collections.emptyList()))
+            );
             rootComponentProperty.set(providerFactory.provider(() -> {
                 // We do not use the public resolution result API to avoid throwing exceptions that we visit above
                 return graphResultsProvider.getValue().getResolutionResult().getRootSource().get();

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
@@ -32,15 +32,17 @@ import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.HasAttributes;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
+import org.gradle.api.internal.artifacts.configurations.ResolutionResultProvider;
 import org.gradle.api.internal.artifacts.configurations.ResolvableDependenciesInternal;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionComparator;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
-import org.gradle.api.internal.artifacts.result.ResolutionResultInternal;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results.VisitedGraphResults;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
@@ -67,6 +69,7 @@ import org.gradle.work.DisableCachingByDefault;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -158,10 +161,20 @@ public abstract class DependencyInsightReportTask extends DefaultTask {
             configurationDescription = configuration.toString();
             zConfigurationAttributes = getProject().provider(configuration::getAttributes);
 
-            ResolvableDependenciesInternal incoming = (ResolvableDependenciesInternal) configuration.getIncoming();
-            ResolutionResultInternal result = incoming.getLenientResolutionResult();
-            errorHandler.addErrorProvider(result.getExtraFailure());
-            rootComponentProperty.set(result.getRootComponent());
+            ProviderFactory providerFactory = getProject().getProviders();
+            ResolutionResultProvider<VisitedGraphResults> graphResultsProvider =
+                ((ResolvableDependenciesInternal) configuration.getIncoming()).getGraphResultsProvider();
+            errorHandler.addErrorSource(providerFactory.provider(() -> {
+                Throwable failure = graphResultsProvider.getValue().getAdditionalResolutionFailure();
+                if (failure != null) {
+                    return Collections.singletonList(failure);
+                }
+                return Collections.emptyList();
+            }));
+            rootComponentProperty.set(providerFactory.provider(() -> {
+                // We do not use the public resolution result API to avoid throwing exceptions that we visit above
+                return graphResultsProvider.getValue().getResolutionResult().getRootSource().get();
+            }));
         }
         return rootComponentProperty;
     }

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/ResolutionErrorRenderer.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/ResolutionErrorRenderer.java
@@ -42,13 +42,13 @@ import static org.gradle.util.internal.TextUtil.getPluralEnding;
 class ResolutionErrorRenderer {
     private final Spec<DependencyResult> dependencySpec;
     private final List<Action<StyledTextOutput>> errorActions = new ArrayList<>(1);
-    private final List<Provider<List<Throwable>>> errorSources = new ArrayList<>(1);
+    private final List<Provider<List<? extends Throwable>>> errorSources = new ArrayList<>(1);
 
     public ResolutionErrorRenderer(@Nullable Spec<DependencyResult> dependencySpec) {
         this.dependencySpec = dependencySpec;
     }
 
-    public void addErrorSource(Provider<List<Throwable>> errorSource) {
+    public void addErrorSource(Provider<List<? extends Throwable>> errorSource) {
         errorSources.add(errorSource);
     }
 


### PR DESCRIPTION
VisitedGraphResults is responsible for encapsulating all results of building a dependency graph This includes the resolution result root component as well as any errors that occurred All code that needs to handle errors related to graph resolution now source their errors from this type. This removes the double source of truth regarding errors, where previously the artifact set also defined their own errors. Now, the artifact results derive their failures from the graph failures.
