### PR TITLE
expand list of public header file extensions for cpp-library

### DIFF
--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppLibrary.java
@@ -149,6 +149,11 @@ public class DefaultCppLibrary extends DefaultCppComponent implements CppLibrary
         PatternSet patterns = new PatternSet();
         patterns.include("**/*.h");
         patterns.include("**/*.hpp");
+        patterns.include("**/*.hxx");
+        patterns.include("**/*.hm");
+        patterns.include("**/*.inl");
+        patterns.include("**/*.inc");
+        patterns.include("**/*.xsd");
         return publicHeadersWithConvention.getAsFileTree().matching(patterns);
     }
 


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->
26828
### Context
<!--- Why do you believe many users will benefit from this change? -->
This is a fix for C++ users of gradle.  There are many 3rd party libraries that contain public header files with extensions beyond ".h" and ".hpp".  

<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
