### PR TITLE
Hide unhelpful import sections from "Implementing Gradle plugins" snippets

### DIFF
--- a/subprojects/docs/src/docs/userguide/developing-plugins/implementing_gradle_plugins.adoc
+++ b/subprojects/docs/src/docs/userguide/developing-plugins/implementing_gradle_plugins.adoc
@@ -56,7 +56,7 @@ The custom task is provided by a plugin that takes care of communicating via HTT
 .LatestArtifactVersion.java
 [source,java]
 ----
-include::{snippetsPath}/developingPlugins/customTask/groovy/buildSrc/src/main/java/org/myorg/LatestArtifactVersion.java[]
+include::{snippetsPath}/developingPlugins/customTask/groovy/buildSrc/src/main/java/org/myorg/LatestArtifactVersion.java[tags=snippet]
 ----
 
 The end user of the task can now easily create multiple tasks of that type with different configuration.
@@ -86,7 +86,7 @@ The text written to those files is provided by a String property.
 .Generate.java
 [source,java]
 ----
-include::{snippetsPath}/developingPlugins/incrementalTask/groovy/buildSrc/src/main/java/Generate.java[]
+include::{snippetsPath}/developingPlugins/incrementalTask/groovy/buildSrc/src/main/java/Generate.java[tags=snippet]
 ----
 
 The first section of this guide talks about the <<plugin-development-plugin,Plugin Development plugin>>.
@@ -119,7 +119,7 @@ First of all, you'll need to introduce a new data object for managing the proper
 .CustomData.java
 [source,java]
 ----
-include::{snippetsPath}/developingPlugins/pluginExtension/groovy/buildSrc/src/main/java/org/myorg/CustomData.java[]
+include::{snippetsPath}/developingPlugins/pluginExtension/groovy/buildSrc/src/main/java/org/myorg/CustomData.java[tags=snippet]
 ----
 
 In the extension, you'll need to create an instance of the `CustomData` class and a method that can delegate the captured values to the data instance.
@@ -129,7 +129,7 @@ The following example demonstrates the use of `Action` in an extension definitio
 .SiteExtension.java
 [source,java]
 ----
-include::{snippetsPath}/developingPlugins/pluginExtension/groovy/buildSrc/src/main/java/org/myorg/SiteExtension.java[]
+include::{snippetsPath}/developingPlugins/pluginExtension/groovy/buildSrc/src/main/java/org/myorg/SiteExtension.java[tags=snippet]
 ----
 
 [[capturing_user_input_to_configure_plugin_runtime_behavior]]
@@ -161,7 +161,7 @@ The plugin creates the extension of type `BinaryRepositoryExtension` and maps th
 .BinaryRepositoryVersionPlugin.java
 [source,java]
 ----
-include::{snippetsPath}/developingPlugins/customTask/groovy/buildSrc/src/main/java/org/myorg/BinaryRepositoryVersionPlugin.java[]
+include::{snippetsPath}/developingPlugins/customTask/groovy/buildSrc/src/main/java/org/myorg/BinaryRepositoryVersionPlugin.java[tags=snippet]
 ----
 
 Instead of using a plain `String` type, the extension defines the properties `coordinates` and `serverUrl` with type `Property<String>`.
