### PR TITLE
Auto accept binary changes for Upgraded properties

### DIFF
--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild.binary-compatibility.gradle
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild.binary-compatibility.gradle
@@ -15,10 +15,11 @@
  */
 
 
+
 import gradlebuild.EnrichedReportRenderer
+import gradlebuild.basics.GradleModuleApiAttribute
 import gradlebuild.basics.PublicApi
 import gradlebuild.basics.PublicKotlinDslApi
-import gradlebuild.basics.GradleModuleApiAttribute
 import gradlebuild.binarycompatibility.AcceptedApiChanges
 import gradlebuild.binarycompatibility.BinaryCompatibilityHelper
 import gradlebuild.binarycompatibility.CleanAcceptedApiChanges
@@ -91,6 +92,11 @@ configurations {
     }
 }
 
+def currentClasspath = configurations.currentApiClasspath.incoming.artifactView { lenient(true) }.files
+def currentDistributionJars = currentClasspath.filter { it.name.startsWith('gradle-') && it.name.endsWith('.jar') }
+def baselineJars = configurations.baselineJars
+def baseVersion = moduleIdentity.version.map { it.baseVersion.version }
+
 dependencies {
     baseline("gradle:gradle:${compatibilityBaselineVersion}@zip")
 
@@ -104,26 +110,6 @@ dependencies {
         from.attribute(ARTIFACT_TYPE, 'gradle-libs-dir')
         to.attribute(ARTIFACT_TYPE, 'gradle-classpath')
     }
-}
-
-def checkBinaryCompatibility = tasks.register("checkBinaryCompatibility", gradlebuild.binarycompatibility.JapicmpTask) {
-    def baseVersion = moduleIdentity.version.map { it.baseVersion.version }
-    def isSnapshot = moduleIdentity.snapshot
-    inputs.property('acceptedViolations', acceptedViolations.toAcceptedChangesMap())
-    inputs.property("baseline.version", compatibilityBaselineVersion)
-    inputs.property("currentVersion", baseVersion)
-    def apiSourceFolders = configurations.currentSources.incoming.artifactView { lenient(true) }.files
-    inputs.files("apiSourceFolders", apiSourceFolders)
-    def currentClasspath = configurations.currentApiClasspath.incoming.artifactView { lenient(true) }.files
-    inputs.files(currentClasspath)
-
-    newClasspath.from(currentClasspath)
-    oldClasspath.from(configurations.baselineClasspath)
-
-    def currentDistributionJars = currentClasspath.filter { it.name.startsWith('gradle-') && it.name.endsWith('.jar') }
-    newArchives.from(currentDistributionJars)
-    oldArchives.from(configurations.baselineJars)
-
     dependencies.registerTransform(FindGradleJars) {
         from.attribute(ARTIFACT_TYPE, 'gradle-libs-dir')
         to.attribute(ARTIFACT_TYPE, 'gradle-baseline-jars')
@@ -132,6 +118,32 @@ def checkBinaryCompatibility = tasks.register("checkBinaryCompatibility", gradle
             currentVersion.set(baseVersion)
         }
     }
+}
+
+def newUpgradedPropertiesFile = layout.buildDirectory.file("gradle-api-info/new-upgraded-properties.json")
+def oldUpgradedPropertiesFile = layout.buildDirectory.file("gradle-api-info/old-upgraded-properties.json")
+def extractGradleApiInfo = tasks.register("extractGradleApiInfo", gradlebuild.binarycompatibility.ExtractGradleApiInfoTask) {
+    newDistributionJars = currentDistributionJars
+    oldDistributionJars = baselineJars
+    newUpgradedProperties = newUpgradedPropertiesFile
+    oldUpgradedProperties = oldUpgradedPropertiesFile
+}
+
+def checkBinaryCompatibility = tasks.register("checkBinaryCompatibility", gradlebuild.binarycompatibility.JapicmpTask) {
+    def isSnapshot = moduleIdentity.snapshot
+    inputs.property('acceptedViolations', acceptedViolations.toAcceptedChangesMap())
+    inputs.property("baseline.version", compatibilityBaselineVersion)
+    inputs.property("currentVersion", baseVersion)
+    def apiSourceFolders = configurations.currentSources.incoming.artifactView { lenient(true) }.files
+    inputs.files("apiSourceFolders", apiSourceFolders)
+    inputs.files(currentClasspath)
+    inputs.files(extractGradleApiInfo)
+
+    newClasspath.from(currentClasspath)
+    oldClasspath.from(configurations.baselineClasspath)
+
+    newArchives.from(currentDistributionJars)
+    oldArchives.from(baselineJars)
 
     // binary breaking change checking setup
     onlyModified = false
@@ -158,7 +170,16 @@ def checkBinaryCompatibility = tasks.register("checkBinaryCompatibility", gradle
         it.renderer.set(EnrichedReportRenderer.class)
     } as Action)
 
-    BinaryCompatibilityHelper.setupJApiCmpRichReportRules(delegate, acceptedViolations, apiSourceFolders, baseVersion.get(), apiChangesJsonFile.asFile, rootProject.layout.projectDirectory)
+    BinaryCompatibilityHelper.setupJApiCmpRichReportRules(
+        delegate,
+        acceptedViolations,
+        apiSourceFolders,
+        baseVersion.get(),
+        apiChangesJsonFile.asFile,
+        rootProject.layout.projectDirectory,
+        newUpgradedPropertiesFile.get().asFile,
+        oldUpgradedPropertiesFile.get().asFile
+    )
 }
 tasks.named("check").configure { dependsOn(checkBinaryCompatibility) }
 

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild.binary-compatibility.gradle
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild.binary-compatibility.gradle
@@ -93,7 +93,7 @@ configurations {
 }
 
 def currentClasspath = configurations.currentApiClasspath.incoming.artifactView { lenient(true) }.files
-def currentDistributionJars = currentClasspath.filter { it.name.startsWith('gradle-') && it.name.endsWith('.jar') }
+def currentDistroJars = currentClasspath.filter { it.name.startsWith('gradle-') && it.name.endsWith('.jar') }
 def baselineJars = configurations.baselineJars
 def baseVersion = moduleIdentity.version.map { it.baseVersion.version }
 
@@ -114,7 +114,7 @@ dependencies {
         from.attribute(ARTIFACT_TYPE, 'gradle-libs-dir')
         to.attribute(ARTIFACT_TYPE, 'gradle-baseline-jars')
         parameters {
-            currentJars.from(currentDistributionJars)
+            currentJars.from(currentDistroJars)
             currentVersion.set(baseVersion)
         }
     }
@@ -123,7 +123,7 @@ dependencies {
 def currentUpgradedPropertiesFile = layout.buildDirectory.file("gradle-api-info/current-upgraded-properties.json")
 def baseUpgradedPropertiesFile = layout.buildDirectory.file("gradle-api-info/base-upgraded-properties.json")
 def extractGradleApiInfo = tasks.register("extractGradleApiInfo", gradlebuild.binarycompatibility.ExtractGradleApiInfoTask) {
-    currentDistributionJars = currentDistributionJars
+    currentDistributionJars = currentDistroJars
     baseDistributionJars = baselineJars
     currentUpgradedProperties = currentUpgradedPropertiesFile
     baseUpgradedProperties = baseUpgradedPropertiesFile
@@ -142,7 +142,7 @@ def checkBinaryCompatibility = tasks.register("checkBinaryCompatibility", gradle
     newClasspath.from(currentClasspath)
     oldClasspath.from(configurations.baselineClasspath)
 
-    newArchives.from(currentDistributionJars)
+    newArchives.from(currentDistroJars)
     oldArchives.from(baselineJars)
 
     // binary breaking change checking setup

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild.binary-compatibility.gradle
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild.binary-compatibility.gradle
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-
-
 import gradlebuild.EnrichedReportRenderer
 import gradlebuild.basics.GradleModuleApiAttribute
 import gradlebuild.basics.PublicApi
@@ -121,12 +119,12 @@ dependencies {
 }
 
 def currentUpgradedPropertiesFile = layout.buildDirectory.file("gradle-api-info/current-upgraded-properties.json")
-def baseUpgradedPropertiesFile = layout.buildDirectory.file("gradle-api-info/base-upgraded-properties.json")
+def baselineUpgradedPropertiesFile = layout.buildDirectory.file("gradle-api-info/baseline-upgraded-properties.json")
 def extractGradleApiInfo = tasks.register("extractGradleApiInfo", gradlebuild.binarycompatibility.ExtractGradleApiInfoTask) {
     currentDistributionJars = currentDistroJars
-    baseDistributionJars = baselineJars
+    baselineDistributionJars = baselineJars
     currentUpgradedProperties = currentUpgradedPropertiesFile
-    baseUpgradedProperties = baseUpgradedPropertiesFile
+    baselineUpgradedProperties = baselineUpgradedPropertiesFile
 }
 
 def checkBinaryCompatibility = tasks.register("checkBinaryCompatibility", gradlebuild.binarycompatibility.JapicmpTask) {
@@ -178,7 +176,7 @@ def checkBinaryCompatibility = tasks.register("checkBinaryCompatibility", gradle
         apiChangesJsonFile.asFile,
         rootProject.layout.projectDirectory,
         currentUpgradedPropertiesFile.get().asFile,
-        baseUpgradedPropertiesFile.get().asFile
+        baselineUpgradedPropertiesFile.get().asFile
     )
 }
 tasks.named("check").configure { dependsOn(checkBinaryCompatibility) }

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild.binary-compatibility.gradle
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild.binary-compatibility.gradle
@@ -120,13 +120,13 @@ dependencies {
     }
 }
 
-def newUpgradedPropertiesFile = layout.buildDirectory.file("gradle-api-info/new-upgraded-properties.json")
-def oldUpgradedPropertiesFile = layout.buildDirectory.file("gradle-api-info/old-upgraded-properties.json")
+def currentUpgradedPropertiesFile = layout.buildDirectory.file("gradle-api-info/current-upgraded-properties.json")
+def baseUpgradedPropertiesFile = layout.buildDirectory.file("gradle-api-info/base-upgraded-properties.json")
 def extractGradleApiInfo = tasks.register("extractGradleApiInfo", gradlebuild.binarycompatibility.ExtractGradleApiInfoTask) {
-    newDistributionJars = currentDistributionJars
-    oldDistributionJars = baselineJars
-    newUpgradedProperties = newUpgradedPropertiesFile
-    oldUpgradedProperties = oldUpgradedPropertiesFile
+    currentDistributionJars = currentDistributionJars
+    baseDistributionJars = baselineJars
+    currentUpgradedProperties = currentUpgradedPropertiesFile
+    baseUpgradedProperties = baseUpgradedPropertiesFile
 }
 
 def checkBinaryCompatibility = tasks.register("checkBinaryCompatibility", gradlebuild.binarycompatibility.JapicmpTask) {
@@ -177,8 +177,8 @@ def checkBinaryCompatibility = tasks.register("checkBinaryCompatibility", gradle
         baseVersion.get(),
         apiChangesJsonFile.asFile,
         rootProject.layout.projectDirectory,
-        newUpgradedPropertiesFile.get().asFile,
-        oldUpgradedPropertiesFile.get().asFile
+        currentUpgradedPropertiesFile.get().asFile,
+        baseUpgradedPropertiesFile.get().asFile
     )
 }
 tasks.named("check").configure { dependsOn(checkBinaryCompatibility) }

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/BinaryCompatibilityHelper.groovy
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/BinaryCompatibilityHelper.groovy
@@ -30,6 +30,7 @@ import gradlebuild.binarycompatibility.rules.NewIncubatingAPIRule
 import gradlebuild.binarycompatibility.rules.NullabilityBreakingChangesRule
 import gradlebuild.binarycompatibility.rules.SinceAnnotationMissingRule
 import gradlebuild.binarycompatibility.rules.SinceAnnotationMissingRuleCurrentGradleVersionSetup
+import gradlebuild.binarycompatibility.rules.UpgradePropertiesRulePostProcess
 import gradlebuild.binarycompatibility.rules.UpgradePropertiesRuleSetup
 import japicmp.model.JApiChangeStatus
 import org.gradle.api.file.Directory
@@ -118,6 +119,7 @@ class BinaryCompatibilityHelper {
 
                 addPostProcessRule(AcceptedRegressionsRulePostProcess)
                 addPostProcessRule(BinaryCompatibilityRepositoryPostProcessRule)
+                addPostProcessRule(UpgradePropertiesRulePostProcess)
             }
         }
     }

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/BinaryCompatibilityHelper.groovy
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/BinaryCompatibilityHelper.groovy
@@ -30,6 +30,7 @@ import gradlebuild.binarycompatibility.rules.NewIncubatingAPIRule
 import gradlebuild.binarycompatibility.rules.NullabilityBreakingChangesRule
 import gradlebuild.binarycompatibility.rules.SinceAnnotationMissingRule
 import gradlebuild.binarycompatibility.rules.SinceAnnotationMissingRuleCurrentGradleVersionSetup
