### PR TITLE
fix: Use "thead" table element instead of "thread"

### DIFF
--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/PackagePageRenderer.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/PackagePageRenderer.java
@@ -32,7 +32,7 @@ class PackagePageRenderer extends PageRenderer<PackageTestResults> {
 
     private void renderClasses(SimpleHtmlWriter htmlWriter) throws IOException {
         htmlWriter.startElement("table");
-        htmlWriter.startElement("thread");
+        htmlWriter.startElement("thead");
         htmlWriter.startElement("tr");
 
         htmlWriter.startElement("th").characters("Class").endElement();


### PR DESCRIPTION
Previous code created a `table` element then immediately created a `thread` element. There is no such element, I assume this is a typo for `thead`.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
