### PR TITLE
Improve performance of RelativePath canonicalization

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/file/RelativePath.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/RelativePath.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.file;
 
-import com.google.common.collect.Iterables;
 import org.gradle.internal.file.FilePathUtil;
 
 import javax.annotation.Nullable;
@@ -49,18 +48,18 @@ public class RelativePath implements Serializable, Comparable<RelativePath>, Cha
     private RelativePath(boolean endsWithFile, @Nullable RelativePath parentPath, String... childSegments) {
         this.endsWithFile = endsWithFile;
         final int expectedLength;
-        final Iterable<String> sourceSegments;
         if (parentPath != null) {
             expectedLength = parentPath.segments.length + childSegments.length;
-            sourceSegments = Iterables.concat(Arrays.asList(parentPath.segments),
-                Arrays.asList(childSegments));
         } else {
             expectedLength = childSegments.length;
-            sourceSegments = Arrays.asList(childSegments);
         }
         String[] newSegments = new String[expectedLength];
         int nextIndex = 0;
-        for (String segment : sourceSegments) {
+        if (parentPath != null) {
+            System.arraycopy(parentPath.segments, 0, newSegments, 0, parentPath.segments.length);
+            nextIndex = parentPath.segments.length;
+        }
+        for (String segment : childSegments) {
             if (segment.equals(".")) {
                 continue;
             }


### PR DESCRIPTION
This is a follow-up to https://github.com/gradle/gradle/pull/24943.

There was some uncertainty as to whether that change resulted in a detectable drop in performance in Gradle's overall performance tests. I put together [some benchmarks](https://github.com/AlexLandau/gradle-relative-path-perf) looking at the constructor method that was modified, and based on my probably-non-representative sample of test cases, the new implementation took around 3.4x as long as the one that did not perform canonicalization.

The version in this PR skips running canonicalization checks on segments that come from existing `RelativePath` objects, which have already been canonicalized. This implementation actually performs better than the original, pre-canonicalization implementation in my benchmark test; I would take this with a grain of salt, as I do not have experience with JMH and may have used a poor setup or poor choice of test cases. (There's at least some evidence that for the range of test cases attempted, copying into the array with a for loop is faster than `System.arraycopy`, which would explain this. This could, of course, vary across JVM versions and other factors.)

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
