### PR TITLE
add releases page to docs + finish fixing issue 26699

### DIFF
--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/dependency_resolution.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/dependency_resolution.adoc
@@ -313,7 +313,7 @@ The dependency cache, both the file and metadata parts, are fully encoded using 
 This means that it is perfectly possible to copy a cache around and see Gradle benefit from it.
 
 The path that can be copied is `$GRADLE_USER_HOME/caches/modules-<version>`.
-The only constraint is placing it using the same structure at the destination, where the value of `GRADLE_HOME` can be different.
+The only constraint is placing it using the same structure at the destination, where the value of `GRADLE_USER_HOME` can be different.
 
 Do not copy the `*.lock` or `gc.properties` files if they exist.
 

--- a/subprojects/docs/src/main/resources/header.html
+++ b/subprojects/docs/src/main/resources/header.html
@@ -96,6 +96,7 @@
 
         <h3 id="what-is-new">Releases</h3>
         <ul>
+            <li><a href="https://gradle.org/releases/">All Releases</a></li>
             <li><a href="../release-notes.html">Release Notes</a></li>
             <li><a href="../userguide/compatibility.html">Compatibility Notes</a></li>
             <li><a class="nav-dropdown" data-toggle="collapse" href="#upgrading-gradle" aria-expanded="false" aria-controls="upgrading-gradle">Upgrading Gradle</a>


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/26699.
Adds https://gradle.org/releases/ to Docs.

### Context
Fixes incorrect GRADLE_HOME links in docs.
Adds releases page to docs at @tresat's request.

This is a documentation change **ONLY**.