### PR TITLE
Use javaVersion instead of path name in test assertion

### DIFF
--- a/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
+++ b/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
@@ -542,7 +542,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         then:
         def compileTask = project.tasks.named("compileCustomJava", JavaCompile).get()
         def configuredToolchain = compileTask.javaCompiler.get().javaToolchain
-        configuredToolchain.displayName.contains(someJdk.javaVersion.getMajorVersion())
+        configuredToolchain.javaVersion.toString().contains(someJdk.javaVersion.getMajorVersion())
     }
 
     def "source and target compatibility are configured if toolchain is configured"() {


### PR DESCRIPTION
This test asserts the java tool chain name (the java home path) contains expected java version, which is not true in some cases. Now let's explicitly use `javaVersion` in the assertion.

For example: https://ge.gradle.org/s/u2ozqmi7wc6cw/tests/task/:plugins-java:parallelIntegTest/details/org.gradle.api.plugins.JavaPluginTest/wires%20toolchain%20for%20sourceset%20if%20toolchain%20is%20configured?top-execution=1