### PR TITLE
Upgrade CompileOptions.compileArgs and CompileOptions.compilerArgumentProviders to lazy property

### DIFF
--- a/platforms/jvm/language-groovy/src/testFixtures/resources/org/gradle/groovy/compile/AbstractBasicGroovyCompilerIntegrationSpec/compileJavaFx8Code/build.gradle
+++ b/platforms/jvm/language-groovy/src/testFixtures/resources/org/gradle/groovy/compile/AbstractBasicGroovyCompilerIntegrationSpec/compileJavaFx8Code/build.gradle
@@ -6,7 +6,7 @@ repositories {
 
 compileGroovy {
     if (JavaVersion.current().isJava9()) {
-        options.compilerArgs += ['--add-modules', 'javafx.graphics']
+        options.compilerArgs.addAll(['--add-modules', 'javafx.graphics'])
         groovyOptions.forkOptions.jvmArgs += ['--add-modules', 'javafx.graphics']
     }
 }

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
@@ -23,6 +23,7 @@ import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.model.ReplacedBy;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Classpath;
@@ -77,7 +78,6 @@ public abstract class CompileOptions extends AbstractOptions {
 
     private String extensionDirs;
 
-    private List<String> compilerArgs = Lists.newArrayList();
     private final List<CommandLineArgumentProvider> compilerArgumentProviders = Lists.newArrayList();
 
     private boolean incremental = true;
@@ -318,9 +318,7 @@ public abstract class CompileOptions extends AbstractOptions {
      * are ignored.
      */
     @Input
-    public List<String> getCompilerArgs() {
-        return compilerArgs;
-    }
+    public abstract ListProperty<String> getCompilerArgs();
 
     /**
      * Returns all compiler arguments, added to the {@link #getCompilerArgs()} or the {@link #getCompilerArgumentProviders()} property.
@@ -330,7 +328,7 @@ public abstract class CompileOptions extends AbstractOptions {
     @Internal
     public List<String> getAllCompilerArgs() {
         ImmutableList.Builder<String> builder = ImmutableList.builder();
-        builder.addAll(CollectionUtils.stringize(getCompilerArgs()));
+        builder.addAll(CollectionUtils.stringize(getCompilerArgs().get()));
         for (CommandLineArgumentProvider compilerArgumentProvider : getCompilerArgumentProviders()) {
             builder.addAll(compilerArgumentProvider.asArguments());
         }
@@ -345,14 +343,6 @@ public abstract class CompileOptions extends AbstractOptions {
     @Nested
     public List<CommandLineArgumentProvider> getCompilerArgumentProviders() {
         return compilerArgumentProviders;
-    }
-
-    /**
-     * Sets any additional arguments to be passed to the compiler.
-     * Defaults to the empty list.
-     */
-    public void setCompilerArgs(List<String> compilerArgs) {
-        this.compilerArgs = compilerArgs;
     }
 
     /**

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
@@ -17,7 +17,6 @@
 package org.gradle.api.tasks.compile;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 import org.gradle.api.Incubating;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
@@ -77,8 +76,6 @@ public abstract class CompileOptions extends AbstractOptions {
     private FileCollection bootstrapClasspath;
 
     private String extensionDirs;
-
-    private final List<CommandLineArgumentProvider> compilerArgumentProviders = Lists.newArrayList();
 
     private boolean incremental = true;
 
@@ -329,7 +326,7 @@ public abstract class CompileOptions extends AbstractOptions {
     public List<String> getAllCompilerArgs() {
         ImmutableList.Builder<String> builder = ImmutableList.builder();
         builder.addAll(CollectionUtils.stringize(getCompilerArgs().get()));
-        for (CommandLineArgumentProvider compilerArgumentProvider : getCompilerArgumentProviders()) {
+        for (CommandLineArgumentProvider compilerArgumentProvider : getCompilerArgumentProviders().get()) {
             builder.addAll(compilerArgumentProvider.asArguments());
         }
         return builder.build();
@@ -341,9 +338,7 @@ public abstract class CompileOptions extends AbstractOptions {
      * @since 4.5
      */
     @Nested
-    public List<CommandLineArgumentProvider> getCompilerArgumentProviders() {
-        return compilerArgumentProviders;
-    }
+    public abstract ListProperty<CommandLineArgumentProvider> getCompilerArgumentProviders();
 
     /**
      * Convenience method to set {@link ForkOptions} with named parameter syntax.

--- a/platforms/jvm/language-java/src/test/groovy/org/gradle/api/tasks/compile/CompileOptionsTest.groovy
+++ b/platforms/jvm/language-java/src/test/groovy/org/gradle/api/tasks/compile/CompileOptionsTest.groovy
@@ -44,7 +44,7 @@ class CompileOptionsTest extends Specification {
         !compileOptions.verbose
         !compileOptions.fork
 
-        compileOptions.compilerArgs.empty
+        compileOptions.compilerArgs.get().empty
         compileOptions.encoding == null
         compileOptions.bootstrapClasspath == null
         compileOptions.extensionDirs == null
@@ -90,7 +90,7 @@ class CompileOptionsTest extends Specification {
 
     def "converts GStrings to Strings when getting all compiler arguments"() {
         given:
-        compileOptions.compilerArgs << "Foo${23}"
+        compileOptions.compilerArgs.add("Foo${23}")
 
         expect:
         compileOptions.allCompilerArgs.contains('Foo23')

--- a/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
+++ b/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
@@ -11,6 +11,15 @@
         },
         {
             "type": "org.gradle.api.tasks.compile.CompileOptions",
+            "member": "Method org.gradle.api.tasks.compile.CompileOptions.getCompilerArgumentProviders()",
+            "acceptation": "Upgraded property",
+            "changes": [
+                "Method return type has changed",
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.tasks.compile.CompileOptions",
             "member": "Method org.gradle.api.tasks.compile.CompileOptions.setCompilerArgs(java.util.List)",
             "acceptation": "Upgraded property",
             "changes": [

--- a/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
+++ b/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
@@ -1,3 +1,21 @@
 {
-    "acceptedApiChanges": []
+    "acceptedApiChanges": [
+        {
+            "type": "org.gradle.api.tasks.compile.CompileOptions",
+            "member": "Method org.gradle.api.tasks.compile.CompileOptions.getCompilerArgs()",
+            "acceptation": "Upgraded property",
+            "changes": [
+                "Method return type has changed",
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.tasks.compile.CompileOptions",
+            "member": "Method org.gradle.api.tasks.compile.CompileOptions.setCompilerArgs(java.util.List)",
+            "acceptation": "Upgraded property",
+            "changes": [
+                "Method has been removed"
+            ]
+        }
+    ]
 }

--- a/subprojects/architecture-test/src/changes/archunit_store/public-api-mutable-properties.txt
+++ b/subprojects/architecture-test/src/changes/archunit_store/public-api-mutable-properties.txt
@@ -251,7 +251,6 @@ Method <org.gradle.api.tasks.compile.BaseForkOptions.getMemoryInitialSize()> doe
 Method <org.gradle.api.tasks.compile.BaseForkOptions.getMemoryMaximumSize()> does not have raw return type assignable to org.gradle.api.provider.Property in (BaseForkOptions.java:0)
 Method <org.gradle.api.tasks.compile.CompileOptions.getAllCompilerArgs()> does not have raw return type assignable to org.gradle.api.provider.Provider in (CompileOptions.java:0)
 Method <org.gradle.api.tasks.compile.CompileOptions.getAnnotationProcessorGeneratedSourcesDirectory()> does not have raw return type assignable to org.gradle.api.provider.Property in (CompileOptions.java:0)
-Method <org.gradle.api.tasks.compile.CompileOptions.getCompilerArgs()> does not have raw return type assignable to org.gradle.api.provider.Property in (CompileOptions.java:0)
 Method <org.gradle.api.tasks.compile.CompileOptions.getCompilerArgumentProviders()> does not have raw return type assignable to org.gradle.api.provider.Provider in (CompileOptions.java:0)
 Method <org.gradle.api.tasks.compile.CompileOptions.getDebugOptions()> does not have raw return type assignable to org.gradle.api.provider.Property in (CompileOptions.java:0)
 Method <org.gradle.api.tasks.compile.CompileOptions.getEncoding()> does not have raw return type assignable to org.gradle.api.provider.Property in (CompileOptions.java:0)

--- a/subprojects/architecture-test/src/changes/archunit_store/public-api-mutable-properties.txt
+++ b/subprojects/architecture-test/src/changes/archunit_store/public-api-mutable-properties.txt
@@ -251,7 +251,6 @@ Method <org.gradle.api.tasks.compile.BaseForkOptions.getMemoryInitialSize()> doe
 Method <org.gradle.api.tasks.compile.BaseForkOptions.getMemoryMaximumSize()> does not have raw return type assignable to org.gradle.api.provider.Property in (BaseForkOptions.java:0)
 Method <org.gradle.api.tasks.compile.CompileOptions.getAllCompilerArgs()> does not have raw return type assignable to org.gradle.api.provider.Provider in (CompileOptions.java:0)
 Method <org.gradle.api.tasks.compile.CompileOptions.getAnnotationProcessorGeneratedSourcesDirectory()> does not have raw return type assignable to org.gradle.api.provider.Property in (CompileOptions.java:0)
-Method <org.gradle.api.tasks.compile.CompileOptions.getCompilerArgumentProviders()> does not have raw return type assignable to org.gradle.api.provider.Provider in (CompileOptions.java:0)
 Method <org.gradle.api.tasks.compile.CompileOptions.getDebugOptions()> does not have raw return type assignable to org.gradle.api.provider.Property in (CompileOptions.java:0)
 Method <org.gradle.api.tasks.compile.CompileOptions.getEncoding()> does not have raw return type assignable to org.gradle.api.provider.Property in (CompileOptions.java:0)
 Method <org.gradle.api.tasks.compile.CompileOptions.getExtensionDirs()> does not have raw return type assignable to org.gradle.api.provider.Property in (CompileOptions.java:0)

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmLanguageUtilities.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmLanguageUtilities.java
@@ -76,7 +76,7 @@ public class DefaultJvmLanguageUtilities implements JvmLanguageUtilities {
                 return compileTask.getOptions().getRelease().get();
             }
 
-            List<String> compilerArgs = compileTask.getOptions().getCompilerArgs();
+            List<String> compilerArgs = compileTask.getOptions().getCompilerArgs().get();
             int flagIndex = compilerArgs.indexOf("--release");
 
             if (flagIndex != -1 && flagIndex + 1 < compilerArgs.size()) {


### PR DESCRIPTION
Blocked by:
- https://github.com/gradle/gradle/issues/23637