### PR TITLE
Add missing pattern for matching leaking java processes

### DIFF
--- a/build-logic/cleanup/src/main/java/gradlebuild/cleanup/services/KillLeakingJavaProcesses.java
+++ b/build-logic/cleanup/src/main/java/gradlebuild/cleanup/services/KillLeakingJavaProcesses.java
@@ -83,7 +83,7 @@ public class KillLeakingJavaProcesses {
         String kotlinCompilerDaemonPattern = "(?:" + Pattern.quote("-Dkotlin.environment.keepalive org.jetbrains.kotlin.daemon.KotlinCompileDaemon") + ")";
         String quotedRootProjectDir = Pattern.quote(rootProjectDir);
         String perfTestClasspathPattern = "(?:-cp.+\\\\build\\\\tmp\\\\performance-test-files.+?" + GRADLE_MAIN_CLASS_PATTERN_STR + ")";
-        String buildDirClasspathPattern = "(?:-classpath.+" + quotedRootProjectDir + ".+?" + Pattern.quote("\\build\\") + ".+?" + GRADLE_MAIN_CLASS_PATTERN_STR + ")";
+        String buildDirClasspathPattern = "(?:-(classpath|cp) .+" + quotedRootProjectDir + ".+?" + Pattern.quote("\\build\\") + ".+?" + GRADLE_MAIN_CLASS_PATTERN_STR + ")";
         String playServerPattern = "(?:-classpath.+" + quotedRootProjectDir + ".+?" + PLAY_SERVER_PATTERN_STR + ")";
         return "(?i)[/\\\\]" + "(" + JAVA_EXECUTABLE_PATTERN_STR + ".+?" + "(?:"
             + perfTestClasspathPattern + "|"

--- a/build-logic/cleanup/src/test/groovy/gradlebuild/cleanup/services/LeakingProcessKillPatternTest.groovy
+++ b/build-logic/cleanup/src/test/groovy/gradlebuild/cleanup/services/LeakingProcessKillPatternTest.groovy
@@ -36,6 +36,14 @@ class LeakingProcessKillPatternTest extends Specification {
         (line =~ KillLeakingJavaProcesses.generateLeakingProcessKillPattern(projectDir)).find()
     }
 
+    def "matches daemon process with distribution full on Windows"() {
+        def line = '8916 "C:\\Program Files\\Java\\open-jdk-20\\bin\\java.exe" -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=C:\\tcagent1\\work\\f63322e10dd6b396\\intTestHomeDir\\distributions-full --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.prefs/java.util.prefs=ALL-UNNAMED --add-opens=java.base/java.nio.charset=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED -Xms256m -Xmx1024m -Dfile.encoding=UTF-8 -Djava.io.tmpdir=C:\\tcagent1\\work\\f63322e10dd6b396\\subprojects\\launcher\\build\\tmp -Duser.country=US -Duser.language=en -Duser.variant -ea -cp "C:\\tcagent1\\work\\f63322e10dd6b396\\subprojects\\distributions-full\\build\\bin distribution\\lib\\gradle-launcher-8.5.jar" "-javaagent:C:\\tcagent1\\work\\f63322e10dd6b396\\subprojects\\distributions-full\\build\\bin distribution\\lib\\agents\\gradle-instrumentation-agent-8.5.jar" org.gradle.launcher.daemon.bootstrap.GradleDaemon 8.5-20230921032409+0000'
+        def projectDir = 'C:\\tcagent1\\work\\f63322e10dd6b396\\'
+
+        expect:
+        (line =~ KillLeakingJavaProcesses.generateLeakingProcessKillPattern(projectDir)).find()
+    }
+
     def "does not match worker process started by main build VM on Windows"() {
         def line = '"C:\\Program Files\\Java\\jdk1.7\\bin\\java.exe" -Djava.security.manager=worker.org.gradle.process.internal.worker.child.BootstrapSecurityManager -Dfile.encoding=UTF-8 -Duser.country=US -Duser.language=en -Duser.variant -cp C:\\some\\agent\\.gradle\\caches\\4.4-rc-1\\workerMain\\gradle-worker.jar worker.org.gradle.process.internal.worker.GradleWorkerMain "\'Gradle Worker Daemon 318\'"'
         def projectDir = 'C:\\some\\agent\\workspace'


### PR DESCRIPTION
We found that a missing pattern might result in leaking GradleDaemons not cleaned up and cause the subsequent clean build fail.