### PR TITLE
Use languageVersion instead of path name in test assertion

### DIFF
--- a/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
+++ b/platforms/jvm/plugins-java/src/integTest/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
@@ -569,7 +569,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         def configuredJavaLauncher = testTask.javaLauncher.get()
 
         then:
-        configuredJavaLauncher.executablePath.toString().contains(someJdk.javaVersion.getMajorVersion())
+        configuredJavaLauncher.metadata.languageVersion.toString().contains(someJdk.javaVersion.getMajorVersion())
     }
 
     def "wires toolchain for javadoc if toolchain is configured"() {


### PR DESCRIPTION
This test asserts the java executable path
contains expected java version, which is not true in some cases. Now let's explicitly use lanaguageVersion in the assertion.

```
  Condition not satisfied:
  
  configuredJavaLauncher.executablePath.toString().contains(someJdk.javaVersion.getMajorVersion())
  |                      |              |          |        |       |           |
  |                      |              |          false    |       17          17
  |                      |              |                   17.0.8 (BellSoft 17.0.8+7-LTS)
  |                      |              /opt/java/openjdk/bin/java
  |                      /opt/java/openjdk/bin/java
  <org.gradle.jvm.toolchain.internal.DefaultToolchainJavaLauncher@71da8575 javaToolchain=JavaToolchain(javaHome=/opt/java/openjdk)>
```