### PR TITLE
[Spike] Use normalized hash for immutable artifacts identity

### DIFF
--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/steps/ResolveChangesStep.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/steps/ResolveChangesStep.java
@@ -30,6 +30,8 @@ import org.gradle.internal.execution.history.changes.IncrementalInputProperties;
 import org.gradle.internal.properties.InputBehavior;
 
 import javax.annotation.Nonnull;
+import java.util.HashSet;
+import java.util.Set;
 
 import static org.gradle.internal.execution.history.changes.ExecutionStateChanges.nonIncremental;
 
@@ -85,11 +87,12 @@ public class ResolveChangesStep<C extends CachingContext, R extends Result> impl
             case NON_INCREMENTAL:
                 return IncrementalInputProperties.NONE;
             case INCREMENTAL:
+                Set<String> alreadyVisitedProperty = new HashSet<>();
                 ImmutableBiMap.Builder<String, Object> builder = ImmutableBiMap.builder();
                 InputVisitor visitor = new InputVisitor() {
                     @Override
                     public void visitInputFileProperty(String propertyName, InputBehavior behavior, InputFileValueSupplier valueSupplier) {
-                        if (behavior.shouldTrackChanges()) {
+                        if (behavior.shouldTrackChanges() && alreadyVisitedProperty.add(propertyName)) {
                             Object value = valueSupplier.getValue();
                             if (value == null) {
                                 throw new InvalidUserDataException("Must specify a value for incremental input property '" + propertyName + "'.");

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformExecutionBuildOperationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformExecutionBuildOperationIntegrationTest.groovy
@@ -166,7 +166,7 @@ class ArtifactTransformExecutionBuildOperationIntegrationTest extends AbstractIn
             hash != null
             classLoaderHash != null
             implementationClassName == 'MakeGreen'
-            inputValueHashes.keySet() ==~ ['inputArtifactPath', 'inputArtifactSnapshot', 'inputPropertiesHash']
+            inputValueHashes.keySet() ==~ ['inputArtifactPath', 'inputPropertiesHash']
             outputPropertyNames == ['outputDirectory', 'resultsFile']
             inputFileProperties.keySet() ==~ ['inputArtifact', 'inputArtifactDependencies']
             with(inputFileProperties.inputArtifactDependencies) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AbstractTransformExecution.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AbstractTransformExecution.java
@@ -61,7 +61,7 @@ import static org.gradle.internal.properties.InputBehavior.NON_INCREMENTAL;
 
 abstract class AbstractTransformExecution implements UnitOfWork {
     private static final CachingDisabledReason NOT_CACHEABLE = new CachingDisabledReason(CachingDisabledReasonCategory.NOT_CACHEABLE, "Caching not enabled.");
-    private static final String INPUT_ARTIFACT_PROPERTY_NAME = "inputArtifact";
+    protected static final String INPUT_ARTIFACT_PROPERTY_NAME = "inputArtifact";
     private static final String OUTPUT_DIRECTORY_PROPERTY_NAME = "outputDirectory";
     private static final String RESULTS_FILE_PROPERTY_NAME = "resultsFile";
     protected static final String INPUT_ARTIFACT_PATH_PROPERTY_NAME = "inputArtifactPath";

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AbstractTransformExecution.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AbstractTransformExecution.java
@@ -78,7 +78,7 @@ abstract class AbstractTransformExecution implements UnitOfWork {
     private final TransformExecutionListener transformExecutionListener;
     private final BuildOperationExecutor buildOperationExecutor;
     private final BuildOperationProgressEventEmitter progressEventEmitter;
-    private final FileCollectionFactory fileCollectionFactory;
+    protected final FileCollectionFactory fileCollectionFactory;
 
     private final Provider<FileSystemLocation> inputArtifactProvider;
     protected final InputFingerprinter inputFingerprinter;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ImmutableTransformExecution.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ImmutableTransformExecution.java
@@ -57,7 +57,7 @@ class ImmutableTransformExecution extends AbstractTransformExecution {
     @Override
     public void visitIdentityInputs(InputVisitor visitor) {
         super.visitIdentityInputs(visitor);
-        visitor.visitInputFileProperty(INPUT_ARTIFACT_SNAPSHOT_PROPERTY_NAME, InputBehavior.NON_INCREMENTAL,
+        visitor.visitInputFileProperty(INPUT_ARTIFACT_PROPERTY_NAME, InputBehavior.INCREMENTAL,
             new InputFileValueSupplier(
                 inputArtifact,
                 transform.getInputArtifactNormalizer(),

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ImmutableTransformExecution.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ImmutableTransformExecution.java
@@ -21,7 +21,6 @@ import org.gradle.internal.execution.InputFingerprinter;
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.BuildOperationProgressEventEmitter;
-import org.gradle.internal.properties.InputBehavior;
 import org.gradle.internal.snapshot.ValueSnapshot;
 import org.gradle.internal.vfs.FileSystemAccess;
 
@@ -29,7 +28,6 @@ import java.io.File;
 import java.util.Map;
 
 class ImmutableTransformExecution extends AbstractTransformExecution {
-    private static final String INPUT_ARTIFACT_SNAPSHOT_PROPERTY_NAME = "inputArtifactSnapshot";
 
     private final FileSystemAccess fileSystemAccess;
 
@@ -57,21 +55,14 @@ class ImmutableTransformExecution extends AbstractTransformExecution {
     @Override
     public void visitIdentityInputs(InputVisitor visitor) {
         super.visitIdentityInputs(visitor);
-        visitor.visitInputFileProperty(INPUT_ARTIFACT_PROPERTY_NAME, InputBehavior.INCREMENTAL,
-            new InputFileValueSupplier(
-                inputArtifact,
-                transform.getInputArtifactNormalizer(),
-                transform.getInputArtifactDirectorySensitivity(),
-                transform.getInputArtifactLineEndingNormalization(),
-                () -> fileCollectionFactory.fixed(inputArtifact)
-            ));
+        visitRegularInputs(visitor);
     }
 
     @Override
     public Identity identify(Map<String, ValueSnapshot> identityInputs, Map<String, CurrentFileCollectionFingerprint> identityFileInputs) {
         ImmutableTransformWorkspaceIdentity transformWorkspaceIdentity = new ImmutableTransformWorkspaceIdentity(
             identityInputs.get(INPUT_ARTIFACT_PATH_PROPERTY_NAME),
-            identityFileInputs.get(INPUT_ARTIFACT_SNAPSHOT_PROPERTY_NAME).getHash(),
+            identityFileInputs.get(INPUT_ARTIFACT_PROPERTY_NAME).getHash(),
             identityInputs.get(SECONDARY_INPUTS_HASH_PROPERTY_NAME),
             identityFileInputs.get(DEPENDENCIES_PROPERTY_NAME).getHash()
         );

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ImmutableTransformExecution.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ImmutableTransformExecution.java
@@ -21,7 +21,7 @@ import org.gradle.internal.execution.InputFingerprinter;
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.BuildOperationProgressEventEmitter;
-import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
+import org.gradle.internal.properties.InputBehavior;
 import org.gradle.internal.snapshot.ValueSnapshot;
 import org.gradle.internal.vfs.FileSystemAccess;
 
@@ -57,17 +57,21 @@ class ImmutableTransformExecution extends AbstractTransformExecution {
     @Override
     public void visitIdentityInputs(InputVisitor visitor) {
         super.visitIdentityInputs(visitor);
-        // This is a performance hack. We could use the regular fingerprint of the input artifact, but that takes longer than
-        // capturing the normalized path and the snapshot of the raw contents, so we are using these to determine the identity
-        FileSystemLocationSnapshot inputArtifactSnapshot = fileSystemAccess.read(inputArtifact.getAbsolutePath());
-        visitor.visitInputProperty(INPUT_ARTIFACT_SNAPSHOT_PROPERTY_NAME, inputArtifactSnapshot::getHash);
+        visitor.visitInputFileProperty(INPUT_ARTIFACT_SNAPSHOT_PROPERTY_NAME, InputBehavior.NON_INCREMENTAL,
+            new InputFileValueSupplier(
+                inputArtifact,
+                transform.getInputArtifactNormalizer(),
+                transform.getInputArtifactDirectorySensitivity(),
+                transform.getInputArtifactLineEndingNormalization(),
+                () -> fileCollectionFactory.fixed(inputArtifact)
+            ));
     }
 
     @Override
     public Identity identify(Map<String, ValueSnapshot> identityInputs, Map<String, CurrentFileCollectionFingerprint> identityFileInputs) {
         ImmutableTransformWorkspaceIdentity transformWorkspaceIdentity = new ImmutableTransformWorkspaceIdentity(
             identityInputs.get(INPUT_ARTIFACT_PATH_PROPERTY_NAME),
-            identityInputs.get(INPUT_ARTIFACT_SNAPSHOT_PROPERTY_NAME),
+            identityFileInputs.get(INPUT_ARTIFACT_SNAPSHOT_PROPERTY_NAME).getHash(),
             identityInputs.get(SECONDARY_INPUTS_HASH_PROPERTY_NAME),
             identityFileInputs.get(DEPENDENCIES_PROPERTY_NAME).getHash()
         );

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ImmutableTransformWorkspaceIdentity.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ImmutableTransformWorkspaceIdentity.java
@@ -23,11 +23,11 @@ import org.gradle.internal.snapshot.ValueSnapshot;
 
 class ImmutableTransformWorkspaceIdentity implements TransformWorkspaceIdentity {
     private final ValueSnapshot inputArtifactPath;
-    private final ValueSnapshot inputArtifactSnapshot;
+    private final HashCode inputArtifactSnapshot;
     private final ValueSnapshot secondaryInputsSnapshot;
     private final HashCode dependenciesHash;
 
-    public ImmutableTransformWorkspaceIdentity(ValueSnapshot inputArtifactPath, ValueSnapshot inputArtifactSnapshot, ValueSnapshot secondaryInputsSnapshot, HashCode dependenciesHash) {
+    public ImmutableTransformWorkspaceIdentity(ValueSnapshot inputArtifactPath, HashCode inputArtifactSnapshot, ValueSnapshot secondaryInputsSnapshot, HashCode dependenciesHash) {
         this.inputArtifactPath = inputArtifactPath;
         this.inputArtifactSnapshot = inputArtifactSnapshot;
         this.secondaryInputsSnapshot = secondaryInputsSnapshot;
@@ -38,7 +38,7 @@ class ImmutableTransformWorkspaceIdentity implements TransformWorkspaceIdentity 
     public String getUniqueId() {
         Hasher hasher = Hashing.newHasher();
         inputArtifactPath.appendToHasher(hasher);
-        inputArtifactSnapshot.appendToHasher(hasher);
+        hasher.putHash(inputArtifactSnapshot);
         secondaryInputsSnapshot.appendToHasher(hasher);
         hasher.putHash(dependenciesHash);
         return hasher.hash().toString();


### PR DESCRIPTION
Let's see what performance we have.

Relates to https://github.com/gradle/gradle/pull/26045, to handle normalization and not reinstrument same artifacts.
