### PR TITLE
Create platform aggregation subprojects

### DIFF
--- a/.teamcity/subprojects.json
+++ b/.teamcity/subprojects.json
@@ -483,6 +483,13 @@
     "crossVersionTests": false
   },
   {
+    "name": "jvm",
+    "path": "platforms/jvm",
+    "unitTests": false,
+    "functionalTests": false,
+    "crossVersionTests": false
+  },
+  {
     "name": "jvm-services",
     "path": "platforms/jvm/jvm-services",
     "unitTests": true,
@@ -858,6 +865,13 @@
     "path": "subprojects/soak",
     "unitTests": false,
     "functionalTests": true,
+    "crossVersionTests": false
+  },
+  {
+    "name": "software",
+    "path": "platforms/software",
+    "unitTests": false,
+    "functionalTests": false,
     "crossVersionTests": false
   },
   {

--- a/build-logic-commons/basics/src/main/kotlin/gradlebuild.minify.gradle.kts
+++ b/build-logic-commons/basics/src/main/kotlin/gradlebuild.minify.gradle.kts
@@ -79,6 +79,8 @@ plugins.withId("java-base") {
         configurations.all {
             if (isCanBeResolved && !isCanBeConsumed) {
                 resolutionStrategy.dependencySubstitution {
+                    // It would be nice if we did not need to include the version here.
+                    // See: https://github.com/gradle/gradle/issues/12459
                     substitute(module("it.unimi.dsi:fastutil")).using(variant(module("it.unimi.dsi:fastutil:8.5.2")) {
                         attributes {
                             attribute(minified, true)

--- a/build-logic/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/SubprojectsInfo.kt
+++ b/build-logic/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/SubprojectsInfo.kt
@@ -49,7 +49,7 @@ abstract class SubprojectsInfo : DefaultTask() {
 
     private
     fun generateSubprojectsDirectories(): List<File> {
-        val subprojectRoots = platformsFolder.asFile.listFiles(File::isDirectory).plus(subprojectsFolder.asFile)
+        val subprojectRoots = platformsFolder.asFile.listFiles(File::isDirectory).plus(platformsFolder.asFile).plus(subprojectsFolder.asFile)
         return subprojectRoots.map { it.listFiles(File::isDirectory).asList() }.flatten()
     }
 

--- a/build-logic/uber-plugins/src/main/kotlin/gradlebuild.gradle-platform.gradle.kts
+++ b/build-logic/uber-plugins/src/main/kotlin/gradlebuild.gradle-platform.gradle.kts
@@ -1,0 +1,54 @@
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier
+import org.gradle.api.attributes.Category
+import org.gradle.api.attributes.TestSuiteType
+import org.gradle.api.attributes.VerificationType
+import org.gradle.kotlin.dsl.*
+
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Should be applied to projects that represent a Gradle platform.
+ * This plugin adds tasks that aggregate actions across all subprojects of the platform.
+ * This plugin should eventually be expanded to handle other platform-scope respoonsibilities,
+ * for example distribution/packaging.
+ */
+
+val subproject = configurations.dependencyScope("subproject")
+
+val resolvedSubprojects = configurations.resolvable("resolvedSubprojects") {
+    extendsFrom(subproject.get())
+    // We do not want to depend on the dependencies of our subprojects.
+    // The intention is to only run the tests of this platform only.
+    isTransitive = false
+}
+
+tasks.register("test") {
+    dependsOn(resolvedSubprojects.get().incoming.artifactView {
+        withVariantReselection()
+        componentFilter { it is ProjectComponentIdentifier }
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category::class.java, Category.VERIFICATION))
+            attribute(TestSuiteType.TEST_SUITE_TYPE_ATTRIBUTE, objects.named(TestSuiteType::class.java, "unit-test"))
+            attribute(VerificationType.VERIFICATION_TYPE_ATTRIBUTE, objects.named(VerificationType::class.java, VerificationType.TEST_RESULTS))
+        }
+    }.files)
+}
+
+// In order to support embeddedIntegTest, etc, we would need to use test suites to implement
+// our own integration testing. That way, there would be a variant exposed with the integ
+// test results. Alternatively, we could expose that variant manually, though it would probably
+// be better to dogfood our own integ test plugin.

--- a/platforms/jvm/build.gradle.kts
+++ b/platforms/jvm/build.gradle.kts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id("gradlebuild.gradle-platform")
+}
+
+dependencies {
+    subproject(project(":code-quality"))
+    subproject(project(":distributions-jvm"))
+    subproject(project(":ear"))
+    subproject(project(":jacoco"))
+    subproject(project(":java-compiler-plugin"))
+    subproject(project(":java-platform"))
+    subproject(project(":jvm-services"))
+    subproject(project(":language-groovy"))
+    subproject(project(":language-java"))
+    subproject(project(":language-jvm"))
+    subproject(project(":normalization-java"))
+    subproject(project(":platform-jvm"))
+    subproject(project(":plugins-groovy"))
+    subproject(project(":plugins-java"))
+    subproject(project(":plugins-java-base"))
+    subproject(project(":plugins-jvm-test-fixtures"))
+    subproject(project(":plugins-jvm-test-suite"))
+    subproject(project(":plugins-test-report-aggregation"))
+    subproject(project(":scala"))
+    subproject(project(":testing-junit-platform"))
+    subproject(project(":testing-jvm"))
+    subproject(project(":testing-jvm-infrastructure"))
+    subproject(project(":toolchains-jvm"))
+    subproject(project(":war"))
+}

--- a/platforms/software/build.gradle.kts
+++ b/platforms/software/build.gradle.kts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id("gradlebuild.gradle-platform")
+}
+
+dependencies {
+    subproject(project(":antlr"))
+    subproject(project(":build-init"))
+    subproject(project(":dependency-management"))
+    subproject(project(":distributions-publishing"))
+    subproject(project(":ivy"))
+    subproject(project(":maven"))
+    subproject(project(":platform-base"))
+    subproject(project(":plugins-distribution"))
+    subproject(project(":plugins-version-catalog"))
+    subproject(project(":publish"))
+    subproject(project(":reporting"))
+    subproject(project(":resources"))
+    subproject(project(":resources-gcs"))
+    subproject(project(":resources-http"))
+    subproject(project(":resources-s3"))
+    subproject(project(":resources-sftp"))
+    subproject(project(":security"))
+    subproject(project(":signing"))
+    subproject(project(":test-suites-base"))
+    subproject(project(":testing-base"))
+    subproject(project(":version-control"))
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -142,6 +142,7 @@ platform("ide") {
 
 // Software Platform
 platform("software") {
+    rootProject()
     subproject("antlr")
     subproject("build-init")
     subproject("dependency-management")
@@ -167,6 +168,7 @@ platform("software") {
 
 // JVM Platform
 platform("jvm") {
+    rootProject()
     subproject("code-quality")
     subproject("distributions-jvm")
     subproject("ear")
@@ -247,14 +249,20 @@ gradle.settingsEvaluated {
 // region platform include DSL
 
 fun platform(platformName: String, platformConfiguration: PlatformScope.() -> Unit) =
-    PlatformScope("platforms/$platformName").platformConfiguration()
+    PlatformScope(platformName, "platforms/$platformName").platformConfiguration()
 
 fun unassigned(platformConfiguration: PlatformScope.() -> Unit) =
-    PlatformScope("subprojects").platformConfiguration()
+    PlatformScope("unassigned", "subprojects").platformConfiguration()
 
 class PlatformScope(
+    private val name: String,
     private val basePath: String
 ) {
+    fun rootProject() {
+        include(name)
+        project(":$name").projectDir = file(basePath)
+    }
+
     fun subproject(projectName: String) {
         include(projectName)
         project(":$projectName").projectDir = file("$basePath/$projectName")


### PR DESCRIPTION
Create infrastructure to declare subprojects for individual platforms.
These platform projects are meant to aggregate tasks across all of their child projects.

For example, running ':jvm:test' will run all unit tests for the jvm platform subprojects.
This currently only works for tests, as we do not have the proper test result variants exposed for integ tests.
This will require us to migrate to test suites for our integ tests.

This has been enabled for the jvm and software platforms.
We cannot enable this across all platforms, as some plaforms contain projects with the same name as their platform.

For example, the root project for the jvm platform has the name ':jvm'.
The 'ide' platform already contains an ':ide' subproject. Same with 'enterprise'.
These will need to be renamed if they want to support platform aggregations

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
