### PR TITLE
Try Ubuntu latest for QuickFeedbackLinuxOnly

### DIFF
--- a/.github/workflows/contributor-pr.yml
+++ b/.github/workflows/contributor-pr.yml
@@ -27,7 +27,7 @@ permissions:
 jobs:
   build:
     name: "Compile All"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: git clone
         uses: actions/checkout@v3
@@ -67,7 +67,7 @@ jobs:
 
   sanity-check:
     name: "Sanity Check on Linux"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: build
     steps:
       - name: git clone
@@ -94,7 +94,7 @@ jobs:
 
   unit-test:
     name: "${{ matrix.bucket.name }} (Unit Test)"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: build
     strategy:
       matrix:


### PR DESCRIPTION
As a first step to use Ubuntu 22.04, let's enable it on contributor PRs.