### PR TITLE
Fix spurious warnings with CC and the `kotlin-dsl` plugin

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/beans/BeanSchema.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/beans/BeanSchema.kt
@@ -188,7 +188,8 @@ val abstractTaskRelevantFields = listOf(
     "actions",
     "enabled",
     "timeout",
-    "onlyIfSpec"
+    "onlyIfSpec",
+    "logger",
 )
 
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/Codecs.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/Codecs.kt
@@ -138,6 +138,7 @@ class Codecs(
 
             providersBlock()
 
+            bind(DefaultContextAwareTaskLoggerCodec)
             bind(LoggerCodec)
 
             fileCollectionTypes(directoryFileTreeFactory, fileCollectionFactory, artifactSetConverter, fileOperations, fileFactory, patternSetFactory)

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/DefaultContextAwareTaskLoggerCodec.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/DefaultContextAwareTaskLoggerCodec.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache.serialization.codecs
+
+import org.gradle.api.Task
+import org.gradle.api.logging.Logging
+import org.gradle.configurationcache.serialization.Codec
+import org.gradle.configurationcache.serialization.ReadContext
+import org.gradle.configurationcache.serialization.WriteContext
+import org.gradle.configurationcache.serialization.decodePreservingIdentity
+import org.gradle.configurationcache.serialization.encodePreservingIdentityOf
+import org.gradle.internal.logging.slf4j.ContextAwareTaskLogger.MessageRewriter
+import org.gradle.internal.logging.slf4j.DefaultContextAwareTaskLogger
+
+
+object DefaultContextAwareTaskLoggerCodec : Codec<DefaultContextAwareTaskLogger> {
+
+    override suspend fun WriteContext.encode(value: DefaultContextAwareTaskLogger) {
+        encodePreservingIdentityOf(value) {
+            write(it.messageRewriter)
+        }
+    }
+
+    override suspend fun ReadContext.decode(): DefaultContextAwareTaskLogger =
+        decodePreservingIdentity { id ->
+            DefaultContextAwareTaskLogger(Logging.getLogger(Task::class.java)).also { logger ->
+                read()?.let { rewriter ->
+                    logger.messageRewriter = rewriter as MessageRewriter
+                }
+                isolate.identities.putInstance(id, logger)
+            }
+        }
+}

--- a/platforms/core-configuration/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinCompilerWarningsTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinCompilerWarningsTest.kt
@@ -16,7 +16,6 @@
 
 package org.gradle.kotlin.dsl.plugins.dsl
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.kotlin.dsl.fixtures.AbstractKotlinIntegrationTest
 import org.junit.Test
 
@@ -33,7 +32,6 @@ class KotlinCompilerWarningsTest : AbstractKotlinIntegrationTest() {
     val experimentalFeatureToWarnAbout = "-XXLanguage:+FunctionReferenceWithDefaultValueAsOtherType"
 
     @Test
-    @ToBeFixedForConfigurationCache(because = "https://github.com/gradle/gradle/issues/25483")
     fun `experimental compiler warnings are not shown for known experimental features`() {
         withBuildScriptForKotlinCompile()
         withKotlinSourceFile()
@@ -45,7 +43,6 @@ class KotlinCompilerWarningsTest : AbstractKotlinIntegrationTest() {
     }
 
     @Test
-    @ToBeFixedForConfigurationCache(because = "https://github.com/gradle/gradle/issues/25483")
     fun `experimental compiler warnings are not shown for known experimental features with allWarningsAsErrors`() {
         withBuildScriptForKotlinCompile("allWarningsAsErrors.set(true)")
         withKotlinSourceFile()
@@ -58,7 +55,6 @@ class KotlinCompilerWarningsTest : AbstractKotlinIntegrationTest() {
 
 
     @Test
-    @ToBeFixedForConfigurationCache(because = "https://github.com/gradle/gradle/issues/25483")
     fun `compileKotlin task output is retained when known experimental feature warnings are silenced`() {
         withBuildScriptForKotlinCompile(
             "",
@@ -82,7 +78,6 @@ class KotlinCompilerWarningsTest : AbstractKotlinIntegrationTest() {
     }
 
     @Test
-    @ToBeFixedForConfigurationCache(because = "https://github.com/gradle/gradle/issues/25483")
     fun `compiler warning for an explicitly enabled experimental feature is shown`() {
         withBuildScriptForKotlinCompile("freeCompilerArgs.add(\"$experimentalFeatureToWarnAbout\")")
         withKotlinSourceFile()
@@ -95,7 +90,6 @@ class KotlinCompilerWarningsTest : AbstractKotlinIntegrationTest() {
     }
 
     @Test
-    @ToBeFixedForConfigurationCache(because = "https://github.com/gradle/gradle/issues/25483")
     fun `compiler warning for an explicitly enabled experimental feature is shown with allWarningsAsErrors`() {
         withBuildScriptForKotlinCompile(
             """

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/slf4j/DefaultContextAwareTaskLogger.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/slf4j/DefaultContextAwareTaskLogger.java
@@ -36,6 +36,12 @@ public class DefaultContextAwareTaskLogger implements ContextAwareTaskLogger {
         this.delegate = Cast.cast(BuildOperationAwareLogger.class, delegate);
     }
 
+    public MessageRewriter getMessageRewriter() {
+        return delegate instanceof MessageRewritingBuildOperationAwareLogger
+            ? ((MessageRewritingBuildOperationAwareLogger) delegate).getMessageRewriter()
+            : null;
+    }
+
     @Override
     public void setMessageRewriter(MessageRewriter messageRewriter) {
         delegate = new MessageRewritingBuildOperationAwareLogger(delegate, messageRewriter);

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/slf4j/MessageRewritingBuildOperationAwareLogger.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/slf4j/MessageRewritingBuildOperationAwareLogger.java
@@ -29,6 +29,10 @@ class MessageRewritingBuildOperationAwareLogger extends BuildOperationAwareLogge
         this.messageRewriter = messageRewriter;
     }
 
+    ContextAwareTaskLogger.MessageRewriter getMessageRewriter() {
+        return messageRewriter;
+    }
+
     @Override
     void log(LogLevel logLevel, Throwable throwable, String message, OperationIdentifier operationIdentifier) {
         final String rewrittenMessage = messageRewriter.rewrite(logLevel, message);


### PR DESCRIPTION
By letting CC store task logger message rewriters

* Fixes https://github.com/gradle/gradle/issues/25483
