### PR TITLE
Do not emit deprecation warning when category/tag/group filters out all tests.

### DIFF
--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/AbstractJUnitCategoriesOrTagsCoverageIntegrationSpec.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/AbstractJUnitCategoriesOrTagsCoverageIntegrationSpec.groovy
@@ -232,7 +232,6 @@ abstract class AbstractJUnitCategoriesOrTagsCoverageIntegrationSpec extends Abst
                     ${excludeCategoryOrTag('CategoryA')}
                     ${excludeCategoryOrTag('CategoryC')}
                 }
-                filter.failOnNoMatchingTests = false
             }
         """
 
@@ -268,7 +267,6 @@ abstract class AbstractJUnitCategoriesOrTagsCoverageIntegrationSpec extends Abst
                 ${configureTestFramework} {
                     ${configureIncludeOrExclude}
                 }
-                filter.failOnNoMatchingTests = false
             }
         """
 

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/AbstractJUnitCategoriesOrTagsCoverageIntegrationSpec.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/AbstractJUnitCategoriesOrTagsCoverageIntegrationSpec.groovy
@@ -232,13 +232,11 @@ abstract class AbstractJUnitCategoriesOrTagsCoverageIntegrationSpec extends Abst
                     ${excludeCategoryOrTag('CategoryA')}
                     ${excludeCategoryOrTag('CategoryC')}
                 }
