### PR TITLE
October Doc Cleanup based on Github issues

### DIFF
--- a/subprojects/docs/src/docs/dsl/org.gradle.api.invocation.Gradle.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.invocation.Gradle.xml
@@ -89,6 +89,9 @@
             <tr>
                 <td>includedBuild</td>
             </tr>
+            <tr>
+                <td>beforeSettings</td>
+            </tr>
         </table>
     </section>
 </section>

--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/declaring_repositories.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/declaring_repositories.adoc
@@ -644,7 +644,7 @@ For details on Google GCS related authentication, see the section <<#sec:gcs-rep
 [[sec:authentication_schemes]]
 == HTTP(S) authentication schemes configuration
 
-When configuring a repository using HTTP or HTTPS transport protocols, multiple authentication schemes are available. By default, Gradle will attempt to use all schemes that are supported by the Apache HttpClient library, http://hc.apache.org/httpcomponents-client-ga/tutorial/html/authentication.html#d5e625[documented here]. In some cases, it may be preferable to explicitly specify which authentication schemes should be used when exchanging credentials with a remote server. When explicitly declared, only those schemes are used when authenticating to a remote repository.
+When configuring a repository using HTTP or HTTPS transport protocols, multiple authentication schemes are available. By default, Gradle will attempt to use all schemes that are supported by the Apache HttpClient library, http://hc.apache.org/httpcomponents-client-ga/[documented here]. In some cases, it may be preferable to explicitly specify which authentication schemes should be used when exchanging credentials with a remote server. When explicitly declared, only those schemes are used when authenticating to a remote repository.
 
 You can specify credentials for Maven repositories secured by basic authentication using link:{javadocPath}/org/gradle/api/credentials/PasswordCredentials.html[PasswordCredentials].
 

--- a/subprojects/docs/src/docs/userguide/extending-gradle/task_configuration_avoidance.adoc
+++ b/subprojects/docs/src/docs/userguide/extending-gradle/task_configuration_avoidance.adoc
@@ -20,7 +20,10 @@ This chapter provides an introduction to "configuration avoidance" when dealing 
 [[sec:how_does_it_work]]
 == How does the configuration avoidance API work?
 
-In a nutshell, the API allows builds to avoid the cost of creating and configuring tasks during Gradle's configuration phase when those tasks will never be executed.  For example, when running a compile task, other unrelated tasks, like code quality, testing and publishing tasks, will not be executed, so any time spent creating and configuring those tasks is unnecessary.  The configuration avoidance API avoids configuring tasks if they will not be needed during the course of a build, which can have a significant impact on total configuration time.
+In a nutshell, the API allows builds to avoid the cost of creating and configuring tasks during Gradle's configuration phase when those tasks will never be executed.
+For example, when running a `compile` task, other unrelated tasks (such as `clean`, `test`, `javadocs`) will not be executed.
+
+The configuration avoidance API avoids configuring tasks if they will not be needed during the course of a build, which can have a significant impact on total configuration time.
 
 To avoid creating and configuring tasks, we say that a task is "registered" but not created.  When a task is in this state, it is known to the build, it can be configured, and references to it can be passed around, but the task object itself has not actually been created, and none of its configuration actions have been executed.  It will remain in this state until something in the build needs the instantiated task object (for instance if the task is executed on the command line or the task is a dependency of a task executed on the command line).  If the task object is never needed, then the task will remain in the registered state, and the cost of creating and configuring the task will be avoided.
 

--- a/subprojects/docs/src/docs/userguide/getting-started/tutorial/part1_gradle_init.adoc
+++ b/subprojects/docs/src/docs/userguide/getting-started/tutorial/part1_gradle_init.adoc
@@ -149,7 +149,7 @@ $ ./gradlew build
 In Windows, the command is:
 [source]
 ----
-$ gradlew.bat build
+$ .\gradlew.bat build
 ----
 
 The first time you run the wrapper, it downloads and caches the Gradle binaries if they are not already installed on your machine.

--- a/subprojects/docs/src/docs/userguide/getting-started/tutorial/part2_gradle_tasks.adoc
+++ b/subprojects/docs/src/docs/userguide/getting-started/tutorial/part2_gradle_tasks.adoc
@@ -82,9 +82,9 @@ Gradle provides many _built-in_ tasks that developers can use to enhance build s
 
 This example task copies `*.war` files from the `source` directory to the `target` directory using the `Copy` built-in task.
 
