### PR TITLE
Verification metadata should be properly re-read with dry-run

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/AbstractSignatureVerificationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/AbstractSignatureVerificationIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.integtests.resolve.verification
 
-
+import org.bouncycastle.openpgp.PGPPublicKey
 import org.gradle.integtests.fixtures.cache.CachingIntegrationFixture
 import org.gradle.integtests.fixtures.executer.GradleExecuter
 import org.gradle.security.fixtures.KeyServer
@@ -48,9 +48,9 @@ abstract class AbstractSignatureVerificationIntegrationTest extends AbstractDepe
         keyServerFixture.withDefaultSigningKey()
     }
 
-    protected SimpleKeyRing newKeyRing() {
+    protected SimpleKeyRing newKeyRing(PGPPublicKey mustBeAfter = SigningFixtures.validPublicKey) {
         def ring = createKeyRing()
-        def minId = new BigInteger(SigningFixtures.validPublicKeyHexString, 16)
+        def minId = new BigInteger(Fingerprint.of(mustBeAfter).toString(), 16)
         // This loop is just to avoid some flakiness in tests which
         // expect error messages in a certain order
         while (new BigInteger(Fingerprint.of(ring.publicKey).toString(), 16) < minId) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/signatures/BuildTreeDefinedKeys.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/signatures/BuildTreeDefinedKeys.java
@@ -16,18 +16,13 @@
 
 package org.gradle.api.internal.artifacts.verification.signatures;
 
-import org.bouncycastle.openpgp.PGPPublicKeyRing;
 import org.gradle.api.internal.artifacts.verification.verifier.DependencyVerificationConfiguration;
 import org.gradle.security.internal.KeyringFilePublicKeyService;
 import org.gradle.security.internal.PublicKeyService;
 import org.gradle.security.internal.PublicKeyServiceChain;
-import org.gradle.security.internal.SecuritySupport;
 
 import javax.annotation.Nullable;
 import java.io.File;
-import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
 
 public class BuildTreeDefinedKeys {
     private static final String VERIFICATION_KEYRING_GPG = "verification-keyring.gpg";
@@ -58,11 +53,10 @@ public class BuildTreeDefinedKeys {
             throw new IllegalArgumentException("Unknown keyring format: " + effectiveFormat);
         }
 
+        this.effectiveKeyringsFile = effectiveFile;
         if (effectiveFile.exists()) {
-            this.effectiveKeyringsFile = effectiveFile;
             this.keyService = new KeyringFilePublicKeyService(effectiveKeyringsFile);
         } else {
-            this.effectiveKeyringsFile = null;
             this.keyService = null;
         }
     }
@@ -77,14 +71,6 @@ public class BuildTreeDefinedKeys {
 
     public File getEffectiveKeyringsFile() {
         return effectiveKeyringsFile;
-    }
-
-    public List<PGPPublicKeyRing> loadKeys() throws IOException {
-        if (effectiveKeyringsFile != null) {
-            return SecuritySupport.loadKeyRingFile(effectiveKeyringsFile);
-        } else {
-            return Collections.emptyList();
-        }
     }
 
     public PublicKeyService applyTo(PublicKeyService original) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/signatures/DefaultSignatureVerificationServiceFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/signatures/DefaultSignatureVerificationServiceFactory.java
@@ -103,7 +103,7 @@ public class DefaultSignatureVerificationServiceFactory implements SignatureVeri
         }
         keyService = keyrings.applyTo(keyService);
         File effectiveKeyringsFile = keyrings.getEffectiveKeyringsFile();
-        HashCode keyringFileHash = effectiveKeyringsFile != null && observed(effectiveKeyringsFile).exists()
+        HashCode keyringFileHash = observed(effectiveKeyringsFile).exists()
             ? fileHasher.hash(effectiveKeyringsFile)
             : NO_KEYRING_FILE_HASH;
         DefaultSignatureVerificationService delegate = new DefaultSignatureVerificationService(keyService);


### PR DESCRIPTION
~~Currently, `buildFinished` is triggered twice - for root build and buildSrc. The order may vary as it is async. In any case, it does not make sense to process anything for a non-root build for verification metadata.~~

Fixes #26289

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
