### PR TITLE
Self-referencing ConfigurableFileCollection improvements

### DIFF
--- a/platforms/core-configuration/base-services-groovy/src/main/java/org/gradle/groovy/scripts/internal/CompoundAssignmentTransformer.java
+++ b/platforms/core-configuration/base-services-groovy/src/main/java/org/gradle/groovy/scripts/internal/CompoundAssignmentTransformer.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.groovy.scripts.internal;
+
+import org.codehaus.groovy.ast.ASTNode;
+import org.codehaus.groovy.ast.ClassCodeExpressionTransformer;
+import org.codehaus.groovy.ast.ClassCodeVisitorSupport;
+import org.codehaus.groovy.ast.ClassHelper;
+import org.codehaus.groovy.ast.ModuleNode;
+import org.codehaus.groovy.ast.Parameter;
+import org.codehaus.groovy.ast.expr.BinaryExpression;
+import org.codehaus.groovy.ast.expr.ClosureExpression;
+import org.codehaus.groovy.ast.expr.Expression;
+import org.codehaus.groovy.ast.expr.PropertyExpression;
+import org.codehaus.groovy.ast.expr.StaticMethodCallExpression;
+import org.codehaus.groovy.ast.expr.VariableExpression;
+import org.codehaus.groovy.control.CompilePhase;
+import org.codehaus.groovy.control.Phases;
+import org.codehaus.groovy.control.SourceUnit;
+import org.codehaus.groovy.syntax.Token;
+import org.codehaus.groovy.syntax.Types;
+import org.codehaus.groovy.transform.ASTTransformation;
+import org.codehaus.groovy.transform.GroovyASTTransformation;
+import org.gradle.api.NonNullApi;
+import org.gradle.api.internal.CompoundAssignmentSupport;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+@GroovyASTTransformation(phase = CompilePhase.CANONICALIZATION)
+@NonNullApi
+public class CompoundAssignmentTransformer extends AbstractScriptTransformer implements ASTTransformation {
+    private static final Map<String, Token> SUPPORTED_OPERATIONS = new HashMap<>();
+
+    static {
+        SUPPORTED_OPERATIONS.put("+=", Token.newSymbol(Types.PLUS, -1, -1));
+        SUPPORTED_OPERATIONS.put("-=", Token.newSymbol(Types.MINUS, -1, -1));
+    }
+
+    private static final Token ASSIGN = Token.newSymbol(Types.ASSIGN, -1, -1);
+
+    @Override
+    public void visit(ASTNode[] nodes, SourceUnit source) {
+        call(source);
+    }
+
+    @Override
+    public void call(SourceUnit source) {
+        ClassCodeVisitorSupport visitor = new ClassCodeExpressionTransformer() {
+            @Override
+            public Expression transform(Expression expr) {
+                if (expr instanceof BinaryExpression) {
+                    return transformBinaryExpression((BinaryExpression) super.transform(expr));
+                } else if (expr instanceof ClosureExpression) {
+                    return transformClosureExpression((ClosureExpression) super.transform(expr));
+                }
+                return super.transform(expr);
+            }
+
+            private ClosureExpression transformClosureExpression(ClosureExpression expr) {
+                // ClosureExpression has code inside of it, but ClosureExpression.transformExpression doesn't descent into it.
+                Parameter[] parameters = expr.getParameters();
+                if (parameters != null) {
+                    for (Parameter parameter : parameters) {
+                        if (parameter.hasInitialExpression()) {
+                            parameter.setInitialExpression(transform(parameter.getInitialExpression()));
+                        }
+                    }
+                }
+                expr.getCode().visit(this);
+                return expr;
+            }
+
+            private BinaryExpression transformBinaryExpression(BinaryExpression expr) {
+                Expression lhs = expr.getLeftExpression();
+                Expression rhs = expr.getRightExpression();
+                if (isSupportedCompoundAssignment(expr) && isValidDestination(lhs)) {
+                    return withSourceLocationOf(expr, new BinaryExpression(
+                        lhs,
+                        ASSIGN,
+                        withSourceLocationOf(expr, new BinaryExpression(
+                            wrapInFreeze(lhs),
+                            getAugmentingOperation(expr),
+                            rhs))));
+                }
+                return expr;
+            }
+
+            @Override
+            protected SourceUnit getSourceUnit() {
+                return source;
+            }
+        };
+
+        ModuleNode moduleAst = source.getAST();
+
+        moduleAst.getStatementBlock().visit(visitor);
+        moduleAst.getClasses().forEach(visitor::visitClass);
+        moduleAst.getMethods().forEach(visitor::visitMethod);
+    }
+
+    private static Expression wrapInFreeze(Expression expression) {
+        return new StaticMethodCallExpression(ClassHelper.make(CompoundAssignmentSupport.class), "freeze", expression);
+    }
+
+    private static boolean isValidDestination(Expression expr) {
+        return expr instanceof VariableExpression || expr instanceof PropertyExpression;
+    }
+
+    private static boolean isSupportedCompoundAssignment(BinaryExpression expression) {
+        return SUPPORTED_OPERATIONS.containsKey(expression.getOperation().getText());
+    }
+
+    private static Token getAugmentingOperation(BinaryExpression expression) {
+        return Objects.requireNonNull(SUPPORTED_OPERATIONS.get(expression.getOperation().getText()));
+    }
+
+    private static <T extends Expression> T withSourceLocationOf(Expression original, T transformed) {
+        transformed.setSourcePosition(original);
+        return transformed;
+    }
+
+    @Override
+    protected int getPhase() {
+        return Phases.CANONICALIZATION;
+    }
+}

