### PR TITLE
Use `KillLeakingJavaProcesses` before performance tests

### DIFF
--- a/.teamcity/src/main/kotlin/common/Os.kt
+++ b/.teamcity/src/main/kotlin/common/Os.kt
@@ -16,43 +16,6 @@
 
 package common
 
-private const val killAllGradleProcessesUnixLike = """
-free -m
-ps aux | egrep 'Gradle(Daemon|Worker)' | awk '{print ${'$'}2}'
-
-COUNTER=0
-
-while [ ${'$'}COUNTER -lt 30 ]
-do
-    if [ `ps aux | egrep 'Gradle(Daemon|Worker)' | wc -l` -eq "0" ]; then
-       echo "All daemons are killed, exit."
-       free -m
-       exit 0
-    fi
-
-    echo "Attempt ${'$'}COUNTER: failed to kill daemons."
-    ps aux | egrep 'Gradle(Daemon|Worker)' | awk '{print ${'$'}2}' | xargs kill
-    sleep 1
-
-    COUNTER=`expr ${'$'}COUNTER + 1`
-done
-
-echo "Waiting timeout for daemons to exit, kill -9 now."
-
-ps aux | egrep 'Gradle(Daemon|Worker)' | awk '{print ${'$'}2}' | xargs kill -9
-free -m
-ps aux | egrep 'Gradle(Daemon|Worker)' | awk '{print ${'$'}2}'
-"""
-
-private const val killAllGradleProcessesWindows = """
-wmic OS get FreePhysicalMemory,FreeVirtualMemory,FreeSpaceInPagingFiles /VALUE
-wmic Path win32_process Where "name='java.exe'"
-wmic Path win32_process Where "name='java.exe' AND CommandLine Like '%%%%GradleDaemon%%%%'" Call Terminate
-wmic Path win32_process Where "name='java.exe' AND CommandLine Like '%%%%GradleWorker%%%%'" Call Terminate
-wmic OS get FreePhysicalMemory,FreeVirtualMemory,FreeSpaceInPagingFiles /VALUE
-wmic Path win32_process Where "name='java.exe'"
-"""
-
 enum class Arch(val suffix: String, val nameOnLinuxWindows: String, val nameOnMac: String) {
     AMD64("64bit", "amd64", "x86_64"),
     AARCH64("aarch64", "aarch64", "aarch64");
@@ -64,7 +27,6 @@ enum class Os(
     val agentRequirement: String,
     val androidHome: String,
     val jprofilerHome: String,
-    val killAllGradleProcesses: String,
     val perfTestWorkingDir: String = "%teamcity.build.checkoutDir%",
     val perfTestJavaVendor: JvmVendor = JvmVendor.openjdk,
     val buildJavaVersion: JvmVersion = JvmVersion.java11,
@@ -74,21 +36,18 @@ enum class Os(
     LINUX(
         "Linux",
         androidHome = "/opt/android/sdk",
-        jprofilerHome = "/opt/jprofiler/jprofiler11.1.4",
-        killAllGradleProcesses = killAllGradleProcessesUnixLike
+        jprofilerHome = "/opt/jprofiler/jprofiler11.1.4"
     ),
     WINDOWS(
         "Windows",
         androidHome = """C:\Program Files\android\sdk""",
         jprofilerHome = """C:\Program Files\jprofiler\jprofiler11.1.4""",
-        killAllGradleProcesses = killAllGradleProcessesWindows,
         perfTestWorkingDir = "P:/",
     ),
     MACOS(
         "Mac",
         androidHome = "/opt/android/sdk",
         jprofilerHome = "/Applications/JProfiler11.1.4.app",
-        killAllGradleProcesses = killAllGradleProcessesUnixLike,
         defaultArch = Arch.AARCH64
     );
 

--- a/.teamcity/src/main/kotlin/common/extensions.kt
+++ b/.teamcity/src/main/kotlin/common/extensions.kt
@@ -18,6 +18,7 @@ package common
 
 import common.KillProcessMode.KILL_ALL_GRADLE_PROCESSES
 import configurations.CompileAll
+import configurations.FunctionalTest
 import configurations.branchesFilterExcluding
 import configurations.buildScanCustomValue
 import configurations.buildScanTag
@@ -279,18 +280,22 @@ enum class KillProcessMode {
     KILL_ALL_GRADLE_PROCESSES
 }
 
-fun BuildType.killProcessStep(mode: KillProcessMode, os: Os, arch: Arch = Arch.AMD64, executionMode: BuildStep.ExecutionMode = BuildStep.ExecutionMode.ALWAYS) {
-    steps {
-        script {
-            name = mode.toString()
-            this.executionMode = executionMode
-            scriptContent = "\"${javaHome(BuildToolBuildJvm, os, arch)}/bin/java\" build-logic/cleanup/src/main/java/gradlebuild/cleanup/services/KillLeakingJavaProcesses.java $mode" +
-                if (os == Os.WINDOWS) "\nwmic Path win32_process Where \"name='java.exe'\"" else ""
-            skipConditionally(this@killProcessStep)
-            if (mode == KILL_ALL_GRADLE_PROCESSES) {
-                onlyRunOnPreTestedCommitBuildBranch()
-            }
+fun BuildSteps.killProcessStep(buildType: BuildType?, mode: KillProcessMode, os: Os, arch: Arch = Arch.AMD64, executionMode: BuildStep.ExecutionMode = BuildStep.ExecutionMode.DEFAULT) {
+    script {
+        name = mode.toString()
+        this.executionMode = executionMode
+        scriptContent = "\"${javaHome(BuildToolBuildJvm, os, arch)}/bin/java\" build-logic/cleanup/src/main/java/gradlebuild/cleanup/services/KillLeakingJavaProcesses.java $mode" +
+            if (os == Os.WINDOWS) "\nwmic Path win32_process Where \"name='java.exe'\"" else ""
+        skipConditionally(buildType)
+        if (mode == KILL_ALL_GRADLE_PROCESSES && buildType is FunctionalTest) {
+            onlyRunOnPreTestedCommitBuildBranch()
         }
+    }
+}
+
+fun BuildType.killProcessStep(mode: KillProcessMode, os: Os, arch: Arch = Arch.AMD64, executionMode: BuildStep.ExecutionMode = BuildStep.ExecutionMode.DEFAULT) {
+    steps {
+        killProcessStep(this@killProcessStep, mode, os, arch, executionMode)
     }
 }
 

--- a/.teamcity/src/main/kotlin/common/performance-test-extensions.kt
+++ b/.teamcity/src/main/kotlin/common/performance-test-extensions.kt
@@ -68,15 +68,6 @@ subprojects/*/build/tmp/**/profile.log => failure-logs
 subprojects/*/build/tmp/**/daemon-*.out.log => failure-logs
 """
 
-fun BuildSteps.killGradleProcessesStep(os: Os) {
-    script {
-        name = "KILL_GRADLE_PROCESSES"
-        executionMode = BuildStep.ExecutionMode.ALWAYS
-        scriptContent = os.killAllGradleProcesses
-        skipConditionally()
-    }
-}
-
 // to avoid pathname too long error
 fun BuildSteps.substDirOnWindows(os: Os) {
     if (os == Os.WINDOWS) {

--- a/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
@@ -16,6 +16,7 @@
 
 package configurations
 
+import common.KillProcessMode.KILL_ALL_GRADLE_PROCESSES
 import common.Os
 import common.applyPerformanceTestSettings
 import common.buildToolGradleParameters
@@ -23,7 +24,7 @@ import common.checkCleanM2AndAndroidUserHome
 import common.cleanUpPerformanceBuildDir
 import common.gradleWrapper
 import common.individualPerformanceTestArtifactRules
-import common.killGradleProcessesStep
+import common.killProcessStep
 import common.performanceTestCommandLine
 import common.removeSubstDirOnWindows
 import common.substDirOnWindows
@@ -52,6 +53,7 @@ class PerformanceTest(
         this.name = "$description${if (performanceTestBuildSpec.withoutDependencies) " (without dependencies)" else ""}"
         val type = performanceTestBuildSpec.type
         val os = performanceTestBuildSpec.os
+        val buildTypeThis = this
         val performanceTestTaskNames = getPerformanceTestTaskNames(performanceSubProject, testProjects, performanceTestTaskSuffix)
         applyPerformanceTestSettings(os = os, arch = os.defaultArch, timeout = type.timeout)
         artifactRules = individualPerformanceTestArtifactRules
@@ -80,7 +82,7 @@ class PerformanceTest(
         if (testProjects.isNotEmpty()) {
             steps {
                 preBuildSteps()
-                killGradleProcessesStep(os)
+                killProcessStep(buildTypeThis, KILL_ALL_GRADLE_PROCESSES, os)
                 cleanUpPerformanceBuildDir(os)
                 substDirOnWindows(os)
 

--- a/.teamcity/src/main/kotlin/configurations/TestPerformanceTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/TestPerformanceTest.kt
@@ -16,21 +16,22 @@
 
 package configurations
 
+import common.KillProcessMode.KILL_ALL_GRADLE_PROCESSES
 import common.Os
 import common.applyPerformanceTestSettings
 import common.buildToolGradleParameters
 import common.checkCleanM2AndAndroidUserHome
 import common.gradleWrapper
 import common.individualPerformanceTestArtifactRules
+import common.killProcessStep
 import common.skipConditionally
-import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import model.CIBuildModel
 import model.Stage
 
 class TestPerformanceTest(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(stage, init = {
     val os = Os.LINUX
+    val buildTypeThis = this
     val testProject = "smallJavaMultiProject"
 
     fun BuildSteps.gradleStep(tasks: List<String>) {
@@ -68,11 +69,7 @@ class TestPerformanceTest(model: CIBuildModel, stage: Stage) : BaseGradleBuildTy
     artifactRules = individualPerformanceTestArtifactRules
 
     steps {
-        script {
-            name = "KILL_GRADLE_PROCESSES"
-            executionMode = BuildStep.ExecutionMode.ALWAYS
-            scriptContent = os.killAllGradleProcesses
-        }
+        killProcessStep(buildTypeThis, KILL_ALL_GRADLE_PROCESSES, os)
         adHocPerformanceTest(
             listOf(
                 "org.gradle.performance.regression.java.JavaIDEModelPerformanceTest.get IDE model for IDEA",

--- a/.teamcity/src/main/kotlin/util/AdHocPerformanceScenario.kt
+++ b/.teamcity/src/main/kotlin/util/AdHocPerformanceScenario.kt
@@ -2,13 +2,14 @@ package util
 
 import common.Arch
 import common.JvmVendor
+import common.KillProcessMode.KILL_ALL_GRADLE_PROCESSES
 import common.Os
 import common.applyPerformanceTestSettings
 import common.buildToolGradleParameters
 import common.checkCleanM2AndAndroidUserHome
 import common.gradleWrapper
 import common.individualPerformanceTestArtifactRules
-import common.killGradleProcessesStep
+import common.killProcessStep
 import common.performanceTestCommandLine
 import common.removeSubstDirOnWindows
 import common.substDirOnWindows
@@ -63,6 +64,7 @@ abstract class AdHocPerformanceScenario(os: Os, arch: Arch = Arch.AMD64) : Build
                 profilerParam("jprofiler")
                 param("env.JPROFILER_HOME", "C:\\Program Files\\jprofiler\\jprofiler11.1.4")
             }
+
             else -> {
                 profilerParam("async-profiler")
                 param("env.FG_HOME_DIR", "/opt/FlameGraph")
@@ -75,8 +77,9 @@ abstract class AdHocPerformanceScenario(os: Os, arch: Arch = Arch.AMD64) : Build
         param("additional.gradle.parameters", "")
     }
 
+    val buildTypeThis = this
     steps {
-        killGradleProcessesStep(os)
+        killProcessStep(buildTypeThis, KILL_ALL_GRADLE_PROCESSES, os)
         substDirOnWindows(os)
         gradleWrapper {
             name = "GRADLE_RUNNER"

--- a/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
+++ b/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
@@ -63,7 +63,7 @@ class PerformanceTestBuildTypeTest {
 
         assertEquals(
             listOf(
-                "KILL_GRADLE_PROCESSES",
+                "KILL_ALL_GRADLE_PROCESSES",
                 "GRADLE_RUNNER",
                 "CHECK_CLEAN_M2_ANDROID_USER_HOME"
             ),
@@ -125,7 +125,7 @@ class PerformanceTestBuildTypeTest {
 
         assertEquals(
             listOf(
-                "KILL_GRADLE_PROCESSES",
+                "KILL_ALL_GRADLE_PROCESSES",
                 "CLEAN_UP_PERFORMANCE_BUILD_DIR",
                 "SETUP_VIRTUAL_DISK_FOR_PERF_TEST",
                 "GRADLE_RUNNER",


### PR DESCRIPTION
See https://github.com/gradle/gradle-private/issues/3990 for context.

We found some problems in the old `KILL_GRADLE_PROCESSES` step, let's try our new `java KillLeakingJavaProcesses.java KILL_ALL_GRADLE_PROCESSES` way.