### PR TITLE
Fix flaky BuildServiceIntegrationTest

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceIntegrationTest.groovy
@@ -471,7 +471,7 @@ service: closed with value 10001
 
         then:
         outputDoesNotContain "'Task#usesService'"
-        outputContains """
+        result.normalizedOutput.contains """
 > Configure project :
 service: created with value = 10
 service: value is 11


### PR DESCRIPTION
We found that `injection by name works at configuration time` output sometimes contains the message with progress:

```
  > Progress: INITIALIZING 0%
  > Progress: CONFIGURING 0%
```

Let's do the assertion with normalized output.

Example: https://ge.gradle.org/s/4sxb4dt2dg6ya/tests/task/:core:noDaemonIntegTest/details/org.gradle.api.services.BuildServiceIntegrationTest/injection%20by%20name%20works%20at%20configuration%20time?top-execution=1