@@ -174,7 +174,7 @@ It allows developers to simplify code like `obj.prop.set 'foo'` to `obj.prop = '
 .BinaryRepositoryExtension.java
 [source,java]
 ----
-include::{snippetsPath}/developingPlugins/customTask/groovy/buildSrc/src/main/java/org/myorg/BinaryRepositoryExtension.java[]
+include::{snippetsPath}/developingPlugins/customTask/groovy/buildSrc/src/main/java/org/myorg/BinaryRepositoryExtension.java[tags=snippet]
 ----
 
 The task property also defines the `serverUrl` with type `Property`.
@@ -183,7 +183,7 @@ It allows for mapping the state of the property without actually accessing its v
 .LatestArtifactVersion.java
 [source,java]
 ----
-include::{snippetsPath}/developingPlugins/customTask/groovy/buildSrc/src/main/java/org/myorg/LatestArtifactVersion.java[]
+include::{snippetsPath}/developingPlugins/customTask/groovy/buildSrc/src/main/java/org/myorg/LatestArtifactVersion.java[tags=snippet]
 ----
 
 NOTE: We encourage plugin developers to migrate their plugins to the public property API as soon as possible.
@@ -212,7 +212,7 @@ The POJO `ServerEnvironment` shown below fulfills those requirements.
 .ServerEnvironment.java
 [source,java]
 ----
-include::{snippetsPath}/developingPlugins/namedDomainObjectContainer/groovy/buildSrc/src/main/java/org/myorg/ServerEnvironment.java[]
+include::{snippetsPath}/developingPlugins/namedDomainObjectContainer/groovy/buildSrc/src/main/java/org/myorg/ServerEnvironment.java[tags=snippet]
 ----
 
 Gradle exposes the factory method
@@ -224,7 +224,7 @@ The created instance of type link:{javadocPath}/org/gradle/api/NamedDomainObject
 .ServerEnvironmentPlugin.java
 [source,java]
 ----
-include::{snippetsPath}/developingPlugins/namedDomainObjectContainer/groovy/buildSrc/src/main/java/org/myorg/ServerEnvironmentPlugin.java[]
+include::{snippetsPath}/developingPlugins/namedDomainObjectContainer/groovy/buildSrc/src/main/java/org/myorg/ServerEnvironmentPlugin.java[tags=snippet]
 ----
 
 It's very common for a plugin to post-process the captured values within the plugin implementation e.g. to configure tasks.
@@ -239,7 +239,7 @@ For example a plugin could assume that it is applied to a Java-based project and
 .InhouseStrongOpinionConventionJavaPlugin.java
 [source,java]
 ----
-include::{snippetsPath}/developingPlugins/reactingToPlugins/groovy/buildSrc/src/main/java/InhouseStrongOpinionConventionJavaPlugin.java[]
+include::{snippetsPath}/developingPlugins/reactingToPlugins/groovy/buildSrc/src/main/java/InhouseStrongOpinionConventionJavaPlugin.java[tags=snippet]
 ----
 
 The drawback to this approach is that it automatically forces the project to apply the Java plugin and therefore imposes a strong opinion on it.
@@ -250,7 +250,7 @@ Only if that is the case then certain configuration is applied.
 .InhouseConventionJavaPlugin.java
 [source,java]
 ----
-include::{snippetsPath}/developingPlugins/reactingToPlugins/groovy/buildSrc/src/main/java/InhouseConventionJavaPlugin.java[]
+include::{snippetsPath}/developingPlugins/reactingToPlugins/groovy/buildSrc/src/main/java/InhouseConventionJavaPlugin.java[tags=snippet]
 ----
 
 Reacting to plugins should be preferred over blindly applying other plugins if there is not a good reason for assuming that the consuming project has the expected setup.
@@ -259,7 +259,7 @@ The same concept applies to task types.
 .InhouseConventionWarPlugin.java
 [source,java]
 ----
-include::{snippetsPath}/developingPlugins/reactingToPlugins/groovy/buildSrc/src/main/java/InhouseConventionWarPlugin.java[]
+include::{snippetsPath}/developingPlugins/reactingToPlugins/groovy/buildSrc/src/main/java/InhouseConventionWarPlugin.java[tags=snippet]
 ----
 
 == Providing default dependencies for plugins
@@ -275,13 +275,13 @@ The plugin implementation declares a custom configuration that allows for <<decl
 .DataProcessingPlugin.java
 [source,java]
 ----
-include::{snippetsPath}/developingPlugins/defaultDependency/groovy/buildSrc/src/main/java/org/myorg/DataProcessingPlugin.java[]
+include::{snippetsPath}/developingPlugins/defaultDependency/groovy/buildSrc/src/main/java/org/myorg/DataProcessingPlugin.java[tags=snippet]
 ----
 
 .DataProcessing.java
 [source,java]
 ----
-include::{snippetsPath}/developingPlugins/defaultDependency/groovy/buildSrc/src/main/java/org/myorg/DataProcessing.java[]
+include::{snippetsPath}/developingPlugins/defaultDependency/groovy/buildSrc/src/main/java/org/myorg/DataProcessing.java[tags=snippet]
 ----
 
 Now, this approach is very convenient for the end user as there’s no need to actively declare a dependency.

--- a/subprojects/docs/src/snippets/developingPlugins/customTask/groovy/buildSrc/src/main/java/org/myorg/BinaryRepositoryExtension.java
+++ b/subprojects/docs/src/snippets/developingPlugins/customTask/groovy/buildSrc/src/main/java/org/myorg/BinaryRepositoryExtension.java
@@ -2,9 +2,11 @@ package org.myorg;
 
 import org.gradle.api.provider.Property;
 
+// tag::snippet[]
 abstract public class BinaryRepositoryExtension {
 
     abstract public Property<String> getCoordinates();
 
     abstract public Property<String> getServerUrl();
 }
+// end::snippet[]

--- a/subprojects/docs/src/snippets/developingPlugins/customTask/groovy/buildSrc/src/main/java/org/myorg/BinaryRepositoryVersionPlugin.java
+++ b/subprojects/docs/src/snippets/developingPlugins/customTask/groovy/buildSrc/src/main/java/org/myorg/BinaryRepositoryVersionPlugin.java
@@ -3,6 +3,7 @@ package org.myorg;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 
+// tag::snippet[]
 public class BinaryRepositoryVersionPlugin implements Plugin<Project> {
     public void apply(Project project) {
         BinaryRepositoryExtension extension =
@@ -14,3 +15,4 @@ public class BinaryRepositoryVersionPlugin implements Plugin<Project> {
         });
     }
 }
+// end::snippet[]

--- a/subprojects/docs/src/snippets/developingPlugins/customTask/groovy/buildSrc/src/main/java/org/myorg/LatestArtifactVersion.java
+++ b/subprojects/docs/src/snippets/developingPlugins/customTask/groovy/buildSrc/src/main/java/org/myorg/LatestArtifactVersion.java
@@ -5,6 +5,7 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskAction;
 
+// tag::snippet[]
 abstract public class LatestArtifactVersion extends DefaultTask {
 
     @Input
@@ -19,3 +20,4 @@ abstract public class LatestArtifactVersion extends DefaultTask {
         // issue HTTP call and parse response
     }
 }
+// end::snippet[]

--- a/subprojects/docs/src/snippets/developingPlugins/customTask/kotlin/buildSrc/src/main/java/org/myorg/BinaryRepositoryExtension.java
+++ b/subprojects/docs/src/snippets/developingPlugins/customTask/kotlin/buildSrc/src/main/java/org/myorg/BinaryRepositoryExtension.java
@@ -2,9 +2,11 @@ package org.myorg;
 
 import org.gradle.api.provider.Property;
 
+// tag::snippet[]
 abstract public class BinaryRepositoryExtension {
 
     abstract public Property<String> getCoordinates();
 
     abstract public Property<String> getServerUrl();
 }
+// end::snippet[]

--- a/subprojects/docs/src/snippets/developingPlugins/customTask/kotlin/buildSrc/src/main/java/org/myorg/BinaryRepositoryVersionPlugin.java
+++ b/subprojects/docs/src/snippets/developingPlugins/customTask/kotlin/buildSrc/src/main/java/org/myorg/BinaryRepositoryVersionPlugin.java
@@ -3,6 +3,7 @@ package org.myorg;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 
+// tag::snippet[]
 public class BinaryRepositoryVersionPlugin implements Plugin<Project> {
     public void apply(Project project) {
         BinaryRepositoryExtension extension =
@@ -14,3 +15,4 @@ public class BinaryRepositoryVersionPlugin implements Plugin<Project> {
         });
     }
 }
+// end::snippet[]

--- a/subprojects/docs/src/snippets/developingPlugins/customTask/kotlin/buildSrc/src/main/java/org/myorg/LatestArtifactVersion.java
+++ b/subprojects/docs/src/snippets/developingPlugins/customTask/kotlin/buildSrc/src/main/java/org/myorg/LatestArtifactVersion.java
@@ -5,6 +5,7 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskAction;
 
+// tag::snippet[]
 abstract public class LatestArtifactVersion extends DefaultTask {
 
     @Input
@@ -19,3 +20,4 @@ abstract public class LatestArtifactVersion extends DefaultTask {
         // issue HTTP call and parse response
     }
 }
+// end::snippet[]

--- a/subprojects/docs/src/snippets/developingPlugins/defaultDependency/groovy/buildSrc/src/main/java/org/myorg/DataProcessing.java
+++ b/subprojects/docs/src/snippets/developingPlugins/defaultDependency/groovy/buildSrc/src/main/java/org/myorg/DataProcessing.java
@@ -5,6 +5,7 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.TaskAction;
 
+// tag::snippet[]
 abstract public class DataProcessing extends DefaultTask {
 
     @InputFiles
@@ -15,3 +16,4 @@ abstract public class DataProcessing extends DefaultTask {
         System.out.println(getDataFiles().getFiles());
     }
 }
+// end::snippet[]

--- a/subprojects/docs/src/snippets/developingPlugins/defaultDependency/groovy/buildSrc/src/main/java/org/myorg/DataProcessingPlugin.java
+++ b/subprojects/docs/src/snippets/developingPlugins/defaultDependency/groovy/buildSrc/src/main/java/org/myorg/DataProcessingPlugin.java
@@ -4,6 +4,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 
+// tag::snippet[]
 public class DataProcessingPlugin implements Plugin<Project> {
     public void apply(Project project) {
         Configuration dataFiles = project.getConfigurations().create("dataFiles", c -> {
@@ -18,3 +19,4 @@ public class DataProcessingPlugin implements Plugin<Project> {
             dataProcessing -> dataProcessing.getDataFiles().from(dataFiles));
     }
 }
+// end::snippet[]

--- a/subprojects/docs/src/snippets/developingPlugins/defaultDependency/kotlin/buildSrc/src/main/java/org/myorg/DataProcessing.java
+++ b/subprojects/docs/src/snippets/developingPlugins/defaultDependency/kotlin/buildSrc/src/main/java/org/myorg/DataProcessing.java
@@ -5,6 +5,7 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.TaskAction;
 
+// tag::snippet[]
 abstract public class DataProcessing extends DefaultTask {
 
     @InputFiles
@@ -15,3 +16,4 @@ abstract public class DataProcessing extends DefaultTask {
         System.out.println(getDataFiles().getFiles());
     }
 }
+// end::snippet[]

--- a/subprojects/docs/src/snippets/developingPlugins/defaultDependency/kotlin/buildSrc/src/main/java/org/myorg/DataProcessingPlugin.java
+++ b/subprojects/docs/src/snippets/developingPlugins/defaultDependency/kotlin/buildSrc/src/main/java/org/myorg/DataProcessingPlugin.java
@@ -4,6 +4,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 
+// tag::snippet[]
 public class DataProcessingPlugin implements Plugin<Project> {
     public void apply(Project project) {
         Configuration dataFiles = project.getConfigurations().create("dataFiles", c -> {
@@ -18,3 +19,4 @@ public class DataProcessingPlugin implements Plugin<Project> {
             dataProcessing -> dataProcessing.getDataFiles().from(dataFiles));
     }
 }
+// end::snippet[]

--- a/subprojects/docs/src/snippets/developingPlugins/incrementalTask/groovy/buildSrc/src/main/java/Generate.java
+++ b/subprojects/docs/src/snippets/developingPlugins/incrementalTask/groovy/buildSrc/src/main/java/Generate.java
@@ -10,6 +10,7 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
 
+// tag::snippet[]
 public abstract class Generate extends DefaultTask {
 
     @Input
@@ -40,3 +41,4 @@ public abstract class Generate extends DefaultTask {
         }
     }
 }
+// end::snippet[]

--- a/subprojects/docs/src/snippets/developingPlugins/namedDomainObjectContainer/groovy/buildSrc/src/main/java/org/myorg/Deploy.java
+++ b/subprojects/docs/src/snippets/developingPlugins/namedDomainObjectContainer/groovy/buildSrc/src/main/java/org/myorg/Deploy.java
@@ -5,6 +5,7 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskAction;
 
+// tag::snippet[]
 abstract public class Deploy extends DefaultTask {
 
     @Input
@@ -15,3 +16,4 @@ abstract public class Deploy extends DefaultTask {
         System.out.println("Deploying to URL " + getUrl().get());
     }
 }
+// end::snippet[]

--- a/subprojects/docs/src/snippets/developingPlugins/namedDomainObjectContainer/groovy/buildSrc/src/main/java/org/myorg/ServerEnvironment.java
+++ b/subprojects/docs/src/snippets/developingPlugins/namedDomainObjectContainer/groovy/buildSrc/src/main/java/org/myorg/ServerEnvironment.java
@@ -2,6 +2,7 @@ package org.myorg;
 
 import org.gradle.api.provider.Property;
 
+// tag::snippet[]
 abstract public class ServerEnvironment {
     private final String name;
 
@@ -16,3 +17,4 @@ abstract public class ServerEnvironment {
 
     abstract public Property<String> getUrl();
 }
+// end::snippet[]

--- a/subprojects/docs/src/snippets/developingPlugins/namedDomainObjectContainer/groovy/buildSrc/src/main/java/org/myorg/ServerEnvironmentPlugin.java
+++ b/subprojects/docs/src/snippets/developingPlugins/namedDomainObjectContainer/groovy/buildSrc/src/main/java/org/myorg/ServerEnvironmentPlugin.java
@@ -5,6 +5,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.model.ObjectFactory;
 
+// tag::snippet[]
 public class ServerEnvironmentPlugin implements Plugin<Project> {
     @Override
     public void apply(final Project project) {
@@ -22,3 +23,4 @@ public class ServerEnvironmentPlugin implements Plugin<Project> {
         });
     }
 }
+// end::snippet[]

--- a/subprojects/docs/src/snippets/developingPlugins/namedDomainObjectContainer/kotlin/buildSrc/src/main/java/org/myorg/Deploy.java
+++ b/subprojects/docs/src/snippets/developingPlugins/namedDomainObjectContainer/kotlin/buildSrc/src/main/java/org/myorg/Deploy.java
@@ -5,6 +5,7 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskAction;
 
+// tag::snippet[]
 abstract public class Deploy extends DefaultTask {
 
     @Input
@@ -15,3 +16,4 @@ abstract public class Deploy extends DefaultTask {
         System.out.println("Deploying to URL " + getUrl().get());
     }
 }
+// end::snippet[]

--- a/subprojects/docs/src/snippets/developingPlugins/namedDomainObjectContainer/kotlin/buildSrc/src/main/java/org/myorg/ServerEnvironment.java
+++ b/subprojects/docs/src/snippets/developingPlugins/namedDomainObjectContainer/kotlin/buildSrc/src/main/java/org/myorg/ServerEnvironment.java
@@ -2,6 +2,7 @@ package org.myorg;
 
 import org.gradle.api.provider.Property;
 
+// tag::snippet[]
 abstract public class ServerEnvironment {
     private final String name;
 
@@ -16,3 +17,4 @@ abstract public class ServerEnvironment {
 
     abstract public Property<String> getUrl();
 }
+// end::snippet[]

--- a/subprojects/docs/src/snippets/developingPlugins/namedDomainObjectContainer/kotlin/buildSrc/src/main/java/org/myorg/ServerEnvironmentPlugin.java
+++ b/subprojects/docs/src/snippets/developingPlugins/namedDomainObjectContainer/kotlin/buildSrc/src/main/java/org/myorg/ServerEnvironmentPlugin.java
@@ -5,6 +5,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.model.ObjectFactory;
 
+// tag::snippet[]
 public class ServerEnvironmentPlugin implements Plugin<Project> {
     @Override
     public void apply(final Project project) {
@@ -22,3 +23,4 @@ public class ServerEnvironmentPlugin implements Plugin<Project> {
         });
     }
 }
+// end::snippet[]

--- a/subprojects/docs/src/snippets/developingPlugins/pluginExtension/groovy/buildSrc/src/main/java/org/myorg/CustomData.java
+++ b/subprojects/docs/src/snippets/developingPlugins/pluginExtension/groovy/buildSrc/src/main/java/org/myorg/CustomData.java
@@ -2,9 +2,11 @@ package org.myorg;
 
 import org.gradle.api.provider.Property;
 
+// tag::snippet[]
 abstract public class CustomData {
 
     abstract public Property<String> getWebsiteUrl();
 
     abstract public Property<String> getVcsUrl();
 }
+// end::snippet[]

--- a/subprojects/docs/src/snippets/developingPlugins/pluginExtension/groovy/buildSrc/src/main/java/org/myorg/SiteExtension.java
+++ b/subprojects/docs/src/snippets/developingPlugins/pluginExtension/groovy/buildSrc/src/main/java/org/myorg/SiteExtension.java
@@ -5,6 +5,7 @@ import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.tasks.Nested;
 
+// tag::snippet[]
 abstract public class SiteExtension {
 
     abstract public RegularFileProperty getOutputDir();
@@ -16,3 +17,4 @@ abstract public class SiteExtension {
         action.execute(getCustomData());
     }
 }
+// end::snippet[]

--- a/subprojects/docs/src/snippets/developingPlugins/pluginExtension/kotlin/buildSrc/src/main/java/org/myorg/CustomData.java
+++ b/subprojects/docs/src/snippets/developingPlugins/pluginExtension/kotlin/buildSrc/src/main/java/org/myorg/CustomData.java
@@ -2,9 +2,11 @@ package org.myorg;
 
 import org.gradle.api.provider.Property;
 
+// tag::snippet[]
 abstract public class CustomData {
 
     abstract public Property<String> getWebsiteUrl();
 
     abstract public Property<String> getVcsUrl();
 }
+// end::snippet[]

--- a/subprojects/docs/src/snippets/developingPlugins/pluginExtension/kotlin/buildSrc/src/main/java/org/myorg/SiteExtension.java
+++ b/subprojects/docs/src/snippets/developingPlugins/pluginExtension/kotlin/buildSrc/src/main/java/org/myorg/SiteExtension.java
@@ -5,6 +5,7 @@ import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.tasks.Nested;
 
+// tag::snippet[]
 abstract public class SiteExtension {
 
     abstract public RegularFileProperty getOutputDir();
@@ -16,3 +17,4 @@ abstract public class SiteExtension {
         action.execute(getCustomData());
     }
 }
+// end::snippet[]

--- a/subprojects/docs/src/snippets/developingPlugins/reactingToPlugins/groovy/buildSrc/src/main/java/InhouseConventionJavaPlugin.java
+++ b/subprojects/docs/src/snippets/developingPlugins/reactingToPlugins/groovy/buildSrc/src/main/java/InhouseConventionJavaPlugin.java
@@ -5,6 +5,7 @@ import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 
+// tag::snippet[]
 public class InhouseConventionJavaPlugin implements Plugin<Project> {
     public void apply(Project project) {
         project.getPlugins().withType(JavaPlugin.class, javaPlugin -> {
@@ -14,3 +15,4 @@ public class InhouseConventionJavaPlugin implements Plugin<Project> {
         });
     }
 }
+// end::snippet[]

--- a/subprojects/docs/src/snippets/developingPlugins/reactingToPlugins/groovy/buildSrc/src/main/java/InhouseConventionWarPlugin.java
+++ b/subprojects/docs/src/snippets/developingPlugins/reactingToPlugins/groovy/buildSrc/src/main/java/InhouseConventionWarPlugin.java
@@ -2,9 +2,11 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.tasks.bundling.War;
 
+// tag::snippet[]
 public class InhouseConventionWarPlugin implements Plugin<Project> {
     public void apply(Project project) {
         project.getTasks().withType(War.class).configureEach(war ->
             war.setWebXml(project.file("src/someWeb.xml")));
     }
 }
+// end::snippet[]

--- a/subprojects/docs/src/snippets/developingPlugins/reactingToPlugins/groovy/buildSrc/src/main/java/InhouseStrongOpinionConventionJavaPlugin.java
+++ b/subprojects/docs/src/snippets/developingPlugins/reactingToPlugins/groovy/buildSrc/src/main/java/InhouseStrongOpinionConventionJavaPlugin.java
@@ -5,6 +5,7 @@ import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 
+// tag::snippet[]
 public class InhouseStrongOpinionConventionJavaPlugin implements Plugin<Project> {
     public void apply(Project project) {
         project.getPlugins().apply(JavaPlugin.class);
@@ -13,3 +14,4 @@ public class InhouseStrongOpinionConventionJavaPlugin implements Plugin<Project>
         main.getJava().setSrcDirs(Arrays.asList("src"));
     }
 }
+// end::snippet[]

--- a/subprojects/docs/src/snippets/developingPlugins/reactingToPlugins/groovy/buildSrc/src/main/java/InhouseStrongOpinionConventionJavaPlugin.java
+++ b/subprojects/docs/src/snippets/developingPlugins/reactingToPlugins/groovy/buildSrc/src/main/java/InhouseStrongOpinionConventionJavaPlugin.java
@@ -8,6 +8,7 @@ import org.gradle.api.tasks.SourceSetContainer;
 // tag::snippet[]
 public class InhouseStrongOpinionConventionJavaPlugin implements Plugin<Project> {
     public void apply(Project project) {
+        // Careful! Eagerly appyling plugins has downsides, and is not always recommended.
         project.getPlugins().apply(JavaPlugin.class);
         SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
         SourceSet main = sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME);


### PR DESCRIPTION
This PR hides noisy import statements from snippets displayed on the "Implementing Gradle plugins" page.

https://docs.gradle.org/8.4/userguide/implementing_gradle_plugins.html

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
