### PR TITLE
Revert workaround for Kotlin lack of Java 21 support in `kotlin-dsl` plugin

### DIFF
--- a/build-logic-commons/gradle-plugin/build.gradle.kts
+++ b/build-logic-commons/gradle-plugin/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     implementation(project(":basics"))
     implementation(project(":module-identity"))
 
-    implementation("org.gradle.kotlin.kotlin-dsl:org.gradle.kotlin.kotlin-dsl.gradle.plugin:4.2.0")
+    implementation("org.gradle.kotlin.kotlin-dsl:org.gradle.kotlin.kotlin-dsl.gradle.plugin:4.2.1")
     // This Kotlin version should only be updated when updating the above kotlin-dsl version
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.20")
     implementation("org.gradle.kotlin:gradle-kotlin-dsl-conventions:0.8.0")

--- a/build-logic/kotlin-dsl/src/main/kotlin/gradlebuild.kotlin-dsl-dependencies-embedded.gradle.kts
+++ b/build-logic/kotlin-dsl/src/main/kotlin/gradlebuild.kotlin-dsl-dependencies-embedded.gradle.kts
@@ -26,7 +26,7 @@ plugins {
 // --- Enable automatic generation of API extensions -------------------
 val apiExtensionsOutputDir = layout.buildDirectory.dir("generated-sources/kotlin")
 
-val publishedKotlinDslPluginVersion = "4.2.0" // TODO:kotlin-dsl
+val publishedKotlinDslPluginVersion = "4.2.1" // TODO:kotlin-dsl
 
 tasks {
     val generateKotlinDependencyExtensions by registering(GenerateKotlinDependencyExtensions::class) {

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/build.gradle.kts
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     integTestImplementation(project(":model-core"))
     integTestImplementation(project(":internal-testing"))
     integTestImplementation(project(":logging"))
+    integTestImplementation(libs.futureKotlin("compiler-embeddable"))
     integTestImplementation("com.squareup.okhttp3:mockwebserver:3.9.1")
 
     integTestDistributionRuntimeOnly(project(":distributions-full"))

--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinDslJvmTargetIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinDslJvmTargetIntegrationTest.kt
@@ -26,6 +26,7 @@ import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.UnitTestPreconditions
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.MatcherAssert.assertThat
+import org.jetbrains.kotlin.config.JvmTarget
 import org.junit.Assume.assumeNotNull
 import org.junit.Test
 
@@ -183,6 +184,8 @@ class KotlinDslJvmTargetIntegrationTest : AbstractKotlinIntegrationTest() {
         "Java Class Major Version = ${JavaClassUtil.getClassMajorVersion(javaVersion)}"
 
     private
-    fun currentJavaVersionOrLastKotlinSupported(): JavaVersion =
-        JavaVersion.current().takeIf { it <= JavaVersion.VERSION_20 } ?: JavaVersion.VERSION_20
+    fun currentJavaVersionOrLastKotlinSupported(): JavaVersion {
+        val maxVersion = JavaVersion.toVersion(JvmTarget.supportedValues().last().majorVersion)
+        return JavaVersion.current().takeIf { it <= maxVersion } ?: maxVersion
+    }
 }

--- a/platforms/core-configuration/kotlin-dsl-plugins/build.gradle.kts
+++ b/platforms/core-configuration/kotlin-dsl-plugins/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 description = "Kotlin DSL Gradle Plugins deployed to the Plugin Portal"
 
 group = "org.gradle.kotlin"
-version = "4.2.1"
+version = "4.2.2"
 
 base.archivesName = "plugins"
 

--- a/platforms/core-configuration/kotlin-dsl-plugins/build.gradle.kts
+++ b/platforms/core-configuration/kotlin-dsl-plugins/build.gradle.kts
@@ -21,8 +21,6 @@ dependencies {
     compileOnly(project(":language-java"))
     compileOnly(project(":platform-jvm"))
     compileOnly(project(":plugin-development"))
-    compileOnly(project(":plugins-java-base"))
-    compileOnly(project(":toolchains-jvm"))
     compileOnly(project(":kotlin-dsl"))
 
     compileOnly(libs.slf4jApi)


### PR DESCRIPTION
This is not required anymore now that we have Kotlin 1.9.20 embedded which supports Java 21 and automatically caps the jvm target to the latest supported.

* Reverts #26758
