### PR TITLE
Deprecate depending on resolved configuration

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ConfigurationBuildDependenciesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ConfigurationBuildDependenciesIntegrationTest.groovy
@@ -21,7 +21,11 @@ import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 
 class ConfigurationBuildDependenciesIntegrationTest extends AbstractHttpDependencyResolutionTest {
     def setup() {
-        settingsFile << "include 'child'"
+        settingsFile << """
+            include 'child'
+            rootProject.name = 'root'
+        """
+
         buildFile << """
             allprojects {
                 configurations {
@@ -146,6 +150,9 @@ class ConfigurationBuildDependenciesIntegrationTest extends AbstractHttpDependen
 """
 
         when:
+        executer.expectDocumentedDeprecationWarning("""The resolved configuration 'compile' has been selected by the following variants:
+    - root:child:unspecified variant default
+Depending on the resolved configuration has been deprecated. This will fail with an error in Gradle 9.0. Be sure to mark non-consumable Configurations as canBeConsumed=false, or use role-based Configuration factory methods to ensure Configurations cannot be both resolved and consumed. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#depending_on_root_configuration""")
         run("useCompileConfiguration")
 
         then:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ConfigurationBuildDependenciesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ConfigurationBuildDependenciesIntegrationTest.groovy
@@ -150,9 +150,7 @@ class ConfigurationBuildDependenciesIntegrationTest extends AbstractHttpDependen
 """
 
         when:
-        executer.expectDocumentedDeprecationWarning("""The resolved configuration 'compile' has been selected by the following variants:
-    - root:child:unspecified variant default
-Depending on the resolved configuration has been deprecated. This will fail with an error in Gradle 9.0. Be sure to mark non-consumable Configurations as canBeConsumed=false, or use role-based Configuration factory methods to ensure Configurations cannot be both resolved and consumed. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#depending_on_root_configuration""")
+        executer.expectDocumentedDeprecationWarning("""The resolved configuration 'compile' has been consumed as a variant, resulting in a circular dependency graph. Depending on the resolved configuration in this manner has been deprecated. This will fail with an error in Gradle 9.0. Be sure to mark configurations meant for resolution as canBeConsumed=false, or use the 'resolvable(String)' configuration factory method. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#depending_on_root_configuration""")
         run("useCompileConfiguration")
 
         then:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DetachedConfigurationsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DetachedConfigurationsIntegrationTest.groovy
@@ -163,7 +163,7 @@ class DetachedConfigurationsIntegrationTest extends AbstractIntegrationSpec {
 
         expect:
         executer.expectDocumentedDeprecationWarning("The detachedConfiguration1 configuration has been deprecated for consumption. This will fail with an error in Gradle 9.0. For more information, please refer to https://docs.gradle.org/current/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.")
-        executer.expectDocumentedDeprecationWarning("""The resolved configuration 'detachedConfiguration1' has been consumed as a variant, resulting in a circular dependency graph. Depending on the resolved configuration in this manner has been deprecated. This will fail with an error in Gradle 9.0. Be sure to mark configurations meant for resolution as canBeConsumed=false, or use the 'resolvable(String)' configuration factory method. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#depending_on_root_configuration""")
+        executer.expectDocumentedDeprecationWarning("While resolving configuration 'detachedConfiguration1', it was also selected as a variant. Configurations should not act as both a resolution root and a variant simultaneously. Depending on the resolved configuration in this manner has been deprecated. This will fail with an error in Gradle 9.0. Be sure to mark configurations meant for resolution as canBeConsumed=false or use the 'resolvable(String)' configuration factory method to create them. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#depending_on_root_configuration")
 
         run "checkDependencies"
     }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DetachedConfigurationsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DetachedConfigurationsIntegrationTest.groovy
@@ -163,9 +163,7 @@ class DetachedConfigurationsIntegrationTest extends AbstractIntegrationSpec {
 
         expect:
         executer.expectDocumentedDeprecationWarning("The detachedConfiguration1 configuration has been deprecated for consumption. This will fail with an error in Gradle 9.0. For more information, please refer to https://docs.gradle.org/current/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.")
-        executer.expectDocumentedDeprecationWarning("""The resolved configuration 'detachedConfiguration1' has been selected by the following variants:
-    - :test:unspecified variant detachedConfiguration1
-Depending on the resolved configuration has been deprecated. This will fail with an error in Gradle 9.0. Be sure to mark non-consumable Configurations as canBeConsumed=false, or use role-based Configuration factory methods to ensure Configurations cannot be both resolved and consumed. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#depending_on_root_configuration""")
+        executer.expectDocumentedDeprecationWarning("""The resolved configuration 'detachedConfiguration1' has been consumed as a variant, resulting in a circular dependency graph. Depending on the resolved configuration in this manner has been deprecated. This will fail with an error in Gradle 9.0. Be sure to mark configurations meant for resolution as canBeConsumed=false, or use the 'resolvable(String)' configuration factory method. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#depending_on_root_configuration""")
 
         run "checkDependencies"
     }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DetachedConfigurationsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DetachedConfigurationsIntegrationTest.groovy
@@ -163,6 +163,10 @@ class DetachedConfigurationsIntegrationTest extends AbstractIntegrationSpec {
 
         expect:
         executer.expectDocumentedDeprecationWarning("The detachedConfiguration1 configuration has been deprecated for consumption. This will fail with an error in Gradle 9.0. For more information, please refer to https://docs.gradle.org/current/userguide/declaring_dependencies.html#sec:deprecated-configurations in the Gradle documentation.")
+        executer.expectDocumentedDeprecationWarning("""The resolved configuration 'detachedConfiguration1' has been selected by the following variants:
+    - :test:unspecified variant detachedConfiguration1
+Depending on the resolved configuration has been deprecated. This will fail with an error in Gradle 9.0. Be sure to mark non-consumable Configurations as canBeConsumed=false, or use role-based Configuration factory methods to ensure Configurations cannot be both resolved and consumed. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#depending_on_root_configuration""")
+
         run "checkDependencies"
     }
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/FileDependencyResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/FileDependencyResolveIntegrationTest.groovy
@@ -176,9 +176,7 @@ class FileDependencyResolveIntegrationTest extends AbstractDependencyResolutionT
 '''
 
         when:
-        executer.expectDocumentedDeprecationWarning("""The resolved configuration 'compile' has been selected by the following variants:
-    - main:sub:unspecified variant compile
-Depending on the resolved configuration has been deprecated. This will fail with an error in Gradle 9.0. Be sure to mark non-consumable Configurations as canBeConsumed=false, or use role-based Configuration factory methods to ensure Configurations cannot be both resolved and consumed. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#depending_on_root_configuration""")
+        executer.expectDocumentedDeprecationWarning("""The resolved configuration 'compile' has been consumed as a variant, resulting in a circular dependency graph. Depending on the resolved configuration in this manner has been deprecated. This will fail with an error in Gradle 9.0. Be sure to mark configurations meant for resolution as canBeConsumed=false, or use the 'resolvable(String)' configuration factory method. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#depending_on_root_configuration""")
         run ":checkDeps"
 
         then:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/FileDependencyResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/FileDependencyResolveIntegrationTest.groovy
@@ -176,6 +176,9 @@ class FileDependencyResolveIntegrationTest extends AbstractDependencyResolutionT
 '''
 
         when:
+        executer.expectDocumentedDeprecationWarning("""The resolved configuration 'compile' has been selected by the following variants:
+    - main:sub:unspecified variant compile
+Depending on the resolved configuration has been deprecated. This will fail with an error in Gradle 9.0. Be sure to mark non-consumable Configurations as canBeConsumed=false, or use role-based Configuration factory methods to ensure Configurations cannot be both resolved and consumed. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#depending_on_root_configuration""")
         run ":checkDeps"
 
         then:

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RootComponentResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RootComponentResolutionIntegrationTest.groovy
@@ -55,7 +55,7 @@ class RootComponentResolutionIntegrationTest extends AbstractIntegrationSpec {
             }
         """
 
-        executer.expectDocumentedDeprecationWarning("""The resolved configuration 'conf' has been consumed as a variant, resulting in a circular dependency graph. Depending on the resolved configuration in this manner has been deprecated. This will fail with an error in Gradle 9.0. Be sure to mark configurations meant for resolution as canBeConsumed=false, or use the 'resolvable(String)' configuration factory method. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#depending_on_root_configuration""")
+        executer.expectDocumentedDeprecationWarning("While resolving configuration 'conf', it was also selected as a variant. Configurations should not act as both a resolution root and a variant simultaneously. Depending on the resolved configuration in this manner has been deprecated. This will fail with an error in Gradle 9.0. Be sure to mark configurations meant for resolution as canBeConsumed=false or use the 'resolvable(String)' configuration factory method to create them. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#depending_on_root_configuration")
 
         expect:
         succeeds("resolve")
@@ -197,7 +197,7 @@ class RootComponentResolutionIntegrationTest extends AbstractIntegrationSpec {
             }
         """
 
-        executer.expectDocumentedDeprecationWarning("""The resolved configuration 'conf' has been consumed as a variant, resulting in a circular dependency graph. Depending on the resolved configuration in this manner has been deprecated. This will fail with an error in Gradle 9.0. Be sure to mark configurations meant for resolution as canBeConsumed=false, or use the 'resolvable(String)' configuration factory method. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#depending_on_root_configuration""")
+        executer.expectDocumentedDeprecationWarning("While resolving configuration 'conf', it was also selected as a variant. Configurations should not act as both a resolution root and a variant simultaneously. Depending on the resolved configuration in this manner has been deprecated. This will fail with an error in Gradle 9.0. Be sure to mark configurations meant for resolution as canBeConsumed=false or use the 'resolvable(String)' configuration factory method to create them. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#depending_on_root_configuration")
 
         expect:
         succeeds("resolve")
@@ -241,7 +241,7 @@ class RootComponentResolutionIntegrationTest extends AbstractIntegrationSpec {
             }
         """
 
-        executer.expectDocumentedDeprecationWarning("""The resolved configuration 'conf' has been consumed as a variant, resulting in a circular dependency graph. Depending on the resolved configuration in this manner has been deprecated. This will fail with an error in Gradle 9.0. Be sure to mark configurations meant for resolution as canBeConsumed=false, or use the 'resolvable(String)' configuration factory method. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#depending_on_root_configuration""")
+        executer.expectDocumentedDeprecationWarning("While resolving configuration 'conf', it was also selected as a variant. Configurations should not act as both a resolution root and a variant simultaneously. Depending on the resolved configuration in this manner has been deprecated. This will fail with an error in Gradle 9.0. Be sure to mark configurations meant for resolution as canBeConsumed=false or use the 'resolvable(String)' configuration factory method to create them. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#depending_on_root_configuration")
 
         expect:
         succeeds("resolve")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RootComponentResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RootComponentResolutionIntegrationTest.groovy
@@ -24,6 +24,10 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
  * ensuring the configuration can select other variants in the same component.
  */
 class RootComponentResolutionIntegrationTest extends AbstractIntegrationSpec {
+    def setup() {
+        settingsFile << "rootProject.name = 'root'"
+    }
+
     def "buildscript configuration can select itself"() {
         buildFile << """
             buildscript {
@@ -50,6 +54,10 @@ class RootComponentResolutionIntegrationTest extends AbstractIntegrationSpec {
                 }
             }
         """
+
+        executer.expectDocumentedDeprecationWarning("""The resolved configuration 'conf' has been selected by the following variants:
+    - :root:unspecified variant conf
+Depending on the resolved configuration has been deprecated. This will fail with an error in Gradle 9.0. Be sure to mark non-consumable Configurations as canBeConsumed=false, or use role-based Configuration factory methods to ensure Configurations cannot be both resolved and consumed. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#depending_on_root_configuration""")
 
         expect:
         succeeds("resolve")
@@ -191,6 +199,10 @@ class RootComponentResolutionIntegrationTest extends AbstractIntegrationSpec {
             }
         """
 
+        executer.expectDocumentedDeprecationWarning("""The resolved configuration 'conf' has been selected by the following variants:
+    - :root:unspecified variant conf
+Depending on the resolved configuration has been deprecated. This will fail with an error in Gradle 9.0. Be sure to mark non-consumable Configurations as canBeConsumed=false, or use role-based Configuration factory methods to ensure Configurations cannot be both resolved and consumed. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#depending_on_root_configuration""")
+
         expect:
         succeeds("resolve")
     }
@@ -233,12 +245,15 @@ class RootComponentResolutionIntegrationTest extends AbstractIntegrationSpec {
             }
         """
 
+        executer.expectDocumentedDeprecationWarning("""The resolved configuration 'conf' has been selected by the following variants:
+    - :root:unspecified variant conf
+Depending on the resolved configuration has been deprecated. This will fail with an error in Gradle 9.0. Be sure to mark non-consumable Configurations as canBeConsumed=false, or use role-based Configuration factory methods to ensure Configurations cannot be both resolved and consumed. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#depending_on_root_configuration""")
+
         expect:
         succeeds("resolve")
     }
 
     def "buildscript resolvable configuration and consumable configuration from same project live in same resolved component"() {
-        settingsFile << "rootProject.name = 'root'"
         buildFile << """
             buildscript {
                 configurations {
@@ -280,7 +295,6 @@ class RootComponentResolutionIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def "resolvable configuration and consumable configuration from same project live in same resolved component"() {
-        settingsFile << "rootProject.name = 'root'"
         buildFile << """
             configurations {
                 conf {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RootComponentResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RootComponentResolutionIntegrationTest.groovy
@@ -55,9 +55,7 @@ class RootComponentResolutionIntegrationTest extends AbstractIntegrationSpec {
             }
         """
 
-        executer.expectDocumentedDeprecationWarning("""The resolved configuration 'conf' has been selected by the following variants:
-    - :root:unspecified variant conf
-Depending on the resolved configuration has been deprecated. This will fail with an error in Gradle 9.0. Be sure to mark non-consumable Configurations as canBeConsumed=false, or use role-based Configuration factory methods to ensure Configurations cannot be both resolved and consumed. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#depending_on_root_configuration""")
+        executer.expectDocumentedDeprecationWarning("""The resolved configuration 'conf' has been consumed as a variant, resulting in a circular dependency graph. Depending on the resolved configuration in this manner has been deprecated. This will fail with an error in Gradle 9.0. Be sure to mark configurations meant for resolution as canBeConsumed=false, or use the 'resolvable(String)' configuration factory method. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#depending_on_root_configuration""")
 
         expect:
         succeeds("resolve")
@@ -199,9 +197,7 @@ Depending on the resolved configuration has been deprecated. This will fail with
             }
         """
 
-        executer.expectDocumentedDeprecationWarning("""The resolved configuration 'conf' has been selected by the following variants:
-    - :root:unspecified variant conf
-Depending on the resolved configuration has been deprecated. This will fail with an error in Gradle 9.0. Be sure to mark non-consumable Configurations as canBeConsumed=false, or use role-based Configuration factory methods to ensure Configurations cannot be both resolved and consumed. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#depending_on_root_configuration""")
+        executer.expectDocumentedDeprecationWarning("""The resolved configuration 'conf' has been consumed as a variant, resulting in a circular dependency graph. Depending on the resolved configuration in this manner has been deprecated. This will fail with an error in Gradle 9.0. Be sure to mark configurations meant for resolution as canBeConsumed=false, or use the 'resolvable(String)' configuration factory method. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#depending_on_root_configuration""")
 
         expect:
         succeeds("resolve")
@@ -245,9 +241,7 @@ Depending on the resolved configuration has been deprecated. This will fail with
             }
         """
 
-        executer.expectDocumentedDeprecationWarning("""The resolved configuration 'conf' has been selected by the following variants:
-    - :root:unspecified variant conf
-Depending on the resolved configuration has been deprecated. This will fail with an error in Gradle 9.0. Be sure to mark non-consumable Configurations as canBeConsumed=false, or use role-based Configuration factory methods to ensure Configurations cannot be both resolved and consumed. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#depending_on_root_configuration""")
+        executer.expectDocumentedDeprecationWarning("""The resolved configuration 'conf' has been consumed as a variant, resulting in a circular dependency graph. Depending on the resolved configuration in this manner has been deprecated. This will fail with an error in Gradle 9.0. Be sure to mark configurations meant for resolution as canBeConsumed=false, or use the 'resolvable(String)' configuration factory method. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#depending_on_root_configuration""")
 
         expect:
         succeeds("resolve")

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -395,13 +395,13 @@ public class DependencyGraphBuilder {
         List<EdgeState> incomingRootEdges = resolveState.getRoot().getIncomingEdges();
         if (!incomingRootEdges.isEmpty()) {
             String rootNodeName = resolveState.getRoot().getResolvedConfigurationId().getConfiguration();
-            String joinedSourceNodes = incomingRootEdges.stream().map(edge -> edge.getFrom().getNameWithVariant()).collect(Collectors.joining("\n    - "));
             DeprecationLogger.deprecate(
                 String.format(
-                    "The resolved configuration '%s' has been selected by the following variants:\n    - %s\nDepending on the resolved configuration",
-                    rootNodeName, joinedSourceNodes
+                    "The resolved configuration '%s' has been consumed as a variant, resulting in a circular dependency graph. " +
+                    "Depending on the resolved configuration in this manner",
+                    rootNodeName
                 ))
-                .withAdvice("Be sure to mark non-consumable Configurations as canBeConsumed=false, or use role-based Configuration factory methods to ensure Configurations cannot be both resolved and consumed.")
+                .withAdvice("Be sure to mark configurations meant for resolution as canBeConsumed=false, or use the 'resolvable(String)' configuration factory method.")
                 .willBecomeAnErrorInGradle9()
                 .withUpgradeGuideSection(8, "depending_on_root_configuration")
                 .nagUser();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -397,11 +397,11 @@ public class DependencyGraphBuilder {
             String rootNodeName = resolveState.getRoot().getResolvedConfigurationId().getConfiguration();
             DeprecationLogger.deprecate(
                 String.format(
-                    "The resolved configuration '%s' has been consumed as a variant, resulting in a circular dependency graph. " +
+                    "While resolving configuration '%s', it was also selected as a variant. Configurations should not act as both a resolution root and a variant simultaneously. " +
                     "Depending on the resolved configuration in this manner",
                     rootNodeName
                 ))
-                .withAdvice("Be sure to mark configurations meant for resolution as canBeConsumed=false, or use the 'resolvable(String)' configuration factory method.")
+                .withAdvice("Be sure to mark configurations meant for resolution as canBeConsumed=false or use the 'resolvable(String)' configuration factory method to create them.")
                 .willBecomeAnErrorInGradle9()
                 .withUpgradeGuideSection(8, "depending_on_root_configuration")
                 .nagUser();

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyReportTaskIntegrationTest.groovy
@@ -34,6 +34,8 @@ allprojects {
     version = 1.0
 }
 
+dependencies { compile project(":c") }
+
 project(":a") {
     dependencies { compile project(":b") }
     dependencies { compile project(":c") }
@@ -49,16 +51,16 @@ project(":c") {
 """
 
         when:
-        executer.expectDocumentedDeprecationWarning("""The resolved configuration 'default' has been consumed as a variant, resulting in a circular dependency graph. Depending on the resolved configuration in this manner has been deprecated. This will fail with an error in Gradle 9.0. Be sure to mark configurations meant for resolution as canBeConsumed=false, or use the 'resolvable(String)' configuration factory method. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#depending_on_root_configuration""")
-        run ":c:dependencies"
+        run ":dependencies"
 
         then:
         output.contains """
 compile
-\\--- project :a
-     +--- project :b
-     |    \\--- project :c (*)
-     \\--- project :c (*)
+\\--- project :c
+     \\--- project :a
+          +--- project :b
+          |    \\--- project :c (*)
+          \\--- project :c (*)
 """
         output.contains '(*) - Indicates repeated occurrences of a transitive dependency subtree. Gradle expands transitive dependency subtrees only once per project; repeat occurrences only display the root of the subtree, followed by this annotation.'
     }

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyReportTaskIntegrationTest.groovy
@@ -49,6 +49,10 @@ project(":c") {
 """
 
         when:
+        executer.expectDocumentedDeprecationWarning("""The resolved configuration 'default' has been selected by the following variants:
+    - group:a:1.0 variant default
+    - group:b:1.0 variant default
+Depending on the resolved configuration has been deprecated. This will fail with an error in Gradle 9.0. Be sure to mark non-consumable Configurations as canBeConsumed=false, or use role-based Configuration factory methods to ensure Configurations cannot be both resolved and consumed. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#depending_on_root_configuration""")
         run ":c:dependencies"
 
         then:

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyReportTaskIntegrationTest.groovy
@@ -49,10 +49,7 @@ project(":c") {
 """
 
         when:
-        executer.expectDocumentedDeprecationWarning("""The resolved configuration 'default' has been selected by the following variants:
-    - group:a:1.0 variant default
-    - group:b:1.0 variant default
-Depending on the resolved configuration has been deprecated. This will fail with an error in Gradle 9.0. Be sure to mark non-consumable Configurations as canBeConsumed=false, or use role-based Configuration factory methods to ensure Configurations cannot be both resolved and consumed. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#depending_on_root_configuration""")
+        executer.expectDocumentedDeprecationWarning("""The resolved configuration 'default' has been consumed as a variant, resulting in a circular dependency graph. Depending on the resolved configuration in this manner has been deprecated. This will fail with an error in Gradle 9.0. Be sure to mark configurations meant for resolution as canBeConsumed=false, or use the 'resolvable(String)' configuration factory method. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#depending_on_root_configuration""")
         run ":c:dependencies"
 
         then:

--- a/subprojects/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -57,6 +57,12 @@ These members will be removed in Gradle 9.0:
 * `VersionNumber.parse(String)`
 * `VersionNumber.compareTo(VersionNumber)`
 
+[[depending_on_root_configuration]]
+==== Deprecated depending on resolved configuration
+
+In some cases, it is possible to construct a dependency graph where the configuration being resolved can also be selected by a dependency in the graph.
+This can only occur when a Configuration is marked as both consumable and resolvable.
+In Gradle 9.0, this will no longer be allowed and will result in an error.
 
 [[changes_8.4]]
 == Upgrading from 8.3 and earlier

--- a/subprojects/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -60,10 +60,14 @@ These members will be removed in Gradle 9.0:
 [[depending_on_root_configuration]]
 ==== Deprecated depending on resolved configuration
 
-In some cases, it is possible to construct a dependency graph where the configuration being resolved can also be selected by a dependency in the graph.
-This can only occur when a configuration is marked as both consumable and resolvable.
-To avoid this, either mark all resolvable configurations as `canBeConsumed=false` or use the `resolvable(String)` configuration factory method.
-In Gradle 9.0, constructing circular graphs in this manner will no longer be allowed and will result in an error.
+When resolving a `Configuration`, it is sometimes possible to select that same configuration as a variant.
+Configurations should be used for one purpose (resolution, consumption or dependency declarations), so this can only occur when a configuration is marked as both consumable and resolvable.
+
+This can lead to confusing circular dependency graphs, as the configuration being resolved is used for two different purposes.
+
+To avoid this problem, plugins should mark all resolvable configurations as `canBeConsumed=false` or use the `resolvable(String)` configuration factory method when creating configurations meant for resolution.
+
+In Gradle 9.0, consuming configurations in this manner will no longer be allowed and will result in an error.
 
 [[changes_8.4]]
 == Upgrading from 8.3 and earlier

--- a/subprojects/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -61,8 +61,9 @@ These members will be removed in Gradle 9.0:
 ==== Deprecated depending on resolved configuration
 
 In some cases, it is possible to construct a dependency graph where the configuration being resolved can also be selected by a dependency in the graph.
-This can only occur when a Configuration is marked as both consumable and resolvable.
-In Gradle 9.0, this will no longer be allowed and will result in an error.
+This can only occur when a configuration is marked as both consumable and resolvable.
+To avoid this, either mark all resolvable configurations as `canBeConsumed=false` or use the `resolvable(String)` configuration factory method.
+In Gradle 9.0, constructing circular graphs in this manner will no longer be allowed and will result in an error.
 
 [[changes_8.4]]
 == Upgrading from 8.3 and earlier


### PR DESCRIPTION
In some edge-case scenarios, it is possible to construct a graph where the configuration being resolved is selected as a variant. Needing to support this edge case makes it very difficult to separate the implementations of resolvable and consumable configurations.

We deprecate this behavior so that in Gradle 9+ we can more easily separate how resolvable and consumable configurations are implemented.