+import gradlebuild.binarycompatibility.rules.UpgradePropertiesRuleSetup
 import japicmp.model.JApiChangeStatus
 import org.gradle.api.file.Directory
 import org.gradle.api.file.FileCollection
@@ -41,7 +42,9 @@ class BinaryCompatibilityHelper {
         FileCollection sourceRoots,
         String currentVersion,
         File apiChangesJsonFile,
-        Directory projectRootDir
+        Directory projectRootDir,
+        File newUpgradedProperties,
+        File oldUpgradedProperties
     ) {
         japicmpTask.tap {
             addExcludeFilter(AnonymousClassesFilter)
@@ -107,6 +110,10 @@ class BinaryCompatibilityHelper {
                 addSetupRule(BinaryCompatibilityRepositorySetupRule, [
                     (BinaryCompatibilityRepositorySetupRule.Params.sourceRoots): sourceRoots.collect { it.absolutePath } as Set,
                     (BinaryCompatibilityRepositorySetupRule.Params.sourceCompilationClasspath): newClasspath.collect { it.absolutePath } as Set
+                ])
+                addSetupRule(UpgradePropertiesRuleSetup, [
+                    newUpgradedProperties: newUpgradedProperties.absolutePath,
+                    oldUpgradedProperties: oldUpgradedProperties.absolutePath
                 ])
 
                 addPostProcessRule(AcceptedRegressionsRulePostProcess)

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/BinaryCompatibilityHelper.groovy
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/BinaryCompatibilityHelper.groovy
@@ -45,7 +45,7 @@ class BinaryCompatibilityHelper {
         File apiChangesJsonFile,
         Directory projectRootDir,
         File currentUpgradedPropertiesFile,
-        File baseUpgradedPropertiesFile
+        File baselineUpgradedPropertiesFile
     ) {
         japicmpTask.tap {
             addExcludeFilter(AnonymousClassesFilter)
@@ -114,7 +114,7 @@ class BinaryCompatibilityHelper {
                 ])
                 addSetupRule(UpgradePropertiesRuleSetup, [
                     currentUpgradedProperties: currentUpgradedPropertiesFile.absolutePath,
-                    baseUpgradedProperties: baseUpgradedPropertiesFile.absolutePath
+                    baselineUpgradedProperties: baselineUpgradedPropertiesFile.absolutePath
                 ])
 
                 addPostProcessRule(AcceptedRegressionsRulePostProcess)

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/BinaryCompatibilityHelper.groovy
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/BinaryCompatibilityHelper.groovy
@@ -43,8 +43,8 @@ class BinaryCompatibilityHelper {
         String currentVersion,
         File apiChangesJsonFile,
         Directory projectRootDir,
-        File newUpgradedProperties,
-        File oldUpgradedProperties
+        File currentUpgradedPropertiesFile,
+        File baseUpgradedPropertiesFile
     ) {
         japicmpTask.tap {
             addExcludeFilter(AnonymousClassesFilter)
@@ -112,8 +112,8 @@ class BinaryCompatibilityHelper {
                     (BinaryCompatibilityRepositorySetupRule.Params.sourceCompilationClasspath): newClasspath.collect { it.absolutePath } as Set
                 ])
                 addSetupRule(UpgradePropertiesRuleSetup, [
-                    newUpgradedProperties: newUpgradedProperties.absolutePath,
-                    oldUpgradedProperties: oldUpgradedProperties.absolutePath
+                    currentUpgradedProperties: currentUpgradedPropertiesFile.absolutePath,
+                    baseUpgradedProperties: baseUpgradedPropertiesFile.absolutePath
                 ])
 
                 addPostProcessRule(AcceptedRegressionsRulePostProcess)

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/ExtractGradleApiInfoTask.java
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/ExtractGradleApiInfoTask.java
@@ -58,18 +58,18 @@ public abstract class ExtractGradleApiInfoTask extends DefaultTask {
     public abstract ConfigurableFileCollection getCurrentDistributionJars();
 
     @CompileClasspath
-    public abstract ConfigurableFileCollection getBaseDistributionJars();
+    public abstract ConfigurableFileCollection getBaselineDistributionJars();
 
     @OutputFile
     public abstract RegularFileProperty getCurrentUpgradedProperties();
 
     @OutputFile
-    public abstract RegularFileProperty getBaseUpgradedProperties();
+    public abstract RegularFileProperty getBaselineUpgradedProperties();
 
     @TaskAction
     public void execute() {
         extractUpgradedProperties(getCurrentDistributionJars(), getCurrentUpgradedProperties());
-        extractUpgradedProperties(getBaseDistributionJars(), getBaseUpgradedProperties());
+        extractUpgradedProperties(getBaselineDistributionJars(), getBaselineUpgradedProperties());
     }
 
     private void extractUpgradedProperties(FileCollection from, RegularFileProperty to) {

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/ExtractGradleApiInfoTask.java
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/ExtractGradleApiInfoTask.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gradlebuild.binarycompatibility;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.CompileClasspath;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+
+/**
+ * Extracts Gradle API information from the given Gradle distribution archives.
+ */
+@CacheableTask
+public abstract class ExtractGradleApiInfoTask extends DefaultTask {
+
+    @CompileClasspath
+    abstract ConfigurableFileCollection getNewDistributionJars();
+
+    @CompileClasspath
+    abstract ConfigurableFileCollection getOldDistributionJars();
+
+    @OutputFile
+    abstract RegularFileProperty getNewUpgradedProperties();
+
+    @OutputFile
+    abstract RegularFileProperty getOldUpgradedProperties();
+
+    @TaskAction
+    public void execute() {
+        // TODO
+    }
+}

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/ExtractGradleApiInfoTask.java
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/ExtractGradleApiInfoTask.java
@@ -55,21 +55,21 @@ public abstract class ExtractGradleApiInfoTask extends DefaultTask {
     public abstract Property<String> getGradleApiInfoJarPrefix();
 
     @CompileClasspath
-    public abstract ConfigurableFileCollection getNewDistributionJars();
+    public abstract ConfigurableFileCollection getCurrentDistributionJars();
 
     @CompileClasspath
-    public abstract ConfigurableFileCollection getOldDistributionJars();
+    public abstract ConfigurableFileCollection getBaseDistributionJars();
 
     @OutputFile
-    public abstract RegularFileProperty getNewUpgradedProperties();
+    public abstract RegularFileProperty getCurrentUpgradedProperties();
 
     @OutputFile
-    public abstract RegularFileProperty getOldUpgradedProperties();
+    public abstract RegularFileProperty getBaseUpgradedProperties();
 
     @TaskAction
     public void execute() {
-        extractUpgradedProperties(getNewDistributionJars(), getNewUpgradedProperties());
-        extractUpgradedProperties(getOldDistributionJars(), getOldUpgradedProperties());
+        extractUpgradedProperties(getCurrentDistributionJars(), getCurrentUpgradedProperties());
+        extractUpgradedProperties(getBaseDistributionJars(), getBaseUpgradedProperties());
     }
 
     private void extractUpgradedProperties(FileCollection from, RegularFileProperty to) {

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/AbstractGradleViolationRule.groovy
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/AbstractGradleViolationRule.groovy
@@ -40,7 +40,7 @@ import org.gradle.api.Incubating
 import javax.inject.Inject
 
 import static gradlebuild.binarycompatibility.upgrades.UpgradedProperties.SEEN_OLD_METHODS_OF_UPGRADED_PROPERTIES
-import static gradlebuild.binarycompatibility.upgrades.UpgradedProperty.MethodKey
+import static gradlebuild.binarycompatibility.upgrades.UpgradedProperty.UpgradedMethodKey
 
 @CompileStatic
 abstract class AbstractGradleViolationRule extends AbstractContextAwareViolationRule {
@@ -136,7 +136,7 @@ abstract class AbstractGradleViolationRule extends AbstractContextAwareViolation
 
     Violation acceptOrReject(JApiCompatibility member, List<String> changes, Violation rejection) {
         Set<ApiChange> seenApiChanges = (Set<ApiChange>) context.userData["seenApiChanges"]
-        Set<MethodKey> seenOldMethodsOfUpgradedProperties = (Set<MethodKey>) context.userData[SEEN_OLD_METHODS_OF_UPGRADED_PROPERTIES]
+        Set<UpgradedMethodKey> seenOldMethodsOfUpgradedProperties = (Set<UpgradedMethodKey>) context.userData[SEEN_OLD_METHODS_OF_UPGRADED_PROPERTIES]
         UpgradedProperties.maybeGetKeyOfOldMethodOfUpgradedProperty(member, context).ifPresent { seenOldMethodsOfUpgradedProperties.add(it) }
 
         def change = new ApiChange(

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/AbstractGradleViolationRule.groovy
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/AbstractGradleViolationRule.groovy
@@ -23,6 +23,7 @@ import gradlebuild.binarycompatibility.AcceptedApiChanges
 import gradlebuild.binarycompatibility.ApiChange
 import gradlebuild.binarycompatibility.BinaryCompatibilityRepository
 import gradlebuild.binarycompatibility.BinaryCompatibilityRepositorySetupRule
+import gradlebuild.binarycompatibility.upgrades.UpgradedProperties
 import groovy.transform.CompileStatic
 import japicmp.model.JApiChangeStatus
 import japicmp.model.JApiClass
@@ -141,6 +142,9 @@ abstract class AbstractGradleViolationRule extends AbstractContextAwareViolation
         if (acceptationReason != null) {
             seenApiChanges.add(change)
             return Violation.accept(member, "${rejection.getHumanExplanation()}. Reason for accepting this: <b>$acceptationReason</b>")
+        } else if (member instanceof JApiMethod && UpgradedProperties.isUpgradedProperty(member, context)) {
+            seenApiChanges.add(change)
+            return Violation.accept(member, "${rejection.getHumanExplanation()}. Reason for accepting this: <b>Upgraded property</b>")
         }
         def acceptanceJson = new AcceptedApiChange(
             change.type,

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/AbstractGradleViolationRule.groovy
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/AbstractGradleViolationRule.groovy
@@ -142,7 +142,7 @@ abstract class AbstractGradleViolationRule extends AbstractContextAwareViolation
         if (acceptationReason != null) {
             seenApiChanges.add(change)
             return Violation.accept(member, "${rejection.getHumanExplanation()}. Reason for accepting this: <b>$acceptationReason</b>")
-        } else if (member instanceof JApiMethod && UpgradedProperties.isUpgradedProperty(member, context)) {
+        } else if (member instanceof JApiMethod && UpgradedProperties.acceptForUpgradedProperty(member, rejection, context)) {
             seenApiChanges.add(change)
             return Violation.accept(member, "${rejection.getHumanExplanation()}. Reason for accepting this: <b>Upgraded property</b>")
         }

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/AbstractGradleViolationRule.groovy
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/AbstractGradleViolationRule.groovy
@@ -40,6 +40,7 @@ import org.gradle.api.Incubating
 import javax.inject.Inject
 
 import static gradlebuild.binarycompatibility.upgrades.UpgradedProperties.SEEN_OLD_METHODS_OF_UPGRADED_PROPERTIES
+import static gradlebuild.binarycompatibility.upgrades.UpgradedProperty.MethodKey
 
 @CompileStatic
 abstract class AbstractGradleViolationRule extends AbstractContextAwareViolationRule {
@@ -135,7 +136,7 @@ abstract class AbstractGradleViolationRule extends AbstractContextAwareViolation
 
     Violation acceptOrReject(JApiCompatibility member, List<String> changes, Violation rejection) {
         Set<ApiChange> seenApiChanges = (Set<ApiChange>) context.userData["seenApiChanges"]
-        Set<String> seenOldMethodsOfUpgradedProperties = (Set<String>) context.userData[SEEN_OLD_METHODS_OF_UPGRADED_PROPERTIES]
+        Set<MethodKey> seenOldMethodsOfUpgradedProperties = (Set<MethodKey>) context.userData[SEEN_OLD_METHODS_OF_UPGRADED_PROPERTIES]
         UpgradedProperties.maybeGetKeyOfOldMethodOfUpgradedProperty(member, context).ifPresent { seenOldMethodsOfUpgradedProperties.add(it) }
 
         def change = new ApiChange(

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/AbstractGradleViolationRule.groovy
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/AbstractGradleViolationRule.groovy
@@ -39,6 +39,8 @@ import org.gradle.api.Incubating
 
 import javax.inject.Inject
 
+import static gradlebuild.binarycompatibility.upgrades.UpgradedProperties.SEEN_OLD_METHODS_OF_UPGRADED_PROPERTIES
+
 @CompileStatic
 abstract class AbstractGradleViolationRule extends AbstractContextAwareViolationRule {
 
@@ -133,6 +135,9 @@ abstract class AbstractGradleViolationRule extends AbstractContextAwareViolation
 
     Violation acceptOrReject(JApiCompatibility member, List<String> changes, Violation rejection) {
         Set<ApiChange> seenApiChanges = (Set<ApiChange>) context.userData["seenApiChanges"]
+        Set<String> seenOldMethodsOfUpgradedProperties = (Set<String>) context.userData[SEEN_OLD_METHODS_OF_UPGRADED_PROPERTIES]
+        UpgradedProperties.maybeGetKeyOfOldMethodOfUpgradedProperty(member, context).ifPresent { seenOldMethodsOfUpgradedProperties.add(it) }
+
         def change = new ApiChange(
             context.className,
             Violation.describe(member),
@@ -142,10 +147,11 @@ abstract class AbstractGradleViolationRule extends AbstractContextAwareViolation
         if (acceptationReason != null) {
             seenApiChanges.add(change)
             return Violation.accept(member, "${rejection.getHumanExplanation()}. Reason for accepting this: <b>$acceptationReason</b>")
-        } else if (member instanceof JApiMethod && UpgradedProperties.acceptForUpgradedProperty(member, rejection, context)) {
+        } else if (member instanceof JApiMethod && UpgradedProperties.shouldAcceptForUpgradedProperty(member, rejection, context)) {
             seenApiChanges.add(change)
             return Violation.accept(member, "${rejection.getHumanExplanation()}. Reason for accepting this: <b>Upgraded property</b>")
         }
+
         def acceptanceJson = new AcceptedApiChange(
             change.type,
             change.member,

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/SinceAnnotationMissingRule.java
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/SinceAnnotationMissingRule.java
@@ -29,6 +29,8 @@ import java.util.Map;
 
 public class SinceAnnotationMissingRule extends AbstractGradleViolationRule {
 
+    public static final String SINCE_ERROR_MESSAGE = "Is not annotated with @since ";
+
     public SinceAnnotationMissingRule(Map<String, Object> params) {
         super(params);
     }
@@ -40,7 +42,7 @@ public class SinceAnnotationMissingRule extends AbstractGradleViolationRule {
             return null;
         }
 
-        return acceptOrReject(member, Violation.error(member, "Is not annotated with @since " + getCurrentVersion()));
+        return acceptOrReject(member, Violation.error(member, SINCE_ERROR_MESSAGE + getCurrentVersion()));
     }
 
     private boolean shouldSkipViolationCheckFor(JApiCompatibility member) {

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/UpgradePropertiesRulePostProcess.java
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/UpgradePropertiesRulePostProcess.java
@@ -17,7 +17,7 @@
 package gradlebuild.binarycompatibility.rules;
 
 import gradlebuild.binarycompatibility.upgrades.UpgradedProperty;
-import gradlebuild.binarycompatibility.upgrades.UpgradedProperty.MethodKey;
+import gradlebuild.binarycompatibility.upgrades.UpgradedProperty.UpgradedMethodKey;
 import me.champeau.gradle.japicmp.report.PostProcessViolationsRule;
 import me.champeau.gradle.japicmp.report.ViolationCheckContextWithViolations;
 import org.gradle.util.internal.CollectionUtils;
@@ -34,9 +34,9 @@ public class UpgradePropertiesRulePostProcess implements PostProcessViolationsRu
     @Override
     @SuppressWarnings("unchecked")
     public void execute(ViolationCheckContextWithViolations context) {
-        Set<MethodKey> seenUpgradedMethodChanges = (Set<MethodKey>) context.getUserData().get(SEEN_OLD_METHODS_OF_UPGRADED_PROPERTIES);
-        Map<MethodKey, UpgradedProperty> oldMethodsOfUpgradedProperties = (Map<MethodKey, UpgradedProperty>) context.getUserData().get(OLD_METHODS_OF_UPGRADED_PROPERTIES);
-        Map<MethodKey, UpgradedProperty> left = new HashMap<>(oldMethodsOfUpgradedProperties);
+        Set<UpgradedMethodKey> seenUpgradedMethodChanges = (Set<UpgradedMethodKey>) context.getUserData().get(SEEN_OLD_METHODS_OF_UPGRADED_PROPERTIES);
+        Map<UpgradedMethodKey, UpgradedProperty> oldMethodsOfUpgradedProperties = (Map<UpgradedMethodKey, UpgradedProperty>) context.getUserData().get(OLD_METHODS_OF_UPGRADED_PROPERTIES);
+        Map<UpgradedMethodKey, UpgradedProperty> left = new HashMap<>(oldMethodsOfUpgradedProperties);
         left.keySet().removeIf(seenUpgradedMethodChanges::contains);
         if (!left.isEmpty()) {
             String formattedLeft = CollectionUtils.join("\n", left.keySet());

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/UpgradePropertiesRulePostProcess.java
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/UpgradePropertiesRulePostProcess.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gradlebuild.binarycompatibility.rules;
+
+import gradlebuild.binarycompatibility.upgrades.UpgradedProperty;
+import me.champeau.gradle.japicmp.report.PostProcessViolationsRule;
+import me.champeau.gradle.japicmp.report.ViolationCheckContextWithViolations;
+import org.gradle.util.internal.CollectionUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static gradlebuild.binarycompatibility.upgrades.UpgradedProperties.OLD_METHODS_OF_UPGRADED_PROPERTIES;
+import static gradlebuild.binarycompatibility.upgrades.UpgradedProperties.SEEN_OLD_METHODS_OF_UPGRADED_PROPERTIES;
+
+public class UpgradePropertiesRulePostProcess implements PostProcessViolationsRule {
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void execute(ViolationCheckContextWithViolations context) {
+        Set<String> seenUpgradedMethodChanges = (Set<String>) context.getUserData().get(SEEN_OLD_METHODS_OF_UPGRADED_PROPERTIES);
+        Map<String, UpgradedProperty> oldMethodsOfUpgradedProperties = (Map<String, UpgradedProperty>) context.getUserData().get(OLD_METHODS_OF_UPGRADED_PROPERTIES);
+        Map<String, UpgradedProperty> left = new HashMap<>(oldMethodsOfUpgradedProperties);
+        left.keySet().removeIf(seenUpgradedMethodChanges::contains);
+        if (!left.isEmpty()) {
+            String formattedLeft = CollectionUtils.join("\n", left.keySet());
+            throw new RuntimeException("The following methods were upgraded, but didn't match any changed method:\n\n" + formattedLeft);
+        }
+    }
+}

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/UpgradePropertiesRulePostProcess.java
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/UpgradePropertiesRulePostProcess.java
@@ -17,6 +17,7 @@
 package gradlebuild.binarycompatibility.rules;
 
 import gradlebuild.binarycompatibility.upgrades.UpgradedProperty;
+import gradlebuild.binarycompatibility.upgrades.UpgradedProperty.MethodKey;
 import me.champeau.gradle.japicmp.report.PostProcessViolationsRule;
 import me.champeau.gradle.japicmp.report.ViolationCheckContextWithViolations;
 import org.gradle.util.internal.CollectionUtils;
@@ -33,9 +34,9 @@ public class UpgradePropertiesRulePostProcess implements PostProcessViolationsRu
     @Override
     @SuppressWarnings("unchecked")
     public void execute(ViolationCheckContextWithViolations context) {
-        Set<String> seenUpgradedMethodChanges = (Set<String>) context.getUserData().get(SEEN_OLD_METHODS_OF_UPGRADED_PROPERTIES);
-        Map<String, UpgradedProperty> oldMethodsOfUpgradedProperties = (Map<String, UpgradedProperty>) context.getUserData().get(OLD_METHODS_OF_UPGRADED_PROPERTIES);
-        Map<String, UpgradedProperty> left = new HashMap<>(oldMethodsOfUpgradedProperties);
+        Set<MethodKey> seenUpgradedMethodChanges = (Set<MethodKey>) context.getUserData().get(SEEN_OLD_METHODS_OF_UPGRADED_PROPERTIES);
+        Map<MethodKey, UpgradedProperty> oldMethodsOfUpgradedProperties = (Map<MethodKey, UpgradedProperty>) context.getUserData().get(OLD_METHODS_OF_UPGRADED_PROPERTIES);
+        Map<MethodKey, UpgradedProperty> left = new HashMap<>(oldMethodsOfUpgradedProperties);
         left.keySet().removeIf(seenUpgradedMethodChanges::contains);
         if (!left.isEmpty()) {
             String formattedLeft = CollectionUtils.join("\n", left.keySet());

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/UpgradePropertiesRuleSetup.java
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/UpgradePropertiesRuleSetup.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gradlebuild.binarycompatibility.rules;
+
+import me.champeau.gradle.japicmp.report.SetupRule;
+import me.champeau.gradle.japicmp.report.ViolationCheckContext;
+
+import java.util.Map;
+
+public class UpgradePropertiesRuleSetup implements SetupRule {
+
+    private Map<String, String> params;
+
+    public UpgradePropertiesRuleSetup(Map<String, String> params) {
+        this.params = params;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void execute(ViolationCheckContext context) {
+        System.out.println("newArchives: " + params.get("newUpgradedProperties"));
+        System.out.println("oldArchives: " + params.get("oldUpgradedProperties"));
+    }
+
+}

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/UpgradePropertiesRuleSetup.java
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/UpgradePropertiesRuleSetup.java
@@ -22,12 +22,14 @@ import me.champeau.gradle.japicmp.report.SetupRule;
 import me.champeau.gradle.japicmp.report.ViolationCheckContext;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 import static gradlebuild.binarycompatibility.upgrades.UpgradedProperties.CURRENT_METHODS_OF_UPGRADED_PROPERTIES;
 import static gradlebuild.binarycompatibility.upgrades.UpgradedProperties.OLD_METHODS_OF_UPGRADED_PROPERTIES;
+import static gradlebuild.binarycompatibility.upgrades.UpgradedProperties.SEEN_OLD_METHODS_OF_UPGRADED_PROPERTIES;
 import static gradlebuild.binarycompatibility.upgrades.UpgradedProperties.getMethodKey;
 
 public class UpgradePropertiesRuleSetup implements SetupRule {
@@ -45,8 +47,15 @@ public class UpgradePropertiesRuleSetup implements SetupRule {
     public void execute(ViolationCheckContext context) {
         List<UpgradedProperty> currentUpgradedProperties = UpgradedProperties.parse(params.get(CURRENT_UPGRADED_PROPERTIES_KEY));
         List<UpgradedProperty> baseUpgradedProperties = UpgradedProperties.parse(params.get(BASE_UPGRADED_PROPERTIES_KEY));
-        context.putUserData(CURRENT_METHODS_OF_UPGRADED_PROPERTIES, diff(mapCurrentMethodsOfUpgradedProperties(currentUpgradedProperties), mapCurrentMethodsOfUpgradedProperties(baseUpgradedProperties)));
-        context.putUserData(OLD_METHODS_OF_UPGRADED_PROPERTIES, diff(mapOldMethodsOfUpgradedProperties(currentUpgradedProperties), mapOldMethodsOfUpgradedProperties(baseUpgradedProperties)));
+        context.putUserData(CURRENT_METHODS_OF_UPGRADED_PROPERTIES, diff(
+            mapCurrentMethodsOfUpgradedProperties(currentUpgradedProperties),
+            mapCurrentMethodsOfUpgradedProperties(baseUpgradedProperties)
+        ));
+        context.putUserData(OLD_METHODS_OF_UPGRADED_PROPERTIES, diff(
+            mapOldMethodsOfUpgradedProperties(currentUpgradedProperties),
+            mapOldMethodsOfUpgradedProperties(baseUpgradedProperties)
+        ));
+        context.putUserData(SEEN_OLD_METHODS_OF_UPGRADED_PROPERTIES, new HashSet<>());
     }
 
     private static Map<String, UpgradedProperty> mapCurrentMethodsOfUpgradedProperties(List<UpgradedProperty> upgradedProperties) {
@@ -76,6 +85,6 @@ public class UpgradePropertiesRuleSetup implements SetupRule {
     private static <T> Map<String, T> diff(Map<String, T> first, Map<String, T> second) {
         return first.entrySet().stream()
             .filter(e -> !second.containsKey(e.getKey()))
-            .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 }

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/UpgradePropertiesRuleSetup.java
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/UpgradePropertiesRuleSetup.java
@@ -17,23 +17,65 @@
 package gradlebuild.binarycompatibility.rules;
 
 import gradlebuild.binarycompatibility.upgrades.UpgradedProperties;
+import gradlebuild.binarycompatibility.upgrades.UpgradedProperty;
 import me.champeau.gradle.japicmp.report.SetupRule;
 import me.champeau.gradle.japicmp.report.ViolationCheckContext;
 
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+
+import static gradlebuild.binarycompatibility.upgrades.UpgradedProperties.CURRENT_METHODS_OF_UPGRADED_PROPERTIES;
+import static gradlebuild.binarycompatibility.upgrades.UpgradedProperties.OLD_METHODS_OF_UPGRADED_PROPERTIES;
+import static gradlebuild.binarycompatibility.upgrades.UpgradedProperties.getMethodKey;
 
 public class UpgradePropertiesRuleSetup implements SetupRule {
 
-    private Map<String, String> params;
+    private static final String CURRENT_UPGRADED_PROPERTIES_KEY = "currentUpgradedProperties";
+    private static final String BASE_UPGRADED_PROPERTIES_KEY = "baseUpgradedProperties";
+
+    private final Map<String, String> params;
 
     public UpgradePropertiesRuleSetup(Map<String, String> params) {
         this.params = params;
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public void execute(ViolationCheckContext context) {
-        context.putUserData("newUpgradedProperties", UpgradedProperties.parse(params.get("newUpgradedProperties")));
-        context.putUserData("oldUpgradedProperties", UpgradedProperties.parse(params.get("oldUpgradedProperties")));
+        List<UpgradedProperty> currentUpgradedProperties = UpgradedProperties.parse(params.get(CURRENT_UPGRADED_PROPERTIES_KEY));
+        List<UpgradedProperty> baseUpgradedProperties = UpgradedProperties.parse(params.get(BASE_UPGRADED_PROPERTIES_KEY));
+        context.putUserData(CURRENT_METHODS_OF_UPGRADED_PROPERTIES, diff(mapCurrentMethodsOfUpgradedProperties(currentUpgradedProperties), mapCurrentMethodsOfUpgradedProperties(baseUpgradedProperties)));
+        context.putUserData(OLD_METHODS_OF_UPGRADED_PROPERTIES, diff(mapOldMethodsOfUpgradedProperties(currentUpgradedProperties), mapOldMethodsOfUpgradedProperties(baseUpgradedProperties)));
+    }
+
+    private static Map<String, UpgradedProperty> mapCurrentMethodsOfUpgradedProperties(List<UpgradedProperty> upgradedProperties) {
+        Map<String, UpgradedProperty> map = new HashMap<>();
+        upgradedProperties.forEach(upgradedProperty -> {
+            String key = getMethodKey(upgradedProperty.getContainingType(), upgradedProperty.getMethodName(), upgradedProperty.getMethodDescriptor());
+            map.put(key, upgradedProperty);
+        });
+        return map;
+    }
+
+    private static Map<String, UpgradedProperty> mapOldMethodsOfUpgradedProperties(List<UpgradedProperty> upgradedProperties) {
+        Map<String, UpgradedProperty> map = new HashMap<>();
+        upgradedProperties.forEach(upgradedProperty -> map.putAll(mapOldMethodsOfUpgradedProperties(upgradedProperty)));
+        return map;
+    }
+
+    private static Map<String, UpgradedProperty> mapOldMethodsOfUpgradedProperties(UpgradedProperty upgradedProperty) {
+        Map<String, UpgradedProperty> map = new HashMap<>();
+        upgradedProperty.getUpgradedMethods().forEach(upgradedMethod -> {
+            String key = getMethodKey(upgradedProperty.getContainingType(), upgradedMethod.getName(), upgradedMethod.getDescriptor());
+            map.put(key, upgradedProperty);
+        });
+        return map;
+    }
+
+    private static <T> Map<String, T> diff(Map<String, T> first, Map<String, T> second) {
+        return first.entrySet().stream()
+            .filter(e -> !second.containsKey(e.getKey()))
+            .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
     }
 }

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/UpgradePropertiesRuleSetup.java
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/UpgradePropertiesRuleSetup.java
@@ -18,7 +18,7 @@ package gradlebuild.binarycompatibility.rules;
 
 import gradlebuild.binarycompatibility.upgrades.UpgradedProperties;
 import gradlebuild.binarycompatibility.upgrades.UpgradedProperty;
-import gradlebuild.binarycompatibility.upgrades.UpgradedProperty.MethodKey;
+import gradlebuild.binarycompatibility.upgrades.UpgradedProperty.UpgradedMethodKey;
 import me.champeau.gradle.japicmp.report.SetupRule;
 import me.champeau.gradle.japicmp.report.ViolationCheckContext;
 
@@ -60,24 +60,25 @@ public class UpgradePropertiesRuleSetup implements SetupRule {
         context.putUserData(SEEN_OLD_METHODS_OF_UPGRADED_PROPERTIES, new HashSet<>());
     }
 
-    private static Map<MethodKey, UpgradedProperty> mapCurrentMethodsOfUpgradedProperties(List<UpgradedProperty> upgradedProperties) {
-        return upgradedProperties.stream().collect(Collectors.toMap(MethodKey::ofUpgradedProperty, Function.identity()));
+    private static Map<UpgradedMethodKey, UpgradedProperty> mapCurrentMethodsOfUpgradedProperties(List<UpgradedProperty> upgradedProperties) {
+        return upgradedProperties.stream().collect(Collectors.toMap(UpgradedMethodKey::ofUpgradedProperty, Function.identity()));
     }
 
-    private static Map<MethodKey, UpgradedProperty> mapOldMethodsOfUpgradedProperties(List<UpgradedProperty> upgradedProperties) {
+    private static Map<UpgradedMethodKey, UpgradedProperty> mapOldMethodsOfUpgradedProperties(List<UpgradedProperty> upgradedProperties) {
         return upgradedProperties.stream()
             .flatMap(UpgradePropertiesRuleSetup::mapOldMethodsOfUpgradedProperty)
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
-    private static Stream<Map.Entry<MethodKey, UpgradedProperty>> mapOldMethodsOfUpgradedProperty(UpgradedProperty upgradedProperty) {
-        return upgradedProperty.getUpgradedMethods().stream().map(upgradedMethod -> {
-            MethodKey key = MethodKey.ofUpgradedMethod(upgradedProperty.getContainingType(), upgradedMethod);
-            return new AbstractMap.SimpleEntry<>(key, upgradedProperty);
-        });
+    private static Stream<Map.Entry<UpgradedMethodKey, UpgradedProperty>> mapOldMethodsOfUpgradedProperty(UpgradedProperty upgradedProperty) {
+        return upgradedProperty.getUpgradedMethods().stream()
+            .map(upgradedMethod -> {
+                UpgradedMethodKey key = UpgradedMethodKey.ofUpgradedMethod(upgradedProperty.getContainingType(), upgradedMethod);
+                return new AbstractMap.SimpleEntry<>(key, upgradedProperty);
+            });
     }
 
-    private static <T> Map<MethodKey, T> diff(Map<MethodKey, T> first, Map<MethodKey, T> second) {
+    private static <T> Map<UpgradedMethodKey, T> diff(Map<UpgradedMethodKey, T> first, Map<UpgradedMethodKey, T> second) {
         return first.entrySet().stream()
             .filter(e -> !second.containsKey(e.getKey()))
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/UpgradePropertiesRuleSetup.java
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/UpgradePropertiesRuleSetup.java
@@ -19,6 +19,10 @@ package gradlebuild.binarycompatibility.rules;
 import me.champeau.gradle.japicmp.report.SetupRule;
 import me.champeau.gradle.japicmp.report.ViolationCheckContext;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.util.Map;
 
 public class UpgradePropertiesRuleSetup implements SetupRule {
@@ -32,8 +36,20 @@ public class UpgradePropertiesRuleSetup implements SetupRule {
     @Override
     @SuppressWarnings("unchecked")
     public void execute(ViolationCheckContext context) {
-        System.out.println("newArchives: " + params.get("newUpgradedProperties"));
-        System.out.println("oldArchives: " + params.get("oldUpgradedProperties"));
+        try {
+            printFileContent(params.get("newUpgradedProperties"));
+            printFileContent(params.get("oldUpgradedProperties"));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
+    private static void printFileContent(String path) throws IOException {
+        File file = new File(path);
+        if (file.exists()) {
+            System.out.println(file.getName() + " content: " + Files.readString(file.toPath()));
+        } else {
+            System.out.println(file.getName() + " does not exist");
+        }
+    }
 }

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/UpgradePropertiesRuleSetup.java
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/UpgradePropertiesRuleSetup.java
@@ -16,13 +16,10 @@
 
 package gradlebuild.binarycompatibility.rules;
 
+import gradlebuild.binarycompatibility.upgrades.UpgradedProperties;
 import me.champeau.gradle.japicmp.report.SetupRule;
 import me.champeau.gradle.japicmp.report.ViolationCheckContext;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.util.Map;
 
 public class UpgradePropertiesRuleSetup implements SetupRule {
@@ -36,20 +33,7 @@ public class UpgradePropertiesRuleSetup implements SetupRule {
     @Override
     @SuppressWarnings("unchecked")
     public void execute(ViolationCheckContext context) {
-        try {
-            printFileContent(params.get("newUpgradedProperties"));
-            printFileContent(params.get("oldUpgradedProperties"));
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
-
-    private static void printFileContent(String path) throws IOException {
-        File file = new File(path);
-        if (file.exists()) {
-            System.out.println(file.getName() + " content: " + Files.readString(file.toPath()));
-        } else {
-            System.out.println(file.getName() + " does not exist");
-        }
+        context.putUserData("newUpgradedProperties", UpgradedProperties.parse(params.get("newUpgradedProperties")));
+        context.putUserData("oldUpgradedProperties", UpgradedProperties.parse(params.get("oldUpgradedProperties")));
     }
 }

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/upgrades/UpgradedProperties.java
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/upgrades/UpgradedProperties.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gradlebuild.binarycompatibility.upgrades;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.UncheckedIOException;
+import java.util.Collections;
+import java.util.List;
+
+public class UpgradedProperties {
+
+    public static List<UpgradedProperty> parse(String path) {
+        File file = new File(path);
+        if (!file.exists()) {
+            return Collections.emptyList();
+        }
+        try {
+            return new Gson().fromJson(new FileReader(file), new TypeToken<List<UpgradedProperty>>() {}.getType());
+        } catch (FileNotFoundException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/upgrades/UpgradedProperties.java
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/upgrades/UpgradedProperties.java
@@ -69,25 +69,25 @@ public class UpgradedProperties {
         Map<String, UpgradedProperty> oldMethods = context.getUserData(OLD_METHODS_OF_UPGRADED_PROPERTIES);
 
         if (jApiMethod.getCompatibilityChanges().contains(METHOD_REMOVED)) {
-            return isOldMethodSetterOfUpgradedProperty(jApiMethod, oldMethods) || isOldMethodBooleanGetterOfUpgradedProperty(jApiMethod, oldMethods);
+            return isOldSetterOfUpgradedProperty(jApiMethod, oldMethods) || isOldBooleanGetterOfUpgradedProperty(jApiMethod, oldMethods);
         } else if (jApiMethod.getCompatibilityChanges().contains(METHOD_RETURN_TYPE_CHANGED)) {
-            return isCurrentMethodGetterOfUpgradedProperty(jApiMethod, currentMethods) && isOldMethodGetterOfUpgradedProperty(jApiMethod, oldMethods);
+            return isCurrentGetterOfUpgradedProperty(jApiMethod, currentMethods) && isOldGetterOfUpgradedProperty(jApiMethod, oldMethods);
         } else if (jApiMethod.getCompatibilityChanges().contains(METHOD_ADDED_TO_PUBLIC_CLASS)) {
-            return isCurrentMethodGetterOfUpgradedProperty(jApiMethod, currentMethods);
+            return isCurrentGetterOfUpgradedProperty(jApiMethod, currentMethods);
         }
 
         return false;
     }
 
-    private static boolean isOldMethodSetterOfUpgradedProperty(JApiMethod jApiMethod, Map<String, UpgradedProperty> upgradedMethods) {
+    private static boolean isOldSetterOfUpgradedProperty(JApiMethod jApiMethod, Map<String, UpgradedProperty> upgradedMethods) {
         return isOldMethod(jApiMethod, upgradedMethods, SETTER_REGEX);
     }
 
-    private static boolean isOldMethodGetterOfUpgradedProperty(JApiMethod jApiMethod, Map<String, UpgradedProperty> upgradedMethods) {
+    private static boolean isOldGetterOfUpgradedProperty(JApiMethod jApiMethod, Map<String, UpgradedProperty> upgradedMethods) {
         return isOldMethod(jApiMethod, upgradedMethods, GETTER_REGEX);
     }
 
-    private static boolean isOldMethodBooleanGetterOfUpgradedProperty(JApiMethod jApiMethod, Map<String, UpgradedProperty> upgradedMethods) {
+    private static boolean isOldBooleanGetterOfUpgradedProperty(JApiMethod jApiMethod, Map<String, UpgradedProperty> upgradedMethods) {
         return isOldMethod(jApiMethod, upgradedMethods, BOOLEAN_GETTER_REGEX) && jApiMethod.getReturnType().getOldReturnType().equals("boolean");
     }
 
@@ -101,7 +101,7 @@ public class UpgradedProperties {
         return upgradedMethods.containsKey(getMethodKey(containingType, name, descriptor));
     }
 
-    private static boolean isCurrentMethodGetterOfUpgradedProperty(JApiMethod jApiMethod, Map<String, UpgradedProperty> currentMethods) {
+    private static boolean isCurrentGetterOfUpgradedProperty(JApiMethod jApiMethod, Map<String, UpgradedProperty> currentMethods) {
         return isCurrentMethod(jApiMethod, currentMethods, GETTER_REGEX);
     }
 

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/upgrades/UpgradedProperties.java
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/upgrades/UpgradedProperties.java
@@ -18,7 +18,7 @@ package gradlebuild.binarycompatibility.upgrades;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-import gradlebuild.binarycompatibility.upgrades.UpgradedProperty.MethodKey;
+import gradlebuild.binarycompatibility.upgrades.UpgradedProperty.UpgradedMethodKey;
 import japicmp.model.JApiCompatibility;
 import japicmp.model.JApiMethod;
 import me.champeau.gradle.japicmp.report.Violation;
@@ -78,8 +78,8 @@ public class UpgradedProperties {
             return false;
         }
 
-        Map<MethodKey, UpgradedProperty> currentMethods = context.getUserData(CURRENT_METHODS_OF_UPGRADED_PROPERTIES);
-        Map<MethodKey, UpgradedProperty> oldMethods = context.getUserData(OLD_METHODS_OF_UPGRADED_PROPERTIES);
+        Map<UpgradedMethodKey, UpgradedProperty> currentMethods = context.getUserData(CURRENT_METHODS_OF_UPGRADED_PROPERTIES);
+        Map<UpgradedMethodKey, UpgradedProperty> oldMethods = context.getUserData(OLD_METHODS_OF_UPGRADED_PROPERTIES);
 
         if (jApiMethod.getCompatibilityChanges().contains(METHOD_REMOVED)) {
             return isOldSetterOfUpgradedProperty(jApiMethod, oldMethods) || isOldBooleanGetterOfUpgradedProperty(jApiMethod, oldMethods);
@@ -92,54 +92,54 @@ public class UpgradedProperties {
         return false;
     }
 
-    private static boolean isOldSetterOfUpgradedProperty(JApiMethod jApiMethod, Map<MethodKey, UpgradedProperty> upgradedMethods) {
+    private static boolean isOldSetterOfUpgradedProperty(JApiMethod jApiMethod, Map<UpgradedMethodKey, UpgradedProperty> upgradedMethods) {
         return isOldMethod(jApiMethod, upgradedMethods, SETTER_REGEX);
     }
 
-    private static boolean isOldGetterOfUpgradedProperty(JApiMethod jApiMethod, Map<MethodKey, UpgradedProperty> upgradedMethods) {
+    private static boolean isOldGetterOfUpgradedProperty(JApiMethod jApiMethod, Map<UpgradedMethodKey, UpgradedProperty> upgradedMethods) {
         return isOldMethod(jApiMethod, upgradedMethods, GETTER_REGEX);
     }
 
-    private static boolean isOldBooleanGetterOfUpgradedProperty(JApiMethod jApiMethod, Map<MethodKey, UpgradedProperty> upgradedMethods) {
+    private static boolean isOldBooleanGetterOfUpgradedProperty(JApiMethod jApiMethod, Map<UpgradedMethodKey, UpgradedProperty> upgradedMethods) {
         return isOldMethod(jApiMethod, upgradedMethods, BOOLEAN_GETTER_REGEX) && jApiMethod.getReturnType().getOldReturnType().equals("boolean");
     }
 
-    private static boolean isOldMethod(JApiMethod jApiMethod, Map<MethodKey, UpgradedProperty> upgradedMethods, Pattern pattern) {
+    private static boolean isOldMethod(JApiMethod jApiMethod, Map<UpgradedMethodKey, UpgradedProperty> upgradedMethods, Pattern pattern) {
         String name = jApiMethod.getName();
         if (!pattern.matcher(name).matches()) {
             return false;
         }
-        return upgradedMethods.containsKey(MethodKey.ofOldMethod(jApiMethod));
+        return upgradedMethods.containsKey(UpgradedMethodKey.ofOldMethod(jApiMethod));
     }
 
-    private static boolean isCurrentGetterOfUpgradedProperty(JApiMethod jApiMethod, Map<MethodKey, UpgradedProperty> currentMethods) {
+    private static boolean isCurrentGetterOfUpgradedProperty(JApiMethod jApiMethod, Map<UpgradedMethodKey, UpgradedProperty> currentMethods) {
         return isCurrentMethod(jApiMethod, currentMethods, GETTER_REGEX);
     }
 
-    private static boolean isCurrentMethod(JApiMethod jApiMethod, Map<MethodKey, UpgradedProperty> currentMethods, Pattern pattern) {
+    private static boolean isCurrentMethod(JApiMethod jApiMethod, Map<UpgradedMethodKey, UpgradedProperty> currentMethods, Pattern pattern) {
         String name = jApiMethod.getName();
         if (!pattern.matcher(name).matches()) {
             return false;
         }
-        return currentMethods.containsKey(MethodKey.ofNewMethod(jApiMethod));
+        return currentMethods.containsKey(UpgradedMethodKey.ofNewMethod(jApiMethod));
     }
 
-    private static boolean hasOldGetterOfUpgradedPropertyBooleanReturnType(JApiMethod jApiMethod, Map<MethodKey, UpgradedProperty> oldMethods, Map<MethodKey, UpgradedProperty> currentMethods) {
-        UpgradedProperty property = currentMethods.get(MethodKey.ofNewMethod(jApiMethod));
+    private static boolean hasOldGetterOfUpgradedPropertyBooleanReturnType(JApiMethod jApiMethod, Map<UpgradedMethodKey, UpgradedProperty> oldMethods, Map<UpgradedMethodKey, UpgradedProperty> currentMethods) {
+        UpgradedProperty property = currentMethods.get(UpgradedMethodKey.ofNewMethod(jApiMethod));
         if (property != null) {
             String oldName = "is" + property.getPropertyName().substring(0, 1).toUpperCase() + property.getPropertyName().substring(1);
-            return oldMethods.containsKey(MethodKey.of(property.getContainingType(), oldName, BOOLEAN_GETTER_DESCRIPTOR));
+            return oldMethods.containsKey(UpgradedMethodKey.of(property.getContainingType(), oldName, BOOLEAN_GETTER_DESCRIPTOR));
         }
         return false;
     }
 
-    public static Optional<MethodKey> maybeGetKeyOfOldMethodOfUpgradedProperty(JApiCompatibility jApiCompatibility, ViolationCheckContext context) {
+    public static Optional<UpgradedMethodKey> maybeGetKeyOfOldMethodOfUpgradedProperty(JApiCompatibility jApiCompatibility, ViolationCheckContext context) {
         if (!(jApiCompatibility instanceof JApiMethod) || !((JApiMethod) jApiCompatibility).getOldMethod().isPresent()) {
             return Optional.empty();
         }
         JApiMethod jApiMethod = (JApiMethod) jApiCompatibility;
-        Map<MethodKey, UpgradedProperty> oldMethods = context.getUserData(OLD_METHODS_OF_UPGRADED_PROPERTIES);
-        MethodKey key = MethodKey.ofOldMethod(jApiMethod);
+        Map<UpgradedMethodKey, UpgradedProperty> oldMethods = context.getUserData(OLD_METHODS_OF_UPGRADED_PROPERTIES);
+        UpgradedMethodKey key = UpgradedMethodKey.ofOldMethod(jApiMethod);
         return oldMethods.containsKey(key) ? Optional.of(key) : Optional.empty();
     }
 }

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/upgrades/UpgradedProperties.java
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/upgrades/UpgradedProperties.java
@@ -19,6 +19,7 @@ package gradlebuild.binarycompatibility.upgrades;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import japicmp.model.JApiMethod;
+import me.champeau.gradle.japicmp.report.Violation;
 import me.champeau.gradle.japicmp.report.ViolationCheckContext;
 
 import java.io.File;
@@ -30,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import static gradlebuild.binarycompatibility.rules.SinceAnnotationMissingRule.SINCE_ERROR_MESSAGE;
 import static japicmp.model.JApiCompatibilityChange.METHOD_ADDED_TO_PUBLIC_CLASS;
 import static japicmp.model.JApiCompatibilityChange.METHOD_REMOVED;
 import static japicmp.model.JApiCompatibilityChange.METHOD_RETURN_TYPE_CHANGED;
@@ -54,7 +56,12 @@ public class UpgradedProperties {
         }
     }
 
-    public static boolean isUpgradedProperty(JApiMethod jApiMethod, ViolationCheckContext context) {
+    public static boolean acceptForUpgradedProperty(JApiMethod jApiMethod, Violation violation, ViolationCheckContext context) {
+        if (violation.getHumanExplanation().startsWith(SINCE_ERROR_MESSAGE)) {
+            // We still want to report the violation if @since is not added to a method
+            return false;
+        }
+
         Map<String, UpgradedProperty> currentMethods = context.getUserData(CURRENT_METHODS_OF_UPGRADED_PROPERTIES);
         Map<String, UpgradedProperty> oldMethods = context.getUserData(OLD_METHODS_OF_UPGRADED_PROPERTIES);
 

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/upgrades/UpgradedProperty.java
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/upgrades/UpgradedProperty.java
@@ -20,12 +20,14 @@ import java.util.List;
 
 public class UpgradedProperty {
     private final String propertyName;
+    private final String methodName;
     private final String containingType;
     private final List<UpgradedMethod> upgradedMethods;
 
-    public UpgradedProperty(String containingType, String propertyName, List<UpgradedMethod> upgradedMethods) {
+    public UpgradedProperty(String containingType, String propertyName, String methodName, List<UpgradedMethod> upgradedMethods) {
         this.containingType = containingType;
         this.propertyName = propertyName;
+        this.methodName = methodName;
         this.upgradedMethods = upgradedMethods;
     }
 
@@ -37,6 +39,10 @@ public class UpgradedProperty {
         return propertyName;
     }
 
+    public String getMethodName() {
+        return methodName;
+    }
+
     public List<UpgradedMethod> getUpgradedMethods() {
         return upgradedMethods;
     }
@@ -45,6 +51,7 @@ public class UpgradedProperty {
     public String toString() {
         return "UpgradedProperty{" +
             "propertyName='" + propertyName + '\'' +
+            ", methodName='" + methodName + '\'' +
             ", containingType='" + containingType + '\'' +
             ", upgradedMethods=" + upgradedMethods +
             '}';

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/upgrades/UpgradedProperty.java
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/upgrades/UpgradedProperty.java
@@ -94,41 +94,41 @@ public class UpgradedProperty {
         }
     }
 
-    public static class MethodKey {
+    public static class UpgradedMethodKey {
         private final String containingType;
         private final String methodName;
         private final String descriptor;
 
-        private MethodKey(String containingType, String methodName, String descriptor) {
+        private UpgradedMethodKey(String containingType, String methodName, String descriptor) {
             this.containingType = containingType;
             this.methodName = methodName;
             this.descriptor = descriptor;
         }
 
-        public static MethodKey of(String containingType, String methodName, String descriptor) {
-            return new MethodKey(containingType, methodName, descriptor);
+        public static UpgradedMethodKey of(String containingType, String methodName, String descriptor) {
+            return new UpgradedMethodKey(containingType, methodName, descriptor);
         }
 
-        public static MethodKey ofUpgradedProperty(UpgradedProperty upgradedProperty) {
-            return new MethodKey(upgradedProperty.getContainingType(), upgradedProperty.getMethodName(), upgradedProperty.getMethodDescriptor());
+        public static UpgradedMethodKey ofUpgradedProperty(UpgradedProperty upgradedProperty) {
+            return new UpgradedMethodKey(upgradedProperty.getContainingType(), upgradedProperty.getMethodName(), upgradedProperty.getMethodDescriptor());
         }
 
-        public static MethodKey ofUpgradedMethod(String containingType, UpgradedMethod upgradedMethod) {
-            return new MethodKey(containingType, upgradedMethod.getName(), upgradedMethod.getDescriptor());
+        public static UpgradedMethodKey ofUpgradedMethod(String containingType, UpgradedMethod upgradedMethod) {
+            return new UpgradedMethodKey(containingType, upgradedMethod.getName(), upgradedMethod.getDescriptor());
         }
 
-        public static MethodKey ofNewMethod(JApiMethod jApiMethod) {
+        public static UpgradedMethodKey ofNewMethod(JApiMethod jApiMethod) {
             String name = jApiMethod.getName();
             String descriptor = jApiMethod.getNewMethod().get().getSignature();
             String containingType = jApiMethod.getjApiClass().getFullyQualifiedName();
-            return new MethodKey(containingType, name, descriptor);
+            return new UpgradedMethodKey(containingType, name, descriptor);
         }
 
-        public static MethodKey ofOldMethod(JApiMethod jApiMethod) {
+        public static UpgradedMethodKey ofOldMethod(JApiMethod jApiMethod) {
             String name = jApiMethod.getName();
             String descriptor = jApiMethod.getOldMethod().get().getSignature();
             String containingType = jApiMethod.getjApiClass().getFullyQualifiedName();
-            return new MethodKey(containingType, name, descriptor);
+            return new UpgradedMethodKey(containingType, name, descriptor);
         }
 
         @Override
@@ -144,7 +144,7 @@ public class UpgradedProperty {
             if (o == null || getClass() != o.getClass()) {
                 return false;
             }
-            MethodKey that = (MethodKey) o;
+            UpgradedMethodKey that = (UpgradedMethodKey) o;
             return Objects.equals(containingType, that.containingType)
                 && Objects.equals(methodName, that.methodName)
                 && Objects.equals(descriptor, that.descriptor);

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/upgrades/UpgradedProperty.java
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/upgrades/UpgradedProperty.java
@@ -21,13 +21,15 @@ import java.util.List;
 public class UpgradedProperty {
     private final String propertyName;
     private final String methodName;
+    private final String methodDescriptor;
     private final String containingType;
     private final List<UpgradedMethod> upgradedMethods;
 
-    public UpgradedProperty(String containingType, String propertyName, String methodName, List<UpgradedMethod> upgradedMethods) {
+    public UpgradedProperty(String containingType, String propertyName, String methodName, String methodDescriptor, List<UpgradedMethod> upgradedMethods) {
         this.containingType = containingType;
         this.propertyName = propertyName;
         this.methodName = methodName;
+        this.methodDescriptor = methodDescriptor;
         this.upgradedMethods = upgradedMethods;
     }
 
@@ -43,6 +45,10 @@ public class UpgradedProperty {
         return methodName;
     }
 
+    public String getMethodDescriptor() {
+        return methodDescriptor;
+    }
+
     public List<UpgradedMethod> getUpgradedMethods() {
         return upgradedMethods;
     }
@@ -52,6 +58,7 @@ public class UpgradedProperty {
         return "UpgradedProperty{" +
             "propertyName='" + propertyName + '\'' +
             ", methodName='" + methodName + '\'' +
+            ", methodDescriptor='" + methodDescriptor + '\'' +
             ", containingType='" + containingType + '\'' +
             ", upgradedMethods=" + upgradedMethods +
             '}';

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/upgrades/UpgradedProperty.java
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/upgrades/UpgradedProperty.java
@@ -99,22 +99,14 @@ public class UpgradedProperty {
         private final String methodName;
         private final String descriptor;
 
-        public MethodKey(String containingType, String methodName, String descriptor) {
+        private MethodKey(String containingType, String methodName, String descriptor) {
             this.containingType = containingType;
             this.methodName = methodName;
             this.descriptor = descriptor;
         }
 
-        public String getMethodName() {
-            return methodName;
-        }
-
-        public String getDescriptor() {
-            return descriptor;
-        }
-
-        public String getContainingType() {
-            return containingType;
+        public static MethodKey of(String containingType, String methodName, String descriptor) {
+            return new MethodKey(containingType, methodName, descriptor);
         }
 
         public static MethodKey ofUpgradedProperty(UpgradedProperty upgradedProperty) {
@@ -153,7 +145,9 @@ public class UpgradedProperty {
                 return false;
             }
             MethodKey that = (MethodKey) o;
-            return Objects.equals(containingType, that.containingType) && Objects.equals(methodName, that.methodName) && Objects.equals(descriptor, that.descriptor);
+            return Objects.equals(containingType, that.containingType)
+                && Objects.equals(methodName, that.methodName)
+                && Objects.equals(descriptor, that.descriptor);
         }
 
         @Override

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/upgrades/UpgradedProperty.java
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/upgrades/UpgradedProperty.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gradlebuild.binarycompatibility.upgrades;
+
+import java.util.List;
+
+public class UpgradedProperty {
+    private final String propertyName;
+    private final String containingType;
+    private final List<UpgradedMethod> upgradedMethods;
+
+    public UpgradedProperty(String containingType, String propertyName, List<UpgradedMethod> upgradedMethods) {
+        this.containingType = containingType;
+        this.propertyName = propertyName;
+        this.upgradedMethods = upgradedMethods;
+    }
+
+    public String getContainingType() {
+        return containingType;
+    }
+
+    public String getPropertyName() {
+        return propertyName;
+    }
+
+    public List<UpgradedMethod> getUpgradedMethods() {
+        return upgradedMethods;
+    }
+
+    @Override
+    public String toString() {
+        return "UpgradedProperty{" +
+            "propertyName='" + propertyName + '\'' +
+            ", containingType='" + containingType + '\'' +
+            ", upgradedMethods=" + upgradedMethods +
+            '}';
+    }
+
+    public static class UpgradedMethod {
+        private final String name;
+        private final String descriptor;
+
+        public UpgradedMethod(String name, String descriptor) {
+            this.name = name;
+            this.descriptor = descriptor;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getDescriptor() {
+            return descriptor;
+        }
+
+        @Override
+        public String toString() {
+            return "UpgradedMethod{" +
+                "name='" + name + '\'' +
+                ", descriptor='" + descriptor + '\'' +
+                '}';
+        }
+    }
+}

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/upgrades/UpgradedProperty.java
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/upgrades/UpgradedProperty.java
@@ -16,7 +16,11 @@
 
 package gradlebuild.binarycompatibility.upgrades;
 
+import com.google.common.collect.ImmutableList;
+import japicmp.model.JApiMethod;
+
 import java.util.List;
+import java.util.Objects;
 
 public class UpgradedProperty {
     private final String propertyName;
@@ -30,7 +34,7 @@ public class UpgradedProperty {
         this.propertyName = propertyName;
         this.methodName = methodName;
         this.methodDescriptor = methodDescriptor;
-        this.upgradedMethods = upgradedMethods;
+        this.upgradedMethods = ImmutableList.copyOf(upgradedMethods);
     }
 
     public String getContainingType() {
@@ -87,6 +91,74 @@ public class UpgradedProperty {
                 "name='" + name + '\'' +
                 ", descriptor='" + descriptor + '\'' +
                 '}';
+        }
+    }
+
+    public static class MethodKey {
+        private final String containingType;
+        private final String methodName;
+        private final String descriptor;
+
+        public MethodKey(String containingType, String methodName, String descriptor) {
+            this.containingType = containingType;
+            this.methodName = methodName;
+            this.descriptor = descriptor;
+        }
+
+        public String getMethodName() {
+            return methodName;
+        }
+
+        public String getDescriptor() {
+            return descriptor;
+        }
+
+        public String getContainingType() {
+            return containingType;
+        }
+
+        public static MethodKey ofUpgradedProperty(UpgradedProperty upgradedProperty) {
+            return new MethodKey(upgradedProperty.getContainingType(), upgradedProperty.getMethodName(), upgradedProperty.getMethodDescriptor());
+        }
+
+        public static MethodKey ofUpgradedMethod(String containingType, UpgradedMethod upgradedMethod) {
+            return new MethodKey(containingType, upgradedMethod.getName(), upgradedMethod.getDescriptor());
+        }
+
+        public static MethodKey ofNewMethod(JApiMethod jApiMethod) {
+            String name = jApiMethod.getName();
+            String descriptor = jApiMethod.getNewMethod().get().getSignature();
+            String containingType = jApiMethod.getjApiClass().getFullyQualifiedName();
+            return new MethodKey(containingType, name, descriptor);
+        }
+
+        public static MethodKey ofOldMethod(JApiMethod jApiMethod) {
+            String name = jApiMethod.getName();
+            String descriptor = jApiMethod.getOldMethod().get().getSignature();
+            String containingType = jApiMethod.getjApiClass().getFullyQualifiedName();
+            return new MethodKey(containingType, name, descriptor);
+        }
+
+        @Override
+        public String toString() {
+            return containingType + "#" + methodName + descriptor;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            MethodKey that = (MethodKey) o;
+            return Objects.equals(containingType, that.containingType) && Objects.equals(methodName, that.methodName) && Objects.equals(descriptor, that.descriptor);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(containingType, methodName, descriptor);
         }
     }
 }

--- a/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/AbstractBinaryCompatibilityTest.kt
+++ b/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/AbstractBinaryCompatibilityTest.kt
@@ -303,9 +303,9 @@ abstract class AbstractBinaryCompatibilityTest {
                     val extractGradleApiInfo = tasks.register<ExtractGradleApiInfoTask>("extractGradleApiInfo") {
                         gradleApiInfoJarPrefix = "v"
                         currentDistributionJars = files(v2Jar)
-                        baseDistributionJars = files(v1Jar)
+                        baselineDistributionJars = files(v1Jar)
                         currentUpgradedProperties = newUpgradedPropertiesFile
-                        baseUpgradedProperties = oldUpgradedPropertiesFile
+                        baselineUpgradedProperties = oldUpgradedPropertiesFile
                     }
 
                     tasks.register<JapicmpTask>("checkBinaryCompatibility") {

--- a/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/AbstractBinaryCompatibilityTest.kt
+++ b/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/AbstractBinaryCompatibilityTest.kt
@@ -227,10 +227,10 @@ abstract class AbstractBinaryCompatibilityTest {
                     val oldUpgradedPropertiesFile = layout.buildDirectory.file("gradle-api-info/old-upgraded-properties.json")
                     val extractGradleApiInfo = tasks.register<ExtractGradleApiInfoTask>("extractGradleApiInfo") {
                         gradleApiInfoJarPrefix = "v"
-                        newDistributionJars = files(v2Jar)
-                        oldDistributionJars = files(v1Jar)
-                        newUpgradedProperties = newUpgradedPropertiesFile
-                        oldUpgradedProperties = oldUpgradedPropertiesFile
+                        currentDistributionJars = files(v2Jar)
+                        baseDistributionJars = files(v1Jar)
+                        currentUpgradedProperties = newUpgradedPropertiesFile
+                        baseUpgradedProperties = oldUpgradedPropertiesFile
                     }
 
                     tasks.register<JapicmpTask>("checkBinaryCompatibility") {

--- a/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/AbstractBinaryCompatibilityTest.kt
+++ b/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/AbstractBinaryCompatibilityTest.kt
@@ -338,6 +338,10 @@ abstract class AbstractBinaryCompatibilityTest {
             assertThat("Has information", richReport.information.map { it.message }, CoreMatchers.equalTo(information.toList()))
         }
 
+        fun assertHasAccepted(vararg information: String) {
+            assertThat("Has accepted", richReport.accepted.map { it.message }, CoreMatchers.equalTo(information.toList()))
+        }
+
         fun assertHasErrors(vararg errors: List<String>) {
             assertHasErrors(*errors.toList().flatten().toTypedArray())
         }

--- a/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/AbstractBinaryCompatibilityTest.kt
+++ b/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/AbstractBinaryCompatibilityTest.kt
@@ -338,8 +338,12 @@ abstract class AbstractBinaryCompatibilityTest {
             assertThat("Has information", richReport.information.map { it.message }, CoreMatchers.equalTo(information.toList()))
         }
 
-        fun assertHasAccepted(vararg information: String) {
-            assertThat("Has accepted", richReport.accepted.map { it.message }, CoreMatchers.equalTo(information.toList()))
+        fun assertHasAccepted(vararg accepted: String) {
+            assertThat("Has accepted", richReport.accepted.map { it.message }, CoreMatchers.equalTo(accepted.toList()))
+        }
+
+        fun assertHasAccepted(vararg accepted: Pair<String, List<String>>) {
+            assertThat("Has accepted", richReport.accepted, CoreMatchers.equalTo(accepted.map { ReportMessage(it.first, it.second) }))
         }
 
         fun assertHasErrors(vararg errors: List<String>) {

--- a/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/RichReportScrapper.kt
+++ b/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/RichReportScrapper.kt
@@ -27,7 +27,8 @@ fun scrapeRichReport(richReportFile: File): RichReport =
         RichReport(
             scrapeMessagesForSeverity("error"),
             scrapeMessagesForSeverity("warning"),
-            scrapeMessagesForSeverity("info")
+            scrapeMessagesForSeverity("info"),
+            scrapeMessagesForSeverity("accepted")
         )
     }
 
@@ -69,7 +70,8 @@ internal
 data class RichReport(
     val errors: List<ReportMessage>,
     val warnings: List<ReportMessage>,
-    val information: List<ReportMessage>
+    val information: List<ReportMessage>,
+    val accepted: List<ReportMessage>
 ) {
 
     val isEmpty: Boolean
@@ -77,7 +79,7 @@ data class RichReport(
 
     fun toText() =
         StringBuilder("Binary compatibility\n").apply {
-            listOf("Errors" to errors, "Warnings" to warnings, "Information" to information).forEach { (name, list) ->
+            listOf("Errors" to errors, "Warnings" to warnings, "Information" to information, "Accepted" to accepted).forEach { (name, list) ->
                 if (list.isNotEmpty()) {
                     append("  $name (").append(list.size).append(")\n")
                     append(list.joinToString(separator = "\n    ", prefix = "    ", postfix = "\n"))

--- a/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/UpgradedPropertiesChangesTest.kt
+++ b/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/UpgradedPropertiesChangesTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gradlebuild.binarycompatibility
+
+import org.junit.Test
+
+class UpgradedPropertiesChangesTest : AbstractBinaryCompatibilityTest() {
+
+    @Test
+    fun `should not report binary incompatibility for upgraded properties`() {
+        checkBinaryCompatible(
+            v1 = {
+                withFile(
+                    "java/com/example/Task.java",
+                    """
+                        package com.example;
+
+                        public abstract class Task {
+                            public String getSourceCompatibility() {
+                                return "";
+                            }
+                            public void setSourceCompatibility(String value) {
+                            }
+                        }
+                    """
+                )
+                withFile(
+                    "resources/upgraded-properties.json",
+                    """
+                    """
+                )
+            },
+            v2 = {
+                withFile(
+                    "java/com/example/Task.java",
+                    """
+                        package com.example;
+                        import org.gradle.api.provider.Property;
+
+                        public abstract class Task {
+                            public abstract Property<String> getSourceCompatibility();
+                        }
+                    """
+                )
+                withFile(
+                    "resources/upgraded-properties.json",
+                    """
+
+                    """
+                )
+            }
+        ) {
+            assertHasNoError()
+        }
+    }
+
+}

--- a/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/UpgradedPropertiesChangesTest.kt
+++ b/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/UpgradedPropertiesChangesTest.kt
@@ -38,11 +38,6 @@ class UpgradedPropertiesChangesTest : AbstractBinaryCompatibilityTest() {
                         }
                     """
                 )
-                withFile(
-                    "resources/upgraded-properties.json",
-                    """
-                    """
-                )
             },
             v2 = {
                 withFile(
@@ -59,8 +54,20 @@ class UpgradedPropertiesChangesTest : AbstractBinaryCompatibilityTest() {
                 withFile(
                     "resources/upgraded-properties.json",
                     """
-
-                    """
+                        [{
+                            "containingType": "com.example.Task",
+                            "methodName": "getSourceCompatibility",
+                            "methodDescriptor": "()Lorg/gradle/api/provider/Property;",
+                            "propertyName": "sourceCompatibility",
+                            "upgradedMethods": [{
+                                "descriptor": "()Ljava/lang/String;",
+                                "name": "getSourceCompatibility"
+                            }, {
+                                "descriptor": "(Ljava/lang/String;)V",
+                                "name": "setSourceCompatibility"
+                            }]
+                        }]
+                        """
                 )
             }
         ) {

--- a/subprojects/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/InstrumentedPropertiesResourceGenerator.java
+++ b/subprojects/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/InstrumentedPropertiesResourceGenerator.java
@@ -98,6 +98,7 @@ public class InstrumentedPropertiesResourceGenerator implements InstrumentationR
         PropertyUpgradeRequestExtra upgradeExtra = request.getRequestExtras().getByType(PropertyUpgradeRequestExtra.class).get();
         String propertyName = upgradeExtra.getPropertyName();
         String methodName = upgradeExtra.getInterceptedPropertyAccessorName();
+        String methodDescriptor = upgradeExtra.getInterceptedPropertyAccessorDescriptor();
         String containingType = request.getInterceptedCallable().getOwner().getType().getClassName();
         List<UpgradedMethod> upgradedMethods = requests.stream()
             .map(CallInterceptionRequest::getInterceptedCallable)
@@ -110,20 +111,22 @@ public class InstrumentedPropertiesResourceGenerator implements InstrumentationR
             })
             .sorted(Comparator.comparing((UpgradedMethod o) -> o.name).thenComparing(o -> o.descriptor))
             .collect(Collectors.toList());
-        return new PropertyEntry(containingType, propertyName, methodName, upgradedMethods);
+        return new PropertyEntry(containingType, propertyName, methodName, methodDescriptor, upgradedMethods);
     }
 
     @JsonPropertyOrder(alphabetic = true)
     static class PropertyEntry {
         private final String propertyName;
         private final String methodName;
+        private final String methodDescriptor;
         private final String containingType;
         private final List<UpgradedMethod> upgradedMethods;
 
-        public PropertyEntry(String containingType, String propertyName, String methodName, List<UpgradedMethod> upgradedMethods) {
+        public PropertyEntry(String containingType, String propertyName, String methodName, String methodDescriptor, List<UpgradedMethod> upgradedMethods) {
             this.containingType = containingType;
             this.propertyName = propertyName;
             this.methodName = methodName;
+            this.methodDescriptor = methodDescriptor;
             this.upgradedMethods = upgradedMethods;
         }
 
@@ -137,6 +140,10 @@ public class InstrumentedPropertiesResourceGenerator implements InstrumentationR
 
         public String getMethodName() {
             return methodName;
+        }
+
+        public String getMethodDescriptor() {
+            return methodDescriptor;
         }
 
         public List<UpgradedMethod> getUpgradedMethods() {

--- a/subprojects/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeAnnotatedMethodReader.java
+++ b/subprojects/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeAnnotatedMethodReader.java
@@ -110,6 +110,8 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
         if (projectName == null) {
             // We validate project name here because we want to fail only if there is an @UpgradedProperty annotation used in the project
             return Collections.singletonList(new InvalidRequest("Project name is not specified or is empty. Use -A" + PROJECT_NAME_OPTIONS + "=<projectName> compiler option to set the project name."));
+        } else if (!method.getParameters().isEmpty() || !method.getSimpleName().toString().startsWith("get")) {
+            return Collections.singletonList(new InvalidRequest(String.format("Method '%s.%s' annotated with @UpgradedProperty should be a simple getter: name should start with 'get' and method should not have any parameters.", method.getEnclosingElement(), method)));
         }
 
         try {

--- a/subprojects/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeAnnotatedMethodReader.java
+++ b/subprojects/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeAnnotatedMethodReader.java
@@ -70,6 +70,7 @@ import static org.gradle.internal.instrumentation.model.CallableKindInfo.INSTANC
 import static org.gradle.internal.instrumentation.model.ParameterKindInfo.METHOD_PARAMETER;
 import static org.gradle.internal.instrumentation.model.ParameterKindInfo.RECEIVER;
 import static org.gradle.internal.instrumentation.processor.AbstractInstrumentationProcessor.PROJECT_NAME_OPTIONS;
+import static org.gradle.internal.instrumentation.processor.modelreader.impl.TypeUtils.extractMethodDescriptor;
 import static org.gradle.internal.instrumentation.processor.modelreader.impl.TypeUtils.extractType;
 
 public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodReaderExtension {
@@ -204,7 +205,8 @@ public class PropertyUpgradeAnnotatedMethodReader implements AnnotatedMethodRead
         extras.add(new RequestExtra.InterceptJvmCalls(interceptorsClassName));
         String implementationClass = getGeneratedClassName(method.getEnclosingElement());
         UpgradedPropertyType upgradedPropertyType = UpgradedPropertyType.from(extractType(method.getReturnType()));
-        extras.add(new PropertyUpgradeRequestExtra(propertyName, isFluentSetter, implementationClass, method.getSimpleName().toString(), upgradedPropertyType));
+        String methodDescriptor = extractMethodDescriptor(method);
+        extras.add(new PropertyUpgradeRequestExtra(propertyName, isFluentSetter, implementationClass, method.getSimpleName().toString(), methodDescriptor, upgradedPropertyType));
         return extras;
     }
 

--- a/subprojects/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeRequestExtra.java
+++ b/subprojects/internal-instrumentation-processor/src/main/java/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeRequestExtra.java
@@ -66,13 +66,22 @@ class PropertyUpgradeRequestExtra implements RequestExtra {
     private final boolean isFluentSetter;
     private final String implementationClassName;
     private final String interceptedPropertyAccessorName;
+    private final String interceptedPropertyAccessorDescriptor;
     private final UpgradedPropertyType upgradedPropertyType;
 
-    public PropertyUpgradeRequestExtra(String propertyName, boolean isFluentSetter, String implementationClassName, String interceptedPropertyAccessorName, UpgradedPropertyType upgradedPropertyType) {
+    public PropertyUpgradeRequestExtra(
+        String propertyName,
+        boolean isFluentSetter,
+        String implementationClassName,
+        String interceptedPropertyAccessorName,
+        String interceptedPropertyAccessorDescriptor,
+        UpgradedPropertyType upgradedPropertyType
+    ) {
         this.propertyName = propertyName;
         this.isFluentSetter = isFluentSetter;
         this.implementationClassName = implementationClassName;
         this.interceptedPropertyAccessorName = interceptedPropertyAccessorName;
+        this.interceptedPropertyAccessorDescriptor = interceptedPropertyAccessorDescriptor;
         this.upgradedPropertyType = upgradedPropertyType;
     }
 
@@ -86,6 +95,10 @@ class PropertyUpgradeRequestExtra implements RequestExtra {
 
     public String getInterceptedPropertyAccessorName() {
         return interceptedPropertyAccessorName;
+    }
+
+    public String getInterceptedPropertyAccessorDescriptor() {
+        return interceptedPropertyAccessorDescriptor;
     }
 
     public UpgradedPropertyType getUpgradedPropertyType() {

--- a/subprojects/internal-instrumentation-processor/src/test/groovy/org/gradle/internal/instrumentation/extensions/property/InstrumentedPropertiesResourceGeneratorTest.groovy
+++ b/subprojects/internal-instrumentation-processor/src/test/groovy/org/gradle/internal/instrumentation/extensions/property/InstrumentedPropertiesResourceGeneratorTest.groovy
@@ -70,10 +70,10 @@ class InstrumentedPropertiesResourceGeneratorTest extends InstrumentationCodeGen
             new UpgradedMethod("setTargetCompatibility", "(Ljava/lang/String;)Lorg/gradle/test/Task;")
         ]
         def properties = [
-                // Order is important
-                new PropertyEntry("org.gradle.test.Task", "maxErrors", "getMaxErrors", maxErrorMethods),
-                new PropertyEntry("org.gradle.test.Task", "sourceCompatibility", "getSourceCompatibility", sourceCompatibilityMethods),
-                new PropertyEntry("org.gradle.test.Task", "targetCompatibility", "getTargetCompatibility", targetCompatibilityMethods)
+            // Order is important
+            new PropertyEntry("org.gradle.test.Task", "maxErrors", "getMaxErrors", "()Lorg/gradle/api/provider/Property;", maxErrorMethods),
+            new PropertyEntry("org.gradle.test.Task", "sourceCompatibility", "getSourceCompatibility", "()Lorg/gradle/api/provider/Property;", sourceCompatibilityMethods),
+            new PropertyEntry("org.gradle.test.Task", "targetCompatibility", "getTargetCompatibility", "()Lorg/gradle/api/provider/Property;", targetCompatibilityMethods)
         ]
         assertThat(compilation)
             .generatedFile(CLASS_OUTPUT, "META-INF/gradle/instrumentation/upgraded-properties.json")
@@ -103,6 +103,6 @@ class InstrumentedPropertiesResourceGeneratorTest extends InstrumentationCodeGen
         assertThat(compilation)
             .generatedFile(CLASS_OUTPUT, "META-INF/gradle/instrumentation/upgraded-properties.json")
             .contentsAsString(StandardCharsets.UTF_8)
-            .isEqualTo("[{\"containingType\":\"org.gradle.test.Task\",\"methodName\":\"getSourceCompatibility\",\"propertyName\":\"sourceCompatibility\",\"upgradedMethods\":[{\"descriptor\":\"()Ljava/lang/String;\",\"name\":\"getSourceCompatibility\"},{\"descriptor\":\"(Ljava/lang/String;)V\",\"name\":\"setSourceCompatibility\"}]}]")
+            .isEqualTo("[{\"containingType\":\"org.gradle.test.Task\",\"methodDescriptor\":\"()Lorg/gradle/api/provider/Property;\",\"methodName\":\"getSourceCompatibility\",\"propertyName\":\"sourceCompatibility\",\"upgradedMethods\":[{\"descriptor\":\"()Ljava/lang/String;\",\"name\":\"getSourceCompatibility\"},{\"descriptor\":\"(Ljava/lang/String;)V\",\"name\":\"setSourceCompatibility\"}]}]")
     }
 }

--- a/subprojects/internal-instrumentation-processor/src/test/groovy/org/gradle/internal/instrumentation/extensions/property/InstrumentedPropertiesResourceGeneratorTest.groovy
+++ b/subprojects/internal-instrumentation-processor/src/test/groovy/org/gradle/internal/instrumentation/extensions/property/InstrumentedPropertiesResourceGeneratorTest.groovy
@@ -70,10 +70,10 @@ class InstrumentedPropertiesResourceGeneratorTest extends InstrumentationCodeGen
             new UpgradedMethod("setTargetCompatibility", "(Ljava/lang/String;)Lorg/gradle/test/Task;")
         ]
         def properties = [
-            // Order is important
-            new PropertyEntry("org.gradle.test.Task", "maxErrors", maxErrorMethods),
-            new PropertyEntry("org.gradle.test.Task", "sourceCompatibility", sourceCompatibilityMethods),
-            new PropertyEntry("org.gradle.test.Task", "targetCompatibility", targetCompatibilityMethods)
+                // Order is important
+                new PropertyEntry("org.gradle.test.Task", "maxErrors", "getMaxErrors", maxErrorMethods),
+                new PropertyEntry("org.gradle.test.Task", "sourceCompatibility", "getSourceCompatibility", sourceCompatibilityMethods),
+                new PropertyEntry("org.gradle.test.Task", "targetCompatibility", "getTargetCompatibility", targetCompatibilityMethods)
         ]
         assertThat(compilation)
             .generatedFile(CLASS_OUTPUT, "META-INF/gradle/instrumentation/upgraded-properties.json")
@@ -103,6 +103,6 @@ class InstrumentedPropertiesResourceGeneratorTest extends InstrumentationCodeGen
         assertThat(compilation)
             .generatedFile(CLASS_OUTPUT, "META-INF/gradle/instrumentation/upgraded-properties.json")
             .contentsAsString(StandardCharsets.UTF_8)
-            .isEqualTo("[{\"containingType\":\"org.gradle.test.Task\",\"propertyName\":\"sourceCompatibility\",\"upgradedMethods\":[{\"descriptor\":\"()Ljava/lang/String;\",\"name\":\"getSourceCompatibility\"},{\"descriptor\":\"(Ljava/lang/String;)V\",\"name\":\"setSourceCompatibility\"}]}]")
+            .isEqualTo("[{\"containingType\":\"org.gradle.test.Task\",\"methodName\":\"getSourceCompatibility\",\"propertyName\":\"sourceCompatibility\",\"upgradedMethods\":[{\"descriptor\":\"()Ljava/lang/String;\",\"name\":\"getSourceCompatibility\"},{\"descriptor\":\"(Ljava/lang/String;)V\",\"name\":\"setSourceCompatibility\"}]}]")
     }
 }

--- a/subprojects/internal-instrumentation-processor/src/test/groovy/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeCodeGenTest.groovy
+++ b/subprojects/internal-instrumentation-processor/src/test/groovy/org/gradle/internal/instrumentation/extensions/property/PropertyUpgradeCodeGenTest.groovy
@@ -262,4 +262,26 @@ class PropertyUpgradeCodeGenTest extends InstrumentationCodeGenTest {
         assertThat(compilation).succeededWithoutWarnings()
         assertThat(compilation).generatedSourceFile("${GENERATED_CLASSES_PACKAGE_NAME}.Task_Adapter")
     }
+
+    def "should fail if @UpgradedProperty is not a simple getter"() {
+        given:
+        def givenSource = source """
+            package org.gradle.test;
+
+            import org.gradle.api.provider.Property;
+            import org.gradle.internal.instrumentation.api.annotations.UpgradedProperty;
+
+            public abstract class Task {
+                @UpgradedProperty
+                public abstract Property<Integer> getMaxErrors(String arg0);
+            }
+        """
+
+        when:
+        Compilation compilation = compile(givenSource)
+
+        then:
+        assertThat(compilation).failed()
+        assertThat(compilation).hadErrorContaining("Method 'org.gradle.test.Task.getMaxErrors(java.lang.String)' annotated with @UpgradedProperty should be a simple getter: name should start with 'get' and method should not have any parameters.")
+    }
 }


### PR DESCRIPTION
With that we don't need to update `accepted-public-api-changes.json` anymore after upgrade. We handle only properties upgraded with `@UpgradedProperty`. All others have to be handled manually.

Additionally we also check, that all interceptod methods are actually present in previous binary: e.g. one could upgrade a property, that has only a getter: there is no need to try to intercept a setter (although we currently don't support that case with `@UpgradedProperty`, but we could).

Fixes https://github.com/gradle/gradle/issues/26293

