### PR TITLE
Support DependencyScopeConfiguration Provider.invoke overload in DependencyHandlerScope

### DIFF
--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/DependencyManagementIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/DependencyManagementIntegrationTest.kt
@@ -24,6 +24,7 @@ import org.hamcrest.CoreMatchers.containsString
 
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
+import spock.lang.Issue
 
 
 class DependencyManagementIntegrationTest : AbstractKotlinIntegrationTest() {
@@ -129,6 +130,57 @@ class DependencyManagementIntegrationTest : AbstractKotlinIntegrationTest() {
             build("dependencyInsight", "--configuration", "compileClasspath", "--dependency", dep).apply {
                 assertThat(output, containsString("$dep:1.0 (by constraint)"))
             }
+        }
+    }
+
+    @Test
+    @Issue("https://github.com/gradle/gradle/issues/26602")
+    fun `can use dependencyScope configuration provider in dependencies block`() {
+
+        withFile("repo/in-block/accessor-1.0.jar")
+
+        withBuildScript(
+            """
+            val foo = configurations.dependencyScope("foo")
+            val bar = configurations.dependencyScope("bar") { }
+            
+            dependencies {
+                foo("in-block:accessor:1.0")
+                bar("in-block:accessor:1.0")
+            }
+            
+            repositories {
+                ivy {
+                    url = uri("${existing("repo").normalisedPath}")
+                    patternLayout {
+                        artifact("[organisation]/[module]-[revision].[ext]")
+                    }
+                }
+            }
+            """
+        )
+
+        build("dependencies", "--configuration", "foo").apply {
+            assertThat(
+                output,
+                containsMultiLineString(
+                    """
+                foo (n)
+                \--- in-block:accessor:1.0 (n)
+                """
+                )
+            )
+        }
+        build("dependencies", "--configuration", "bar").apply {
+            assertThat(
+                output,
+                containsMultiLineString(
+                    """
+                bar (n)
+                \--- in-block:accessor:1.0 (n)
+                """
+                )
+            )
         }
     }
 }

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyConstraintHandlerScope.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyConstraintHandlerScope.kt
@@ -20,6 +20,7 @@ import org.gradle.api.Incubating
 import org.gradle.api.NamedDomainObjectProvider
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.DependencyConstraint
+import org.gradle.api.artifacts.DependencyScopeConfiguration
 import org.gradle.api.artifacts.dsl.DependencyConstraintHandler
 import org.gradle.kotlin.dsl.support.delegates.DependencyConstraintHandlerDelegate
 