--- a/platforms/core-configuration/file-collections/src/integTest/groovy/org/gradle/api/file/FileCollectionIntegrationTest.groovy
+++ b/platforms/core-configuration/file-collections/src/integTest/groovy/org/gradle/api/file/FileCollectionIntegrationTest.groovy
@@ -181,7 +181,7 @@ class FileCollectionIntegrationTest extends AbstractIntegrationSpec implements T
             def files2 = files('b.txt', 'b.bin')
             task merge(type: LegacyTask) {
                 inFiles = files1
-                inFiles = files(inFiles, files2).filter { f -> f.name.endsWith('.txt') }
+                inFiles.update { (it + files2).filter { f -> f.name.endsWith('.txt') } }
             }
         """
         file('a.txt').text = 'a'
@@ -210,8 +210,10 @@ class FileCollectionIntegrationTest extends AbstractIntegrationSpec implements T
             def files2 = files('b.txt', 'b.bin')
             task merge(type: LegacyTask) {
                 inFiles = files1
-                def sum = inFiles.plus(files2)
-                inFiles = sum.filter { f -> f.name.endsWith('.txt') } + sum.filter { f -> f.name.endsWith('.bin') }
+                inFiles.update {
+                    def sum = it + files2
+                    sum.filter { f -> f.name.endsWith('.txt') } + sum.filter { f -> f.name.endsWith('.bin') }
+                }
             }
         """
         file('a.txt').text = 'a1'

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionInternal.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/FileCollectionInternal.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.file;
 
 
+import org.gradle.api.internal.CompoundAssignmentSupport;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.tasks.TaskDependencyContainer;
 import org.gradle.api.specs.Spec;
@@ -25,7 +26,7 @@ import org.gradle.internal.logging.text.TreeFormatter;
 import java.io.File;
 import java.util.function.Supplier;
 
-public interface FileCollectionInternal extends FileCollection, TaskDependencyContainer {
+public interface FileCollectionInternal extends FileCollection, TaskDependencyContainer, CompoundAssignmentSupport.Freezable<FileCollectionInternal> {
     String DEFAULT_COLLECTION_DISPLAY_NAME = "file collection";
 
     @Override
@@ -71,4 +72,8 @@ public interface FileCollectionInternal extends FileCollection, TaskDependencyCo
      */
     Source OTHER = new Source() {
     };
+
+    default FileCollectionInternal freeze() {
+        return this;
+    }
 }

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
@@ -349,6 +349,11 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
         super.visitDependencies(context);
     }
 
