### PR TITLE
Disable invalidation of coupled projects with internal flag

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ kotlin.js.ir.output.granularity=whole-program
 # Temporarily force IDEs to produce build scans
 systemProp.org.gradle.internal.ide.scan=true
 # If you're experimenting with changes and don't want to update the verification file right away, please change the mode to "lenient" (not "off")
-org.gradle.dependency.verification=off
+org.gradle.dependency.verification=strict
 # TD releated properties
 gradle.internal.testdistribution.writeTraceFile=false
 systemProp.gradle.internal.testdistribution.writeTraceFile=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ kotlin.js.ir.output.granularity=whole-program
 # Temporarily force IDEs to produce build scans
 systemProp.org.gradle.internal.ide.scan=true
 # If you're experimenting with changes and don't want to update the verification file right away, please change the mode to "lenient" (not "off")
-org.gradle.dependency.verification=strict
+org.gradle.dependency.verification=off
 # TD releated properties
 gradle.internal.testdistribution.writeTraceFile=false
 systemProp.gradle.internal.testdistribution.writeTraceFile=false

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsAccessFromGroovyDslIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsAccessFromGroovyDslIntegrationTest.groovy
@@ -784,7 +784,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         then:
         failure.assertHasErrorOutput("Could not find method foo() for arguments [] on project ':b' of type org.gradle.api.Project")
         problems.assertResultHasProblems(failure) {
-            withProblem("Build file 'a/build.gradle': line 3: Cannot access project ':b' from project ':a'. 'Project.evaluationDependsOn' must be used to establish a dependency between project ':b' and project ':a' evaluation")
+            withProblem("Build file '${relativePath('a/build.gradle')}': line 3: Cannot access project ':b' from project ':a'. 'Project.evaluationDependsOn' must be used to establish a dependency between project ':b' and project ':a' evaluation")
         }
 
     }
@@ -818,7 +818,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         then:
         failure.assertHasErrorOutput("Could not get unknown property 'myExtension' for project ':b' of type org.gradle.api.Project")
         problems.assertResultHasProblems(failure) {
-            withProblem("Build file 'a/build.gradle': line 3: Cannot access project ':b' from project ':a'. 'Project.evaluationDependsOn' must be used to establish a dependency between project ':b' and project ':a' evaluation")
+            withProblem("Build file '${relativePath('a/build.gradle')}': line 3: Cannot access project ':b' from project ':a'. 'Project.evaluationDependsOn' must be used to establish a dependency between project ':b' and project ':a' evaluation")
         }
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsAccessFromGroovyDslIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsAccessFromGroovyDslIntegrationTest.groovy
@@ -762,7 +762,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         }
     }
 
