### PR TITLE
Provide a way to control dynamic version caching for imported version catalog

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/management/DefaultDependencyResolutionManagement.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/management/DefaultDependencyResolutionManagement.java
@@ -25,6 +25,7 @@ import org.gradle.api.NamedDomainObjectList;
 import org.gradle.api.NonNullApi;
 import org.gradle.api.artifacts.ComponentMetadataDetails;
 import org.gradle.api.artifacts.ComponentMetadataRule;
+import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.dsl.ComponentMetadataHandler;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.artifacts.repositories.ArtifactRepository;
@@ -160,6 +161,11 @@ public class DefaultDependencyResolutionManagement implements DependencyResoluti
     @Override
     public List<VersionCatalogBuilder> getDependenciesModelBuilders() {
         return ImmutableList.copyOf(versionCatalogs);
+    }
+
+    @Override
+    public ConfigurationContainer getConfigurations() {
+        return dependencyResolutionServices.get().getConfigurationContainer();
     }
 
     @Override

--- a/platforms/software/plugins-version-catalog/src/integTest/groovy/org/gradle/catalog/VersionCatalogResolveIntegrationTest.groovy
+++ b/platforms/software/plugins-version-catalog/src/integTest/groovy/org/gradle/catalog/VersionCatalogResolveIntegrationTest.groovy
@@ -19,7 +19,7 @@ package org.gradle.catalog
 
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
 import org.gradle.test.fixtures.file.TestFile
-
+import org.gradle.test.fixtures.server.http.MavenHttpRepository
 
 class VersionCatalogResolveIntegrationTest extends AbstractHttpDependencyResolutionTest implements VersionCatalogSupport {
     def setup() {
@@ -268,6 +268,58 @@ org.gradle.test:my-platform:1.0=incomingCatalogForLibs0
         expectPlatformContents 'composed-platform'
     }
 
+    def "can configure dynamic version caching for platform in settings"() {
+        given:
+        // we can't use mavenRepo as in other tests since it's a local repo which doesn't use persistent cache
+        def repo = mavenHttpRepo('repo')
+        repo.module('com.company', 'some-lib', '5.2.0').allowAll().publish()
+        repo.module('com.company', 'some-lib', '5.2.8').allowAll().publish()
+
+        and:
+        settingsFile << """
+            dependencyResolutionManagement {
+                repositories {
+                    maven { url "${repo.uri}" }
+                }
+
+                configurations.all {
+                    resolutionStrategy.cacheDynamicVersionsFor(0, "seconds")
+                }
+
+                versionCatalogs {
+                    libs {
+                        from("org.gradle.test:my-platform:[1.0,2.0)")
+                    }
+                }
+            }
+        """
+
+        and:
+        buildFile << """
+            dependencies {
+                implementation(libs.some.lib)
+            }
+        """
+
+        and:
+        preparePublishedPlatformArtifact(repo, '1.0', '5.2.0')
+
+        when:
+        run ':checkDeps'
+
+        then:
+        outputContains 'Resolved: some-lib-5.2.0.jar'
+
+        and:
+        preparePublishedPlatformArtifact(repo, '1.1', '5.2.8')
+
+        when:
+        run ':checkDeps'
+
+        then:
+        outputContains 'Resolved: some-lib-5.2.8.jar'
+    }
+
     private TestFile preparePlatformProject(String platformSpec = "", String version = "1.0") {
         def platformDir = file('platform')
         platformDir.file("settings.gradle").text = """
@@ -303,5 +355,23 @@ org.gradle.test:my-platform:1.0=incomingCatalogForLibs0
         """
 
         return platformDir
+    }
+
+    private void preparePublishedPlatformArtifact(MavenHttpRepository repo, String platformVersion, String libraryVersion) {
+        def module = repo
+            .module("org.gradle.test", "my-platform", platformVersion)
+            .variant('versionCatalogElements', [
+                'org.gradle.category': 'platform',
+                'org.gradle.usage': 'version-catalog'
+            ])
+            .hasType("toml")
+            .withModuleMetadata()
+            .allowAll()
+        module.rootMetaData.allowGetOrHead()
+        module.publish()
+        module.artifact.file.text = """
+            [libraries]
+            some-lib = {group = "com.company", name = "some-lib", version = "$libraryVersion" }
+        """
     }
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/resolve/DependencyResolutionManagement.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/resolve/DependencyResolutionManagement.java
@@ -17,6 +17,7 @@ package org.gradle.api.initialization.resolve;
 
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
+import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.dsl.ComponentMetadataHandler;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.provider.Property;
@@ -89,4 +90,29 @@ public interface DependencyResolutionManagement {
      * @since 7.0
      */
     Property<String> getDefaultLibrariesExtensionName();
+
+    /**
+     * <p>Returns the configurations used internally by the dependency resolution management.</p>
+     *
+     * <p>For example, you can use it to disable caching of the version catalog dynamic version:</p>
+     *
+     * <pre>
+     * dependencyResolutionManagement {
+     *
+     *     configurations.all {
+     *         resolutionStrategy.cacheDynamicVersionsFor(0, "seconds")
+     *     }
+     *
+     *     versionCatalogs {
+     *         create("libs") {
+     *             from("org.gradle.test:my-platform:[1.0,2.0)")
+     *         }
+     *     }
+     * }
+     * </pre>
+     *
+     * @since 8.5
+     */
+    @Incubating
+    ConfigurationContainer getConfigurations();
 }

--- a/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/platforms.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/platforms.adoc
@@ -430,6 +430,26 @@ In the example above, any dependency which was using the `groovy` version as ref
 NOTE: Again, overwriting a version doesn't mean that the actual _resolved_ dependency version will be the same: this only changes what is _imported_, that is to say what is used when declaring a dependency.
 The actual version will be subject to traditional conflict resolution, if any.
 
+[[sec:dynamic-versions-and-caching]]
+==== Using dynamic version in catalog import
+
+You can specify a dynamic version for your version catalog import:
+
+.Importing version catalog with the dynamic version
+====
+include::sample[dir="snippets/dependencyManagement/catalogs-javaPlatformCatalog/kotlin/consumer",files="settings.gradle.kts[tags=dynamic_version]"]
+include::sample[dir="snippets/dependencyManagement/catalogs-javaPlatformCatalog/groovy/consumer",files="settings.gradle[tags=dynamic_version]"]
+====
+
+By default, Gradle caches dynamic versions for 24 hours. To change how long Gradle will cache the resolved version of the version catalog, use:
+
+.Dynamic version cache control
+====
+include::sample[dir="snippets/dependencyManagement/catalogs-javaPlatformCatalog/kotlin/consumer",files="settings.gradle.kts[tags=disable_caching]"]
+include::sample[dir="snippets/dependencyManagement/catalogs-javaPlatformCatalog/groovy/consumer",files="settings.gradle[tags=disable_caching]"]
+====
+
+
 [[sub:using-platform-to-control-transitive-deps]]
 == Using a platform to control transitive versions
 

--- a/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/platforms.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/platforms.adoc
@@ -441,7 +441,8 @@ include::sample[dir="snippets/dependencyManagement/catalogs-javaPlatformCatalog/
 include::sample[dir="snippets/dependencyManagement/catalogs-javaPlatformCatalog/groovy/consumer",files="settings.gradle[tags=dynamic_version]"]
 ====
 
-By default, Gradle caches dynamic versions for 24 hours. To change how long Gradle will cache the resolved version of the version catalog, use:
+By default, Gradle caches dynamic versions for 24 hours. 
+To change how long Gradle will cache the resolved version of the version catalog, use:
 
 .Dynamic version cache control
 ====

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-javaPlatformCatalog/groovy/consumer/settings.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-javaPlatformCatalog/groovy/consumer/settings.gradle
@@ -46,3 +46,21 @@ dependencyResolutionManagement {
     }
 }
 // end::overwrite_version[]
+
+// tag::dynamic_version[]
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from("com.mycompany:catalog:[1.0,2.0)")
+        }
+    }
+}
+// end::dynamic_version[]
+
+// tag::disable_caching[]
+dependencyResolutionManagement {
+    configurations.all {
+        resolutionStrategy.cacheDynamicVersionsFor 0, 'seconds'
+    }
+}
+// end::disable_caching[]

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-javaPlatformCatalog/kotlin/consumer/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-javaPlatformCatalog/kotlin/consumer/settings.gradle.kts
@@ -50,3 +50,25 @@ if (providers.systemProperty("create2").getOrNull() != null) {
     }
     // end::overwrite_version[]
 }