+    @Override
+    public FileCollectionInternal freeze() {
+        return value.freeze(host);
+    }
+
     private interface ValueCollector {
         void collectSource(Collection<Object> dest);
 
@@ -365,7 +370,7 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
         @Nullable
         List<Object> replace(FileCollectionInternal original, Supplier<FileCollectionInternal> supplier);
 
-        FileCollection freeze(PropertyHost propertyHost);
+        FileCollectionInternal freeze(PropertyHost propertyHost);
     }
 
     private static class EmptyCollector implements ValueCollector {
@@ -404,7 +409,7 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
         }
 
         @Override
-        public FileCollection freeze(PropertyHost propertyHost) {
+        public FileCollectionInternal freeze(PropertyHost propertyHost) {
             return FileCollectionFactory.empty();
         }
     }
@@ -520,7 +525,7 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
         }
 
         @Override
-        public FileCollection freeze(PropertyHost propertyHost) {
+        public FileCollectionInternal freeze(PropertyHost propertyHost) {
             DefaultConfigurableFileCollection frozen = new DefaultConfigurableFileCollection(null, resolver, taskDependencyFactory, patternSetFactory, propertyHost);
             frozen.from(items.toArray());
             return frozen;
@@ -573,7 +578,7 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
         }
 
         @Override
-        public FileCollection freeze(PropertyHost propertyHost) {
+        public FileCollectionInternal freeze(PropertyHost propertyHost) {
             throw new UnsupportedOperationException("Should not be called");
         }
     }

--- a/platforms/core-configuration/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollectionSpec.groovy
+++ b/platforms/core-configuration/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollectionSpec.groovy
@@ -352,7 +352,7 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
         def src = containing(file1, file2)
 
         when:
-        collection.from = src + collection
+        collection.update { src + it }
         def files = collection.files
 
         then:
@@ -367,7 +367,7 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
 
         when:
         collection.from = "src2"
-        collection.from = src + collection
+        collection.update { src + it }
         def files = collection.files
 
         then:

--- a/platforms/core-configuration/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollectionSpec.groovy
+++ b/platforms/core-configuration/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollectionSpec.groovy
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.file.collections
 
 import org.gradle.api.Task
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.internal.file.AbstractFileCollection
 import org.gradle.api.internal.file.FileCollectionInternal
 import org.gradle.api.internal.file.FileCollectionSpec
@@ -304,6 +305,28 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
 
         then:
         files as List == [file1, file2]
+    }
+
+
+    def "further modifications to appended collection"() {
+        given:
+        def fileA = new File("a.txt")
+        def fileB = new File("b.txt")
+        def fileC = new File("c.txt")
+
+        def a = containing(fileA) as ConfigurableFileCollection
+        collection.from = containing(fileB)
+        when:
+        a.from(collection)
+        collection.from = a
+        a.from(containing(fileC))
+
+        def filesA = a.files
+        def filesB = collection.files
+
+        then:
+        filesA as List == [fileA, fileB, fileC]
+        filesB as List == [fileA, fileB]
     }
 
     def "can append contents to collection using plus operator"() {

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyAssignmentIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyAssignmentIntegrationTest.groovy
@@ -252,7 +252,7 @@ class PropertyAssignmentIntegrationTest extends AbstractIntegrationSpec {
         "FileCollection = Object"          | "="       | "ConfigurableFileCollection" | 'new MyObject("a.txt")' | unsupportedWithCause("Failed to cast object")
         "FileCollection = File"            | "="       | "ConfigurableFileCollection" | 'file("a.txt")'         | unsupportedWithCause("Failed to cast object")
         "FileCollection = Iterable<File>"  | "="       | "ConfigurableFileCollection" | '[file("a.txt")]'       | unsupportedWithCause("Failed to cast object")
-        "FileCollection += FileCollection" | "+="      | "ConfigurableFileCollection" | 'files("a.txt")'        | unsupportedWithCause("Self-referencing ConfigurableFileCollections are not supported. Use the from() method to add to a ConfigurableFileCollection.")
+        "FileCollection += FileCollection" | "+="      | "ConfigurableFileCollection" | 'files("a.txt")'        | '[a.txt]'
         "FileCollection << FileCollection" | "<<"      | "ConfigurableFileCollection" | 'files("a.txt")'        | unsupportedWithCause("No signature of method")
         "FileCollection += String"         | "+="      | "ConfigurableFileCollection" | '"a.txt"'               | unsupportedWithCause("Failed to cast object")
         "FileCollection += Object"         | "+="      | "ConfigurableFileCollection" | 'new MyObject("a.txt")' | unsupportedWithCause("Failed to cast object")

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
@@ -486,4 +486,14 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
             return left.getProducer().plus(right.getProducer());
         }
     }
