### PR TITLE
Split adding test repos and forcing locally built kotlin-dsl plugins versions

### DIFF
--- a/platforms/core-configuration/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginCrossVersionSmokeTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginCrossVersionSmokeTest.kt
@@ -31,7 +31,7 @@ import org.junit.Test
  */
 class KotlinDslPluginCrossVersionSmokeTest : AbstractKotlinIntegrationTest() {
 
-    override val injectLocalKotlinDslPluginsRepositories = false
+    override val forceLocallyBuiltKotlinDslPlugins = false
 
     // Previous versions depend on Kotlin that is not supported with Gradle >= 8.0
     val oldestSupportedKotlinDslPluginVersion = "3.2.4"
@@ -89,7 +89,7 @@ class KotlinDslPluginCrossVersionSmokeTest : AbstractKotlinIntegrationTest() {
         // Kotlin version leaks on the classpath when running embedded
         assumeNonEmbeddedGradleExecuter()
 
-        doInjectLocallyBuiltKotlinDslPluginsRepositories()
+        doForceLocallyBuiltKotlinDslPlugins()
 
         `can build plugin for oldest supported Kotlin language version`()
     }


### PR DESCRIPTION
This is another follow up to:
* https://github.com/gradle/gradle/pull/26501

Another stepstone towards using K2 for scripting.