### PR TITLE
Clarify where BuildLayout is available

### DIFF
--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildRegistryTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildRegistryTest.groovy
@@ -349,15 +349,15 @@ class DefaultIncludedBuildRegistryTest extends Specification {
     private BuildLifecycleController buildController(SettingsInternal settings, GradleInternal gradle) {
         def buildController = Stub(BuildLifecycleController)
         def services = Stub(ServiceRegistry)
-        def buildLocations = Stub(BuildLayout)
+        def buildLayout = Stub(BuildLayout)
 
         _ * buildController.gradle >> gradle
         if (settings != null) {
             _ * gradle.settings >> settings
         }
         _ * gradle.services >> services
-        _ * services.get(BuildLayout) >> buildLocations
-        _ * buildLocations.rootDirectory >> tmpDir.file("root-dir")
+        _ * services.get(BuildLayout) >> buildLayout
+        _ * buildLayout.rootDirectory >> tmpDir.file("root-dir")
         _ * services.get(PublicBuildPath) >> Stub(PublicBuildPath)
 
         return buildController

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/BuildLayout.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/BuildLayout.java
@@ -24,7 +24,7 @@ import org.gradle.internal.service.scopes.ServiceScope;
 /**
  * Provides access to important locations for a Gradle build.
  * <p>
- * An instance of this type can be injected into a plugin or other object by
+ * An instance of this type can be injected into a settings plugin by
  * annotating a public constructor or method with {@code javax.inject.Inject}.
  * It is also available via {@link Settings#getLayout()}.
  * <p>


### PR DESCRIPTION
Follow-up to: #27045

Se also: #13654 for exposing root dir from `ProjectLayout`