### PR TITLE
Update tested AGP versions

### DIFF
--- a/gradle/dependency-management/agp-versions.properties
+++ b/gradle/dependency-management/agp-versions.properties
@@ -1,4 +1,4 @@
 # Generated - Update by running `./gradlew updateAgpVersions`
-latests=7.3.1,7.4.2,8.0.2,8.1.1,8.2.0-beta02,8.3.0-alpha02
-nightlyBuildId=10767672
+latests=7.3.1,7.4.2,8.0.2,8.1.1,8.2.0-beta06,8.3.0-alpha05
+nightlyBuildId=10874730
 nightlyVersion=8.3.0-dev


### PR DESCRIPTION
from 8.2.0-beta02 to 8.2.0-beta06
from 8.3.0-alpha02 to 8.3.0-alpha05
bumping the 8.3.0-dev nightly
