### PR TITLE
Make `-Xskip-metadata-version-check` for Kotlin DSL script compiler configurable

### DIFF
--- a/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/kotlindsl/kotlin-compiler-configuration.kt
+++ b/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/kotlindsl/kotlin-compiler-configuration.kt
@@ -17,7 +17,6 @@
 package gradlebuild.basics.kotlindsl
 
 import org.gradle.kotlin.dsl.*
-import org.jetbrains.kotlin.config.AnalysisFlags
 import org.jetbrains.kotlin.config.ApiVersion
 import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfiguration
@@ -44,7 +43,6 @@ fun KotlinCompile.configureKotlinCompilerForGradleBuild() {
             "-Xjsr305=strict",
             "-java-parameters",
             "-Xsam-conversions=class",
-            "-Xskip-metadata-version-check",
         )
     }
 }
@@ -61,7 +59,6 @@ fun CompilerConfiguration.configureKotlinCompilerForGradleBuild() {
                 JvmAnalysisFlags.javaTypeEnhancementState to JavaTypeEnhancementState(
                     Jsr305Settings(ReportLevel.STRICT, ReportLevel.STRICT)
                 ) { ReportLevel.STRICT },
-                AnalysisFlags.skipMetadataVersionCheck to true,
             )
         )
     )

--- a/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/CompilePrecompiledScriptPluginPlugins.kt
+++ b/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/CompilePrecompiledScriptPluginPlugins.kt
@@ -37,6 +37,7 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.jvm.toolchain.JavaLauncher
 import org.gradle.kotlin.dsl.precompile.v1.PrecompiledPluginsBlock
 import org.gradle.kotlin.dsl.support.ImplicitImports
+import org.gradle.kotlin.dsl.support.KotlinCompilerOptions
 import org.gradle.kotlin.dsl.support.compileKotlinScriptModuleTo
 import org.gradle.kotlin.dsl.support.scriptDefinitionFromTemplate
 import javax.inject.Inject
@@ -94,7 +95,9 @@ abstract class CompilePrecompiledScriptPluginPlugins @Inject constructor(
             if (scriptFiles.isNotEmpty())
                 compileKotlinScriptModuleTo(
                     outputDir,
-                    resolveJvmTarget(),
+                    KotlinCompilerOptions(
+                        jvmTarget = resolveJvmTarget()
+                    ),
                     kotlinModuleName,
                     scriptFiles,
                     scriptDefinitionFromTemplate(
@@ -103,7 +106,6 @@ abstract class CompilePrecompiledScriptPluginPlugins @Inject constructor(
                     ),
                     classPathFiles.filter { it.exists() },
                     logger,
-                    allWarningsAsErrors = false
                 ) { it } // TODO: translate paths
         }
     }

--- a/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/CompilePrecompiledScriptPluginPlugins.kt
+++ b/platforms/core-configuration/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/CompilePrecompiledScriptPluginPlugins.kt
@@ -34,11 +34,13 @@ import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.initialization.GradlePropertiesController
 import org.gradle.jvm.toolchain.JavaLauncher
 import org.gradle.kotlin.dsl.precompile.v1.PrecompiledPluginsBlock
 import org.gradle.kotlin.dsl.support.ImplicitImports
 import org.gradle.kotlin.dsl.support.KotlinCompilerOptions
 import org.gradle.kotlin.dsl.support.compileKotlinScriptModuleTo
+import org.gradle.kotlin.dsl.support.kotlinCompilerOptions
 import org.gradle.kotlin.dsl.support.scriptDefinitionFromTemplate
 import javax.inject.Inject
 
