### PR TITLE
Add option to use on demand shared cache

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheRepository.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheRepository.kt
@@ -223,7 +223,7 @@ class ConfigurationCacheRepository(
 
     private
     fun CacheBuilder.withOnDemandLockMode() =
-        withLockOptions(LockOptionsBuilder.mode(FileLockManager.LockMode.OnDemand))
+        withLockOptions(LockOptionsBuilder.mode(FileLockManager.LockMode.OnDemandExclusive))
 
     private
     fun CacheBuilder.withLruCacheCleanup(cleanupActionDecorator: CleanupActionDecorator): CacheBuilder =

--- a/platforms/core-execution/build-cache/src/main/java/org/gradle/caching/local/internal/DirectoryBuildCacheServiceFactory.java
+++ b/platforms/core-execution/build-cache/src/main/java/org/gradle/caching/local/internal/DirectoryBuildCacheServiceFactory.java
@@ -41,7 +41,7 @@ import javax.inject.Inject;
 import java.io.File;
 import java.util.function.Supplier;
 
-import static org.gradle.cache.FileLockManager.LockMode.OnDemand;
+import static org.gradle.cache.FileLockManager.LockMode.OnDemandExclusive;
 import static org.gradle.cache.internal.filelock.LockOptionsBuilder.mode;
 
 public class DirectoryBuildCacheServiceFactory implements BuildCacheServiceFactory<DirectoryBuildCache> {
@@ -95,7 +95,7 @@ public class DirectoryBuildCacheServiceFactory implements BuildCacheServiceFacto
             .cache(target)
             .withCleanupStrategy(createCacheCleanupStrategy(removeUnusedEntriesOlderThan))
             .withDisplayName("Build cache")
-            .withLockOptions(mode(OnDemand))
+            .withLockOptions(mode(OnDemandExclusive))
             .withCrossVersionCache(CacheBuilder.LockTarget.DefaultTarget)
             .open();
         BuildCacheTempFileStore tempFileStore = new DefaultBuildCacheTempFileStore(temporaryFileProvider);

--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/workspace/impl/DefaultImmutableWorkspaceProvider.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/workspace/impl/DefaultImmutableWorkspaceProvider.java
@@ -109,7 +109,7 @@ public class DefaultImmutableWorkspaceProvider implements WorkspaceProvider, Clo
     ) {
         PersistentCache cache = cacheBuilder
             .withCleanupStrategy(createCacheCleanupStrategy(fileAccessTimeJournal, treeDepthToTrackAndCleanup, cacheConfigurations))
-            .withLockOptions(mode(FileLockManager.LockMode.OnDemand)) // Lock on demand
+            .withLockOptions(mode(FileLockManager.LockMode.OnDemandExclusive)) // Lock on demand
             .open();
         this.cache = cache;
         this.baseDirectory = cache.getBaseDir();

--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/CacheBuilder.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/CacheBuilder.java
@@ -85,7 +85,7 @@ public interface CacheBuilder {
      * </p>
      * <ul>
      *     <li>Using {@link org.gradle.cache.FileLockManager.LockMode#Exclusive} will lock the cache on open() and keep it locked until {@link PersistentCache#close()} is called.</li>
-     *     <li>Using {@link org.gradle.cache.FileLockManager.LockMode#OnDemand} or {@link org.gradle.cache.FileLockManager.LockMode#Shared} will <em>not</em> lock the cache on open().</li>
+     *     <li>Using {@link org.gradle.cache.FileLockManager.LockMode#OnDemandExclusive} or {@link org.gradle.cache.FileLockManager.LockMode#OnDemandShared} or {@link org.gradle.cache.FileLockManager.LockMode#Shared} will <em>not</em> lock the cache on open().</li>
      * </ul>
      *
      * @return The cache.

--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/FileLockManager.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/FileLockManager.java
@@ -63,9 +63,13 @@ public interface FileLockManager {
 
     enum LockMode {
         /**
-         * Support processes asking for access.
+         * Support processes asking for access for exclusive lock mode.
          */
-        OnDemand,
+        OnDemandExclusive,
+        /**
+         * Support processes asking for access for shared lock mode.
+         */
+        OnDemandShared,
         /**
          * Multiple readers, no writers.
          */
@@ -77,6 +81,10 @@ public interface FileLockManager {
         /**
          * No locking whatsoever.
          */
-        None
+        None;
+
+        public boolean isOnDemand() {
+            return this == OnDemandExclusive || this == OnDemandShared;
+        }
     }
 }

--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheCoordinator.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheCoordinator.java
@@ -58,6 +58,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import static org.gradle.cache.FileLockManager.LockMode.Exclusive;
+import static org.gradle.cache.FileLockManager.LockMode.Shared;
 
 @ThreadSafe
 public class DefaultCacheCoordinator implements CacheCreationCoordinator, ExclusiveCacheAccessCoordinator {
@@ -107,8 +108,12 @@ public class DefaultCacheCoordinator implements CacheCreationCoordinator, Exclus
                 crossProcessCacheAccess = new FixedExclusiveModeCrossProcessCacheAccess(cacheDisplayName, lockTarget, lockOptions, lockManager, initializationAction, onFileLockAcquireAction, onFileLockReleaseAction);
                 fileAccess = new UnitOfWorkFileAccess();
                 break;
-            case OnDemand:
+            case OnDemandExclusive:
                 crossProcessCacheAccess = new LockOnDemandCrossProcessCacheAccess(cacheDisplayName, lockTarget, lockOptions.withMode(Exclusive), lockManager, stateLock, initializationAction, onFileLockAcquireAction, onFileLockReleaseAction);
+                fileAccess = new UnitOfWorkFileAccess();
+                break;
+            case OnDemandShared:
+                crossProcessCacheAccess = new LockOnDemandCrossProcessCacheAccess(cacheDisplayName, lockTarget, lockOptions.withMode(Shared), lockManager, stateLock, initializationAction, onFileLockAcquireAction, onFileLockReleaseAction);
                 fileAccess = new UnitOfWorkFileAccess();
                 break;
             case None:

--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultDecompressionCache.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultDecompressionCache.java
@@ -39,7 +39,7 @@ public class DefaultDecompressionCache implements DecompressionCache {
     public DefaultDecompressionCache(ScopedCacheBuilderFactory cacheBuilderFactory) {
         this.cache = cacheBuilderFactory.createCrossVersionCacheBuilder(EXPANSION_CACHE_KEY)
                 .withDisplayName(EXPANSION_CACHE_NAME)
-                .withLockOptions(mode(FileLockManager.LockMode.OnDemand)) //TODO: the documentation above says this is a cross-version cache, not it's not! should it be?
+                .withLockOptions(mode(FileLockManager.LockMode.OnDemandExclusive)) //TODO: the documentation above says this is a cross-version cache, not it's not! should it be?
                 .open();
     }
 

--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultFileLockManager.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultFileLockManager.java
@@ -33,6 +33,7 @@ import org.gradle.cache.internal.filelock.LockStateAccess;
 import org.gradle.cache.internal.filelock.LockStateSerializer;
 import org.gradle.cache.internal.filelock.Version1LockStateSerializer;
 import org.gradle.cache.internal.locklistener.FileLockContentionHandler;
+import org.gradle.internal.Actions;
 import org.gradle.internal.Factory;
 import org.gradle.internal.FileUtils;
 import org.gradle.internal.concurrent.CompositeStoppable;
@@ -158,7 +159,7 @@ public class DefaultFileLockManager implements FileLockManager {
             LockStateSerializer stateProtocol = options.isUseCrossVersionImplementation() ? new Version1LockStateSerializer() : new DefaultLockStateSerializer();
             lockFileAccess = new LockFileAccess(lockFile, new LockStateAccess(stateProtocol));
             try {
-                if (whenContended != null) {
+                if (whenContended != null && whenContended != Actions.<FileLockReleasedSignal>doNothing()) {
                     fileLockContentionHandler.start(lockId, whenContended);
                 }
                 lockState = lock(options.getMode());

--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultFileLockManager.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultFileLockManager.java
@@ -98,7 +98,7 @@ public class DefaultFileLockManager implements FileLockManager {
 
     @Override
     public FileLock lock(File target, LockOptions options, String targetDisplayName, String operationDisplayName, Action<FileLockReleasedSignal> whenContended) {
-        if (options.getMode() == LockMode.OnDemand) {
+        if (options.getMode().isOnDemand()) {
             throw new UnsupportedOperationException(String.format("No %s mode lock implementation available.", options));
         }
         File canonicalTarget = FileUtils.canonicalize(target);
@@ -137,7 +137,7 @@ public class DefaultFileLockManager implements FileLockManager {
         public DefaultFileLock(File target, LockOptions options, String displayName, String operationDisplayName, int port, Action<FileLockReleasedSignal> whenContended) throws Throwable {
             this.port = port;
             this.lockId = generator.generateId();
-            if (options.getMode() == LockMode.OnDemand) {
+            if (options.getMode().isOnDemand()) {
                 throw new UnsupportedOperationException("Locking mode OnDemand is not supported.");
             }
 

--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/FixedExclusiveModeCrossProcessCacheAccess.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/FixedExclusiveModeCrossProcessCacheAccess.java
@@ -63,23 +63,30 @@ public class FixedExclusiveModeCrossProcessCacheAccess extends AbstractCrossProc
         if (fileLock != null) {
             throw new IllegalStateException("File lock " + lockTarget + " is already open.");
         }
-        final FileLock fileLock = lockManager.lock(lockTarget, lockOptions, cacheDisplayName, "", NO_OP_CONTENDED_ACTION);
+        this.fileLock = getFileLock(lockManager, lockTarget, lockOptions, cacheDisplayName, initializationAction, onOpenAction, NO_OP_CONTENDED_ACTION);
+    }
+
+    static FileLock getFileLock(
+        FileLockManager lockManager,
+        File lockTarget,
+        LockOptions lockOptions,
+        String cacheDisplayName,
+        CacheInitializationAction initializationAction,
+        Action<FileLock> onOpenAction,
+        Action<FileLockReleasedSignal> whenContended
+    ) {
+        final FileLock fileLock = lockManager.lock(lockTarget, lockOptions, cacheDisplayName, "", whenContended);
         try {
             boolean rebuild = initializationAction.requiresInitialization(fileLock);
             if (rebuild) {
-                fileLock.writeFile(new Runnable() {
-                    @Override
-                    public void run() {
-                        initializationAction.initialize(fileLock);
-                    }
-                });
+                fileLock.writeFile(() -> initializationAction.initialize(fileLock));
             }
             onOpenAction.execute(fileLock);
+            return fileLock;
         } catch (Exception e) {
             fileLock.close();
             throw UncheckedException.throwAsUncheckedException(e);
         }
-        this.fileLock = fileLock;
     }
 
     @Override

--- a/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/FixedSharedModeCrossProcessCacheAccess.java
+++ b/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/FixedSharedModeCrossProcessCacheAccess.java
@@ -105,7 +105,7 @@ public class FixedSharedModeCrossProcessCacheAccess extends AbstractCrossProcess
                             exclusiveLock.close();
                         }
                     }
-                    fileLock = lockManager.lock(lockTarget, lockOptions, cacheDisplayName);
+                    fileLock = lockManager.lock(lockTarget, lockOptions, cacheDisplayName, "", whenContended);
                     rebuild = initializationAction.requiresInitialization(fileLock);
                 }
                 if (rebuild) {

--- a/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultExclusiveCacheAccessCoordinatorTest.groovy
+++ b/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultExclusiveCacheAccessCoordinatorTest.groovy
@@ -35,7 +35,7 @@ import org.junit.Rule
 
 import static org.gradle.cache.FileLockManager.LockMode.Exclusive
 import static org.gradle.cache.FileLockManager.LockMode.None
-import static org.gradle.cache.FileLockManager.LockMode.OnDemand
+import static org.gradle.cache.FileLockManager.LockMode.OnDemandExclusive
 import static org.gradle.cache.FileLockManager.LockMode.Shared
 import static org.gradle.cache.internal.filelock.LockOptionsBuilder.mode
 
@@ -115,11 +115,11 @@ class DefaultExclusiveCacheAccessCoordinatorTest extends ConcurrentSpec {
         0 * _._
 
         where:
-        accessType << [Exclusive, Shared, OnDemand, None]
+        accessType << [Exclusive, Shared, OnDemandExclusive, None]
     }
 
     def "cleans up on close when clean up has not already occurred"() {
-        def access = newAccess(OnDemand)
+        def access = newAccess(OnDemandExclusive)
 
         when:
         access.open()
@@ -131,7 +131,7 @@ class DefaultExclusiveCacheAccessCoordinatorTest extends ConcurrentSpec {
     }
 
     def "does not clean up on close when clean up has already occurred"() {
-        def access = newAccess(OnDemand)
+        def access = newAccess(OnDemandExclusive)
 
         when:
         access.open()
@@ -149,7 +149,7 @@ class DefaultExclusiveCacheAccessCoordinatorTest extends ConcurrentSpec {
     }
 
     def "can explicitly clean up multiple times"() {
-        def access = newAccess(OnDemand)
+        def access = newAccess(OnDemandExclusive)
 
         when:
         access.cleanup()
@@ -254,7 +254,7 @@ class DefaultExclusiveCacheAccessCoordinatorTest extends ConcurrentSpec {
 
     def "initializes cache on open when lock mode is none"() {
         def action = Mock(Runnable)
-        def access = newAccess(OnDemand)
+        def access = newAccess(OnDemandExclusive)
 
         def contentionAction
 
@@ -300,7 +300,7 @@ class DefaultExclusiveCacheAccessCoordinatorTest extends ConcurrentSpec {
     }
 
     def "does not acquire lock on open when initial lock mode is none"() {
-        def access = newAccess(OnDemand)
+        def access = newAccess(OnDemandExclusive)
 
         when:
         access.open()
@@ -335,12 +335,12 @@ class DefaultExclusiveCacheAccessCoordinatorTest extends ConcurrentSpec {
         thrown(IllegalStateException)
 
         where:
-        lockMode << [Shared, Exclusive, OnDemand]
+        lockMode << [Shared, Exclusive, OnDemandExclusive]
     }
 
     def "with file lock operation acquires lock but does not release it at the end of the operation"() {
         Factory<String> action = Mock()
-        def access = newAccess(OnDemand)
+        def access = newAccess(OnDemandExclusive)
 
         when:
         access.open()
@@ -363,7 +363,7 @@ class DefaultExclusiveCacheAccessCoordinatorTest extends ConcurrentSpec {
 
     def "with file lock operation reuses existing file lock"() {
         Factory<String> action = Mock()
-        def access = newAccess(OnDemand)
+        def access = newAccess(OnDemandExclusive)
 
         when:
         access.open()
@@ -389,7 +389,7 @@ class DefaultExclusiveCacheAccessCoordinatorTest extends ConcurrentSpec {
 
     def "nested with file lock operation does not release the lock"() {
         Factory<String> action = Mock()
-        def access = newAccess(OnDemand)
+        def access = newAccess(OnDemandExclusive)
 
         when:
         access.open()
@@ -414,7 +414,7 @@ class DefaultExclusiveCacheAccessCoordinatorTest extends ConcurrentSpec {
 
     def "using cache pushes an operation and acquires lock but does not release it at the end of the operation"() {
         Factory<String> action = Mock()
-        def access = newAccess(OnDemand)
+        def access = newAccess(OnDemandExclusive)
 
         when:
         access.open()
@@ -439,7 +439,7 @@ class DefaultExclusiveCacheAccessCoordinatorTest extends ConcurrentSpec {
 
     def "nested use cache operation does not release the lock"() {
         Factory<String> action = Mock()
-        def access = newAccess(OnDemand)
+        def access = newAccess(OnDemandExclusive)
 
         when:
         access.open()
@@ -459,7 +459,7 @@ class DefaultExclusiveCacheAccessCoordinatorTest extends ConcurrentSpec {
 
     def "use cache operation reuses existing file lock"() {
         Factory<String> action = Mock()
-        def access = newAccess(OnDemand)
+        def access = newAccess(OnDemandExclusive)
 
         when:
         access.open()
@@ -496,7 +496,7 @@ class DefaultExclusiveCacheAccessCoordinatorTest extends ConcurrentSpec {
     }
 
     def "can create new cache"() {
-        def access = newAccess(OnDemand)
+        def access = newAccess(OnDemandExclusive)
 
         when:
         def cache = access.newCache(IndexedCacheParameters.of('cache', String.class, Integer.class))
@@ -508,7 +508,7 @@ class DefaultExclusiveCacheAccessCoordinatorTest extends ConcurrentSpec {
 
     def "contended action safely closes the lock when cache is not busy"() {
         Factory<String> action = Mock()
-        def access = newAccess(OnDemand)
+        def access = newAccess(OnDemandExclusive)
         def contendedAction
 
         when:
@@ -541,7 +541,7 @@ class DefaultExclusiveCacheAccessCoordinatorTest extends ConcurrentSpec {
         thrown(IllegalStateException)
 
         where:
-        mode << [Exclusive, OnDemand]
+        mode << [Exclusive, OnDemandExclusive]
     }
 
     def "file access is available when there is an owner"() {
@@ -557,7 +557,7 @@ class DefaultExclusiveCacheAccessCoordinatorTest extends ConcurrentSpec {
         1 * lock.updateFile(runnable)
 
         where:
-        mode << [Exclusive, OnDemand]
+        mode << [Exclusive, OnDemandExclusive]
     }
 
     def "file access can not be accessed when there is no owner"() {
@@ -577,11 +577,11 @@ class DefaultExclusiveCacheAccessCoordinatorTest extends ConcurrentSpec {
         thrown(IllegalStateException)
 
         where:
-        mode << [Exclusive, OnDemand]
+        mode << [Exclusive, OnDemandExclusive]
     }
 
     def "can close cache when the cache has not been used"() {
-        def access = newAccess(OnDemand)
+        def access = newAccess(OnDemandExclusive)
 
         when:
         access.open()
@@ -593,7 +593,7 @@ class DefaultExclusiveCacheAccessCoordinatorTest extends ConcurrentSpec {
     }
 
     def "can close cache when there is no owner"() {
-        def access = newAccess(OnDemand)
+        def access = newAccess(OnDemandExclusive)
 
         given:
         lockManager.lock(lockFile, mode(Exclusive), "<display-name>", "", _) >> lock
@@ -610,7 +610,7 @@ class DefaultExclusiveCacheAccessCoordinatorTest extends ConcurrentSpec {
     }
 
     def "can close cache when the lock has been released"() {
-        def access = newAccess(OnDemand)
+        def access = newAccess(OnDemandExclusive)
         def contendedAction
 
         given:
@@ -632,7 +632,7 @@ class DefaultExclusiveCacheAccessCoordinatorTest extends ConcurrentSpec {
 
     def "releases lock acquired by cache decorator when contended"() {
         def decorator = Mock(CacheDecorator)
-        def access = newAccess(OnDemand)
+        def access = newAccess(OnDemandExclusive)
         def contendedAction
 
         given:
@@ -669,7 +669,7 @@ class DefaultExclusiveCacheAccessCoordinatorTest extends ConcurrentSpec {
 
     def "does not acquire file lock for cleanup"() {
         given:
-        def access = newAccess(OnDemand)
+        def access = newAccess(OnDemandExclusive)
         access.open()
 
         when:
@@ -681,7 +681,7 @@ class DefaultExclusiveCacheAccessCoordinatorTest extends ConcurrentSpec {
     }
 
     def "releases file lock before running cleanup"() {
-        def access = newAccess(OnDemand)
+        def access = newAccess(OnDemandExclusive)
 
         given:
         lockManager.lock(lockFile, mode(Exclusive), "<display-name>", "", _) >> lock
@@ -701,7 +701,7 @@ class DefaultExclusiveCacheAccessCoordinatorTest extends ConcurrentSpec {
     }
 
     def "returns the same cache object when using same cache parameters"() {
-        def access = newAccess(OnDemand)
+        def access = newAccess(OnDemandExclusive)
 
         when:
         def cache1 = access.newCache(IndexedCacheParameters.of('cache', String.class, Integer.class))
@@ -715,7 +715,7 @@ class DefaultExclusiveCacheAccessCoordinatorTest extends ConcurrentSpec {
     }
 
     def "throws InvalidCacheReuseException when cache value type differs"() {
-        def access = newAccess(OnDemand)
+        def access = newAccess(OnDemandExclusive)
 
         when:
         access.newCache(IndexedCacheParameters.of('cache', String.class, Integer.class))
@@ -729,7 +729,7 @@ class DefaultExclusiveCacheAccessCoordinatorTest extends ConcurrentSpec {
     }
 
     def "throws InvalidCacheReuseException when cache key type differs"() {
-        def access = newAccess(OnDemand)
+        def access = newAccess(OnDemandExclusive)
 
         when:
         access.newCache(IndexedCacheParameters.of('cache', String.class, Integer.class))
@@ -743,7 +743,7 @@ class DefaultExclusiveCacheAccessCoordinatorTest extends ConcurrentSpec {
     }
 
     def "throws InvalidCacheReuseException when cache decorator differs"() {
-        def access = newAccess(OnDemand)
+        def access = newAccess(OnDemandExclusive)
         def decorator = Mock(CacheDecorator)
         lockManager.lock(lockFile, mode(Exclusive), "<display-name>") >> lock
         decorator.decorate(_, _, _, _, _) >> { String cacheId, String cacheName, MultiProcessSafeIndexedCache indexedCacheche, CrossProcessCacheAccess crossProcessCacheAccess, AsyncCacheAccess asyncCacheAccess ->
@@ -762,7 +762,7 @@ class DefaultExclusiveCacheAccessCoordinatorTest extends ConcurrentSpec {
     }
 
     def "returns the same cache object when cache decorator match"() {
-        def access = newAccess(OnDemand)
+        def access = newAccess(OnDemandExclusive)
         def decorator = Mock(CacheDecorator)
         lockManager.lock(lockFile, mode(Exclusive), "<display-name>", "", _) >> lock
         decorator.decorate(_, _, _, _, _) >> { String cacheId, String cacheName, MultiProcessSafeIndexedCache indexedCache, CrossProcessCacheAccess crossProcessCacheAccess, AsyncCacheAccess asyncCacheAccess ->
@@ -782,7 +782,7 @@ class DefaultExclusiveCacheAccessCoordinatorTest extends ConcurrentSpec {
     }
 
     def "returns the same cache object when using compatible value serializer"() {
-        def access = newAccess(OnDemand)
+        def access = newAccess(OnDemandExclusive)
 
         when:
         def cache1 = access.newCache(IndexedCacheParameters.of('cache', String.class, Integer.class))
@@ -797,7 +797,7 @@ class DefaultExclusiveCacheAccessCoordinatorTest extends ConcurrentSpec {
     }
 
     def "returns the same cache object when using compatible key serializer"() {
-        def access = newAccess(OnDemand)
+        def access = newAccess(OnDemandExclusive)
 
         when:
         def cache1 = access.newCache(IndexedCacheParameters.of('cache', String.class, Integer.class))

--- a/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultExclusiveCacheAccessCoordinatorTest.groovy
+++ b/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultExclusiveCacheAccessCoordinatorTest.groovy
@@ -67,7 +67,7 @@ class DefaultExclusiveCacheAccessCoordinatorTest extends ConcurrentSpec {
         access.open()
 
         then:
-        1 * lockManager.lock(lockFile, mode(Shared), "<display-name>") >> lock
+        1 * lockManager.lock(lockFile, mode(Shared), "<display-name>", "", _) >> lock
         1 * initializationAction.requiresInitialization(lock) >> false
         _ * lock.state
         0 * _._
@@ -175,19 +175,19 @@ class DefaultExclusiveCacheAccessCoordinatorTest extends ConcurrentSpec {
         access.open()
 
         then:
-        1 * lockManager.lock(lockFile, mode(Shared), "<display-name>") >> lock
+        1 * lockManager.lock(lockFile, mode(Shared), "<display-name>", "", _) >> lock
         1 * initializationAction.requiresInitialization(lock) >> true
         1 * lock.close()
 
         then:
-        1 * lockManager.lock(lockFile, mode(Exclusive), "<display-name>") >> exclusiveLock
+        1 * lockManager.lock(lockFile, mode(Exclusive), "<display-name>", "", _) >> exclusiveLock
         1 * initializationAction.requiresInitialization(exclusiveLock) >> true
         1 * exclusiveLock.writeFile(_) >> { Runnable r -> r.run() }
         1 * initializationAction.initialize(exclusiveLock)
         1 * exclusiveLock.close()
 
         then:
-        1 * lockManager.lock(lockFile, mode(Shared), "<display-name>") >> sharedLock
+        1 * lockManager.lock(lockFile, mode(Shared), "<display-name>", "", _) >> sharedLock
         1 * initializationAction.requiresInitialization(sharedLock) >> false
         _ * sharedLock.state
         0 * _._
@@ -235,12 +235,12 @@ class DefaultExclusiveCacheAccessCoordinatorTest extends ConcurrentSpec {
         access.open()
 
         then:
-        1 * lockManager.lock(lockFile, mode(Shared), "<display-name>") >> lock
+        1 * lockManager.lock(lockFile, mode(Shared), "<display-name>", "", _) >> lock
         1 * initializationAction.requiresInitialization(lock) >> true
         1 * lock.close()
 
         then:
-        1 * lockManager.lock(lockFile, mode(Exclusive), "<display-name>") >> exclusiveLock
+        1 * lockManager.lock(lockFile, mode(Exclusive), "<display-name>", "", _) >> exclusiveLock
         1 * initializationAction.requiresInitialization(exclusiveLock) >> true
         1 * exclusiveLock.writeFile(_) >> { Runnable r -> r.run() }
         1 * initializationAction.initialize(exclusiveLock) >> { throw failure }
@@ -320,11 +320,7 @@ class DefaultExclusiveCacheAccessCoordinatorTest extends ConcurrentSpec {
     }
 
     def "cannot be opened more than once for mode #lockMode"() {
-        if (lockMode == Shared) {
-            lockManager.lock(lockFile, _, "<display-name>") >> lock
-        } else {
-            lockManager.lock(lockFile, _, "<display-name>", "", _) >> lock
-        }
+        lockManager.lock(lockFile, _, "<display-name>", "", _) >> lock
         def access = newAccess(lockMode)
 
         when:
@@ -485,7 +481,7 @@ class DefaultExclusiveCacheAccessCoordinatorTest extends ConcurrentSpec {
         def access = newAccess(Shared)
 
         given:
-        1 * lockManager.lock(lockFile, mode(Shared), "<display-name>") >> lock
+        1 * lockManager.lock(lockFile, mode(Shared), "<display-name>", "", _) >> lock
         access.open()
 
         when:

--- a/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultFileLockManagerWithCrossVersionProtocolTest.groovy
+++ b/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultFileLockManagerWithCrossVersionProtocolTest.groovy
@@ -23,7 +23,7 @@ import org.gradle.test.fixtures.file.TestFile
 class DefaultFileLockManagerWithCrossVersionProtocolTest extends AbstractFileLockManagerTest {
     @Override
     protected LockOptionsBuilder options() {
-        return LockOptionsBuilder.mode(FileLockManager.LockMode.OnDemand).useCrossVersionImplementation()
+        return LockOptionsBuilder.mode(FileLockManager.LockMode.OnDemandExclusive).useCrossVersionImplementation()
     }
 
     void isVersionLockFile(TestFile lockFile, boolean dirty) {

--- a/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultFileLockManagerWithNewProtocolTest.groovy
+++ b/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultFileLockManagerWithNewProtocolTest.groovy
@@ -26,7 +26,7 @@ import static org.gradle.cache.FileLockManager.LockMode.Shared
 class DefaultFileLockManagerWithNewProtocolTest extends AbstractFileLockManagerTest {
     @Override
     protected LockOptionsBuilder options() {
-        return LockOptionsBuilder.mode(FileLockManager.LockMode.OnDemand)
+        return LockOptionsBuilder.mode(FileLockManager.LockMode.OnDemandExclusive)
     }
 
     def "a lock has been updated when never written to"() {

--- a/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultPersistentDirectoryStoreConcurrencyTest.groovy
+++ b/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultPersistentDirectoryStoreConcurrencyTest.groovy
@@ -27,7 +27,7 @@ import org.gradle.testfixtures.internal.NativeServicesTestFixture
 import org.junit.Rule
 import spock.lang.Issue
 
-import static org.gradle.cache.FileLockManager.LockMode.OnDemand
+import static org.gradle.cache.FileLockManager.LockMode.OnDemandExclusive
 import static org.gradle.cache.internal.filelock.LockOptionsBuilder.mode
 
 class DefaultPersistentDirectoryStoreConcurrencyTest extends ConcurrentSpec {
@@ -40,7 +40,7 @@ class DefaultPersistentDirectoryStoreConcurrencyTest extends ConcurrentSpec {
 
     @Issue("GRADLE-3206")
     def "can create new caches and access them in parallel"() {
-        def store = new DefaultPersistentDirectoryStore(cacheDir, "<display>", CacheBuilder.LockTarget.DefaultTarget, mode(OnDemand), null, lockManager, executorFactory, new NoOpProgressLoggerFactory())
+        def store = new DefaultPersistentDirectoryStore(cacheDir, "<display>", CacheBuilder.LockTarget.DefaultTarget, mode(OnDemandExclusive), null, lockManager, executorFactory, new NoOpProgressLoggerFactory())
         store.open()
 
         when:

--- a/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultPersistentDirectoryStoreTest.groovy
+++ b/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultPersistentDirectoryStoreTest.groovy
@@ -92,7 +92,7 @@ class DefaultPersistentDirectoryStoreTest extends Specification {
         store.open()
 
         then:
-        1 * lockManager.lock(cacheDir, mode(Shared), "<display> ($cacheDir)") >> lock
+        1 * lockManager.lock(cacheDir, mode(Shared), "<display> ($cacheDir)", "", _) >> lock
 
         when:
         store.close()
@@ -110,7 +110,7 @@ class DefaultPersistentDirectoryStoreTest extends Specification {
         store.open()
 
         then:
-        1 * lockManager.lock(cacheDir.file(lockFile), mode(Shared), "<display> ($cacheDir)") >> lock
+        1 * lockManager.lock(cacheDir.file(lockFile), mode(Shared), "<display> ($cacheDir)", "", _) >> lock
 
         when:
         store.close()

--- a/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultPersistentDirectoryStoreTest.groovy
+++ b/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultPersistentDirectoryStoreTest.groovy
@@ -33,7 +33,7 @@ import spock.lang.Subject
 
 import java.util.concurrent.TimeUnit
 
-import static org.gradle.cache.FileLockManager.LockMode.OnDemand
+import static org.gradle.cache.FileLockManager.LockMode.OnDemandExclusive
 import static org.gradle.cache.FileLockManager.LockMode.Shared
 import static org.gradle.cache.internal.filelock.LockOptionsBuilder.mode
 
@@ -56,7 +56,7 @@ class DefaultPersistentDirectoryStoreTest extends Specification {
     }
 
     @Subject @AutoCleanup
-    def store = new DefaultPersistentDirectoryStore(cacheDir, "<display>", CacheBuilder.LockTarget.DefaultTarget, mode(OnDemand), cacheCleanup, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
+    def store = new DefaultPersistentDirectoryStore(cacheDir, "<display>", CacheBuilder.LockTarget.DefaultTarget, mode(OnDemandExclusive), cacheCleanup, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
 
     def "has useful toString() implementation"() {
         expect:
@@ -128,7 +128,7 @@ class DefaultPersistentDirectoryStoreTest extends Specification {
     }
 
     def "open does not lock cache directory when None mode requested"() {
-        final store = new DefaultPersistentDirectoryStore(cacheDir, "<display>", CacheBuilder.LockTarget.DefaultTarget, mode(OnDemand), null, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
+        final store = new DefaultPersistentDirectoryStore(cacheDir, "<display>", CacheBuilder.LockTarget.DefaultTarget, mode(OnDemandExclusive), null, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
 
         when:
         store.open()
@@ -191,7 +191,7 @@ class DefaultPersistentDirectoryStoreTest extends Specification {
 
     def "does not use gc.properties when no cleanup action is defined"() {
         given:
-        store = new DefaultPersistentDirectoryStore(cacheDir, "<display>", CacheBuilder.LockTarget.DefaultTarget, mode(OnDemand), null, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
+        store = new DefaultPersistentDirectoryStore(cacheDir, "<display>", CacheBuilder.LockTarget.DefaultTarget, mode(OnDemandExclusive), null, lockManager, Mock(ExecutorFactory), progressLoggerFactory)
 
         when:
         store.open()

--- a/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultUnscopedCacheBuilderFactoryTest.groovy
+++ b/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultUnscopedCacheBuilderFactoryTest.groovy
@@ -23,7 +23,7 @@ import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
 import spock.lang.Specification
 
-import static org.gradle.cache.FileLockManager.LockMode.OnDemand
+import static org.gradle.cache.FileLockManager.LockMode.OnDemandExclusive
 import static org.gradle.cache.FileLockManager.LockMode.Shared
 import static org.gradle.cache.internal.filelock.LockOptionsBuilder.mode
 
@@ -88,11 +88,11 @@ class DefaultUnscopedCacheBuilderFactoryTest extends Specification {
 
     void canSpecifyLockModeForDirectoryCache() {
         when:
-        repository.cache("a").withLockOptions(mode(OnDemand)).open()
+        repository.cache("a").withLockOptions(mode(OnDemandExclusive)).open()
 
         then:
         1 * scopeMapping.getBaseDirectory(null, "a", VersionStrategy.CachePerVersion) >> sharedCacheDir
-        1 * cacheFactory.open(sharedCacheDir, null, [:], CacheBuilder.LockTarget.DefaultTarget, mode(OnDemand), null, null) >> cache
+        1 * cacheFactory.open(sharedCacheDir, null, [:], CacheBuilder.LockTarget.DefaultTarget, mode(OnDemandExclusive), null, null) >> cache
     }
 
     void canSpecifyDisplayNameForDirectoryCache() {

--- a/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/FixedSharedModeCrossProcessCacheAccessTest.groovy
+++ b/platforms/core-execution/persistent-cache/src/test/groovy/org/gradle/cache/internal/FixedSharedModeCrossProcessCacheAccessTest.groovy
@@ -39,7 +39,7 @@ class FixedSharedModeCrossProcessCacheAccessTest extends Specification {
         cacheAccess.open()
 
         then:
-        1 * lockManager.lock(file, lockOptions, "<cache>") >> lock
+        1 * lockManager.lock(file, lockOptions, "<cache>", "", _) >> lock
 
         then:
         1 * initAction.requiresInitialization(lock) >> false
@@ -58,21 +58,21 @@ class FixedSharedModeCrossProcessCacheAccessTest extends Specification {
         cacheAccess.open()
 
         then:
-        1 * lockManager.lock(file, lockOptions, "<cache>") >> initialLock
+        1 * lockManager.lock(file, lockOptions, "<cache>", "", _) >> initialLock
 
         then:
         1 * initAction.requiresInitialization(initialLock) >> true
         1 * initialLock.close()
 
         then:
-        1 * lockManager.lock(file, {it.mode == FileLockManager.LockMode.Exclusive }, "<cache>") >> exclusiveLock
+        1 * lockManager.lock(file, {it.mode == FileLockManager.LockMode.Exclusive }, "<cache>", "", _) >> exclusiveLock
         1 * initAction.requiresInitialization(exclusiveLock) >> true
         1 * exclusiveLock.writeFile(_) >> { Runnable r -> r.run() }
         1 * initAction.initialize(exclusiveLock)
         1 * exclusiveLock.close()
 
         then:
-        1 * lockManager.lock(file, lockOptions, "<cache>") >> sharedLock
+        1 * lockManager.lock(file, lockOptions, "<cache>", "", _) >> sharedLock
         1 * initAction.requiresInitialization(sharedLock) >> false
 
         then:
@@ -101,12 +101,12 @@ class FixedSharedModeCrossProcessCacheAccessTest extends Specification {
         e == failure
 
         and:
-        1 * lockManager.lock(file, lockOptions, "<cache>") >> initialLock
+        1 * lockManager.lock(file, lockOptions, "<cache>", "", _) >> initialLock
         1 * initAction.requiresInitialization(initialLock) >> true
         1 * initialLock.close()
 
         then:
-        1 * lockManager.lock(file, {it.mode == FileLockManager.LockMode.Exclusive}, "<cache>") >> exclusiveLock
+        1 * lockManager.lock(file, {it.mode == FileLockManager.LockMode.Exclusive}, "<cache>", "", _) >> exclusiveLock
         1 * initAction.requiresInitialization(exclusiveLock) >> true
         1 * exclusiveLock.writeFile(_) >> { Runnable r -> r.run() }
         1 * initAction.initialize(exclusiveLock) >> { throw failure }
@@ -134,19 +134,19 @@ class FixedSharedModeCrossProcessCacheAccessTest extends Specification {
         e == failure
 
         and:
-        1 * lockManager.lock(file, lockOptions, "<cache>") >> initialLock
+        1 * lockManager.lock(file, lockOptions, "<cache>", "", _) >> initialLock
         1 * initAction.requiresInitialization(initialLock) >> true
         1 * initialLock.close()
 
         then:
-        1 * lockManager.lock(file, {it.mode == FileLockManager.LockMode.Exclusive}, "<cache>") >> exclusiveLock
+        1 * lockManager.lock(file, {it.mode == FileLockManager.LockMode.Exclusive}, "<cache>", "", _) >> exclusiveLock
         1 * initAction.requiresInitialization(exclusiveLock) >> true
         1 * exclusiveLock.writeFile(_) >> { Runnable r -> r.run() }
         1 * initAction.initialize(exclusiveLock)
         1 * exclusiveLock.close()
 
         then:
-        1 * lockManager.lock(file, lockOptions, "<cache>") >> sharedLock
+        1 * lockManager.lock(file, lockOptions, "<cache>", "", _) >> sharedLock
         1 * initAction.requiresInitialization(sharedLock) >> false
 
         then:
@@ -165,7 +165,7 @@ class FixedSharedModeCrossProcessCacheAccessTest extends Specification {
         def lock = Mock(FileLock)
 
         given:
-        lockManager.lock(file, lockOptions, "<cache>") >> lock
+        lockManager.lock(file, lockOptions, "<cache>", "", _) >> lock
         cacheAccess.open()
 
         when:

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/cache/UserHomeScopedCompileCaches.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/cache/UserHomeScopedCompileCaches.java
@@ -43,7 +43,7 @@ public class UserHomeScopedCompileCaches implements GeneralCompileCaches, Closea
         cache = cacheBuilderFactory
             .createCacheBuilder("javaCompile")
             .withDisplayName("Java compile cache")
-            .withLockOptions(mode(FileLockManager.LockMode.OnDemand)) // Lock on demand
+            .withLockOptions(mode(FileLockManager.LockMode.OnDemandExclusive)) // Lock on demand
             .open();
         IndexedCacheParameters<HashCode, ClassSetAnalysisData> jarCacheParameters = IndexedCacheParameters.of(
             "jarAnalysis",

--- a/platforms/jvm/scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincScalaCompilerFactory.java
+++ b/platforms/jvm/scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincScalaCompilerFactory.java
@@ -109,7 +109,7 @@ public class ZincScalaCompilerFactory {
         String zincCacheName = String.format("%s compiler cache", zincCacheKey);
         final PersistentCache zincCache = unscopedCacheBuilderFactory.cache(zincCacheKey)
             .withDisplayName(zincCacheName)
-            .withLockOptions(mode(FileLockManager.LockMode.OnDemand))
+            .withLockOptions(mode(FileLockManager.LockMode.OnDemandExclusive))
             .open();
 
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/WritableArtifactCacheLockingAccessCoordinator.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/WritableArtifactCacheLockingAccessCoordinator.java
@@ -58,7 +58,7 @@ public class WritableArtifactCacheLockingAccessCoordinator implements ArtifactCa
                 .cache(cacheMetaData.getCacheDir())
                 .withCrossVersionCache(CacheBuilder.LockTarget.CacheDirectory)
                 .withDisplayName("artifact cache")
-                .withLockOptions(mode(FileLockManager.LockMode.OnDemand)) // Don't need to lock anything until we use the caches
+                .withLockOptions(mode(FileLockManager.LockMode.OnDemandExclusive)) // Don't need to lock anything until we use the caches
                 .withCleanupStrategy(createCacheCleanupStrategy(cacheMetaData, fileAccessTimeJournal, usedGradleVersions, cacheConfigurations))
                 .open();
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/signatures/CrossBuildCachingKeyService.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/signatures/CrossBuildCachingKeyService.java
@@ -80,7 +80,7 @@ public class CrossBuildCachingKeyService implements PublicKeyService, Closeable 
         cache = cacheBuilderFactory
             .createCrossVersionCacheBuilder("keyrings")
             .withCrossVersionCache(CacheBuilder.LockTarget.DefaultTarget)
-            .withLockOptions(LockOptionsBuilder.mode(FileLockManager.LockMode.OnDemand))
+            .withLockOptions(LockOptionsBuilder.mode(FileLockManager.LockMode.OnDemandExclusive))
             .open();
         this.buildOperationExecutor = buildOperationExecutor;
         this.delegate = delegate;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/signatures/CrossBuildSignatureVerificationService.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/signatures/CrossBuildSignatureVerificationService.java
@@ -68,7 +68,7 @@ public class CrossBuildSignatureVerificationService implements SignatureVerifica
         this.keyringFileHash = keyringFileHash;
         store = cacheBuilderFactory.createCacheBuilder("signature-verification")
             .withDisplayName("Signature verification cache")
-            .withLockOptions(mode(FileLockManager.LockMode.OnDemand)) // Lock on demand
+            .withLockOptions(mode(FileLockManager.LockMode.OnDemandExclusive)) // Lock on demand
             .open();
         InterningStringSerializer stringSerializer = new InterningStringSerializer(new StringInterner());
         cache = store.createIndexedCache(

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/caching/CrossBuildCachingRuleExecutor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/caching/CrossBuildCachingRuleExecutor.java
@@ -80,7 +80,7 @@ public class CrossBuildCachingRuleExecutor<KEY, DETAILS, RESULT> implements Cach
         this.timeProvider = timeProvider;
         this.cache = cacheBuilderFactory
             .createCacheBuilder(name)
-            .withLockOptions(LockOptionsBuilder.mode(FileLockManager.LockMode.OnDemand))
+            .withLockOptions(LockOptionsBuilder.mode(FileLockManager.LockMode.OnDemandExclusive))
             .open();
         IndexedCacheParameters<HashCode, CachedEntry<RESULT>> cacheParams = createCacheConfiguration(name, resultSerializer, cacheDecoratorFactory);
         this.store = this.cache.createIndexedCache(cacheParams);

--- a/platforms/software/version-control/src/main/java/org/gradle/vcs/internal/resolver/PersistentVcsMetadataCache.java
+++ b/platforms/software/version-control/src/main/java/org/gradle/vcs/internal/resolver/PersistentVcsMetadataCache.java
@@ -43,7 +43,7 @@ public class PersistentVcsMetadataCache implements Stoppable {
         cache = cacheBuilderFactory
             .createCacheBuilder("vcsMetadata")
             .withDisplayName("VCS metadata")
-            .withLockOptions(mode(FileLockManager.LockMode.OnDemand)) // Don't need to lock anything until we use the caches
+            .withLockOptions(mode(FileLockManager.LockMode.OnDemandExclusive)) // Don't need to lock anything until we use the caches
             .open();
         workingDirCache = cache.createIndexedCache("workingDirs", String.class, VALUE_SERIALIZER);
     }

--- a/platforms/software/version-control/src/main/java/org/gradle/vcs/internal/services/DefaultVersionControlRepositoryFactory.java
+++ b/platforms/software/version-control/src/main/java/org/gradle/vcs/internal/services/DefaultVersionControlRepositoryFactory.java
@@ -52,7 +52,7 @@ public class DefaultVersionControlRepositoryFactory implements VersionControlRep
     public DefaultVersionControlRepositoryFactory(BuildTreeScopedCacheBuilderFactory cacheBuilderFactory, CleanupActionDecorator cleanupActionDecorator) {
         this.vcsWorkingDirCache = cacheBuilderFactory
             .createCrossVersionCacheBuilder("vcs-1")
-            .withLockOptions(mode(FileLockManager.LockMode.OnDemand))
+            .withLockOptions(mode(FileLockManager.LockMode.OnDemandExclusive))
             .withDisplayName("VCS Checkout Cache")
             .withCleanupStrategy(createCacheCleanupStrategy(cleanupActionDecorator))
             .open();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/CrossBuildFileHashCache.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/CrossBuildFileHashCache.java
@@ -36,7 +36,7 @@ public class CrossBuildFileHashCache implements Closeable {
         this.inMemoryCacheDecoratorFactory = inMemoryCacheDecoratorFactory;
         cache = cacheBuilderFactory.createCacheBuilder(cacheKind.cacheId)
             .withDisplayName(cacheKind.description)
-            .withLockOptions(mode(FileLockManager.LockMode.OnDemand)) // Lock on demand
+            .withLockOptions(mode(FileLockManager.LockMode.OnDemandExclusive)) // Lock on demand
             .open();
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultExecutionHistoryCacheAccess.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultExecutionHistoryCacheAccess.java
@@ -31,7 +31,7 @@ public class DefaultExecutionHistoryCacheAccess implements ExecutionHistoryCache
         this.cache = cacheBuilderFactory
             .createCacheBuilder("executionHistory")
             .withDisplayName("execution history cache")
-            .withLockOptions(mode(FileLockManager.LockMode.OnDemand)) // Lock on demand
+            .withLockOptions(mode(FileLockManager.LockMode.OnDemandExclusive)) // Lock on demand
             .open();
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultFileAccessTimeJournal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultFileAccessTimeJournal.java
@@ -50,7 +50,7 @@ public class DefaultFileAccessTimeJournal implements FileAccessTimeJournal, Stop
             .createCrossVersionCacheBuilder(CACHE_KEY)
             .withCrossVersionCache(CacheBuilder.LockTarget.CacheDirectory)
             .withDisplayName("journal cache")
-            .withLockOptions(mode(FileLockManager.LockMode.OnDemand)) // lock on demand
+            .withLockOptions(mode(FileLockManager.LockMode.OnDemandExclusive)) // lock on demand
             .open();
         store = cache.createIndexedCache(IndexedCacheParameters.of(FILE_ACCESS_CACHE_NAME, FILE_SERIALIZER, LONG_SERIALIZER)
             .withCacheDecorator(cacheDecoratorFactory.decorator(10000, true)));

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultFileContentCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultFileContentCacheFactory.java
@@ -53,7 +53,7 @@ public class DefaultFileContentCacheFactory implements FileContentCacheFactory, 
         cache = cacheBuilderFactory
             .createCacheBuilder("fileContent")
             .withDisplayName("file content cache")
-            .withLockOptions(mode(FileLockManager.LockMode.OnDemand)) // Lock on demand
+            .withLockOptions(mode(FileLockManager.LockMode.OnDemandExclusive)) // Lock on demand
             .open();
     }
 

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultGeneratedGradleJarCache.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultGeneratedGradleJarCache.java
@@ -36,7 +36,7 @@ public class DefaultGeneratedGradleJarCache implements GeneratedGradleJarCache, 
     public DefaultGeneratedGradleJarCache(GlobalScopedCacheBuilderFactory cacheBuilderFactory, String gradleVersion) {
         this.cache = cacheBuilderFactory.createCacheBuilder(CACHE_KEY)
             .withDisplayName(CACHE_DISPLAY_NAME)
-            .withLockOptions(mode(FileLockManager.LockMode.OnDemand))
+            .withLockOptions(mode(FileLockManager.LockMode.OnDemandExclusive))
             .open();
         this.gradleVersion = gradleVersion;
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultClasspathTransformerCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultClasspathTransformerCacheFactory.java
@@ -64,7 +64,7 @@ public class DefaultClasspathTransformerCacheFactory implements ClasspathTransfo
             .createCrossVersionCacheBuilder(CACHE_KEY)
             .withDisplayName(CACHE_NAME)
             .withCrossVersionCache(CacheBuilder.LockTarget.DefaultTarget)
-            .withLockOptions(mode(FileLockManager.LockMode.OnDemand))
+            .withLockOptions(mode(FileLockManager.LockMode.OnDemandExclusive))
             .withCleanupStrategy(createCacheCleanupStrategy(fileAccessTimeJournal))
             .open();
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGradleServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGradleServices.java
@@ -105,7 +105,7 @@ public class ExecutionGradleServices {
             .createCrossVersionCacheBuilder("buildOutputCleanup")
             .withCrossVersionCache(CacheBuilder.LockTarget.DefaultTarget)
             .withDisplayName("Build Output Cleanup Cache")
-            .withLockOptions(mode(FileLockManager.LockMode.OnDemand))
+            .withLockOptions(mode(FileLockManager.LockMode.OnDemandExclusive))
             .withProperties(Collections.singletonMap("gradle.version", GradleVersion.current().getVersion()))
             .open();
         return new DefaultOutputFilesRepository(cacheAccess, inMemoryCacheDecoratorFactory);

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultPreviousExecutionCacheAccessTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultPreviousExecutionCacheAccessTest.groovy
@@ -36,7 +36,7 @@ class DefaultPreviousExecutionCacheAccessTest extends Specification {
         then:
         1 * cacheBuilderFactory.createCacheBuilder("executionHistory") >> cacheBuilder
         1 * cacheBuilder.withDisplayName(_) >> cacheBuilder
-        1 * cacheBuilder.withLockOptions(LockOptionsBuilder.mode(FileLockManager.LockMode.OnDemand)) >> cacheBuilder
+        1 * cacheBuilder.withLockOptions(LockOptionsBuilder.mode(FileLockManager.LockMode.OnDemandExclusive)) >> cacheBuilder
         1 * cacheBuilder.open() >> backingCache
         0 * _._
     }

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/DefaultGeneratedGradleJarCacheTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/DefaultGeneratedGradleJarCacheTest.groovy
@@ -48,7 +48,7 @@ class DefaultGeneratedGradleJarCacheTest extends Specification {
         then:
         1 * cacheBuilderFactory.createCacheBuilder(CACHE_KEY) >> cacheBuilder
         1 * cacheBuilder.withDisplayName(CACHE_DISPLAY_NAME) >> cacheBuilder
-        1 * cacheBuilder.withLockOptions(mode(FileLockManager.LockMode.OnDemand)) >> cacheBuilder
+        1 * cacheBuilder.withLockOptions(mode(FileLockManager.LockMode.OnDemandExclusive)) >> cacheBuilder
         1 * cacheBuilder.open() >> { cache }
         1 * cache.close()
     }
@@ -66,7 +66,7 @@ class DefaultGeneratedGradleJarCacheTest extends Specification {
         then:
         1 * cacheBuilderFactory.createCacheBuilder(CACHE_KEY) >> cacheBuilder
         1 * cacheBuilder.withDisplayName(CACHE_DISPLAY_NAME) >> cacheBuilder
-        1 * cacheBuilder.withLockOptions(mode(FileLockManager.LockMode.OnDemand)) >> cacheBuilder
+        1 * cacheBuilder.withLockOptions(mode(FileLockManager.LockMode.OnDemandExclusive)) >> cacheBuilder
         1 * cacheBuilder.open() >> { cache }
         _ * cache.getBaseDir() >> cacheDir
         1 * cache.useCache(_)
@@ -89,7 +89,7 @@ class DefaultGeneratedGradleJarCacheTest extends Specification {
         then:
         1 * cacheBuilderFactory.createCacheBuilder(CACHE_KEY) >> cacheBuilder
         1 * cacheBuilder.withDisplayName(CACHE_DISPLAY_NAME) >> cacheBuilder
-        1 * cacheBuilder.withLockOptions(mode(FileLockManager.LockMode.OnDemand)) >> cacheBuilder
+        1 * cacheBuilder.withLockOptions(mode(FileLockManager.LockMode.OnDemandExclusive)) >> cacheBuilder
         1 * cacheBuilder.open() >> { cache }
         _ * cache.getBaseDir() >> cacheDir
         1 * cache.useCache(_)
@@ -102,7 +102,7 @@ class DefaultGeneratedGradleJarCacheTest extends Specification {
         then:
         0 * cacheBuilderFactory.createCacheBuilder(CACHE_KEY) >> cacheBuilder
         0 * cacheBuilder.withDisplayName(CACHE_DISPLAY_NAME) >> cacheBuilder
-        0 * cacheBuilder.withLockOptions(mode(FileLockManager.LockMode.OnDemand)) >> cacheBuilder
+        0 * cacheBuilder.withLockOptions(mode(FileLockManager.LockMode.OnDemandExclusive)) >> cacheBuilder
         0 * cacheBuilder.open() >> { cache }
         _ * cache.getBaseDir() >> cacheDir
         1 * cache.useCache(_)

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/NativeDependencyCache.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/NativeDependencyCache.java
@@ -35,7 +35,7 @@ public class NativeDependencyCache implements Stoppable {
     private final PersistentCache cache;
 
     public NativeDependencyCache(GlobalScopedCacheBuilderFactory cacheBuilderFactory) {
-        cache = cacheBuilderFactory.createCacheBuilder("native-dep").withLockOptions(LockOptionsBuilder.mode(FileLockManager.LockMode.OnDemand)).open();
+        cache = cacheBuilderFactory.createCacheBuilder("native-dep").withLockOptions(LockOptionsBuilder.mode(FileLockManager.LockMode.OnDemandExclusive)).open();
     }
 
     public File getModuleMapFile(final ModuleMap moduleMap) {

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/DefaultCompilationStateCacheFactory.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/DefaultCompilationStateCacheFactory.java
@@ -40,7 +40,7 @@ public class DefaultCompilationStateCacheFactory implements CompilationStateCach
         cache = cacheBuilderFactory
                 .createCacheBuilder("nativeCompile")
                 .withDisplayName("native compile cache")
-                .withLockOptions(mode(FileLockManager.LockMode.OnDemand)) // Lock on demand
+                .withLockOptions(mode(FileLockManager.LockMode.OnDemandExclusive)) // Lock on demand
                 .open();
         IndexedCacheParameters<String, CompilationState> parameters = IndexedCacheParameters.of("nativeCompile", String.class, new CompilationStateSerializer())
             .withCacheDecorator(inMemoryCacheDecoratorFactory.decorator(2000, false));


### PR DESCRIPTION
Before that we supported only on demand exclusive cache.

Required part for https://github.com/gradle/gradle/pull/26660.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
