### PR TITLE
Work around `help` task execution request

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheAwareBuildModelController.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheAwareBuildModelController.kt
@@ -50,9 +50,9 @@ class ConfigurationCacheAwareBuildModelController(
         } // Else, already done
     }
 
-    override fun scheduleRequestedTasks(selector: EntryTaskSelector?, plan: ExecutionPlan) {
+    override fun scheduleRequestedTasks(selector: EntryTaskSelector?, plan: ExecutionPlan, isModelBuildingRequested: Boolean) {
         if (!maybeLoadFromCache()) {
-            delegate.scheduleRequestedTasks(selector, plan)
+            delegate.scheduleRequestedTasks(selector, plan, isModelBuildingRequested)
         } // Else, already scheduled
     }
 

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheAwareBuildTreeWorkController.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheAwareBuildTreeWorkController.kt
@@ -44,7 +44,7 @@ class ConfigurationCacheAwareBuildTreeWorkController(
         val executionResult = workGraph.withNewWorkGraph { graph ->
             val result = cache.loadOrScheduleRequestedTasks(
                 graph = graph,
-                scheduler = { workPreparer.scheduleRequestedTasks(graph, taskSelector) },
+                scheduler = { workPreparer.scheduleRequestedTasks(graph, taskSelector, isModelBuildingRequested) },
                 graphBuilder = scheduleTaskSelectorPostProcessing,
                 isModelBuildingRequested = isModelBuildingRequested
             )

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/VintageBuildTreeWorkController.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/VintageBuildTreeWorkController.kt
@@ -33,7 +33,7 @@ class VintageBuildTreeWorkController(
 
     override fun scheduleAndRunRequestedTasks(taskSelector: EntryTaskSelector?, isModelBuildingRequested: Boolean): ExecutionResult<Void> {
         return taskGraph.withNewWorkGraph { graph: BuildTreeWorkGraph ->
-            val finalizedGraph: BuildTreeWorkGraph.FinalizedGraph = workPreparer.scheduleRequestedTasks(graph, taskSelector)
+            val finalizedGraph: BuildTreeWorkGraph.FinalizedGraph = workPreparer.scheduleRequestedTasks(graph, taskSelector, isModelBuildingRequested)
             workExecutor.execute(finalizedGraph)
         }
     }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/initialization/SyncWorkaroundTaskExecutionPreparer.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/initialization/SyncWorkaroundTaskExecutionPreparer.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache.initialization
+
+import org.gradle.api.internal.GradleInternal
+import org.gradle.configurationcache.problems.ProblemFactory
+import org.gradle.configurationcache.problems.ProblemsListener
+import org.gradle.execution.EntryTaskSelector
+import org.gradle.execution.plan.ExecutionPlan
+import org.gradle.initialization.TaskExecutionPreparer
+import org.gradle.internal.buildtree.BuildModelParameters
+
+/**
+ * This service must be removed in prior to use [DefaultTaskExecutionPreparer] as soon as
+ * IDE will stop requesting `help` task execution during sync.
+ * */
+class SyncWorkaroundTaskExecutionPreparer(
+    private val buildModelParameters: BuildModelParameters,
+    private val problemsListener: ProblemsListener,
+    private val problemFactory: ProblemFactory,
+    private val delegate: TaskExecutionPreparer,
+) : TaskExecutionPreparer {
+
+    override fun scheduleRequestedTasks(
+        gradle: GradleInternal,
+        selector: EntryTaskSelector?,
+        plan: ExecutionPlan,
+        isModelBuildingRequested: Boolean
+    ) {
+        val helpTaskOnly = gradle.startParameter.taskRequests.size == 1 &&
+            gradle.startParameter.taskRequests.first().args.contains("help")
+
+        if (buildModelParameters.isIsolatedProjects && isModelBuildingRequested) {
+            if (helpTaskOnly) {
+                return // sync scenario
+            } else {
+                val problem = problemFactory.problem {
+                    text("Requesting tasks execution during model building is not compatible with incremental sync.")
+                }.build()
+
+                problemsListener.onProblem(problem)
+                delegate.scheduleRequestedTasks(gradle, selector, plan, true)
+            }
+        } else {
+            delegate.scheduleRequestedTasks(gradle, selector, plan, isModelBuildingRequested)
+        }
+    }
+}

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/initialization/SyncWorkaroundTaskExecutionPreparer.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/initialization/SyncWorkaroundTaskExecutionPreparer.kt
@@ -24,6 +24,7 @@ import org.gradle.execution.plan.ExecutionPlan
 import org.gradle.initialization.TaskExecutionPreparer
 import org.gradle.internal.buildtree.BuildModelParameters
 
+
 /**
  * This service must be removed in prior to use [DefaultTaskExecutionPreparer] as soon as
  * IDE will stop requesting `help` task execution during sync.

--- a/subprojects/core/src/main/java/org/gradle/execution/BuildTaskScheduler.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/BuildTaskScheduler.java
@@ -21,5 +21,5 @@ import org.gradle.execution.plan.ExecutionPlan;
 import javax.annotation.Nullable;
 
 public interface BuildTaskScheduler {
-    void scheduleRequestedTasks(GradleInternal gradle, @Nullable EntryTaskSelector selector, ExecutionPlan plan);
+    void scheduleRequestedTasks(GradleInternal gradle, @Nullable EntryTaskSelector selector, ExecutionPlan plan, boolean isModelBuildingRequested);
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/DefaultTasksBuildTaskScheduler.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/DefaultTasksBuildTaskScheduler.java
@@ -45,7 +45,7 @@ public class DefaultTasksBuildTaskScheduler implements BuildTaskScheduler {
     }
 
     @Override
-    public void scheduleRequestedTasks(GradleInternal gradle, @Nullable EntryTaskSelector selector, ExecutionPlan plan) {
+    public void scheduleRequestedTasks(GradleInternal gradle, @Nullable EntryTaskSelector selector, ExecutionPlan plan, boolean isModelBuildingRequested) {
         StartParameter startParameter = gradle.getStartParameter();
 
         if (startParameter.getTaskRequests().size() == 1 && startParameter.getTaskRequests().get(0) instanceof RunDefaultTasksExecutionRequest) {
@@ -69,6 +69,6 @@ public class DefaultTasksBuildTaskScheduler implements BuildTaskScheduler {
             startParameter.setTaskNames(defaultTasks);
         }
 
-        delegate.scheduleRequestedTasks(gradle, selector, plan);
+        delegate.scheduleRequestedTasks(gradle, selector, plan, isModelBuildingRequested);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/TaskNameResolvingBuildTaskScheduler.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/TaskNameResolvingBuildTaskScheduler.java
@@ -42,7 +42,7 @@ public class TaskNameResolvingBuildTaskScheduler implements BuildTaskScheduler {
     }
 
     @Override
-    public void scheduleRequestedTasks(GradleInternal gradle, @Nullable EntryTaskSelector selector, ExecutionPlan plan) {
+    public void scheduleRequestedTasks(GradleInternal gradle, @Nullable EntryTaskSelector selector, ExecutionPlan plan, boolean isModelBuildingRequested) {
         if (selector != null) {
             selector.applyTasksTo(new EntryTaskSelectorContext(gradle), plan);
         }

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultTaskExecutionPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultTaskExecutionPreparer.java
@@ -41,7 +41,7 @@ public class DefaultTaskExecutionPreparer implements TaskExecutionPreparer {
     }
 
     @Override
-    public void scheduleRequestedTasks(GradleInternal gradle, @Nullable EntryTaskSelector selector, ExecutionPlan plan) {
+    public void scheduleRequestedTasks(GradleInternal gradle, @Nullable EntryTaskSelector selector, ExecutionPlan plan, boolean isModelBuildingRequested) {
         gradle.getOwner().getProjects().withMutableStateOfAllProjects(() -> {
             buildTaskScheduler.scheduleRequestedTasks(gradle, selector, plan);
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultTaskExecutionPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultTaskExecutionPreparer.java
@@ -43,7 +43,7 @@ public class DefaultTaskExecutionPreparer implements TaskExecutionPreparer {
     @Override
     public void scheduleRequestedTasks(GradleInternal gradle, @Nullable EntryTaskSelector selector, ExecutionPlan plan, boolean isModelBuildingRequested) {
         gradle.getOwner().getProjects().withMutableStateOfAllProjects(() -> {
-            buildTaskScheduler.scheduleRequestedTasks(gradle, selector, plan);
+            buildTaskScheduler.scheduleRequestedTasks(gradle, selector, plan, isModelBuildingRequested);
 
             if (buildModelParameters.isConfigureOnDemand() && gradle.isRootBuild()) {
                 new ProjectsEvaluatedNotifier(buildOperationExecutor).notify(gradle);

--- a/subprojects/core/src/main/java/org/gradle/initialization/TaskExecutionPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/TaskExecutionPreparer.java
@@ -28,5 +28,5 @@ import javax.annotation.Nullable;
  * <p>This includes resolving the entry tasks and calculating the task graph.</p>
  */
 public interface TaskExecutionPreparer {
-    void scheduleRequestedTasks(GradleInternal gradle, @Nullable EntryTaskSelector selector, ExecutionPlan plan);
+    void scheduleRequestedTasks(GradleInternal gradle, @Nullable EntryTaskSelector selector, ExecutionPlan plan, boolean isModelBuildingRequested);
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/VintageBuildModelController.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/VintageBuildModelController.java
@@ -72,8 +72,8 @@ public class VintageBuildModelController implements BuildModelController {
     }
 
     @Override
-    public void scheduleRequestedTasks(@Nullable EntryTaskSelector selector, ExecutionPlan plan) {
-        state.inState(Stage.Configured, () -> taskExecutionPreparer.scheduleRequestedTasks(gradle, selector, plan));
+    public void scheduleRequestedTasks(@Nullable EntryTaskSelector selector, ExecutionPlan plan, boolean isModelBuildingRequested) {
+        state.inState(Stage.Configured, () -> taskExecutionPreparer.scheduleRequestedTasks(gradle, selector, plan, isModelBuildingRequested));
     }
 
     private void prepareSettings() {

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildLifecycleController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildLifecycleController.java
@@ -140,7 +140,7 @@ public interface BuildLifecycleController {
         /**
          * Adds requested tasks, as defined in the {@link org.gradle.StartParameter}, and their dependencies to the work graph for this build.
          */
-        void addRequestedTasks(@Nullable EntryTaskSelector selector);
+        void addRequestedTasks(@Nullable EntryTaskSelector selector, boolean isModelBuildingRequested);
 
         /**
          * Adds the given tasks and their dependencies to the work graph for this build.

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildModelController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildModelController.java
@@ -51,5 +51,5 @@ public interface BuildModelController {
     /**
      * Schedules the user requested tasks for this build into the given plan.
      */
-    void scheduleRequestedTasks(@Nullable EntryTaskSelector selector, ExecutionPlan plan);
+    void scheduleRequestedTasks(@Nullable EntryTaskSelector selector, ExecutionPlan plan, boolean isModelBuildingRequested);
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/build/DefaultBuildLifecycleController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/DefaultBuildLifecycleController.java
@@ -400,8 +400,8 @@ public class DefaultBuildLifecycleController implements BuildLifecycleController
         }
 
         @Override
-        public void addRequestedTasks(@Nullable EntryTaskSelector selector) {
-            modelController.scheduleRequestedTasks(selector, plan);
+        public void addRequestedTasks(@Nullable EntryTaskSelector selector, boolean isModelBuildingRequested) {
+            modelController.scheduleRequestedTasks(selector, plan, isModelBuildingRequested);
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeWorkPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeWorkPreparer.java
@@ -27,5 +27,5 @@ public interface BuildTreeWorkPreparer {
     /**
      * Prepares the given work graph for execution. May configure the build model and calculate the task graph from this, or may load a cached task graph if available.
      */
-    BuildTreeWorkGraph.FinalizedGraph scheduleRequestedTasks(BuildTreeWorkGraph graph, @Nullable EntryTaskSelector selector);
+    BuildTreeWorkGraph.FinalizedGraph scheduleRequestedTasks(BuildTreeWorkGraph graph, @Nullable EntryTaskSelector selector, boolean isModelBuildingRequested);
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/DefaultBuildTreeWorkPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/DefaultBuildTreeWorkPreparer.java
@@ -32,13 +32,13 @@ public class DefaultBuildTreeWorkPreparer implements BuildTreeWorkPreparer {
     }
 
     @Override
-    public BuildTreeWorkGraph.FinalizedGraph scheduleRequestedTasks(BuildTreeWorkGraph graph, @Nullable EntryTaskSelector selector) {
+    public BuildTreeWorkGraph.FinalizedGraph scheduleRequestedTasks(BuildTreeWorkGraph graph, @Nullable EntryTaskSelector selector, boolean isModelBuildingRequested) {
         targetBuildController.prepareToScheduleTasks();
         return graph.scheduleWork(graphBuilder -> {
             if (selector != null) {
                 graphBuilder.addFinalization(targetBuild, selector::postProcessExecutionPlan);
             }
-            graphBuilder.withWorkGraph(targetBuild, builder -> builder.addRequestedTasks(selector));
+            graphBuilder.withWorkGraph(targetBuild, builder -> builder.addRequestedTasks(selector, isModelBuildingRequested));
         });
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
@@ -55,10 +55,7 @@ import org.gradle.execution.selection.BuildTaskSelector;
 import org.gradle.execution.taskgraph.DefaultTaskExecutionGraph;
 import org.gradle.execution.taskgraph.TaskExecutionGraphInternal;
 import org.gradle.execution.taskgraph.TaskListenerInternal;
-import org.gradle.initialization.DefaultTaskExecutionPreparer;
-import org.gradle.initialization.TaskExecutionPreparer;
 import org.gradle.internal.build.BuildState;
-import org.gradle.internal.buildtree.BuildModelParameters;
 import org.gradle.internal.cleanup.DefaultBuildOutputCleanupRegistry;
 import org.gradle.internal.event.ListenerBroadcast;
 import org.gradle.internal.event.ListenerManager;
@@ -106,10 +103,6 @@ public class GradleScopeServices extends DefaultServiceRegistry {
 
     BuildTaskScheduler createBuildTaskScheduler(CommandLineTaskParser commandLineTaskParser, ProjectConfigurer projectConfigurer, BuildTaskSelector.BuildSpecificSelector selector, List<BuiltInCommand> builtInCommands) {
         return new DefaultTasksBuildTaskScheduler(projectConfigurer, builtInCommands, new TaskNameResolvingBuildTaskScheduler(commandLineTaskParser, selector));
-    }
-
-    TaskExecutionPreparer createTaskExecutionPreparer(BuildTaskScheduler buildTaskScheduler, BuildOperationExecutor buildOperationExecutor, BuildModelParameters buildModelParameters) {
-        return new DefaultTaskExecutionPreparer(buildTaskScheduler, buildOperationExecutor, buildModelParameters);
     }
 
     ProjectFinder createProjectFinder(final GradleInternal gradle) {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
@@ -35,16 +35,11 @@ import org.gradle.cache.internal.SplitFileContentCacheFactory;
 import org.gradle.cache.scopes.BuildScopedCacheBuilderFactory;
 import org.gradle.configuration.ConfigurationTargetIdentifier;
 import org.gradle.configuration.internal.ListenerBuildOperationDecorator;
-import org.gradle.internal.code.UserCodeApplicationContext;
-import org.gradle.configuration.project.BuiltInCommand;
 import org.gradle.execution.BuildOperationFiringBuildWorkerExecutor;
 import org.gradle.execution.BuildTaskScheduler;
 import org.gradle.execution.BuildWorkExecutor;
-import org.gradle.execution.DefaultTasksBuildTaskScheduler;
 import org.gradle.execution.DryRunBuildExecutionAction;
-import org.gradle.execution.ProjectConfigurer;
 import org.gradle.execution.SelectedTaskExecutionAction;
-import org.gradle.execution.TaskNameResolvingBuildTaskScheduler;
 import org.gradle.execution.commandline.CommandLineTaskConfigurer;
 import org.gradle.execution.commandline.CommandLineTaskParser;
 import org.gradle.execution.plan.LocalTaskNodeExecutor;
@@ -55,8 +50,12 @@ import org.gradle.execution.selection.BuildTaskSelector;
 import org.gradle.execution.taskgraph.DefaultTaskExecutionGraph;
 import org.gradle.execution.taskgraph.TaskExecutionGraphInternal;
 import org.gradle.execution.taskgraph.TaskListenerInternal;
+import org.gradle.initialization.DefaultTaskExecutionPreparer;
+import org.gradle.initialization.TaskExecutionPreparer;
 import org.gradle.internal.build.BuildState;
+import org.gradle.internal.buildtree.BuildModelParameters;
 import org.gradle.internal.cleanup.DefaultBuildOutputCleanupRegistry;
+import org.gradle.internal.code.UserCodeApplicationContext;
 import org.gradle.internal.event.ListenerBroadcast;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.id.UniqueId;
@@ -101,8 +100,8 @@ public class GradleScopeServices extends DefaultServiceRegistry {
             buildOperationExecutor);
     }
 
-    BuildTaskScheduler createBuildTaskScheduler(CommandLineTaskParser commandLineTaskParser, ProjectConfigurer projectConfigurer, BuildTaskSelector.BuildSpecificSelector selector, List<BuiltInCommand> builtInCommands) {
-        return new DefaultTasksBuildTaskScheduler(projectConfigurer, builtInCommands, new TaskNameResolvingBuildTaskScheduler(commandLineTaskParser, selector));
+    TaskExecutionPreparer createTaskExecutionPreparer(BuildTaskScheduler buildTaskScheduler, BuildOperationExecutor buildOperationExecutor, BuildModelParameters buildModelParameters) {
+        return new DefaultTaskExecutionPreparer(buildTaskScheduler, buildOperationExecutor, buildModelParameters);
     }
 
     ProjectFinder createProjectFinder(final GradleInternal gradle) {

--- a/subprojects/core/src/test/groovy/org/gradle/execution/DefaultTasksBuildTaskSchedulerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/DefaultTasksBuildTaskSchedulerTest.groovy
@@ -49,7 +49,7 @@ class DefaultTasksBuildTaskSchedulerTest extends Specification {
         action.scheduleRequestedTasks(gradle, selector, plan, false)
 
         then:
-        1 * delegate.scheduleRequestedTasks(gradle, selector, plan,)
+        1 * delegate.scheduleRequestedTasks(gradle, selector, plan, false)
     }
 
     def "proceeds when no task requests specified in StartParameter"() {
@@ -60,7 +60,7 @@ class DefaultTasksBuildTaskSchedulerTest extends Specification {
         action.scheduleRequestedTasks(gradle, selector, plan, false)
 
         then:
-        1 * delegate.scheduleRequestedTasks(gradle, selector, plan,)
+        1 * delegate.scheduleRequestedTasks(gradle, selector, plan, false)
     }
 
     def "sets task names to project defaults when single task requests specified in StartParameter"() {
@@ -73,7 +73,7 @@ class DefaultTasksBuildTaskSchedulerTest extends Specification {
 
         then:
         1 * startParameter.setTaskNames(['a', 'b'])
-        1 * delegate.scheduleRequestedTasks(gradle, selector, plan,)
+        1 * delegate.scheduleRequestedTasks(gradle, selector, plan, false)
     }
 
     def "uses default build-in tasks if no tasks specified in StartParameter or project"() {
@@ -87,6 +87,6 @@ class DefaultTasksBuildTaskSchedulerTest extends Specification {
 
         then:
         1 * startParameter.setTaskNames(['default1', 'default2'])
-        1 * delegate.scheduleRequestedTasks(gradle, selector, plan,)
+        1 * delegate.scheduleRequestedTasks(gradle, selector, plan, false)
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/execution/DefaultTasksBuildTaskSchedulerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/DefaultTasksBuildTaskSchedulerTest.groovy
@@ -46,10 +46,10 @@ class DefaultTasksBuildTaskSchedulerTest extends Specification {
         _ * startParameter.taskRequests >> [new DefaultTaskExecutionRequest(['a'])]
 
         when:
-        action.scheduleRequestedTasks(gradle, selector, plan)
+        action.scheduleRequestedTasks(gradle, selector, plan, false)
 
         then:
-        1 * delegate.scheduleRequestedTasks(gradle, selector, plan)
+        1 * delegate.scheduleRequestedTasks(gradle, selector, plan,)
     }
 
     def "proceeds when no task requests specified in StartParameter"() {
@@ -57,10 +57,10 @@ class DefaultTasksBuildTaskSchedulerTest extends Specification {
         _ * startParameter.taskRequests >> []
 
         when:
-        action.scheduleRequestedTasks(gradle, selector, plan)
+        action.scheduleRequestedTasks(gradle, selector, plan, false)
 
         then:
-        1 * delegate.scheduleRequestedTasks(gradle, selector, plan)
+        1 * delegate.scheduleRequestedTasks(gradle, selector, plan,)
     }
 
     def "sets task names to project defaults when single task requests specified in StartParameter"() {
@@ -69,11 +69,11 @@ class DefaultTasksBuildTaskSchedulerTest extends Specification {
         _ * defaultProject.defaultTasks >> ['a', 'b']
 
         when:
-        action.scheduleRequestedTasks(gradle, selector, plan)
+        action.scheduleRequestedTasks(gradle, selector, plan, false)
 
         then:
         1 * startParameter.setTaskNames(['a', 'b'])
-        1 * delegate.scheduleRequestedTasks(gradle, selector, plan)
+        1 * delegate.scheduleRequestedTasks(gradle, selector, plan,)
     }
 
     def "uses default build-in tasks if no tasks specified in StartParameter or project"() {
@@ -83,10 +83,10 @@ class DefaultTasksBuildTaskSchedulerTest extends Specification {
         _ * buildInCommand.asDefaultTask() >> ['default1', 'default2']
 
         when:
-        action.scheduleRequestedTasks(gradle, selector, plan)
+        action.scheduleRequestedTasks(gradle, selector, plan, false)
 
         then:
         1 * startParameter.setTaskNames(['default1', 'default2'])
-        1 * delegate.scheduleRequestedTasks(gradle, selector, plan)
+        1 * delegate.scheduleRequestedTasks(gradle, selector, plan,)
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/execution/TaskNameResolvingBuildTaskSchedulerSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/TaskNameResolvingBuildTaskSchedulerSpec.groovy
@@ -48,7 +48,7 @@ class TaskNameResolvingBuildTaskSchedulerSpec extends Specification {
         _ * gradle.getStartParameter() >> startParameters
         _ * startParameters.getTaskRequests() >> []
 
-        action.scheduleRequestedTasks(gradle, null, executionPlan)
+        action.scheduleRequestedTasks(gradle, null, executionPlan, false)
 
         then:
         0 * executionPlan._
@@ -75,7 +75,7 @@ class TaskNameResolvingBuildTaskSchedulerSpec extends Specification {
         _ * selection2.tasks >> tasks2
 
         when:
-        action.scheduleRequestedTasks(gradle, null, executionPlan)
+        action.scheduleRequestedTasks(gradle, null, executionPlan, false)
 
         then:
         1 * parser.parseTasks(request1) >> [selection1]
@@ -92,7 +92,7 @@ class TaskNameResolvingBuildTaskSchedulerSpec extends Specification {
         _ * gradle.getStartParameter() >> startParameters
         _ * startParameters.getTaskRequests() >> []
 
-        action.scheduleRequestedTasks(gradle, selector, executionPlan)
+        action.scheduleRequestedTasks(gradle, selector, executionPlan,)
 
         then:
         1 * selector.applyTasksTo(_, executionPlan)

--- a/subprojects/core/src/test/groovy/org/gradle/execution/TaskNameResolvingBuildTaskSchedulerSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/TaskNameResolvingBuildTaskSchedulerSpec.groovy
@@ -92,7 +92,7 @@ class TaskNameResolvingBuildTaskSchedulerSpec extends Specification {
         _ * gradle.getStartParameter() >> startParameters
         _ * startParameters.getTaskRequests() >> []
 
-        action.scheduleRequestedTasks(gradle, selector, executionPlan,)
+        action.scheduleRequestedTasks(gradle, selector, executionPlan, false)
 
         then:
         1 * selector.applyTasksTo(_, executionPlan)

--- a/subprojects/core/src/test/groovy/org/gradle/internal/build/DefaultBuildLifecycleControllerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/build/DefaultBuildLifecycleControllerTest.groovy
@@ -90,7 +90,7 @@ class DefaultBuildLifecycleControllerTest extends Specification {
 
         controller.prepareToScheduleTasks()
         def plan = controller.newWorkGraph()
-        controller.populateWorkGraph(plan) { b -> b.addRequestedTasks(,) }
+        controller.populateWorkGraph(plan) { b -> b.addRequestedTasks(null, false) }
         controller.finalizeWorkGraph(plan)
         def executionResult = controller.executeTasks(plan)
         executionResult.failures.empty
@@ -114,7 +114,7 @@ class DefaultBuildLifecycleControllerTest extends Specification {
 
         controller.prepareToScheduleTasks()
         def plan1 = controller.newWorkGraph()
-        controller.populateWorkGraph(plan1) { b -> b.addRequestedTasks(,) }
+        controller.populateWorkGraph(plan1) { b -> b.addRequestedTasks(null, false) }
         controller.finalizeWorkGraph(plan1)
         def executionResult = controller.executeTasks(plan1)
         executionResult.failures.empty
@@ -145,7 +145,7 @@ class DefaultBuildLifecycleControllerTest extends Specification {
 
         controller.prepareToScheduleTasks()
         def plan1 = controller.newWorkGraph()
-        controller.populateWorkGraph(plan1) { b -> b.addRequestedTasks(,) }
+        controller.populateWorkGraph(plan1) { b -> b.addRequestedTasks(null, false) }
         controller.finalizeWorkGraph(plan1)
 
         def resetResult = controller.beforeModelReset()
@@ -405,13 +405,13 @@ class DefaultBuildLifecycleControllerTest extends Specification {
         given:
         1 * workPreparer.newExecutionPlan() >> executionPlan
         1 * workPreparer.populateWorkGraph(gradleMock, executionPlan, _) >> { GradleInternal gradle, ExecutionPlan executionPlan, Consumer consumer -> consumer.accept(executionPlan) }
-        1 * buildModelController.scheduleRequestedTasks(null, executionPlan,) >> { throw failure }
+        1 * buildModelController.scheduleRequestedTasks(null, executionPlan, false) >> { throw failure }
 
         when:
         def controller = this.controller()
         controller.prepareToScheduleTasks()
         def plan = controller.newWorkGraph()
-        controller.populateWorkGraph(plan) { b -> b.addRequestedTasks(,) }
+        controller.populateWorkGraph(plan) { b -> b.addRequestedTasks(null, false) }
 
         then:
         def t = thrown RuntimeException
@@ -442,7 +442,7 @@ class DefaultBuildLifecycleControllerTest extends Specification {
         def controller = this.controller()
         controller.prepareToScheduleTasks()
         def plan = controller.newWorkGraph()
-        controller.populateWorkGraph(plan) { b -> b.addRequestedTasks(,) }
+        controller.populateWorkGraph(plan) { b -> b.addRequestedTasks(null, false) }
         controller.finalizeWorkGraph(plan)
         def executionResult = controller.executeTasks(plan)
 
@@ -476,7 +476,7 @@ class DefaultBuildLifecycleControllerTest extends Specification {
         def controller = this.controller()
         controller.prepareToScheduleTasks()
         def plan = controller.newWorkGraph()
-        controller.populateWorkGraph(plan) { b -> b.addRequestedTasks(,) }
+        controller.populateWorkGraph(plan) { b -> b.addRequestedTasks(null, false) }
         controller.finalizeWorkGraph(plan)
         def executionResult = controller.executeTasks(plan)
 
@@ -508,7 +508,7 @@ class DefaultBuildLifecycleControllerTest extends Specification {
         def controller = controller()
         controller.prepareToScheduleTasks()
         def plan = controller.newWorkGraph()
-        controller.populateWorkGraph(plan) { b -> b.addRequestedTasks(,) }
+        controller.populateWorkGraph(plan) { b -> b.addRequestedTasks(null, false) }
         controller.finalizeWorkGraph(plan)
         controller.executeTasks(plan)
 
@@ -539,7 +539,7 @@ class DefaultBuildLifecycleControllerTest extends Specification {
         def controller = controller()
         controller.prepareToScheduleTasks()
         def plan = controller.newWorkGraph()
-        controller.populateWorkGraph(plan) { b -> b.addRequestedTasks(,) }
+        controller.populateWorkGraph(plan) { b -> b.addRequestedTasks(null, false) }
         controller.finalizeWorkGraph(plan)
 
         when:
@@ -632,7 +632,7 @@ class DefaultBuildLifecycleControllerTest extends Specification {
         1 * workPreparer.newExecutionPlan() >> executionPlan
         1 * buildModelController.prepareToScheduleTasks()
         1 * workPreparer.populateWorkGraph(gradleMock, executionPlan, _) >> { GradleInternal gradle, ExecutionPlan executionPlan, Consumer consumer -> consumer.accept(executionPlan) }
-        1 * buildModelController.scheduleRequestedTasks(null, executionPlan,)
+        1 * buildModelController.scheduleRequestedTasks(null, executionPlan, false)
         1 * workPreparer.finalizeWorkGraph(gradleMock, executionPlan) >> finalizedPlan
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/internal/build/DefaultBuildLifecycleControllerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/build/DefaultBuildLifecycleControllerTest.groovy
@@ -90,7 +90,7 @@ class DefaultBuildLifecycleControllerTest extends Specification {
 
         controller.prepareToScheduleTasks()
         def plan = controller.newWorkGraph()
-        controller.populateWorkGraph(plan) { b -> b.addRequestedTasks() }
+        controller.populateWorkGraph(plan) { b -> b.addRequestedTasks(,) }
         controller.finalizeWorkGraph(plan)
         def executionResult = controller.executeTasks(plan)
         executionResult.failures.empty
@@ -114,7 +114,7 @@ class DefaultBuildLifecycleControllerTest extends Specification {
 
         controller.prepareToScheduleTasks()
         def plan1 = controller.newWorkGraph()
-        controller.populateWorkGraph(plan1) { b -> b.addRequestedTasks() }
+        controller.populateWorkGraph(plan1) { b -> b.addRequestedTasks(,) }
         controller.finalizeWorkGraph(plan1)
         def executionResult = controller.executeTasks(plan1)
         executionResult.failures.empty
@@ -145,7 +145,7 @@ class DefaultBuildLifecycleControllerTest extends Specification {
 
         controller.prepareToScheduleTasks()
         def plan1 = controller.newWorkGraph()
-        controller.populateWorkGraph(plan1) { b -> b.addRequestedTasks() }
+        controller.populateWorkGraph(plan1) { b -> b.addRequestedTasks(,) }
         controller.finalizeWorkGraph(plan1)
 
         def resetResult = controller.beforeModelReset()
@@ -405,13 +405,13 @@ class DefaultBuildLifecycleControllerTest extends Specification {
         given:
         1 * workPreparer.newExecutionPlan() >> executionPlan
         1 * workPreparer.populateWorkGraph(gradleMock, executionPlan, _) >> { GradleInternal gradle, ExecutionPlan executionPlan, Consumer consumer -> consumer.accept(executionPlan) }
-        1 * buildModelController.scheduleRequestedTasks(null, executionPlan) >> { throw failure }
+        1 * buildModelController.scheduleRequestedTasks(null, executionPlan,) >> { throw failure }
 
         when:
         def controller = this.controller()
         controller.prepareToScheduleTasks()
         def plan = controller.newWorkGraph()
-        controller.populateWorkGraph(plan) { b -> b.addRequestedTasks() }
+        controller.populateWorkGraph(plan) { b -> b.addRequestedTasks(,) }
 
         then:
         def t = thrown RuntimeException
@@ -442,7 +442,7 @@ class DefaultBuildLifecycleControllerTest extends Specification {
         def controller = this.controller()
         controller.prepareToScheduleTasks()
         def plan = controller.newWorkGraph()
-        controller.populateWorkGraph(plan) { b -> b.addRequestedTasks() }
+        controller.populateWorkGraph(plan) { b -> b.addRequestedTasks(,) }
         controller.finalizeWorkGraph(plan)
         def executionResult = controller.executeTasks(plan)
 
@@ -476,7 +476,7 @@ class DefaultBuildLifecycleControllerTest extends Specification {
         def controller = this.controller()
         controller.prepareToScheduleTasks()
         def plan = controller.newWorkGraph()
-        controller.populateWorkGraph(plan) { b -> b.addRequestedTasks() }
+        controller.populateWorkGraph(plan) { b -> b.addRequestedTasks(,) }
         controller.finalizeWorkGraph(plan)
         def executionResult = controller.executeTasks(plan)
 
@@ -508,7 +508,7 @@ class DefaultBuildLifecycleControllerTest extends Specification {
         def controller = controller()
         controller.prepareToScheduleTasks()
         def plan = controller.newWorkGraph()
-        controller.populateWorkGraph(plan) { b -> b.addRequestedTasks() }
+        controller.populateWorkGraph(plan) { b -> b.addRequestedTasks(,) }
         controller.finalizeWorkGraph(plan)
         controller.executeTasks(plan)
 
@@ -539,7 +539,7 @@ class DefaultBuildLifecycleControllerTest extends Specification {
         def controller = controller()
         controller.prepareToScheduleTasks()
         def plan = controller.newWorkGraph()
-        controller.populateWorkGraph(plan) { b -> b.addRequestedTasks() }
+        controller.populateWorkGraph(plan) { b -> b.addRequestedTasks(,) }
         controller.finalizeWorkGraph(plan)
 
         when:
@@ -632,7 +632,7 @@ class DefaultBuildLifecycleControllerTest extends Specification {
         1 * workPreparer.newExecutionPlan() >> executionPlan
         1 * buildModelController.prepareToScheduleTasks()
         1 * workPreparer.populateWorkGraph(gradleMock, executionPlan, _) >> { GradleInternal gradle, ExecutionPlan executionPlan, Consumer consumer -> consumer.accept(executionPlan) }
-        1 * buildModelController.scheduleRequestedTasks(null, executionPlan)
+        1 * buildModelController.scheduleRequestedTasks(null, executionPlan,)
         1 * workPreparer.finalizeWorkGraph(gradleMock, executionPlan) >> finalizedPlan
     }
 


### PR DESCRIPTION
Most of the changes are passing `isModelBuildingRequested` parameter into the deep of infrastructure.

The idea is to have an implementation of `BuildTaskScheduler` that keeps logic for skipping `help` task and emit a problem for other tasks during running a build action.

Before this PR the chain of responsibility of `BuildTaskScheduler`s was:

`DefaultTasksBuildTaskScheduler -> TaskNameResolvingBuildTaskScheduler`

This PR is changes that for IP builds:

`DefaultTasksBuildTaskSchedule -> IgnoreHelpBuildTaskScheduler -> TaskNameResolvingBuildTaskScheduler`.

What concerning me is that now `IgnoreHelpBuildTaskScheduler`'s logic is emitting a problem on **any**. Is it something that we really want? For instance, during a first sync IDE asks `prepareKotlinScriptModel` task execution during model building.

There is a lack of test coverage for yet, but I want to make sure firstly that understood @adammurdoch comment in Slack correctly.