+
+    /**
+     * Returns the frozen view of this Property. Further updates to this Property do not affect the return provider.
+     * However, the Provider itself is live - it reflects changes to its dependencies.
+     *
+     * @return the frozen view of this Property
+     */
+    protected Provider<C> freeze() {
+        return Providers.of(get());
+    }
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultListProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultListProperty.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.provider;
 
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
+import org.gradle.api.Transformer;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.Cast;
@@ -79,6 +80,19 @@ public class DefaultListProperty<T> extends AbstractCollectionProperty<T, List<T
     @Override
     public ListProperty<T> convention(Provider<? extends Iterable<? extends T>> provider) {
         super.convention(provider);
+        return this;
+    }
+
+    /**
+     * Updates the value of this property in place by executing the provided transformer.
+     * The transformer accepts the frozen value of this property.
+     *
+     * @param transformer the transformer to apply to frozen value of the property
+     * @return this
+     */
+    @Override
+    public ListProperty<T> updateList(Transformer<? extends Provider<? extends Iterable<? extends T>>, ? super Provider<? extends List<? extends T>>> transformer)  {
+        set(transformer.transform(freeze()));
         return this;
     }
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultListProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultListProperty.java
@@ -91,7 +91,7 @@ public class DefaultListProperty<T> extends AbstractCollectionProperty<T, List<T
      * @return this
      */
     @Override
-    public ListProperty<T> updateList(Transformer<? extends Provider<? extends Iterable<? extends T>>, ? super Provider<? extends List<? extends T>>> transformer)  {
+    public ListProperty<T> update(Transformer<? extends Provider<? extends Iterable<? extends T>>, ? super Provider<? extends List<? extends T>>> transformer)  {
         set(transformer.transform(freeze()));
         return this;
     }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.Action;
+import org.gradle.api.Transformer;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Provider;
 
@@ -597,5 +598,15 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
         public ValueProducer getProducer() {
             return left.getProducer().plus(right.getProducer());
         }
+    }
+
+    private Provider<Map<K, V>> frozen() {
+        return Providers.of(get());
+    }
+
+    @Override
+    public MapProperty<K, V> update(Transformer<? extends Provider<? extends Map<? extends K, ? extends V>>, ? super Provider<? extends Map<? extends K, ? extends V>>> transformer)  {
+        set(transformer.transform(frozen()));
+        return this;
     }
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.provider;
 
 import com.google.common.base.Preconditions;
