### PR TITLE
Rename 'Gradle Enterprise' to 'Develocity' in the Gradle User Manual

### DIFF
--- a/subprojects/docs/src/docs/userguide/authoring-builds/logging.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/logging.adoc
@@ -82,7 +82,7 @@ This information can include but is not limited to:
 
 - Environment variables
 - Private repository credentials
-- Build cache & Gradle Enterprise Credentials
+- Build cache & Develocity Credentials
 - https://plugins.gradle.org/[Plugin Portal] publishing credentials
 
 The DEBUG log level should *not* be used when running on public Continuous Integration services.

--- a/subprojects/docs/src/docs/userguide/getting-started/tutorial/part6_gradle_caching.adoc
+++ b/subprojects/docs/src/docs/userguide/getting-started/tutorial/part6_gradle_caching.adoc
@@ -162,7 +162,7 @@ When both remote and local caches are enabled, then the build output is first ch
 If the output isn't present in the local cache, it'll be downloaded from the remote cache and also stored in the local cache.
 
 To try out the remote Build Cache, Gradle provides a free link:https://hub.docker.com/r/gradle/build-cache-node[Docker image] for a single remote Build Cache node.
-For production grade deployments, link:https://gradle.com/gradle-enterprise-solutions/build-cache/[Gradle Enterprise] is recommended.
+For production grade deployments, link:https://gradle.com/gradle-enterprise-solutions/build-cache/[Develocity] is recommended.
 
 [.text-right]
 **Next Step:** <<part7_gradle_refs.adoc#part7_begin,Using Reference Materials>> >>

--- a/subprojects/docs/src/docs/userguide/jvm/java_testing.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/java_testing.adoc
@@ -305,7 +305,7 @@ If the test does not succeed (i.e. it fails for every retry), it will be indicat
 
 When `mergeReruns` is disabled (the default), each execution of a test will be listed as a separate test case.
 
-If you are using link:https://scans.gradle.com[build scans] or link:https://gradle.com/gradle-enterprise-solution-overview/failure-analytics/[Gradle Enterprise],
+If you are using link:https://scans.gradle.com[build scans] or link:https://gradle.com/gradle-enterprise-solution-overview/failure-analytics/[Develocity],
 flaky tests will be detected regardless of this setting.
 
 Enabling this option is especially useful when using a CI tool that uses the XML test results to determine build failure instead of relying on Gradle's determination of whether the build failed or not,

--- a/subprojects/docs/src/docs/userguide/optimizing-performance/build-cache/build_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/optimizing-performance/build-cache/build_cache.adoc
@@ -423,8 +423,8 @@ This configuration precedence does not apply to <<composite_builds.adoc#included
 [[sec:build_cache_setup_http_backend]]
 == How to set up an HTTP build cache backend
 
-Gradle provides a Docker image for a link:https://hub.docker.com/r/gradle/build-cache-node/[build cache node], which can connect with Gradle Enterprise for centralized management.
-The cache node can also be used without a Gradle Enterprise installation with restricted functionality.
+Gradle provides a Docker image for a link:https://hub.docker.com/r/gradle/build-cache-node/[build cache node], which can connect with Develocity for centralized management.
+The cache node can also be used without a Develocity installation with restricted functionality.
 
 [[sec:build_cache_implement]]
 == Implement your own Build Cache