@@ -73,7 +74,19 @@ private constructor(
      * @since 8.3
      */
     @Incubating
-    operator fun NamedDomainObjectProvider<out Configuration>.invoke(dependencyConstraintNotation: Any): DependencyConstraint =
+    operator fun NamedDomainObjectProvider<Configuration>.invoke(dependencyConstraintNotation: Any): DependencyConstraint =
+        constraints.add(name, dependencyConstraintNotation)
+
+    /**
+     * Adds a dependency constraint to the given [DependencyScopeConfiguration].
+     *
+     * @param dependencyConstraintNotation notation for the dependency constraint to be added.
+     * @return The dependency constraint.
+     * @see [DependencyConstraintHandler.add]
+     * @since 8.5
+     */
+    @Incubating
+    operator fun NamedDomainObjectProvider<DependencyScopeConfiguration>.invoke(dependencyConstraintNotation: Any): DependencyConstraint =
         constraints.add(name, dependencyConstraintNotation)
 
     /**
@@ -86,7 +99,20 @@ private constructor(
      * @since 8.3
      */
     @Incubating
-    operator fun NamedDomainObjectProvider<out Configuration>.invoke(dependencyConstraintNotation: String, configuration: DependencyConstraint.() -> Unit): DependencyConstraint =
+    operator fun NamedDomainObjectProvider<Configuration>.invoke(dependencyConstraintNotation: String, configuration: DependencyConstraint.() -> Unit): DependencyConstraint =
+        constraints.add(name, dependencyConstraintNotation, configuration)
+
+    /**
+     * Adds a dependency constraint to the given [DependencyScopeConfiguration].
+     *
+     * @param dependencyConstraintNotation notation for the dependency constraint to be added.
+     * @param configuration expression to use to configure the dependency constraint.
+     * @return The dependency constraint.
+     * @see [DependencyConstraintHandler.add]
+     * @since 8.5
+     */
+    @Incubating
+    operator fun NamedDomainObjectProvider<DependencyScopeConfiguration>.invoke(dependencyConstraintNotation: String, configuration: DependencyConstraint.() -> Unit): DependencyConstraint =
         constraints.add(name, dependencyConstraintNotation, configuration)
 
     /**

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyConstraintHandlerScope.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyConstraintHandlerScope.kt
@@ -86,6 +86,7 @@ private constructor(
      * @since 8.5
      */
     @Incubating
+    @JvmName("invokeDependencyScope")
     operator fun NamedDomainObjectProvider<DependencyScopeConfiguration>.invoke(dependencyConstraintNotation: Any): DependencyConstraint =
         constraints.add(name, dependencyConstraintNotation)
 
@@ -112,6 +113,7 @@ private constructor(
      * @since 8.5
      */
     @Incubating
+    @JvmName("invokeDependencyScope")
     operator fun NamedDomainObjectProvider<DependencyScopeConfiguration>.invoke(dependencyConstraintNotation: String, configuration: DependencyConstraint.() -> Unit): DependencyConstraint =
         constraints.add(name, dependencyConstraintNotation, configuration)
 

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyConstraintHandlerScope.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyConstraintHandlerScope.kt
@@ -73,7 +73,7 @@ private constructor(
      * @since 8.3
      */
     @Incubating
-    operator fun NamedDomainObjectProvider<Configuration>.invoke(dependencyConstraintNotation: Any): DependencyConstraint =
+    operator fun NamedDomainObjectProvider<out Configuration>.invoke(dependencyConstraintNotation: Any): DependencyConstraint =
         constraints.add(name, dependencyConstraintNotation)
 
     /**
@@ -86,7 +86,7 @@ private constructor(
      * @since 8.3
      */
     @Incubating
-    operator fun NamedDomainObjectProvider<Configuration>.invoke(dependencyConstraintNotation: String, configuration: DependencyConstraint.() -> Unit): DependencyConstraint =
+    operator fun NamedDomainObjectProvider<out Configuration>.invoke(dependencyConstraintNotation: String, configuration: DependencyConstraint.() -> Unit): DependencyConstraint =
         constraints.add(name, dependencyConstraintNotation, configuration)
 
     /**

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerScope.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerScope.kt
@@ -178,6 +178,7 @@ private constructor(
      * @since 8.5
      */
     @Incubating
+    @JvmName("invokeDependencyScope")
     operator fun NamedDomainObjectProvider<DependencyScopeConfiguration>.invoke(dependencyNotation: Any): Dependency? =
         add(name, dependencyNotation)
 
@@ -215,6 +216,7 @@ private constructor(
      * @since 8.5
      */
     @Incubating
+    @JvmName("invokeDependencyScope")
     inline operator fun NamedDomainObjectProvider<DependencyScopeConfiguration>.invoke(dependencyNotation: String, dependencyConfiguration: ExternalModuleDependency.() -> Unit): ExternalModuleDependency =
         add(name, dependencyNotation, dependencyConfiguration)
 
@@ -281,6 +283,7 @@ private constructor(
      * @since 8.5
      */
     @Incubating
+    @JvmName("invokeDependencyScope")
     operator fun NamedDomainObjectProvider<DependencyScopeConfiguration>.invoke(
         group: String,
         name: String,
@@ -363,6 +366,7 @@ private constructor(
      * @since 8.5
      */
     @Incubating
+    @JvmName("invokeDependencyScope")
     inline operator fun NamedDomainObjectProvider<DependencyScopeConfiguration>.invoke(
         group: String,
         name: String,
@@ -411,6 +415,7 @@ private constructor(
      * @since 8.5
      */
     @Incubating
+    @JvmName("invokeDependencyScope")
     inline operator fun <T : ModuleDependency> NamedDomainObjectProvider<DependencyScopeConfiguration>.invoke(dependency: T, dependencyConfiguration: T.() -> Unit): T =
         add(name, dependency, dependencyConfiguration)
 
@@ -450,6 +455,7 @@ private constructor(
      * @since 8.5
      */
     @Incubating
+    @JvmName("invokeDependencyScope")
     operator fun <T : Any> NamedDomainObjectProvider<DependencyScopeConfiguration>.invoke(dependency: Provider<T>, dependencyConfiguration: ExternalModuleDependency.() -> Unit) =
         addProvider(name, dependency, dependencyConfiguration)
 
@@ -485,6 +491,7 @@ private constructor(
      * @since 8.5
      */
     @Incubating
+    @JvmName("invokeDependencyScope")
     operator fun <T : Any> NamedDomainObjectProvider<DependencyScopeConfiguration>.invoke(dependency: Provider<T>) =
         addProvider(name, dependency)
 
@@ -524,6 +531,7 @@ private constructor(
      * @since 8.5
      */
     @Incubating
+    @JvmName("invokeDependencyScope")
     operator fun <T : Any> NamedDomainObjectProvider<DependencyScopeConfiguration>.invoke(dependency: ProviderConvertible<T>, dependencyConfiguration: ExternalModuleDependency.() -> Unit) =
         addProviderConvertible(name, dependency, dependencyConfiguration)
 
@@ -559,6 +567,7 @@ private constructor(
      * @since 8.5
      */
     @Incubating
+    @JvmName("invokeDependencyScope")
     operator fun <T : Any> NamedDomainObjectProvider<DependencyScopeConfiguration>.invoke(dependency: ProviderConvertible<T>) =
         addProviderConvertible(name, dependency)
 

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerScope.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerScope.kt
@@ -21,6 +21,7 @@ import org.gradle.api.Incubating
 import org.gradle.api.NamedDomainObjectProvider
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.DependencyScopeConfiguration
 import org.gradle.api.artifacts.ExternalModuleDependency
 import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.dsl.DependencyConstraintHandler
@@ -165,7 +166,19 @@ private constructor(
      * @since 8.3
      */
     @Incubating
-    operator fun NamedDomainObjectProvider<out Configuration>.invoke(dependencyNotation: Any): Dependency? =
+    operator fun NamedDomainObjectProvider<Configuration>.invoke(dependencyNotation: Any): Dependency? =
+        add(name, dependencyNotation)
+
+    /**
+     * Adds a dependency to the given [DependencyScopeConfiguration].
+     *
+     * @param dependencyNotation notation for the dependency to be added.
+     * @return The dependency.
+     * @see [DependencyHandler.add]
+     * @since 8.5
+     */
+    @Incubating
+    operator fun NamedDomainObjectProvider<DependencyScopeConfiguration>.invoke(dependencyNotation: Any): Dependency? =
         add(name, dependencyNotation)
 
     /**
@@ -189,7 +202,20 @@ private constructor(
      * @since 8.3
      */
     @Incubating
-    inline operator fun NamedDomainObjectProvider<out Configuration>.invoke(dependencyNotation: String, dependencyConfiguration: ExternalModuleDependency.() -> Unit): ExternalModuleDependency =
+    inline operator fun NamedDomainObjectProvider<Configuration>.invoke(dependencyNotation: String, dependencyConfiguration: ExternalModuleDependency.() -> Unit): ExternalModuleDependency =
+        add(name, dependencyNotation, dependencyConfiguration)
+
+    /**
+     * Adds a dependency to the given [DependencyScopeConfiguration].
+     *
+     * @param dependencyNotation notation for the dependency to be added.
+     * @param dependencyConfiguration expression to use to configure the dependency.
+     * @return The dependency.
+     * @see [DependencyHandler.add]
+     * @since 8.5
+     */
+    @Incubating
+    inline operator fun NamedDomainObjectProvider<DependencyScopeConfiguration>.invoke(dependencyNotation: String, dependencyConfiguration: ExternalModuleDependency.() -> Unit): ExternalModuleDependency =
         add(name, dependencyNotation, dependencyConfiguration)
 
     /**
@@ -230,7 +256,32 @@ private constructor(
      * @since 8.3
      */
     @Incubating
-    operator fun NamedDomainObjectProvider<out Configuration>.invoke(
+    operator fun NamedDomainObjectProvider<Configuration>.invoke(
+        group: String,
+        name: String,
+        version: String? = null,
+        configuration: String? = null,
+        classifier: String? = null,
+        ext: String? = null
+    ): ExternalModuleDependency =
+        create(group, name, version, configuration, classifier, ext).apply { add(this@invoke.name, this) }
+
+    /**
+     * Adds a dependency to the given [DependencyScopeConfiguration].
+     *
+     * @param group the group of the module to be added as a dependency.
+     * @param name the name of the module to be added as a dependency.
+     * @param version the optional version of the module to be added as a dependency.
+     * @param configuration the optional configuration of the module to be added as a dependency.
+     * @param classifier the optional classifier of the module artifact to be added as a dependency.
+     * @param ext the optional extension of the module artifact to be added as a dependency.
+     * @return The dependency.
+     *
+     * @see [DependencyHandler.add]
+     * @since 8.5
+     */
+    @Incubating
+    operator fun NamedDomainObjectProvider<DependencyScopeConfiguration>.invoke(
         group: String,
         name: String,
         version: String? = null,
@@ -283,7 +334,36 @@ private constructor(
      * @since 8.3
      */
     @Incubating
-    inline operator fun NamedDomainObjectProvider<out Configuration>.invoke(
+    inline operator fun NamedDomainObjectProvider<Configuration>.invoke(
+        group: String,
+        name: String,
+        version: String? = null,
+        configuration: String? = null,
+        classifier: String? = null,
+        ext: String? = null,
+        dependencyConfiguration: ExternalModuleDependency.() -> Unit
+    ): ExternalModuleDependency =
+        add(this.name, create(group, name, version, configuration, classifier, ext), dependencyConfiguration)
+
+
+    /**
+     * Adds a dependency to the given [DependencyScopeConfiguration].
+     *
+     * @param group the group of the module to be added as a dependency.
+     * @param name the name of the module to be added as a dependency.
+     * @param version the optional version of the module to be added as a dependency.
+     * @param configuration the optional configuration of the module to be added as a dependency.
+     * @param classifier the optional classifier of the module artifact to be added as a dependency.
+     * @param ext the optional extension of the module artifact to be added as a dependency.
+     * @param dependencyConfiguration expression to use to configure the dependency.
+     * @return The dependency.
+     *
+     * @see [DependencyHandler.create]
+     * @see [DependencyHandler.add]
+     * @since 8.5
+     */
+    @Incubating
+    inline operator fun NamedDomainObjectProvider<DependencyScopeConfiguration>.invoke(
         group: String,
         name: String,
         version: String? = null,
@@ -317,7 +397,21 @@ private constructor(
      * @since 8.3
      */
     @Incubating
-    inline operator fun <T : ModuleDependency> NamedDomainObjectProvider<out Configuration>.invoke(dependency: T, dependencyConfiguration: T.() -> Unit): T =
+    inline operator fun <T : ModuleDependency> NamedDomainObjectProvider<Configuration>.invoke(dependency: T, dependencyConfiguration: T.() -> Unit): T =
+        add(name, dependency, dependencyConfiguration)
+
+    /**
+     * Adds a dependency to the given [DependencyScopeConfiguration].
+     *
+     * @param dependency dependency to be added.
+     * @param dependencyConfiguration expression to use to configure the dependency.
+     * @return The dependency.
+     *
+     * @see [DependencyHandler.add]
+     * @since 8.5
+     */
+    @Incubating
+    inline operator fun <T : ModuleDependency> NamedDomainObjectProvider<DependencyScopeConfiguration>.invoke(dependency: T, dependencyConfiguration: T.() -> Unit): T =
         add(name, dependency, dependencyConfiguration)
 
     /**
@@ -343,7 +437,20 @@ private constructor(
      * @since 8.3
      */
     @Incubating
-    operator fun <T : Any> NamedDomainObjectProvider<out Configuration>.invoke(dependency: Provider<T>, dependencyConfiguration: ExternalModuleDependency.() -> Unit) =
+    operator fun <T : Any> NamedDomainObjectProvider<Configuration>.invoke(dependency: Provider<T>, dependencyConfiguration: ExternalModuleDependency.() -> Unit) =
+        addProvider(name, dependency, dependencyConfiguration)
+
+    /**
+     * Adds a dependency provider to the given [DependencyScopeConfiguration].
+     *
+     * @param dependency the dependency provider to be added.
+     * @param dependencyConfiguration the configuration to be applied to the dependency
+     *
+     * @see [DependencyHandler.addProvider]
+     * @since 8.5
+     */
+    @Incubating
+    operator fun <T : Any> NamedDomainObjectProvider<DependencyScopeConfiguration>.invoke(dependency: Provider<T>, dependencyConfiguration: ExternalModuleDependency.() -> Unit) =
         addProvider(name, dependency, dependencyConfiguration)
 
     /**
@@ -366,7 +473,19 @@ private constructor(
      * @since 8.3
      */
     @Incubating
-    operator fun <T : Any> NamedDomainObjectProvider<out Configuration>.invoke(dependency: Provider<T>) =
+    operator fun <T : Any> NamedDomainObjectProvider<Configuration>.invoke(dependency: Provider<T>) =
+        addProvider(name, dependency)
+
+    /**
+     * Adds a dependency provider to the given [DependencyScopeConfiguration].
+     *
+     * @param dependency the dependency provider to be added.
+     *
+     * @see [DependencyHandler.addProvider]
+     * @since 8.5
+     */
+    @Incubating
+    operator fun <T : Any> NamedDomainObjectProvider<DependencyScopeConfiguration>.invoke(dependency: Provider<T>) =
         addProvider(name, dependency)
 
     /**
@@ -392,7 +511,20 @@ private constructor(
      * @since 8.3
      */
     @Incubating
-    operator fun <T : Any> NamedDomainObjectProvider<out Configuration>.invoke(dependency: ProviderConvertible<T>, dependencyConfiguration: ExternalModuleDependency.() -> Unit) =
+    operator fun <T : Any> NamedDomainObjectProvider<Configuration>.invoke(dependency: ProviderConvertible<T>, dependencyConfiguration: ExternalModuleDependency.() -> Unit) =
+        addProviderConvertible(name, dependency, dependencyConfiguration)
+
+    /**
+     * Adds a dependency provider to the given [DependencyScopeConfiguration].
+     *
+     * @param dependency the dependency provider to be added.
+     * @param dependencyConfiguration the configuration to be applied to the dependency
+     *
+     * @see [DependencyHandler.addProviderConvertible]
+     * @since 8.5
+     */
+    @Incubating
+    operator fun <T : Any> NamedDomainObjectProvider<DependencyScopeConfiguration>.invoke(dependency: ProviderConvertible<T>, dependencyConfiguration: ExternalModuleDependency.() -> Unit) =
         addProviderConvertible(name, dependency, dependencyConfiguration)
 
     /**
@@ -415,7 +547,19 @@ private constructor(
      * @since 8.3
      */
     @Incubating
-    operator fun <T : Any> NamedDomainObjectProvider<out Configuration>.invoke(dependency: ProviderConvertible<T>) =
+    operator fun <T : Any> NamedDomainObjectProvider<Configuration>.invoke(dependency: ProviderConvertible<T>) =
+        addProviderConvertible(name, dependency)
+
+    /**
+     * Adds a dependency provider to the given [DependencyScopeConfiguration].
+     *
+     * @param dependency the dependency provider to be added.
+     *
+     * @see [DependencyHandler.addProviderConvertible]
+     * @since 8.5
+     */
+    @Incubating
+    operator fun <T : Any> NamedDomainObjectProvider<DependencyScopeConfiguration>.invoke(dependency: ProviderConvertible<T>) =
         addProviderConvertible(name, dependency)
 
     /**

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerScope.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerScope.kt
@@ -165,7 +165,7 @@ private constructor(
      * @since 8.3
      */
     @Incubating
-    operator fun NamedDomainObjectProvider<Configuration>.invoke(dependencyNotation: Any): Dependency? =
+    operator fun NamedDomainObjectProvider<out Configuration>.invoke(dependencyNotation: Any): Dependency? =
         add(name, dependencyNotation)
 
     /**
@@ -189,7 +189,7 @@ private constructor(
      * @since 8.3
      */
     @Incubating
-    inline operator fun NamedDomainObjectProvider<Configuration>.invoke(dependencyNotation: String, dependencyConfiguration: ExternalModuleDependency.() -> Unit): ExternalModuleDependency =
+    inline operator fun NamedDomainObjectProvider<out Configuration>.invoke(dependencyNotation: String, dependencyConfiguration: ExternalModuleDependency.() -> Unit): ExternalModuleDependency =
         add(name, dependencyNotation, dependencyConfiguration)
 
     /**
@@ -230,7 +230,7 @@ private constructor(
      * @since 8.3
      */
     @Incubating
-    operator fun NamedDomainObjectProvider<Configuration>.invoke(
+    operator fun NamedDomainObjectProvider<out Configuration>.invoke(
         group: String,
         name: String,
         version: String? = null,
@@ -283,7 +283,7 @@ private constructor(
      * @since 8.3
      */
     @Incubating
-    inline operator fun NamedDomainObjectProvider<Configuration>.invoke(
+    inline operator fun NamedDomainObjectProvider<out Configuration>.invoke(
         group: String,
         name: String,
         version: String? = null,
@@ -317,7 +317,7 @@ private constructor(
      * @since 8.3
      */
     @Incubating
-    inline operator fun <T : ModuleDependency> NamedDomainObjectProvider<Configuration>.invoke(dependency: T, dependencyConfiguration: T.() -> Unit): T =
+    inline operator fun <T : ModuleDependency> NamedDomainObjectProvider<out Configuration>.invoke(dependency: T, dependencyConfiguration: T.() -> Unit): T =
         add(name, dependency, dependencyConfiguration)
 
     /**
@@ -343,7 +343,7 @@ private constructor(
      * @since 8.3
      */
     @Incubating
-    operator fun <T : Any> NamedDomainObjectProvider<Configuration>.invoke(dependency: Provider<T>, dependencyConfiguration: ExternalModuleDependency.() -> Unit) =
+    operator fun <T : Any> NamedDomainObjectProvider<out Configuration>.invoke(dependency: Provider<T>, dependencyConfiguration: ExternalModuleDependency.() -> Unit) =
         addProvider(name, dependency, dependencyConfiguration)
 
     /**
@@ -366,7 +366,7 @@ private constructor(
      * @since 8.3
      */
     @Incubating
-    operator fun <T : Any> NamedDomainObjectProvider<Configuration>.invoke(dependency: Provider<T>) =
+    operator fun <T : Any> NamedDomainObjectProvider<out Configuration>.invoke(dependency: Provider<T>) =
         addProvider(name, dependency)
 
     /**
@@ -392,7 +392,7 @@ private constructor(
      * @since 8.3
      */
     @Incubating
-    operator fun <T : Any> NamedDomainObjectProvider<Configuration>.invoke(dependency: ProviderConvertible<T>, dependencyConfiguration: ExternalModuleDependency.() -> Unit) =
+    operator fun <T : Any> NamedDomainObjectProvider<out Configuration>.invoke(dependency: ProviderConvertible<T>, dependencyConfiguration: ExternalModuleDependency.() -> Unit) =
         addProviderConvertible(name, dependency, dependencyConfiguration)
 
     /**
@@ -415,7 +415,7 @@ private constructor(
      * @since 8.3
      */
     @Incubating
-    operator fun <T : Any> NamedDomainObjectProvider<Configuration>.invoke(dependency: ProviderConvertible<T>) =
+    operator fun <T : Any> NamedDomainObjectProvider<out Configuration>.invoke(dependency: ProviderConvertible<T>) =
         addProviderConvertible(name, dependency)
 
     /**

--- a/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensionsTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensionsTest.kt
@@ -13,6 +13,7 @@ import org.gradle.api.Action
 import org.gradle.api.NamedDomainObjectProvider
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.DependencyScopeConfiguration
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.DependencyConstraint
 import org.gradle.api.artifacts.ExternalModuleDependency
@@ -325,6 +326,24 @@ class DependencyHandlerExtensionsTest {
             verify(constraintHandler).add(eq("c"), eq("other:thing:1.0"))
             verifyNoMoreInteractions()
         }
+    }
+
+    @Test
+    @Issue("https://github.com/gradle/gradle/issues/26602")
+    fun `given new configuration shortcuts and dependency notation, it will add the dependency to the configuration provider`() {
+        val dependencyHandler = newDependencyHandlerMock {
+            on { add(any(), any()) } doReturn mock<Dependency>()
+        }
+        val configuration = mock<NamedDomainObjectProvider<DependencyScopeConfiguration>> {
+            on { name } doReturn "c"
+        }
+
+        val dependencies = DependencyHandlerScope.of(dependencyHandler)
+        dependencies {
+            configuration("some:thing:1.0")
+        }
+
+        verify(dependencyHandler).add("c", "some:thing:1.0")
     }
 
     @Test

--- a/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
+++ b/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
@@ -1,3 +1,108 @@
 {
-    "acceptedApiChanges": []
+    "acceptedApiChanges": [
+        {
+            "type": "org.gradle.kotlin.dsl.DependencyConstraintHandlerScope",
+            "member": "Method org.gradle.kotlin.dsl.DependencyConstraintHandlerScope.invokeDependencyScope(org.gradle.api.NamedDomainObjectProvider,java.lang.Object)",
+            "acceptation": "false-positive, Kotlin name invoke is marked correctly, but uses @JvmName",
+            "changes": [
+                "Method added to public class"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.DependencyConstraintHandlerScope",
+            "member": "Method org.gradle.kotlin.dsl.DependencyConstraintHandlerScope.invokeDependencyScope(org.gradle.api.NamedDomainObjectProvider,java.lang.String,kotlin.jvm.functions.Function1)",
+            "acceptation": "false-positive, Kotlin name invoke is marked correctly, but uses @JvmName",
+            "changes": [
+                "Method added to public class"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.DependencyHandlerScope",
+            "member": "Method org.gradle.kotlin.dsl.DependencyHandlerScope.invokeDependencyScope$default(org.gradle.kotlin.dsl.DependencyHandlerScope,org.gradle.api.NamedDomainObjectProvider,java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String,int,java.lang.Object)",
+            "acceptation": "false-positive, Kotlin name invoke is marked correctly, but uses @JvmName",
+            "changes": [
+                "Method added to public class"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.DependencyHandlerScope",
+            "member": "Method org.gradle.kotlin.dsl.DependencyHandlerScope.invokeDependencyScope$default(org.gradle.kotlin.dsl.DependencyHandlerScope,org.gradle.api.NamedDomainObjectProvider,java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String,kotlin.jvm.functions.Function1,int,java.lang.Object)",
+            "acceptation": "false-positive, Kotlin name invoke is marked correctly, but uses @JvmName",
+            "changes": [
+                "Method added to public class"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.DependencyHandlerScope",
+            "member": "Method org.gradle.kotlin.dsl.DependencyHandlerScope.invokeDependencyScope(org.gradle.api.NamedDomainObjectProvider,java.lang.Object)",
+            "acceptation": "false-positive, Kotlin name invoke is marked correctly, but uses @JvmName",
+            "changes": [
+                "Method added to public class"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.DependencyHandlerScope",
+            "member": "Method org.gradle.kotlin.dsl.DependencyHandlerScope.invokeDependencyScope(org.gradle.api.NamedDomainObjectProvider,java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String)",
+            "acceptation": "false-positive, Kotlin name invoke is marked correctly, but uses @JvmName",
+            "changes": [
+                "Method added to public class"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.DependencyHandlerScope",
+            "member": "Method org.gradle.kotlin.dsl.DependencyHandlerScope.invokeDependencyScope(org.gradle.api.NamedDomainObjectProvider,java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String,kotlin.jvm.functions.Function1)",
+            "acceptation": "false-positive, Kotlin name invoke is marked correctly, but uses @JvmName",
+            "changes": [
+                "Method added to public class"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.DependencyHandlerScope",
+            "member": "Method org.gradle.kotlin.dsl.DependencyHandlerScope.invokeDependencyScope(org.gradle.api.NamedDomainObjectProvider,java.lang.String,kotlin.jvm.functions.Function1)",
+            "acceptation": "false-positive, Kotlin name invoke is marked correctly, but uses @JvmName",
+            "changes": [
+                "Method added to public class"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.DependencyHandlerScope",
+            "member": "Method org.gradle.kotlin.dsl.DependencyHandlerScope.invokeDependencyScope(org.gradle.api.NamedDomainObjectProvider,org.gradle.api.artifacts.ModuleDependency,kotlin.jvm.functions.Function1)",
+            "acceptation": "false-positive, Kotlin name invoke is marked correctly, but uses @JvmName",
+            "changes": [
+                "Method added to public class"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.DependencyHandlerScope",
+            "member": "Method org.gradle.kotlin.dsl.DependencyHandlerScope.invokeDependencyScope(org.gradle.api.NamedDomainObjectProvider,org.gradle.api.provider.Provider)",
+            "acceptation": "false-positive, Kotlin name invoke is marked correctly, but uses @JvmName",
+            "changes": [
+                "Method added to public class"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.DependencyHandlerScope",
+            "member": "Method org.gradle.kotlin.dsl.DependencyHandlerScope.invokeDependencyScope(org.gradle.api.NamedDomainObjectProvider,org.gradle.api.provider.Provider,kotlin.jvm.functions.Function1)",
+            "acceptation": "false-positive, Kotlin name invoke is marked correctly, but uses @JvmName",
+            "changes": [
+                "Method added to public class"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.DependencyHandlerScope",
+            "member": "Method org.gradle.kotlin.dsl.DependencyHandlerScope.invokeDependencyScope(org.gradle.api.NamedDomainObjectProvider,org.gradle.api.provider.ProviderConvertible)",
+            "acceptation": "false-positive, Kotlin name invoke is marked correctly, but uses @JvmName",
+            "changes": [
+                "Method added to public class"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.DependencyHandlerScope",
+            "member": "Method org.gradle.kotlin.dsl.DependencyHandlerScope.invokeDependencyScope(org.gradle.api.NamedDomainObjectProvider,org.gradle.api.provider.ProviderConvertible,kotlin.jvm.functions.Function1)",
+            "acceptation": "false-positive, Kotlin name invoke is marked correctly, but uses @JvmName",
+            "changes": [
+                "Method added to public class"
+            ]
+        }
+    ]
 }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #26602

### Context
Add `out` to the type parameter of the incubating `invoke` overlaods introduced in https://github.com/gradle/gradle/pull/25005
Underlaying issue is the Provider interface, which is written in Java, so it does not support Kotlin `out T` out of the box.

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [X] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [X] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [X] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
