### PR TITLE
Fix the wrong Groovy3OrEarlier

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/preconditions/IntegTestPreconditions.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/preconditions/IntegTestPreconditions.groovy
@@ -431,7 +431,7 @@ class IntegTestPreconditions {
     static final class Groovy3OrEarlier implements TestPrecondition {
         @Override
         boolean isSatisfied() throws Exception {
-            return VersionNumber.parse(GroovySystem.version).major < 3
+            return VersionNumber.parse(GroovySystem.version).major <= 3
         }
     }
 }


### PR DESCRIPTION
We're mostly using Groovy 3 now. Otherwise some tests are forever disabled.