### PR TITLE
Clean up version-control build dir on Windows

### DIFF
--- a/.teamcity/src/main/kotlin/common/performance-test-extensions.kt
+++ b/.teamcity/src/main/kotlin/common/performance-test-extensions.kt
@@ -95,12 +95,15 @@ fun BuildType.cleanUpGitUntrackedFilesAndDirectories() {
     }
 }
 
-fun BuildSteps.cleanUpPerformanceBuildDir(os: Os) {
+fun BuildSteps.cleanUpReadOnlyDir(os: Os) {
     if (os == Os.WINDOWS) {
         script {
-            name = "CLEAN_UP_PERFORMANCE_BUILD_DIR"
+            name = "CLEAN_UP_READ_ONLY_DIR"
             executionMode = BuildStep.ExecutionMode.ALWAYS
-            scriptContent = """rmdir /s /q %teamcity.build.checkoutDir%\subprojects\performance\build && (echo Directory removed) || (echo Directory not found) """
+            scriptContent = """
+                rmdir /s /q %teamcity.build.checkoutDir%\subprojects\performance\build && (echo performance-build-dir removed) || (echo performance-build-dir not found)
+                rmdir /s /q %teamcity.build.checkoutDir%\subprojects\version-control\build && (echo version-control-build-dir removed) || (echo version-control-build-dir not found)
+                """
             skipConditionally()
         }
     }

--- a/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
+++ b/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
@@ -12,7 +12,7 @@ import common.applyDefaultSettings
 import common.buildToolGradleParameters
 import common.checkCleanM2AndAndroidUserHome
 import common.cleanUpGitUntrackedFilesAndDirectories
-import common.cleanUpPerformanceBuildDir
+import common.cleanUpReadOnlyDir
 import common.compileAllDependency
 import common.dependsOn
 import common.functionalTestParameters
@@ -141,7 +141,7 @@ fun applyDefaults(
     buildType.applyDefaultSettings(os, timeout = timeout)
 
     buildType.killProcessStep(KILL_LEAKED_PROCESSES_FROM_PREVIOUS_BUILDS, os)
-    buildType.steps.cleanUpPerformanceBuildDir(os)
+    buildType.steps.cleanUpReadOnlyDir(os)
     buildType.gradleRunnerStep(model, gradleTasks, os, extraParameters, daemon)
 
     buildType.steps {
@@ -188,7 +188,7 @@ fun applyTestDefaults(
     }
 
     buildType.killProcessStep(KILL_LEAKED_PROCESSES_FROM_PREVIOUS_BUILDS, os, arch)
-    buildType.steps.cleanUpPerformanceBuildDir(os)
+    buildType.steps.cleanUpReadOnlyDir(os)
     buildType.gradleRunnerStep(model, gradleTasks, os, extraParameters, daemon, maxParallelForks = maxParallelForks)
     buildType.addRetrySteps(model, gradleTasks, os, arch, extraParameters)
     buildType.killProcessStep(KILL_PROCESSES_STARTED_BY_GRADLE, os, arch)

--- a/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
@@ -21,7 +21,7 @@ import common.Os
 import common.applyPerformanceTestSettings
 import common.buildToolGradleParameters
 import common.checkCleanM2AndAndroidUserHome
-import common.cleanUpPerformanceBuildDir
+import common.cleanUpReadOnlyDir
 import common.gradleWrapper
 import common.individualPerformanceTestArtifactRules
 import common.killProcessStep
@@ -83,7 +83,7 @@ class PerformanceTest(
             steps {
                 preBuildSteps()
                 killProcessStep(buildTypeThis, KILL_ALL_GRADLE_PROCESSES, os)
-                cleanUpPerformanceBuildDir(os)
+                cleanUpReadOnlyDir(os)
                 substDirOnWindows(os)
 
                 repeat(if (performanceTestBuildSpec.type == PerformanceTestType.flakinessDetection) 2 else 1) { repeatIndex: Int ->

--- a/.teamcity/src/main/kotlin/util/RerunFlakyTest.kt
+++ b/.teamcity/src/main/kotlin/util/RerunFlakyTest.kt
@@ -26,7 +26,7 @@ import common.Os
 import common.applyDefaultSettings
 import common.buildToolGradleParameters
 import common.checkCleanM2AndAndroidUserHome
-import common.cleanUpPerformanceBuildDir
+import common.cleanUpReadOnlyDir
 import common.compileAllDependency
 import common.functionalTestExtraParameters
 import common.functionalTestParameters
@@ -61,7 +61,7 @@ class RerunFlakyTest(os: Os, arch: Arch = Arch.AMD64) : BuildType({
         ).joinToString(separator = " ")
 
     killProcessStep(KILL_LEAKED_PROCESSES_FROM_PREVIOUS_BUILDS, os, arch)
-    steps.cleanUpPerformanceBuildDir(os)
+    steps.cleanUpReadOnlyDir(os)
 
     (1..10).forEach { idx ->
         steps {

--- a/.teamcity/src/test/kotlin/ApplyDefaultConfigurationTest.kt
+++ b/.teamcity/src/test/kotlin/ApplyDefaultConfigurationTest.kt
@@ -123,7 +123,7 @@ class ApplyDefaultConfigurationTest {
         assertEquals(
             listOf(
                 "KILL_LEAKED_PROCESSES_FROM_PREVIOUS_BUILDS",
-                "CLEAN_UP_PERFORMANCE_BUILD_DIR",
+                "CLEAN_UP_READ_ONLY_DIR",
                 "GRADLE_RUNNER",
                 "KILL_ALL_GRADLE_PROCESSES",
                 "CLEAN_UP_GIT_UNTRACKED_FILES_AND_DIRECTORIES",

--- a/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
+++ b/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
@@ -126,7 +126,7 @@ class PerformanceTestBuildTypeTest {
         assertEquals(
             listOf(
                 "KILL_ALL_GRADLE_PROCESSES",
-                "CLEAN_UP_PERFORMANCE_BUILD_DIR",
+                "CLEAN_UP_READ_ONLY_DIR",
                 "SETUP_VIRTUAL_DISK_FOR_PERF_TEST",
                 "GRADLE_RUNNER",
                 "REMOVE_VIRTUAL_DISK_FOR_PERF_TEST",


### PR DESCRIPTION
We found some read-only git blob objects in `version-control/build/` tmp test files which can't be deleted by `gradle clean`, thus breaking subsequent builds.

Now let's clean up the dir with `rmdir`