+import org.gradle.api.Transformer;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.Cast;
@@ -137,5 +138,15 @@ public class DefaultProperty<T> extends AbstractProperty<T, ProviderInternal<? e
     protected String describeContents() {
         // NOTE: Do not realize the value of the Provider in toString().  The debugger will try to call this method and make debugging really frustrating.
         return String.format("property(%s, %s)", type.getName(), getSupplier());
+    }
+
+    private Provider<T> frozen() {
+        return Providers.of(get());
+    }
+
+    @Override
+    public Property<T> update(Transformer<? extends Provider<? extends T>, ? super Provider<T>> transformer)  {
+        set(transformer.transform(frozen()));
+        return this;
     }
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultSetProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultSetProperty.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.provider;
 
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableSet;
+import org.gradle.api.Transformer;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.internal.Cast;
@@ -79,6 +80,12 @@ public class DefaultSetProperty<T> extends AbstractCollectionProperty<T, Set<T>>
     @Override
     public SetProperty<T> convention(Provider<? extends Iterable<? extends T>> provider) {
         super.convention(provider);
+        return this;
+    }
+
+    @Override
+    public SetProperty<T> updateSet(Transformer<? extends Provider<? extends Iterable<? extends T>>, ? super Provider<? extends Set<? extends T>>> transformer) {
+        set(transformer.transform(freeze()));
         return this;
     }
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultSetProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultSetProperty.java
@@ -84,7 +84,7 @@ public class DefaultSetProperty<T> extends AbstractCollectionProperty<T, Set<T>>
     }
 
     @Override
