### PR TITLE
September Doc Cleanup based on Github issues

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/tasks/WriteProperties.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/WriteProperties.java
@@ -210,6 +210,8 @@ public abstract class WriteProperties extends DefaultTask {
     /**
      * Sets the output file to write the properties to.
      *
+     * @deprecated Use {@link #getDestinationFile()} instead.
+     *
      * @since 4.0
      */
     @Deprecated
@@ -220,6 +222,8 @@ public abstract class WriteProperties extends DefaultTask {
 
     /**
      * Sets the output file to write the properties to.
+     *
+     * @deprecated Use {@link #getDestinationFile()} instead.
      */
     @Deprecated
     public void setOutputFile(Object outputFile) {

--- a/subprojects/docs/src/docs/css/javadoc.css
+++ b/subprojects/docs/src/docs/css/javadoc.css
@@ -186,7 +186,6 @@ sup {
     padding-top: 107px;
 }
 .fixedNav {
-    position:fixed;
     width:100%;
     z-index:999;
     background-color:#ffffff;

--- a/subprojects/docs/src/docs/css/javadoc.css
+++ b/subprojects/docs/src/docs/css/javadoc.css
@@ -38,6 +38,9 @@
 /*
  * Javadoc style sheet
  */
+.ui-menu {
+    background-color: white;
+}
 
 /*
  * Styles for individual HTML elements.

--- a/subprojects/docs/src/docs/css/manual.css
+++ b/subprojects/docs/src/docs/css/manual.css
@@ -500,7 +500,8 @@ table.tableblock #preamble > .sectionbody > .paragraph:first-of-type p { font-si
     word-wrap: anywhere;
     background: var(--admonition-background);
     padding: 1rem 1rem 0rem;
-    width: 100%
+    width: 100%;
+    border-radius: 4px;
 }
 
 .admonitionblock td.icon {

--- a/subprojects/docs/src/docs/css/manual.css
+++ b/subprojects/docs/src/docs/css/manual.css
@@ -499,7 +499,7 @@ table.tableblock #preamble > .sectionbody > .paragraph:first-of-type p { font-si
 .admonitionblock td.content {
     word-wrap: anywhere;
     background: var(--admonition-background);
-    padding: 1rem 1rem .75rem;
+    padding: 1rem 1rem 0rem;
     width: 100%
 }
 

--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/declaring_repositories.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/declaring_repositories.adoc
@@ -504,8 +504,7 @@ include::sample[dir="snippets/artifacts/defineRepositoryInSettings/groovy",files
 
 The `dependencyResolutionManagement` repositories block accepts the same notations as in a project. This includes Maven or Ivy repositories, with or without credentials, etc.
 
-By default, repositories declared by a project will *override* whatever is declared in settings.
-This means that repositories declared in a project `build.gradle(.kts)` file *override* those declared in the `settings.gradle(.kts)` file:
+By default, repositories declared by a project in `build.gradle(.kts)` will *override* whatever is declared in `settings.gradle(.kts)`:
 
 .Preferring project repositories
 ====
@@ -522,17 +521,17 @@ There are three modes for dependency resolution management:
 |`PREFER_PROJECT`
 |Any repository declared on a project will cause the project to use the repositories declared by the project, ignoring those declared in settings.
 |Yes
-|Useful when teams need to use many different plugins not shared among subprojects.
+|Useful when teams need to use different repositories not common among subprojects.
 
 |`PREFER_SETTINGS`
 |Any repository declared directly in a project, either directly or via a plugin, will be ignored.
 |No
-|Useful for enforcing large teams to use the same plugin versions.
+|Useful for enforcing large teams to use approved repositories only, but will not fail the build when a project or plugin declares a repository.
 
 |`FAIL_ON_PROJECT_REPOS`
 |Any repository declared directly in a project, either directly or via a plugin, will trigger a build error.
 |No
-|Useful for enforcing large teams to use approved and secure plugins only.
+|Useful for enforcing large teams to use approved repositories only.
 |===
 
 You can change the behavior to prefer the repositories in the `settings.gradle(.kts)` file by using `repositoriesMode`:
@@ -545,7 +544,7 @@ include::sample[dir="snippets/artifacts/defineRepositoryInSettings/groovy",files
 
 [[sub:fail_build_on_project_repositories]]
 
-If, for some reason, a project or a plugin declares a repository in a project, Gradle will warn you.
+Gradle will warn you if a project or a plugin declares a repository in a project.
 
 You can force Gradle to _fail the build_ if you want to enforce that *only* settings repositories are used:
 

--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/declaring_repositories.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/declaring_repositories.adoc
@@ -490,11 +490,11 @@ As the way to declare the repositories and what they are expected to contain dep
 [[sub:centralized-repository-declaration]]
 == Centralizing repositories declaration
 
-Instead of declaring repositories in every subproject of your build or via an `allprojects` block, Gradle offers a way to declare them in a central place for all project.
+Instead of declaring repositories in every subproject of your build or via an `allprojects` block, Gradle offers a way to declare them in a central place for all projects.
 
-NOTE: Central declaration of repositories is an incubating feature
+NOTE: Central declaration of repositories is an incubating feature.
 
-Repositories used by convention by every subproject can be declared in the `settings.gradle(.kts)` file:
+Repositories used by convention in every subproject can be declared in the `settings.gradle(.kts)` file:
 
 .Declaring a Maven repository in settings
 ====
@@ -502,10 +502,40 @@ include::sample[dir="snippets/artifacts/defineRepositoryInSettings/kotlin",files
 include::sample[dir="snippets/artifacts/defineRepositoryInSettings/groovy",files="settings.gradle[tags=declare_repositories_settings]"]
 ====
 
-The `dependencyResolutionManagement` repositories block accepts the same notations as in a project, which includes Maven or Ivy repositories, with or without credentials, etc.
+The `dependencyResolutionManagement` repositories block accepts the same notations as in a project. This includes Maven or Ivy repositories, with or without credentials, etc.
 
 By default, repositories declared by a project will *override* whatever is declared in settings.
-You can change this behavior to make sure that you always use the settings repositories:
+This means that repositories declared in a project `build.gradle(.kts)` file *override* those declared in the `settings.gradle(.kts)` file:
+
+.Preferring project repositories
+====
+include::sample[dir="snippets/artifacts/defineRepositoryInSettings/kotlin",files="settings.gradle.kts[tags=prefer_projects]"]
+include::sample[dir="snippets/artifacts/defineRepositoryInSettings/groovy",files="settings.gradle[tags=prefer_projects]"]
+====
+
+There are three modes for dependency resolution management:
+
+[cols="1,1,1,1"]
+|===
+|Mode |Description |Default? |Use-Case
+
+|`PREFER_PROJECT`
+|Any repository declared on a project will cause the project to use the repositories declared by the project, ignoring those declared in settings.
+|Yes
+|Useful when teams need to use many different plugins not shared among subprojects.
+
+|`PREFER_SETTINGS`
+|Any repository declared directly in a project, either directly or via a plugin, will be ignored.
+|No
+|Useful for enforcing large teams to use the same plugin versions.
+
+|`FAIL_ON_PROJECT_REPOS`
+|Any repository declared directly in a project, either directly or via a plugin, will trigger a build error.
+|No
+|Useful for enforcing large teams to use approved and secure plugins only.
+|===
+
+You can change the behavior to prefer the repositories in the `settings.gradle(.kts)` file by using `repositoriesMode`:
 
 .Preferring settings repositories
 ====
@@ -515,21 +545,14 @@ include::sample[dir="snippets/artifacts/defineRepositoryInSettings/groovy",files
 
 [[sub:fail_build_on_project_repositories]]
 
-If, for some reason, a project or a plugin declares a repository in a project, Gradle would warn you.
-You can however make it _fail the build_ if you want to enforce that only settings repositories are used:
+If, for some reason, a project or a plugin declares a repository in a project, Gradle will warn you.
+
+You can force Gradle to _fail the build_ if you want to enforce that *only* settings repositories are used:
 
 .Enforcing settings repositories
 ====
 include::sample[dir="snippets/artifacts/defineRepositoryInSettings/kotlin",files="settings.gradle.kts[tags=enforce_settings]"]
 include::sample[dir="snippets/artifacts/defineRepositoryInSettings/groovy",files="settings.gradle[tags=enforce_settings]"]
-====
-
-Eventually, the default is equivalent to setting `PREFER_PROJECT`:
-
-.Preferring project repositories
-====
-include::sample[dir="snippets/artifacts/defineRepositoryInSettings/kotlin",files="settings.gradle.kts[tags=prefer_projects]"]
-include::sample[dir="snippets/artifacts/defineRepositoryInSettings/groovy",files="settings.gradle[tags=prefer_projects]"]
 ====
 
 [[sec:supported_transport_protocols]]

--- a/subprojects/docs/src/docs/userguide/optimizing-performance/file_system_watching.adoc
+++ b/subprojects/docs/src/docs/userguide/optimizing-performance/file_system_watching.adoc
@@ -75,7 +75,7 @@ Network file systems like Samba and NFS are not supported.
 ====
 
 File system watching is not compatible with symlinks.
-If your project files include symlinks, symlinked files do not benefit from file system-watching optimizations.
+If your project files include symlinks, you must disable `vfs.watch` by setting `org.gradle.vfs.watch=false` in `gradle.properties`.
 
 ====
 

--- a/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
@@ -453,6 +453,14 @@ Specifies the JDK installation directory to use for the client VM.
 +
 This VM is also used for the daemon unless a different one is specified in a Gradle properties file with `org.gradle.java.home`.
 
+`GRADLE_LIBS_REPO_OVERRIDE`::
+Overrides for the default Gradle library repository.
++
+Can be used to specify a default Gradle repository URL in `org.gradle.plugins.ide.internal.resolver`.
++
+Useful override to specify an internally hosted repository in case your company uses a firewall/proxy.
+
+
 The following examples demonstrate how to use environment variables.
 
 *Example 1:* Reading environment variables at configuration time:

--- a/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
@@ -37,7 +37,17 @@ When configuring Gradle behavior, you can use these methods, listed in order of 
 |3
 |<<#sec:gradle_configuration_properties, Gradle properties>>
 |`org.gradle.caching=true`
-|Typically stored in a `gradle.properties` file in a project directory or in the `<<directory_layout.adoc#dir:gradle_user_home,GRADLE_USER_HOME>>`.
+|Stored in a `gradle.properties` file in the `<<directory_layout.adoc#dir:gradle_user_home,GRADLE_USER_HOME>>`.
+
+|3.1
+|<<#sec:gradle_configuration_properties, Gradle properties>>
+|`org.gradle.caching=true`
+|Stored in a `gradle.properties` file in a project directory, then its parent project’s directory up to the project’s root directory.
+
+|3.2
+|<<#sec:gradle_configuration_properties, Gradle properties>>
+|`org.gradle.caching=true`
+|Stored in a `gradle.properties` file in the <<sec:gradle_environment_variables,GRADLE_HOME>>.
 
 |4
 |<<#sec:gradle_environment_variables, Environment variables>>

--- a/subprojects/docs/src/docs/userguide/running-builds/command_line_interface.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/command_line_interface.adoc
@@ -791,7 +791,7 @@ Full details on using these options are documented in the <<gradle_wrapper.adoc#
 [[sec:continuous_build]]
 == Continuous build
 
-Continuous Build allows you to automatically re-execute the requested tasks when task inputs change.
+Continuous Build allows you to automatically re-execute the requested tasks when file inputs change.
 You can execute the build in this mode using the `-t` or `--continuous` command-line option.
 
 For example, you can continuously run the `test` task and all dependent tasks by running:


### PR DESCRIPTION
### Context
Handles Github issues and a few internal issues in sections that have been recently updated in the Gradle User Manual.

This is a documentation change ONLY.

### Fixes:
- Continuous build description - https://github.com/gradle/gradle/issues/26252
- Document GRADLE_LIBS_REPO_OVERRIDE - https://github.com/gradle/gradle/issues/24217
- Deprecated alternative to `setOutputFile` - https://github.com/gradle/gradle/issues/25586
- Fix build order preference - https://github.com/gradle/gradle/issues/26088
- How to use system file watch with symlinks - https://github.com/gradle/gradle/issues/26201
- Update *Centralizing repositories declaration* section of [Dependency Management](https://docs.gradle.org/current/userguide/dependency_management.html) for @erichaagdev 
- Update admonition block CSS for @alllex 
- Fix javadocs CSS for search background color for @lkasso 

### Reviewers:
Under development.