### PR TITLE
Copy gr8 processed `gradle-wrapper.jar` back to `wrapper/build/libs`

### DIFF
--- a/platforms/core-runtime/wrapper/build.gradle.kts
+++ b/platforms/core-runtime/wrapper/build.gradle.kts
@@ -72,6 +72,16 @@ tasks.named<EmbeddedJarTask>("gr8EmbeddedJar") {
     dependsOn(executableJar)
 }
 
+// https://github.com/gradle/gradle/issues/26658
+// Before introducing gr8, wrapper jar is generated as build/libs/gradle-wrapper.jar and used in promotion build
+// After introducing gr8, wrapper jar is generated as build/libs/gradle-wrapper-executable.jar and processed
+//   by gr8, then the processed `gradle-wrapper.jar` need to be copied back to build/libs for promotion build
+val copyGr8OutputJarAsGradleWrapperJar by tasks.registering(Copy::class) {
+    from(tasks.named<Gr8Task>("gr8R8Jar").flatMap { it.outputJar() })
+    into(layout.buildDirectory.dir("libs"))
+}
+
 tasks.jar {
     from(tasks.named<Gr8Task>("gr8R8Jar").flatMap { it.outputJar() })
+    dependsOn(copyGr8OutputJarAsGradleWrapperJar)
 }


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/26658

Before introducing gr8, wrapper jar is generated as `build/libs/gradle-wrapper.jar` and used in promotion build. After introducing gr8, wrapper jar is generated as `build/libs/gradle-wrapper-executable.jar` and processed by gr8, then the processed `gradle-wrapper.jar` need to be copied `back to build/libs` for promotion build
