### PR TITLE
Create empty project directories to avoid deprecation warnings

### DIFF
--- a/platforms/ide/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeCompositeBuildIntegrationTest.groovy
+++ b/platforms/ide/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeCompositeBuildIntegrationTest.groovy
@@ -29,6 +29,9 @@ class XcodeCompositeBuildIntegrationTest extends AbstractXcodeIntegrationSpec {
             includeBuild 'util'
             includeBuild 'other'
         """
+        createDirs("greeter")
+        createDirs("app")
+        createDirs("empty")
 
         buildFile << """
             allprojects {

--- a/platforms/ide/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeMultipleProjectIntegrationTest.groovy
+++ b/platforms/ide/ide-native/src/integTest/groovy/org/gradle/ide/xcode/XcodeMultipleProjectIntegrationTest.groovy
@@ -45,6 +45,9 @@ class XcodeMultipleProjectIntegrationTest extends AbstractXcodeIntegrationSpec {
             }
         """
 
+        createDirs("app")
+        createDirs("greeter")
+
         when:
         succeeds(":xcode")
 
@@ -68,6 +71,10 @@ class XcodeMultipleProjectIntegrationTest extends AbstractXcodeIntegrationSpec {
         settingsFile << """
             include 'empty'
         """
+
+        createDirs("greeter")
+        createDirs("app")
+        createDirs("empty")
 
         buildFile << """
             allprojects {


### PR DESCRIPTION
e.g.

```
Configuring project ':greeter' without an existing directory is deprecated.
```

This is missed in https://github.com/gradle/gradle/pull/26509 because they're running at late stages.