+                filter.failOnNoMatchingTests = false
             }
         """
 
         when:
-        executer.expectDocumentedDeprecationWarning("No test executed. This behavior has been deprecated. " +
-            "This will fail with an error in Gradle 9.0. There are test sources present but no test was executed. Please check your test configuration. " +
-            "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#test_task_fail_on_no_test_executed")
         run('test')
 
         then:
@@ -247,6 +245,42 @@ abstract class AbstractJUnitCategoriesOrTagsCoverageIntegrationSpec extends Abst
         and:
         DefaultTestExecutionResult result = new DefaultTestExecutionResult(testDirectory)
         result.assertNoTestClassesExecuted()
+    }
+
+    def "does not emit deprecation warning about no tests executing when categories or tags are specified (#configureIncludeOrExclude)"() {
+        given:
+        testSources.with {
+            testClass('CategoryATests')
+                .withCategoryOrTag('CategoryA')
+                .with {
+                    testMethod('catAOk1').shouldPass()
+                    testMethod('catAOk2').shouldPass()
+                    testMethod('catAOk3').shouldPass()
+                    testMethod('catAOk4').shouldPass()
+                }
+            testCategory('CategoryA')
+            testCategory('CategoryC')
+        }
+        testSourceGenerator.writeAllSources(testSources)
+
+        buildFile << """
+            test {
+                ${configureTestFramework} {
+                    ${configureIncludeOrExclude}
+                }
+                filter.failOnNoMatchingTests = false
+            }
+        """
+
+        when:
+        run('test')
+
+        then:
+        DefaultTestExecutionResult result = new DefaultTestExecutionResult(testDirectory)
+        result.assertNoTestClassesExecuted()
+
+        where:
+        configureIncludeOrExclude << [excludeCategoryOrTag('CategoryA'), includeCategoryOrTag('CategoryC')]
     }
 
     void assertOutputContainsCategoryOrTagWarning(String... categories) {

--- a/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGIntegrationTest.groovy
+++ b/platforms/jvm/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGIntegrationTest.groovy
@@ -194,7 +194,6 @@ class TestNGIntegrationTest extends MultiVersionIntegrationSpec {
                 useTestNG {
                     ${configureIncludeOrExcludeGroups}
                 }
-                filter.failOnNoMatchingTests = false
             }
         """.stripIndent()
         file('src/test/java/org/gradle/groups/SomeTest.java') << '''

--- a/platforms/jvm/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/platforms/jvm/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -1278,6 +1278,35 @@ public abstract class Test extends AbstractTestTask implements JavaForkOptions, 
         return javaLauncher;
     }
 
+    @Override
+    boolean testsAreFiltered() {
+        return super.testsAreFiltered()
+            || hasCategoryOrTagOrGroup();
+    }
+
+    private boolean hasCategoryOrTagOrGroup() {
+        TestFrameworkOptions frameworkOptions = getTestFramework().getOptions();
+        if (frameworkOptions == null) {
+            return false;
+        }
+
+        if (JUnitOptions.class.isAssignableFrom(frameworkOptions.getClass())) {
+            JUnitOptions junitOptions = (JUnitOptions) frameworkOptions;
+            return !junitOptions.getIncludeCategories().isEmpty()
+                || !junitOptions.getExcludeCategories().isEmpty();
+        } else if (JUnitPlatformOptions.class.isAssignableFrom(frameworkOptions.getClass())) {
+            JUnitPlatformOptions junitPlatformOptions = (JUnitPlatformOptions) frameworkOptions;
+            return !junitPlatformOptions.getIncludeTags().isEmpty()
+                || !junitPlatformOptions.getExcludeTags().isEmpty();
+        } else if (TestNGOptions.class.isAssignableFrom(frameworkOptions.getClass())) {
+            TestNGOptions testNGOptions = (TestNGOptions) frameworkOptions;
+            return !testNGOptions.getIncludeGroups().isEmpty()
+                || !testNGOptions.getExcludeGroups().isEmpty();
+        } else {
+            throw new IllegalArgumentException("Unknown test framework: " + frameworkOptions.getClass().getName());
+        }
+    }
+
     @Inject
     protected ObjectFactory getObjectFactory() {
         throw new UnsupportedOperationException();

--- a/platforms/jvm/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/platforms/jvm/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -1279,29 +1279,29 @@ public abstract class Test extends AbstractTestTask implements JavaForkOptions, 
     }
 
     @Override
-    boolean testsAreFiltered() {
-        return super.testsAreFiltered()
-            || hasCategoryOrTagOrGroup();
+    boolean testsAreNotFiltered() {
+        return super.testsAreNotFiltered()
+            && noCategoryOrTagOrGroupSpecified();
     }
 
-    private boolean hasCategoryOrTagOrGroup() {
+    private boolean noCategoryOrTagOrGroupSpecified() {
         TestFrameworkOptions frameworkOptions = getTestFramework().getOptions();
         if (frameworkOptions == null) {
-            return false;
+            return true;
         }
 
         if (JUnitOptions.class.isAssignableFrom(frameworkOptions.getClass())) {
             JUnitOptions junitOptions = (JUnitOptions) frameworkOptions;
-            return !junitOptions.getIncludeCategories().isEmpty()
-                || !junitOptions.getExcludeCategories().isEmpty();
+            return junitOptions.getIncludeCategories().isEmpty()
+                && junitOptions.getExcludeCategories().isEmpty();
         } else if (JUnitPlatformOptions.class.isAssignableFrom(frameworkOptions.getClass())) {
             JUnitPlatformOptions junitPlatformOptions = (JUnitPlatformOptions) frameworkOptions;
-            return !junitPlatformOptions.getIncludeTags().isEmpty()
-                || !junitPlatformOptions.getExcludeTags().isEmpty();
+            return junitPlatformOptions.getIncludeTags().isEmpty()
+                && junitPlatformOptions.getExcludeTags().isEmpty();
         } else if (TestNGOptions.class.isAssignableFrom(frameworkOptions.getClass())) {
             TestNGOptions testNGOptions = (TestNGOptions) frameworkOptions;
-            return !testNGOptions.getIncludeGroups().isEmpty()
-                || !testNGOptions.getExcludeGroups().isEmpty();
+            return testNGOptions.getIncludeGroups().isEmpty()
+                && testNGOptions.getExcludeGroups().isEmpty();
         } else {
             throw new IllegalArgumentException("Unknown test framework: " + frameworkOptions.getClass().getName());
         }

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
@@ -532,7 +532,7 @@ public abstract class AbstractTestTask extends ConventionTask implements Verific
         if (testCountLogger.hadFailures()) {
             handleTestFailures();
         } else if (testCountLogger.getTotalTests() == 0) {
-            if (!hasFilter()) {
+            if (!testsAreFiltered()) {
                 emitDeprecationMessage();
             } else if (shouldFailOnNoMatchingTests()) {
                 throw new TestExecutionException(createNoMatchingTestErrorMessage());
@@ -549,10 +549,10 @@ public abstract class AbstractTestTask extends ConventionTask implements Verific
     }
 
     private boolean shouldFailOnNoMatchingTests() {
-        return filter.isFailOnNoMatchingTests() && hasFilter();
+        return filter.isFailOnNoMatchingTests() && testsAreFiltered();
     }
 
-    private boolean hasFilter() {
+    boolean testsAreFiltered() {
         return !filter.getIncludePatterns().isEmpty()
             || !filter.getCommandLineIncludePatterns().isEmpty()
             || !filter.getExcludePatterns().isEmpty();

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
@@ -532,9 +532,9 @@ public abstract class AbstractTestTask extends ConventionTask implements Verific
         if (testCountLogger.hadFailures()) {
             handleTestFailures();
         } else if (testCountLogger.getTotalTests() == 0) {
-            if (!testsAreFiltered()) {
+            if (testsAreNotFiltered()) {
                 emitDeprecationMessage();
-            } else if (shouldFailOnNoMatchingTests()) {
+            } else if (filter.isFailOnNoMatchingTests()) {
                 throw new TestExecutionException(createNoMatchingTestErrorMessage());
             }
         }
@@ -548,14 +548,10 @@ public abstract class AbstractTestTask extends ConventionTask implements Verific
             .nagUser();
     }
 
-    private boolean shouldFailOnNoMatchingTests() {
-        return filter.isFailOnNoMatchingTests() && testsAreFiltered();
-    }
-
-    boolean testsAreFiltered() {
-        return !filter.getIncludePatterns().isEmpty()
-            || !filter.getCommandLineIncludePatterns().isEmpty()
-            || !filter.getExcludePatterns().isEmpty();
+    boolean testsAreNotFiltered() {
+        return filter.getIncludePatterns().isEmpty()
+            && filter.getCommandLineIncludePatterns().isEmpty()
+            && filter.getExcludePatterns().isEmpty();
     }
 
     private String createNoMatchingTestErrorMessage() {

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
@@ -534,10 +534,14 @@ public abstract class AbstractTestTask extends ConventionTask implements Verific
         } else if (testCountLogger.getTotalTests() == 0) {
             if (testsAreNotFiltered()) {
                 emitDeprecationMessage();
-            } else if (filter.isFailOnNoMatchingTests()) {
+            } else if (shouldFailOnNoMatchingTests()) {
                 throw new TestExecutionException(createNoMatchingTestErrorMessage());
             }
         }
+    }
+
+    private boolean shouldFailOnNoMatchingTests() {
+        return patternFiltersSpecified() && filter.isFailOnNoMatchingTests();
     }
 
     private void emitDeprecationMessage() {
@@ -549,9 +553,13 @@ public abstract class AbstractTestTask extends ConventionTask implements Verific
     }
 
     boolean testsAreNotFiltered() {
-        return filter.getIncludePatterns().isEmpty()
-            && filter.getCommandLineIncludePatterns().isEmpty()
-            && filter.getExcludePatterns().isEmpty();
+        return !patternFiltersSpecified();
+    }
+
+    private boolean patternFiltersSpecified() {
+        return !filter.getIncludePatterns().isEmpty()
+            || !filter.getCommandLineIncludePatterns().isEmpty()
+            || !filter.getExcludePatterns().isEmpty();
     }
 
     private String createNoMatchingTestErrorMessage() {


### PR DESCRIPTION
Similar to test class name filters, when tests exist, but they are all filtered out by the categories/tags/groups, this is not the same as a test task with no tests.  This changes behavior so that we don't emit a deprecation warning in this scenario.

Fixes #26623 

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
