### PR TITLE
Refine trusted gradle gpg keys

### DIFF
--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -82,7 +82,10 @@
          <trusted-key id="0a123c1ed3f13a6a0140e166c71fb765cd9de313" group="org.apache.ant"/>
          <trusted-key id="0cb5871fb7bf3b351614bbf6ca85ffe638d4407a" group="it.unimi.dsi" name="fastutil"/>
          <trusted-key id="0e18eae07b7774eac5db3f2113bb90ce8eafbe37" group="com.microsoft.playwright"/>
-         <trusted-key id="7b79add11f8a779fe90fd3d0893a028475557671" group="com.gradle" name="gradle-enterprise-gradle-plugin"/>
+         <trusted-key id="7b79add11f8a779fe90fd3d0893a028475557671">
+            <trusting group="com.gradle"/>
+            <trusting group="org.gradle"/>
+         </trusted-key>
          <trusted-key id="120d6f34e627ed3a772ebbfe55c7e5e701832382" group="org.yaml" name="snakeyaml"/>
          <trusted-key id="160a7a9cf46221a56b06ad64461a804f2609fd89" group="^com[.]github[.]shyiko($|([.].*))" regex="true"/>
          <trusted-key id="1616273079fe63e31c938f10f0df21d1d0a3c384" group="com.google.inject" name="guice" version="4.2.3"/>
@@ -116,12 +119,7 @@
             <trusting group="xml-apis"/>
          </trusted-key>
          <trusted-key id="314fe82e5a4c5377bca2edec5208812e1e4a6db0">
-            <trusting group="com.gradle"/>
-            <trusting group="com.gradle" name="gradle-enterprise-gradle-plugin"/>
             <trusting group="net.rubygrapefruit"/>
-            <trusting group="org.gradle"/>
-            <trusting group="org.gradle.exemplar"/>
-            <trusting group="org.gradle.profiler"/>
             <trusting group="^com[.]gradle($|([.].*))" regex="true"/>
             <trusting group="^org[.]gradle($|([.].*))" regex="true"/>
          </trusted-key>


### PR DESCRIPTION
- Trust `org.gradle` artifact signed by gradle.com key
- Remove redundant entries of gradle.org key
