### PR TITLE
Add asymmetric value mapping

### DIFF
--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/TestFailureSpecification.groovy
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/TestFailureSpecification.groovy
@@ -103,8 +103,6 @@ class TestFailureSpecification extends ToolingApiSpecification {
 
     /**
      * Runs the test task and collects all test failures.
-     *
-     * @param enableOutput if true, the stdout/stderr of the test task is piped to the console. Handy for debugging task failures. Defaults to false.
      */
     protected List<TestAssertionFailure> runTestTaskWithFailureCollection(TestFailureEventCollector progressEventCollector) {
         withConnection { connection ->

--- a/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/failure/mappers/OpenTestAssertionFailedMapper.java
+++ b/platforms/jvm/testing-jvm-infrastructure/src/main/java/org/gradle/api/internal/tasks/testing/failure/mappers/OpenTestAssertionFailedMapper.java
@@ -20,6 +20,7 @@ import org.gradle.api.internal.tasks.testing.failure.TestFailureMapper;
 import org.gradle.api.internal.tasks.testing.failure.ThrowableToTestFailureMapper;
 import org.gradle.api.tasks.testing.TestFailure;
 
+import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 
@@ -46,7 +47,7 @@ public class OpenTestAssertionFailedMapper extends TestFailureMapper {
         Object actualValueWrapper = invokeMethod(throwable, "getActual", Object.class);
         Object actualValue = invokeMethod(actualValueWrapper, "getValue", Object.class);
 
-        if (expectedValue.getClass().getName().equals("org.opentest4j.FileInfo") && actualValue.getClass().getName().equals("org.opentest4j.FileInfo")) {
+        if (expectedValue.getClass().getName().equals("org.opentest4j.FileInfo") || actualValue.getClass().getName().equals("org.opentest4j.FileInfo")) {
             return mapFileInfoComparisonFailure(throwable, expectedValue, actualValue);
         } else {
             return mapStringBasedComparisonFailure(throwable, expectedValueWrapper, actualValueWrapper);
@@ -54,17 +55,47 @@ public class OpenTestAssertionFailedMapper extends TestFailureMapper {
     }
 
     private static TestFailure mapFileInfoComparisonFailure(Throwable throwable, Object expected, Object actual) throws Exception {
-        String expectedPath = invokeMethod(expected, "getPath", String.class);
-        byte[] expectedContent = invokeMethod(expected, "getContents", byte[].class);
-        String actualPath = invokeMethod(actual, "getPath", String.class);
-        byte[] actualContent = invokeMethod(actual, "getContents", byte[].class);
+        String expectedPath = extractValue(expected);
+        byte[] expectedContent = extractContent(expected);
+        String actualPath = extractValue(actual);
+        byte[] actualContent = extractContent(actual);
         return TestFailure.fromFileComparisonFailure(throwable, expectedPath, actualPath, expectedContent, actualContent, null);
     }
 
-    private static TestFailure mapStringBasedComparisonFailure(Throwable throwable, Object expectedWrapper, Object actualWrapper) throws Exception {
-        String expectedValue = invokeMethod(expectedWrapper, "getStringRepresentation", String.class);
-        String actualValue = invokeMethod(actualWrapper, "getStringRepresentation", String.class);
+    private static TestFailure mapStringBasedComparisonFailure(Throwable throwable, Object expected, Object actual) throws Exception {
+        String expectedValue = extractValue(expected);
+        String actualValue = extractValue(actual);
         return TestFailure.fromTestAssertionFailure(throwable, expectedValue, actualValue, null);
+    }
+
+    @Nullable
+    private static String extractValue(@Nullable Object valueWrapper) throws Exception {
+        if (valueWrapper == null) {
+            return null;
+        }
+
+        if (valueWrapper.getClass().getName().equals("org.opentest4j.FileInfo")) {
+            return invokeMethod(valueWrapper, "getPath", String.class);
+        } else if (valueWrapper.getClass().getName().equals("org.opentest4j.ValueWrapper")) {
+            return invokeMethod(valueWrapper, "getStringRepresentation", String.class);
+        } else if (valueWrapper.getClass().getName().equals("java.lang.String")) {
+            return (String) valueWrapper;
+        } else {
+            return null;
+        }
+    }
+
+    @Nullable
+    private static byte[] extractContent(@Nullable Object valueWrapper) throws Exception {
+        if (valueWrapper == null) {
+            return null;
+        }
+
+        if (valueWrapper.getClass().getName().equals("org.opentest4j.FileInfo")) {
+            return invokeMethod(valueWrapper, "getContents", byte[].class);
+        } else {
+            return null;
+        }
     }
 
 }


### PR DESCRIPTION
We've missed the possibility that in case of an exception, it's not granted that both sides of the assertions (i.e. expected and actual values) are of the same type, especially in the case of `FileInfo`.

This PR addresses:
 - Issues around this asymmetric mapping: from now on, any supported value should be present on either side. As an example, an expected string could have a `FileInfo` actual value.
 - Expanded and refined the algorithm, which reflectively unpacks the supported values. Also added some tests to support 