### PR TITLE
Fix issue 26699 - wrong GRADLE_HOME link

### DIFF
--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/dependency_resolution.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/dependency_resolution.adoc
@@ -312,7 +312,7 @@ To help with this scenario, Gradle provides a couple of options:
 The dependency cache, both the file and metadata parts, are fully encoded using relative paths.
 This means that it is perfectly possible to copy a cache around and see Gradle benefit from it.
 
-The path that can be copied is `$GRADLE_HOME/caches/modules-<version>`.
+The path that can be copied is `$GRADLE_USER_HOME/caches/modules-<version>`.
 The only constraint is placing it using the same structure at the destination, where the value of `GRADLE_HOME` can be different.
 
 Do not copy the `*.lock` or `gc.properties` files if they exist.

--- a/subprojects/docs/src/docs/userguide/optimizing-performance/build-cache/build_cache_performance.adoc
+++ b/subprojects/docs/src/docs/userguide/optimizing-performance/build-cache/build_cache_performance.adoc
@@ -29,7 +29,7 @@ Proper configuration and maintenance of a build can improve caching performance 
 
 The most straightforward way to get a feel for what the cache can do for you is to measure the difference between a non-cached build and a _fully cached_ build. This will give you the theoretical limit of how fast builds with the cache can get, if everything you're trying to build has already been built. The easiest way to measure this is using the local cache:
 
-1. Clean the cache directory to avoid any hits from previous builds (`rm -rf $GRADLE_HOME/caches/build-cache-*`)
+1. Clean the cache directory to avoid any hits from previous builds (`rm -rf $GRADLE_USER_HOME/caches/build-cache-*`)
 2. Run the build (e.g. `./gradlew --build-cache clean assemble`), so that all the results from cacheable tasks get stored in the cache.
 3. Run the build again (e.g. `./gradlew --build-cache clean assemble`); depending on your build, you should see many of the tasks being retrieved from the cache.
 4. Compare the execution time for the two builds


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/26699.

### Context
Fixes incorrect GRADLE_HOME links in docs.

This is a documentation change **ONLY**.
