### PR TITLE
Add version information to catalog javadoc

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/LibrariesSourceGenerator.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/LibrariesSourceGenerator.java
@@ -24,6 +24,7 @@ import org.gradle.api.NonNullApi;
 import org.gradle.api.artifacts.ExternalModuleDependencyBundle;
 import org.gradle.api.artifacts.MinimalExternalModuleDependency;
 import org.gradle.api.artifacts.MutableVersionConstraint;
+import org.gradle.api.internal.artifacts.ImmutableVersionConstraint;
 import org.gradle.api.internal.artifacts.dsl.CapabilityNotationParser;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.catalog.problems.VersionCatalogProblemId;
@@ -565,11 +566,7 @@ public class LibrariesSourceGenerator extends AbstractSourceGenerator {
         String name = leafNodeForAlias(alias);
         writeLn("    /**");
         writeLn("     * Creates a dependency provider for " + name + " (" + coordinatesDescriptorFor(dependency) + ")");
-        if (dependency.getVersionRef() != null) {
-            writeLn(" * with versionRef '" + dependency.getVersionRef() + "'.");
-        } else {
-            writeLn(" * with version '" + dependency.getVersion().getDisplayName() + "'.");
-        }
+        writeVersionInformation(dependency.getVersionRef(), dependency.getVersion());
         String context = dependency.getContext();
         if (context != null) {
             writeLn("     * This dependency was declared in " + sanitizeUnicodeEscapes(context));
@@ -583,6 +580,19 @@ public class LibrariesSourceGenerator extends AbstractSourceGenerator {
         writeLn("        return create(\"" + alias + "\");");
         writeLn("}");
         writeLn();
+    }
+
+    private void writeVersionInformation(@Nullable String versionRef, ImmutableVersionConstraint version) throws IOException {
+        if (versionRef != null) {
+            writeLn(" * with versionRef '" + versionRef + "'.");
+        } else {
+            String versionDisplay = version.getDisplayName();
+            if (versionDisplay.isEmpty()) {
+                writeLn(" * with no version specified");
+            } else {
+                writeLn(" * with version '" + versionDisplay + "'.");
+            }
+        }
     }
 
     private static String leafNodeForAlias(String alias) {
@@ -662,11 +672,7 @@ public class LibrariesSourceGenerator extends AbstractSourceGenerator {
         indent(() -> {
             writeLn("/**");
             writeLn(" * Creates a plugin provider for " + alias + " to the plugin id '" + plugin.getId() + "'");
-            if (plugin.getVersionRef() != null) {
-                writeLn(" * with versionRef '" + plugin.getVersionRef() + "'.");
-            } else {
-                writeLn(" * with version '" + plugin.getVersion().getDisplayName() + "'.");
-            }
+            writeVersionInformation(plugin.getVersionRef(), plugin.getVersion());
             String context = plugin.getContext();
             if (context != null) {
                 writeLn(" * This plugin was declared in " + sanitizeUnicodeEscapes(context));

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/catalog/LibrariesSourceGeneratorTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/catalog/LibrariesSourceGeneratorTest.groovy
@@ -149,6 +149,29 @@ class LibrariesSourceGeneratorTest extends AbstractVersionCatalogTest implements
         'lang3Version'  | 'getLang3Version'
     }
 
+    def "generates version info in javadoc for dependencies and plugins"() {
+        when:
+        generate {
+            version('barVersion', '2.0')
+            library('foo', 'group:foo:1.0')
+            library('fooBaz', 'group', 'foo-baz').version {
+                it.prefer('1.2')
+                it.strictly('[1.0, 2.0[')
+            }
+            library('bar', 'group', 'bar').versionRef('barVersion')
+            plugin('fooPlugin', 'org.foo.plugin').version('1.0')
+            plugin('barPlugin', 'org.bar.plugin').versionRef('barVersion')
+        }
+
+        then:
+        sources.hasDependencyAlias('foo', 'getFoo', "with version '1.0'")
+        sources.hasDependencyAlias('fooBaz', 'getFooBaz', "with version '{strictly [1.0, 2.0[; prefer 1.2}'")
+        sources.hasDependencyAlias('bar', 'getBar', "with versionRef 'barVersion'")
+
+        sources.hasPlugin('fooPlugin', 'getFooPlugin', "with version '1.0'")
+        sources.hasPlugin('barPlugin', 'getBarPlugin', "with versionRef 'barVersion'")
+    }
+
     @VersionCatalogProblemTestFor(
         VersionCatalogProblemId.ACCESSOR_NAME_CLASH
     )
@@ -428,6 +451,15 @@ ${nameClash { noIntro().kind('dependency bundles').inConflict('one.cool', 'oneCo
 
         void hasVersion(String name, String methodName = "get${toJavaName(name)}Version", String javadoc = null) {
             def lookup = "public Provider<String> $methodName() {"
+            def result = Lookup.find(lines, lookup)
+            assert result.match
+            if (javadoc) {
+                assert result.javadocContains(javadoc)
+            }
+        }
+
+        void hasPlugin(String name, String methodName = "get${toJavaName(name)}", String javadoc = null) {
+            def lookup = "public Provider<PluginDependency> $methodName() {"
             def result = Lookup.find(lines, lookup)
             assert result.match
             if (javadoc) {

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/catalog/LibrariesSourceGeneratorTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/catalog/LibrariesSourceGeneratorTest.groovy
@@ -159,17 +159,21 @@ class LibrariesSourceGeneratorTest extends AbstractVersionCatalogTest implements
                 it.strictly('[1.0, 2.0[')
             }
             library('bar', 'group', 'bar').versionRef('barVersion')
+            library('boo', 'group', 'boo').withoutVersion()
             plugin('fooPlugin', 'org.foo.plugin').version('1.0')
             plugin('barPlugin', 'org.bar.plugin').versionRef('barVersion')
+            plugin('bazPlugin', 'org.baz.plugin').version('')
         }
 
         then:
         sources.hasDependencyAlias('foo', 'getFoo', "with version '1.0'")
         sources.hasDependencyAlias('fooBaz', 'getFooBaz', "with version '{strictly [1.0, 2.0[; prefer 1.2}'")
         sources.hasDependencyAlias('bar', 'getBar', "with versionRef 'barVersion'")
+        sources.hasDependencyAlias('boo', 'getBoo', "with no version specified")
 
         sources.hasPlugin('fooPlugin', 'getFooPlugin', "with version '1.0'")
         sources.hasPlugin('barPlugin', 'getBarPlugin', "with versionRef 'barVersion'")
+        sources.hasPlugin('bazPlugin', 'getBazPlugin', "with no version specified")
     }
 
     @VersionCatalogProblemTestFor(

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -216,6 +216,13 @@ These API are currently incubating, but eventually should replace existing acces
 * `Settings.rootDir` -> `Settings.layout.rootDirectory`
 * `Settings.settingsDir` -> `Settings.layout.settingsDirectory`
 
+#### Improvements to Javadoc of generated version catalog accessors
+
+The Javadoc for generated accessors for plugins and libraries from a [version catalog](userguide/platforms.html#sub:mapping-aliases-to-accessors) now includes information about the version of the plugin or library.
+This version information can be either a value, a version reference or the indication that no version was provided.
+
+TODO include image, will be done as late as possible as images in this file make it a mess right now
+
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ADD RELEASE FEATURES ABOVE
 ==========================================================


### PR DESCRIPTION
Generated accessors for version catalogs now contain the version information for dependency and plugin entries.

* Fixes #26741

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
