### PR TITLE
Do not nag yet for skipMetadataVersionCheck

### DIFF
--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompilerOptions.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompilerOptions.kt
@@ -60,4 +60,3 @@ fun getCompilerOptionBoolean(gradleProperties: GradlePropertiesController, prope
         else -> defaultValue.also { whenUnset?.invoke() }
     }
 }
-

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompilerOptions.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompilerOptions.kt
@@ -18,7 +18,6 @@ package org.gradle.kotlin.dsl.support
 
 import org.gradle.api.JavaVersion
 import org.gradle.initialization.GradlePropertiesController
-import org.gradle.internal.deprecation.DeprecationLogger
 import java.io.Serializable
 
 
@@ -32,9 +31,7 @@ data class KotlinCompilerOptions(
 fun kotlinCompilerOptions(gradleProperties: GradlePropertiesController): KotlinCompilerOptions =
     KotlinCompilerOptions(
         allWarningsAsErrors = getCompilerOptionBoolean(gradleProperties, allWarningsAsErrorsPropertyName, false),
-        skipMetadataVersionCheck = getCompilerOptionBoolean(gradleProperties, skipMetadataVersionCheckPropertyName, true) {
-            nagAboutUnsetSkipMetadataVersionCheckProperty()
-        }
+        skipMetadataVersionCheck = getCompilerOptionBoolean(gradleProperties, skipMetadataVersionCheckPropertyName, true)
     )
 
 
@@ -64,13 +61,3 @@ fun getCompilerOptionBoolean(gradleProperties: GradlePropertiesController, prope
     }
 }
 
-
-private
-fun nagAboutUnsetSkipMetadataVersionCheckProperty() {
-    DeprecationLogger.deprecateBuildInvocationFeature("Skipping Kotlin metadata version check in Kotlin DSL script compilation")
-        .withContext("Skipping the check may lead to hard to troubleshoot errors when libraries built with Kotlin versions unsupported by the Kotlin embedded in Gradle are used in build logic.")
-        .withAdvice("To opt in to the future behaviour, set the '$skipMetadataVersionCheckPropertyName' System property to `false`.")
-        .startingWithGradle9("the Kotlin metadata version check will be enabled by default")
-        .withUpgradeGuideSection(8, "kotlin_dsl_skip_metadata_version_check")
-        .nagUser()
-}

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -135,11 +135,17 @@ Check the [version catalog API](javadoc/org/gradle/api/artifacts/VersionCatalog.
 
 #### Control skipping Kotlin metadata version check for script compilation
 
-Skipping [Kotlin metadata](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-metadata/) version check in Kotlin DSL script compilation is now deprecated.
+[Kotlin/JVM metadata](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-metadata/) is backward-compatible with all Kotlin releases and forward-compatible with one Kotlin release.
+For example, Kotlin 1.9 supports Kotlin metadata from Kotlin 1.0 up to Kotlin 2.0, but not from Kotlin 2.1.
 
-You can control if Kotlin DSL script compilation should skip Kotlin metadata version check with the `org.gradle.kotlin.dsl.skipMetadataVersionCheck` property.
+The Kotlin compiler checks that the metadata of all dependencies is compatible.
+Skipping that check is the current default for Gradle script compilation.
+This may lead to hard-to-troubleshoot errors when libraries built with Kotlin versions unsupported by the Kotlin embedded in Gradle are used in build logic.
 
-To opt-in early to this future-proof behavior, set the `org.gradle.kotlin.dsl.skipMetadataVersionCheck` property to `false`.
+Skipping the check will be deprecated soon.
+Starting with Gradle 9.0, the Kotlin metadata version check will be enabled by default.
+
+To opt-in early to the future-proof behavior, set the `org.gradle.kotlin.dsl.skipMetadataVersionCheck` property to `false`.
 This will enable the metadata check.
 
 To enable the check persistently, set the property in the `gradle.properties` file of your build root directory:
@@ -148,8 +154,6 @@ To enable the check persistently, set the property in the `gradle.properties` fi
 ----
 org.gradle.kotlin.dsl.skipMetadataVersionCheck=false
 ----
-
-Please see the dedicated [upgrade guide section](userguide/upgrading_version_8.html#kotlin_dsl_skip_metadata_version_check) for more information.
 
 <a name="error-reporting"></a>
 ### Error and Warning Reporting Improvements

--- a/subprojects/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -107,28 +107,6 @@ project(":project-without-directory").projectDir.mkdirs()
 ======
 =====
 
-[[kotlin_dsl_skip_metadata_version_check]]
-==== Skipping Kotlin metadata version check for Kotlin DSL scripts
-
-Skipping link:https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-metadata/[Kotlin metadata] version check in Kotlin DSL script compilation is now deprecated.
-Skipping the check may lead to hard-to-troubleshoot errors when libraries built with Kotlin versions unsupported by the Kotlin embedded in Gradle are used in build logic.
-
-Kotlin/JVM metadata is backward-compatible with all Kotlin releases and forward-compatible with one Kotlin release.
-For example, Kotlin 1.9 supports Kotlin metadata from Kotlin 1.0 up to Kotlin 2.0, but not Kotlin 2.1.
-
-Because skipping this check is the current default behaviour in Kotlin DSL script compilation, a warning will be emitted for every build using `.gradle.kts` scripts.
-Starting with Gradle 9.0, the Kotlin metadata version check will be enabled by default.
-
-To enable the check, set the `org.gradle.kotlin.dsl.skipMetadataVersionCheck` property to `false`.
-
-To persistently enable the check, set the property in the `gradle.properties` file in your build root directory:
-
-[source,properties]
-----
-org.gradle.kotlin.dsl.skipMetadataVersionCheck=false
-----
-
-To skip the Kotlin metadata check, you can set that property to `true` to disable the warning.
 
 [[changes_8.4]]
 == Upgrading from 8.3 and earlier


### PR DESCRIPTION
We need to figure out a way to only nag if the check would fail. Nagging everyone is problematic.

* Follows up https://github.com/gradle/gradle/pull/26789
* See https://github.com/gradle/gradle/issues/26810#issuecomment-1780582268