### PR TITLE
Provides new methods on FileSystemOperations to enable CopySpec creation in execution phase

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/file/FileSystemOperations.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/FileSystemOperations.java
@@ -35,6 +35,26 @@ import org.gradle.internal.service.scopes.ServiceScope;
 public interface FileSystemOperations {
 
     /**
+     * Creates a {@link CopySpec} which can later be used to copy files or create an archive. The given action is used
+     * to configure the {@link CopySpec} before it is returned by this method.
+     *
+     * @param action Action to configure the CopySpec
+     * @return The CopySpec
+     * @since 8.5
+     */
+    @Incubating
+    CopySpec copySpec(Action<? super CopySpec> action);
+
+    /**
+     * Creates a {@link CopySpec} which can later be used to copy files or create an archive.
+     *
+     * @return a newly created copy spec
+     * @since 8.5
+     */
+    @Incubating
+    CopySpec copySpec();
+
+    /**
      * Copies the specified files.
      * The given action is used to configure a {@link CopySpec}, which is then used to copy the files.
      *

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileSystemOperations.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileSystemOperations.java
@@ -25,6 +25,7 @@ import org.gradle.api.internal.lambdas.SerializableLambdas;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.WorkResult;
+import org.gradle.internal.Actions;
 
 
 public class DefaultFileSystemOperations implements FileSystemOperations {
@@ -36,6 +37,16 @@ public class DefaultFileSystemOperations implements FileSystemOperations {
     public DefaultFileSystemOperations(ObjectFactory objectFactory, FileOperations fileOperations) {
         this.objectFactory = objectFactory;
         this.fileOperations = fileOperations;
+    }
+
+    @Override
+    public CopySpec copySpec(Action<? super CopySpec> action) {
+        return Actions.with(copySpec(), action);
+    }
+
+    @Override
+    public CopySpec copySpec() {
+        return fileOperations.copySpec();
     }
 
     @Override

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultFileSystemOperationsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultFileSystemOperationsTest.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.file
+
+import org.gradle.api.model.ObjectFactory
+import spock.lang.Specification
+
+class DefaultFileSystemOperationsTest extends Specification {
+
+    private FileOperations fileOperations = Mock()
+    private ObjectFactory objectFactory = Mock()
+    private DefaultFileSystemOperations fileSystemOperations = new DefaultFileSystemOperations(objectFactory, fileOperations)
+
+    def 'copySpec forwards to FileOperations::copySpec'() {
+        when:
+        fileSystemOperations.copySpec()
+
+        then:
+        1 * fileOperations.copySpec()
+    }
+}

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -84,6 +84,15 @@ The Wrapper and the Gradle Build Tool are licensed under the [Apache Software Li
 The JAR file is now self-attributing so that you don't need to add a separate `LICENSE` file in your codebase.
 
 
+<a name="plugin-authoring-improvements"></a>
+### Plugin authoring improvements
+
+#### New API in `FileSystemOperations` to create `CopySpec` instances when no `Project` is available
+
+The `FileSystemOperations` service now has a [copySpec()](javadoc/org/gradle/api/file/FileSystemOperations.html#copySpec--) method for creating `CopySpec` instances in a [configuration cache](userguide/configuration_cache.html) friendly way.
+The new method allows you to create, configure, and use `CopySpec` instances during the [execution phase](userguide/build_lifecycle.html#sec:build_phases).
+
+
 <a name="kotlin-dsl"></a>
 ### Kotlin DSL improvements
 

--- a/subprojects/docs/src/docs/userguide/optimizing-performance/configuration_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/optimizing-performance/configuration_cache.adoc
@@ -860,7 +860,7 @@ The following table shows what APIs or injected service should be used as a repl
 | A task input or output property or a script variable to capture the result of using `project.resource` to calculate the actual parameter.
 
 | `project.copySpec {}`
-| A task input or output property or a script variable to capture the result of using `project.copySpec {}` to calculate the actual parameter.
+| link:{javadocPath}/org/gradle/api/file/FileSystemOperations.html#copySpec--[FileSystemOperations.copySpec {}]
 
 | `project.copy {}`
 | link:{javadocPath}/org/gradle/api/file/FileSystemOperations.html#copy-org.gradle.api.Action-[FileSystemOperations.copy {}]


### PR DESCRIPTION

* Fixes #13968

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
