### PR TITLE
Use `DynamicLookupRoutine` in `ProblemReportingCrossProjectModelAccess`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ kotlin.js.ir.output.granularity=whole-program
 # Temporarily force IDEs to produce build scans
 systemProp.org.gradle.internal.ide.scan=true
 # If you're experimenting with changes and don't want to update the verification file right away, please change the mode to "lenient" (not "off")
-org.gradle.dependency.verification=off
+org.gradle.dependency.verification=strict
 # TD releated properties
 gradle.internal.testdistribution.writeTraceFile=false
 systemProp.gradle.internal.testdistribution.writeTraceFile=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ kotlin.js.ir.output.granularity=whole-program
 # Temporarily force IDEs to produce build scans
 systemProp.org.gradle.internal.ide.scan=true
 # If you're experimenting with changes and don't want to update the verification file right away, please change the mode to "lenient" (not "off")
-org.gradle.dependency.verification=strict
+org.gradle.dependency.verification=off
 # TD releated properties
 gradle.internal.testdistribution.writeTraceFile=false
 systemProp.gradle.internal.testdistribution.writeTraceFile=false

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/AbstractConfigurationCacheIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/AbstractConfigurationCacheIntegrationTest.groovy
@@ -53,10 +53,6 @@ abstract class AbstractConfigurationCacheIntegrationTest extends AbstractConfigu
         fails(ENABLE_CLI_OPT, LOG_REPORT_LINK_AS_WARNING, *tasks)
     }
 
