### PR TITLE
Add resources to the Gradle all distribution

### DIFF
--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleJavadocsPlugin.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleJavadocsPlugin.java
@@ -91,7 +91,7 @@ public abstract class GradleJavadocsPlugin implements Plugin<Project> {
             // TODO: This breaks the provider
             options.links(javadocs.getJavaApi().get().toString(), javadocs.getGroovyApi().get().toString());
 
-            task.source(extension.getDocumentedSource());
+            task.source(extension.getDocumentedSource().filter(f -> f.getName().endsWith(".java") || f.getName().endsWith(".kt")));
 
             task.setClasspath(extension.getClasspath());
 

--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleJavadocsPlugin.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleJavadocsPlugin.java
@@ -91,7 +91,7 @@ public abstract class GradleJavadocsPlugin implements Plugin<Project> {
             // TODO: This breaks the provider
             options.links(javadocs.getJavaApi().get().toString(), javadocs.getGroovyApi().get().toString());
 
-            task.source(extension.getDocumentedSource().filter(f -> f.getName().endsWith(".java") || f.getName().endsWith(".kt")));
+            task.source(extension.getDocumentedSource().filter(f -> f.getName().endsWith(".java")));
 
             task.setClasspath(extension.getClasspath());
 

--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/dsl/source/ExtractDslMetaDataTask.groovy
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/dsl/source/ExtractDslMetaDataTask.groovy
@@ -58,7 +58,7 @@ abstract class ExtractDslMetaDataTask extends SourceTask {
         //and placing them in the repository object
         SimpleClassMetaDataRepository<gradlebuild.docs.dsl.source.model.ClassMetaData> repository = new SimpleClassMetaDataRepository<gradlebuild.docs.dsl.source.model.ClassMetaData>()
         int counter = 0
-        source.filter { File f -> f.name.endsWith(".java") || f.name.endsWith(".kt") }.each { File f ->
+        source.filter { File f -> f.name.endsWith(".java") || f.name.endsWith(".groovy") }.each { File f ->
             parse(f, repository)
             counter++
         }

--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/dsl/source/ExtractDslMetaDataTask.groovy
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/dsl/source/ExtractDslMetaDataTask.groovy
@@ -58,7 +58,7 @@ abstract class ExtractDslMetaDataTask extends SourceTask {
         //and placing them in the repository object
         SimpleClassMetaDataRepository<gradlebuild.docs.dsl.source.model.ClassMetaData> repository = new SimpleClassMetaDataRepository<gradlebuild.docs.dsl.source.model.ClassMetaData>()
         int counter = 0
-        source.each { File f ->
+        source.filter { File f -> f.name.endsWith(".java") || f.name.endsWith(".kt") }.each { File f ->
             parse(f, repository)
             counter++
         }

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -96,6 +96,9 @@ fun configureSourcesVariant() {
         main.groovy.srcDirs.forEach {
             outgoing.artifact(it)
         }
+        main.resources.srcDirs.forEach {
+            outgoing.artifact(it)
+        }
         pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
             main.kotlin.srcDirs.forEach {
                 outgoing.artifact(it)

--- a/build-logic/packaging/src/main/kotlin/gradlebuild/packaging/GradleDistributionSpecs.kt
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild/packaging/GradleDistributionSpecs.kt
@@ -57,7 +57,7 @@ object GradleDistributionSpecs {
     }
 
     /**
-     * The binary distribution enriched with the sources for the classes and an offline version of Gradle's documentation (without samples).
+     * The binary distribution enriched with source files (including resources) and an offline version of Gradle's documentation (without samples).
      */
     fun Project.allDistributionSpec() = copySpec {
         val sourcesPath by configurations.getting
@@ -122,8 +122,8 @@ object GradleDistributionSpecs {
     }
 
     private
-    fun File.containingSubprojectFolder(relativePathLenght: Int): File =
-        if (relativePathLenght == 0) this else this.parentFile.containingSubprojectFolder(relativePathLenght - 1)
+    fun File.containingSubprojectFolder(relativePathLength: Int): File =
+        if (relativePathLength == 0) this else this.parentFile.containingSubprojectFolder(relativePathLength - 1)
 
     private
     fun Array<String>.subArray(toIndex: Int) = listOf(*this).subList(0, toIndex).toTypedArray()

--- a/build-logic/uber-plugins/src/main/kotlin/gradlebuild.kotlin-library.gradle.kts
+++ b/build-logic/uber-plugins/src/main/kotlin/gradlebuild.kotlin-library.gradle.kts
@@ -28,7 +28,7 @@ plugins {
 
 configurations.transitiveSourcesElements {
     val main = sourceSets.main.get()
-    main.kotlin.srcDirs.forEach {
+    (main.kotlin.srcDirs + main.resources.srcDirs).forEach {
         outgoing.artifact(it)
     }
 }


### PR DESCRIPTION
Add resources dir to source and transitive source, filter to just `.java` files in consumers of the source that aren't expecting resource files.

Fixes #26711