### PR TITLE
Assume unresolved packaging variables in a POM mean jar

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/BadPomFileResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/BadPomFileResolveIntegrationTest.groovy
@@ -214,6 +214,7 @@ dependencies {
         attribute << ["groupId", "artifactId"]
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/23208")
     @Issue("https://github.com/gradle/gradle/issues/3065")
     def "handles broken packaging type gracefully"() {
         given:
@@ -251,7 +252,7 @@ dependencies {
         resolve.expectGraph {
             root(":", ":test:") {
                 module("group:projectA:1.2") {
-                    artifact(fileName: "projectA-1.2.jar", type: "\${package.type}")
+                    artifact(fileName: "projectA-1.2.jar", type: "jar")
                 }
             }
         }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReader.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReader.java
@@ -51,6 +51,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import static org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.PomDomParser.AddDTDFilterInputStream;
 import static org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.PomDomParser.getAllChilds;
@@ -735,4 +736,10 @@ public class PomReader implements PomParent {
             return IvyPatternHelper.substituteVariables(val, effectiveProperties).trim();
         }
     }
+
+    public static boolean hasUnresolvedSubstitutions(String packaging) {
+        return packaging.contains("$") && PomReader.VAR_PATTERN.matcher(packaging).matches();
+    }
+    // Copied from IvyPatternHelper
+    private static final Pattern VAR_PATTERN = Pattern.compile("\\$\\{(.*?)\\}");
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReader.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReader.java
@@ -39,6 +39,7 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 
+import javax.annotation.Nonnull;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -341,6 +342,7 @@ public class PomReader implements PomParent {
         return replaceProps(val);
     }
 
+    @Nonnull
     public String getPackaging() {
         String val = getFirstChildText(projectElement, PACKAGING);
         if (val == null) {
@@ -737,9 +739,16 @@ public class PomReader implements PomParent {
         }
     }
 
-    public static boolean hasUnresolvedSubstitutions(String packaging) {
-        return packaging.contains("$") && PomReader.VAR_PATTERN.matcher(packaging).matches();
+    /**
+     * Checks if the given value contains variable substitutions.
+     *
+     * @param value value to check
+     * @return true if the value contains substitutions, false otherwise.
+     */
+    public static boolean hasUnresolvedSubstitutions(String value) {
+        return value.contains("$") && PomReader.VAR_PATTERN.matcher(value).matches();
     }
+
     // Copied from IvyPatternHelper
     private static final Pattern VAR_PATTERN = Pattern.compile("\\$\\{(.*?)\\}");
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializer.java
@@ -127,6 +127,7 @@ public class ModuleMetadataSerializer {
             writeNullableString(metadata.getSnapshotTimestamp());
             writeMavenDependencies(metadata.getDependencies(), deduplicationDependencyCache);
             writeSharedInfo(metadata);
+            // NOTE: This looks nullable, but only non-null Strings are provided. Changing this to write a non-null string would not be backwards compatible.
             writeNullableString(metadata.getPackaging());
             writeBoolean(metadata.isRelocated());
             writeVariants(metadata);
@@ -444,6 +445,7 @@ public class ModuleMetadataSerializer {
             MutableMavenModuleResolveMetadata metadata = mavenMetadataFactory.create(id, dependencies);
             readSharedInfo(metadata);
             metadata.setSnapshotTimestamp(snapshotTimestamp);
+            // NOTE: this looks nullable, but only non-null Strings are written
             metadata.setPackaging(readNullableString());
             metadata.setRelocated(readBoolean());
             metadata.setAttributes(attributes);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/DefaultMavenModuleResolveMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/DefaultMavenModuleResolveMetadata.java
@@ -39,6 +39,7 @@ import org.gradle.internal.component.model.ModuleConfigurationMetadata;
 import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.internal.component.model.VariantGraphResolveMetadata;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
@@ -219,7 +220,7 @@ public class DefaultMavenModuleResolveMetadata extends AbstractLazyModuleCompone
     }
 
     @Override
-    public String getPackaging() {
+    public @Nonnull String getPackaging() {
         return packaging;
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/DefaultMutableMavenModuleResolveMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/DefaultMutableMavenModuleResolveMetadata.java
@@ -27,6 +27,7 @@ import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.internal.component.external.descriptor.Configuration;
 import org.gradle.internal.component.external.model.AbstractMutableModuleComponentResolveMetadata;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collection;
 
@@ -111,12 +112,12 @@ public class DefaultMutableMavenModuleResolveMetadata extends AbstractMutableMod
     }
 
     @Override
-    public String getPackaging() {
+    public @Nonnull String getPackaging() {
         return packaging;
     }
 
     @Override
-    public void setPackaging(String packaging) {
+    public void setPackaging(@Nonnull String packaging) {
         this.packaging = packaging;
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/MavenModuleResolveMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/MavenModuleResolveMetadata.java
@@ -19,6 +19,7 @@ package org.gradle.internal.component.external.model.maven;
 import com.google.common.collect.ImmutableList;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -31,7 +32,7 @@ public interface MavenModuleResolveMetadata extends ModuleComponentResolveMetada
     @Override
     MutableMavenModuleResolveMetadata asMutable();
 
-    String getPackaging();
+    @Nonnull String getPackaging();
     boolean isRelocated();
     boolean isPomPackaging();
     boolean isKnownJarPackaging();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/MutableMavenModuleResolveMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/MutableMavenModuleResolveMetadata.java
@@ -19,6 +19,7 @@ package org.gradle.internal.component.external.model.maven;
 import com.google.common.collect.ImmutableList;
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public interface MutableMavenModuleResolveMetadata extends MutableModuleComponentResolveMetadata {
@@ -30,8 +31,8 @@ public interface MutableMavenModuleResolveMetadata extends MutableModuleComponen
     @Nullable
     String getSnapshotTimestamp();
 
-    String getPackaging();
-    void setPackaging(String packaging);
+    @Nonnull String getPackaging();
+    void setPackaging(@Nonnull String packaging);
 
     boolean isPomPackaging();
     boolean isKnownJarPackaging();


### PR DESCRIPTION
Maven ignores the declared packaging and assumes jar unless told otherwise.

Gradle attempts to resolve a dependency's artifact based on its packaging.

In the past, we would have attempted to resolve an artifact with the extension ${packaging.type} and, failing that, tried jar.

Now, when we detect that the packaging isn't something valid, we immediately default to jar in our internal representation of the POM.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
