### PR TITLE
Avoid unnecessary exists check in DefaultSourceDirectorySet.getSourceTrees

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultSourceDirectorySet.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultSourceDirectorySet.java
@@ -249,7 +249,7 @@ public class DefaultSourceDirectorySet extends CompositeFileTree implements Sour
                 result.addAll(nested.getSourceTrees());
             } else {
                 for (File srcDir : fileCollectionFactory.resolving(path)) {
-                    if (srcDir.exists() && !srcDir.isDirectory()) {
+                    if (!srcDir.isDirectory() && srcDir.exists()) {
                         throw new InvalidUserDataException(String.format("Source directory '%s' is not a directory.", srcDir));
                     }
                     result.add(directoryFileTreeFactory.create(srcDir, patterns));


### PR DESCRIPTION
Issue #26757

### Context

This isn't a complete mitigation for this issue, but at least halves the number of `stat` calls in this hot path during snapshotting.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
