### PR TITLE
Attach public headers task dependencies to outgoing API elements

### DIFF
--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppGeneratedPublicHeadersIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppGeneratedPublicHeadersIntegrationTest.groovy
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.language.cpp
+
+import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
+import org.gradle.nativeplatform.fixtures.app.CppAppWithLibrary
+import org.gradle.test.fixtures.file.TestFile
+import spock.lang.Issue
+
+class CppGeneratedPublicHeadersIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
+    def app = new CppAppWithLibrary()
+
+    @ToBeFixedForConfigurationCache
+    @Issue("https://github.com/gradle/gradle-native/issues/994")
+    def "can depends on library with generated headers"() {
+        given:
+        settingsFile << """
+            include 'app', 'lib'
+        """
+
+        writeApp()
+        writeLibrary()
+
+        when:
+        succeeds ":app:compileDebugCpp"
+        then:
+        result.assertTasksExecuted(":lib:generatePublicHeaders", ":app:compileDebugCpp")
+    }
+
+    private writeApp() {
+        app.main.writeToProject(file("app"))
+        file("app/build.gradle") << """
+            apply plugin: 'cpp-application'
+            group = 'org.gradle.cpp'
+            version = '1.0'
+
+            dependencies {
+                implementation project(':lib')
+            }
+        """
+    }
+
+    private writeLibrary(TestFile dir = testDirectory) {
+        def libraryPath = dir.file("lib")
+        app.greeter.publicHeaders.writeToSourceDir(testDirectory.file("staging-includes"))
+        app.greeter.privateHeaders.writeToSourceDir(libraryPath.file("src/main/headers"))
+        app.greeter.sources.writeToSourceDir(libraryPath.file("src/main/cpp"))
+        libraryPath.file("build.gradle") << """
+            apply plugin: 'cpp-library'
+            group = 'org.gradle.cpp'
+            version = '1.0'
+
+            library {
+                def generatorTask = tasks.register('generatePublicHeaders', Sync) {
+                    from(rootProject.file('staging-includes'))
+                    into({ temporaryDir })
+                }
+
+                publicHeaders.from(generatorTask)
+            }
+        """
+    }
+}

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppLibraryPlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppLibraryPlugin.java
@@ -158,7 +158,7 @@ public abstract class CppLibraryPlugin implements Plugin<Project> {
                 }
                 return files.iterator().next();
             });
-            apiElements.getOutgoing().artifact(publicHeaders);
+            apiElements.getOutgoing().artifact(publicHeaders, it -> it.builtBy(library.getPublicHeaderDirs()));
 
             project.getPluginManager().withPlugin("maven-publish", appliedPlugin -> {
                 final TaskProvider<Zip> headersZip = tasks.register("cppHeaders", Zip.class, task -> {


### PR DESCRIPTION
This change allows for generated public headers to work correctly. Gradle core plugins are still limited to a single public header directory.

<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
This fix is provided as part of [Nokee's consultation](https://nokee.dev/services/consulting.html), feel free to send us an inquiry.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
