### PR TITLE
Fix NormalizingCopyActionDecorator to respect directory permissions

### DIFF
--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileTreeElement.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileTreeElement.java
@@ -18,8 +18,8 @@ package org.gradle.api.internal.file;
 import org.apache.commons.io.IOUtils;
 import org.gradle.api.GradleException;
 import org.gradle.api.UncheckedIOException;
-import org.gradle.api.file.FileTreeElement;
 import org.gradle.api.file.FilePermissions;
+import org.gradle.api.file.FileTreeElement;
 import org.gradle.internal.exceptions.Contextual;
 import org.gradle.internal.file.Chmod;
 import org.gradle.util.internal.GFileUtils;
@@ -117,8 +117,8 @@ public abstract class AbstractFileTreeElement implements FileTreeElement {
     }
 
     @Contextual
-    private static class CopyFileElementException extends GradleException {
-        CopyFileElementException(String message, Throwable cause) {
+    protected static class CopyFileElementException extends GradleException {
+        public CopyFileElementException(String message, Throwable cause) {
             super(message, cause);
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/DefaultFileCopyDetails.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/DefaultFileCopyDetails.java
@@ -23,8 +23,8 @@ import org.gradle.api.file.ConfigurableFilePermissions;
 import org.gradle.api.file.ContentFilterable;
 import org.gradle.api.file.DuplicatesStrategy;
 import org.gradle.api.file.ExpandDetails;
-import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.file.FilePermissions;
+import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.file.RelativePath;
 import org.gradle.api.internal.file.AbstractFileTreeElement;
 import org.gradle.api.internal.file.DefaultConfigurableFilePermissions;
@@ -62,11 +62,6 @@ public class DefaultFileCopyDetails extends AbstractFileTreeElement implements F
         this.objectFactory = objectFactory;
         this.duplicatesStrategy = specResolver.getDuplicatesStrategy();
         this.defaultDuplicatesStrategy = specResolver.isDefaultDuplicateStrategy();
-    }
-
-    @Override
-    public boolean isIncludeEmptyDirs() {
-        return specResolver.getIncludeEmptyDirs();
     }
 
     @Override
@@ -266,6 +261,11 @@ public class DefaultFileCopyDetails extends AbstractFileTreeElement implements F
 
     public boolean isDefaultDuplicatesStrategy() {
         return defaultDuplicatesStrategy;
+    }
+
+    @Override
+    public CopySpecResolver getSpecResolver() {
+        return specResolver;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/FileCopyDetailsInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/FileCopyDetailsInternal.java
@@ -20,7 +20,7 @@ import org.gradle.api.file.FileCopyDetails;
 
 public interface FileCopyDetailsInternal extends FileCopyDetails {
 
-    boolean isIncludeEmptyDirs();
-
     boolean isDefaultDuplicatesStrategy();
+
+    CopySpecResolver getSpecResolver();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/NormalizingCopyActionDecorator.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/NormalizingCopyActionDecorator.java
@@ -20,17 +20,20 @@ import com.google.common.collect.ListMultimap;
 import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.Transformer;
+import org.gradle.api.file.ConfigurableFilePermissions;
 import org.gradle.api.file.ContentFilterable;
 import org.gradle.api.file.DuplicatesStrategy;
 import org.gradle.api.file.ExpandDetails;
-import org.gradle.api.file.ConfigurableFilePermissions;
 import org.gradle.api.file.FilePermissions;
 import org.gradle.api.file.RelativePath;
 import org.gradle.api.internal.file.AbstractFileTreeElement;
 import org.gradle.api.internal.file.CopyActionProcessingStreamAction;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.internal.file.Chmod;
+import org.gradle.util.internal.GFileUtils;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.io.FilterReader;
 import java.io.InputStream;
@@ -68,7 +71,7 @@ public class NormalizingCopyActionDecorator implements CopyAction {
                         pendingDirs.put(path, details);
                     }
                 } else {
-                    maybeVisit(details.getRelativePath().getParent(), details.isIncludeEmptyDirs(), action, visitedDirs, pendingDirs);
+                    maybeVisit(details.getRelativePath().getParent(), details.getSpecResolver(), action, visitedDirs, pendingDirs);
                     action.processFile(details);
                 }
             });
@@ -76,8 +79,8 @@ public class NormalizingCopyActionDecorator implements CopyAction {
             for (RelativePath path : new LinkedHashSet<>(pendingDirs.keySet())) {
                 List<FileCopyDetailsInternal> detailsList = new ArrayList<>(pendingDirs.get(path));
                 for (FileCopyDetailsInternal details : detailsList) {
-                    if (details.isIncludeEmptyDirs()) {
-                        maybeVisit(path, details.isIncludeEmptyDirs(), action, visitedDirs, pendingDirs);
+                    if (details.getSpecResolver().getIncludeEmptyDirs()) {
+                        maybeVisit(path, details.getSpecResolver(), action, visitedDirs, pendingDirs);
                     }
                 }
             }
@@ -87,37 +90,39 @@ public class NormalizingCopyActionDecorator implements CopyAction {
         });
     }
 
-    private void maybeVisit(RelativePath path, boolean includeEmptyDirs, CopyActionProcessingStreamAction delegateAction, Set<RelativePath> visitedDirs, ListMultimap<RelativePath, FileCopyDetailsInternal> pendingDirs) {
+    private void maybeVisit(@Nullable RelativePath path, CopySpecResolver specResolver, CopyActionProcessingStreamAction delegateAction, Set<RelativePath> visitedDirs, ListMultimap<RelativePath, FileCopyDetailsInternal> pendingDirs) {
         if (path == null || path.getParent() == null || !visitedDirs.add(path)) {
             return;
         }
-        maybeVisit(path.getParent(), includeEmptyDirs, delegateAction, visitedDirs, pendingDirs);
-        List<FileCopyDetailsInternal> detailsForPath = pendingDirs.removeAll(path);
 
+        List<FileCopyDetailsInternal> detailsForPath = pendingDirs.removeAll(path);
         FileCopyDetailsInternal dir;
         if (detailsForPath.isEmpty()) {
             // TODO - this is pretty nasty, look at avoiding using a time bomb stub here
-            dir = new StubbedFileCopyDetails(path, includeEmptyDirs, chmod);
+            dir = new ParentDirectoryStub(specResolver, path, chmod);
         } else {
             dir = detailsForPath.get(0);
         }
+        maybeVisit(path.getParent(), dir.getSpecResolver(), delegateAction, visitedDirs, pendingDirs);
+
         delegateAction.processFile(dir);
     }
 
-    private static class StubbedFileCopyDetails extends AbstractFileTreeElement implements FileCopyDetailsInternal {
+    private static class ParentDirectoryStub extends AbstractFileTreeElement implements FileCopyDetailsInternal {
         private final RelativePath path;
-        private final boolean includeEmptyDirs;
-        private long lastModified = System.currentTimeMillis();
 
-        private StubbedFileCopyDetails(RelativePath path, boolean includeEmptyDirs, Chmod chmod) {
+        private final long lastModified = System.currentTimeMillis();
+
+        private final CopySpecResolver specResolver;
+
+        private ParentDirectoryStub(CopySpecResolver specResolver, RelativePath path, Chmod chmod) {
             super(chmod);
             this.path = path;
-            this.includeEmptyDirs = includeEmptyDirs;
+            this.specResolver = specResolver;
         }
 
-        @Override
-        public boolean isIncludeEmptyDirs() {
-            return includeEmptyDirs;
+        private static UnsupportedOperationException unsupported() {
+            return new UnsupportedOperationException("It's a synthetic FileCopyDetails just to create parent directories");
         }
 
         @Override
@@ -127,12 +132,12 @@ public class NormalizingCopyActionDecorator implements CopyAction {
 
         @Override
         public File getFile() {
-            throw new UnsupportedOperationException();
+            throw unsupported();
         }
 
         @Override
         public boolean isDirectory() {
-            return !path.isFile();
+            return true;
         }
 
         @Override
@@ -142,12 +147,12 @@ public class NormalizingCopyActionDecorator implements CopyAction {
 
         @Override
         public long getSize() {
-            throw new UnsupportedOperationException();
+            throw unsupported();
         }
 
         @Override
         public InputStream open() {
-            throw new UnsupportedOperationException();
+            throw unsupported();
         }
 
         @Override
@@ -156,98 +161,124 @@ public class NormalizingCopyActionDecorator implements CopyAction {
         }
 
         @Override
+        public boolean copyTo(File target) {
+            try {
+                GFileUtils.mkdirs(target);
+                getChmod().chmod(target, getPermissions().toUnixNumeric());
+                return true;
+            } catch (Exception e) {
+                throw new CopyFileElementException(String.format("Could not copy %s to '%s'.", getDisplayName(), target), e);
+            }
+        }
+
+        @Override
+        public FilePermissions getPermissions() {
+            Provider<FilePermissions> specMode = specResolver.getImmutableDirPermissions();
+            if (specMode.isPresent()) {
+                return specMode.get();
+            }
+
+            return super.getPermissions();
+        }
+
+        @Override
         public void exclude() {
-            throw new UnsupportedOperationException();
+            throw unsupported();
         }
 
         @Override
         public void setName(String name) {
-            throw new UnsupportedOperationException();
+            throw unsupported();
         }
 
         @Override
         public void setPath(String path) {
-            throw new UnsupportedOperationException();
+            throw unsupported();
         }
 
         @Override
         public void setRelativePath(RelativePath path) {
-            throw new UnsupportedOperationException();
+            throw unsupported();
         }
 
         @Override
         public void setMode(int mode) {
-            throw new UnsupportedOperationException();
+            throw unsupported();
         }
 
         @Override
         public void permissions(Action<? super ConfigurableFilePermissions> configureAction) {
-            throw new UnsupportedOperationException();
+            throw unsupported();
         }
 
         @Override
         public void setPermissions(FilePermissions permissions) {
-            throw new UnsupportedOperationException();
+            throw unsupported();
         }
 
         @Override
         public void setDuplicatesStrategy(DuplicatesStrategy strategy) {
-            throw new UnsupportedOperationException();
+            throw unsupported();
         }
 
         @Override
         public DuplicatesStrategy getDuplicatesStrategy() {
-            throw new UnsupportedOperationException();
+            throw unsupported();
         }
 
         @Override
         public boolean isDefaultDuplicatesStrategy() {
-            throw new UnsupportedOperationException();
+            throw unsupported();
         }
 
         @Override
         public String getSourceName() {
-            throw new UnsupportedOperationException();
+            throw unsupported();
         }
 
         @Override
         public String getSourcePath() {
-            throw new UnsupportedOperationException();
+            throw unsupported();
         }
 
         @Override
         public RelativePath getRelativeSourcePath() {
-            throw new UnsupportedOperationException();
+            throw unsupported();
         }
 
         @Override
         public ContentFilterable filter(Map<String, ?> properties, Class<? extends FilterReader> filterType) {
-            throw new UnsupportedOperationException();
+            throw unsupported();
         }
 
         @Override
         public ContentFilterable filter(Class<? extends FilterReader> filterType) {
-            throw new UnsupportedOperationException();
+            throw unsupported();
         }
 
         @Override
         public ContentFilterable filter(Closure closure) {
-            throw new UnsupportedOperationException();
+            throw unsupported();
         }
 
         @Override
         public ContentFilterable filter(Transformer<String, String> transformer) {
-            throw new UnsupportedOperationException();
+            throw unsupported();
         }
 
         @Override
         public ContentFilterable expand(Map<String, ?> properties) {
-            throw new UnsupportedOperationException();
+            throw unsupported();
         }
 
         @Override
         public ContentFilterable expand(Map<String, ?> properties, Action<? super ExpandDetails> action) {
-            throw new UnsupportedOperationException();
+            throw unsupported();
+        }
+
+        @Override
+        public CopySpecResolver getSpecResolver() {
+            return specResolver;
         }
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/NormalizingCopyActionDecoratorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/NormalizingCopyActionDecoratorTest.groovy
@@ -15,13 +15,10 @@
  */
 package org.gradle.api.internal.file.copy
 
-import org.gradle.api.file.FileCopyDetails
+
 import org.gradle.api.file.RelativePath
 import org.gradle.api.internal.file.CopyActionProcessingStreamAction
 import org.gradle.api.tasks.WorkResults
-import org.hamcrest.BaseMatcher
-import org.hamcrest.Description
-import org.hamcrest.Matcher
 import spock.lang.Specification
 
 import static org.gradle.api.internal.file.TestFiles.fileSystem
@@ -112,19 +109,8 @@ class NormalizingCopyActionDecoratorTest extends Specification {
         return Stub(FileCopyDetailsInternal) {
             getRelativePath() >> RelativePath.parse(false, path)
             isDirectory() >> isDir
-            isIncludeEmptyDirs() >> includeEmptyDirs
-        }
-    }
-
-    private Matcher<FileCopyDetailsInternal> hasPath(final String path) {
-        return new BaseMatcher<FileCopyDetailsInternal>() {
-            void describeTo(Description description) {
-                description.appendText("has path ").appendValue(path)
-            }
-
-            boolean matches(Object o) {
-                FileCopyDetails details = (FileCopyDetails) o
-                return details.getRelativePath().getPathString().equals(path)
+            getSpecResolver() >> Stub(CopySpecResolver) {
+                getIncludeEmptyDirs() >> includeEmptyDirs
             }
         }
     }


### PR DESCRIPTION
NormalizingCopyActionDecorator ignores file permissions set from dirPermissions.

It's hard to eliminate `ParentDirectoryStub` completely as it might require bigger refactoring of `AbstractFileTreeElement` and related file APIs.

### Context
The problem arose during implementation of #25264

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
