### PR TITLE
Make Kotlin DSL project setup fixture Isolated Projects compatible

### DIFF
--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/AbstractKotlinScriptModelCrossVersionTest.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/AbstractKotlinScriptModelCrossVersionTest.groovy
@@ -17,8 +17,8 @@
 package org.gradle.kotlin.dsl.tooling.builders
 
 import groovy.transform.CompileStatic
+import org.gradle.integtests.fixtures.build.KotlinDslTestProjectInitiation
 import org.gradle.integtests.fixtures.build.ProjectSourceRoots
-import org.gradle.integtests.fixtures.build.TestProjectInitiation
 import org.gradle.integtests.tooling.fixture.TextUtil
 import org.gradle.integtests.tooling.fixture.ToolingApiAdditionalClasspath
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
@@ -47,7 +47,7 @@ import static org.hamcrest.MatcherAssert.assertThat
 @ToolingApiVersion(">=4.1")
 @ToolingApiAdditionalClasspath(KotlinDslToolingModelsClasspathProvider)
 @CompileStatic
-abstract class AbstractKotlinScriptModelCrossVersionTest extends ToolingApiSpecification  implements TestProjectInitiation {
+abstract class AbstractKotlinScriptModelCrossVersionTest extends ToolingApiSpecification implements KotlinDslTestProjectInitiation {
 
     def setup() {
         // Required for the lenient classpath mode

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/integTest/groovy/org/gradle/kotlin/dsl/tooling/builders/KotlinDslScriptsModelSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/integTest/groovy/org/gradle/kotlin/dsl/tooling/builders/KotlinDslScriptsModelSpec.groovy
@@ -17,14 +17,14 @@
 package org.gradle.kotlin.dsl.tooling.builders
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.build.TestProjectInitiation
+import org.gradle.integtests.fixtures.build.KotlinDslTestProjectInitiation
 import org.gradle.integtests.tooling.fixture.TestOutputStream
 import org.gradle.integtests.tooling.fixture.ToolingApi
 import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptsModel
 import org.junit.Rule
 import org.junit.rules.RuleChain
 
-class KotlinDslScriptsModelSpec extends AbstractIntegrationSpec implements TestProjectInitiation{
+class KotlinDslScriptsModelSpec extends AbstractIntegrationSpec implements KotlinDslTestProjectInitiation {
     @Delegate
     ToolingApi toolingApi = new ToolingApi(distribution, temporaryFolder)
     TestOutputStream stderr = new TestOutputStream()

--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/model/kotlin/dsl/KotlinDslScriptsModel.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/model/kotlin/dsl/KotlinDslScriptsModel.java
@@ -22,17 +22,17 @@ import java.util.Map;
 
 /**
  * Editor model for a set of Kotlin DSL scripts.
- *
+ * <p>
  * Can only be requested on the root project, the builder will throw otherwise.
- *
+ * <p>
  * Requires the <code>prepareKotlinBuildScriptModel</code> task to be executed before building the model.
  * See {@link KotlinDslModelsParameters#PREPARATION_TASK_NAME}
- *
+ * <p>
  * The set of scripts can be provided as a Gradle property named <code>org.gradle.kotlin.dsl.provider.scripts</code>,
  * as a list of absolute paths separated by <code>|</code>.
  * If none are provided, then the model is built for all the Kotlin DSL scripts known to belong to this build.
  * See {@link KotlinDslScriptsModel#SCRIPTS_GRADLE_PROPERTY_NAME}.
- *
+ * <p>
  * The Gradle Kotlin DSL script provider must be running in "classpath" mode.
  * This is done by providing the system property <code>-Dorg.gradle.kotlin.dsl.provider.mode=classpath</code>.
  * See {@link KotlinDslModelsParameters#CLASSPATH_MODE_SYSTEM_PROPERTY_DECLARATION}.
@@ -40,7 +40,7 @@ import java.util.Map;
  * exceptions will be returned in the built model.
  * Optionally, it can also be set in a strict mode by providing the system property value <code>-Dorg.gradle.kotlin.dsl.provider.mode=strict-classpath</code>.
  * See {@link KotlinDslModelsParameters#STRICT_CLASSPATH_MODE_SYSTEM_PROPERTY_DECLARATION}.
- *
+ * <p>
  * Optionally, an identifier can be provided as a Gradle property named <code>org.gradle.kotlin.dsl.provider.cid</code>,
  * it can then be used to correlate Gradle and TAPI client log statements.
  * See {@link KotlinDslModelsParameters#CORRELATION_ID_GRADLE_PROPERTY_NAME}.

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiSpecification.groovy
@@ -21,7 +21,7 @@ import groovy.transform.stc.SimpleType
 import org.gradle.integtests.fixtures.RepoScriptBlockUtil
 import org.gradle.integtests.fixtures.build.BuildTestFile
 import org.gradle.integtests.fixtures.build.BuildTestFixture
-import org.gradle.integtests.fixtures.build.TestProjectInitiation
+import org.gradle.integtests.fixtures.build.KotlinDslTestProjectInitiation
 import org.gradle.integtests.fixtures.daemon.DaemonsFixture
 import org.gradle.integtests.fixtures.executer.ExecutionFailure
 import org.gradle.integtests.fixtures.executer.ExecutionResult
@@ -66,7 +66,7 @@ import static spock.lang.Retry.Mode.SETUP_FEATURE_CLEANUP
 @ToolingApiVersion('>=7.0')
 @TargetGradleVersion('>=3.0')
 @Retry(condition = { onIssueWithReleasedGradleVersion(instance, failure) }, mode = SETUP_FEATURE_CLEANUP, count = 2)
-abstract class ToolingApiSpecification extends Specification implements TestProjectInitiation {
+abstract class ToolingApiSpecification extends Specification implements KotlinDslTestProjectInitiation {
     /**
      * See https://github.com/gradle/gradle-private/issues/3216
      * To avoid flakiness when reusing daemons between CLI and TAPI
@@ -88,6 +88,8 @@ abstract class ToolingApiSpecification extends Specification implements TestProj
     TestDistributionDirectoryProvider temporaryDistributionFolder = new TestDistributionDirectoryProvider(getClass())
     @Delegate
     final ToolingApi toolingApi = new ToolingApi(null, temporaryFolder, stdout, stderr)
+
+    // TODO: react to the isolatedProejcts prop coming from build settings
 
     @Rule
     public RuleChain cleanupRule = RuleChain.outerRule(temporaryFolder).around(temporaryDistributionFolder).around(toolingApi)
@@ -128,13 +130,13 @@ abstract class ToolingApiSpecification extends Specification implements TestProj
     @Override
     TestFile getBuildFileKts() {
         validateKotlinCompatibility()
-        TestProjectInitiation.super.getBuildFileKts()
+        KotlinDslTestProjectInitiation.super.getBuildFileKts()
     }
 
     @Override
     TestFile getSettingsFileKts() {
         validateKotlinCompatibility()
-        TestProjectInitiation.super.getSettingsFileKts()
+        KotlinDslTestProjectInitiation.super.getSettingsFileKts()
     }
 
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/build/KotlinDslTestProjectInitiation.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/build/KotlinDslTestProjectInitiation.groovy
@@ -26,7 +26,7 @@ import java.util.zip.ZipOutputStream
 import static org.gradle.util.internal.TextUtil.escapeString
 
 @CompileStatic
-trait TestProjectInitiation {
+trait KotlinDslTestProjectInitiation {
 
     abstract TestFile file(Object... path)
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/build/KotlinDslTestProjectInitiation.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/build/KotlinDslTestProjectInitiation.groovy
@@ -226,13 +226,19 @@ trait KotlinDslTestProjectInitiation {
                     "runtimeOnly"(project(it.path))
                 }
             }
-
-            allprojects {
-                $repositoriesBlock
-            }
         """)
-        withFile("buildSrc/b/$defaultBuildKotlinFileName", """dependencies { implementation(project(":c")) }""")
-        withFile("buildSrc/c/$defaultBuildKotlinFileName", "plugins { java }")
+
+        withFile("buildSrc/a/$defaultBuildKotlinFileName", """
+            $repositoriesBlock
+        """)
+        withFile("buildSrc/b/$defaultBuildKotlinFileName", """
+            $repositoriesBlock
+            dependencies { implementation(project(":c")) }
+        """)
+        withFile("buildSrc/c/$defaultBuildKotlinFileName", """
+            plugins { java }
+            $repositoriesBlock
+        """)
 
         return [
             withMainSourceSetJavaIn("buildSrc"),


### PR DESCRIPTION
By avoding the use of `allprojects` block