### PR TITLE
Implement MavenResolveTestFixture

### DIFF
--- a/build-logic/dependency-modules/src/main/kotlin/gradlebuild/modules/extension/ExternalModulesExtension.kt
+++ b/build-logic/dependency-modules/src/main/kotlin/gradlebuild/modules/extension/ExternalModulesExtension.kt
@@ -110,9 +110,16 @@ abstract class ExternalModulesExtension(isBundleGroovy4: Boolean) {
     val log4jToSlf4j = "org.slf4j:log4j-over-slf4j"
     val maven3BuilderSupport = "org.apache.maven:maven-builder-support"
     val maven3Model = "org.apache.maven:maven-model"
+    val maven3ResolverProvider = "org.apache.maven:maven-resolver-provider"
     val maven3RepositoryMetadata = "org.apache.maven:maven-repository-metadata"
     val maven3Settings = "org.apache.maven:maven-settings"
     val maven3SettingsBuilder = "org.apache.maven:maven-settings-builder"
+    val mavenResolverApi = "org.apache.maven.resolver:maven-resolver-api"
+    val mavenResolverConnectorBasic = "org.apache.maven.resolver:maven-resolver-connector-basic"
+    val mavenResolverImpl = "org.apache.maven.resolver:maven-resolver-impl"
+    val mavenResolverSupplier = "org.apache.maven.resolver:maven-resolver-supplier"
+    val mavenResolverTransportFile = "org.apache.maven.resolver:maven-resolver-transport-file"
+    val mavenResolverTransportHttp = "org.apache.maven.resolver:maven-resolver-transport-http"
     val minlog = "com.esotericsoftware.minlog:minlog"
     val nativePlatform = "net.rubygrapefruit:native-platform"
     val nativePlatformFileEvents = "net.rubygrapefruit:file-events"
@@ -253,9 +260,16 @@ abstract class ExternalModulesExtension(isBundleGroovy4: Boolean) {
         log4jToSlf4j to License.MIT,
         maven3BuilderSupport to License.Apache2,
         maven3Model to License.Apache2,
+        maven3ResolverProvider to License.Apache2,
         maven3RepositoryMetadata to License.Apache2,
         maven3Settings to License.Apache2,
         maven3SettingsBuilder to License.Apache2,
+        mavenResolverApi to License.Apache2,
+        mavenResolverConnectorBasic to License.Apache2,
+        mavenResolverImpl to License.Apache2,
+        mavenResolverSupplier to License.Apache2,
+        mavenResolverTransportFile to License.Apache2,
+        mavenResolverTransportHttp to License.Apache2,
         minlog to License.BSD3,
         nativePlatform to License.Apache2,
         nativePlatformFileEvents to License.Apache2,

--- a/platforms/software/build-init/src/main/java/org/gradle/buildinit/plugins/internal/maven/PomProjectInitDescriptor.java
+++ b/platforms/software/build-init/src/main/java/org/gradle/buildinit/plugins/internal/maven/PomProjectInitDescriptor.java
@@ -45,9 +45,9 @@ import java.util.Set;
 import java.util.TreeSet;
 
 public class PomProjectInitDescriptor implements BuildConverter {
-    private final static String MAVEN_VERSION = "3.9.3";
+    private final static String MAVEN_VERSION = "3.9.5";
     private final static String MAVEN_WAGON_VERSION = "3.5.3";
-    private final static String MAVEN_RESOLVER_VERSION = "1.9.13";
+    private final static String MAVEN_RESOLVER_VERSION = "1.9.16";
 
     private final MavenSettingsProvider settingsProvider;
     private final DocumentationRegistry documentationRegistry;

--- a/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishExternalVariantIntegrationTest.groovy
+++ b/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishExternalVariantIntegrationTest.groovy
@@ -1057,16 +1057,18 @@ class MavenPublishExternalVariantIntegrationTest extends AbstractMavenPublishInt
             task print${name.capitalize()}RuntimeClasspath {
                 def artifacts = configurations.${runtimeElements}.outgoing.artifacts.files
                 def classpath = configurations.${runtimeClasspath}.incoming.files
+                def outputFile = layout.buildDir.file("${name}-classpath.txt")
+                outputs.file(outputFile)
                 doLast {
                     def allFiles = classpath.files + artifacts.files
-                    println "'${name}' classpath: " + allFiles*.name.join(",")
+                    outputFile.get().getAsFile().text = allFiles*.name.join("\\n")
                 }
             }
         """
     }
 
     Set<String> readClasspath(String name = "") {
-        output.readLines().find { it.startsWith("'${name}' classpath: ") }.split(":")[1].substring(1).split(",") as Set
+        file("build/${name}-classpath.txt").readLines() as Set
     }
 
     // endregion

--- a/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishExternalVariantIntegrationTest.groovy
+++ b/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishExternalVariantIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api.publish.maven
 
 import groovy.test.NotYetImplemented
+import org.gradle.integtests.fixtures.maven.MavenResolveTestFixture
 import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTest
 
 /**
@@ -28,7 +29,7 @@ import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTes
  * {@link org.gradle.api.internal.artifacts.ivyservice.projectmodule.DefaultProjectDependencyPublicationResolver}
  * are exercised.
  */
-class MavenPublishExternalVariantIntegrationTest extends AbstractMavenPublishIntegTest {
+class MavenPublishExternalVariantIntegrationTest extends AbstractMavenPublishIntegTest implements MavenResolveTestFixture {
 
     def setup() {
         settingsFile << """
@@ -43,6 +44,8 @@ class MavenPublishExternalVariantIntegrationTest extends AbstractMavenPublishInt
                 id 'java-library'
                 id 'maven-publish'
             }
+
+            version = "1.0"
 
             ${mavenCentralRepository()}
             dependencies {
@@ -62,14 +65,14 @@ class MavenPublishExternalVariantIntegrationTest extends AbstractMavenPublishInt
                 publications {
                     maven(MavenPublication) {
                         groupId = "org"
-                        artifactId = "pub"
-                        version = "1.0"
                         from components.java
                     }
                 }
             }
+
+            ${printClasspathTask()}
         """
-        def repoModule = javaLibrary(mavenRepo.module('org', "pub", '1.0'))
+        def repoModule = javaLibrary(mavenRepo.module('org', "root", '1.0'))
 
         when:
         succeeds "publish"
@@ -90,6 +93,18 @@ class MavenPublishExternalVariantIntegrationTest extends AbstractMavenPublishInt
         gmmDependency.group == "org.jetbrains.kotlinx"
         gmmDependency.module == "kotlinx-coroutines-core"
         gmmDependency.version == "1.7.2"
+
+        when:
+        def result = mavenResolver.resolveDependency("org", "root", "1.0")
+
+        then:
+        result.firstLevelDependencies == ["org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:jar:1.7.2"]
+
+        when:
+        succeeds "printRuntimeClasspath"
+
+        then:
+        readClasspath() == result.artifactFileNames
     }
 
     def "publishes resolved non-jvm coordinates for multi-coordinate external module dependency"() {
@@ -133,9 +148,17 @@ class MavenPublishExternalVariantIntegrationTest extends AbstractMavenPublishInt
         gmmDependency.group == "org.jetbrains.kotlinx"
         gmmDependency.module == "kotlinx-coroutines-core"
         gmmDependency.version == "1.7.2"
+
+        when:
+        mavenResolver.resolveDependency("org", "root-first", "1.0")
+
+        then:
+        def e = thrown(Exception)
+        // We fail to publish <type>klib</type>
+        e.message.contains("Could not find artifact org.jetbrains.kotlinx:kotlinx-coroutines-core-iosx64:jar:1.7.2")
     }
 
-    def "preserves artifacts and excludes when publishing multi-coordinate external module dependencies"() {
+    def "preserves artifacts but does not map coordinates when publishing multi-coordinate external module dependencies"() {
         given:
         buildFile << """
             ${header()}
@@ -148,25 +171,14 @@ class MavenPublishExternalVariantIntegrationTest extends AbstractMavenPublishInt
                         attribute(Attribute.of("org.jetbrains.kotlin.platform.type", String), "native")
                     """
                 }
-                compilation("second") {
-                    attributes = """
-                        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "library"))
-                        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, "kotlin-api"))
-                        attribute(Attribute.of("org.jetbrains.kotlin.js.compiler", String), "ir")
-                        attribute(Attribute.of("org.jetbrains.kotlin.platform.type", String), "js")
-                    """
-                }
             }}
             ${mavenCentralRepository()}
             dependencies {
                 firstImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.2") {
                     artifact {
-                        classifier = "foo"
-                        type = "something"
+                        classifier = "kotlin-tooling-metadata"
+                        type = "json"
                     }
-                }
-                secondImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.2") {
-                    exclude group: "group", module: "module"
                 }
             }
         """
