### PR TITLE
Introduce Tencent as a known JVM vendor

### DIFF
--- a/platforms/jvm/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/JvmVendor.java
+++ b/platforms/jvm/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/JvmVendor.java
@@ -34,6 +34,7 @@ public interface JvmVendor {
         MICROSOFT("microsoft", "Microsoft"),
         ORACLE("oracle", "Oracle"),
         SAP("sap se", "SAP SapMachine"),
+        TENCENT("tencent", "Tencent"),
         UNKNOWN("gradle", "Unknown Vendor");
 
         private final String indicatorString;

--- a/platforms/jvm/toolchains-jvm/src/main/java/org/gradle/jvm/toolchain/JvmVendorSpec.java
+++ b/platforms/jvm/toolchains-jvm/src/main/java/org/gradle/jvm/toolchain/JvmVendorSpec.java
@@ -84,6 +84,14 @@ public abstract class JvmVendorSpec {
     public static final JvmVendorSpec SAP = matching(KnownJvmVendor.SAP);
 
     /**
+     * A constant for using <a href="https://github.com/Tencent/TencentKona-8">Tencent Kona JDK</a> as the JVM vendor.
+     *
+     * @since 8.6
+     */
+    @Incubating
+    public static final JvmVendorSpec TENCENT = matching(KnownJvmVendor.TENCENT);
+
+    /**
      * Determines if the vendor passed as an argument matches this spec.
      * @param vendor the vendor to test
      * @return true if this spec matches the vendor

--- a/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
@@ -379,6 +379,7 @@ Sorting is done based on the following rules:
 .. MICROSOFT
 .. ORACLE
 .. SAP
+.. TENCENT
 .. everything else
 . higher major versions take precedence over lower ones
 . higher minor versions take precedence over lower ones


### PR DESCRIPTION
### Context
Tencent is a notable contributor to OpenJDK, and has been publishing its own OpenJDK distribution, exactly Kona JDK, for years.
- https://github.com/Tencent/TencentKona-8
- https://github.com/Tencent/TencentKona-11
- https://github.com/Tencent/TencentKona-17

And SDKMAN already supports Tencent Kona JDK
- https://sdkman.io/jdks#kona

This PR just adds Tencent as a known JVM vendor so that we can easily apply Kona JDK with Gradle toolchain feature.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
