### PR TITLE
Let default imports skip non-public types

### DIFF
--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/dsl/source/SourceMetaDataVisitor.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/dsl/source/SourceMetaDataVisitor.java
@@ -99,6 +99,9 @@ public class SourceMetaDataVisitor extends VoidVisitorAdapter<ClassMetaDataRepos
     }
 
     private void visitTypeDeclaration(TypeDeclaration<?> typeDeclaration, ClassMetaDataRepository<ClassMetaData> repository, ClassMetaData.MetaType metaType, Runnable action) {
+        if (!typeDeclaration.isPublic()) {
+            return;
+        }
         ClassMetaData outerClass = classStack.isEmpty() ? null : getCurrentClass();
         String baseName = typeDeclaration.getNameAsString();
         String className = outerClass == null ? packageName + '.' + baseName : outerClass.getClassName() + '.' + baseName;

--- a/subprojects/core/src/test/groovy/org/gradle/configuration/DefaultImportsReaderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/configuration/DefaultImportsReaderTest.groovy
@@ -25,8 +25,16 @@ class DefaultImportsReaderTest extends Specification {
     public Resources resources = new Resources()
     DefaultImportsReader reader = new DefaultImportsReader()
 
-    public void testReadImportPackagesFromResource() {
+    def "default import packages contain org.gradle.api"() {
         expect:
         reader.importPackages.contains('org.gradle.api')
+    }
+
+    def "fq default imports do not contain package private types"() {
+        expect:
+        null == reader.simpleNameToFullClassNamesMapping
+            .collectMany { it.value }
+            .find { it == "org.gradle.plugin.devel.plugins.MavenPluginPublishPlugin" }
+
     }
 }


### PR DESCRIPTION
This PR changes the Java source metadata visitor used for the Groovy DSL reference, default imports and api mappings to skip non public members.

This is a stepstone towards supporting K2 for Kotlin DSL scripts.

* Fixes https://github.com/gradle/gradle/issues/25018

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
