### PR TITLE
Release notes: Mention simpler property assignment in Kotlin dsl section

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -140,6 +140,10 @@ Gradle's [Kotlin DSL](userguide/kotlin_dsl.html) provides an enhanced editing ex
 
 The embedded Kotlin has been updated from 1.9.0 to [Kotlin 1.9.10](https://github.com/JetBrains/kotlin/releases/tag/v1.9.10).
 
+#### Simple property assignment in Kotlin DSL
+
+The simple property assignment with the `=` operator has been [promoted to stable](#assign-stable).
+
 <a name="doc-link-source"></a>
 #### Links to GitHub sources in Kotlin DSL Reference
 


### PR DESCRIPTION
I had to use a different title compared to the one in `Promoted features`. There we have:
```
#### Simple property assignment in Kotlin DSL is now stable
```
and here is
```
#### Simple property assignment in Kotlin DSL
```
If I use the same title, one of release notes tests fail with "duplicated id found" exception.


Preview:
https://builds.gradle.org/repository/download/Gradle_Release_Check_BuildDistributions/72510956:id/distributions/gradle-8.4-docs.zip!/gradle-8.4-20230928142441%2B0000/docs/release-notes.html
