### PR TITLE
Rebaseline performance test

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,4 +18,4 @@ gradle.internal.testdistribution.writeTraceFile=false
 systemProp.gradle.internal.testdistribution.writeTraceFile=false
 systemProp.gradle.internal.testdistribution.queryResponseTimeout=PT20S
 # Default performance baseline
-defaultPerformanceBaselines=8.5-commit-972c3e5c6ef9
+defaultPerformanceBaselines=8.6-commit-5e42e9f58ae9


### PR DESCRIPTION
I have observed performance tests failing with a doc-only change, which is a sign that we need to rebaseline performance tests.