### PR TITLE
Deprecate mutating dependency attributes after resolution

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/DefaultExcludeRule.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/DefaultExcludeRule.java
@@ -17,6 +17,8 @@ package org.gradle.api.internal.artifacts;
 
 import org.gradle.api.artifacts.ExcludeRule;
 
+import javax.annotation.Nullable;
+
 public class DefaultExcludeRule implements ExcludeRule {
     private String group;
     private String module;
@@ -24,7 +26,7 @@ public class DefaultExcludeRule implements ExcludeRule {
     public DefaultExcludeRule(){
     }
 
-    public DefaultExcludeRule(String group, String module) {
+    public DefaultExcludeRule(@Nullable String group, @Nullable String module) {
         this.group = group;
         this.module = module;
     }
@@ -34,17 +36,9 @@ public class DefaultExcludeRule implements ExcludeRule {
         return group;
     }
 
-    public void setGroup(String groupValue) {
-        this.group = groupValue;
-    }
-
     @Override
     public String getModule() {
         return module;
-    }
-
-    public void setModule(String moduleValue) {
-        this.module = moduleValue;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractModuleDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractModuleDependency.java
@@ -120,6 +120,7 @@ public abstract class AbstractModuleDependency extends AbstractDependency implem
     public AbstractModuleDependency addArtifact(DependencyArtifact artifact) {
         validateNotVariantAware();
         validateNoTargetConfiguration();
+        validateMutation();
         artifacts.add(artifact);
         return this;
     }
@@ -131,12 +132,10 @@ public abstract class AbstractModuleDependency extends AbstractDependency implem
 
     @Override
     public DependencyArtifact artifact(Action<? super DependencyArtifact> configureAction) {
-        validateNotVariantAware();
-        validateNoTargetConfiguration();
         DefaultDependencyArtifact artifact = createDependencyArtifactWithDefaults();
         configureAction.execute(artifact);
         artifact.validate();
-        artifacts.add(artifact);
+        addArtifact(artifact);
         return artifact;
     }
 
@@ -254,11 +253,13 @@ public abstract class AbstractModuleDependency extends AbstractDependency implem
 
     @Override
     public void endorseStrictVersions() {
+        validateMutation();
         this.endorsing = true;
     }
 
     @Override
     public void doNotEndorseStrictVersions() {
+        validateMutation();
         this.endorsing = false;
     }
 
@@ -291,7 +292,6 @@ public abstract class AbstractModuleDependency extends AbstractDependency implem
         this.attributes = attributes;
     }
 
-    @SuppressWarnings("unchecked")
     public void addMutationValidator(Action<? super ModuleDependency> action) {
         this.onMutate = onMutate.add(action);
     }
@@ -300,7 +300,7 @@ public abstract class AbstractModuleDependency extends AbstractDependency implem
         onMutate.execute(this);
     }
 
-    protected void validateMutation(Object currentValue, Object newValue) {
+    protected void validateMutation(@Nullable Object currentValue,@Nullable Object newValue) {
         if (!Objects.equal(currentValue, newValue)) {
             validateMutation();
         }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/BeforeResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/BeforeResolveIntegrationTest.groovy
@@ -179,7 +179,7 @@ task copyFiles(type:Copy) {
                 testImplementation('org.test:module2:1.0')
             }
 
-            configurations.all { configuration -> 
+            configurations.all { configuration ->
                 if (configuration.canBeResolved) {
                     configuration.incoming.beforeResolve { resolvableDependencies ->
                         resolvableDependencies.dependencies.each { dependency ->
@@ -251,6 +251,8 @@ task resolveDependencies {
 """
 
         expect: "that resolving conf a, then b, then a again, succeeds"
+        executer.expectDocumentedDeprecationWarning("Changing the dependency attributes of dependency configuration ':shared' after it has been included in dependency resolution has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#mutating_dependencies_after_resolve")
+        executer.expectDocumentedDeprecationWarning("Changing dependency attributes of parent of configuration ':a' after it has been resolved has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#mutating_dependencies_after_resolve")
         succeeds 'resolveDependencies'
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
@@ -32,7 +32,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
-public interface ConfigurationInternal extends ResolveContext, DeprecatableConfiguration, FinalizableValue, Configuration {
+public interface ConfigurationInternal extends ResolveContext, DeprecatableConfiguration, FinalizableValue, MutationValidator, Configuration {
     enum InternalState {
         UNRESOLVED,
         BUILD_DEPENDENCIES_RESOLVED,

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -1121,12 +1121,14 @@ class DefaultConfigurationSpec extends Specification implements InspectableConfi
         def config = conf("conf")
         config.extendsFrom parent
         resolveConfig(config)
+        config.resolve() // Marks parent as resolved
 
         when:
-        config.resolve()
+        parent.getDependencies().add(Mock(Dependency))
 
         then:
-        parent.observedState == ConfigurationInternal.InternalState.GRAPH_RESOLVED
+        def e = thrown(InvalidUserDataException)
+        e.getMessage() == "Cannot change dependencies of dependency configuration ':parent:parent' after it has been included in dependency resolution."
     }
 
     def "resolving configuration puts it into the right state and broadcasts events"() {


### PR DESCRIPTION
This is already deprecated for other mutation types, but not for mutating aspects of existing dependencies

<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
