### PR TITLE
Refine exception message, when `enableProblemsApiCheck()` is called

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -487,7 +487,7 @@ tmpdir is currently ${System.getProperty("java.io.tmpdir")}""")
         failure = executer.withTasks(*tasks).runWithFailure()
 
         if (enableProblemsApiCheck && buildOperationsFixture.problems().isEmpty()) {
-            throw new AssertionFailedError("Expected to receive a problem event accompanying the build failure but did not.")
+            throw new AssertionFailedError("Expected problem to reported for the failed build, but none was reported.")
         }
 
         return failure

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -487,7 +487,7 @@ tmpdir is currently ${System.getProperty("java.io.tmpdir")}""")
         failure = executer.withTasks(*tasks).runWithFailure()
 
         if (enableProblemsApiCheck && buildOperationsFixture.problems().isEmpty()) {
-            throw new AssertionFailedError("Expected problem to reported for the failed build, but none was reported.")
+            throw new AssertionFailedError("Expected to find a problem emitted via the 'Problems' service for the failing build, but none was received.")
         }
 
         return failure


### PR DESCRIPTION
The previous message was a bit hard to understand, this hopefully is an improvement over that one.