-    public SetProperty<T> updateSet(Transformer<? extends Provider<? extends Iterable<? extends T>>, ? super Provider<? extends Set<? extends T>>> transformer) {
+    public SetProperty<T> update(Transformer<? extends Provider<? extends Iterable<? extends T>>, ? super Provider<? extends Set<? extends T>>> transformer) {
         set(transformer.transform(freeze()));
         return this;
     }

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/api/internal/CompoundAssignmentSupport.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/api/internal/CompoundAssignmentSupport.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal;
+
+public class CompoundAssignmentSupport {
+    public interface Freezable<T extends Freezable<T>> {
+        T freeze();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> T freeze(T object) {
+        if (object instanceof Freezable) {
+            return (T) ((Freezable<?>) object).freeze();
+        }
+        return object;
+    }
+
+    public static <T extends Freezable<T>> T freeze(T object) {
+        return object.freeze();
+    }
+
+    public static byte freeze(byte v) {
+        return v;
+    }
+
+    public static short freeze(short v) {
+        return v;
+    }
+
+    public static char freeze(char v) {
+        return v;
+    }
+
+    public static int freeze(int v) {
+        return v;
+    }
+
+    public static long freeze(long v) {
+        return v;
+    }
+
+    public static float freeze(float v) {
+        return v;
+    }
+
+    public static double freeze(double v) {
+        return v;
+    }
+
+    public static String freeze(String v) {
+        return v;
+    }
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/HasMultipleValues.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/HasMultipleValues.java
@@ -16,7 +16,9 @@
 
 package org.gradle.api.provider;
 
+import org.gradle.api.Incubating;
 import org.gradle.api.SupportsKotlinAssignmentOverloading;
+import org.gradle.api.Transformer;
 
 import javax.annotation.Nullable;
 
@@ -152,4 +154,15 @@ public interface HasMultipleValues<T> extends HasConfigurableValue {
      */
     @Override
     void finalizeValue();
+
+    /**
+     * Updates the value of this property in place by executing the provided transformer.
+     * The transformer accepts the frozen value of this property.
+     *
+     * @param transformer the transformer to apply to frozen value of the property
+     * @return this
+     * @since 8.5
+     */
+    @Incubating
+    HasMultipleValues<T> update(Transformer<? extends Provider<? extends Iterable<? extends T>>, ? super Provider<? extends Iterable<? extends T>>> transformer);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/HasMultipleValues.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/HasMultipleValues.java
@@ -164,5 +164,5 @@ public interface HasMultipleValues<T> extends HasConfigurableValue {
      * @since 8.5
      */
     @Incubating
-    HasMultipleValues<T> update(Transformer<? extends Provider<? extends Iterable<? extends T>>, ? super Provider<? extends Iterable<? extends T>>> transformer);
+    HasMultipleValues<T> updateValues(Transformer<? extends Provider<? extends Iterable<? extends T>>, ? super Provider<? extends Iterable<? extends T>>> transformer);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ListProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ListProperty.java
@@ -70,8 +70,8 @@ public interface ListProperty<T> extends Provider<List<T>>, HasMultipleValues<T>
      */
     @Incubating
     @Override
-    default ListProperty<T> update(Transformer<? extends Provider<? extends Iterable<? extends T>>, ? super Provider<? extends Iterable<? extends T>>> transformer) {
-        return updateList(transformer);
+    default ListProperty<T> updateValues(Transformer<? extends Provider<? extends Iterable<? extends T>>, ? super Provider<? extends Iterable<? extends T>>> transformer) {
+        return update(transformer);
     }
 
     /**
@@ -83,5 +83,5 @@ public interface ListProperty<T> extends Provider<List<T>>, HasMultipleValues<T>
      * @since 8.5
      */
     @Incubating
-    ListProperty<T> updateList(Transformer<? extends Provider<? extends Iterable<? extends T>>, ? super Provider<? extends List<? extends T>>> transformer);
+    ListProperty<T> update(Transformer<? extends Provider<? extends Iterable<? extends T>>, ? super Provider<? extends List<? extends T>>> transformer);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ListProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ListProperty.java
@@ -16,6 +16,9 @@
 
 package org.gradle.api.provider;
 
+import org.gradle.api.Incubating;
+import org.gradle.api.Transformer;
+
 import javax.annotation.Nullable;
 import java.util.List;
 
@@ -61,4 +64,24 @@ public interface ListProperty<T> extends Provider<List<T>>, HasMultipleValues<T>
      */
     @Override
     ListProperty<T> convention(Provider<? extends Iterable<? extends T>> provider);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Incubating
+    @Override
+    default ListProperty<T> update(Transformer<? extends Provider<? extends Iterable<? extends T>>, ? super Provider<? extends Iterable<? extends T>>> transformer) {
+        return updateList(transformer);
+    }
+
+    /**
+     * Updates the value of this property in place by executing the provided transformer.
+     * The transformer accepts the frozen value of this property.
+     *
+     * @param transformer the transformer to apply to frozen value of the property
+     * @return this
+     * @since 8.5
+     */
+    @Incubating
+    ListProperty<T> updateList(Transformer<? extends Provider<? extends Iterable<? extends T>>, ? super Provider<? extends List<? extends T>>> transformer);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/MapProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/MapProperty.java
@@ -16,7 +16,9 @@
 
 package org.gradle.api.provider;
 
+import org.gradle.api.Incubating;
 import org.gradle.api.SupportsKotlinAssignmentOverloading;
+import org.gradle.api.Transformer;
 
 import javax.annotation.Nullable;
 import java.util.Map;
@@ -188,4 +190,15 @@ public interface MapProperty<K, V> extends Provider<Map<K, V>>, HasConfigurableV
      */
     @Override
     void finalizeValue();
+
+    /**
+     * Updates the value of this property in place by executing the provided transformer.
+     * The transformer accepts the frozen value of this property.
+     *
+     * @param transformer the transformer to apply to frozen value of the property
+     * @return this
+     * @since 8.5
+     */
+    @Incubating
+    MapProperty<K, V> update(Transformer<? extends Provider<? extends Map<? extends K, ? extends V>>, ? super Provider<? extends Map<? extends K, ? extends V>>> transformer);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/Property.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/Property.java
@@ -16,7 +16,9 @@
 
 package org.gradle.api.provider;
 
+import org.gradle.api.Incubating;
 import org.gradle.api.SupportsKotlinAssignmentOverloading;
+import org.gradle.api.Transformer;
 import org.gradle.api.model.ObjectFactory;
 
 import javax.annotation.Nullable;
@@ -178,4 +180,15 @@ public interface Property<T> extends Provider<T>, HasConfigurableValue {
      */
     @Override
     void finalizeValue();
+
+    /**
+     * Updates the value of this property in place by executing the provided transformer.
+     * The transformer accepts the frozen value of this property.
+     *
+     * @param transformer the transformer to apply to frozen value of the property
+     * @return this
+     * @since 8.5
+     */
+    @Incubating
+    Property<T> update(Transformer<? extends Provider<? extends T>, ? super Provider<T>> transformer);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/SetProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/SetProperty.java
@@ -16,6 +16,9 @@
 
 package org.gradle.api.provider;
 
+import org.gradle.api.Incubating;
+import org.gradle.api.Transformer;
+
 import javax.annotation.Nullable;
 import java.util.Set;
 
@@ -61,4 +64,24 @@ public interface SetProperty<T> extends Provider<Set<T>>, HasMultipleValues<T> {
      */
     @Override
     SetProperty<T> convention(Provider<? extends Iterable<? extends T>> provider);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Incubating
+    @Override
+    default SetProperty<T> update(Transformer<? extends Provider<? extends Iterable<? extends T>>, ? super Provider<? extends Iterable<? extends T>>> transformer) {
+        return updateSet(transformer);
+    }
+
+    /**
+     * Updates the value of this property in place by executing the provided transformer.
+     * The transformer accepts the frozen value of this property.
+     *
+     * @param transformer the transformer to apply to frozen value of the property
+     * @return this
+     * @since 8.5
+     */
+    @Incubating
+    SetProperty<T> updateSet(Transformer<? extends Provider<? extends Iterable<? extends T>>, ? super Provider<? extends Set<? extends T>>> transformer);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/SetProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/SetProperty.java
@@ -70,8 +70,8 @@ public interface SetProperty<T> extends Provider<Set<T>>, HasMultipleValues<T> {
      */
     @Incubating
     @Override
-    default SetProperty<T> update(Transformer<? extends Provider<? extends Iterable<? extends T>>, ? super Provider<? extends Iterable<? extends T>>> transformer) {
-        return updateSet(transformer);
+    default SetProperty<T> updateValues(Transformer<? extends Provider<? extends Iterable<? extends T>>, ? super Provider<? extends Iterable<? extends T>>> transformer) {
+        return update(transformer);
     }
 
     /**
@@ -83,5 +83,5 @@ public interface SetProperty<T> extends Provider<Set<T>>, HasMultipleValues<T> {
      * @since 8.5
      */
     @Incubating
-    SetProperty<T> updateSet(Transformer<? extends Provider<? extends Iterable<? extends T>>, ? super Provider<? extends Set<? extends T>>> transformer);
+    SetProperty<T> update(Transformer<? extends Provider<? extends Iterable<? extends T>>, ? super Provider<? extends Set<? extends T>>> transformer);
 }

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/BuildScriptTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/BuildScriptTransformer.java
@@ -53,6 +53,7 @@ public class BuildScriptTransformer implements Transformer, Factory<BuildScriptD
         new StatementLabelsScriptTransformer().register(compilationUnit);
         new ModelBlockTransformer(scriptSource.getDisplayName(), scriptSource.getResource().getLocation().getURI()).register(compilationUnit);
         imperativeStatementDetectingTransformer.register(compilationUnit);
+        new CompoundAssignmentTransformer().register(compilationUnit);
     }
 
     @Override


### PR DESCRIPTION
TBD. This is work-in-progress. It includes the following parts of the spec:
* Deprecating circular references in ConfigurableFileCollections
* Freezing for ConfigurableFileCollection
* Self-ref-free incremental update method for ConfigurableFileCollection

The following are in a draft state, when the implementation works but needs polishing:
* Groovy ASTTransform that rewrites `a += b` into "a = freeze(a) + b" to support self-ref-free compound assignments
* Self-ref-free incremental update method for Properties (with a stub eager implementation under the hood)

These items aren't included:
* Compound assignments for List, Set, and Map properties
* Better errors for circular references in providers