-    String relativePath(String path) {
-        return path.replace('/', File.separator)
-    }
-
     protected void assertTestsExecuted(String testClass, String... testNames) {
         new DefaultTestExecutionResult(testDirectory)
             .testClass(testClass)

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsAccessFromGroovyDslIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsAccessFromGroovyDslIntegrationTest.groovy
@@ -789,6 +789,10 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
 
         then:
         failure.assertHasErrorOutput(expectedOutput)
+        problems.assertResultHasProblems(failure) {
+            withProblem("Build file 'a/build.gradle': line 3: Cannot access project ':b' from project ':a'")
+            withProblem("Build file 'a/build.gradle': line 3: Project ':b' cannot dynamically look up a $type in the parent project ':'")
+        }
 
         where:
         type       | referentConfiguration                           | referrerConfiguration                   | expectedOutput

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsAccessFromGroovyDslIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsAccessFromGroovyDslIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.configurationcache.isolated
 
+import org.gradle.api.provider.Property
 import spock.lang.Issue
 
 class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolatedProjectsIntegrationTest {
@@ -759,5 +760,39 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         fixture.assertStateStored {
             projectsConfigured(":", ":a", ":b")
         }
+    }
+
+    def "fails on access #type of unconfigured project"() {
+        given:
+        settingsFile << """
+            include(':a')
+            include(':b')
+        """
+
+        file("a/build.gradle") << """
+            def unconfiguredProject = project(':b')
+            $referrerConfiguration
+        """
+
+        file("a/build.gradle") << """
+            import ${Property.name}
+
+            interface MyExtension {
+                Property<String> bar()
+            }
+
+            $referentConfiguration
+        """
+
+        when:
+        isolatedProjectsFails 'help', WARN_PROBLEMS_CLI_OPT
+
+        then:
+        failure.assertHasErrorOutput(expectedOutput)
+
+        where:
+        type       | referentConfiguration                           | referrerConfiguration                   | expectedOutput
+        "property" | "extensions.create('myExtension', MyExtension)" | "unconfiguredProject.myExtension.bar()" | "Could not get unknown property 'myExtension' for project ':b' of type org.gradle.api.Project."
+        "method"   | "def foo(){}"                                   | "unconfiguredProject.foo()"             | "Could not find method foo() for arguments [] on project ':b' of type org.gradle.api.Project."
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsAccessFromGroovyDslIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsAccessFromGroovyDslIntegrationTest.groovy
@@ -774,7 +774,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
             $referrerConfiguration
         """
 
-        file("a/build.gradle") << """
+        file("b/build.gradle") << """
             import ${Property.name}
 
             interface MyExtension {
@@ -790,8 +790,8 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         then:
         failure.assertHasErrorOutput(expectedOutput)
         problems.assertResultHasProblems(failure) {
-            withProblem("Build file 'a/build.gradle': line 3: Cannot access project ':b' from project ':a'")
-            withProblem("Build file 'a/build.gradle': line 3: Project ':b' cannot dynamically look up a $type in the parent project ':'")
+            withProblem("Build file '${relativePath('a/build.gradle')}': line 3: Cannot access project ':b' from project ':a'")
+            withProblem("Build file '${relativePath('a/build.gradle')}': line 3: Project ':b' cannot dynamically look up a $type in the parent project ':'")
         }
 
         where:

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ProblemReportingCrossProjectModelAccess.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ProblemReportingCrossProjectModelAccess.kt
@@ -145,14 +145,14 @@ class ProblemReportingCrossProjectModelAccess(
         return if (this == referrer) {
             this
         } else {
-            ProblemReportingProject(this, referrer, problems, coupledProjectsListener, problemFactory)
+            ProblemReportingProject(this as DefaultProject, referrer as DefaultProject, problems, coupledProjectsListener, problemFactory)
         }
     }
 
     private
     class ProblemReportingProject(
-        val delegate: ProjectInternal,
-        val referrer: ProjectInternal,
+        val delegate: DefaultProject,
+        val referrer: DefaultProject,
         val problems: ProblemsListener,
         val coupledProjectsListener: CoupledProjectsListener,
         val problemFactory: ProblemFactory
@@ -186,7 +186,7 @@ class ProblemReportingCrossProjectModelAccess(
             }
             onAccess()
 
-            return (delegate as DefaultProject).getProperty(propertyName)
+            return delegate.getProperty(propertyName)
         }
 
         override fun invokeMethod(name: String, args: Any): Any? {
@@ -199,7 +199,7 @@ class ProblemReportingCrossProjectModelAccess(
             }
             onAccess()
 
-            return (delegate as DefaultProject).invokeMethod(name, args)
+            return delegate.invokeMethod(name, args)
         }
 
         override fun compareTo(other: Project?): Int {

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ProblemReportingCrossProjectModelAccess.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ProblemReportingCrossProjectModelAccess.kt
@@ -40,7 +40,6 @@ import org.gradle.api.file.DeleteSpec
 import org.gradle.api.file.FileTree
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.SyncSpec
-import org.gradle.api.internal.DynamicObjectAware
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.ProcessOperations
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider
@@ -52,6 +51,7 @@ import org.gradle.api.internal.initialization.ScriptHandlerInternal
 import org.gradle.api.internal.plugins.ExtensionContainerInternal
 import org.gradle.api.internal.plugins.PluginManagerInternal
 import org.gradle.api.internal.project.CrossProjectModelAccess
+import org.gradle.api.internal.project.DefaultProject
 import org.gradle.api.internal.project.ProjectIdentifier
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.project.ProjectState
@@ -177,7 +177,7 @@ class ProblemReportingCrossProjectModelAccess(
             return delegate.hashCode()
         }
 
-        override fun getProperty(propertyName: String): Any {
+        override fun getProperty(propertyName: String): Any? {
             // Attempt to get the property value via this instance. If not present, then attempt to lookup via the delegate
             val thisBean = BeanDynamicObject(this).withNotImplementsMissing()
             val result = thisBean.tryGetProperty(propertyName)
@@ -185,15 +185,11 @@ class ProblemReportingCrossProjectModelAccess(
                 return result.value
             }
             onAccess()
-            val delegateBean = (delegate as DynamicObjectAware).asDynamicObject
-            val delegateResult = delegateBean.tryGetProperty(propertyName)
-            if (delegateResult.isFound) {
-                return delegateResult.value
-            }
-            throw thisBean.getMissingProperty(propertyName)
+
+            return (delegate as DefaultProject).getProperty(propertyName)
         }
 
-        override fun invokeMethod(name: String, args: Any): Any {
+        override fun invokeMethod(name: String, args: Any): Any? {
             // Attempt to get the property value via this instance. If not present, then attempt to lookup via the delegate
             val varargs: Array<Any?> = args.uncheckedCast()
             val thisBean = BeanDynamicObject(this).withNotImplementsMissing()
@@ -202,12 +198,8 @@ class ProblemReportingCrossProjectModelAccess(
                 return result.value
             }
             onAccess()
-            val delegateBean = (delegate as DynamicObjectAware).asDynamicObject
-            val delegateResult = delegateBean.tryInvokeMethod(name, *varargs)
-            if (delegateResult.isFound) {
-                return delegateResult.value
-            }
-            throw thisBean.methodMissingException(name, args)
+
+            return (delegate as DefaultProject).invokeMethod(name, args)
         }
 
         override fun compareTo(other: Project?): Int {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -418,6 +418,7 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
     }
 
     @Override
+    @Nullable
     public ProjectInternal getParent() {
         return getParent(this);
     }
@@ -453,12 +454,13 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
     }
 
     @Override
+    @Nullable
     public String getDescription() {
         return description;
     }
 
     @Override
-    public void setDescription(String description) {
+    public void setDescription(@Nullable String description) {
         this.description = description;
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -281,6 +281,10 @@ abstract class AbstractIntegrationSpec extends Specification {
         return new ConfigurationCacheBuildOperationsFixture(new BuildOperationsFixture(executer, temporaryFolder))
     }
 
+    String relativePath(String path) {
+        return path.replace('/', File.separator)
+    }
+
     TestFile getTestDirectory() {
         if (testDirOverride != null) {
             return testDirOverride


### PR DESCRIPTION
Fix bypassing of `DynamicLookupRountine` usage.

Normally, all `getProperty`/`invokeMethod` requests must go through `DynamicLookupRoutine` as it implemented in `DefaultProject` or `BasicScript`. However, `ProblemReportingCrossProjectModelAccess` contained direct invocations on `DynamicObject` what is was bypassing usage of `DynamicLookupRoutine`