-[source]
+[source,kotlin]
 ----
-tasks.register("copyTask",Copy) {
+tasks.register<Copy>("copyTask") {
     from("source")
     into("target")
     include("*.war")

--- a/subprojects/docs/src/docs/userguide/getting-started/tutorial/part3_gradle_dep_man.adoc
+++ b/subprojects/docs/src/docs/userguide/getting-started/tutorial/part3_gradle_dep_man.adoc
@@ -46,8 +46,8 @@ repositories {
 }
 
 dependencies {
-    // Use JUnit test framework.
-    testImplementation("junit:junit:4.13.2")
+    // Use JUnit Jupiter for testing.
+    testImplementation("org.junit.jupiter:junit-jupiter:5.9.1")
 
     // This dependency is used by the application.
     implementation("com.google.guava:guava:32.1.2-jre")
@@ -61,29 +61,29 @@ Some key concepts in Gradle dependency management include:
 https://mvnrepository.com/repos/central[Maven Central] is a collection of jar files, plugins, and libraries provided by the Maven community and backed by https://central.sonatype.org/[Sonatype^].
 It is the de-facto public artifact store for Java and is used by many build systems.
 
-*Dependencies* - Dependencies declared via configuration types -> https://mvnrepository.com/artifact/junit/junit[`junit`] and https://mvnrepository.com/artifact/com.google.guava/guava[`guava`] +
+*Dependencies* - Dependencies declared via configuration types -> https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api[`junit`] and https://mvnrepository.com/artifact/com.google.guava/guava[`guava`] +
 
 Gradle needs specific information to find a dependency.
-Let's look at `com.google.guava:guava:32.1.2-jre` and `junit:junit:4.13.2`; they are broken down as follows:
+Let's look at `com.google.guava:guava:32.1.2-jre` and `org.junit.jupiter:junit-jupiter-api:5.9.1`; they are broken down as follows:
 
 [cols="10h,30,40,20"]
 |===
-| |Description | com.google.guava:guava:32.1.2-jre | junit:junit:4.13.2
+| |Description | com.google.guava:guava:32.1.2-jre | org.junit.jupiter:junit-jupiter-api:5.9.1
 
 |Group
 |identifier of an organization
 |`com.google.guava`
-|`junit`
+|`org.junit.jupiter`
 
 |Name
 |dependency identifier
 |`guava`
-|`junit`
+|`junit-jupiter-api`
 
 |Version
 |version # to import
 |`32.1.2-jre`
-|`4.13.2`
+|`5.9.1`
 |===
 
 == Step 2. Understanding Transitive Dependencies
@@ -227,6 +227,8 @@ dependencies {
     implementation(libs.guava)
 }
 ----
+
+Run `./gradlew build` to make sure the changes take effect.
 
 Finally, make sure everything is working using the `run` task, either in your terminal or IDE:
 ----

--- a/subprojects/docs/src/docs/userguide/getting-started/tutorial/part4_gradle_plugins.adoc
+++ b/subprojects/docs/src/docs/userguide/getting-started/tutorial/part4_gradle_plugins.adoc
@@ -174,7 +174,7 @@ BUILD SUCCESSFUL in 331ms
 
 The `publishToMavenLocal` task builds the POM file and the artifacts to be published. It then _installs_ them into the local Maven repository.
 
-You can view the POM and JSON file in the `build` directory:
+You can view the POM and GMM file in the `build` directory:
 
 image::tutorial/intellij-idea-dist.png[]
 

--- a/subprojects/docs/src/docs/userguide/getting-started/tutorial/part4_gradle_plugins.adoc
+++ b/subprojects/docs/src/docs/userguide/getting-started/tutorial/part4_gradle_plugins.adoc
@@ -173,7 +173,7 @@ BUILD SUCCESSFUL in 331ms
 
 The `publishToMavenLocal` task builds the POM file and the artifacts to be published. It then _installs_ them into the local Maven repository.
 
-You can view the POM and JAR file in the `build` directory:
+You can view the POM and JSON file in the `build` directory:
 
 image::tutorial/intellij-idea-dist.png[]
 

--- a/subprojects/docs/src/docs/userguide/getting-started/tutorial/part4_gradle_plugins.adoc
+++ b/subprojects/docs/src/docs/userguide/getting-started/tutorial/part4_gradle_plugins.adoc
@@ -119,7 +119,7 @@ Add the publishing information to your `build.gradle.kts` file:
 ----
 publishing {
     publications {
-        mavenJava(MavenPublication)("maven") {
+        create("maven") {
             groupId = "org.gradle.tutorial"
             artifactId = "tutorial"
             version = "1.0"

--- a/subprojects/docs/src/docs/userguide/getting-started/tutorial/part4_gradle_plugins.adoc
+++ b/subprojects/docs/src/docs/userguide/getting-started/tutorial/part4_gradle_plugins.adoc
@@ -114,7 +114,8 @@ Similarly, the new tasks from the Maven Publish plugin are now available in Inte
 image::tutorial/intellij-idea-plugin.png[]
 
 == Step 3. Configuring the Plugin
-Add the publishing information to your `build.gradle.kts` file:
+Add the publishing block below to the end of your `build.gradle.kts` file:
+
 [source]
 ----
 publishing {

--- a/subprojects/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -315,7 +315,7 @@ It uses eager APIs and has ordering issues if the value is read in build logic a
 It could result in outputs ending up in different locations.
 
 It is replaced by a `link:{javadocPath}/org/gradle/api/file/DirectoryProperty.html[DirectoryProperty]` found at `Project.layout.buildDirectory`.
-See the `link:{dslPath}/org.gradle.api.file.ProjectLayout.html[ProjectLayout]` interface for details.
+See the `link:{groovyDslPath}/org.gradle.api.file.ProjectLayout.html[ProjectLayout]` interface for details.
 
 Note that, at this stage, Gradle will not print deprecation warnings if you still use `Project.buildDir`.
 We know this is a big change and want to give time for authors of major plugins to move away from its usage first.

--- a/subprojects/docs/src/snippets/developingPlugins/publishingPlugins/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/developingPlugins/publishingPlugins/groovy/build.gradle
@@ -1,6 +1,6 @@
 // tag::plugins_block[]
 plugins {
-    id 'com.gradle.plugin-publish' version '1.1.0'
+    id 'com.gradle.plugin-publish' version '1.2.1'
 }
 // end::plugins_block[]
 

--- a/subprojects/docs/src/snippets/developingPlugins/publishingPlugins/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/developingPlugins/publishingPlugins/kotlin/build.gradle.kts
@@ -1,6 +1,6 @@
 // tag::plugins_block[]
 plugins {
-    id("com.gradle.plugin-publish") version "1.1.0"
+    id("com.gradle.plugin-publish") version "1.2.1"
 }
 // end::plugins_block[]
 


### PR DESCRIPTION
### Context
Handles Github issues and a few internal issues in sections that have been recently updated in the Gradle User Manual.

This is a documentation change ONLY.

### Fixes:
- Address https://github.com/gradle/gradle/issues/26659
- Fix https://github.com/gradle/gradle/issues/26814
- Fix https://github.com/gradle/gradle/issues/26861
- Fix https://github.com/gradle/gradle/issues/26750
- Fix version of Gradle Plugin Portal in docs for @runningcode 
- Update the description of [task_configuration_avoidance_migration_guidelines](https://docs.gradle.org/8.4/userguide/task_configuration_avoidance.html#sec:task_configuration_avoidance_migration_guidelines) requested anonymously
- Fix the broken link of [`ProjectLayout`](https://docs.gradle.org/8.4/userguide/upgrading_version_8.html#project_builddir) requested anonymously
- Update the file description of [Tutorial Part 4 step 3](https://docs.gradle.org/8.4/userguide/part4_gradle_plugins.html)
- Update the build file referenced in [Tutorial Part 3 step 1](https://docs.gradle.org/8.4/userguide/part3_gradle_dep_man.html) and add a command to [Tutorial Part 3 step 6](https://docs.gradle.org/8.4/userguide/part3_gradle_dep_man.html)
- Update where the code block should be placed in code in [Tutorial Part 4 step 3](https://docs.gradle.org/8.4/userguide/part3_gradle_dep_man.html)
- Fix bad Windows invocation of Gradle Wrapper in [Tutorial Part 1 step 3](https://docs.gradle.org/8.4/userguide/part1_gradle_init.html)

### Reviewers:
Under development.