@@ -176,7 +188,62 @@ class MavenPublishExternalVariantIntegrationTest extends AbstractMavenPublishInt
 
         then:
         def first = javaLibrary(mavenRepo.module('org', "root-first", '1.0'))
-        def second = javaLibrary(mavenRepo.module('org', "root-second", '1.0'))
+
+        def firstDependencies = first.parsedPom.scopes.runtime.dependencies
+        firstDependencies.size() == 1
+        with(firstDependencies.values().first()) {
+            groupId == "org.jetbrains.kotlinx"
+            artifactId == "kotlinx-coroutines-core"
+            version == "1.7.2"
+            classifier == "kotlin-tooling-metadata"
+            type == "json"
+            exclusions.isEmpty()
+        }
+
+        when:
+        def firstResolution = mavenResolver.resolveDependency("org", "root-first", "1.0")
+
+        then:
+        firstResolution.firstLevelDependencies == ["org.jetbrains.kotlinx:kotlinx-coroutines-core:json:kotlin-tooling-metadata:1.7.2"]
+
+        when:
+        succeeds ":printFirstRuntimeClasspath"
+
+        then:
+        firstResolution.artifactFileNames.contains("kotlinx-coroutines-core-1.7.2-kotlin-tooling-metadata.json")
+        // We expect these to be different. Since we are publishing a type/classifier, we the POM depends
+        // on different artifacts without also including their transitive dependencies. Instead, maven
+        // uses the dependencies of the root component and resolves the JDK variant dependencies instead.
+        readClasspath("first") != firstResolution.artifactFileNames
+    }
+
+    def "preserves excludes when publishing multi-coordinate external module dependencies"() {
+        given:
+        buildFile << """
+            ${header()}
+            ${multiCoordinateComponent {
+                compilation("first") {
+                    attributes = """
+                        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "library"))
+                        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, "kotlin-api"))
+                        attribute(Attribute.of("org.jetbrains.kotlin.native.target", String), "ios_x64")
+                        attribute(Attribute.of("org.jetbrains.kotlin.platform.type", String), "native")
+                    """
+                }
+            }}
+            ${mavenCentralRepository()}
+            dependencies {
+                firstImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.2") {
+                    exclude group: "org.jetbrains.kotlin", module: "kotlin-stdlib-common"
+                }
+            }
+        """
+
+        when:
+        succeeds "publish"
+
+        then:
+        def first = javaLibrary(mavenRepo.module('org', "root-first", '1.0'))
 
         def firstDependencies = first.parsedPom.scopes.runtime.dependencies
         firstDependencies.size() == 1
