### PR TITLE
Fix YAML file pattern in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,7 +19,7 @@ insert_final_newline = true
 [*.md]
 trim_trailing_whitespace = false
 
-[*.{yml, yaml}]
+[*.{yml,yaml}]
 indent_size = 2
 
 [gradle/verification-metadata.xml]


### PR DESCRIPTION
It seems like spaces within EditorConfig patterns are not ignored, and currently designed to match space-characters inside file names.

See: https://github.com/editorconfig/editorconfig/issues/148

It means that our `.editorconfig` never matched `*.yaml` files. Though, we have exactly one such file that might not even be used in a test in participates in:
- `subprojects/smoke-test/src/smokeTest/resources/org/gradle/play/integtest/fixtures/external/basicplayapp/test/notATest.yaml`


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
