### PR TITLE
Fix missing `buildTreePath` on tasks of `BuildInvocations` and `CppProject`

### DIFF
--- a/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/BuildInvocationsBuilder.java
+++ b/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/BuildInvocationsBuilder.java
@@ -23,7 +23,6 @@ import com.google.common.collect.Sets;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.project.ProjectTaskLister;
 import org.gradle.api.internal.tasks.PublicTaskSpecification;
 import org.gradle.plugins.ide.internal.tooling.model.DefaultBuildInvocations;
@@ -38,7 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static java.util.stream.Collectors.toList;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static org.gradle.api.internal.project.ProjectHierarchyUtils.getChildProjectsForInternalUse;
 import static org.gradle.plugins.ide.internal.tooling.ToolingModelBuilderSupport.buildFromTask;
 
@@ -72,12 +71,12 @@ public class BuildInvocationsBuilder implements ToolingModelBuilder {
         findTasks(project, selectorsByName, visibleTasks);
         for (String selectorName : selectorsByName.keySet()) {
             LaunchableGradleTaskSelector selector = selectorsByName.get(selectorName);
-            selectors.add(selector.
-                setName(selectorName).
-                setTaskName(selectorName).
-                setProjectIdentifier(projectIdentifier).
-                setDisplayName(selectorName + " in " + project + " and subprojects.").
-                setPublic(visibleTasks.contains(selectorName)));
+            selectors.add(selector
+                .setName(selectorName)
+                .setTaskName(selectorName)
+                .setProjectIdentifier(projectIdentifier)
+                .setDisplayName(selectorName + " in " + project + " and subprojects.")
+                .setPublic(visibleTasks.contains(selectorName)));
         }
 
         // construct project tasks
@@ -97,12 +96,8 @@ public class BuildInvocationsBuilder implements ToolingModelBuilder {
     // build tasks without project reference
     private List<LaunchableGradleTask> tasks(Project project, DefaultProjectIdentifier projectIdentifier) {
         return taskLister.listProjectTasks(project).stream()
-            .map(task -> {
-                LaunchableGradleTask launchableGradleTask = buildFromTask(new LaunchableGradleTask(), projectIdentifier, task);
-                launchableGradleTask.setBuildTreePath(((TaskInternal) task).getIdentityPath().getPath());
-                return launchableGradleTask;
-            })
-            .collect(toList());
+            .map(task -> buildFromTask(new LaunchableGradleTask(), projectIdentifier, task))
+            .collect(toImmutableList());
     }
 
     private void findTasks(Project project, Map<String, LaunchableGradleTaskSelector> taskSelectors, Collection<String> visibleTasks) {
@@ -115,8 +110,8 @@ public class BuildInvocationsBuilder implements ToolingModelBuilder {
             // replace the LaunchableGradleTaskSelector stored in the map iff we come across a task with the same name whose path has a smaller ordering
             // this way, for each task selector, its description will be the one from the selected task with the 'smallest' path
             if (!taskSelectors.containsKey(task.getName())) {
-                LaunchableGradleTaskSelector taskSelector = new LaunchableGradleTaskSelector().
-                    setDescription(task.getDescription()).setPath(task.getPath());
+                LaunchableGradleTaskSelector taskSelector = new LaunchableGradleTaskSelector()
+                    .setDescription(task.getDescription()).setPath(task.getPath());
                 taskSelectors.put(task.getName(), taskSelector);
             } else {
                 LaunchableGradleTaskSelector taskSelector = taskSelectors.get(task.getName());

--- a/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/GradleProjectBuilder.java
+++ b/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/GradleProjectBuilder.java
@@ -100,7 +100,6 @@ public class GradleProjectBuilder implements GradleProjectBuilderInternal {
     private static LaunchableGradleProjectTask buildTask(DefaultGradleProject owner, Task task) {
         LaunchableGradleProjectTask model = buildFromTask(new LaunchableGradleProjectTask(), owner.getProjectIdentifier(), task);
         model.setProject(owner);
-        model.setBuildTreePath(getBuildTreePath(task));
         return model;
     }
 

--- a/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/ToolingModelBuilderSupport.java
+++ b/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/ToolingModelBuilderSupport.java
@@ -16,6 +16,7 @@
 package org.gradle.plugins.ide.internal.tooling;
 
 import org.gradle.api.Task;
+import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.tasks.PublicTaskSpecification;
 import org.gradle.plugins.ide.internal.tooling.model.LaunchableGradleTask;
 import org.gradle.tooling.internal.gradle.DefaultProjectIdentifier;
@@ -28,7 +29,8 @@ public abstract class ToolingModelBuilderSupport {
                 .setDisplayName(task.toString())
                 .setDescription(task.getDescription())
                 .setPublic(PublicTaskSpecification.INSTANCE.isSatisfiedBy(task))
-                .setProjectIdentifier(projectIdentifier);
+                .setProjectIdentifier(projectIdentifier)
+                .setBuildTreePath(((TaskInternal) task).getIdentityPath().getPath());
         return target;
     }
 }

--- a/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/model/DefaultBuildInvocations.java
+++ b/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/model/DefaultBuildInvocations.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.plugins.ide.internal.tooling.model;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.tooling.internal.gradle.DefaultProjectIdentifier;
 import org.gradle.tooling.internal.gradle.GradleProjectIdentity;
 
@@ -40,7 +41,7 @@ public class DefaultBuildInvocations implements Serializable, GradleProjectIdent
     }
 
     public DefaultBuildInvocations setTasks(List<? extends LaunchableGradleTask> tasks) {
-        this.tasks = tasks;
+        this.tasks = ImmutableList.copyOf(tasks);
         return this;
     }
 

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r82/CompositeBuildCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r82/CompositeBuildCrossVersionSpec.groovy
@@ -44,6 +44,24 @@ class CompositeBuildCrossVersionSpec extends ToolingApiSpecification {
         model.projects.first().buildTreePath == ":"
     }
 
+    @TargetGradleVersion('>=8.6')
+    def "buildTreePath available on BuildInvocations"() {
+        given:
+        includedBuild("b1")
+        includedBuild("b2")
+
+        when:
+        def tasks = withConnection {
+            it.action(new FetchBuildInvocationsTasks()).run()
+        }
+
+        then:
+        tasks.size() > 0
+
+        tasks.buildTreePath.every { it != null }
+        tasks.buildTreePath.containsAll([":b1:buildEnvironment", ":b2:buildEnvironment"])
+    }
+
     def "buildTreePath is available for tasks"() {
         given:
         includedBuild("b1")
@@ -51,7 +69,7 @@ class CompositeBuildCrossVersionSpec extends ToolingApiSpecification {
 
         when:
         def model = withConnection {
-            it.action(new FetchTasksAction()).run();
+            it.action(new FetchRootProjectsTasks()).run()
         }.collect { it.buildTreePath }
 
         then:
@@ -67,7 +85,7 @@ class CompositeBuildCrossVersionSpec extends ToolingApiSpecification {
 
         when:
         withConnection {
-            it.action(new FetchTasksAction()).run();
+            it.action(new FetchRootProjectsTasks()).run();
         }.collect { it.buildTreePath }
 
         then:

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r82/FetchBuildInvocationsTasks.java
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r82/FetchBuildInvocationsTasks.java
@@ -27,7 +27,7 @@ import static java.util.stream.Collectors.toList;
 
 public class FetchBuildInvocationsTasks implements BuildAction<List<Task>> {
     @Override
-    public List<Task> execute(final BuildController controller) {
+    public List<Task> execute(BuildController controller) {
         return controller.getBuildModel().getEditableBuilds().stream()
             .map(build -> controller.getModel(build.getRootProject(), BuildInvocations.class))
             .flatMap(invocations -> invocations.getTasks().stream())

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r82/FetchBuildInvocationsTasks.java
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r82/FetchBuildInvocationsTasks.java
@@ -18,19 +18,19 @@ package org.gradle.plugins.ide.tooling.r82;
 
 import org.gradle.tooling.BuildAction;
 import org.gradle.tooling.BuildController;
-import org.gradle.tooling.model.GradleProject;
 import org.gradle.tooling.model.Task;
+import org.gradle.tooling.model.gradle.BuildInvocations;
 
 import java.util.List;
 
 import static java.util.stream.Collectors.toList;
 
-public class FetchTasksAction implements BuildAction<List<Task>> {
+public class FetchBuildInvocationsTasks implements BuildAction<List<Task>> {
     @Override
-    public List<Task> execute(BuildController controller) {
+    public List<Task> execute(final BuildController controller) {
         return controller.getBuildModel().getEditableBuilds().stream()
-            .flatMap(build -> build.getProjects().stream())
-            .flatMap(project -> controller.getModel(project, GradleProject.class).getTasks().stream())
+            .map(build -> controller.getModel(build.getRootProject(), BuildInvocations.class))
+            .flatMap(invocations -> invocations.getTasks().stream())
             .collect(toList());
     }
 }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r82/FetchRootProjectsTasks.java
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r82/FetchRootProjectsTasks.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugins.ide.tooling.r82;
+
+import org.gradle.tooling.BuildAction;
+import org.gradle.tooling.BuildController;
+import org.gradle.tooling.model.GradleProject;
+import org.gradle.tooling.model.Task;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+public class FetchRootProjectsTasks implements BuildAction<List<Task>> {
+    @Override
+    public List<Task> execute(BuildController controller) {
+        return controller.getBuildModel().getEditableBuilds().stream()
+            .flatMap(build -> controller.getModel(build.getRootProject(), GradleProject.class).getTasks().stream())
+            .collect(toList());
+    }
+}

--- a/subprojects/tooling-native/src/main/java/org/gradle/language/cpp/internal/tooling/CppModelBuilder.java
+++ b/subprojects/tooling-native/src/main/java/org/gradle/language/cpp/internal/tooling/CppModelBuilder.java
@@ -19,7 +19,6 @@ package org.gradle.language.cpp.internal.tooling;
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.language.cpp.CppApplication;
 import org.gradle.language.cpp.CppBinary;
@@ -47,7 +46,6 @@ import org.gradle.tooling.internal.gradle.DefaultProjectIdentifier;
 import org.gradle.tooling.model.cpp.CppProject;
 import org.gradle.tooling.provider.model.ToolingModelBuilder;
 
-import javax.annotation.Nonnull;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -121,11 +119,8 @@ public class CppModelBuilder implements ToolingModelBuilder {
         return binaries;
     }
 
-    @Nonnull
     private static LaunchableGradleTask buildLaunchableTask(DefaultProjectIdentifier projectIdentifier, Task task) {
-        LaunchableGradleTask launchableGradleTask = ToolingModelBuilderSupport.buildFromTask(new LaunchableGradleTask(), projectIdentifier, task);
-        launchableGradleTask.setBuildTreePath(((TaskInternal) task).getIdentityPath().getPath());
-        return launchableGradleTask;
+        return ToolingModelBuilderSupport.buildFromTask(new LaunchableGradleTask(), projectIdentifier, task);
     }
 
     private List<DefaultSourceFile> sourceFiles(CompilerOutputFileNamingSchemeFactory namingSchemeFactory, PlatformToolProvider platformToolProvider, File objDir, Set<File> files) {

--- a/subprojects/tooling-native/src/main/java/org/gradle/language/cpp/internal/tooling/CppModelBuilder.java
+++ b/subprojects/tooling-native/src/main/java/org/gradle/language/cpp/internal/tooling/CppModelBuilder.java
@@ -18,6 +18,8 @@ package org.gradle.language.cpp.internal.tooling;
 
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.language.cpp.CppApplication;
 import org.gradle.language.cpp.CppBinary;
@@ -45,6 +47,7 @@ import org.gradle.tooling.internal.gradle.DefaultProjectIdentifier;
 import org.gradle.tooling.model.cpp.CppProject;
 import org.gradle.tooling.provider.model.ToolingModelBuilder;
 
+import javax.annotation.Nonnull;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -94,28 +97,35 @@ public class CppModelBuilder implements ToolingModelBuilder {
             List<String> additionalArgs = args(compileTask.getCompilerArgs().get());
             CommandLineToolSearchResult compilerLookup = platformToolProvider.locateTool(ToolType.CPP_COMPILER);
             File compilerExe = compilerLookup.isAvailable() ? compilerLookup.getTool() : null;
-            LaunchableGradleTask compileTaskModel = ToolingModelBuilderSupport.buildFromTask(new LaunchableGradleTask(), projectIdentifier, compileTask);
+            LaunchableGradleTask compileTaskModel = buildLaunchableTask(projectIdentifier, compileTask);
             DefaultCompilationDetails compilationDetails = new DefaultCompilationDetails(compileTaskModel, compilerExe, compileTask.getObjectFileDir().get().getAsFile(), sourceFiles, headerDirsCopy,  systemIncludes, userIncludes, macroDefines, additionalArgs);
             if (binary instanceof CppExecutable || binary instanceof CppTestExecutable) {
                 ComponentWithExecutable componentWithExecutable = (ComponentWithExecutable) binary;
                 LinkExecutable linkTask = componentWithExecutable.getLinkTask().get();
-                LaunchableGradleTask linkTaskModel = ToolingModelBuilderSupport.buildFromTask(new LaunchableGradleTask(), projectIdentifier, componentWithExecutable.getExecutableFileProducer().get());
+                LaunchableGradleTask linkTaskModel = buildLaunchableTask(projectIdentifier, componentWithExecutable.getExecutableFileProducer().get());
                 DefaultLinkageDetails linkageDetails = new DefaultLinkageDetails(linkTaskModel, componentWithExecutable.getExecutableFile().get().getAsFile(), args(linkTask.getLinkerArgs().get()));
                 binaries.add(new DefaultCppExecutableModel(binary.getName(), cppBinary.getIdentity().getName(), binary.getBaseName().get(), compilationDetails, linkageDetails));
             } else if (binary instanceof CppSharedLibrary) {
                 CppSharedLibrary sharedLibrary = (CppSharedLibrary) binary;
                 LinkSharedLibrary linkTask = sharedLibrary.getLinkTask().get();
-                LaunchableGradleTask linkTaskModel = ToolingModelBuilderSupport.buildFromTask(new LaunchableGradleTask(), projectIdentifier, sharedLibrary.getLinkFileProducer().get());
+                LaunchableGradleTask linkTaskModel = buildLaunchableTask(projectIdentifier, sharedLibrary.getLinkFileProducer().get());
                 DefaultLinkageDetails linkageDetails = new DefaultLinkageDetails(linkTaskModel, sharedLibrary.getLinkFile().get().getAsFile(), args(linkTask.getLinkerArgs().get()));
                 binaries.add(new DefaultCppSharedLibraryModel(binary.getName(), cppBinary.getIdentity().getName(), binary.getBaseName().get(), compilationDetails, linkageDetails));
             } else if (binary instanceof CppStaticLibrary) {
                 CppStaticLibrary staticLibrary = (CppStaticLibrary) binary;
-                LaunchableGradleTask createTaskModel = ToolingModelBuilderSupport.buildFromTask(new LaunchableGradleTask(), projectIdentifier, staticLibrary.getLinkFileProducer().get());
+                LaunchableGradleTask createTaskModel = buildLaunchableTask(projectIdentifier, staticLibrary.getLinkFileProducer().get());
                 DefaultLinkageDetails linkageDetails = new DefaultLinkageDetails(createTaskModel, staticLibrary.getLinkFile().get().getAsFile(), Collections.<String>emptyList());
                 binaries.add(new DefaultCppStaticLibraryModel(binary.getName(), cppBinary.getIdentity().getName(), binary.getBaseName().get(), compilationDetails, linkageDetails));
             }
         }
         return binaries;
+    }
+
+    @Nonnull
+    private static LaunchableGradleTask buildLaunchableTask(DefaultProjectIdentifier projectIdentifier, Task task) {
+        LaunchableGradleTask launchableGradleTask = ToolingModelBuilderSupport.buildFromTask(new LaunchableGradleTask(), projectIdentifier, task);
+        launchableGradleTask.setBuildTreePath(((TaskInternal) task).getIdentityPath().getPath());
+        return launchableGradleTask;
     }
 
     private List<DefaultSourceFile> sourceFiles(CompilerOutputFileNamingSchemeFactory namingSchemeFactory, PlatformToolProvider platformToolProvider, File objDir, Set<File> files) {


### PR DESCRIPTION
Fix #26899

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
