### PR TITLE
Adds `plusAssign` to Kotlin Property DSL extensions

### DIFF
--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/PropertyExtensions.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/PropertyExtensions.kt
@@ -103,3 +103,53 @@ fun <K, V> MapProperty<K, V>.assign(entries: Map<out K?, V?>?) {
 fun <K, V> MapProperty<K, V>.assign(provider: Provider<out Map<out K?, V?>?>) {
     this.set(provider)
 }
+
+
+/**
+ * Adds to the value of the property the given element, appending to any existing value
+ *
+ * @since 8.5
+ */
+operator fun <T : Any> HasMultipleValues<T>.plusAssign(element: T) {
+    this.add(element)
+}
+
+
+/**
+ * Adds to the value of the property the elements of the given iterable, appending to any existing value
+ *
+ * @since 8.5
+ */
+operator fun <T> HasMultipleValues<T>.plusAssign(elements: Iterable<T?>) {
+    this.addAll(elements)
+}
+
+
+/**
+ * Adds to the property the values of the given provider, appending to any existing value
+ *
+ * @since 8.5
+ */
+operator fun <T> HasMultipleValues<T>.plusAssign(provider: Provider<out Iterable<T?>>) {
+    this.addAll(provider)
+}
+
+
+/**
+ * Adds to the value of this property the entries of the given Map, appending to any existing value
+ *
+ * @since 8.5
+ */
+operator fun <K, V> MapProperty<K, V>.plusAssign(entries: Map<out K?, V?>) {
+    this.putAll(entries)
+}
+
+
+/**
+ * Adds to the property the values of the given provider, appending to any existing value
+ *
+ * @since 8.5
+ */
+operator fun <K, V> MapProperty<K, V>.plusAssign(provider: Provider<out Map<out K?, V?>>) {
+    this.putAll(provider)
+}

--- a/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/PropertyExtensionsTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/PropertyExtensionsTest.kt
@@ -1,0 +1,102 @@
+package org.gradle.kotlin.dsl
+
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Test
+import kotlin.test.assertEquals
+
+
+class PropertyExtensionsTest {
+
+    val project: Project = ProjectBuilder.builder().build()
+
+    @Test
+    fun `plusAssign on ListProperty add a value`() {
+        val property = project.objects.listProperty<String>()
+        property.set(listOf("first"))
+
+        property += "second"
+
+        assertEquals(listOf("first", "second"), property.get())
+    }
+
+    @Test
+    fun `plusAssign on ListProperty adds multiple values`() {
+        val property = project.objects.listProperty<String>()
+        property.set(listOf("first"))
+
+        property += listOf("second", "third")
+
+        assertEquals(listOf("first", "second", "third"), property.get())
+    }
+
+    @Test
+    fun `plusAssign on ListProperty adds multiple values from provider`() {
+        val property = project.objects.listProperty<String>()
+        property.set(listOf("first"))
+
+        property += project.provider { listOf("second", "third") }
+
+        assertEquals(listOf("first", "second", "third"), property.get())
+    }
+
+    @Test
+    fun `plusAssign on SetProperty add a value`() {
+        val property = project.objects.setProperty<String>()
+        property.set(listOf("first"))
+
+        property += "second"
+
+        assertEquals(setOf("first", "second"), property.get())
+    }
+
+    @Test
+    fun `plusAssign on SetProperty adds multiple values`() {
+        val property = project.objects.setProperty<String>()
+        property.set(listOf("first"))
+
+        property += listOf("second", "third")
+
+        assertEquals(setOf("first", "second", "third"), property.get())
+    }
+
+    @Test
+    fun `plusAssign on SetProperty adds multiple values from provider`() {
+        val property = project.objects.setProperty<String>()
+        property.set(listOf("first"))
+
+        property += project.provider { listOf("second", "third") }
+
+        assertEquals(setOf("first", "second", "third"), property.get())
+    }
+
+    @Test
+    fun `plusAssign on MapProperty add a entry`() {
+        val property = project.objects.mapProperty<String, Int>()
+        property.set(mapOf("first" to 1))
+
+        property += mapOf("second" to 2)
+
+        assertEquals(mapOf("first" to 1, "second" to 2), property.get())
+    }
+
+    @Test
+    fun `plusAssign on MapProperty adds multiple entries`() {
+        val property = project.objects.mapProperty<String, Int>()
+        property.set(mapOf("first" to 1))
+
+        property += mapOf("second" to 2, "third" to 3)
+
+        assertEquals(mapOf("first" to 1, "second" to 2, "third" to 3), property.get())
+    }
+
+    @Test
+    fun `plusAssign on MapProperty adds multiple entries from provider`() {
+        val property = project.objects.mapProperty<String, Int>()
+        property.set(mapOf("first" to 1))
+
+        property += project.provider { mapOf("second" to 2, "third" to 3) }
+
+        assertEquals(mapOf("first" to 1, "second" to 2, "third" to 3), property.get())
+    }
+}

--- a/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
+++ b/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
@@ -2275,6 +2275,46 @@
             "changes": [
                 "Method added to public class"
             ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.PropertyExtensionsKt",
+            "member": "Method org.gradle.kotlin.dsl.PropertyExtensionsKt.plusAssign(org.gradle.api.provider.HasMultipleValues,java.lang.Iterable)",
+            "acceptation": "New `plusAssign` DSL extension is backward compatible as it's a new function",
+            "changes": [
+                "Method added to public class"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.PropertyExtensionsKt",
+            "member": "Method org.gradle.kotlin.dsl.PropertyExtensionsKt.plusAssign(org.gradle.api.provider.HasMultipleValues,java.lang.Object)",
+            "acceptation": "New `plusAssign` DSL extension is backward compatible as it's a new function",
+            "changes": [
+                "Method added to public class"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.PropertyExtensionsKt",
+            "member": "Method org.gradle.kotlin.dsl.PropertyExtensionsKt.plusAssign(org.gradle.api.provider.HasMultipleValues,org.gradle.api.provider.Provider)",
+            "acceptation": "New `plusAssign` DSL extension is backward compatible as it's a new function",
+            "changes": [
+                "Method added to public class"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.PropertyExtensionsKt",
+            "member": "Method org.gradle.kotlin.dsl.PropertyExtensionsKt.plusAssign(org.gradle.api.provider.MapProperty,java.util.Map)",
+            "acceptation": "New `plusAssign` DSL extension is backward compatible as it's a new function",
+            "changes": [
+                "Method added to public class"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.PropertyExtensionsKt",
+            "member": "Method org.gradle.kotlin.dsl.PropertyExtensionsKt.plusAssign(org.gradle.api.provider.MapProperty,org.gradle.api.provider.Provider)",
+            "acceptation": "New `plusAssign` DSL extension is backward compatible as it's a new function",
+            "changes": [
+                "Method added to public class"
+            ]
         }
     ]
 }


### PR DESCRIPTION
### Context
https://blog.gradle.org/simpler-kotlin-dsl-property-assignment mentions the addition of `=` overload operator for `Property` API, but it seems you didn't include the possibility of using `+=` for appending elements to a `ListProperty`, `SetProperty` or `MapProperty`.

This PR contributes to `PropertyExtensions.kt` by adding some `plusAssign` extension functions for them, for single and multiple elements (but excluding `vararg` or `Pair`s for map)

I couldn't find test/intTests for `PropertyExtensions.kt`, I can add them it's required.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
