### PR TITLE
Rename Gradle Enterprise to Develocity in docs

### DIFF
--- a/subprojects/docs/src/docs/stylesheets/userGuideHtmlCommon.xsl
+++ b/subprojects/docs/src/docs/stylesheets/userGuideHtmlCommon.xsl
@@ -173,7 +173,7 @@
                             </div>
                         </li>
                         <li class="site-header__navigation-item" itemprop="name">
-                            <a target="_top" class="site-header__navigation-link" href="https://gradle.com/enterprise" itemprop="url">Enterprise</a>
+                            <a target="_top" class="site-header__navigation-link" href="https://gradle.com/enterprise" itemprop="url">Develocity</a>
                         </li>
                         <li class="site-header__navigation-item">
                             <a class="site-header__navigation-link" title="Gradle on GitHub" href="https://github.com/gradle/gradle"><svg width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><title>github</title><path d="M10 0C4.477 0 0 4.477 0 10c0 4.418 2.865 8.166 6.839 9.489.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.342-3.369-1.342-.454-1.155-1.11-1.462-1.11-1.462-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.268 2.75 1.026A9.578 9.578 0 0 1 10 4.836c.85.004 1.705.114 2.504.337 1.909-1.294 2.747-1.026 2.747-1.026.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.579.688.481C17.137 18.163 20 14.418 20 10c0-5.523-4.478-10-10-10" fill="#02303A" fill-rule="evenodd"/></svg></a>
@@ -211,7 +211,7 @@
                         <ul class="site-footer__links-list">
                             <li itemprop="name"><a href="https://gradle.com/build-scans" itemprop="url">Build Scan™</a></li>
                             <li itemprop="name"><a href="https://gradle.com/build-cache" itemprop="url">Build Cache</a></li>
-                            <li itemprop="name"><a href="https://gradle.com/enterprise/resources" itemprop="url">Enterprise Docs</a></li>
+                            <li itemprop="name"><a href="https://gradle.com/enterprise/resources" itemprop="url">Develocity Docs</a></li>
                         </ul>
                     </div>
                     <div class="site-footer__link-group">

--- a/subprojects/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/subprojects/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -607,12 +607,12 @@ dependencies {
 =====
 
 [[unsupported_ge_plugin_3.13]]
-==== Earliest supported Gradle Enterprise plugin version is 3.13.1
+==== Earliest supported Develocity plugin version is 3.13.1
 
-Starting in Gradle 9.0, the earliest supported Gradle Enterprise plugin version is 3.13.1.
+Starting in Gradle 9.0, the earliest supported Develocity plugin version is 3.13.1.
 The plugin versions from 3.0 up to 3.13 will be ignored when applied.
 
-Upgrade to version 3.13.1 or later of the Gradle Enterprise plugin.
+Upgrade to version 3.13.1 or later of the Develocity plugin.
 You can find the link:https://plugins.gradle.org/plugin/com.gradle.enterprise[latest available version on the Gradle Plugin Portal].
 More information on the compatibility can be found link:https://docs.gradle.com/enterprise/compatibility/#build_scans[here].
 

--- a/subprojects/docs/src/main/resources/footer.html
+++ b/subprojects/docs/src/main/resources/footer.html
@@ -27,7 +27,7 @@
                 <ul class="site-footer__links-list">
                     <li itemprop="name"><a href="https://gradle.com/build-scans/" itemprop="url">Build Scan™</a></li>
                     <li itemprop="name"><a href="https://gradle.com/build-cache/" itemprop="url">Build Cache</a></li>
-                    <li itemprop="name"><a href="https://gradle.com/enterprise/resources/" itemprop="url">Enterprise Docs</a></li>
+                    <li itemprop="name"><a href="https://gradle.com/enterprise/resources/" itemprop="url">Develocity Docs</a></li>
                 </ul>
             </div>
             <div class="site-footer__link-group">

--- a/subprojects/docs/src/main/resources/header.html
+++ b/subprojects/docs/src/main/resources/header.html
@@ -72,7 +72,7 @@
                     </div>
                 </li>
                 <li class="site-header__navigation-item" itemprop="name">
-                    <a target="_top" class="site-header__navigation-link" href="https://gradle.com" itemprop="url">Enterprise</a>
+                    <a target="_top" class="site-header__navigation-link" href="https://gradle.com" itemprop="url">Develocity</a>
                 </li>
                 <li class="site-header__navigation-item">
                     <a class="site-header__navigation-link" title="Gradle on GitHub" href="https://github.com/gradle/gradle"><svg width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><title>github</title><path d="M10 0C4.477 0 0 4.477 0 10c0 4.418 2.865 8.166 6.839 9.489.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.342-3.369-1.342-.454-1.155-1.11-1.462-1.11-1.462-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.268 2.75 1.026A9.578 9.578 0 0 1 10 4.836c.85.004 1.705.114 2.504.337 1.909-1.294 2.747-1.026 2.747-1.026.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.579.688.481C17.137 18.163 20 14.418 20 10c0-5.523-4.478-10-10-10" fill="#02303A" fill-rule="evenodd"/></svg></a>


### PR DESCRIPTION
<!--- The issue this PR addresses -->
<!-- Fixes #? -->
This PR renames Gradle Enterprise to Develocity in remaining elements of user guide and header/footer.

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
