### PR TITLE
Add support for multiple features in one component

### DIFF
--- a/platforms/jvm/language-java/build.gradle.kts
+++ b/platforms/jvm/language-java/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     implementation(project(":build-events"))
     implementation(project(":tooling-api"))
     implementation(project(":toolchains-jvm"))
-    implementation(project(":testing-base"))
+    implementation(project(":test-suites-base"))
 
     implementation(libs.groovy)
     implementation(libs.slf4jApi)

--- a/platforms/jvm/language-java/build.gradle.kts
+++ b/platforms/jvm/language-java/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     implementation(project(":build-events"))
     implementation(project(":tooling-api"))
     implementation(project(":toolchains-jvm"))
+    implementation(project(":testing-base"))
 
     implementation(libs.groovy)
     implementation(libs.slf4jApi)

--- a/platforms/jvm/language-java/src/main/java/org/gradle/api/plugins/jvm/internal/JvmFeatureInternal.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/api/plugins/jvm/internal/JvmFeatureInternal.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.plugins.jvm.internal;
 
+import org.gradle.api.Named;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.capabilities.CapabilitiesMetadata;
 import org.gradle.api.tasks.SourceSet;
@@ -42,7 +43,7 @@ import javax.annotation.Nullable;
  * SingleTargetJvmFeature now and in the future implement a MultiTargetJvmFeature when we're ready.
  * This would allow us to use the JvmFeature interface as a common parent interface.</p>
  */
