### PR TITLE
Ensure artifact varaints have consistent capabilities with graph variants

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesLocalComponentIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesLocalComponentIntegrationTest.groovy
@@ -93,12 +93,13 @@ class CapabilitiesLocalComponentIntegrationTest extends AbstractIntegrationSpec 
                 dependencyScope("api") {
                     outgoing {
                         capability("com.foo:producer:2.0")
-                        capability("org.bar:extra-capability:1.0")
+                        capability("org.bar:dependency-scope-capability:1.0")
                     }
                 }
                 consumable("elements") {
                     extendsFrom(api)
                     outgoing.artifact(tasks.zip)
+                    outgoing.capability("org.bar:consumable-capability:1.0")
                     attributes {
                         attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.class, Category.LIBRARY))
                     }
@@ -129,6 +130,9 @@ class CapabilitiesLocalComponentIntegrationTest extends AbstractIntegrationSpec 
                     def graphVariant = root.dependencies.find { it.selected.id.projectPath == ":producer" }.resolvedVariant
                     def artifactVariant = artifactVariants.find { it.owner.projectPath == ":producer" }
                     assert graphVariant.capabilities == artifactVariant.capabilities
+
+                    def expected = ["com.foo:producer:2.0", "org.bar:dependency-scope-capability:1.0", "org.bar:consumable-capability:1.0"] as Set
+                    assert graphVariant.capabilities.collect { "\${it.group}:\${it.name}:\${it.version}" } as Set == expected
                 }
             }
         """

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
@@ -19,7 +19,6 @@ import org.gradle.api.GradleException;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ExcludeRule;
 import org.gradle.api.artifacts.PublishArtifact;
-import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.ResolveContext;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
@@ -145,9 +144,9 @@ public interface ConfigurationInternal extends ResolveContext, DeprecatableConfi
         void visitArtifacts(Collection<? extends PublishArtifact> artifacts);
 
         // This configuration as a variant. May not always be present
-        void visitOwnVariant(DisplayName displayName, ImmutableAttributes attributes, Collection<? extends Capability> capabilities, Collection<? extends PublishArtifact> artifacts);
+        void visitOwnVariant(DisplayName displayName, ImmutableAttributes attributes, Collection<? extends PublishArtifact> artifacts);
 
         // A child variant. May not always be present
-        void visitChildVariant(String name, DisplayName displayName, ImmutableAttributes attributes, Collection<? extends Capability> capabilities, Collection<? extends PublishArtifact> artifacts);
+        void visitChildVariant(String name, DisplayName displayName, ImmutableAttributes attributes, Collection<? extends PublishArtifact> artifacts);
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublications.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublications.java
@@ -97,11 +97,11 @@ public class DefaultConfigurationPublications implements ConfigurationPublicatio
         visitor.visitArtifacts(artifacts);
         PublishArtifactSet allArtifactSet = allArtifacts.getPublishArtifactSet();
         if (variants == null || variants.isEmpty() || !allArtifactSet.isEmpty()) {
-            visitor.visitOwnVariant(displayName, attributes.asImmutable(), getCapabilities(), allArtifactSet);
+            visitor.visitOwnVariant(displayName, attributes.asImmutable(), allArtifactSet);
         }
         if (variants != null) {
-            for (DefaultVariant variant : variants.withType(DefaultVariant.class)) {
-                variant.visit(visitor, getCapabilities());
+            for (ConfigurationVariantInternal variant : variants.withType(ConfigurationVariantInternal.class)) {
+                visitor.visitChildVariant(variant.getName(), variant.getDisplayName(), variant.getAttributes().asImmutable(), variant.getArtifacts());
             }
         }
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultVariant.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultVariant.java
@@ -23,7 +23,6 @@ import org.gradle.api.artifacts.ConfigurationVariant;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.artifacts.PublishArtifactSet;
 import org.gradle.api.attributes.AttributeContainer;
-import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.ConfigurationVariantInternal;
 import org.gradle.api.internal.artifacts.DefaultPublishArtifactSet;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
@@ -38,7 +37,6 @@ import org.gradle.internal.Factory;
 import org.gradle.internal.typeconversion.NotationParser;
 
 import javax.annotation.Nullable;
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -63,7 +61,7 @@ public class DefaultVariant implements ConfigurationVariantInternal {
         this.name = name;
         attributes = cache.mutable(parentAttributes);
         this.artifactNotationParser = artifactNotationParser;
-        artifacts = new DefaultPublishArtifactSet(getAsDescribable(), domainObjectCollectionFactory.newDomainObjectSet(PublishArtifact.class), fileCollectionFactory, taskDependencyFactory);
+        artifacts = new DefaultPublishArtifactSet(getDisplayName(), domainObjectCollectionFactory.newDomainObjectSet(PublishArtifact.class), fileCollectionFactory, taskDependencyFactory);
     }
 
     @Override
@@ -82,14 +80,11 @@ public class DefaultVariant implements ConfigurationVariantInternal {
     }
 
     public OutgoingVariant convertToOutgoingVariant() {
-        return new LeafOutgoingVariant(getAsDescribable(), attributes, getArtifacts());
+        return new LeafOutgoingVariant(getDisplayName(), attributes, getArtifacts());
     }
 
-    public void visit(ConfigurationInternal.VariantVisitor visitor, Collection<? extends Capability> capabilities) {
-        visitor.visitChildVariant(name, getAsDescribable(), attributes.asImmutable(), capabilities, getArtifacts());
-    }
-
-    private DisplayName getAsDescribable() {
+    @Override
+    public DisplayName getDisplayName() {
         return Describables.of(parentDisplayName, "variant", name);
     }
 
@@ -127,7 +122,7 @@ public class DefaultVariant implements ConfigurationVariantInternal {
 
     @Override
     public String toString() {
-        return getAsDescribable().getDisplayName();
+        return getDisplayName().getDisplayName();
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalConfigurationMetadataBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultLocalConfigurationMetadataBuilder.java
@@ -27,7 +27,6 @@ import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.attributes.Category;
-import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.artifacts.configurations.Configurations;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationsProvider;
@@ -88,10 +87,16 @@ public class DefaultLocalConfigurationMetadataBuilder implements LocalConfigurat
         ModelContainer<?> model,
         CalculatedValueContainerFactory calculatedValueContainerFactory
     ) {
+        // Ensure all actions are executed against this configuration and its hierarchy before reading its state.
+        // Dependency actions may modify the hierarchy.
+        runDependencyActionsInHierarchy(configuration);
+
         String configurationName = configuration.getName();
         String description = configuration.getDescription();
         ComponentIdentifier componentId = parent.getId();
         ComponentConfigurationIdentifier configurationIdentifier = new ComponentConfigurationIdentifier(componentId, configuration.getName());
+
+        ImmutableCapabilities capabilities = ImmutableCapabilities.of(Configurations.collectCapabilities(configuration, Sets.newHashSet(), Sets.newHashSet()));
 
         // Collect all artifacts and sub-variants.
         ImmutableList.Builder<PublishArtifact> artifactBuilder = ImmutableList.builder();
@@ -103,20 +108,17 @@ public class DefaultLocalConfigurationMetadataBuilder implements LocalConfigurat
             }
 
             @Override
-            public void visitOwnVariant(DisplayName displayName, ImmutableAttributes attributes, Collection<? extends Capability> capabilities, Collection<? extends PublishArtifact> artifacts) {
+            public void visitOwnVariant(DisplayName displayName, ImmutableAttributes attributes, Collection<? extends PublishArtifact> artifacts) {
                 CalculatedValue<ImmutableList<LocalComponentArtifactMetadata>> variantArtifacts = getVariantArtifacts(componentId, displayName, artifacts, model, calculatedValueContainerFactory);
-                variantsBuilder.add(new LocalVariantMetadata(configurationName, configurationIdentifier, displayName, attributes, ImmutableCapabilities.of(capabilities), variantArtifacts));
+                variantsBuilder.add(new LocalVariantMetadata(configurationName, configurationIdentifier, displayName, attributes, capabilities, variantArtifacts));
             }
 
             @Override
-            public void visitChildVariant(String name, DisplayName displayName, ImmutableAttributes attributes, Collection<? extends Capability> capabilities, Collection<? extends PublishArtifact> artifacts) {
+            public void visitChildVariant(String name, DisplayName displayName, ImmutableAttributes attributes, Collection<? extends PublishArtifact> artifacts) {
                 CalculatedValue<ImmutableList<LocalComponentArtifactMetadata>> variantArtifacts = getVariantArtifacts(componentId, displayName, artifacts, model, calculatedValueContainerFactory);
-                variantsBuilder.add(new LocalVariantMetadata(configurationName + "-" + name, new NestedVariantIdentifier(configurationIdentifier, name), displayName, attributes, ImmutableCapabilities.of(capabilities), variantArtifacts));
+                variantsBuilder.add(new LocalVariantMetadata(configurationName + "-" + name, new NestedVariantIdentifier(configurationIdentifier, name), displayName, attributes, capabilities, variantArtifacts));
             }
         });
-
-        // We must call this before collecting dependency state, since dependency actions may modify the hierarchy.
-        runDependencyActionsInHierarchy(configuration);
 
         // Collect all dependencies and excludes in hierarchy.
         ImmutableAttributes attributes = configuration.getAttributes().asImmutable();
@@ -143,7 +145,7 @@ public class DefaultLocalConfigurationMetadataBuilder implements LocalConfigurat
             configuration.isTransitive(),
             hierarchy,
             attributes,
-            ImmutableCapabilities.of(Configurations.collectCapabilities(configuration, Sets.newHashSet(), Sets.newHashSet())),
+            capabilities,
             configuration.isCanBeConsumed(),
             configuration.isDeprecatedForConsumption(),
             configuration.isCanBeResolved(),

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultLocalComponentMetadataTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultLocalComponentMetadataTest.groovy
@@ -408,9 +408,9 @@ class DefaultLocalComponentMetadataTest extends Specification {
             getExcludeRules() >> new LinkedHashSet<ExcludeRule>()
             collectVariants(_ as ConfigurationInternal.VariantVisitor) >> { ConfigurationInternal.VariantVisitor visitor ->
                 visitor.visitArtifacts(artifacts)
-                visitor.visitOwnVariant(Describables.of(name), ImmutableAttributes.EMPTY, Collections.emptySet(), artifacts)
+                visitor.visitOwnVariant(Describables.of(name), ImmutableAttributes.EMPTY, artifacts)
                 variants.each {
-                    visitor.visitChildVariant(it.name, Describables.of(it.name), it.attributes as ImmutableAttributes, Collections.emptySet(), it.artifacts)
+                    visitor.visitChildVariant(it.name, Describables.of(it.name), it.attributes as ImmutableAttributes, it.artifacts)
                 }
             }
             getOutgoing() >> outgoing

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/ConfigurationVariantInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/ConfigurationVariantInternal.java
@@ -17,12 +17,23 @@ package org.gradle.api.internal.artifacts;
 
 import org.gradle.api.artifacts.ConfigurationVariant;
 import org.gradle.api.artifacts.PublishArtifact;
+import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.internal.DisplayName;
 import org.gradle.internal.Factory;
 
 import java.util.List;
 
 public interface ConfigurationVariantInternal extends ConfigurationVariant {
+
+    // TODO: Remove this and replace usages with getArtifacts().addAllLater(Provider)
     void artifactsProvider(Factory<List<PublishArtifact>> artifacts);
+
     void preventFurtherMutation();
+
     void setDescription(String description);
+
+    DisplayName getDisplayName();
+
+    @Override
+    AttributeContainerInternal getAttributes();
 }


### PR DESCRIPTION
The artifact variants found in ArtifactCollection have different capabilities than their corresponding graph variant in the ResolutionResult This is because we failed to use the capabilities in the configuration hierarchy when building artifact metadata

In the long run, we want do deprecate inheriting capabilities from the configuration hierarchy, but for now we fix this discrepancy

Fixes https://github.com/gradle/gradle/issues/26377

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