@@ -433,4 +433,4 @@ Using a different build cache backend to store build outputs (which is not cover
 your own logic for connecting to your custom build cache backend.
 To this end, custom build cache types can be registered via link:{javadocPath}/org/gradle/caching/configuration/BuildCacheConfiguration.html#registerBuildCacheService-java.lang.Class-java.lang.Class-[BuildCacheConfiguration.registerBuildCacheService(java.lang.Class, java.lang.Class)].
 
-link:https://gradle.com/gradle-enterprise-solutions/build-cache/[Gradle Enterprise] includes a high-performance, easy to install and operate, shared build cache backend.
+link:https://gradle.com/gradle-enterprise-solutions/build-cache/[Develocity] includes a high-performance, easy to install and operate, shared build cache backend.

--- a/subprojects/docs/src/docs/userguide/optimizing-performance/build-cache/build_cache_concepts.adoc
+++ b/subprojects/docs/src/docs/userguide/optimizing-performance/build-cache/build_cache_concepts.adoc
@@ -175,7 +175,7 @@ Having two tasks in the same build that do the same might sound like a problem t
 For example, the Android plugin creates several tasks for each variant of the project; some of those tasks will potentially do the same thing.
 These tasks can safely reuse each other's outputs.
 
-As <<build_cache_use_cases.adoc#share_results_between_ci_builds,discussed previously>>, you can use Gradle Enterprise to diagnose the source build of these unexpected cache-hits.
+As <<build_cache_use_cases.adoc#share_results_between_ci_builds,discussed previously>>, you can use Develocity to diagnose the source build of these unexpected cache-hits.
 
 == Non-cacheable tasks
 

--- a/subprojects/docs/src/docs/userguide/optimizing-performance/build-cache/build_cache_debugging.adoc
+++ b/subprojects/docs/src/docs/userguide/optimizing-performance/build-cache/build_cache_debugging.adoc
@@ -210,7 +210,7 @@ Build cache key for task ':compileJava' is 8ebf682168823f662b9be34d27afdf77
 The log shows e.g. which source files constitute the `stableSources` for the `compileJava` task.
 To find the actual differences between two builds you need to resort to matching up and comparing those hashes yourself.
 
-TIP: link:https://docs.gradle.com/enterprise/tutorials/task-inputs-comparison/[Gradle Enterprise] already takes care of this for you; it lets you quickly diagnose a cache miss with the Build Scan(TM) Comparison tool.
+TIP: link:https://docs.gradle.com/enterprise/tutorials/task-inputs-comparison/[Develocity] already takes care of this for you; it lets you quickly diagnose a cache miss with the Build Scan(TM) Comparison tool.
 
 [[diagnosing_cache_miss]]
 == Diagnosing the reasons for a cache miss

--- a/subprojects/docs/src/docs/userguide/optimizing-performance/build-cache/build_cache_performance.adoc
+++ b/subprojects/docs/src/docs/userguide/optimizing-performance/build-cache/build_cache_performance.adoc
@@ -63,8 +63,8 @@ The best way to learn about the impact of caching on CI is to set up the same bu
 Measuring complex pipelines may require more work or external tools to collect and process measurements.
 It's important to distinguish those parts of the pipeline that caching has no effect on, for example, the time builds spend waiting in the CI system's queue, or time taken by checking out source code from version control.
 
-When using Gradle Enterprise, you can use the https://docs.gradle.com/enterprise/export-api/[Export API] to access the necessary data and run your analytics.
-Gradle Enterprise provides much richer data compared to what can be obtained from CI servers.
+When using Develocity, you can use the https://docs.gradle.com/enterprise/export-api/[Export API] to access the necessary data and run your analytics.
+Develocity provides much richer data compared to what can be obtained from CI servers.
 For example, you can get insights into the execution of single tasks, how many tasks were retrieved from the cache, how long it took to download from the cache, the properties that were used to calculate the cache key and more.
 When using your CI servers built in functions, you can use https://confluence.jetbrains.com/display/TCD10/Statistic+Charts[statistic charts] if you use Teamcity for your CI builds.
 Most of time you will end up extracting data from your CI server via the corresponding REST API (see https://wiki.jenkins-ci.org/display/JENKINS/Remote+access+API[Jenkins remote access API] and https://confluence.jetbrains.com/display/TCD10/REST+API[Teamcity REST API]).
@@ -83,11 +83,11 @@ Gradle's build cache can be very useful in reducing CI infrastructure cost and f
 * developers can have different hardware, or have different settings
 * developers run all kinds of other things on their machines that can slow them down
 
-When using Gradle Enterprise you can use the https://docs.gradle.com/enterprise/export-api/[Export API] to extract data about developer builds, too.
+When using Develocity you can use the https://docs.gradle.com/enterprise/export-api/[Export API] to extract data about developer builds, too.
 You can then create statistics on how many tasks were cached per developer or build.
 You can even compare the times it took to execute the task vs loading it from the cache and then estimate the time saved per developer.
 
-When using the https://gradle.com/build-cache[Gradle Enterprise build cache backend] you should pay close attention to the hit rate in the admin UI.
+When using the https://gradle.com/build-cache[Develocity build cache backend] you should pay close attention to the hit rate in the admin UI.
 A rise in the hit rate there probably indicates better usage by developers:
 
 [.screenshot]
@@ -110,6 +110,6 @@ This is particularly important for assessing the impact of network link quality 
 Improving the network link between the build and the remote cache can significantly improve build cache performance.
 How to do this depends on the remote cache in use and your network environment.
 
-The multi-node remote build cache provided by Gradle Enterprise is a fast and efficient, purpose built, remote build cache.
+The multi-node remote build cache provided by Develocity is a fast and efficient, purpose built, remote build cache.
 In particular, if your development team is geographically distributed, its replication features can significantly improve performance by allowing developers to use a cache that they have a good network link to.
-See the https://docs.gradle.com/enterprise/admin/current/#replication[“Build Cache Replication” section of the Gradle Enterprise Admin Manual] for more information.
+See the https://docs.gradle.com/enterprise/admin/current/#replication[“Build Cache Replication” section of the Develocity Admin Manual] for more information.

--- a/subprojects/docs/src/docs/userguide/optimizing-performance/build-cache/build_cache_use_cases.adoc
+++ b/subprojects/docs/src/docs/userguide/optimizing-performance/build-cache/build_cache_use_cases.adoc
@@ -31,7 +31,7 @@ The local cache can also be useful when working with a project that has multiple
 == Share results between CI builds
 
 The build cache can do more than go back-and-forth in time: it can also bridge physical distance between computers, allowing results generated on one machine to be re-used by another.
-A typical first step when introducing the build cache within a team is to enable it for builds running as part of _continuous integration_ only. Using a shared HTTP build cache backend (such as https://gradle.com/build-cache/[the one provided by Gradle Enterprise]) can significantly reduce the work CI agents need to do.
+A typical first step when introducing the build cache within a team is to enable it for builds running as part of _continuous integration_ only. Using a shared HTTP build cache backend (such as https://gradle.com/build-cache/[the one provided by Develocity]) can significantly reduce the work CI agents need to do.
 This translates into faster feedback for developers, and less money spent on the CI resources.
 Faster builds also mean fewer commits being part of each build, which makes debugging issues more efficient.
 
@@ -39,7 +39,7 @@ Beginning with the build cache on CI is a good first step as the environment on 
 This helps to identify any possible issues with the build that may affect cacheability.
 
 If you are subject to audit requirements regarding the artifacts you ship to your customers you may need to disable the build cache for certain builds.
-Gradle Enterprise may help you with fulfilling these requirements while still using the build cache for all your builds.
+Develocity may help you with fulfilling these requirements while still using the build cache for all your builds.
 It allows you to easily find out which build produced an artifact coming from the build cache via build scans.
 
 [.screenshot]

--- a/subprojects/docs/src/docs/userguide/optimizing-performance/build-cache/common_caching_problems.adoc
+++ b/subprojects/docs/src/docs/userguide/optimizing-performance/build-cache/common_caching_problems.adoc
@@ -204,7 +204,7 @@ You already saw that <<build_cache_concepts.adoc#concepts_overlapping_outputs,ov
 When you add new tasks to your build or re-configure built-in tasks make sure you do not create overlapping outputs for cacheable tasks.
 If you must you can add a `Sync` task which then would sync the merged outputs into the target directory while the original tasks remain cacheable.
 
-Gradle Enterprise will show tasks where caching was disabled for overlapping outputs in the timeline and in the task input comparison:
+Develocity will show tasks where caching was disabled for overlapping outputs in the timeline and in the task input comparison:
 
 [.screenshot]
 image::build-cache/overlapping-outputs-input-comparison.png[]

--- a/subprojects/docs/src/docs/userguide/optimizing-performance/performance.adoc
+++ b/subprojects/docs/src/docs/userguide/optimizing-performance/performance.adoc
@@ -25,7 +25,7 @@ All this means that it’s worth investing some time and effort into making your
 This section offers several ways to make a build faster. Additionally, you'll find details about what leads to
 build performance degradation, and how you can avoid it.
 
-TIP: Want faster Gradle Builds? https://gradle.org/training/#build-cache-deep-dive[Register here] for our Build Cache training session to learn how Gradle Enterprise can speed up builds by up to 90%.
+TIP: Want faster Gradle Builds? https://gradle.org/training/#build-cache-deep-dive[Register here] for our Build Cache training session to learn how Develocity can speed up builds by up to 90%.
 
 == Inspect your build
 
@@ -260,7 +260,7 @@ org.gradle.caching=true
 
 You can use a local build cache to speed up repeated builds on a single machine.
 You can also use a shared build cache to speed up repeated builds across multiple machines.
-Gradle Enterprise https://gradle.com/build-cache/[provides one].
+Develocity https://gradle.com/build-cache/[provides one].
 Shared build caches can decrease build times for both CI and developer builds.
 
 For more information about the build cache, check out the

--- a/subprojects/docs/src/docs/userguide/releases/upgrading/upgrading_version_5.adoc
+++ b/subprojects/docs/src/docs/userguide/releases/upgrading/upgrading_version_5.adoc
@@ -155,7 +155,7 @@ Gradle 6.0 supports Android Gradle Plugin versions 3.4 and later.
 
 ==== Build scan plugin 2.x is no longer supported
 
-For Gradle 6, usage of the build scan plugin must be replaced with the Gradle Enterprise plugin.
+For Gradle 6, usage of the build scan plugin must be replaced with the Develocity plugin.
 This also requires changing how the plugin is applied.
 Please see https://gradle.com/help/gradle-6-build-scan-plugin for more information.
 
@@ -624,7 +624,7 @@ The built-in <<play_plugin.adoc#play_plugin, Play plugin>> has been deprecated a
 
 The _build comparison_ plugin has been deprecated and will be removed in the next major version of Gradle.
 
-link:https://gradle.com/build-scans[Build scans] show much deeper insights into your build and you can use link:https://gradle.com/[Gradle Enterprise] to directly compare two build's build-scans.
+link:https://gradle.com/build-scans[Build scans] show much deeper insights into your build and you can use link:https://gradle.com/[Develocity] to directly compare two build's build-scans.
 
 === Potential breaking changes
 


### PR DESCRIPTION
### Details
This is a Documentation change ONLY.

### Context
- Any instance of "Gradle Enterprise" is renamed to "Develocity" in the User Manual
- No changes to the "Gradle Enterprise Plugin"