### PR TITLE
Let `:soak-test` kotlin tests run against locally built `:kotlin-dsl-plugins`

### DIFF
--- a/subprojects/soak/build.gradle.kts
+++ b/subprojects/soak/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("gradlebuild.internal.kotlin")
+    id("gradlebuild.kotlin-dsl-plugin-bundle-integ-tests")
 }
 
 dependencies {


### PR DESCRIPTION
To fix currently failing soak tests, e.g. https://ge.gradle.org/s/eeowpp6ksj5ya/tests/task/:soak:forkingIntegTest/details/org.gradle.kotlin.dsl.caching.ScriptCachingIntegrationTest/same%20script%2C%20target%20type%20%26%20classpath?top-execution=1

* Fixes https://github.com/gradle/gradle-private/issues/3998