### PR TITLE
Add AutoTest runners to Ivy and Platform-JVM projects

### DIFF
--- a/.teamcity/subprojects.json
+++ b/.teamcity/subprojects.json
@@ -640,7 +640,7 @@
     "name": "platform-jvm",
     "path": "platforms/jvm/platform-jvm",
     "unitTests": true,
-    "functionalTests": false,
+    "functionalTests": true,
     "crossVersionTests": false
   },
   {

--- a/platforms/jvm/platform-jvm/build.gradle.kts
+++ b/platforms/jvm/platform-jvm/build.gradle.kts
@@ -42,6 +42,8 @@ dependencies {
     testImplementation(testFixtures(project(":platform-base")))
     testImplementation(testFixtures(project(":platform-native")))
 
+    integTestImplementation(project(":internal-integ-testing"))
+
     integTestImplementation(libs.slf4jApi)
 
     testRuntimeOnly(project(":distributions-core")) {

--- a/platforms/jvm/platform-jvm/src/integTest/groovy/org/gradle/api/AutoTestedSamplesPlatformJvmIntegrationTest.groovy
+++ b/platforms/jvm/platform-jvm/src/integTest/groovy/org/gradle/api/AutoTestedSamplesPlatformJvmIntegrationTest.groovy
@@ -19,7 +19,7 @@ package org.gradle.api
 import org.gradle.integtests.fixtures.AbstractAutoTestedSamplesTest
 import org.junit.Test
 
-class AutoTestedSamplesMavenIntegrationTest extends AbstractAutoTestedSamplesTest {
+class AutoTestedSamplesPlatformJvmIntegrationTest extends AbstractAutoTestedSamplesTest {
 
     @Test
     void runSamples() {

--- a/platforms/software/ivy/src/integTest/groovy/org/gradle/api/AutoTestedSamplesIvyIntegrationTest.groovy
+++ b/platforms/software/ivy/src/integTest/groovy/org/gradle/api/AutoTestedSamplesIvyIntegrationTest.groovy
@@ -19,7 +19,7 @@ package org.gradle.api
 import org.gradle.integtests.fixtures.AbstractAutoTestedSamplesTest
 import org.junit.Test
 
-class AutoTestedSamplesMavenIntegrationTest extends AbstractAutoTestedSamplesTest {
+class AutoTestedSamplesIvyIntegrationTest extends AbstractAutoTestedSamplesTest {
 
     @Test
     void runSamples() {


### PR DESCRIPTION
In the JVM and Software platforms, these were projects missing auto test runners that had autotested samples in their javadocs.