@@ -184,24 +251,21 @@ class MavenPublishExternalVariantIntegrationTest extends AbstractMavenPublishInt
             groupId == "org.jetbrains.kotlinx"
             artifactId == "kotlinx-coroutines-core-iosx64"
             version == "1.7.2"
-            classifier == "foo"
-            type == "something"
-            exclusions.isEmpty()
-        }
-
-        def secondDependencies = second.parsedPom.scopes.runtime.dependencies
-        secondDependencies.size() == 1
-        with(secondDependencies.values().first()) {
-            groupId == "org.jetbrains.kotlinx"
-            artifactId == "kotlinx-coroutines-core-js"
-            version == "1.7.2"
             classifier == null
             type == null
             exclusions.size() == 1
             def exclusion = exclusions.first()
-            exclusion.groupId == "group"
-            exclusion.artifactId == "module"
+            exclusion.groupId == "org.jetbrains.kotlin"
+            exclusion.artifactId == "kotlin-stdlib-common"
         }
+
+        when:
+        mavenResolver.resolveDependency("org", "root-first", "1.0")
+
+        then:
+        def e = thrown(Exception)
+        // We fail to publish <type>klib</type>
+        e.message.contains("Could not find artifact org.jetbrains.kotlinx:kotlinx-coroutines-core-iosx64:jar:1.7.2")
     }
 
     def "publishes resolved child coordinates for multi-coordinate project dependency"() {
@@ -219,7 +283,7 @@ class MavenPublishExternalVariantIntegrationTest extends AbstractMavenPublishInt
         """
 
         when:
-        succeeds(":publish")
+        succeeds "publish"
 
         then:
         def root = javaLibrary(mavenRepo.module('org', 'root', '1.0'))
@@ -242,6 +306,21 @@ class MavenPublishExternalVariantIntegrationTest extends AbstractMavenPublishInt
         secondDep.groupId == "org"
         secondDep.artifactId == "other-second"
         secondDep.version == "1.0"
+
+        when:
+        def firstResolution = mavenResolver.resolveDependency("org", "root-first", "1.0")
+        def secondResolution = mavenResolver.resolveDependency("org", "root-second", "1.0")
+
+        then:
+        firstResolution.firstLevelDependencies == ["org:other-first:jar:1.0"]
+        secondResolution.firstLevelDependencies == ["org:other-second:jar:1.0"]
+
+        when:
+        succeeds ":printFirstRuntimeClasspath", ":printSecondRuntimeClasspath"
+
+        then:
+        readClasspath("first") == firstResolution.artifactFileNames
+        readClasspath("second") == secondResolution.artifactFileNames
     }
 
     def "publishes resolved coordinates when using explicit dependency attributes"() {
@@ -262,12 +341,24 @@ class MavenPublishExternalVariantIntegrationTest extends AbstractMavenPublishInt
         """
 
         when:
-        succeeds(":publish")
+        succeeds "publish"
 
         then:
         def first = javaLibrary(mavenRepo.module('org', 'root-first', '1.0'))
         def resolved = first.parsedPom.scopes.runtime.dependencies.values()
         resolved*.artifactId == ["other-second"]
+
+        when:
+        def resolution = mavenResolver.resolveDependency("org", "root-first", "1.0")
+
+        then:
+        resolution.firstLevelDependencies == ["org:other-second:jar:1.0"]
+
+        when:
+        succeeds ":printFirstRuntimeClasspath"
+
+        then:
+        readClasspath("first") == resolution.artifactFileNames
     }
 
     def "publishes resolved coordinates when using explicit dependency capabilities"() {
@@ -291,12 +382,24 @@ class MavenPublishExternalVariantIntegrationTest extends AbstractMavenPublishInt
         """
 
         when:
-        succeeds(":publish")
+        succeeds "publish"
 
         then:
         def first = javaLibrary(mavenRepo.module('org', 'root-first', '1.0'))
         def resolved = first.parsedPom.scopes.runtime.dependencies.values()
         resolved*.artifactId == ["other-second"]
+
+        when:
+        def resolution = mavenResolver.resolveDependency("org", "root-first", "1.0")
+
+        then:
+        resolution.firstLevelDependencies == ["org:other-second:jar:1.0"]
+
+        when:
+        succeeds ":printFirstRuntimeClasspath"
+
+        then:
+        readClasspath("first") == resolution.artifactFileNames
     }
 
     def "publishes resolved coordinates when using targetConfiguration"() {
@@ -315,12 +418,24 @@ class MavenPublishExternalVariantIntegrationTest extends AbstractMavenPublishInt
         """
 
         when:
-        succeeds(":publish")
+        succeeds "publish"
 
         then:
         def first = javaLibrary(mavenRepo.module('org', 'root-first', '1.0'))
         def resolved = first.parsedPom.scopes.runtime.dependencies.values()
         resolved*.artifactId == ["other-second"]
+
+        when:
+        def resolution = mavenResolver.resolveDependency("org", "root-first", "1.0")
+
+        then:
+        resolution.firstLevelDependencies == ["org:other-second:jar:1.0"]
+
+        when:
+        succeeds ":printFirstRuntimeClasspath"
+
+        then:
+        readClasspath("first") == resolution.artifactFileNames
     }
 
     def "publishes coordinates for multiple dependencies"() {
@@ -357,12 +472,24 @@ class MavenPublishExternalVariantIntegrationTest extends AbstractMavenPublishInt
         """
 
         when:
-        succeeds(":publish")
+        succeeds "publish"
 
         then:
         def first = javaLibrary(mavenRepo.module('org', 'root-first', '1.0'))
         def resolved = first.parsedPom.scopes.runtime.dependencies.values()
         resolved*.artifactId == ["other-first", "other-second", "other-third"]
+
+        when:
+        def resolution = mavenResolver.resolveDependency("org", "root-first", "1.0")
+
+        then:
+        resolution.firstLevelDependencies == ["org:other-first:jar:1.0", "org:other-second:jar:1.0", "org:other-third:jar:1.0"]
+
+        when:
+        succeeds ":printFirstRuntimeClasspath"
+
+        then:
+        readClasspath("first") == resolution.artifactFileNames
     }
 
     def "publishes resolved coordinates when two dependencies map to the same coordinates"() {
@@ -392,25 +519,45 @@ class MavenPublishExternalVariantIntegrationTest extends AbstractMavenPublishInt
         """
 
         when:
-        succeeds(":publish")
+        succeeds "publish"
 
         then:
         def first = javaLibrary(mavenRepo.module('org', 'root-first', '1.0'))
         def resolved = first.parsedPom.scopes.runtime.dependencies.values()
         resolved*.artifactId == ["other-first"]
+
+        when:
+        def resolution = mavenResolver.resolveDependency("org", "root-first", "1.0")
+
+        then:
+        resolution.firstLevelDependencies == ["org:other-first:jar:1.0"]
+
+        when:
+        succeeds ":printFirstRuntimeClasspath"
+
+        then:
+        readClasspath("first") == resolution.artifactFileNames
     }
 
     def "preserves excludes when publishing multi-coordinate project dependencies"() {
         given:
+        mavenRepo.module("com", "example", "2.0").publish()
         publishes(multiCoordinateComponent {
             compilation("first")
             compilation("second")
         })
 
+        file("other/build.gradle") << """
+            repositories { maven { url "${mavenRepo.uri}" } }
+            dependencies {
+                firstImplementation "com:example:2.0"
+            }
+        """
+
         buildFile << """
             dependencies {
                 firstImplementation create(project(':other')) {
-                    exclude group: "group", module: "module"
+                    exclude group: "com", module: "example"
                 }
             }
         """
@@ -430,9 +577,21 @@ class MavenPublishExternalVariantIntegrationTest extends AbstractMavenPublishInt
             type == null
             exclusions.size() == 1
             def exclusion = exclusions.first()
-            exclusion.groupId == "group"
-            exclusion.artifactId == "module"
+            exclusion.groupId == "com"
+            exclusion.artifactId == "example"
         }