-public interface JvmFeatureInternal {
+public interface JvmFeatureInternal extends Named {
 
     /**
      * Get the capabilities of this feature. All variants exposed by this feature must provide at least

--- a/platforms/jvm/language-java/src/main/java/org/gradle/jvm/component/internal/JvmSoftwareComponentInternal.java
+++ b/platforms/jvm/language-java/src/main/java/org/gradle/jvm/component/internal/JvmSoftwareComponentInternal.java
@@ -16,15 +16,17 @@
 
 package org.gradle.jvm.component.internal;
 
+import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.component.SoftwareComponent;
 import org.gradle.api.plugins.jvm.internal.JvmFeatureInternal;
+import org.gradle.testing.base.TestSuite;
 
 /**
  * A {@link SoftwareComponent} which produces variants intended for use within the JVM ecosystem.
  *
  * <p>TODO: There is currently no public interface for this type of component, as the JVM component
  * infrastructure is still under construction. The main blocker for publicizing this component
- * is the lack of a proper variant API and support for dynamically adding Features to a component.</p>
+ * is the lack of a proper variant API and support for automatically aggregating variants of owned features.</p>
  *
  * <p>TODO: Before publicizing this component, we also need to consider how component extensibility works.
  * For example, for the java-library plugin we have the additional {@code api} and {@code compileOnlyApi}
@@ -42,6 +44,7 @@ public interface JvmSoftwareComponentInternal extends SoftwareComponent {
     // instance with the value changed, but these mutate the component. However, other names
     // like like "enableJavadocJar" or "addJavadocJar" are also not great since their names
     // are not declarative.
+
     /**
      * Configures this component to publish a javadoc jar alongside the primary artifacts. As a result,
      * this method also configures the necessary configurations and tasks required to produce
@@ -56,10 +59,23 @@ public interface JvmSoftwareComponentInternal extends SoftwareComponent {
      */
     void withSourcesJar();
 
-    // TODO: Future iterations of this component should support dynamically adding new features.
+    /**
+     * Get all features owned by this component.
+     */
+    NamedDomainObjectContainer<JvmFeatureInternal> getFeatures();
+
+    /**
+     * Get all test suites owned by this component.
+     *
+     * TODO: A test suite is a feature, so this method should eventually be removed and all
+     * suites should be accessed via {@link #getFeatures()}.
+     */
+    NamedDomainObjectContainer<TestSuite> getTestSuites();
 
     /**
      * Get the feature which encapsulates all logic and domain objects for building the production software product.
+     *
+     * <p>This is a legacy API. Plugins should support components with multiple features by calling {@link #getFeatures()}.</p>
      */
     JvmFeatureInternal getMainFeature();
 

--- a/platforms/jvm/plugins-java-base/src/integTest/groovy/org/gradle/api/plugins/jvm/internal/DefaultJvmFeatureTest.groovy
+++ b/platforms/jvm/plugins-java-base/src/integTest/groovy/org/gradle/api/plugins/jvm/internal/DefaultJvmFeatureTest.groovy
@@ -31,7 +31,7 @@ import org.gradle.test.fixtures.AbstractProjectBuilderSpec
  */
 class DefaultJvmFeatureTest extends AbstractProjectBuilderSpec {
 
-    def "can create a single feature"() {
+    def "can create a single main feature with a main source set"() {
         given:
         project.plugins.apply(JavaBasePlugin)
         def ext = project.getExtensions().getByType(JavaPluginExtension.class)
@@ -56,7 +56,7 @@ class DefaultJvmFeatureTest extends AbstractProjectBuilderSpec {
         project.tasks.getByName(JvmConstants.PROCESS_RESOURCES_TASK_NAME)
     }
 
-    def "can create a single feature with a non-main source set"() {
+    def "can create a single non-main feature with a non-main source set"() {
         given:
         project.plugins.apply(JavaBasePlugin)
         def ext = project.getExtensions().getByType(JavaPluginExtension.class)
@@ -121,7 +121,7 @@ class DefaultJvmFeatureTest extends AbstractProjectBuilderSpec {
         project.tasks.getByName(feature.sourceSet.sourcesJarTaskName)
     }
 
-    def "can create multiple features in a project"() {
+    def "can create multiple features in a project without adding them to a component"() {
         given:
         project.plugins.apply(JavaBasePlugin)
         def ext = project.getExtensions().getByType(JavaPluginExtension)
@@ -129,9 +129,23 @@ class DefaultJvmFeatureTest extends AbstractProjectBuilderSpec {
         SourceSet one = ext.getSourceSets().create("one")
         SourceSet two = ext.getSourceSets().create("two")
 
-        expect:
-        new DefaultJvmFeature("feature1", one, Collections.emptyList(), project, false, false)
-        new DefaultJvmFeature("feature2", two, Collections.emptyList(), project, false, false)
+        when:
+        // The constructor and `with` methods have side effects, like creating domain objects in project-scope containers
+        def f1 = new DefaultJvmFeature("feature1", one, Collections.emptyList(), project, false, false)
+        def f2 = new DefaultJvmFeature("feature2", two, Collections.emptyList(), project, false, false)
+
+        f1.withJavadocJar()
+        f1.withSourcesJar()
+        f1.withApi()
+        f1.withSourceElements()
+
+        f2.withJavadocJar()
+        f2.withSourcesJar()
+        f2.withApi()
+        f2.withSourceElements()
+
+        then:
+        noExceptionThrown()
     }
 
     private JvmFeatureInternal createFeature(String name, String sourceSetName = name) {

--- a/platforms/jvm/plugins-java-base/src/integTest/groovy/org/gradle/api/plugins/jvm/internal/DefaultJvmFeatureTest.groovy
+++ b/platforms/jvm/plugins-java-base/src/integTest/groovy/org/gradle/api/plugins/jvm/internal/DefaultJvmFeatureTest.groovy
@@ -16,13 +16,111 @@
 
 package org.gradle.api.plugins.jvm.internal
 
+import org.gradle.api.attributes.Bundling
+import org.gradle.api.attributes.Category
+import org.gradle.api.attributes.DocsType
+import org.gradle.api.attributes.Usage
+import org.gradle.api.internal.tasks.JvmConstants
 import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.tasks.SourceSet
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 
-// There aren't many tests for this class yet, but there will likely be more as we continue defining and refactoring the component/feature/target model
+/**
+ * Tests {@link DefaultJvmFeature}.
+ */
 class DefaultJvmFeatureTest extends AbstractProjectBuilderSpec {
+
+    def "can create a single feature"() {
+        given:
+        project.plugins.apply(JavaBasePlugin)
+        def ext = project.getExtensions().getByType(JavaPluginExtension.class)
+
+        when:
+        def feature = createFeature("main")
+
+        then:
+        feature.name == "main"
+        feature.sourceSet == ext.sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME)
+        feature.runtimeClasspathConfiguration == project.configurations.getByName(JvmConstants.RUNTIME_CLASSPATH_CONFIGURATION_NAME)
+        feature.compileClasspathConfiguration == project.configurations.getByName(JvmConstants.COMPILE_CLASSPATH_CONFIGURATION_NAME)
+        feature.runtimeElementsConfiguration == project.configurations.getByName(JvmConstants.RUNTIME_ELEMENTS_CONFIGURATION_NAME)
+        feature.apiElementsConfiguration == project.configurations.getByName(JvmConstants.API_ELEMENTS_CONFIGURATION_NAME)
+        feature.implementationConfiguration == project.configurations.getByName(JvmConstants.IMPLEMENTATION_CONFIGURATION_NAME)
+        feature.runtimeOnlyConfiguration == project.configurations.getByName(JvmConstants.RUNTIME_ONLY_CONFIGURATION_NAME)
+        feature.compileOnlyConfiguration == project.configurations.getByName(JvmConstants.COMPILE_ONLY_CONFIGURATION_NAME)
+        project.configurations.getByName(JvmConstants.ANNOTATION_PROCESSOR_CONFIGURATION_NAME)
+        feature.compileJavaTask.get() == project.tasks.getByName(JvmConstants.COMPILE_JAVA_TASK_NAME)
+        feature.jarTask.get() == project.tasks.getByName(JvmConstants.JAR_TASK_NAME)
+        project.tasks.getByName(JvmConstants.JAVADOC_TASK_NAME)
+        project.tasks.getByName(JvmConstants.PROCESS_RESOURCES_TASK_NAME)
+    }
+
+    def "can create a single feature with a non-main source set"() {
+        given:
+        project.plugins.apply(JavaBasePlugin)
+        def ext = project.getExtensions().getByType(JavaPluginExtension.class)
+
+        when:
+        def feature = createFeature("feature")
+
+        then:
+        feature.name == "feature"
+        feature.sourceSet == ext.sourceSets.getByName('feature')
+        feature.runtimeClasspathConfiguration == project.configurations.getByName('featureRuntimeClasspath')
+        feature.compileClasspathConfiguration == project.configurations.getByName('featureCompileClasspath')
+        feature.runtimeElementsConfiguration == project.configurations.getByName('featureRuntimeElements')
+        feature.apiElementsConfiguration == project.configurations.getByName('featureApiElements')
+        feature.implementationConfiguration == project.configurations.getByName('featureImplementation')
+        feature.runtimeOnlyConfiguration == project.configurations.getByName('featureRuntimeOnly')
+        feature.compileOnlyConfiguration == project.configurations.getByName('featureCompileOnly')
+        project.configurations.getByName('featureAnnotationProcessor')
+        feature.compileJavaTask.get() == project.tasks.getByName('compileFeatureJava')
+        feature.jarTask.get() == project.tasks.getByName('featureJar')
+        project.tasks.getByName('featureJavadoc')
+        project.tasks.getByName('processFeatureResources')
+    }
+
+    def "can configure javadoc jar variant"() {
+        given:
+        project.plugins.apply(JavaBasePlugin)
+
+        when:
+        def feature = createFeature("main")
+        feature.withJavadocJar()
+
+        then:
+        def configuration = project.configurations.getByName(JvmConstants.JAVADOC_ELEMENTS_CONFIGURATION_NAME)
+        !configuration.visible
+        !configuration.canBeResolved
+        configuration.canBeConsumed
+        (configuration.attributes.getAttribute(Usage.USAGE_ATTRIBUTE) as Usage).name == Usage.JAVA_RUNTIME
+        (configuration.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE) as Category).name == Category.DOCUMENTATION
+        (configuration.attributes.getAttribute(Bundling.BUNDLING_ATTRIBUTE) as Bundling).name == Bundling.EXTERNAL
+        (configuration.attributes.getAttribute(DocsType.DOCS_TYPE_ATTRIBUTE) as DocsType).name == DocsType.JAVADOC
+        project.tasks.getByName(feature.sourceSet.javadocJarTaskName)
+    }
+
+    def "can configure sources jar variant"() {
+        given:
+        project.plugins.apply(JavaBasePlugin)
+
+        when:
+        def feature = createFeature("main")
+        feature.withSourcesJar()
+
+        then:
+        def configuration = project.configurations.getByName(JvmConstants.SOURCES_ELEMENTS_CONFIGURATION_NAME)
+        !configuration.visible
+        !configuration.canBeResolved
+        configuration.canBeConsumed
+        (configuration.attributes.getAttribute(Usage.USAGE_ATTRIBUTE) as Usage).name == Usage.JAVA_RUNTIME
+        (configuration.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE) as Category).name == Category.DOCUMENTATION
+        (configuration.attributes.getAttribute(Bundling.BUNDLING_ATTRIBUTE) as Bundling).name == Bundling.EXTERNAL
+        (configuration.attributes.getAttribute(DocsType.DOCS_TYPE_ATTRIBUTE) as DocsType).name == DocsType.SOURCES
+        project.tasks.getByName(feature.sourceSet.sourcesJarTaskName)
+    }
+
     def "can create multiple features in a project"() {
         given:
         project.plugins.apply(JavaBasePlugin)
@@ -31,15 +129,20 @@ class DefaultJvmFeatureTest extends AbstractProjectBuilderSpec {
         SourceSet one = ext.getSourceSets().create("one")
         SourceSet two = ext.getSourceSets().create("two")
 
-        when:
+        expect:
         new DefaultJvmFeature("feature1", one, Collections.emptyList(), project, false, false)
         new DefaultJvmFeature("feature2", two, Collections.emptyList(), project, false, false)
+    }
 
-        then:
-        // TODO: There's no way to get the feature by name, so we'll check that some associated tasks and configurations are created
-        project.tasks.getByName(one.getJarTaskName())
-        project.tasks.getByName(two.getJarTaskName())
-        project.configurations.getByName('oneImplementation')
-        project.configurations.getByName('twoImplementation')
+    private JvmFeatureInternal createFeature(String name, String sourceSetName = name) {
+        SourceSet sourceSet = project.getExtensions().getByType(JavaPluginExtension).getSourceSets().create(sourceSetName)
+        return new DefaultJvmFeature(
+            name,
+            sourceSet,
+            Collections.emptyList(),
+            project,
+            false,
+            false
+        )
     }
 }

--- a/platforms/jvm/plugins-java-base/src/main/java/org/gradle/api/plugins/internal/DefaultJavaFeatureSpec.java
+++ b/platforms/jvm/plugins-java-base/src/main/java/org/gradle/api/plugins/internal/DefaultJavaFeatureSpec.java
@@ -15,20 +15,14 @@
  */
 package org.gradle.api.plugins.internal;
 
-import org.gradle.api.GradleException;
 import org.gradle.api.InvalidUserCodeException;
-import org.gradle.api.NamedDomainObjectSet;
-import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.capabilities.Capability;
-import org.gradle.api.component.AdhocComponentWithVariants;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.plugins.jvm.internal.DefaultJvmFeature;
 import org.gradle.api.plugins.jvm.internal.JvmFeatureInternal;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.internal.component.external.model.DefaultImmutableCapability;
 import org.gradle.internal.component.external.model.ProjectDerivedCapability;
-import org.gradle.jvm.component.internal.JvmSoftwareComponentInternal;
-import org.gradle.util.internal.CollectionUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -59,26 +53,6 @@ public class DefaultJavaFeatureSpec implements FeatureSpecInternal {
     }
 
     @Override
-    public void create() {
-        NamedDomainObjectSet<JvmSoftwareComponentInternal> jvmComponents = project.getComponents().withType(JvmSoftwareComponentInternal.class);
-        if (jvmComponents.size() > 1) {
-            String componentNames = CollectionUtils.join(", ", jvmComponents.getNames());
-            throw new GradleException("Cannot register feature '" + name + "' because multiple JVM components are present.  These components were found: " + componentNames + ".");
-        }
-
-        JvmFeatureInternal feature = createFeature();
-
-        // TODO: #23495 Investigate the implications of using this class without
-        //       the java plugin applied, and thus no java component present.
-        //       In the long run, all domain objects created by this feature should be
-        //       owned by a component. If we do not add them to the default java component,
-        //       we should be adding them to a user-provided or new component instead.
-        if (!jvmComponents.isEmpty()) {
-            addFeatureToComponent(feature, jvmComponents.iterator().next());
-        }
-    }
-
-    @Override
     public void withJavadocJar() {
         withJavadocJar = true;
     }
@@ -93,7 +67,13 @@ public class DefaultJavaFeatureSpec implements FeatureSpecInternal {
         allowPublication = false;
     }
 
-    private JvmFeatureInternal createFeature() {
+    @Override
+    public boolean isPublished() {
+        return allowPublication;
+    }
+
+    @Override
+    public JvmFeatureInternal create() {
         if (sourceSet == null) {
             throw new InvalidUserCodeException("You must specify which source set to use for feature '" + name + "'");
         }
@@ -105,28 +85,15 @@ public class DefaultJavaFeatureSpec implements FeatureSpecInternal {
         JvmFeatureInternal feature = new DefaultJvmFeature(name, sourceSet, capabilities, project, true, SourceSet.isMain(sourceSet));
         feature.withApi();
 
+        if (withJavadocJar) {
+            feature.withJavadocJar();
+        }
+
+        if (withSourcesJar) {
+            feature.withSourcesJar();
+        }
+
         return feature;
     }
 
-    private void addFeatureToComponent(JvmFeatureInternal feature, JvmSoftwareComponentInternal component) {
-
-        component.getFeatures().add(feature);
-
-        AdhocComponentWithVariants adhocComponent = (AdhocComponentWithVariants) component;
-        if (withJavadocJar) {
-            feature.withJavadocJar();
-            Configuration javadocElements = feature.getJavadocElementsConfiguration();
-            adhocComponent.addVariantsFromConfiguration(javadocElements, new JavaConfigurationVariantMapping("runtime", true));
-        }
-        if (withSourcesJar) {
-            feature.withSourcesJar();
-            Configuration sourcesElements = feature.getSourcesElementsConfiguration();
-            adhocComponent.addVariantsFromConfiguration(sourcesElements, new JavaConfigurationVariantMapping("runtime", true));
-        }
-
-        if (allowPublication) {
-            adhocComponent.addVariantsFromConfiguration(feature.getApiElementsConfiguration(), new JavaConfigurationVariantMapping("compile", true));
-            adhocComponent.addVariantsFromConfiguration(feature.getRuntimeElementsConfiguration(), new JavaConfigurationVariantMapping("runtime", true));
-        }
-    }
 }

--- a/platforms/jvm/plugins-java-base/src/main/java/org/gradle/api/plugins/internal/FeatureSpecInternal.java
+++ b/platforms/jvm/plugins-java-base/src/main/java/org/gradle/api/plugins/internal/FeatureSpecInternal.java
@@ -16,7 +16,9 @@
 package org.gradle.api.plugins.internal;
 
 import org.gradle.api.plugins.FeatureSpec;
+import org.gradle.api.plugins.jvm.internal.JvmFeatureInternal;
 
 public interface FeatureSpecInternal extends FeatureSpec {
-    void create();
+    boolean isPublished();
+    JvmFeatureInternal create();
 }

--- a/platforms/jvm/plugins-java-base/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmFeature.java
+++ b/platforms/jvm/plugins-java-base/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmFeature.java
@@ -378,6 +378,11 @@ public class DefaultJvmFeature implements JvmFeatureInternal {
     }
 
     @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
     public CapabilitiesMetadata getCapabilities() {
         return ImmutableCapabilities.of(capabilities);
     }

--- a/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/api/plugins/DefaultJvmSoftwareComponentTest.groovy
+++ b/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/api/plugins/DefaultJvmSoftwareComponentTest.groovy
@@ -16,195 +16,41 @@
 
 package org.gradle.api.plugins
 
-import org.gradle.api.attributes.Bundling
-import org.gradle.api.attributes.Category
-import org.gradle.api.attributes.DocsType
-import org.gradle.api.attributes.Usage
-import org.gradle.api.internal.tasks.JvmConstants
-import org.gradle.api.plugins.jvm.internal.DefaultJvmFeature
 import org.gradle.api.plugins.jvm.internal.JvmFeatureInternal
-import org.gradle.api.tasks.SourceSet
 import org.gradle.jvm.component.internal.DefaultJvmSoftwareComponent
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 
 /**
  * Tests {@link DefaultJvmSoftwareComponent}.
- *
- * TODO: This tests a lot of the functionality of the {@link DefaultJvmFeature}. We should probably
- *       move some of the testing to another feature-specific test class. However, given that the
- *       DefaultJvmFeature itself is probably going to change heavily when adding multi-target support,
- *       we should wait to avoid rework.
  */
 class DefaultJvmSoftwareComponentTest extends AbstractProjectBuilderSpec {
 
-    def "configures the project when using the main source set"() {
-        when:
-        project.plugins.apply(JavaBasePlugin)
-        def ext = project.getExtensions().getByType(JavaPluginExtension.class)
-
-        // Verify the JavaBasePlugin does not create the below tested objects so we can
-        // ensure the DefaultJvmSoftwareComponent is actually creating these domain objects.
-        then:
-        ext.sourceSets.findByName(SourceSet.MAIN_SOURCE_SET_NAME) == null
-        project.configurations.findByName(JvmConstants.RUNTIME_CLASSPATH_CONFIGURATION_NAME) == null
-        project.configurations.findByName(JvmConstants.COMPILE_CLASSPATH_CONFIGURATION_NAME) == null
-        project.configurations.findByName(JvmConstants.RUNTIME_ELEMENTS_CONFIGURATION_NAME) == null
-        project.configurations.findByName(JvmConstants.API_ELEMENTS_CONFIGURATION_NAME) == null
-        project.configurations.findByName(JvmConstants.IMPLEMENTATION_CONFIGURATION_NAME) == null
-        project.configurations.findByName(JvmConstants.RUNTIME_ONLY_CONFIGURATION_NAME) == null
-        project.configurations.findByName(JvmConstants.COMPILE_ONLY_CONFIGURATION_NAME) == null
-        project.configurations.findByName(JvmConstants.ANNOTATION_PROCESSOR_CONFIGURATION_NAME) == null
-        project.tasks.findByName(JvmConstants.COMPILE_JAVA_TASK_NAME) == null
-        project.tasks.findByName(JvmConstants.JAR_TASK_NAME) == null
-        project.tasks.findByName(JvmConstants.JAVADOC_TASK_NAME) == null
-        project.tasks.findByName(JvmConstants.PROCESS_RESOURCES_TASK_NAME) == null
-
-        when:
-        def component = project.objects.newInstance(DefaultJvmSoftwareComponent, "name", createFeature("main"), project.getExtensions())
-
-        then:
-        component.mainFeature instanceof DefaultJvmFeature
-        component.mainFeature.sourceSet == ext.sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME)
-        component.mainFeature.runtimeClasspathConfiguration == project.configurations.getByName(JvmConstants.RUNTIME_CLASSPATH_CONFIGURATION_NAME)
-        component.mainFeature.compileClasspathConfiguration == project.configurations.getByName(JvmConstants.COMPILE_CLASSPATH_CONFIGURATION_NAME)
-        component.mainFeature.runtimeElementsConfiguration == project.configurations.getByName(JvmConstants.RUNTIME_ELEMENTS_CONFIGURATION_NAME)
-        component.mainFeature.apiElementsConfiguration == project.configurations.getByName(JvmConstants.API_ELEMENTS_CONFIGURATION_NAME)
-        component.mainFeature.implementationConfiguration == project.configurations.getByName(JvmConstants.IMPLEMENTATION_CONFIGURATION_NAME)
-        component.mainFeature.runtimeOnlyConfiguration == project.configurations.getByName(JvmConstants.RUNTIME_ONLY_CONFIGURATION_NAME)
-        component.mainFeature.compileOnlyConfiguration == project.configurations.getByName(JvmConstants.COMPILE_ONLY_CONFIGURATION_NAME)
-        project.configurations.getByName(JvmConstants.ANNOTATION_PROCESSOR_CONFIGURATION_NAME)
-        component.mainFeature.compileJavaTask.get() == project.tasks.getByName(JvmConstants.COMPILE_JAVA_TASK_NAME)
-        component.mainFeature.jarTask.get() == project.tasks.getByName(JvmConstants.JAR_TASK_NAME)
-        project.tasks.getByName(JvmConstants.JAVADOC_TASK_NAME)
-        project.tasks.getByName(JvmConstants.PROCESS_RESOURCES_TASK_NAME)
-    }
-
-    def "configures the project when using the non-main source set"() {
-        when:
-        project.plugins.apply(JavaBasePlugin)
-        def ext = project.getExtensions().getByType(JavaPluginExtension.class)
-
-        // Verify the JavaBasePlugin does not create the below tested objects so we can
-        // ensure the DefaultJvmSoftwareComponent is actually creating these domain objects.
-        then:
-        ext.sourceSets.findByName("feature") == null
-        project.configurations.findByName('featureRuntimeClasspath') == null
-        project.configurations.findByName('featureCompileClasspath') == null
-        project.configurations.findByName('featureRuntimeElements') == null
-        project.configurations.findByName('featureApiElements') == null
-        project.configurations.findByName('featureSourceElements') == null
-        project.configurations.findByName('featureImplementation') == null
-        project.configurations.findByName('featureRuntimeOnly') == null
-        project.configurations.findByName('featureCompileOnly') == null
-        project.configurations.findByName('featureAnnotationProcessor') == null
-        project.tasks.findByName('compileFeatureJava') == null
-        project.tasks.findByName('featureJar') == null
-        project.tasks.findByName('featureJavadoc') == null
-        project.tasks.findByName('processFeatureResources') == null
-
-        when:
-        def component = project.objects.newInstance(DefaultJvmSoftwareComponent, "name", createFeature("feature"), project.getExtensions())
-
-        then:
-        component.mainFeature instanceof DefaultJvmFeature
-        component.mainFeature.sourceSet == ext.sourceSets.getByName('feature')
-        component.mainFeature.runtimeClasspathConfiguration == project.configurations.getByName('featureRuntimeClasspath')
-        component.mainFeature.compileClasspathConfiguration == project.configurations.getByName('featureCompileClasspath')
-        component.mainFeature.runtimeElementsConfiguration == project.configurations.getByName('featureRuntimeElements')
-        component.mainFeature.apiElementsConfiguration == project.configurations.getByName('featureApiElements')
-        component.mainFeature.implementationConfiguration == project.configurations.getByName('featureImplementation')
-        component.mainFeature.runtimeOnlyConfiguration == project.configurations.getByName('featureRuntimeOnly')
-        component.mainFeature.compileOnlyConfiguration == project.configurations.getByName('featureCompileOnly')
-        project.configurations.getByName('featureAnnotationProcessor')
-        component.mainFeature.compileJavaTask.get() == project.tasks.getByName('compileFeatureJava')
-        component.mainFeature.jarTask.get() == project.tasks.getByName('featureJar')
-        project.tasks.getByName('featureJavadoc')
-        project.tasks.getByName('processFeatureResources')
-    }
-
-    def "can create multiple component instances"() {
+    def "can create multiple component instances in a single project"() {
         given:
         project.plugins.apply(JavaBasePlugin)
-        def ext = project.getExtensions().getByType(JavaPluginExtension.class)
 
-        when:
-        project.objects.newInstance(DefaultJvmSoftwareComponent, "name", createFeature("main"), project.getExtensions())
-        project.objects.newInstance(DefaultJvmSoftwareComponent, "name", createFeature("feature1"), project.getExtensions())
-        project.objects.newInstance(DefaultJvmSoftwareComponent, "name", createFeature("feature2"), project.getExtensions())
-
-        then:
-        ext.sourceSets.getByName('main')
-        ext.sourceSets.getByName('feature1')
-        ext.sourceSets.getByName('feature2')
+        expect:
+        project.objects.newInstance(DefaultJvmSoftwareComponent, "name")
+        project.objects.newInstance(DefaultJvmSoftwareComponent, "name2")
+        project.objects.newInstance(DefaultJvmSoftwareComponent, "name3")
     }
 
-    def "can configure javadoc jar variant"() {
-        when:
+    def "can add multiple feature instances to the same component"() {
+        given:
         project.plugins.apply(JavaBasePlugin)
 
-        // Verify the JavaBasePlugin does not create the below tested objects so we can
-        // ensure the DefaultJvmSoftwareComponent is actually creating these domain objects.
-        then:
-        project.configurations.findByName(JvmConstants.JAVADOC_ELEMENTS_CONFIGURATION_NAME) == null
-        project.tasks.findByName("javadoc") == null
-
         when:
-        def component = project.objects.newInstance(DefaultJvmSoftwareComponent, "name", createFeature("main"), project.getExtensions())
-        component.withJavadocJar()
+        def component = project.objects.newInstance(DefaultJvmSoftwareComponent, "name")
 
         then:
-        def configuration = project.configurations.getByName(JvmConstants.JAVADOC_ELEMENTS_CONFIGURATION_NAME)
-        configuration != null
-        !configuration.visible
-        !configuration.canBeResolved
-        configuration.canBeConsumed
-        (configuration.attributes.getAttribute(Usage.USAGE_ATTRIBUTE) as Usage).name == Usage.JAVA_RUNTIME
-        (configuration.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE) as Category).name == Category.DOCUMENTATION
-        (configuration.attributes.getAttribute(Bundling.BUNDLING_ATTRIBUTE) as Bundling).name == Bundling.EXTERNAL
-        (configuration.attributes.getAttribute(DocsType.DOCS_TYPE_ATTRIBUTE) as DocsType).name == DocsType.JAVADOC
-        project.tasks.getByName(component.mainFeature.sourceSet.javadocJarTaskName)
-        component.usages.find { it.name == JvmConstants.JAVADOC_ELEMENTS_CONFIGURATION_NAME}
+        component.features.add(createFeature("main"))
+        component.features.add(createFeature("foo"))
+        component.features.add(createFeature("bar"))
     }
 
-    def "can configure sources jar variant"() {
-        when:
-        project.plugins.apply(JavaBasePlugin)
-
-        // Verify the JavaBasePlugin does not create the below tested objects so we can
-        // ensure the DefaultJvmSoftwareComponent is actually creating these domain objects.
-        then:
-        project.configurations.findByName(JvmConstants.SOURCES_ELEMENTS_CONFIGURATION_NAME) == null
-        project.tasks.findByName("sources") == null
-
-        when:
-        def component = project.objects.newInstance(DefaultJvmSoftwareComponent, "name", createFeature("main"), project.getExtensions())
-        component.withSourcesJar()
-
-        then:
-        def configuration = project.configurations.getByName(JvmConstants.SOURCES_ELEMENTS_CONFIGURATION_NAME)
-        configuration != null
-        !configuration.visible
-        !configuration.canBeResolved
-        configuration.canBeConsumed
-        (configuration.attributes.getAttribute(Usage.USAGE_ATTRIBUTE) as Usage).name == Usage.JAVA_RUNTIME
-        (configuration.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE) as Category).name == Category.DOCUMENTATION
-        (configuration.attributes.getAttribute(Bundling.BUNDLING_ATTRIBUTE) as Bundling).name == Bundling.EXTERNAL
-        (configuration.attributes.getAttribute(DocsType.DOCS_TYPE_ATTRIBUTE) as DocsType).name == DocsType.SOURCES
-        project.tasks.getByName(component.mainFeature.sourceSet.sourcesJarTaskName)
-        component.usages.find { it.name == JvmConstants.SOURCES_ELEMENTS_CONFIGURATION_NAME}
-    }
-
-    def "has expected variants"() {
-        when:
-        project.plugins.apply(JavaBasePlugin)
-        def ext = project.getExtensions().getByType(JavaPluginExtension.class)
-        def component = project.objects.newInstance(DefaultJvmSoftwareComponent, "name", createFeature("main"), project.getExtensions())
-
-        then:
-        component.usages*.name == ["apiElements", "runtimeElements"]
-    }
-
-    private JvmFeatureInternal createFeature(String name, String sourceSetName = name) {
-        return new DefaultJvmFeature(name, project.getExtensions().getByType(JavaPluginExtension).getSourceSets().create(sourceSetName), Collections.emptyList(), project, false, false)
+    def createFeature(String name) {
+        Mock(JvmFeatureInternal) {
+            getName() >> name
+        }
     }
 }

--- a/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/api/plugins/DefaultJvmSoftwareComponentTest.groovy
+++ b/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/api/plugins/DefaultJvmSoftwareComponentTest.groovy
@@ -39,13 +39,19 @@ class DefaultJvmSoftwareComponentTest extends AbstractProjectBuilderSpec {
         given:
         project.plugins.apply(JavaBasePlugin)
 
+        def f1 = createFeature("main")
+        def f2 = createFeature("foo")
+        def f3 = createFeature("bar")
+
         when:
         def component = project.objects.newInstance(DefaultJvmSoftwareComponent, "name")
 
+        component.features.add(f1)
+        component.features.add(f2)
+        component.features.add(f3)
+
         then:
-        component.features.add(createFeature("main"))
-        component.features.add(createFeature("foo"))
-        component.features.add(createFeature("bar"))
+        component.features.containsAll([f1, f2, f3])
     }
 
     def createFeature(String name) {

--- a/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/api/plugins/JavaPluginIntegrationTest.groovy
+++ b/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/api/plugins/JavaPluginIntegrationTest.groovy
@@ -609,19 +609,24 @@ Artifacts
 
             sourceSets {
                 foo
+                bar
             }
 
             java {
                 registerFeature("foo") {
                     usingSourceSet(sourceSets.foo)
                 }
+                registerFeature("bar") {
+                    usingSourceSet(sourceSets.bar)
+                }
             }
 
             task verify {
                 components.java.features {
-                    assert size() == 2
+                    assert size() == 3
                     assert main.sourceSet == sourceSets.main
                     assert foo.sourceSet == sourceSets.foo
+                    assert bar.sourceSet == sourceSets.bar
                 }
             }
         """

--- a/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/api/plugins/JavaPluginIntegrationTest.groovy
+++ b/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/api/plugins/JavaPluginIntegrationTest.groovy
@@ -599,4 +599,34 @@ Artifacts
 
         succeeds("help")
     }
+
+    def "registerFeature features are added to java component"() {
+        given:
+        buildFile << """
+            plugins {
+                id("java-library")
+            }
+
+            sourceSets {
+                foo
+            }
+
+            java {
+                registerFeature("foo") {
+                    usingSourceSet(sourceSets.foo)
+                }
+            }
+
+            task verify {
+                components.java.features {
+                    assert size() == 2
+                    assert main.sourceSet == sourceSets.main
+                    assert foo.sourceSet == sourceSets.foo
+                }
+            }
+        """
+
+        expect:
+        succeeds("verify")
+    }
 }

--- a/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/jvm/component/internal/DefaultJvmSoftwareComponentIntegrationTest.groovy
+++ b/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/jvm/component/internal/DefaultJvmSoftwareComponentIntegrationTest.groovy
@@ -22,6 +22,93 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
  * Tests {@link DefaultJvmSoftwareComponent}.
  */
 class DefaultJvmSoftwareComponentIntegrationTest extends AbstractIntegrationSpec {
+
+    def "can instantiate component instances in Groovy DSL"() {
+        given:
+        buildFile << """
+            ${factoryRegistrationGroovy()}
+
+            components {
+                thing(JvmSoftwareComponentInternal)
+                feature(JvmSoftwareComponentInternal)
+            }
+
+            task verify {
+                assert components.thing instanceof DefaultJvmSoftwareComponent
+                assert components.feature instanceof DefaultJvmSoftwareComponent
+            }
+        """
+
+        expect:
+        succeeds "verify"
+    }
+
+    def "can instantiate component instances in Kotlin DSL"() {
+        given:
+        buildKotlinFile << """
+            ${factoryRegistrationKotlin()}
+
+            components {
+                create<JvmSoftwareComponentInternal>("thing")
+                create<JvmSoftwareComponentInternal>("feature")
+            }
+
+            tasks.register("verify") {
+                assert(components.named("thing").get() is DefaultJvmSoftwareComponent)
+                assert(components.named("feature").get() is DefaultJvmSoftwareComponent)
+            }
+        """
+
+        expect:
+        succeeds "verify"
+    }
+
+    def "can instantiate component instances adjacent to java component with java-library plugin applied in Groovy DSL"() {
+        given:
+        buildFile << """
+            plugins {
+                id('java-library')
+            }
+
+            ${factoryRegistrationGroovy()}
+
+            components {
+                comp(JvmSoftwareComponentInternal)
+            }
+
+            task verify {
+                assert components.java instanceof DefaultJvmSoftwareComponent
+                assert components.comp instanceof DefaultJvmSoftwareComponent
+            }
+        """
+
+        expect:
+        succeeds "verify"
+    }
+
+    def "can instantiate component instances adjacent to java component with java-library plugin applied in Kotlin DSL"() {
+        given:
+        buildKotlinFile << """
+            plugins {
+                id("java-library")
+            }
+
+            ${factoryRegistrationKotlin()}
+
+            components {
+                create<JvmSoftwareComponentInternal>("comp")
+            }
+
+            tasks.register("verify") {
+                assert(components.named("java").get() is DefaultJvmSoftwareComponent)
+                assert(components.named("comp").get() is DefaultJvmSoftwareComponent)
+            }
+        """
+
+        expect:
+        succeeds "verify"
+    }
+
     def "can configure java component added by java-library plugin in Groovy DSL"() {
         given:
         buildFile << """
@@ -74,6 +161,56 @@ class DefaultJvmSoftwareComponentIntegrationTest extends AbstractIntegrationSpec
 
         expect:
         succeeds "verify"
+    }
+
+    def "can not registerFeature with multiple component instances"() {
+        given:
+        buildKotlinFile << """
+            plugins {
+                id("java-base")
+            }
+
+            ${factoryRegistrationKotlin()}
+
+            sourceSets {
+                val custom by registering
+            }
+
+            components {
+                create<JvmSoftwareComponentInternal>("module")
+                create<JvmSoftwareComponentInternal>("thing")
+            }
+
+            java {
+                registerFeature("myFeature") {
+                    usingSourceSet(sourceSets["custom"])
+                }
+            }
+        """
+
+        expect:
+        fails "tasks"
+        result.assertHasErrorOutput("Cannot register feature 'myFeature' because multiple JVM components are present.  These components were found: module, thing.")
+    }
+
+    private static final String factoryRegistrationGroovy() {
+        """
+            ${importStatements()}
+
+            components {
+                registerBinding(JvmSoftwareComponentInternal, DefaultJvmSoftwareComponent)
+            }
+        """
+    }
+
+    private static final String factoryRegistrationKotlin() {
+        """
+            ${importStatements()}
+
+            components {
+                registerBinding(JvmSoftwareComponentInternal::class.java, DefaultJvmSoftwareComponent::class.java)
+            }
+        """
     }
 
     /**

--- a/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/jvm/component/internal/DefaultJvmSoftwareComponentIntegrationTest.groovy
+++ b/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/jvm/component/internal/DefaultJvmSoftwareComponentIntegrationTest.groovy
@@ -30,12 +30,12 @@ class DefaultJvmSoftwareComponentIntegrationTest extends AbstractIntegrationSpec
 
             components {
                 thing(JvmSoftwareComponentInternal)
-                feature(JvmSoftwareComponentInternal)
+                comp(JvmSoftwareComponentInternal)
             }
 
             task verify {
                 assert components.thing instanceof DefaultJvmSoftwareComponent
-                assert components.feature instanceof DefaultJvmSoftwareComponent
+                assert components.comp instanceof DefaultJvmSoftwareComponent
             }
         """
 
@@ -50,12 +50,12 @@ class DefaultJvmSoftwareComponentIntegrationTest extends AbstractIntegrationSpec
 
             components {
                 create<JvmSoftwareComponentInternal>("thing")
-                create<JvmSoftwareComponentInternal>("feature")
+                create<JvmSoftwareComponentInternal>("comp")
             }
 
             tasks.register("verify") {
                 assert(components.named("thing").get() is DefaultJvmSoftwareComponent)
-                assert(components.named("feature").get() is DefaultJvmSoftwareComponent)
+                assert(components.named("comp").get() is DefaultJvmSoftwareComponent)
             }
         """
 
@@ -189,8 +189,8 @@ class DefaultJvmSoftwareComponentIntegrationTest extends AbstractIntegrationSpec
         """
 
         expect:
-        fails "tasks"
-        result.assertHasErrorOutput("Cannot register feature 'myFeature' because multiple JVM components are present.  These components were found: module, thing.")
+        fails("tasks")
+        failure.assertHasErrorOutput("Cannot register feature because multiple JVM components are present. The following components were found: module, thing")
     }
 
     private static final String factoryRegistrationGroovy() {

--- a/platforms/jvm/plugins-java/src/main/java/org/gradle/jvm/component/internal/DefaultJvmSoftwareComponent.java
+++ b/platforms/jvm/plugins-java/src/main/java/org/gradle/jvm/component/internal/DefaultJvmSoftwareComponent.java
@@ -57,26 +57,26 @@ public abstract class DefaultJvmSoftwareComponent extends DefaultAdhocSoftwareCo
 
     @Override
     public void withJavadocJar() {
-        getFeatures().configureEach(feature -> {
-            feature.withJavadocJar();
+        JvmFeatureInternal feature = getMainFeature();
 
-            Configuration javadocElements = feature.getJavadocElementsConfiguration();
-            if (!isRegisteredAsLegacyVariant(javadocElements)) {
-                addVariantsFromConfiguration(javadocElements, new JavaConfigurationVariantMapping("runtime", true));
-            }
-        });
+        feature.withJavadocJar();
+
+        Configuration javadocElements = feature.getJavadocElementsConfiguration();
+        if (!isRegisteredAsLegacyVariant(javadocElements)) {
+            addVariantsFromConfiguration(javadocElements, new JavaConfigurationVariantMapping("runtime", true));
+        }
     }
 
     @Override
     public void withSourcesJar() {
-        getFeatures().configureEach(feature -> {
-            feature.withSourcesJar();
+        JvmFeatureInternal feature = getMainFeature();
 
-            Configuration sourcesElements = feature.getSourcesElementsConfiguration();
-            if (!isRegisteredAsLegacyVariant(sourcesElements)) {
-                addVariantsFromConfiguration(sourcesElements, new JavaConfigurationVariantMapping("runtime", true));
-            }
-        });
+        feature.withSourcesJar();
+
+        Configuration sourcesElements = feature.getSourcesElementsConfiguration();
+        if (!isRegisteredAsLegacyVariant(sourcesElements)) {
+            addVariantsFromConfiguration(sourcesElements, new JavaConfigurationVariantMapping("runtime", true));
+        }
     }
 
     @Override

--- a/platforms/jvm/plugins-java/src/main/java/org/gradle/jvm/component/internal/DefaultJvmSoftwareComponent.java
+++ b/platforms/jvm/plugins-java/src/main/java/org/gradle/jvm/component/internal/DefaultJvmSoftwareComponent.java
@@ -16,59 +16,38 @@
 
 package org.gradle.jvm.component.internal;
 
-import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.artifacts.configurations.RoleBasedConfigurationContainerInternal;
 import org.gradle.api.internal.tasks.JvmConstants;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.BasePlugin;
-import org.gradle.api.plugins.ExtensionContainer;
-import org.gradle.api.plugins.JavaBasePlugin;
-import org.gradle.api.plugins.JvmTestSuitePlugin;
 import org.gradle.api.plugins.internal.JavaConfigurationVariantMapping;
 import org.gradle.api.plugins.jvm.JvmTestSuite;
 import org.gradle.api.plugins.jvm.internal.JvmFeatureInternal;
-import org.gradle.api.plugins.jvm.internal.JvmPluginServices;
-import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.publish.internal.component.DefaultAdhocSoftwareComponent;
-import org.gradle.api.tasks.SourceSet;
-import org.gradle.api.tasks.TaskContainer;
-import org.gradle.testing.base.TestingExtension;
 
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 
 /**
- * The software component created by the Java plugin. This component owns the main {@link JvmFeatureInternal} which itself
- * is responsible for compiling and packaging the main production jar. Therefore, this component transitively owns the
- * corresponding source set and any domain objects which are created by the {@link BasePlugin} on the source set's behalf.
- * This includes the source set's resolvable configurations and dependency scopes, as well as any associated tasks.
+ * A component with a set of features. Each feature is responsible for compiling, executing, packaging, etc a software
+ * product such as a library or application. This component owns all features it contains and therefore transitively owns their
+ * corresponding source sets and any domain objects which are created by the {@link BasePlugin} on the source sets' behalf.
+ * This includes their resolvable configurations and dependency scopes, as well as any associated tasks.
+ *
+ * TODO: We should strip almost all logic from this class. It should be a simple container for features and should provide
+ * a means of querying all variants of all features.
  */
-public class DefaultJvmSoftwareComponent extends DefaultAdhocSoftwareComponent implements JvmSoftwareComponentInternal {
+public abstract class DefaultJvmSoftwareComponent extends DefaultAdhocSoftwareComponent implements JvmSoftwareComponentInternal {
     private final RoleBasedConfigurationContainerInternal configurations;
-
-    private final JvmFeatureInternal mainFeature;
-    @Nullable private final JvmTestSuite testSuite;
 
     @Inject
     public DefaultJvmSoftwareComponent(
         String componentName,
-        JvmFeatureInternal mainFeature,
         ObjectFactory objectFactory,
-        ProviderFactory providerFactory,
-        RoleBasedConfigurationContainerInternal configurations,
-        TaskContainer tasks,
-        ExtensionContainer extensions,
-        JvmPluginServices jvmPluginServices
+        RoleBasedConfigurationContainerInternal configurations
     ) {
         super(componentName, objectFactory);
-
-        this.mainFeature = mainFeature;
         this.configurations = configurations;
-        this.testSuite = configureBuiltInTest(configurations, tasks, extensions, objectFactory);
-
-        configureFeature(mainFeature, providerFactory, jvmPluginServices);
     }
 
     // TODO: The component itself should not be concerned with configuring the sources and javadoc jars
@@ -78,100 +57,51 @@ public class DefaultJvmSoftwareComponent extends DefaultAdhocSoftwareComponent i
 
     @Override
     public void withJavadocJar() {
-        mainFeature.withJavadocJar();
+        getFeatures().configureEach(feature -> {
+            feature.withJavadocJar();
 
-        Configuration javadocElements = mainFeature.getJavadocElementsConfiguration();
-        if (!isRegisteredAsLegacyVariant(javadocElements)) {
-            addVariantsFromConfiguration(javadocElements, new JavaConfigurationVariantMapping("runtime", true));
-        }
+            Configuration javadocElements = feature.getJavadocElementsConfiguration();
+            if (!isRegisteredAsLegacyVariant(javadocElements)) {
+                addVariantsFromConfiguration(javadocElements, new JavaConfigurationVariantMapping("runtime", true));
+            }
+        });
     }
 
     @Override
     public void withSourcesJar() {
-        mainFeature.withSourcesJar();
+        getFeatures().configureEach(feature -> {
+            feature.withSourcesJar();
 
-        Configuration sourcesElements = mainFeature.getSourcesElementsConfiguration();
-        if (!isRegisteredAsLegacyVariant(sourcesElements)) {
-            addVariantsFromConfiguration(sourcesElements, new JavaConfigurationVariantMapping("runtime", true));
-        }
+            Configuration sourcesElements = feature.getSourcesElementsConfiguration();
+            if (!isRegisteredAsLegacyVariant(sourcesElements)) {
+                addVariantsFromConfiguration(sourcesElements, new JavaConfigurationVariantMapping("runtime", true));
+            }
+        });
     }
 
     @Override
     public JvmFeatureInternal getMainFeature() {
+        JvmFeatureInternal mainFeature = getFeatures().findByName(JvmConstants.JAVA_MAIN_FEATURE_NAME);
+        if (mainFeature == null) {
+            throw new IllegalStateException("Expected to find a feature named '" + JvmConstants.JAVA_MAIN_FEATURE_NAME + "' but found none.");
+        }
+
         return mainFeature;
-    }
-
-    // Eventually, we'll want to expand this and maybe make it public to support dynamically adding new features,
-    // for now, this just isolates what is done to configure the main feature
-    private void configureFeature(JvmFeatureInternal feature,
-                                  ProviderFactory providerFactory,
-                                  JvmPluginServices jvmPluginServices) {
-        // Register the consumable configurations as providing variants for consumption.
-        addVariantsFromConfiguration(feature.getApiElementsConfiguration(), new JavaConfigurationVariantMapping("compile", false));
-        addVariantsFromConfiguration(feature.getRuntimeElementsConfiguration(), new JavaConfigurationVariantMapping("runtime", false));
-    }
-
-    @Nullable
-    public JvmTestSuite getTestSuite() {
-        return testSuite;
     }
 
     @Override
     public void useCompileClasspathConsistency() {
-        if (testSuite != null) {
+        getTestSuites().withType(JvmTestSuite.class).configureEach(testSuite -> {
             configurations.getByName(testSuite.getSources().getCompileClasspathConfigurationName())
-                .shouldResolveConsistentlyWith(mainFeature.getCompileClasspathConfiguration());
-        }
+                .shouldResolveConsistentlyWith(getMainFeature().getCompileClasspathConfiguration());
+        });
     }
 
     @Override
     public void useRuntimeClasspathConsistency() {
-        if (testSuite != null) {
+        getTestSuites().withType(JvmTestSuite.class).configureEach(testSuite -> {
             configurations.getByName(testSuite.getSources().getRuntimeClasspathConfigurationName())
-                .shouldResolveConsistentlyWith(mainFeature.getRuntimeClasspathConfiguration());
-        }
-    }
-
-    private JvmTestSuite configureBuiltInTest(RoleBasedConfigurationContainerInternal configurations,
-                                              TaskContainer tasks,
-                                              ExtensionContainer extensions,
-                                              ObjectFactory objectFactory) {
-        /*
-         * At some point we may want to create a test suite per component, but for now we only want to create one for the `java`
-         * component, in case multiple DefaultJvmSoftwareComponents are created.
-         */
-        TestingExtension testing = extensions.findByType(TestingExtension.class);
-        if (null != testing && JvmConstants.JAVA_MAIN_COMPONENT_NAME.equals(getName())) {
-            final NamedDomainObjectProvider<JvmTestSuite> testSuite = testing.getSuites().register(JvmTestSuitePlugin.DEFAULT_TEST_SUITE_NAME, JvmTestSuite.class, suite -> {
-                final SourceSet testSourceSet = suite.getSources();
-
-                Configuration testImplementationConfiguration = configurations.getByName(testSourceSet.getImplementationConfigurationName());
-                Configuration testRuntimeOnlyConfiguration = configurations.getByName(testSourceSet.getRuntimeOnlyConfigurationName());
-                Configuration testCompileClasspathConfiguration = configurations.getByName(testSourceSet.getCompileClasspathConfigurationName());
-                Configuration testRuntimeClasspathConfiguration = configurations.getByName(testSourceSet.getRuntimeClasspathConfigurationName());
-
-                // We cannot reference the main source set lazily (via a callable) since the IntelliJ model builder
-                // relies on the main source set being created before the tests. So, this code here cannot live in the
-                // JvmTestSuitePlugin and must live here, so that we can ensure we register this test suite after we've
-                // created the main source set.
-                final SourceSet mainSourceSet = getMainFeature().getSourceSet();
-                final FileCollection mainSourceSetOutput = mainSourceSet.getOutput();
-                final FileCollection testSourceSetOutput = testSourceSet.getOutput();
-                testSourceSet.setCompileClasspath(objectFactory.fileCollection().from(mainSourceSetOutput, testCompileClasspathConfiguration));
-                testSourceSet.setRuntimeClasspath(objectFactory.fileCollection().from(testSourceSetOutput, mainSourceSetOutput, testRuntimeClasspathConfiguration));
-
-                testImplementationConfiguration.extendsFrom(configurations.getByName(mainSourceSet.getImplementationConfigurationName()));
-                testRuntimeOnlyConfiguration.extendsFrom(configurations.getByName(mainSourceSet.getRuntimeOnlyConfigurationName()));
-            });
-
-            // Force the realization of this test suite, targets and task
-            JvmTestSuite suite = testSuite.get();
-
-            tasks.named(JavaBasePlugin.CHECK_TASK_NAME, task -> task.dependsOn(testSuite));
-
-            return suite;
-        } else {
-            return null;
-        }
+                .shouldResolveConsistentlyWith(getMainFeature().getRuntimeClasspathConfiguration());
+        });
     }
 }

--- a/platforms/jvm/plugins-jvm-test-fixtures/src/main/java/org/gradle/api/plugins/JavaTestFixturesPlugin.java
+++ b/platforms/jvm/plugins-jvm-test-fixtures/src/main/java/org/gradle/api/plugins/JavaTestFixturesPlugin.java
@@ -75,6 +75,8 @@ public abstract class JavaTestFixturesPlugin implements Plugin<Project> {
 
         project.getPluginManager().withPlugin("java", plugin -> {
             DefaultJvmSoftwareComponent component = (DefaultJvmSoftwareComponent) JavaPluginHelper.getJavaComponent(project);
+            component.getFeatures().add(feature);
+
             component.addVariantsFromConfiguration(feature.getApiElementsConfiguration(), new JavaConfigurationVariantMapping("compile", true));
             component.addVariantsFromConfiguration(feature.getRuntimeElementsConfiguration(), new JavaConfigurationVariantMapping("runtime", true));
 

--- a/platforms/jvm/plugins-jvm-test-fixtures/src/testFixtures/groovy/org/gradle/java/fixtures/AbstractJavaProjectTestFixturesIntegrationTest.groovy
+++ b/platforms/jvm/plugins-jvm-test-fixtures/src/testFixtures/groovy/org/gradle/java/fixtures/AbstractJavaProjectTestFixturesIntegrationTest.groovy
@@ -438,4 +438,22 @@ hamcrest-core-1.3.jar
             }
         }
     }
+
+    def "test fixtures feature is added to java component"() {
+        given:
+        buildFile << """
+            apply plugin: 'java-test-fixtures'
+
+            task verify {
+                components.java.features {
+                    assert size() == 2
+                    assert main.sourceSet == sourceSets.main
+                    assert testFixtures.sourceSet == sourceSets.testFixtures
+                }
+            }
+        """
+
+        expect:
+        succeeds("verify")
+    }
 }


### PR DESCRIPTION
Allow Jvm components to track multiple features and test suites. Test suites should eventually become features so these can be tracked together.

This allows us to pull logic for creating the main feature and default test suite outside of the default jvm component. This moves the component more towards a data-only model, leaving the actual configuration to the java plugin.

Additionally, we update registerFeature and the test fixtures plugin to register their features with the component. Previously, these features were detached from the component, however now the component owns these features as it should

Significant clean-up to DefaultJvmSoftwareComponentTest -- all feature-specific functionality is now tested in DefaultJvmFeatureTest Restore many tests in DefaultJvmSoftwareComponentIntegrationTest which were previously removed. These can be added back now that the constructor does not require a feature instance.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
