### PR TITLE
Add default methods to dependency graph visitors

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/InMemoryResolutionResultBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/InMemoryResolutionResultBuilder.java
@@ -21,7 +21,6 @@ import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.internal.artifacts.ResolveContext;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphComponent;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphSelector;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedGraphVariant;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.RootGraphNode;
@@ -43,10 +42,6 @@ public class InMemoryResolutionResultBuilder implements DependencyGraphVisitor {
     private ImmutableAttributes requestAttributes;
 
     @Override
-    public void start(RootGraphNode root) {
-    }
-
-    @Override
     public void visitNode(DependencyGraphNode node) {
         DependencyGraphComponent component = node.getOwner();
         resolutionResultBuilder.startVisitComponent(component.getResultId(), component.getSelectionReason(), component.getRepositoryName());
@@ -59,16 +54,12 @@ public class InMemoryResolutionResultBuilder implements DependencyGraphVisitor {
     }
 
     @Override
-    public void visitSelector(DependencyGraphSelector selector) {
-    }
-
-    @Override
     public void visitEdges(DependencyGraphNode node) {
         resolutionResultBuilder.visitOutgoingEdges(node.getOwner().getResultId(), node.getOutgoingEdges());
     }
 
     @Override
-    public void finish(DependencyGraphNode root) {
+    public void finish(RootGraphNode root) {
         Long resultId = root.getOwner().getResultId();
         this.root = resolutionResultBuilder.getRoot(resultId);
         this.requestAttributes = root.getResolveState().getAttributes();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultResolvedArtifactsBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultResolvedArtifactsBuilder.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
 import org.gradle.api.artifacts.ResolutionStrategy;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.RootGraphNode;
 import org.gradle.internal.component.local.model.LocalFileDependencyMetadata;
 
 import java.util.ArrayList;
@@ -35,14 +34,6 @@ public class DefaultResolvedArtifactsBuilder implements DependencyArtifactsVisit
     public DefaultResolvedArtifactsBuilder(boolean buildProjectDependencies, ResolutionStrategy.SortOrder sortOrder) {
         this.buildProjectDependencies = buildProjectDependencies;
         this.sortOrder = sortOrder;
-    }
-
-    @Override
-    public void startArtifacts(RootGraphNode root) {
-    }
-
-    @Override
-    public void visitNode(DependencyGraphNode node) {
     }
 
     @Override
@@ -65,10 +56,6 @@ public class DefaultResolvedArtifactsBuilder implements DependencyArtifactsVisit
         if (artifactSetsById.size() == artifactSetId) {
             artifactSetsById.add(artifacts);
         }
-    }
-
-    @Override
-    public void finishArtifacts() {
     }
 
     public VisitedArtifactsResults complete() {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DependencyArtifactsVisitor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DependencyArtifactsVisitor.java
@@ -22,30 +22,25 @@ import org.gradle.internal.component.local.model.LocalFileDependencyMetadata;
 
 public interface DependencyArtifactsVisitor {
     /**
-     * Starts visiting.
-     */
-    void startArtifacts(RootGraphNode root);
-
-    /**
      * Visits a node in the graph. All nodes are visited prior to visiting the edges
      */
-    void visitNode(DependencyGraphNode node);
+    default void visitNode(DependencyGraphNode node) {}
 
     /**
      * Visits the artifacts introduced by a particular edge in the graph. Called for every edge in the graph.
      * The nodes are visited in consumer-first order.
      */
-    void visitArtifacts(DependencyGraphNode from, DependencyGraphNode to, int artifactSetId, ArtifactSet artifacts);
+    default void visitArtifacts(DependencyGraphNode from, DependencyGraphNode to, int artifactSetId, ArtifactSet artifacts) {}
 
     /**
      * Visits the artifacts introduce by a particular node in the graph. Called *zero or more* times for each node.
      * Currently local files are treated differently to other dependencies.
      * The nodes are visited in consumer-first order
      */
-    void visitArtifacts(DependencyGraphNode from, LocalFileDependencyMetadata fileDependency, int artifactSetId, ArtifactSet artifactSet);
+    default void visitArtifacts(DependencyGraphNode from, LocalFileDependencyMetadata fileDependency, int artifactSetId, ArtifactSet artifactSet) {}
 
     /**
      * Completes visiting.
      */
-    void finishArtifacts();
+    default void finishArtifacts(RootGraphNode root) {}
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedArtifactsGraphVisitor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedArtifactsGraphVisitor.java
@@ -20,7 +20,6 @@ import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphEdge;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphSelector;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.RootGraphNode;
 import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry;
@@ -59,17 +58,8 @@ public class ResolvedArtifactsGraphVisitor implements DependencyGraphVisitor {
     }
 
     @Override
-    public void start(RootGraphNode root) {
-        artifactResults.startArtifacts(root);
-    }
-
-    @Override
     public void visitNode(DependencyGraphNode node) {
         artifactResults.visitNode(node);
-    }
-
-    @Override
-    public void visitSelector(DependencyGraphSelector selector) {
     }
 
     @Override
@@ -88,8 +78,8 @@ public class ResolvedArtifactsGraphVisitor implements DependencyGraphVisitor {
     }
 
     @Override
-    public void finish(DependencyGraphNode root) {
-        artifactResults.finishArtifacts();
+    public void finish(RootGraphNode root) {
+        artifactResults.finishArtifacts(root);
         artifactsByNodeId.clear();
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/CompositeDependencyArtifactsVisitor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/CompositeDependencyArtifactsVisitor.java
@@ -30,13 +30,6 @@ public class CompositeDependencyArtifactsVisitor implements DependencyArtifactsV
     }
 
     @Override
-    public void startArtifacts(RootGraphNode root) {
-        for (DependencyArtifactsVisitor visitor : visitors) {
-            visitor.startArtifacts(root);
-        }
-    }
-
-    @Override
     public void visitNode(DependencyGraphNode node) {
         for (DependencyArtifactsVisitor visitor : visitors) {
             visitor.visitNode(node);
@@ -58,9 +51,9 @@ public class CompositeDependencyArtifactsVisitor implements DependencyArtifactsV
     }
 
     @Override
-    public void finishArtifacts() {
+    public void finishArtifacts(RootGraphNode root) {
         for (DependencyArtifactsVisitor visitor : visitors) {
-            visitor.finishArtifacts();
+            visitor.finishArtifacts(root);
         }
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/CompositeDependencyGraphVisitor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/CompositeDependencyGraphVisitor.java
@@ -16,15 +16,10 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph;
 
-import java.util.Arrays;
 import java.util.List;
 
 public class CompositeDependencyGraphVisitor implements DependencyGraphVisitor {
     private final List<DependencyGraphVisitor> visitors;
-
-    public CompositeDependencyGraphVisitor(DependencyGraphVisitor... visitors) {
-        this(Arrays.asList(visitors));
-    }
 
     public CompositeDependencyGraphVisitor(List<DependencyGraphVisitor> visitors) {
         this.visitors = visitors;
@@ -59,7 +54,7 @@ public class CompositeDependencyGraphVisitor implements DependencyGraphVisitor {
     }
 
     @Override
-    public void finish(DependencyGraphNode root) {
+    public void finish(RootGraphNode root) {
         for (DependencyGraphVisitor visitor : visitors) {
             visitor.finish(root);
         }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphVisitor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphVisitor.java
@@ -25,26 +25,26 @@ public interface DependencyGraphVisitor {
     /**
      * Starts traversal of the graph.
      */
-    void start(RootGraphNode root);
+    default void start(RootGraphNode root) {}
 
     /**
      * Visits a node of the graph. Includes the root. This method is called for all nodes before {@link #visitEdges(DependencyGraphNode)} is called.
      */
-    void visitNode(DependencyGraphNode node);
+    default void visitNode(DependencyGraphNode node) {}
 
     /**
      * Visits a selector. This method is called for all selectors before {@link #visitEdges(DependencyGraphNode)} is called.
      */
-    void visitSelector(DependencyGraphSelector selector);
+    default void visitSelector(DependencyGraphSelector selector) {}
 
     /**
      * Visits edges to/from a node of the graph. Includes the root. This method is called for all nodes after {@link #visitNode(DependencyGraphNode)} has been called for all nodes.
      * Nodes are visited in consumer-first order.
      */
-    void visitEdges(DependencyGraphNode node);
+    default void visitEdges(DependencyGraphNode node) {}
 
     /**
      * Completes traversal of the graph.
      */
-    void finish(DependencyGraphNode root);
+    default void finish(RootGraphNode root) {}
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/FailOnVersionConflictGraphVisitor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/FailOnVersionConflictGraphVisitor.java
@@ -23,9 +23,7 @@ import org.gradle.api.artifacts.result.ComponentSelectionDescriptor;
 import org.gradle.api.artifacts.result.ComponentSelectionReason;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphComponent;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphSelector;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphVisitor;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.RootGraphNode;
 
 import java.util.Collections;
 import java.util.Set;
@@ -43,11 +41,6 @@ public class FailOnVersionConflictGraphVisitor implements DependencyGraphVisitor
     public FailOnVersionConflictGraphVisitor(String projectPath, String configurationName) {
         this.projectPath = projectPath;
         this.configurationName = configurationName;
-    }
-
-    @Override
-    public void start(RootGraphNode root) {
-
     }
 
     @Override
@@ -74,21 +67,6 @@ public class FailOnVersionConflictGraphVisitor implements DependencyGraphVisitor
         }
         assert conflictDescription != null;
         return owner.getGroup() + ":" + owner.getName() + " " + conflictDescription;
-    }
-
-    @Override
-    public void visitSelector(DependencyGraphSelector selector) {
-
-    }
-
-    @Override
-    public void visitEdges(DependencyGraphNode node) {
-
-    }
-
-    @Override
-    public void finish(DependencyGraphNode root) {
-
     }
 
     public Set<Throwable> collectConflictFailures() {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/ResolutionFailureCollector.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/ResolutionFailureCollector.java
@@ -26,7 +26,6 @@ import org.gradle.api.internal.artifacts.ivyservice.DefaultUnresolvedDependency;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphEdge;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphPathResolver;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphSelector;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.RootGraphNode;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
@@ -53,10 +52,6 @@ public class ResolutionFailureCollector implements DependencyGraphVisitor {
     }
 
     @Override
-    public void visitSelector(DependencyGraphSelector selector) {
-    }
-
-    @Override
     public void visitNode(DependencyGraphNode node) {
         for (DependencyGraphEdge dependency : node.getOutgoingEdges()) {
             ModuleVersionResolveException failure = dependency.getFailure();
@@ -64,14 +59,6 @@ public class ResolutionFailureCollector implements DependencyGraphVisitor {
                 addUnresolvedDependency(dependency, dependency.getRequested(), failure);
             }
         }
-    }
-
-    @Override
-    public void visitEdges(DependencyGraphNode node) {
-    }
-
-    @Override
-    public void finish(DependencyGraphNode root) {
     }
 
     public Set<UnresolvedDependency> complete(Set<UnresolvedDependency> extraFailures) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/ResolvedConfigurationDependencyGraphVisitor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/ResolvedConfigurationDependencyGraphVisitor.java
@@ -31,7 +31,6 @@ import org.gradle.internal.component.local.model.LocalFileDependencyMetadata;
  */
 public class ResolvedConfigurationDependencyGraphVisitor implements DependencyArtifactsVisitor {
     private final ResolvedConfigurationBuilder builder;
-    private RootGraphNode root;
 
     public ResolvedConfigurationDependencyGraphVisitor(ResolvedConfigurationBuilder builder) {
         this.builder = builder;
@@ -41,18 +40,13 @@ public class ResolvedConfigurationDependencyGraphVisitor implements DependencyAr
     public void visitNode(DependencyGraphNode node) {
         builder.newResolvedDependency(node);
         for (DependencyGraphEdge dependency : node.getIncomingEdges()) {
-            if (dependency.getFrom() == root) {
+            if (dependency.getFrom().isRoot()) {
                 Dependency moduleDependency = dependency.getOriginalDependency();
                 if (moduleDependency != null) {
                     builder.addFirstLevelDependency(moduleDependency, node);
                 }
             }
         }
-    }
-
-    @Override
-    public void startArtifacts(RootGraphNode root) {
-        this.root = root;
     }
 
     @Override
@@ -66,7 +60,7 @@ public class ResolvedConfigurationDependencyGraphVisitor implements DependencyAr
     }
 
     @Override
-    public void finishArtifacts() {
+    public void finishArtifacts(RootGraphNode root) {
         builder.done(root);
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/projectresult/ResolvedLocalComponentsResultGraphVisitor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/projectresult/ResolvedLocalComponentsResultGraphVisitor.java
@@ -20,7 +20,6 @@ import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphSelector;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.RootGraphNode;
 
@@ -50,18 +49,6 @@ public class ResolvedLocalComponentsResultGraphVisitor implements DependencyGrap
                 resolvedProjectConfigurations.add(new DefaultResolvedProjectConfiguration(projectComponentId, node.getResolvedConfigurationId().getConfiguration()));
             }
         }
-    }
-
-    @Override
-    public void visitSelector(DependencyGraphSelector selector) {
-    }
-
-    @Override
-    public void visitEdges(DependencyGraphNode node) {
-    }
-
-    @Override
-    public void finish(DependencyGraphNode root) {
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/FileDependencyCollectingGraphVisitor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/FileDependencyCollectingGraphVisitor.java
@@ -22,7 +22,6 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.Artif
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.DependencyArtifactsVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.VisitedFileDependencyResults;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.RootGraphNode;
 import org.gradle.internal.component.local.model.LocalFileDependencyMetadata;
 
 import java.util.Map;
@@ -31,26 +30,10 @@ public class FileDependencyCollectingGraphVisitor implements DependencyArtifacts
     private final Map<FileCollectionDependency, Integer> rootFiles = Maps.newLinkedHashMap();
 
     @Override
-    public void startArtifacts(RootGraphNode root) {
-    }
-
-    @Override
-    public void visitNode(DependencyGraphNode node) {
-    }
-
-    @Override
-    public void visitArtifacts(DependencyGraphNode from, DependencyGraphNode to, int artifactSetId, ArtifactSet artifacts) {
-    }
-
-    @Override
     public void visitArtifacts(DependencyGraphNode node, LocalFileDependencyMetadata fileDependency, int artifactSetId, ArtifactSet artifactSet) {
         if (node.isRoot()) {
             rootFiles.put(fileDependency.getSource(), artifactSetId);
         }
-    }
-
-    @Override
-    public void finishArtifacts() {
     }
 
     public VisitedFileDependencyResults complete() {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilder.java
@@ -101,7 +101,7 @@ public class StreamingResolutionResultBuilder implements DependencyGraphVisitor 
     }
 
     @Override
-    public void finish(final DependencyGraphNode root) {
+    public void finish(final RootGraphNode root) {
         store.write(encoder -> {
             encoder.writeByte(ROOT);
             encoder.writeSmallLong(root.getOwner().getResultId());

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/locking/DependencyLockingGraphVisitor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/locking/DependencyLockingGraphVisitor.java
@@ -27,7 +27,6 @@ import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvi
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingState;
 import org.gradle.api.internal.artifacts.ivyservice.DefaultUnresolvedDependency;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphSelector;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.RootGraphNode;
 import org.gradle.api.internal.artifacts.repositories.resolver.MavenUniqueSnapshotComponentIdentifier;
@@ -117,21 +116,6 @@ public class DependencyLockingGraphVisitor implements DependencyGraphVisitor {
             changingResolvedModules = new HashSet<>();
         }
         changingResolvedModules.add(id);
-    }
-
-    @Override
-    public void visitSelector(DependencyGraphSelector selector) {
-        // No-op
-    }
-
-    @Override
-    public void visitEdges(DependencyGraphNode node) {
-        // No-op
-    }
-
-    @Override
-    public void finish(DependencyGraphNode root) {
-
     }
 
     public void writeLocks() {

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -39,7 +39,6 @@ import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.RootComponen
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusions
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphPathResolver
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphSelector
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphVisitor
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.RootGraphNode
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.DependencyGraphBuilder
@@ -1181,10 +1180,6 @@ class DependencyGraphBuilderTest extends Specification {
         }
 
         @Override
-        void visitSelector(DependencyGraphSelector configurationSelector) {
-        }
-
-        @Override
         void visitEdges(DependencyGraphNode node) {
             node.outgoingEdges.each {
                 if (it.failure) {
@@ -1206,10 +1201,6 @@ class DependencyGraphBuilderTest extends Specification {
             throw new ResolveException("config", failures.values().collect {
                 it.failure.withIncomingPaths(DependencyGraphPathResolver.calculatePaths(it.requiredBy, root))
             })
-        }
-
-        @Override
-        void finish(DependencyGraphNode root) {
         }
 
         static class FailureDetails {


### PR DESCRIPTION
Many of the visitors only override some of the visitor methods. Having so many empty method implementations makes it difficult to navigate in the IDE to determine which visitor actually implements certain functionality. Adding these default implementations makes it much easier to see which methods are used where.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