+
+        when:
+        def resolution = mavenResolver.resolveDependency("org", "root-first", "1.0")
+
+        then:
+        resolution.firstLevelDependencies == ["org:other-first:jar:1.0"]
+
+        when:
+        succeeds ":printFirstRuntimeClasspath"
+
+        then:
+        readClasspath("first") == resolution.artifactFileNames
     }
 
     def "resolves single-coordinate components"() {
@@ -444,10 +603,15 @@ class MavenPublishExternalVariantIntegrationTest extends AbstractMavenPublishInt
         file("other/build.gradle") << """
             ${header()}
 
+            file("other-2.0.jar").createNewFile()
+
             configurations {
                 consumable("elements") {
                     attributes {
                         attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "first"))
+                    }
+                    outgoing {
+                        artifact(file("other-2.0.jar"))
                     }
                 }
             }
@@ -484,7 +648,7 @@ class MavenPublishExternalVariantIntegrationTest extends AbstractMavenPublishInt
         """
 
         when:
-        succeeds(":publish")
+        succeeds "publish"
 
         then:
         def first = javaLibrary(mavenRepo.module('org', 'root-first', '1.0'))
@@ -492,6 +656,18 @@ class MavenPublishExternalVariantIntegrationTest extends AbstractMavenPublishInt
         resolved*.groupId == ["com", "org"]
         resolved*.artifactId == ["other", "foo"]
         resolved*.version == ["2.0", "3.0"]
+
+        when:
+        def resolution = mavenResolver.resolveDependency("org", "root-first", "1.0")
+
+        then:
+        resolution.firstLevelDependencies == ["com:other:jar:2.0", "org:foo:jar:3.0"]
+
+        when:
+        succeeds ":printFirstRuntimeClasspath"
+
+        then:
+        readClasspath("first") == resolution.artifactFileNames
     }
 
     def "warns when when two dependencies are ambiguous"() {
@@ -511,7 +687,7 @@ class MavenPublishExternalVariantIntegrationTest extends AbstractMavenPublishInt
         """
 
         when:
-        succeeds(":publish")
+        succeeds "publish"
 
         then:
         outputContains("""Maven publication 'firstPub' pom metadata warnings (silence with 'suppressPomMetadataWarningsFor(variant)'):
@@ -548,7 +724,7 @@ class MavenPublishExternalVariantIntegrationTest extends AbstractMavenPublishInt
         """
 
         when:
-        succeeds(":publish")
+        succeeds "publish"
 
         then:
         outputContains("""Maven publication 'firstPub' pom metadata warnings (silence with 'suppressPomMetadataWarningsFor(variant)'):
@@ -586,7 +762,7 @@ class MavenPublishExternalVariantIntegrationTest extends AbstractMavenPublishInt
         """
 
         when:
-        succeeds(":publish")
+        succeeds "publish"
 
         then:
         outputContains("""Maven publication 'firstPub' pom metadata warnings (silence with 'suppressPomMetadataWarningsFor(variant)'):
@@ -647,7 +823,7 @@ class MavenPublishExternalVariantIntegrationTest extends AbstractMavenPublishInt
         """
 
         when:
-        succeeds(":publish")
+        succeeds "publish"
 
         then:
         def root = javaLibrary(mavenRepo.module('org', 'root', '1.0'))
@@ -683,6 +859,7 @@ class MavenPublishExternalVariantIntegrationTest extends AbstractMavenPublishInt
         boolean withSeparatePublishedConfiguration = false
         String attributes
         String capabilities = ""
+        String outputFile
     }
 
     class RootComponentDetails {
@@ -692,6 +869,7 @@ class MavenPublishExternalVariantIntegrationTest extends AbstractMavenPublishInt
             compilationDetails.attributes = """
                 attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, "${name}"))
             """
+            compilationDetails.outputFile = "\${project.name}-${name}-1.0.jar"
 
             spec.delegate = compilationDetails
             spec.call(compilationDetails)
@@ -793,6 +971,8 @@ class MavenPublishExternalVariantIntegrationTest extends AbstractMavenPublishInt
         def runtimeElements = "${name}RuntimeElements"
 
         def output = """
