### PR TITLE
Ensure role-locked configurations are non-visible

### DIFF
--- a/platforms/jvm/java-platform/src/main/java/org/gradle/api/plugins/JavaPlatformPlugin.java
+++ b/platforms/jvm/java-platform/src/main/java/org/gradle/api/plugins/JavaPlatformPlugin.java
@@ -126,6 +126,7 @@ public abstract class JavaPlatformPlugin implements Plugin<Project> {
 
     private Configuration createConsumableRuntime(ProjectInternal project, Configuration apiElements, String name, String platformKind) {
         Configuration runtimeElements = project.getConfigurations().migratingUnlocked(name, ConfigurationRolesForMigration.CONSUMABLE_DEPENDENCY_SCOPE_TO_CONSUMABLE);
+        runtimeElements.setVisible(false);
         runtimeElements.extendsFrom(apiElements);
         declareConfigurationUsage(project.getObjects(), runtimeElements, Usage.JAVA_RUNTIME);
         declareConfigurationCategory(project.getObjects(), runtimeElements, platformKind);
@@ -134,6 +135,7 @@ public abstract class JavaPlatformPlugin implements Plugin<Project> {
 
     private Configuration createConsumableApi(ProjectInternal project, Configuration api, String name, String platformKind) {
         Configuration apiElements = project.getConfigurations().migratingUnlocked(name, ConfigurationRolesForMigration.CONSUMABLE_DEPENDENCY_SCOPE_TO_CONSUMABLE);
+        apiElements.setVisible(false);
         apiElements.extendsFrom(api);
         declareConfigurationUsage(project.getObjects(), apiElements, Usage.JAVA_API);
         declareConfigurationCategory(project.getObjects(), apiElements, platformKind);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -1831,15 +1831,16 @@ since users cannot create non-legacy configurations and there is no current publ
     /**
      * Determine if this is a configuration that is permitted to change its usage, to support important 3rd party
      * plugins such as Kotlin that do this.
-     * <p>
-     * This method is temporary, so the duplication of the configuration names defined in
-     * {@link JvmConstants}, which are not available to be referenced directly from here, is unfortunate, but not a showstopper.
+     *
+     * <p>This method is temporary and all usage-changing exceptions should be removed once Kotlin 1.9.20 is released.
+     * The duplication of the configuration names defined in {@link JvmConstants}, which are not available to be
+     * referenced directly from here, is unfortunate, but not a showstopper.</p>
      *
      * @return {@code true} if this is a configuration that is permitted to change its usage; {@code false} otherwise
      */
     @SuppressWarnings("JavadocReference")
     private boolean isPermittedConfigurationForUsageChange(String usage, boolean current) {
-        return name.equals("apiElements") || name.equals("runtimeElements") && usage.equals("consumable") && !current;
+        return (name.equals("apiElements") || name.equals("runtimeElements")) && usage.equals("consumable") && !current;
     }
 
     /**

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConsumableConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConsumableConfiguration.java
@@ -101,6 +101,8 @@ public class DefaultConsumableConfiguration extends DefaultConfiguration impleme
             ConfigurationRoles.CONSUMABLE,
             true
         );
+
+        setVisible(false);
     }
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultDependencyScopeConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultDependencyScopeConfiguration.java
@@ -101,6 +101,8 @@ public class DefaultDependencyScopeConfiguration extends DefaultConfiguration im
             ConfigurationRoles.DEPENDENCY_SCOPE,
             true
         );
+
+        setVisible(false);
     }
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultResolvableConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultResolvableConfiguration.java
@@ -101,6 +101,8 @@ public class DefaultResolvableConfiguration extends DefaultConfiguration impleme
             ConfigurationRoles.RESOLVABLE,
             true
         );
+
+        setVisible(false);
     }
 
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
@@ -368,6 +368,16 @@ class DefaultConfigurationContainerTest extends Specification {
         "resolvableDependencyScopeUnlocked(String, Action)" | { resolvableDependencyScopeUnlocked("foo", it) }
     }
 
+    def "role locked configurations default to non-visible"() {
+        expect:
+        !configurationContainer.consumable("a").get().visible
+        !configurationContainer.consumable("b", {}).get().visible
+        !configurationContainer.resolvable("c").get().visible
+        !configurationContainer.resolvable("d", {}).get().visible
+        !configurationContainer.dependencyScope("e").get().visible
+        !configurationContainer.dependencyScope("f", {}).get().visible
+    }
+
     // withType when used with a class that is not a super-class of the container does not work with registered elements
     @NotYetImplemented
     def "can find all configurations even when they're registered"() {

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftLibraryPlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftLibraryPlugin.java
@@ -148,7 +148,7 @@ public abstract class SwiftLibraryPlugin implements Plugin<Project> {
 
             library.getBinaries().whenElementKnown(SwiftSharedLibrary.class, sharedLibrary -> {
                 Names names = ((ComponentWithNames) sharedLibrary).getNames();
-                @SuppressWarnings("deprecation") Configuration apiElements = configurations.migratingUnlocked(names.withSuffix("SwiftApiElements"), ConfigurationRolesForMigration.CONSUMABLE_DEPENDENCY_SCOPE_TO_CONSUMABLE);
+                Configuration apiElements = configurations.migratingUnlocked(names.withSuffix("SwiftApiElements"), ConfigurationRolesForMigration.CONSUMABLE_DEPENDENCY_SCOPE_TO_CONSUMABLE);
                 // TODO This should actually extend from the api dependencies, but since Swift currently
                 // requires all dependencies to be treated like api dependencies (with transitivity) we just
                 // use the implementation dependencies here.  See https://bugs.swift.org/browse/SR-1393.
@@ -163,7 +163,7 @@ public abstract class SwiftLibraryPlugin implements Plugin<Project> {
 
             library.getBinaries().whenElementKnown(SwiftStaticLibrary.class, staticLibrary -> {
                 Names names = ((ComponentWithNames) staticLibrary).getNames();
-                @SuppressWarnings("deprecation") Configuration apiElements = configurations.migratingUnlocked(names.withSuffix("SwiftApiElements"), ConfigurationRolesForMigration.CONSUMABLE_DEPENDENCY_SCOPE_TO_CONSUMABLE);
+                Configuration apiElements = configurations.migratingUnlocked(names.withSuffix("SwiftApiElements"), ConfigurationRolesForMigration.CONSUMABLE_DEPENDENCY_SCOPE_TO_CONSUMABLE);
                 // TODO This should actually extend from the api dependencies, but since Swift currently
                 // requires all dependencies to be treated like api dependencies (with transitivity) we just
                 // use the implementation dependencies here.  See https://bugs.swift.org/browse/SR-1393.

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/catalog/VersionCatalogIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/catalog/VersionCatalogIntegrationTest.groovy
@@ -23,17 +23,14 @@ class VersionCatalogIntegrationTest extends AbstractIntegrationSpec implements V
         settingsFile << """
             rootProject.name = 'test'
         """
-        buildFile << """
-            plugins {
-                id 'version-catalog'
-            }
-
-            group = 'org.gradle'
-            version = '1.0'
-        """
     }
 
     def "can generate a Gradle platform file"() {
+        buildFile << """
+            plugins {
+                id("version-catalog")
+            }
+        """
         withSampleCatalog()
 
         when:
@@ -43,7 +40,32 @@ class VersionCatalogIntegrationTest extends AbstractIntegrationSpec implements V
         expectPlatformContents 'expected1'
     }
 
+    def "assemble task generates platform file"() {
+        buildFile << """
+            plugins {
+                id("version-catalog")
+                id("base")
+            }
+        """
+        withSampleCatalog()
+
+        when:
+        succeeds ':assemble'
+
+        then:
+        executedAndNotSkipped(":generateCatalogAsToml")
+        expectPlatformContents 'expected1'
+    }
+
     def "can publish a Gradle platform"() {
+        buildFile << """
+            plugins {
+                id("version-catalog")
+            }
+
+            group = 'org.gradle'
+            version = '1.0'
+        """
         withSampleCatalog()
         withPublishing()
 
@@ -71,6 +93,10 @@ class VersionCatalogIntegrationTest extends AbstractIntegrationSpec implements V
 
     def "can generate a Gradle platform file from a dependencies configuration"() {
         buildFile << """
+            plugins {
+                id("version-catalog")
+            }
+
             dependencies {
                 versionCatalog 'org:foo:1.0'
                 versionCatalog('org:bar') {
@@ -90,6 +116,10 @@ class VersionCatalogIntegrationTest extends AbstractIntegrationSpec implements V
 
     def "can generate a Gradle platform file from a dependencies configuration and the extension"() {
         buildFile << """
+            plugins {
+                id("version-catalog")
+            }
+
             catalog {
                 versionCatalog {
                     bundle('my', ['foo', 'bar'])
@@ -114,6 +144,10 @@ class VersionCatalogIntegrationTest extends AbstractIntegrationSpec implements V
 
     def "reasonable error message if there's a name clash between two dependencies"() {
         buildFile << """
+            plugins {
+                id("version-catalog")
+            }
+
             dependencies {
                 versionCatalog 'org1:foo:1.0'
                 versionCatalog 'org2:foo:1.0'
@@ -129,6 +163,10 @@ class VersionCatalogIntegrationTest extends AbstractIntegrationSpec implements V
 
     def "can declare a different alias in case of name clash"() {
         buildFile << """
+            plugins {
+                id("version-catalog")
+            }
+
             catalog {
                configureExplicitAlias 'foo2', 'org2', 'foo'
             }
@@ -147,6 +185,10 @@ class VersionCatalogIntegrationTest extends AbstractIntegrationSpec implements V
 
     def "can declare a explicit alias without name clash"() {
         buildFile << """
+            plugins {
+                id("version-catalog")
+            }
+
             catalog {
                configureExplicitAlias 'other', 'org', 'bar'
             }
@@ -165,6 +207,10 @@ class VersionCatalogIntegrationTest extends AbstractIntegrationSpec implements V
 
     def "can use either dependencies or constraints"() {
         buildFile << """
+            plugins {
+                id("version-catalog")
+            }
+
             dependencies {
                 versionCatalog 'org:foo:1.0'
                 constraints {
@@ -186,6 +232,10 @@ class VersionCatalogIntegrationTest extends AbstractIntegrationSpec implements V
 
     def "can detect name clash between dependencies and constraints"() {
         buildFile << """
+            plugins {
+                id("version-catalog")
+            }
+
             dependencies {
                 versionCatalog 'org:foo:1.0'
                 constraints {
@@ -207,6 +257,10 @@ class VersionCatalogIntegrationTest extends AbstractIntegrationSpec implements V
 
     def "can fix name clash between dependencies and constraints"() {
         buildFile << """
+            plugins {
+                id("version-catalog")
+            }
+
             catalog {
                 configureExplicitAlias 'foo2', 'org2', 'foo'
             }
@@ -231,6 +285,10 @@ class VersionCatalogIntegrationTest extends AbstractIntegrationSpec implements V
 
     def "can mix plugins, dependencies, constraints and model to create a platform"() {
         buildFile << """
+            plugins {
+                id("version-catalog")
+            }
+
             catalog {
                 configureExplicitAlias 'foo2', 'org', 'foo'
                 versionCatalog {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/catalog/VersionCatalogPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/catalog/VersionCatalogPlugin.java
@@ -60,14 +60,22 @@ public abstract class VersionCatalogPlugin implements Plugin<Project> {
     }
 
     private void createPublication(ProjectInternal project, TaskProvider<TomlFileGenerator> generator) {
-        @SuppressWarnings("deprecation") Configuration exported = project.getConfigurations().migratingUnlocked(VERSION_CATALOG_ELEMENTS, ConfigurationRolesForMigration.CONSUMABLE_DEPENDENCY_SCOPE_TO_CONSUMABLE, cnf -> {
+        Configuration exported = project.getConfigurations().migratingUnlocked(VERSION_CATALOG_ELEMENTS, ConfigurationRolesForMigration.CONSUMABLE_DEPENDENCY_SCOPE_TO_CONSUMABLE, cnf -> {
             cnf.setDescription("Artifacts for the version catalog");
             cnf.getOutgoing().artifact(generator);
+            cnf.setVisible(false);
             cnf.attributes(attrs -> {
                 attrs.attribute(Category.CATEGORY_ATTRIBUTE, project.getObjects().named(Category.class, Category.REGULAR_PLATFORM));
                 attrs.attribute(Usage.USAGE_ATTRIBUTE, project.getObjects().named(Usage.class, Usage.VERSION_CATALOG));
             });
         });
+
+        project.getPlugins().withType(BasePlugin.class, plugin -> {
+            project.getTasks().named(BasePlugin.ASSEMBLE_TASK_NAME).configure(assemble -> {
+                assemble.dependsOn(exported.getArtifacts());
+            });
+        });
+
         AdhocComponentWithVariants versionCatalog = softwareComponentFactory.adhoc("versionCatalog");
         project.getComponents().add(versionCatalog);
         versionCatalog.addVariantsFromConfiguration(exported, new JavaConfigurationVariantMapping("compile", true));

--- a/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningConfigurationsIntegrationSpec.groovy
+++ b/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningConfigurationsIntegrationSpec.groovy
@@ -50,6 +50,29 @@ class SigningConfigurationsIntegrationSpec extends SigningIntegrationSpec {
         file("build", "libs", "sign-1.0-sources.jar.asc").text
     }
 
+    def "configurations are signed when executing assemble task"() {
+        given:
+        buildFile << """
+            configurations {
+                meta
+            }
+
+            signing {
+                ${signingConfiguration()}
+                sign configurations.archives, configurations.meta
+            }
+
+            ${keyInfo.addAsPropertiesScript()}
+            ${getJavadocAndSourceJarsScript("meta")}
+        """
+
+        when:
+        run "assemble"
+
+        then:
+        executedAndNotSkipped ":signArchives", ":signMeta"
+    }
+
     @Issue([
         "https://github.com/gradle/gradle/issues/21857",
         "https://github.com/gradle/gradle/issues/22375"


### PR DESCRIPTION
Configurations with visible=true are automatically built when the assemble task is executed.
We do not want this behavior going forward, so we disable visible on these new configuration types

Further add tests to verify current functionality where the assmeble task executes other tasks by default
Change behavior so that platform plugin variants are non-visible. Artifacts should not be declared on these configurations

Fixes: https://github.com/gradle/gradle/issues/26578