### PR TITLE
Add documentation for removing auto-provisioned toolchains

### DIFF
--- a/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
@@ -333,7 +333,7 @@ In order to disable auto-provisioning, you can use the `org.gradle.java.installa
 [[sub:remove_auto_provisioned_toolchain]]
 === How to remove an auto-provisioned toolchain
 
-To properly remove any auto-provisioned toolchain, you can remove the `jdk` directory from the <<directory_layout.adoc#dir:gradle_user_home,Gradle User Home>>.
+To properly remove any auto-provisioned toolchain, you can remove the `jdks` directory from the <<directory_layout.adoc#dir:gradle_user_home,Gradle User Home>>.
 
 [NOTE]
 ====

--- a/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
@@ -333,7 +333,7 @@ In order to disable auto-provisioning, you can use the `org.gradle.java.installa
 [[sub:remove_auto_provisioned_toolchain]]
 === How to remove an auto-provisioned toolchain
 
-To properly remove an auto-provisioned toolchain, you can remove or modify any reference to the toolchain from `settings.gradle.kts` or `settings.gradle`
+To properly remove an auto-provisioned toolchain, you can remove or modify any reference to the toolchain from `settings.gradle.kts` or `settings.gradle`.
 
 [NOTE]
 ====

--- a/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
@@ -333,8 +333,6 @@ In order to disable auto-provisioning, you can use the `org.gradle.java.installa
 [[sub:removing_auto_provisioned_toolchain]]
 === Removing an auto-provisioned toolchain
 
-In some cases, a user might want explicit control over the toolchain configuration for their project.
-This could include specifying custom versions of a toolchain, ensuring compatibility with specific project requirements, or addressing issues related to the auto-provisioned toolchain.
 
 When removing an auto-provisioned toolchain is necessary, remove the relevant toolchain located in the `/jdks` directory within the <<directory_layout.adoc#dir:gradle_user_home,Gradle User Home>>.
 

--- a/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
@@ -333,11 +333,13 @@ In order to disable auto-provisioning, you can use the `org.gradle.java.installa
 [[sub:remove_auto_provisioned_toolchain]]
 === How to remove an auto-provisioned toolchain
 
-To properly remove any auto-provisioned toolchain, you can remove the `jdks` directory from the <<directory_layout.adoc#dir:gradle_user_home,Gradle User Home>>.
+There are cases where a user might want to take explicit control over the toolchain configuration for their project. This could include specifying custom versions of a toolchain, ensuring compatibility with specific project requirements, or addressing issues related to the auto-provisioned toolchain.
+
+In a situation where it's necessary to remove an auto-provisioned toolchain, remove the relevant toolchain located in the `/jdks` directory within the <<directory_layout.adoc#dir:gradle_user_home,Gradle User Home>>.
 
 [NOTE]
 ====
-<<gradle_daemon.adoc#sec:stopping_an_existing_daemon,Stop the Gradle Daemon>> to clear the cache when removing an auto-provisioned toolchain.
+The <<gradle_daemon.adoc#sec:gradle_daemon,Gradle Daemon>> caches information about your project, including configuration details such as toolchain paths or versions. Changes made to a project's toolchain configuration might not take effect until the Gradle Daemon is restarted. It's recommended to  <<gradle_daemon.adoc#sec:stopping_an_existing_daemon,stop the Gradle Daemon>> to ensure that Gradle updates the configuration for subsequent builds.
 ====
 
 [[sec:custom_loc]]

--- a/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
@@ -330,6 +330,16 @@ In order to disable auto-provisioning, you can use the `org.gradle.java.installa
 * Either start gradle using `-Porg.gradle.java.installations.auto-download=false`
 * Or put `org.gradle.java.installations.auto-download=false` into a `gradle.properties` file.
 
+[[sub:remove_auto_provisioned_toolchain]]
+=== How to remove an auto-provisioned toolchain
+
+To properly remove an auto-provisioned toolchain, you can remove or modify any reference to the toolchain from `settings.gradle.kts` or `settings.gradle`
+
+[NOTE]
+====
+<<gradle_daemon.adoc#sec:stopping_an_existing_daemon,Stop the Gradle Daemon>> to clear the cache before running the build again.
+====
+
 [[sec:custom_loc]]
 == Custom toolchain locations
 

--- a/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
@@ -330,8 +330,8 @@ In order to disable auto-provisioning, you can use the `org.gradle.java.installa
 * Either start gradle using `-Porg.gradle.java.installations.auto-download=false`
 * Or put `org.gradle.java.installations.auto-download=false` into a `gradle.properties` file.
 
