### PR TITLE
Deprecate configuration methods for certain roles

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DetachedConfigurationsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DetachedConfigurationsIntegrationTest.groovy
@@ -144,7 +144,11 @@ class DetachedConfigurationsIntegrationTest extends AbstractIntegrationSpec {
                 from "artifact.txt"
             }
 
-            detached.outgoing.artifact(tasks.makeArtifact)
+            def dummy = configurations.consumable("dummy").get()
+            dummy.outgoing.artifact(tasks.makeArtifact)
+            def artifact = dummy.outgoing.artifacts.first()
+
+            detached.artifacts.add(artifact)
 
             task checkDependencies {
                 def result = detached.incoming.resolutionResult.rootComponent

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRolesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRolesIntegrationTest.groovy
@@ -121,6 +121,17 @@ This method is only meant to be called on configurations which allow the (non-de
 \tDeclarable - this configuration can have dependencies added to it
 This method is only meant to be called on configurations which allow the (non-deprecated) usage(s): 'Resolvable'. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_configuration_usage""")
             }
+        } else if (method.contains('getIncoming()')) {
+            if (role == 'canBeResolved = false') {
+                executer.expectDocumentedDeprecationWarning("""Calling configuration method 'getIncoming()' is deprecated for configuration 'internal', which has permitted usage(s):
+\tConsumable - this configuration can be selected by another project as a dependency
+\tDeclarable - this configuration can have dependencies added to it
+This method is only meant to be called on configurations which allow the (non-deprecated) usage(s): 'Resolvable'. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_configuration_usage""")
+            } else {
+                executer.expectDocumentedDeprecationWarning("""Calling configuration method 'getIncoming()' is deprecated for configuration 'internal', which has permitted usage(s):
+\tDeclarable - this configuration can have dependencies added to it
+This method is only meant to be called on configurations which allow the (non-deprecated) usage(s): 'Resolvable'. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_configuration_usage""")
+            }
         }
         fails 'checkState'
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/DeprecatedConfigurationUsageIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/DeprecatedConfigurationUsageIntegrationTest.groovy
@@ -69,8 +69,8 @@ class DeprecatedConfigurationUsageIntegrationTest extends AbstractIntegrationSpe
         where:
         methodName                                     | role              | methodCall                                                     || allowed
         'attributes(Action)'                           | 'dependencyScope' | "attributes { attribute(Attribute.of('foo', String), 'bar') }" || [ProperMethodUsage.CONSUMABLE, ProperMethodUsage.RESOLVABLE]
-        'defaultDependencies(Action)'                  | 'consumable'      | 'defaultDependencies { }'                                      || [ProperMethodUsage.DECLARABLE_AGAINST]
-        'defaultDependencies(Action)'                  | 'resolvable'      | 'defaultDependencies { }'                                      || [ProperMethodUsage.DECLARABLE_AGAINST]
+        'defaultDependencies(Action)'                  | 'consumable'      | 'defaultDependencies { }'                                      || [ProperMethodUsage.DEPENDENCY_SCOPE]
+        'defaultDependencies(Action)'                  | 'resolvable'      | 'defaultDependencies { }'                                      || [ProperMethodUsage.DEPENDENCY_SCOPE]
         'shouldResolveConsistentlyWith(Configuration)' | 'consumable'      | 'shouldResolveConsistentlyWith(null)'                          || [ProperMethodUsage.RESOLVABLE]
         'shouldResolveConsistentlyWith(Configuration)' | 'dependencyScope' | 'shouldResolveConsistentlyWith(null)'                          || [ProperMethodUsage.RESOLVABLE]
         'disableConsistentResolution()'                | 'consumable'      | 'disableConsistentResolution()'                                || [ProperMethodUsage.RESOLVABLE]
@@ -101,7 +101,7 @@ class DeprecatedConfigurationUsageIntegrationTest extends AbstractIntegrationSpe
 
         where:
         methodName                         | role              | methodCall                         || allowed
-        'setExcludeRules(Set)'             | 'consumable'      | "setExcludeRules([] as Set)"       || [ProperMethodUsage.DECLARABLE_AGAINST, ProperMethodUsage.RESOLVABLE]
+        'setExcludeRules(Set)'             | 'consumable'      | "setExcludeRules([] as Set)"       || [ProperMethodUsage.DEPENDENCY_SCOPE, ProperMethodUsage.RESOLVABLE]
         'getConsistentResolutionSource()'  | 'consumable'      | "getConsistentResolutionSource()"  || [ProperMethodUsage.RESOLVABLE]
         'getConsistentResolutionSource()'  | 'dependencyScope' | "getConsistentResolutionSource()"  || [ProperMethodUsage.RESOLVABLE]
         'getDependenciesResolverFactory()' | 'consumable'      | "getDependenciesResolverFactory()" || [ProperMethodUsage.RESOLVABLE]

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/PublishedCapabilitiesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/PublishedCapabilitiesIntegrationTest.groovy
@@ -124,16 +124,12 @@ class PublishedCapabilitiesIntegrationTest extends AbstractModuleDependencyResol
         buildFile << """
             apply plugin: 'java-library'
 
-            configurations.api.outgoing {
-                capability 'org:capability:1.0'
-            }
-
             dependencies {
                 conf 'org:test:1.0'
             }
 
-            configurations {
-                conf.extendsFrom(api)
+            configurations.conf.outgoing {
+                capability 'org:capability:1.0'
             }
         """
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
@@ -68,6 +68,15 @@ public interface ConfigurationInternal extends ResolveContext, DeprecatableConfi
     boolean isCanBeMutated();
 
     /**
+     * Equivalent to {@code getOutgoing().getCapabilities()}, but does not warn if the configuration is deprecated for consumption.
+     *
+     * <p>Intended for building configuration metadata and publication variants since capabilities
+     * still need to be retrieved from configurations deprecated for consumption or non-consumable configurations
+     * that users are still able to add capabilities to.</p>
+     */
+    Collection<? extends Capability> getCapabilitiesInternal();
+
+    /**
      * Locks the configuration for mutation
      * <p>
      * Any invalid state at this point will be added to the returned list of exceptions.

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/Configurations.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/Configurations.java
@@ -40,7 +40,7 @@ public class Configurations {
 
     public static Set<Capability> collectCapabilities(Configuration configuration, Set<Capability> out, Set<Configuration> visited) {
         if (visited.add(configuration)) {
-            out.addAll(configuration.getOutgoing().getCapabilities());
+            out.addAll(((ConfigurationInternal) configuration).getCapabilitiesInternal());
             for (Configuration parent : configuration.getExtendsFrom()) {
                 collectCapabilities(parent, out, visited);
             }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalConfigurationMetadataBuilderTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalConfigurationMetadataBuilderTest.groovy
@@ -63,6 +63,7 @@ class DefaultLocalConfigurationMetadataBuilderTest extends Specification {
         configuration.extendsFrom >> []
         configuration.hierarchy >> [configuration]
         configuration.outgoing >> outgoing
+        configuration.getCapabilitiesInternal() >> { configuration.outgoing.capabilities }
         configuration.dependencies >> dependencySet
         configuration.dependencyConstraints >> dependencyConstraintSet
         configuration.attributes >> Stub(AttributeContainerInternal)

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultLocalComponentMetadataTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultLocalComponentMetadataTest.groovy
@@ -416,6 +416,7 @@ class DefaultLocalComponentMetadataTest extends Specification {
             getOutgoing() >> outgoing
             getExtendsFrom() >> extendsFrom
             getArtifacts() >> artifacts
+            getCapabilitiesInternal() >> {outgoing.capabilities}
         }
         conf.getHierarchy() >> [conf] + extendsFrom
         return conf

--- a/platforms/software/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
+++ b/platforms/software/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
@@ -925,8 +925,8 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         given:
         createBuildScripts("""
 
-            configurations.api.outgoing.capability 'org:foo:1.0'
-            configurations.implementation.outgoing.capability 'org:bar:1.0'
+            configurations.apiElements.outgoing.capability 'org:foo:1.0'
+            configurations.runtimeElements.outgoing.capability 'org:bar:1.0'
 
             publishing {
                 publications {
@@ -952,7 +952,6 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         }
 
         javaLibrary.parsedModuleMetadata.variant('runtimeElements') {
-            capability('org', 'foo', '1.0')
             capability('org', 'bar', '1.0')
             noMoreCapabilities()
         }
@@ -963,8 +962,8 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         def silenceMethod = "suppressIvyMetadataWarningsFor"
         createBuildScripts("""
 
-            configurations.api.outgoing.capability 'org:foo:1.0'
-            configurations.implementation.outgoing.capability 'org:bar:1.0'
+            configurations.apiElements.outgoing.capability 'org:foo:1.0'
+            configurations.runtimeElements.outgoing.capability 'org:bar:1.0'
 
             publishing {
                 publications {
@@ -982,7 +981,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         then:
         outputContains(IvyComponentParser.PUBLICATION_WARNING_FOOTER)
         outputContains("$silenceMethod(variant)")
-        outputContains('Declares capability org:foo:1.0')
+        outputContains('Declares capability org:bar:1.0')
         outputContains("Variant runtimeElements")
         outputDoesNotContain("Variant apiElements")
         javaLibrary.assertPublished()
@@ -993,8 +992,8 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         def silenceMethod = "suppressIvyMetadataWarningsFor"
         createBuildScripts("""
 
-            configurations.api.outgoing.capability 'org:foo:1.0'
-            configurations.implementation.outgoing.capability 'org:bar:1.0'
+            configurations.apiElements.outgoing.capability 'org:foo:1.0'
+            configurations.runtimeElements.outgoing.capability 'org:bar:1.0'
 
             publishing {
                 publications {
@@ -1021,8 +1020,8 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         given:
         createBuildScripts("""
 
-            configurations.api.outgoing.capability 'org:foo:1.0'
-            configurations.implementation.outgoing.capability 'org:bar:1.0'
+            configurations.apiElements.outgoing.capability 'org:foo:1.0'
+            configurations.runtimeElements.outgoing.capability 'org:bar:1.0'
 
             publishing {
                 publications {

--- a/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/AbstractMavenPublishJavaIntegTest.groovy
+++ b/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/AbstractMavenPublishJavaIntegTest.groovy
@@ -613,8 +613,8 @@ abstract class AbstractMavenPublishJavaIntegTest extends AbstractMavenPublishInt
     def "can publish java-library with capabilities"() {
         given:
         createBuildScripts("""
-            configurations.api.outgoing.capability 'org:foo:1.0'
-            configurations.implementation.outgoing.capability 'org:bar:1.0'
+            configurations.apiElements.outgoing.capability 'org:foo:1.0'
+            configurations.runtimeElements.outgoing.capability 'org:bar:1.0'
 
             publishing {
                 publications {
@@ -635,8 +635,7 @@ Maven publication 'maven' pom metadata warnings (silence with 'suppressPomMetada
       - Declares capability org:foo:1.0 which cannot be mapped to Maven'''
         outputContains '''
   - Variant runtimeElements:
-      - Declares capability org:bar:1.0 which cannot be mapped to Maven
-      - Declares capability org:foo:1.0 which cannot be mapped to Maven'''
+      - Declares capability org:bar:1.0 which cannot be mapped to Maven'''
 
         for (def feature : features().findAll { it != MavenJavaModule.MAIN_FEATURE }) {
             outputContains """
@@ -653,7 +652,6 @@ Maven publication 'maven' pom metadata warnings (silence with 'suppressPomMetada
         }
 
         javaLibrary.parsedModuleMetadata.variant("runtimeElements") {
-            capability('org', 'foo', '1.0')
             capability('org', 'bar', '1.0')
             noMoreCapabilities()
         }
@@ -711,8 +709,8 @@ Maven publication 'maven' pom metadata warnings (silence with 'suppressPomMetada
     def "does not warn for the default capability if it was declared explicitly"() {
         given:
         createBuildScripts("""
-            configurations.api.outgoing.capability 'org.gradle.test:publishTest:1.9'
-            configurations.implementation.outgoing.capability 'org:bar:1.0'
+            configurations.apiElements.outgoing.capability 'org.gradle.test:publishTest:1.9'
+            configurations.runtimeElements.outgoing.capability 'org:bar:1.0'
 
             publishing {
                 publications {
@@ -746,7 +744,6 @@ Maven publication 'maven' pom metadata warnings (silence with 'suppressPomMetada
         }
 
         javaLibrary.parsedModuleMetadata.variant("runtimeElements") {
-            capability('org.gradle.test', 'publishTest', '1.9')
             capability('org', 'bar', '1.0')
             noMoreCapabilities()
         }
@@ -757,8 +754,8 @@ Maven publication 'maven' pom metadata warnings (silence with 'suppressPomMetada
         def silenceMethod = "suppressPomMetadataWarningsFor"
         createBuildScripts("""
 
-            configurations.api.outgoing.capability 'org:foo:1.0'
-            configurations.implementation.outgoing.capability 'org:bar:1.0'
+            configurations.apiElements.outgoing.capability 'org:foo:1.0'
+            configurations.runtimeElements.outgoing.capability 'org:bar:1.0'
 
             publishing {
                 publications {
@@ -786,8 +783,8 @@ Maven publication 'maven' pom metadata warnings (silence with 'suppressPomMetada
         given:
         createBuildScripts("""
 
-            configurations.api.outgoing.capability 'org:foo:1.0'
-            configurations.implementation.outgoing.capability 'org:bar:1.0'
+            configurations.apiElements.outgoing.capability 'org:foo:1.0'
+            configurations.runtimeElements.outgoing.capability 'org:bar:1.0'
 
             publishing {
                 publications {

--- a/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
+++ b/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
@@ -120,8 +120,8 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishJavaIntegTest {
         def silenceMethod = "suppressPomMetadataWarningsFor"
         createBuildScripts("""
 
-            configurations.api.outgoing.capability 'org:foo:1.0'
-            configurations.implementation.outgoing.capability 'org:bar:1.0'
+            configurations.apiElements.outgoing.capability 'org:foo:1.0'
+            configurations.runtimeElements.outgoing.capability 'org:bar:1.0'
 
             publishing {
                 publications {

--- a/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/component/ConfigurationSoftwareComponentVariant.java
+++ b/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/component/ConfigurationSoftwareComponentVariant.java
@@ -62,7 +62,8 @@ public class ConfigurationSoftwareComponentVariant extends AbstractSoftwareCompo
     @Override
     public Set<ModuleDependency> getDependencies() {
         if (dependencies == null) {
-            dependencies = configuration.getIncoming().getDependencies().withType(ModuleDependency.class);
+            ((ConfigurationInternal) configuration).runDependencyActions();
+            dependencies = configuration.getAllDependencies().withType(ModuleDependency.class);
         }
         return dependencies;
     }
@@ -70,7 +71,8 @@ public class ConfigurationSoftwareComponentVariant extends AbstractSoftwareCompo
     @Override
     public Set<? extends DependencyConstraint> getDependencyConstraints() {
         if (dependencyConstraints == null) {
-            dependencyConstraints = configuration.getIncoming().getDependencyConstraints();
+            ((ConfigurationInternal) configuration).runDependencyActions();
+            dependencyConstraints = configuration.getAllDependencyConstraints();
         }
         return dependencyConstraints;
     }


### PR DESCRIPTION
Most importantly, ensure getIncoming and getOutgoing are properly restricted Also limit setTransitive, withDependencies, iterator, isEmepty, getResolutionStrategy

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
