### PR TITLE
Set build-init test JVM Xmx to 1g

### DIFF
--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild.distribution-testing.gradle.kts
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild.distribution-testing.gradle.kts
@@ -16,6 +16,7 @@
 
 import gradlebuild.basics.repoRoot
 import gradlebuild.cleanup.services.CachesCleaner
+import gradlebuild.integrationtests.extension.IntegrationTestExtension
 import gradlebuild.integrationtests.setSystemPropertiesOfTestJVM
 import gradlebuild.integrationtests.tasks.DistributionTest
 
@@ -87,7 +88,7 @@ fun DistributionTest.configureGradleTestEnvironment() {
 }
 
 fun DistributionTest.setJvmArgsOfTestJvm() {
-    jvmArgs("-Xmx512m", "-XX:+HeapDumpOnOutOfMemoryError")
+    jvmArgs("-Xmx${project.the<IntegrationTestExtension>().testJvmXmx.get()}", "-XX:+HeapDumpOnOutOfMemoryError")
     if (!javaVersion.isJava8Compatible) {
         jvmArgs("-XX:MaxPermSize=768m")
     }

--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild.integration-tests.gradle.kts
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild.integration-tests.gradle.kts
@@ -30,6 +30,7 @@ plugins {
 
 extensions.create<IntegrationTestExtension>("integTest").apply {
     usesJavadocCodeSnippets.convention(false)
+    testJvmXmx.convention("512m")
 }
 
 val sourceSet = addSourceSet(TestType.INTEGRATION)

--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/extension/IntegrationTestExtension.kt
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/extension/IntegrationTestExtension.kt
@@ -21,4 +21,5 @@ import org.gradle.api.provider.Property
 
 abstract class IntegrationTestExtension {
     abstract val usesJavadocCodeSnippets: Property<Boolean>
+    abstract val testJvmXmx: Property<String>
 }

--- a/platforms/software/build-init/build.gradle.kts
+++ b/platforms/software/build-init/build.gradle.kts
@@ -74,3 +74,5 @@ dependencies {
 packageCycles {
     excludePatterns.add("org/gradle/api/tasks/wrapper/internal/*")
 }
+
+integTest.testJvmXmx = "1g"

--- a/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MultiProjectJvmApplicationInitIntegrationTest.groovy
+++ b/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MultiProjectJvmApplicationInitIntegrationTest.groovy
@@ -20,7 +20,6 @@ import org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl
 import org.gradle.buildinit.plugins.internal.modifiers.Language
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import org.gradle.internal.jvm.Jvm
-import org.gradle.test.fixtures.Flaky
 import spock.lang.Unroll
 
 import static org.gradle.buildinit.plugins.internal.modifiers.Language.GROOVY
@@ -38,7 +37,6 @@ abstract class AbstractMultiProjectJvmApplicationInitIntegrationTest extends Abs
         return null
     }
 
-    @Flaky(because = "https://github.com/gradle/gradle-private/issues/4010")
     @Unroll("creates multi-project application sample when incubating flag = #incubating")
     def "creates multi-project application sample"() {
         given:


### PR DESCRIPTION
See https://github.com/gradle/gradle-private/issues/4010

The OOM only happens in `InProcessGradleExecuter` (`:build-init:iembeddedIntegTest` and `:build-init:integForceRealizeTest`), which makes me wonder if that's just insufficient memory for `build-init` integration tests. Let's start with increasing the memory and see if the problem gets solved/mitigated.