-[[sub:remove_auto_provisioned_toolchain]]
-=== How to remove an auto-provisioned toolchain
+[[sub:removing_auto_provisioned_toolchain]]
+=== Removing an auto-provisioned toolchain
 
 There are cases where a user might want to take explicit control over the toolchain configuration for their project. This could include specifying custom versions of a toolchain, ensuring compatibility with specific project requirements, or addressing issues related to the auto-provisioned toolchain.
 

--- a/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
@@ -333,7 +333,6 @@ In order to disable auto-provisioning, you can use the `org.gradle.java.installa
 [[sub:removing_auto_provisioned_toolchain]]
 === Removing an auto-provisioned toolchain
 
-
 When removing an auto-provisioned toolchain is necessary, remove the relevant toolchain located in the `/jdks` directory within the <<directory_layout.adoc#dir:gradle_user_home,Gradle User Home>>.
 
 [NOTE]

--- a/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
@@ -333,11 +333,11 @@ In order to disable auto-provisioning, you can use the `org.gradle.java.installa
 [[sub:remove_auto_provisioned_toolchain]]
 === How to remove an auto-provisioned toolchain
 
-To properly remove an auto-provisioned toolchain, you can remove or modify any reference to the toolchain from `settings.gradle.kts` or `settings.gradle`.
+To properly remove any auto-provisioned toolchain, you can remove the `jdk` directory from the <<directory_layout.adoc#dir:gradle_user_home,Gradle User Home>>.
 
 [NOTE]
 ====
-<<gradle_daemon.adoc#sec:stopping_an_existing_daemon,Stop the Gradle Daemon>> to clear the cache before running the build again.
+<<gradle_daemon.adoc#sec:stopping_an_existing_daemon,Stop the Gradle Daemon>> to clear the cache when removing an auto-provisioned toolchain.
 ====
 
 [[sec:custom_loc]]

--- a/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
@@ -333,13 +333,14 @@ In order to disable auto-provisioning, you can use the `org.gradle.java.installa
 [[sub:removing_auto_provisioned_toolchain]]
 === Removing an auto-provisioned toolchain
 
-There are cases where a user might want to take explicit control over the toolchain configuration for their project. This could include specifying custom versions of a toolchain, ensuring compatibility with specific project requirements, or addressing issues related to the auto-provisioned toolchain.
+In some cases, a user might want explicit control over the toolchain configuration for their project.
+This could include specifying custom versions of a toolchain, ensuring compatibility with specific project requirements, or addressing issues related to the auto-provisioned toolchain.
 
-In a situation where it's necessary to remove an auto-provisioned toolchain, remove the relevant toolchain located in the `/jdks` directory within the <<directory_layout.adoc#dir:gradle_user_home,Gradle User Home>>.
+When removing an auto-provisioned toolchain is necessary, remove the relevant toolchain located in the `/jdks` directory within the <<directory_layout.adoc#dir:gradle_user_home,Gradle User Home>>.
 
 [NOTE]
 ====
-The <<gradle_daemon.adoc#sec:gradle_daemon,Gradle Daemon>> caches information about your project, including configuration details such as toolchain paths or versions. Changes made to a project's toolchain configuration might not take effect until the Gradle Daemon is restarted. It's recommended to  <<gradle_daemon.adoc#sec:stopping_an_existing_daemon,stop the Gradle Daemon>> to ensure that Gradle updates the configuration for subsequent builds.
+The <<gradle_daemon.adoc#sec:gradle_daemon,Gradle Daemon>> caches information about your project, including configuration details such as toolchain paths or versions. Changes to a project's toolchain configuration might only occur once the Gradle Daemon is restarted. It is recommended to  <<gradle_daemon.adoc#sec:stopping_an_existing_daemon,stop the Gradle Daemon>> to ensure that Gradle updates the configuration for subsequent builds.
 ====
 
 [[sec:custom_loc]]


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Added instructions to properly remove an auto-provisioned toolchain and a note about stopping the Gradle Daemon to clear the cache

Documentation change only.
<!-- Fixes #? -->
Fixes #24581 

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`