### PR TITLE
Change log level of "Watching X directories" to debug

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/AbstractConfigurationCacheIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/AbstractConfigurationCacheIntegrationTest.groovy
@@ -67,7 +67,6 @@ abstract class AbstractConfigurationCacheIntegrationTest extends AbstractConfigu
         normalizedOutput
             .replaceAll(/Received \d+ file system events .*\n/, '')
             .replaceAll(/Spent \d+ ms processing file system events since last build\n/, '')
-            .replaceAll(/Watching \d+ (directory hierarchies to track changes between builds in \d+ directories|directories to track changes between builds)\n/, '')
             .replaceAll(/Spent \d+ ms registering watches for file system events\n/, '')
             .replaceAll(/Virtual file system .*\n/, '')
     }

--- a/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdater.java
+++ b/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdater.java
@@ -122,7 +122,7 @@ public class HierarchicalFileWatcherUpdater extends AbstractFileWatcherUpdater {
             fileWatcher.startWatching(hierarchiesToStartWatching);
         }
 
-        LOGGER.info("Watching {} directory hierarchies to track changes", watchedHierarchies.size());
+        LOGGER.debug("Watching {} directory hierarchies to track changes", watchedHierarchies.size());
     }
 
     @Override

--- a/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdater.java
+++ b/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdater.java
@@ -147,7 +147,7 @@ public class NonHierarchicalFileWatcherUpdater extends AbstractFileWatcherUpdate
             }
         });
 
-        LOGGER.info("Watching {} directories to track changes", watchedDirectories.entrySet().size());
+        LOGGER.debug("Watching {} directories to track changes", watchedDirectories.entrySet().size());
 
         try {
             if (!directoriesToStopWatching.isEmpty()) {


### PR DESCRIPTION
Fixes #26350

### Context
This log on info level clutters the console output and renders it unusable as described in the previous issue. This PR 

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