@@ -50,7 +52,10 @@ import javax.inject.Inject
 abstract class CompilePrecompiledScriptPluginPlugins @Inject constructor(
 
     private
-    val implicitImports: ImplicitImports
+    val implicitImports: ImplicitImports,
+
+    private
+    val gradleProperties: GradlePropertiesController
 
 ) : DefaultTask(), SharedAccessorsPackageAware {
 
@@ -88,6 +93,12 @@ abstract class CompilePrecompiledScriptPluginPlugins @Inject constructor(
     internal
     abstract val jvmTarget: Property<JavaVersion>
 
+    @get:Input
+    protected
+    val compilerOptions: KotlinCompilerOptions by lazy {
+        kotlinCompilerOptions(gradleProperties).copy(jvmTarget = resolveJvmTarget())
+    }
+
     @TaskAction
     fun compile() {
         outputDir.withOutputDirectory { outputDir ->
@@ -95,9 +106,7 @@ abstract class CompilePrecompiledScriptPluginPlugins @Inject constructor(
             if (scriptFiles.isNotEmpty())
                 compileKotlinScriptModuleTo(
                     outputDir,
-                    KotlinCompilerOptions(
-                        jvmTarget = resolveJvmTarget()
-                    ),
+                    compilerOptions,
                     kotlinModuleName,
                     scriptFiles,
                     scriptDefinitionFromTemplate(

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/AbstractKotlinScriptModelCrossVersionTest.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/AbstractKotlinScriptModelCrossVersionTest.groovy
@@ -61,6 +61,9 @@ abstract class AbstractKotlinScriptModelCrossVersionTest extends ToolingApiSpeci
         if (GradleVersion.version(releasedGradleVersion) == GradleVersion.version("6.5.1")) {
             toolingApi.requireIsolatedUserHome()
         }
+        // Having this unset is now deprecated, will default to `false` in Gradle 9.0
+        // TODO remove - see https://github.com/gradle/gradle/issues/26810
+        file('gradle.properties') << 'org.gradle.kotlin.dsl.skipMetadataVersionCheck=false'
     }
 
     private String targetKotlinVersion

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinBuildScript.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinBuildScript.kt
@@ -43,7 +43,6 @@ import kotlin.script.templates.ScriptTemplateDefinition
         "-api-version", "1.8",
         "-Xjvm-default=all",
         "-Xjsr305=strict",
-        "-Xskip-metadata-version-check",
         "-Xskip-prerelease-check",
         "-Xallow-unstable-dependencies",
         "-XXLanguage:+DisableCompatibilityModeForNewInference",

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinDslStandaloneScriptCompilationConfiguration.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinDslStandaloneScriptCompilationConfiguration.kt
@@ -38,7 +38,6 @@ abstract class KotlinDslStandaloneScriptCompilationConfiguration protected const
         "-api-version", "1.8",
         "-Xjvm-default=all",
         "-Xjsr305=strict",
-        "-Xskip-metadata-version-check",
         "-Xskip-prerelease-check",
         "-Xallow-unstable-dependencies",
         "-XXLanguage:+DisableCompatibilityModeForNewInference",

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinInitScript.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinInitScript.kt
@@ -43,7 +43,6 @@ import kotlin.script.templates.ScriptTemplateDefinition
         "-api-version", "1.8",
         "-Xjvm-default=all",
         "-Xjsr305=strict",
-        "-Xskip-metadata-version-check",
         "-Xskip-prerelease-check",
         "-Xallow-unstable-dependencies",
         "-XXLanguage:+DisableCompatibilityModeForNewInference",

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScript.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScript.kt
@@ -42,7 +42,6 @@ import kotlin.script.templates.ScriptTemplateDefinition
         "-api-version", "1.8",
         "-Xjvm-default=all",
         "-Xjsr305=strict",
-        "-Xskip-metadata-version-check",
         "-Xskip-prerelease-check",
         "-Xallow-unstable-dependencies",
         "-XXLanguage:+DisableCompatibilityModeForNewInference",

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/Interpreter.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/Interpreter.kt
@@ -18,7 +18,6 @@ package org.gradle.kotlin.dsl.execution
 
 import com.google.common.annotations.VisibleForTesting
 import org.gradle.api.GradleScriptException
-import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.initialization.Settings
 import org.gradle.api.initialization.dsl.ScriptHandler
@@ -32,6 +31,7 @@ import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.exceptions.LocationAwareException
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.service.ServiceRegistry
+import org.gradle.kotlin.dsl.support.KotlinCompilerOptions
 import org.gradle.kotlin.dsl.support.KotlinScriptHost
 import org.gradle.kotlin.dsl.support.ScriptCompilationException
 import org.gradle.kotlin.dsl.support.loggerFor
@@ -139,9 +139,7 @@ class Interpreter(val host: Host) {
 
         val implicitImports: List<String>
 
-        val jvmTarget: JavaVersion
-
-        val allWarningsAsErrors: Boolean
+        val compilerOptions: KotlinCompilerOptions
 
         fun serviceRegistryFor(programTarget: ProgramTarget, target: Any): ServiceRegistry = when (programTarget) {
             ProgramTarget.Project -> serviceRegistryOf(target as Project)
@@ -179,7 +177,7 @@ class Interpreter(val host: Host) {
                 templateId,
                 sourceHash,
                 parentClassLoader,
-                allWarningsAsErrors = host.allWarningsAsErrors
+                compilerOptions = host.compilerOptions
             )
 
         val cachedProgram =
@@ -323,8 +321,7 @@ class Interpreter(val host: Host) {
             scriptSource.withLocationAwareExceptionHandling {
                 ResidualProgramCompiler(
                     outputDir = cachedDir,
-                    jvmTarget = host.jvmTarget,
-                    allWarningsAsErrors = host.allWarningsAsErrors,
+                    compilerOptions = host.compilerOptions,
                     classPath = compilationClassPath,
                     originalSourceHash = programId.sourceHash,
                     programKind = programKind,
@@ -421,7 +418,7 @@ class Interpreter(val host: Host) {
                 parentClassLoader,
                 host.hashOf(accessorsClassPath),
                 host.hashOf(compileClassPath),
-                host.allWarningsAsErrors
+                host.compilerOptions
             )
 
             val cachedProgram = host.cachedClassFor(programId)
@@ -482,8 +479,7 @@ class Interpreter(val host: Host) {
 
                                 ResidualProgramCompiler(
                                     outputDir,
-                                    host.jvmTarget,
-                                    host.allWarningsAsErrors,
+                                    host.compilerOptions,
                                     compilationClassPath,
                                     sourceHash,
                                     programKind,

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/ProgramId.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/ProgramId.kt
@@ -17,7 +17,7 @@
 package org.gradle.kotlin.dsl.execution
 
 import org.gradle.internal.hash.HashCode
-
+import org.gradle.kotlin.dsl.support.KotlinCompilerOptions
 import java.lang.ref.WeakReference
 
 
@@ -27,7 +27,7 @@ class ProgramId(
     parentClassLoader: ClassLoader,
     private val accessorsClassPathHash: HashCode? = null,
     private val classPathHash: HashCode? = null,
-    val allWarningsAsErrors: Boolean = false
+    private val compilerOptions: KotlinCompilerOptions = KotlinCompilerOptions(),
 ) {
 
     private
@@ -45,7 +45,7 @@ class ProgramId(
             && sourceHash == that.sourceHash
             && accessorsClassPathHash == that.accessorsClassPathHash
             && classPathHash == that.classPathHash
-            && allWarningsAsErrors == that.allWarningsAsErrors
+            && compilerOptions == that.compilerOptions
     }
 
     override fun hashCode(): Int {
@@ -60,6 +60,6 @@ class ProgramId(
         classPathHash?.let { classPathHash ->
             result = 31 * result + classPathHash.hashCode()
         }
-        return 31 * result + allWarningsAsErrors.hashCode()
+        return 31 * result + compilerOptions.hashCode()
     }
 }

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/ProgramId.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/ProgramId.kt
@@ -27,7 +27,7 @@ class ProgramId(
     parentClassLoader: ClassLoader,
     private val accessorsClassPathHash: HashCode? = null,
     private val classPathHash: HashCode? = null,
-    private val compilerOptions: KotlinCompilerOptions = KotlinCompilerOptions(),
+    val compilerOptions: KotlinCompilerOptions = KotlinCompilerOptions(),
 ) {
 
     private

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/ResidualProgramCompiler.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/ResidualProgramCompiler.kt
@@ -59,7 +59,6 @@ import org.gradle.kotlin.dsl.support.bytecode.publicClass
 import org.gradle.kotlin.dsl.support.bytecode.publicDefaultConstructor
 import org.gradle.kotlin.dsl.support.bytecode.publicMethod
 import org.gradle.kotlin.dsl.support.compileKotlinScriptToDirectory
-import org.gradle.kotlin.dsl.support.messageCollectorFor
 import org.gradle.kotlin.dsl.support.scriptDefinitionFromTemplate
 import org.gradle.plugin.management.internal.MultiPluginRequests
 import org.gradle.plugin.use.internal.PluginRequestCollector
@@ -715,11 +714,12 @@ class ResidualProgramCompiler(
                 scriptFile,
                 scriptDefinition,
                 compileClassPath.asFiles,
-                messageCollectorFor(logger, allWarningsAsErrors) { path ->
-                    if (path == scriptFile.path) originalPath
-                    else path
-                }
-            )
+                allWarningsAsErrors,
+                logger
+            ) { path ->
+                if (path == scriptFile.path) originalPath
+                else path
+            }
         }.let { compiledScriptClassName ->
             packageName
                 ?.let { "$it.$compiledScriptClassName" }

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/ResidualProgramCompiler.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/ResidualProgramCompiler.kt
@@ -16,7 +16,6 @@
 
 package org.gradle.kotlin.dsl.execution
 
-import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.internal.file.temp.TemporaryFileProvider
 import org.gradle.internal.classpath.ClassPath
@@ -35,6 +34,7 @@ import org.gradle.kotlin.dsl.support.CompiledKotlinSettingsBuildscriptBlock
 import org.gradle.kotlin.dsl.support.CompiledKotlinSettingsPluginManagementBlock
 import org.gradle.kotlin.dsl.support.CompiledKotlinSettingsScript
 import org.gradle.kotlin.dsl.support.ImplicitReceiver
+import org.gradle.kotlin.dsl.support.KotlinCompilerOptions
 import org.gradle.kotlin.dsl.support.KotlinScriptHost
 import org.gradle.kotlin.dsl.support.bytecode.ALOAD
 import org.gradle.kotlin.dsl.support.bytecode.ARETURN
@@ -83,8 +83,7 @@ typealias CompileBuildOperationRunner = (String, String, () -> String) -> String
 internal
 class ResidualProgramCompiler(
     private val outputDir: File,
-    private val jvmTarget: JavaVersion,
-    private val allWarningsAsErrors: Boolean,
+    private val compilerOptions: KotlinCompilerOptions,
     private val classPath: ClassPath = ClassPath.EMPTY,
     private val originalSourceHash: HashCode,
     private val programKind: ProgramKind,
@@ -710,11 +709,10 @@ class ResidualProgramCompiler(
         compileBuildOperationRunner(originalPath, stage) {
             compileKotlinScriptToDirectory(
                 outputDir,
-                jvmTarget,
+                compilerOptions,
                 scriptFile,
                 scriptDefinition,
                 compileClassPath.asFiles,
-                allWarningsAsErrors,
                 logger
             ) { path ->
                 if (path == scriptFile.path) originalPath

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptEvaluator.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptEvaluator.kt
@@ -158,8 +158,13 @@ class StandardKotlinScriptEvaluator(
 
         override val compilerOptions: KotlinCompilerOptions =
             KotlinCompilerOptions(
-                allWarningsAsErrors = gradlePropertiesController.gradleProperties.find("org.gradle.kotlin.dsl.allWarningsAsErrors") == "true",
+                allWarningsAsErrors = gradlePropertiesController.getBoolean("allWarningsAsErrors"),
+                skipMetadataVersionCheck = gradlePropertiesController.getBoolean("skipMetadataVersionCheck"),
             )
+
+        private
+        fun GradlePropertiesController.getBoolean(name: String): Boolean =
+            gradleProperties.find("org.gradle.kotlin.dsl.$name") == "true"
 
         override fun stage1BlocksAccessorsFor(scriptHost: KotlinScriptHost<*>): ClassPath =
             (scriptHost.target as? ProjectInternal)?.let {

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
@@ -89,13 +89,6 @@ import kotlin.script.experimental.jvm.JvmDependency
 import kotlin.script.experimental.jvm.JvmGetScriptingClass
 
 
-data class KotlinCompilerOptions(
-    val jvmTarget: JavaVersion = JavaVersion.current(),
-    val allWarningsAsErrors: Boolean = false,
-    val skipMetadataVersionCheck: Boolean = false,
-)
-
-
 fun compileKotlinScriptModuleTo(
     outputDirectory: File,
     compilerOptions: KotlinCompilerOptions,

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
@@ -92,6 +92,7 @@ import kotlin.script.experimental.jvm.JvmGetScriptingClass
 data class KotlinCompilerOptions(
     val jvmTarget: JavaVersion = JavaVersion.current(),
     val allWarningsAsErrors: Boolean = false,
+    val skipMetadataVersionCheck: Boolean = false,
 )
 
 
@@ -370,7 +371,7 @@ fun compilerConfigurationFor(messageCollector: MessageCollector, compilerOptions
         put(IR, true)
         put(SAM_CONVERSIONS, JvmClosureGenerationScheme.CLASS)
         addJvmSdkRoots(PathUtil.getJdkClassesRootsFromCurrentJre())
-        put(CommonConfigurationKeys.LANGUAGE_VERSION_SETTINGS, gradleKotlinDslLanguageVersionSettings)
+        put(CommonConfigurationKeys.LANGUAGE_VERSION_SETTINGS, gradleKotlinDslLanguageVersionSettingsFor(compilerOptions))
         put(CommonConfigurationKeys.ALLOW_ANY_SCRIPTS_IN_SOURCE_ROOTS, true)
     }
 
@@ -386,11 +387,11 @@ fun JavaVersion.toKotlinJvmTarget(): JvmTarget {
 
 
 private
-val gradleKotlinDslLanguageVersionSettings = LanguageVersionSettingsImpl(
+fun gradleKotlinDslLanguageVersionSettingsFor(compilerOptions: KotlinCompilerOptions) = LanguageVersionSettingsImpl(
     languageVersion = LanguageVersion.KOTLIN_1_8,
     apiVersion = ApiVersion.KOTLIN_1_8,
     analysisFlags = mapOf(
-        AnalysisFlags.skipMetadataVersionCheck to true,
+        AnalysisFlags.skipMetadataVersionCheck to compilerOptions.skipMetadataVersionCheck,
         AnalysisFlags.skipPrereleaseCheck to true,
         AnalysisFlags.allowUnstableDependencies to true,
         JvmAnalysisFlags.jvmDefaultMode to JvmDefaultMode.ENABLE,

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompilerOptions.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompilerOptions.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.support
+
+import org.gradle.api.JavaVersion
+import org.gradle.initialization.GradlePropertiesController
+import org.gradle.internal.deprecation.DeprecationLogger
+import java.io.Serializable
+
+
+data class KotlinCompilerOptions(
+    val jvmTarget: JavaVersion = JavaVersion.current(),
+    val allWarningsAsErrors: Boolean = false,
+    val skipMetadataVersionCheck: Boolean = true,
+) : Serializable
+
+
+fun kotlinCompilerOptions(gradleProperties: GradlePropertiesController): KotlinCompilerOptions =
+    KotlinCompilerOptions(
+        allWarningsAsErrors = getCompilerOptionBoolean(gradleProperties, allWarningsAsErrorsPropertyName, false),
+        skipMetadataVersionCheck = getCompilerOptionBoolean(gradleProperties, skipMetadataVersionCheckPropertyName, true) {
+            nagAboutUnsetSkipMetadataVersionCheckProperty()
+        }
+    )
+
+
+private
+val allWarningsAsErrorsPropertyName = "org.gradle.kotlin.dsl.allWarningsAsErrors"
+
+
+private
+val skipMetadataVersionCheckPropertyName = "org.gradle.kotlin.dsl.skipMetadataVersionCheck"
+
+
+/**
+ * Read property value for compiler options.
+ *
+ * Kotlin compiler options for scripts can be set either via a System property or a Gradle property.
+ * System properties have precedence, same as in `LayoutToPropertiesConverter`.
+ */
+private
+fun getCompilerOptionBoolean(gradleProperties: GradlePropertiesController, propertyName: String, defaultValue: Boolean, whenUnset: (() -> Unit)? = null): Boolean {
+    val systemProp = System.getProperty(propertyName)
+    val gradleProp = gradleProperties.gradleProperties.find(propertyName)
+    return when {
+        // System properties have precedence, same as in LayoutToPropertiesConverter
+        systemProp != null -> systemProp == "true"
+        gradleProp != null -> gradleProp == "true"
+        else -> defaultValue.also { whenUnset?.invoke() }
+    }
+}
+
+
+private
+fun nagAboutUnsetSkipMetadataVersionCheckProperty() {
+    DeprecationLogger.deprecateBuildInvocationFeature("Skipping Kotlin metadata version check in Kotlin DSL script compilation")
+        .withContext("Skipping the check may lead to hard to troubleshoot errors when libraries built with Kotlin versions unsupported by the Kotlin embedded in Gradle are used in build logic.")
+        .withAdvice("To opt in to the future behaviour, set the '$skipMetadataVersionCheckPropertyName' System property to `false`.")
+        .startingWithGradle9("the Kotlin metadata version check will be enabled by default")
+        .withUpgradeGuideSection(8, "kotlin_skip_metadata_version_check")
+        .nagUser()
+}

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompilerOptions.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompilerOptions.kt
@@ -71,6 +71,6 @@ fun nagAboutUnsetSkipMetadataVersionCheckProperty() {
         .withContext("Skipping the check may lead to hard to troubleshoot errors when libraries built with Kotlin versions unsupported by the Kotlin embedded in Gradle are used in build logic.")
         .withAdvice("To opt in to the future behaviour, set the '$skipMetadataVersionCheckPropertyName' System property to `false`.")
         .startingWithGradle9("the Kotlin metadata version check will be enabled by default")
-        .withUpgradeGuideSection(8, "kotlin_skip_metadata_version_check")
+        .withUpgradeGuideSection(8, "kotlin_dsl_skip_metadata_version_check")
         .nagUser()
 }

--- a/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/accessors/ProjectAccessorsClassPathTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/accessors/ProjectAccessorsClassPathTest.kt
@@ -23,7 +23,6 @@ import com.nhaarman.mockito_kotlin.inOrder
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.same
 import org.gradle.api.Action
-import org.gradle.api.JavaVersion
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.NamedDomainObjectProvider
 import org.gradle.api.Project
@@ -52,6 +51,7 @@ import org.gradle.kotlin.dsl.fixtures.AbstractDslTest
 import org.gradle.kotlin.dsl.fixtures.eval
 import org.gradle.kotlin.dsl.fixtures.testRuntimeClassPath
 import org.gradle.kotlin.dsl.fixtures.withClassLoaderFor
+import org.gradle.kotlin.dsl.support.KotlinCompilerOptions
 import org.gradle.kotlin.dsl.support.compileToDirectory
 import org.gradle.kotlin.dsl.support.loggerFor
 import org.gradle.kotlin.dsl.support.uppercaseFirstChar
@@ -253,7 +253,7 @@ class ProjectAccessorsClassPathTest : AbstractDslTest() {
         require(
             compileToDirectory(
                 binDir,
-                JavaVersion.current(),
+                KotlinCompilerOptions(),
                 "bin",
                 kotlinFilesIn(srcDir),
                 loggerFor<ProjectAccessorsClassPathTest>(),

--- a/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensionsTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensionsTest.kt
@@ -31,7 +31,6 @@ import org.gradle.kotlin.dsl.fixtures.codegen.ClassToKClass
 import org.gradle.kotlin.dsl.fixtures.codegen.ClassToKClassParameterizedType
 import org.gradle.kotlin.dsl.fixtures.codegen.GroovyNamedArguments
 import org.gradle.kotlin.dsl.internal.sharedruntime.codegen.generateKotlinDslApiExtensionsSourceTo
-import org.gradle.kotlin.dsl.support.EmbeddedKotlinCompilerWarning
 import org.gradle.kotlin.dsl.support.bytecode.GradleJvmVersion
 import org.gradle.kotlin.dsl.support.compileToDirectory
 import org.gradle.test.fixtures.file.LeaksFileHandles
@@ -442,8 +441,7 @@ fun compileKotlinApiExtensionsTo(
         "gradle-api-extensions",
         sourceFiles,
         logger,
-        classPath = classPath,
-        onCompilerWarning = EmbeddedKotlinCompilerWarning.DEBUG
+        classPath = classPath
     )
 
     if (!success) {

--- a/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensionsTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensionsTest.kt
@@ -31,6 +31,7 @@ import org.gradle.kotlin.dsl.fixtures.codegen.ClassToKClass
 import org.gradle.kotlin.dsl.fixtures.codegen.ClassToKClassParameterizedType
 import org.gradle.kotlin.dsl.fixtures.codegen.GroovyNamedArguments
 import org.gradle.kotlin.dsl.internal.sharedruntime.codegen.generateKotlinDslApiExtensionsSourceTo
+import org.gradle.kotlin.dsl.support.KotlinCompilerOptions
 import org.gradle.kotlin.dsl.support.bytecode.GradleJvmVersion
 import org.gradle.kotlin.dsl.support.compileToDirectory
 import org.gradle.test.fixtures.file.LeaksFileHandles
@@ -437,7 +438,9 @@ fun compileKotlinApiExtensionsTo(
 
     val success = compileToDirectory(
         outputDirectory,
-        GradleJvmVersion.minimalJavaVersion,
+        KotlinCompilerOptions(
+            jvmTarget = GradleJvmVersion.minimalJavaVersion
+        ),
         "gradle-api-extensions",
         sourceFiles,
         logger,

--- a/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/InterpreterTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/InterpreterTest.kt
@@ -23,7 +23,6 @@ import com.nhaarman.mockito_kotlin.eq
 import com.nhaarman.mockito_kotlin.inOrder
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.same
-import org.gradle.api.JavaVersion
 import org.gradle.api.initialization.Settings
 import org.gradle.api.internal.file.temp.GradleUserHomeTemporaryFileProvider
 import org.gradle.api.internal.initialization.ClassLoaderScope
@@ -39,6 +38,7 @@ import org.gradle.kotlin.dsl.fixtures.TestWithTempFiles
 import org.gradle.kotlin.dsl.fixtures.assertStandardOutputOf
 import org.gradle.kotlin.dsl.fixtures.classLoaderFor
 import org.gradle.kotlin.dsl.fixtures.testRuntimeClassPath
+import org.gradle.kotlin.dsl.support.KotlinCompilerOptions
 import org.junit.Test
 import java.io.File
 import java.net.URLClassLoader
@@ -168,7 +168,7 @@ class InterpreterTest : TestWithTempFiles() {
                 )
             }
 
-            on { jvmTarget } doReturn JavaVersion.current()
+            on { compilerOptions } doReturn KotlinCompilerOptions()
         }
 
         try {

--- a/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/TestWithCompiler.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/TestWithCompiler.kt
@@ -22,7 +22,6 @@ import com.nhaarman.mockito_kotlin.doAnswer
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import org.gradle.api.Action
-import org.gradle.api.JavaVersion
 import org.gradle.api.initialization.Settings
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.initialization.ScriptHandlerInternal
@@ -33,6 +32,7 @@ import org.gradle.internal.hash.TestHashCodes
 import org.gradle.kotlin.dsl.fixtures.TestWithTempFiles
 import org.gradle.kotlin.dsl.fixtures.testRuntimeClassPath
 import org.gradle.kotlin.dsl.fixtures.withClassLoaderFor
+import org.gradle.kotlin.dsl.support.KotlinCompilerOptions
 import org.gradle.kotlin.dsl.support.KotlinScriptHost
 import org.gradle.plugin.management.PluginManagementSpec
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -74,8 +74,7 @@ abstract class TestWithCompiler : TestWithTempFiles() {
     ) {
         ResidualProgramCompiler(
             outputDir,
-            JavaVersion.current(),
-            false,
+            KotlinCompilerOptions(),
             testRuntimeClassPath,
             sourceHash,
             programKind,

--- a/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/integration/KotlinScriptCompilerTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/integration/KotlinScriptCompilerTest.kt
@@ -17,10 +17,10 @@
 package org.gradle.kotlin.dsl.integration
 
 import com.nhaarman.mockito_kotlin.mock
-import org.gradle.api.JavaVersion
 import org.gradle.kotlin.dsl.fixtures.TestWithTempFiles
 import org.gradle.kotlin.dsl.fixtures.testRuntimeClassPath
 import org.gradle.kotlin.dsl.fixtures.withClassLoaderFor
+import org.gradle.kotlin.dsl.support.KotlinCompilerOptions
 import org.gradle.kotlin.dsl.support.compileKotlinScriptToDirectory
 import org.gradle.kotlin.dsl.support.scriptDefinitionFromTemplate
 import org.hamcrest.CoreMatchers.equalTo
@@ -88,13 +88,12 @@ class KotlinScriptCompilerTest : TestWithTempFiles() {
     ) {
         compileKotlinScriptToDirectory(
             outputDir,
-            JavaVersion.current(),
+            KotlinCompilerOptions(),
             file("script.kts").apply {
                 writeText(script)
             },
             scriptDefinition,
             testRuntimeClassPath.asFiles,
-            false,
             mock()
         ) { it }
     }

--- a/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/integration/KotlinScriptCompilerTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/integration/KotlinScriptCompilerTest.kt
@@ -18,21 +18,15 @@ package org.gradle.kotlin.dsl.integration
 
 import com.nhaarman.mockito_kotlin.mock
 import org.gradle.api.JavaVersion
-
 import org.gradle.kotlin.dsl.fixtures.TestWithTempFiles
 import org.gradle.kotlin.dsl.fixtures.testRuntimeClassPath
 import org.gradle.kotlin.dsl.fixtures.withClassLoaderFor
 import org.gradle.kotlin.dsl.support.compileKotlinScriptToDirectory
-import org.gradle.kotlin.dsl.support.messageCollectorFor
 import org.gradle.kotlin.dsl.support.scriptDefinitionFromTemplate
-
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
-
 import org.jetbrains.kotlin.scripting.definitions.ScriptDefinition
-
 import org.junit.Test
-
 import java.io.File
 
 
@@ -100,7 +94,8 @@ class KotlinScriptCompilerTest : TestWithTempFiles() {
             },
             scriptDefinition,
             testRuntimeClassPath.asFiles,
-            messageCollectorFor(mock())
-        )
+            false,
+            mock()
+        ) { it }
     }
 }

--- a/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/normalization/KotlinApiClassExtractorTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/normalization/KotlinApiClassExtractorTest.kt
@@ -16,8 +16,8 @@
 
 package org.gradle.kotlin.dsl.normalization
 
-import org.gradle.api.JavaVersion
 import org.gradle.kotlin.dsl.fixtures.TestWithTempFiles
+import org.gradle.kotlin.dsl.support.KotlinCompilerOptions
 import org.gradle.kotlin.dsl.support.compileToDirectory
 import org.gradle.kotlin.dsl.support.loggerFor
 import org.hamcrest.CoreMatchers.equalTo
@@ -311,7 +311,7 @@ class KotlinApiClassExtractorTest : TestWithTempFiles() {
         val binDir = newFolder("bin")
         compileToDirectory(
             binDir,
-            JavaVersion.current(),
+            KotlinCompilerOptions(),
             "test",
             listOf(sourceFile),
             loggerFor<KotlinApiClassExtractorTest>(),

--- a/platforms/core-configuration/kotlin-dsl/src/testFixtures/kotlin/org/gradle/kotlin/dsl/fixtures/SimplifiedKotlinScriptEvaluator.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/testFixtures/kotlin/org/gradle/kotlin/dsl/fixtures/SimplifiedKotlinScriptEvaluator.kt
@@ -18,7 +18,6 @@ package org.gradle.kotlin.dsl.fixtures
 
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
-import org.gradle.api.JavaVersion
 import org.gradle.api.internal.file.temp.GradleUserHomeTemporaryFileProvider
 import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.api.internal.project.ProjectInternal
@@ -40,6 +39,7 @@ import org.gradle.kotlin.dsl.execution.Interpreter
 import org.gradle.kotlin.dsl.execution.ProgramId
 import org.gradle.kotlin.dsl.execution.ProgramTarget
 import org.gradle.kotlin.dsl.support.ImplicitImports
+import org.gradle.kotlin.dsl.support.KotlinCompilerOptions
 import org.gradle.kotlin.dsl.support.KotlinScriptHost
 import org.gradle.plugin.management.internal.PluginRequests
 import java.io.File
@@ -206,11 +206,8 @@ class SimplifiedKotlinScriptEvaluator(
         override val implicitImports: List<String>
             get() = ImplicitImports(DefaultImportsReader()).list
 
-        override val jvmTarget: JavaVersion
-            get() = JavaVersion.current()
-
-        override val allWarningsAsErrors: Boolean
-            get() = false
+        override val compilerOptions: KotlinCompilerOptions
+            get() = KotlinCompilerOptions()
     }
 }
 

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r82/CustomToolingModelCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r82/CustomToolingModelCrossVersionSpec.groovy
@@ -110,7 +110,13 @@ include 'a', 'b', 'c', 'd', 'e'
         connection.action(new FetchProjectsCustomModelsAction())
             .setStandardError(stderr)
             .setStandardOutput(stdout)
-            .setJvmArguments("-Xmx256m")
+            .setJvmArguments(["-Xmx256m"] + kotlinDslJvmArguments())
             .run()
+    }
+
+    private static List<String> kotlinDslJvmArguments() {
+        // Having this unset is now deprecated, will default to `false` in Gradle 9.0
+        // TODO remove - see https://github.com/gradle/gradle/issues/26810
+        ['-Dorg.gradle.kotlin.dsl.skipMetadataVersionCheck=false']
     }
 }

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -133,6 +133,22 @@ versionCatalogs.named("libs").findLibrary("assertj-core").ifPresent { assertjCor
 
 Check the [version catalog API](javadoc/org/gradle/api/artifacts/VersionCatalog.html) for all supported methods.
 
+#### Control skipping Kotlin metadata version check for script compilation
+
+You can now control if Kotlin DSL script compilation should skip Kotlin metadata version check.
+Skipping Kotlin metadata version check in Kotlin DSL script compilation is now deprecated.
+
+To opt in to the future-proof behaviour Today, set the `org.gradle.kotlin.dsl.skipMetadataVersionCheck` property to `false`.
+
+This can be achieved persistently in the `gradle.properties` file in your build root directory:
+
+[source,properties]
+----
+org.gradle.kotlin.dsl.skipMetadataVersionCheck=false
+----
+
+Please see the dedicated [upgrade guide section](userguide/upgrading_version_8.html#kotlin_dsl_skip_metadata_version_check) for more information.
+
 <a name="error-reporting"></a>
 ### Error and Warning Reporting Improvements
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -135,12 +135,14 @@ Check the [version catalog API](javadoc/org/gradle/api/artifacts/VersionCatalog.
 
 #### Control skipping Kotlin metadata version check for script compilation
 
-You can now control if Kotlin DSL script compilation should skip Kotlin metadata version check.
-Skipping Kotlin metadata version check in Kotlin DSL script compilation is now deprecated.
+Skipping [Kotlin metadata](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-metadata/) version check in Kotlin DSL script compilation is now deprecated.
 
-To opt in to the future-proof behaviour Today, set the `org.gradle.kotlin.dsl.skipMetadataVersionCheck` property to `false`.
+You can control if Kotlin DSL script compilation should skip Kotlin metadata version check with the `org.gradle.kotlin.dsl.skipMetadataVersionCheck` property.
 
-This can be achieved persistently in the `gradle.properties` file in your build root directory:
+To opt-in early to this future-proof behavior, set the `org.gradle.kotlin.dsl.skipMetadataVersionCheck` property to `false`.
+This will enable the metadata check.
+
+To enable the check persistently, set the property in the `gradle.properties` file of your build root directory:
 
 [source,properties]
 ----

--- a/subprojects/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -103,6 +103,29 @@ project(":project-without-directory").projectDir.mkdirs()
 ======
 =====
 
+[[kotlin_dsl_skip_metadata_version_check]]
+==== Skipping Kotlin metadata version check for Kotlin DSL scripts
+
+Skipping Kotlin metadata version check in Kotlin DSL script compilation is now deprecated.
+Skipping the check may lead to hard to troubleshoot errors when libraries built with Kotlin versions unsupported by the Kotlin embedded in Gradle are used in build logic.
+
+Kotlin/JVM metadata is backwards-compatible with all Kotlin releases, and forwards-compatible with one Kotlin release.
+For example Kotlin 1.9 supports Kotlin metadata from Kotlin 1.0 up to Kotlin 2.0, but not Kotlin 2.1.
+
+Because skipping this check is the current default behaviour in Kotlin DSL script compilation, a warning will be emitted for every build using `.gradle.kts` scripts.
+Starting with Gradle 9.0 the Kotlin metadata version check will be enabled by default.
+
+To opt in to the future-proof behaviour Today, set the `org.gradle.kotlin.dsl.skipMetadataVersionCheck` property to `false`.
+
+This can be achieved persistently in the `gradle.properties` file in your build root directory:
+
+[source,properties]
+----
+org.gradle.kotlin.dsl.skipMetadataVersionCheck=false
+----
+
+If you really need to skip the Kotlin metadata check you can set that property to `true` to disable the warning.
+
 [[changes_8.4]]
 == Upgrading from 8.3 and earlier
 

--- a/subprojects/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -106,25 +106,25 @@ project(":project-without-directory").projectDir.mkdirs()
 [[kotlin_dsl_skip_metadata_version_check]]
 ==== Skipping Kotlin metadata version check for Kotlin DSL scripts
 
-Skipping Kotlin metadata version check in Kotlin DSL script compilation is now deprecated.
-Skipping the check may lead to hard to troubleshoot errors when libraries built with Kotlin versions unsupported by the Kotlin embedded in Gradle are used in build logic.
+Skipping link:https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-metadata/[Kotlin metadata] version check in Kotlin DSL script compilation is now deprecated.
+Skipping the check may lead to hard-to-troubleshoot errors when libraries built with Kotlin versions unsupported by the Kotlin embedded in Gradle are used in build logic.
 
-Kotlin/JVM metadata is backwards-compatible with all Kotlin releases, and forwards-compatible with one Kotlin release.
-For example Kotlin 1.9 supports Kotlin metadata from Kotlin 1.0 up to Kotlin 2.0, but not Kotlin 2.1.
+Kotlin/JVM metadata is backward-compatible with all Kotlin releases and forward-compatible with one Kotlin release.
+For example, Kotlin 1.9 supports Kotlin metadata from Kotlin 1.0 up to Kotlin 2.0, but not Kotlin 2.1.
 
 Because skipping this check is the current default behaviour in Kotlin DSL script compilation, a warning will be emitted for every build using `.gradle.kts` scripts.
-Starting with Gradle 9.0 the Kotlin metadata version check will be enabled by default.
+Starting with Gradle 9.0, the Kotlin metadata version check will be enabled by default.
 
-To opt in to the future-proof behaviour Today, set the `org.gradle.kotlin.dsl.skipMetadataVersionCheck` property to `false`.
+To enable the check, set the `org.gradle.kotlin.dsl.skipMetadataVersionCheck` property to `false`.
 
-This can be achieved persistently in the `gradle.properties` file in your build root directory:
+To persistently enable the check, set the property in the `gradle.properties` file in your build root directory:
 
 [source,properties]
 ----
 org.gradle.kotlin.dsl.skipMetadataVersionCheck=false
 ----
 
-If you really need to skip the Kotlin metadata check you can set that property to `true` to disable the warning.
+To skip the Kotlin metadata check, you can set that property to `true` to disable the warning.
 
 [[changes_8.4]]
 == Upgrading from 8.3 and earlier

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -1182,6 +1182,10 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
 
         properties.put(DefaultCommandLineActionFactory.WELCOME_MESSAGE_ENABLED_SYSTEM_PROPERTY, Boolean.toString(renderWelcomeMessage));
 
+        // Having this unset is now deprecated, will default to `false` in Gradle 9.0
+        // TODO remove - see https://github.com/gradle/gradle/issues/26810
+        properties.put("org.gradle.kotlin.dsl.skipMetadataVersionCheck", "false");
+
         return properties;
     }
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -249,7 +249,7 @@ abstract class AbstractSmokeTest extends Specification {
             .withProjectDir(testProjectDir)
             .forwardOutput()
             .withArguments(
-                tasks.toList() + outputParameters() + repoMirrorParameters() + configurationCacheParameters() + toolchainParameters()
+                tasks.toList() + outputParameters() + repoMirrorParameters() + configurationCacheParameters() + toolchainParameters() + kotlinDslParameters()
             ) as DefaultGradleRunner
         gradleRunner.withJvmArguments(["-Xmx8g", "-XX:MaxMetaspaceSize=1024m", "-XX:+HeapDumpOnOutOfMemoryError"])
         return new SmokeTestGradleRunner(gradleRunner)
@@ -292,6 +292,14 @@ abstract class AbstractSmokeTest extends Specification {
             "-Porg.gradle.java.installations.paths=${AvailableJavaHomes.getAvailableJvms().collect { it.javaHome.absolutePath }.join(",")}" as String,
             '-Porg.gradle.java.installations.auto-detect=false',
             '-Porg.gradle.java.installations.auto-download=false',
+        ]
+    }
+
+    private static List<String> kotlinDslParameters() {
+        return [
+            // Having this unset is now deprecated, will default to `false` in Gradle 9.0
+            // TODO remove - see https://github.com/gradle/gradle/issues/26810
+            '-Dorg.gradle.kotlin.dsl.skipMetadataVersionCheck=false',
         ]
     }
 


### PR DESCRIPTION
As explained in https://github.com/gradle/gradle/issues/26810#issuecomment-1780582268 this is a breaking change and making that option disabled by default will need to happen in the next major, Gradle 9.0.

This PR adds a property to configure the compiler option and nag if you don't explicitly set it.

Behavior with validation check failures can't really be integration tested just yet because we'd need some Kotlin 2.1 release to exercise this. This was validated locally.

* First step of https://github.com/gradle/gradle/issues/26810