+            file("${details.outputFile}").createNewFile()
+
             configurations {
                 dependencyScope("${implementation}")
                 consumable("${runtimeElements}") {
@@ -802,6 +982,7 @@ class MavenPublishExternalVariantIntegrationTest extends AbstractMavenPublishInt
                     }
                     outgoing {
                         ${details.capabilities}
+                        artifact(file("${details.outputFile}"))
                     }
                 }
                 resolvable("${runtimeClasspath}") {
@@ -811,6 +992,8 @@ class MavenPublishExternalVariantIntegrationTest extends AbstractMavenPublishInt
                     }
                 }
             }
+
+            ${printClasspathTask(name)}
         """
 
         def publicationConf = runtimeElements
@@ -859,6 +1042,31 @@ class MavenPublishExternalVariantIntegrationTest extends AbstractMavenPublishInt
         """
 
         output
+    }
+
+    /**
+     * Prints the classpath for a compilation with the given name, including the compilation's own artifacts.
+     * {@link #readClasspath(String)} will read the output of this task into a set, which should match the
+     * classpath resolved by Maven.
+     */
+    def printClasspathTask(String name = "") {
+        String runtimeClasspath = name.isEmpty() ? "runtimeClasspath" : "${name}RuntimeClasspath"
+        String runtimeElements = name.isEmpty() ? "runtimeElements" : "${name}RuntimeElements"
+
+        """
+            task print${name.capitalize()}RuntimeClasspath {
+                def artifacts = configurations.${runtimeElements}.outgoing.artifacts.files
+                def classpath = configurations.${runtimeClasspath}.incoming.files
+                doLast {
+                    def allFiles = classpath.files + artifacts.files
+                    println "'${name}' classpath: " + allFiles*.name.join(",")
+                }
+            }
+        """
+    }
+
+    Set<String> readClasspath(String name = "") {
+        output.readLines().find { it.startsWith("'${name}' classpath: ") }.split(":")[1].substring(1).split(",") as Set
     }
 
     // endregion

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/MavenComponentParser.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/MavenComponentParser.java
@@ -282,13 +282,17 @@ public class MavenComponentParser {
             }
 
             Set<ExcludeRule> allExcludeRules = getExcludeRules(globalExcludes, dependency);
-            ResolvedCoordinates coordinates = resolveDependency(dependency);
 
             if (dependency.getArtifacts().isEmpty()) {
+                ResolvedCoordinates coordinates = resolveDependency(dependency);
                 collector.accept(newDependency(coordinates, null, null, scope, allExcludeRules, optional));
                 return;
             }
 
