### PR TITLE
Increase TeamCity history/artifact retention to 28/14 days

### DIFF
--- a/.teamcity/src/main/kotlin/projects/CheckProject.kt
+++ b/.teamcity/src/main/kotlin/projects/CheckProject.kt
@@ -72,8 +72,8 @@ class CheckProject(
     subProjectsOrder = subProjects
 
     cleanupRule(
-        historyDays = 14,
-        artifactsDays = 7,
+        historyDays = 28,
+        artifactsDays = 14,
         artifactsPatterns = """
                 +:**/*
                 +:$hiddenArtifactDestination/**/*"

--- a/.teamcity/src/main/kotlin/promotion/PromotionProject.kt
+++ b/.teamcity/src/main/kotlin/promotion/PromotionProject.kt
@@ -11,7 +11,7 @@ class PromotionProject(branch: VersionedSettingsBranch) : Project({
     id("Promotion")
     name = "Promotion"
 
-    cleanupRule(historyDays = 14, artifactsDays = 7)
+    cleanupRule(historyDays = 28, artifactsDays = 14)
 
     buildType(SanityCheck)
     buildType(PublishNightlySnapshot(branch))


### PR DESCRIPTION
Given that now we have larger data disk on TeamCity