-    def "fails on access #type of unconfigured project"() {
+    def "fails on invoke method of unconfigured project"() {
         given:
         settingsFile << """
             include(':a')
@@ -771,32 +771,54 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
 
         file("a/build.gradle") << """
             def unconfiguredProject = project(':b')
-            $referrerConfiguration
+            println 'Unconfigured project value = ' + unconfiguredProject.foo()
         """
 
         file("b/build.gradle") << """
-            import ${Property.name}
-
-            interface MyExtension {
-                Property<String> bar()
-            }
-
-            $referentConfiguration
+            String foo(){ 'configured' }
         """
 
         when:
         isolatedProjectsFails 'help', WARN_PROBLEMS_CLI_OPT
 
         then:
-        failure.assertHasErrorOutput(expectedOutput)
+        failure.assertHasErrorOutput("Could not find method foo() for arguments [] on project ':b' of type org.gradle.api.Project")
         problems.assertResultHasProblems(failure) {
-            withProblem("Build file '${relativePath('a/build.gradle')}': line 3: Cannot access project ':b' from project ':a'")
-            withProblem("Build file '${relativePath('a/build.gradle')}': line 3: Project ':b' cannot dynamically look up a $type in the parent project ':'")
+            withProblem("Build file 'a/build.gradle': line 3: Cannot access project ':b' from project ':a'. 'Project.evaluationDependsOn' must be used to establish a dependency between project ':b' and project ':a' evaluation")
         }
 
-        where:
-        type       | referentConfiguration                           | referrerConfiguration                   | expectedOutput
-        "property" | "extensions.create('myExtension', MyExtension)" | "unconfiguredProject.myExtension.bar()" | "Could not get unknown property 'myExtension' for project ':b' of type org.gradle.api.Project."
-        "method"   | "def foo(){}"                                   | "unconfiguredProject.foo()"             | "Could not find method foo() for arguments [] on project ':b' of type org.gradle.api.Project."
+    }
+
+    def "fails on access property of unconfigured project"() {
+        given:
+        settingsFile << """
+            include(':a')
+            include(':b')
+        """
+
+        file("a/build.gradle") << """
+            def unconfiguredProject = project(':b')
+            println 'Unconfigured project value = ' + unconfiguredProject.myExtension.get()
+        """
+
+        file("b/build.gradle") << """
+            import ${Property.name}
+
+            interface MyExtension {
+                Property<String> getFoo()
+            }
+
+            def myExtension= extensions.create('myExtension', MyExtension)
+            myExtension.foo.set('configured')
+        """
+
+        when:
+        isolatedProjectsFails 'help', WARN_PROBLEMS_CLI_OPT
+
+        then:
+        failure.assertHasErrorOutput("Could not get unknown property 'myExtension' for project ':b' of type org.gradle.api.Project")
+        problems.assertResultHasProblems(failure) {
+            withProblem("Build file 'a/build.gradle': line 3: Cannot access project ':b' from project ':a'. 'Project.evaluationDependsOn' must be used to establish a dependency between project ':b' and project ':a' evaluation")
+        }
     }
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/CrossProjectModelAccessTrackingParentDynamicObject.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/CrossProjectModelAccessTrackingParentDynamicObject.kt
@@ -138,7 +138,6 @@ class CrossProjectModelAccessTrackingParentDynamicObject(
         }
     }
 
-    private
     companion object {
         val PROBLEM_KEY = Any()
     }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultBuildModelControllerServices.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultBuildModelControllerServices.kt
@@ -147,11 +147,12 @@ class DefaultBuildModelControllerServices(
             problemsListener: ProblemsListener,
             problemFactory: ProblemFactory,
             listenerManager: ListenerManager,
-            dynamicCallProblemReporting: DynamicCallProblemReporting
+            dynamicCallProblemReporting: DynamicCallProblemReporting,
+            buildModelParameters: BuildModelParameters
         ): CrossProjectModelAccess {
             val delegate = VintageIsolatedProjectsProvider().createCrossProjectModelAccess(projectRegistry)
             return ProblemReportingCrossProjectModelAccess(
-                delegate, problemsListener, listenerManager.getBroadcaster(CoupledProjectsListener::class.java), problemFactory, dynamicCallProblemReporting
+                delegate, problemsListener, listenerManager.getBroadcaster(CoupledProjectsListener::class.java), problemFactory, dynamicCallProblemReporting, buildModelParameters
             )
         }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ProblemReportingCrossProjectModelAccess.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ProblemReportingCrossProjectModelAccess.kt
@@ -1045,7 +1045,8 @@ class ProblemReportingCrossProjectModelAccess(
             }
         }
 
-        private fun <T> DefaultProject.withEvaluationOrderCheck(action: DefaultProject.() -> T?): T? {
+        private
+        fun <T> DefaultProject.withEvaluationOrderCheck(action: DefaultProject.() -> T?): T? {
             // Attempt to get a result, since plugin might to contribute to DynamicObject properties
             var failure: Throwable? = null
             val result =
@@ -1078,7 +1079,8 @@ class ProblemReportingCrossProjectModelAccess(
             }
         }
 
-        private fun reportMissedConfigurationProblem() {
+        private
+        fun reportMissedConfigurationProblem() {
             val problem = problemFactory.problem {
                 reference("org.gradle.internal.invalidate-coupled-projects=false")
                 text(" is preventing configuration of project ")
@@ -1089,7 +1091,8 @@ class ProblemReportingCrossProjectModelAccess(
             problems.onProblem(problem)
         }
 
-        private fun reportEvaluationOrderProblem() {
+        private
+        fun reportEvaluationOrderProblem() {
             val problem = problemFactory.problem {
                 reference("Project.evaluationDependsOn")
                 text(" must be used to establish a dependency between project ")

--- a/subprojects/core/src/integTest/groovy/org/gradle/configuration/project/LifecycleProjectEvaluatorIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/configuration/project/LifecycleProjectEvaluatorIntegrationTest.groovy
@@ -155,8 +155,4 @@ class LifecycleProjectEvaluatorIntegrationTest extends AbstractIntegrationSpec {
             parentId == configureIncludedBuild.id
         }
     }
-
-    String relativePath(String path) {
-        return path.replace('/', File.separator)
-    }
 }


### PR DESCRIPTION
Fixes #26628 
The last step for experimental support of incremental sync is an avoiding of referent project configuration during cross project access.
For instance, if `:b` accesses `:a` and `:a` is not configured yet, cross project access shouldn't imply implicit configuration of `:a`. We agreed to hide this behavior behind the internal flag.

There is some "ordering" in which projects are configuring.
For instance, `:a < :b` means literally `while in a vintage mode, project A will be configured before project B`. However, with parallel model building for sync it can't be trusted anymore. 

In this PR, when coupled project invalidation is disabled, access to not-configured referent project is considering as a sort of "undefined behavior", so we return `null` and emit a problem.
