### PR TITLE
Remove :wrapper-shared dependency from :build-cache-packaging

### DIFF
--- a/platforms/core-execution/build-cache-packaging/build.gradle.kts
+++ b/platforms/core-execution/build-cache-packaging/build.gradle.kts
@@ -12,9 +12,6 @@ dependencies {
     api(project(":files"))
 
     implementation(project(":base-annotations"))
-    implementation(project(":wrapper-shared")) {
-        because("We need to access the ZipSlip helper class")
-    }
     implementation(libs.guava)
     implementation(libs.commonsCompress)
     implementation(libs.commonsIo)


### PR DESCRIPTION
This is not necessary after https://github.com/gradle/gradle/pull/26242.

Fixes https://github.com/gradle/gradle/issues/26676.
