### PR TITLE
Fix InstrumentationMetadataTransform when there are no changes to upgraded properties file

### DIFF
--- a/build-logic/packaging/src/main/kotlin/gradlebuild/instrumentation/extensions/InstrumentationMetadataExtension.kt
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild/instrumentation/extensions/InstrumentationMetadataExtension.kt
@@ -56,6 +56,6 @@ abstract class InstrumentationMetadataExtension(private val configurations: Conf
     private
     fun Configuration.toProjectsOnlyView() = incoming.artifactView {
         componentFilter { id -> id is ProjectComponentIdentifier }
-        lenient(true)
+        lenient(false)
     }.files
 }

--- a/build-logic/packaging/src/main/kotlin/gradlebuild/instrumentation/extensions/InstrumentationMetadataExtension.kt
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild/instrumentation/extensions/InstrumentationMetadataExtension.kt
@@ -56,6 +56,5 @@ abstract class InstrumentationMetadataExtension(private val configurations: Conf
     private
     fun Configuration.toProjectsOnlyView() = incoming.artifactView {
         componentFilter { id -> id is ProjectComponentIdentifier }
-        lenient(false)
     }.files
 }

--- a/build-logic/packaging/src/main/kotlin/gradlebuild/instrumentation/transforms/InstrumentationMetadataTransform.kt
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild/instrumentation/transforms/InstrumentationMetadataTransform.kt
@@ -121,8 +121,12 @@ abstract class InstrumentationMetadataTransform : TransformAction<TransformParam
         }
     }
 
-    private sealed interface MetadataFileChange
-    private object MetadataNotChanged: MetadataFileChange
-    private object MetadataRemoved : MetadataFileChange
-    private data class MetadataModified(val newFile: File): MetadataFileChange
+    private
+    sealed interface MetadataFileChange
+    private
+    object MetadataNotChanged : MetadataFileChange
+    private
+    object MetadataRemoved : MetadataFileChange
+    private
+    data class MetadataModified(val newFile: File) : MetadataFileChange
 }

--- a/build-logic/packaging/src/test/kotlin/gradlebuild/instrumentation/InstrumentationMetadataPluginTest.kt
+++ b/build-logic/packaging/src/test/kotlin/gradlebuild/instrumentation/InstrumentationMetadataPluginTest.kt
@@ -150,7 +150,7 @@ class InstrumentationMetadataPluginTest {
     fun File.assertContentContains(text: String) {
         val fullContent = this.readText()
         assert(fullContent.contains(text)) {
-            "Expected ${this.name} content to contain text: '$text', but it didn't. Full content:\n${fullContent}"
+            "Expected ${this.name} content to contain text: '$text', but it didn't. Full content:\n$fullContent"
         }
     }
 


### PR DESCRIPTION
So it turns out that artifact transform failed if there were no changes to upgraded properties file. This happened because we were trying to overwrite a file itself. So basically if there were no changes, we did:
```
val changes: File = changes(...)
changes.copyTo(output) // where output was actually the same file  
```

Due to that artifact transform failed. But we didn't notice that because we used `lenient(true)` on the configuration.

Fixes https://github.com/gradle/gradle/issues/26570