+
+if (providers.systemProperty("create3").getOrNull() != null) {
+    // tag::dynamic_version[]
+    dependencyResolutionManagement {
+        versionCatalogs {
+            create("libs") {
+                from("com.mycompany:catalog:[1.0,2.0)")
+            }
+        }
+    }
+    // end::dynamic_version[]
+
+    // tag::disable_caching[]
+    dependencyResolutionManagement {
+        configurations.all {
+            resolutionStrategy.cacheDynamicVersionsFor(0, "seconds")
+        }
+    }
+    // end::disable_caching[]
+}
+
+


### PR DESCRIPTION
Fixes #26009

### Context
Users who use version catalog with dynamic version can disable/configure the cache.

In this PR I propose to reuse the existing API for configuring dynamic version caching:
```kotlin
dependencyResolutionManagement {
    configurations.all {
        cacheDynamiVersionsFor(0, "seconds")
    }
}
```

#### Advantages:
* ✅  we reuse existing API and follow the same convention as for regular configurations
* ✅  it provides more flexibility for the user

#### Disadvantages:
* ⛔️ we can't explicitly use it like that:
```kotlin
dependencyResolutionManagement {
    configurations {
        named("incomingCatalogForLibs0") {
            cacheDynamiVersionsFor(0, "seconds")
        }
    }
}
```
because the `incomingCatalogForLibs0` configuration is created ad hoc later and can't be found during the settings file evaluation.
* ⛔️ due to the above limitation, it will always affect all configurations used internally by the dependency resolution management

### Alternative API

Maybe we could think of some less general API, tailored to this specific use case. For example:
```kotlin
dependencyResolutionManagement {
    cacheVersionCatalogDynamicVersionsFor(0, "seconds")
}
```
but I'm not sure about it.

Please let me know what you think 😉 

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
