### PR TITLE
Clean up code-quality build dir before build

### DIFF
--- a/.teamcity/src/main/kotlin/common/performance-test-extensions.kt
+++ b/.teamcity/src/main/kotlin/common/performance-test-extensions.kt
@@ -95,6 +95,7 @@ fun BuildType.cleanUpGitUntrackedFilesAndDirectories() {
     }
 }
 
+// TODO: Remove this after https://github.com/gradle/gradle/issues/26539 is resolved
 fun BuildSteps.cleanUpReadOnlyDir(os: Os) {
     if (os == Os.WINDOWS) {
         script {
@@ -103,6 +104,7 @@ fun BuildSteps.cleanUpReadOnlyDir(os: Os) {
             scriptContent = """
                 rmdir /s /q %teamcity.build.checkoutDir%\subprojects\performance\build && (echo performance-build-dir removed) || (echo performance-build-dir not found)
                 rmdir /s /q %teamcity.build.checkoutDir%\platforms\software\version-control\build && (echo version-control-build-dir removed) || (echo version-control-build-dir not found)
+                rmdir /s /q %teamcity.build.checkoutDir%\platforms\jvm\code-quality\build && (echo code-quality-build-dir removed) || (echo code-quality-build-dir not found)
                 """
             skipConditionally()
         }


### PR DESCRIPTION
We've noticed build failures caused by read-only files in code-quality build dir. Let's clean them up.


```
:configuration-cache:quickTest
Execution failed for task ':code-quality:clean'. org.gradle.api.UncheckedIOException: java.io.IOException: Unable to delete directory 'C:\tcagent1\work\f63322e10dd6b396\platforms\jvm\code-quality\build'
  Failed to delete some children. This might happen because a process has files open or has its working directory set in the target directory.
  - C:\tcagent1\work\f63322e10dd6b396\platforms\jvm\code-quality\build\tmp\test files\AntWorkerMe.Test\g8mub\.git\objects\d3\fa1d3824cc60ec4af90ee4d52072a8c77c0394
  - C:\tcagent1\work\f63322e10dd6b396\platforms\jvm\code-quality\build\tmp\test files\AntWorkerMe.Test\g8mub\.git\objects\d3
  - C:\tcagent1\work\f63322e10dd6b396\platforms\jvm\code-quality\build\tmp\test files\AntWorkerMe.Test\g8mub\.git\objects\d7\de16b4907353533da5adf3e049eacde65ab06c
  - C:\tcagent1\work\f63322e10dd6b396\platforms\jvm\code-quality\build\tmp\test files\AntWorkerMe.Test\g8mub\.git\objects\d7
  - C:\tcagent1\work\f63322e10dd6b396\platforms\jvm\code-quality\build\tmp\test files\AntWorkerMe.Test\g8mub\.git\objects\e6\9de29bb2d1d6434b8b29ae775ad8c2e48c5391
  - C:\tcagent1\work\f63322e10dd6b396\platforms\jvm\code-quality\build\tmp\test files\AntWorkerMe.Test\g8mub\.git\objects\e6
  - C:\tcagent1\work\f63322e10dd6b396\platforms\jvm\code-quality\build\tmp\test files\AntWorkerMe.Test\g8mub\.git\objects
  - C:\tcagent1\work\f63322e10dd6b396\platforms\jvm\code-quality\build\tmp\test files\AntWorkerMe.Test\g8mub\.git
  - C:\tcagent1\work\f63322e10dd6b396\platforms\jvm\code-quality\build\tmp\test files\AntWorkerMe.Test\g8mub
  - C:\tcagent1\work\f63322e10dd6b396\platforms\jvm\code-quality\build\tmp\test files\AntWorkerMe.Test\idyq2\.git\objects\25\c0d3014cbad6480050964b18cd5ad3e48a7338
  - C:\tcagent1\work\f63322e10dd6b396\platforms\jvm\code-quality\build\tmp\test files\AntWorkerMe.Test\idyq2\.git\objects\25
  - C:\tcagent1\work\f63322e10dd6b396\platforms\jvm\code-quality\build\tmp\test files\AntWorkerMe.Test\idyq2\.git\objects\d7\de16b4907353533da5adf3e049eacde65ab06c
  - C:\tcagent1\work\f63322e10dd6b396\platforms\jvm\code-quality\build\tmp\test files\AntWorkerMe.Test\idyq2\.git\objects\d7
  - C:\tcagent1\work\f63322e10dd6b396\platforms\jvm\code-quality\build\tmp\test files\AntWorkerMe.Test\idyq2\.git\objects\e6\9de29bb2d1d6434b8b29ae775ad8c2e48c5391
  - C:\tcagent1\work\f63322e10dd6b396\platforms\jvm\code-quality\build\tmp\test files\AntWorkerMe.Test\idyq2\.git\objects\e6
  - C:\tcagent1\work\f63322e10dd6b396\platforms\jvm\code-quality\build\tmp\test files\AntWorkerMe.Test\idyq2\.git\objects
  - and more ...
  New files were found. This might happen because a process is still writing to the target directory.
  - C:\tcagent1\work\f63322e10dd6b396\platforms\jvm\code-quality\build\tmp\test files\AntWorkerMe.Test\idyq2\.git
```