+            // If the dependency has artifacts, do not map the coordinates.
+            // This is so we match the Gradle behavior where an explicit artifact on a dependency
+            // that would otherwise map to different coordinates resolves to the declared coordinates.
+            ResolvedCoordinates coordinates = convertDeclaredCoordinates(dependency.getGroup(), dependency.getName(), dependency.getVersion());
             for (DependencyArtifact artifact : dependency.getArtifacts()) {
                 ResolvedCoordinates artifactCoordinates = coordinates;
                 if (!artifact.getName().equals(dependency.getName())) {

--- a/subprojects/distributions-dependencies/build.gradle.kts
+++ b/subprojects/distributions-dependencies/build.gradle.kts
@@ -25,7 +25,8 @@ val bouncycastleVersion = "1.68"
 val jacksonVersion = "2.14.1"
 val jaxbVersion = "3.0.0"
 val junit5Version = "5.8.2"
-val mavenVersion = "3.9.3"
+val mavenVersion = "3.9.5"
+val mavenResolverVersion = "1.9.16" // Should remain in-sync with `mavenVersion`
 val nativePlatformVersion = "0.22-milestone-25"
 val slf4jVersion = "1.7.30"
 val spockVersion = if (isBundleGroovy4) "2.3-groovy-4.0" else "2.3-groovy-3.0"
@@ -177,6 +178,13 @@ dependencies {
         api(libs.kotlinCoroutines)      { version { strictly("1.5.2") }}
         api(libs.kotlinCoroutinesDebug) { version { strictly("1.5.2") }}
         api(libs.littleproxy)           { version { strictly("2.0.5") }}
+        api(libs.maven3ResolverProvider){ version { strictly(mavenVersion) }}
+        api(libs.mavenResolverApi)              { version { strictly(mavenResolverVersion) }}
+        api(libs.mavenResolverConnectorBasic)   { version { strictly(mavenResolverVersion) }}
+        api(libs.mavenResolverImpl)             { version { strictly(mavenResolverVersion) }}
+        api(libs.mavenResolverSupplier)         { version { strictly(mavenResolverVersion) }}
+        api(libs.mavenResolverTransportFile)    { version { strictly(mavenResolverVersion) }}
+        api(libs.mavenResolverTransportHttp)    { version { strictly(mavenResolverVersion) }}
         api(libs.mina)                  { version { strictly("2.0.17") }}
         api(libs.mockitoCore)           { version { strictly("3.7.7") }}
         api(libs.mockitoKotlin)         { version { strictly("1.6.0") }}

--- a/subprojects/internal-integ-testing/build.gradle.kts
+++ b/subprojects/internal-integ-testing/build.gradle.kts
@@ -97,6 +97,28 @@ dependencies {
     }
     implementation(testFixtures(project(":core")))
 
+    implementation(libs.mavenResolverApi) {
+        because("For ApiMavenResolver. API we interact with to resolve Maven graphs & artifacts")
+    }
+    implementation(libs.mavenResolverSupplier) {
+        because("For ApiMavenResolver. Wires together implementation for maven-resolver-api")
+    }
+    implementation(libs.maven3ResolverProvider) {
+        because("For ApiMavenResolver. Provides MavenRepositorySystemUtils")
+    }
+    runtimeOnly(libs.mavenResolverImpl) {
+        because("For ApiMavenResolver. Implements maven-resolver-api")
+    }
+    runtimeOnly(libs.mavenResolverConnectorBasic) {
+        because("For ApiMavenResolver. To use resolver transporters")
+    }
+    runtimeOnly(libs.mavenResolverTransportFile) {
+        because("For ApiMavenResolver. To resolve file:// URLs")
+    }
+    runtimeOnly(libs.mavenResolverTransportHttp) {
+        because("For ApiMavenResolver. To resolve http:// URLs")
+    }
+
     testRuntimeOnly(project(":distributions-core")) {
         because("Tests instantiate DefaultClassLoaderRegistry which requires a 'gradle-plugins.properties' through DefaultPluginModuleRegistry")
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/RepoScriptBlockUtil.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/RepoScriptBlockUtil.groovy
@@ -47,7 +47,7 @@ class RepoScriptBlockUtil {
         }
     }
 
-    private static enum MirroredRepository {
+    static enum MirroredRepository {
         JCENTER(BINTRAY_JCENTER_URL, System.getProperty('org.gradle.integtest.mirrors.jcenter'), "maven"),
         MAVEN_CENTRAL(MAVEN_CENTRAL_URL, System.getProperty('org.gradle.integtest.mirrors.mavencentral'), "maven"),
         GOOGLE(GOOGLE_URL, System.getProperty('org.gradle.integtest.mirrors.google'), "maven"),

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/RepoScriptBlockUtil.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/RepoScriptBlockUtil.groovy
@@ -47,7 +47,7 @@ class RepoScriptBlockUtil {
         }
     }
 
-    static enum MirroredRepository {
+    private static enum MirroredRepository {
         JCENTER(BINTRAY_JCENTER_URL, System.getProperty('org.gradle.integtest.mirrors.jcenter'), "maven"),
         MAVEN_CENTRAL(MAVEN_CENTRAL_URL, System.getProperty('org.gradle.integtest.mirrors.mavencentral'), "maven"),
         GOOGLE(GOOGLE_URL, System.getProperty('org.gradle.integtest.mirrors.google'), "maven"),
@@ -98,6 +98,10 @@ class RepoScriptBlockUtil {
                 ${jcenterRepositoryDefinition(dsl)}
             }
         """
+    }
+
+    static String getMavenCentralMirrorUrl() {
+        MirroredRepository.MAVEN_CENTRAL.mirrorUrl
     }
 
     static void configureMavenCentral(RepositoryHandler repositories) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/maven/ApiMavenResolver.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/maven/ApiMavenResolver.groovy
@@ -50,13 +50,13 @@ class ApiMavenResolver {
      * The local repository used for caching resolved artifacts.
      * This is the the repository usually located at ~/.m2/repository.
      */
-    File localRepoDir
+    private final File localRepoDir
 
     /**
      * The URI of the repository to resolve artifacts from.
      * This repository should contain the artifacts under test.
      */
-    URI testRepoUri
+    private final URI testRepoUri
 
     ApiMavenResolver(File localRepoDir, URI testRepoUri) {
         this.localRepoDir = localRepoDir
@@ -108,7 +108,7 @@ class ApiMavenResolver {
         def graphResolutionRequest = new CollectRequest()
             .setRepositories([
                 new RemoteRepository.Builder("test-repo", "default", testRepoUri.toString()).build(),
-                new RemoteRepository.Builder("central", "default", RepoScriptBlockUtil.MirroredRepository.MAVEN_CENTRAL.mirrorUrl).build()
+                new RemoteRepository.Builder("central", "default", RepoScriptBlockUtil.mavenCentralMirrorUrl).build()
             ])
             .addDependency(new Dependency(
                 new DefaultArtifact(group, module, null, "jar", version),

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/maven/ApiMavenResolver.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/maven/ApiMavenResolver.groovy
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures.maven
+
+import org.apache.maven.repository.internal.MavenRepositorySystemUtils
+import org.eclipse.aether.DefaultRepositorySystemSession
+import org.eclipse.aether.RepositorySystem
+import org.eclipse.aether.artifact.Artifact
+import org.eclipse.aether.artifact.DefaultArtifact
+import org.eclipse.aether.collection.CollectRequest
+import org.eclipse.aether.collection.CollectResult
+import org.eclipse.aether.graph.Dependency
+import org.eclipse.aether.graph.DependencyNode
+import org.eclipse.aether.repository.LocalRepository
+import org.eclipse.aether.repository.LocalRepositoryManager
+import org.eclipse.aether.repository.RemoteRepository
+import org.eclipse.aether.resolution.ArtifactResult
+import org.eclipse.aether.resolution.DependencyRequest
+import org.eclipse.aether.resolution.DependencyResult
+import org.eclipse.aether.supplier.RepositorySystemSupplier
+import org.eclipse.aether.transfer.AbstractTransferListener
+import org.eclipse.aether.transfer.ArtifactNotFoundException
+import org.eclipse.aether.transfer.TransferEvent
+import org.eclipse.aether.transfer.TransferResource
+import org.gradle.integtests.fixtures.RepoScriptBlockUtil
+
+/**
+ * Performs resolution of dependencies against Maven repositories.
+ *
+ * <p>This resolver leverages Maven's stable public API for dependency resolution and does
+ * not run a full Maven build.</p>
+ */
+class ApiMavenResolver {
+
+    /**
+     * The local repository used for caching resolved artifacts.
+     * This is the the repository usually located at ~/.m2/repository.
+     */
+    File localRepoDir
+
+    /**
+     * The URI of the repository to resolve artifacts from.
+     * This repository should contain the artifacts under test.
+     */
+    URI testRepoUri
+
+    ApiMavenResolver(File localRepoDir, URI testRepoUri) {
+        this.localRepoDir = localRepoDir
+        this.testRepoUri = testRepoUri
+    }
+
+    /**
+     * Resolves the provided dependency, returning the dependency graph and resolved artifacts.
+     */
+    MavenResolutionResult resolveDependency(String group, String module, String version) {
+        long time = System.currentTimeMillis()
+
+        println()
+        println("Resolving Maven artifact ${group}:${module}:${version}")
+        MavenResolutionResult output = doResolveDependency(group, module, version)
+        println("Resolved Maven graph in ${System.currentTimeMillis() - time} ms")
+
+        return output
+    }
+
+    private MavenResolutionResult doResolveDependency(String group, String module, String version) {
+        // Configures the majority of the infrastructure required for resolving dependencies.
+        // This is the dependency-injection-less approach to obtain a `RepositorySystem`.
+        // Maven generally recommends using Eclipse Sisu and Guice for DI, however this approach is also supported.
+        RepositorySystem repoSystem = new RepositorySystemSupplier().get()
+
+        // `MavenRepositorySystemUtils` is _technically_ internal, however it is also widely used across
+        // many software projects embedding Maven and is unlikely to change.
+        // If this ever does change, we can easily copy the code directly here.
+        DefaultRepositorySystemSession session = MavenRepositorySystemUtils.newSession()
+        session.setTransferListener(new AbstractTransferListener() {
+            @Override
+            void transferSucceeded(TransferEvent event) {
+                TransferResource resource = event.getResource()
+                long contentLength = event.getTransferredBytes()
+
+                long duration = System.currentTimeMillis() - resource.getTransferStartTime()
+                println("Downloaded ${contentLength} bytes in ${duration} ms from ${resource.getRepositoryId()}: ${resource.getResourceName()}")
+            }
+        })
+
+        // Setup local cache repository
+        // We cannot reuse this repository between tests since it will contain artifacts from the test repo.
+        // There does not seem to be a way to get Maven to avoid caching artifacts from the test repo.
+        LocalRepository localRepo = new LocalRepository(localRepoDir)
+        LocalRepositoryManager lrm = repoSystem.newLocalRepositoryManager(session, localRepo)
+        session.setLocalRepositoryManager(lrm)
+
+        def graphResolutionRequest = new CollectRequest()
+            .setRepositories([
+                new RemoteRepository.Builder("test-repo", "default", testRepoUri.toString()).build(),
+                new RemoteRepository.Builder("central", "default", RepoScriptBlockUtil.MirroredRepository.MAVEN_CENTRAL.mirrorUrl).build()
+            ])
+            .addDependency(new Dependency(
+                new DefaultArtifact(group, module, null, "jar", version),
+                "runtime"
+            ))
+
+        // Resolve graph & rethrow any exceptions
+        CollectResult graph = repoSystem.collectDependencies(session, graphResolutionRequest)
+        graph.getExceptions().each { throw it }
+
+        // Resolve artifacts to ensure they are all present
+        DependencyResult result = repoSystem.resolveDependencies(session, new DependencyRequest(graph.getRoot(), null))
+
+        // Rethrow artifact exceptions if necessary
+        // Maven returns an exception if an artifact is found in one repo but not another, so we need extra logic here
+        Set<String> allRepoIds = graph.request.repositories.collect { it.id } as Set
+        result.artifactResults.each {
+            assert it.artifact.file
+
+            Set<String> missingRepos = it.getExceptions()
+                .findAll { it instanceof ArtifactNotFoundException }
+                .collect { ((ArtifactNotFoundException) it).repository.id } as Set
+            assert missingRepos.size() < allRepoIds.size(): "Artifact ${it.getArtifact()} not found in any repository."
+
+            it.getExceptions().findAll { !(it instanceof ArtifactNotFoundException) }.each { throw it }
+        }
+
+        new MavenResolutionResult(graph.getRoot(), result.artifactResults)
+    }
+
+    static class MavenResolutionResult {
+
+        final List<Artifact> artifacts
+        final DependencyNode root
+
+        private MavenResolutionResult(DependencyNode root, List<ArtifactResult> artifacts) {
+            this.root = root
+            this.artifacts = artifacts*.artifact
+        }
+
+        /**
+         * Returns a list of all artifacts that are direct transitive dependencies of the resolved dependency.
+         *
+         * <p>Only a subset of the graph is returned.</p>
+         */
+        List<String> getFirstLevelDependencies() {
+            // The root has a single child, where the first child is our requested dependency's node
+            def requestedNode = root.children.first()
+
+            def firstLevelNodes = requestedNode.children
+            return firstLevelNodes*.artifact*.toString()
+        }
+
+        /**
+         * Returns a set of all file names resolved for the dependency, including transitive dependencies.
+         */
+        Set<String> getArtifactFileNames() {
+            artifacts*.file*.name as Set
+        }
+    }
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/maven/MavenResolveTestFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/maven/MavenResolveTestFixture.groovy
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures.maven
+
+import groovy.transform.SelfType
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+/**
+ * Provides access to a {@link ApiMavenResolver} that is configured to resolve artifacts
+ * from the integration test's local maven repository.
+ *
+ * <p>Intended to verify that POMs published by Gradle can be consumed by Maven. Tests should
+ * publish artifacts to {@link AbstractIntegrationSpec#mavenRepo} and then use the resolve exposed
+ * by this fixture to run tests against those published artifacts.</p>
+ */
+@SelfType(AbstractIntegrationSpec.class)
+trait MavenResolveTestFixture {
+
+    /**
+     * Get a resolver that can be used to perform a Maven resolution.
+     */
+    ApiMavenResolver getMavenResolver() {
+        def localRepoDir = temporaryFolder.testDirectory.file("maven-resolver-test-fixture-m2")
+        return new ApiMavenResolver(localRepoDir, mavenRepo.uri)
+    }
+
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/maven/MavenResolveTestFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/maven/MavenResolveTestFixture.groovy
@@ -34,6 +34,11 @@ trait MavenResolveTestFixture {
      * Get a resolver that can be used to perform a Maven resolution.
      */
     ApiMavenResolver getMavenResolver() {
+        // We intentionally use a different m2 directory than the one defined in AbstractIntegrationSpec
+        // since we want to resolve artifacts independently from the build being tested.
+        // The m2 installation on the integ spec is intended to verify the way Gradle interacts
+        // with the system's local m2 repo, however the resolutions performed by this fixture
+        // should be isolated from the build.
         def localRepoDir = temporaryFolder.testDirectory.file("maven-resolver-test-fixture-m2")
         return new ApiMavenResolver(localRepoDir, mavenRepo.uri)
     }


### PR DESCRIPTION
This test fixture leverages Maven's public APIs for performing dependency resolution with its artifact repository engine. We skip running Maven entirely since that requires downloading a Maven distribution, which itself downloads plugins upon startup. This approach is more flexible for future expansion since it offers the ability to traverse the resolved graph itself, in-process This approach is much faster than running maven in a forked process or running MavenCli embedded.

Fixes #26826

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
