### PR TITLE
Set progressDisplayName for ConfigurationCache store and load operations

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheBuildOperations.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheBuildOperations.kt
@@ -26,12 +26,12 @@ import org.gradle.internal.operations.CallableBuildOperation
 
 internal
 fun <T : Any> BuildOperationExecutor.withLoadOperation(block: () -> T) =
-    withOperation("Load configuration cache state", block, LoadDetails, LoadResult)
+    withOperation("Load configuration cache state", "Loading configuration cache state", block, LoadDetails, LoadResult)
 
 
 internal
 fun BuildOperationExecutor.withStoreOperation(@Suppress("UNUSED_PARAMETER") cacheKey: String, block: () -> Unit) =
-    withOperation("Store configuration cache state", block, StoreDetails, StoreResult)
+    withOperation("Store configuration cache state", "Storing configuration cache state", block, StoreDetails, StoreResult)
 
 
 private
@@ -51,10 +51,10 @@ object StoreResult : ConfigurationCacheStoreBuildOperationType.Result
 
 
 private
-fun <T : Any, D : Any, R : Any> BuildOperationExecutor.withOperation(displayName: String, block: () -> T, details: D, result: R): T =
+fun <T : Any, D : Any, R : Any> BuildOperationExecutor.withOperation(displayName: String, progressDisplayName: String, block: () -> T, details: D, result: R): T =
     call(object : CallableBuildOperation<T> {
         override fun description(): BuildOperationDescriptor.Builder =
-            BuildOperationDescriptor.displayName(displayName).details(details)
+            BuildOperationDescriptor.displayName(displayName).progressDisplayName(progressDisplayName).details(details)
 
         override fun call(context: BuildOperationContext): T =
             block().also { context.setResult(result) }

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/configurationcache/ConfigurationCacheBuildOperationsTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/configurationcache/ConfigurationCacheBuildOperationsTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache
+
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import org.gradle.internal.operations.BuildOperationExecutor
+import org.gradle.internal.operations.CallableBuildOperation
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.any
+
+
+class ConfigurationCacheBuildOperationsTest {
+    @Test
+    fun `sets progress display name on store`() {
+        // given:
+        val buildOperationExecutor = mock<BuildOperationExecutor> {
+            on { call<Unit>(any()) } doReturn Unit
+        }
+
+        // when:
+        buildOperationExecutor.withStoreOperation("key") {
+        }
+
+        // then:
+        val callableBuildOperation = ArgumentCaptor.forClass(CallableBuildOperation::class.java)
+        verify(buildOperationExecutor).call(callableBuildOperation.capture())
+
+        // and:
+        assertThat(
+            callableBuildOperation.value.description().build().progressDisplayName,
+            equalTo("Storing configuration cache state")
+        )
+    }
+
+    @Test
+    fun `sets progress display name on load`() {
+        // given:
+        val buildOperationExecutor = mock<BuildOperationExecutor> {
+            on { call<Unit>(any()) } doReturn Unit
+        }
+
+        // when:
+        buildOperationExecutor.withLoadOperation() {
+        }
+
+        // then:
+        val callableBuildOperation = ArgumentCaptor.forClass(CallableBuildOperation::class.java)
+        verify(buildOperationExecutor).call(callableBuildOperation.capture())
+
+        // and:
+        assertThat(
+            callableBuildOperation.value.description().build().progressDisplayName,
+            equalTo("Loading configuration cache state")
+        )
+    }
+}


### PR DESCRIPTION
First step in fixing #24274

### Context
Set progressDisplayName for ConfigurationCache store and load operations to allow users to see progress when Gradle is storing and loading CC.

![image](https://github.com/gradle/gradle/assets/1418185/46519a5d-b2ec-48f7-833b-f06876e5564c)

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
