### PR TITLE
Let Kotlin DSL x v. tests run (TAPI previous -> Gradle current) again

### DIFF
--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslDefaultScriptsModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslDefaultScriptsModelCrossVersionSpec.groovy
@@ -21,7 +21,7 @@ import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptsModel
 
-import static org.gradle.kotlin.dsl.tooling.builders.KotlinScriptModelParameters.setModelParameters
+import static org.gradle.kotlin.dsl.tooling.fixtures.KotlinScriptModelParameters.setModelParameters
 
 @TargetGradleVersion(">=6.0")
 @LeaksFileHandles("Kotlin Compiler Daemon taking time to shut down")

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslGivenScriptsModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslGivenScriptsModelCrossVersionSpec.groovy
@@ -21,7 +21,7 @@ import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptsModel
 
-import static org.gradle.kotlin.dsl.tooling.builders.KotlinScriptModelParameters.setModelParameters
+import static org.gradle.kotlin.dsl.tooling.fixtures.KotlinScriptModelParameters.setModelParameters
 
 @TargetGradleVersion(">=6.0")
 @LeaksFileHandles("Kotlin Compiler Daemon taking time to shut down")

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslScriptsModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslScriptsModelCrossVersionSpec.groovy
@@ -25,7 +25,7 @@ import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptsModel
 
 import java.lang.reflect.Proxy
 
-import static org.gradle.kotlin.dsl.tooling.builders.KotlinScriptModelParameters.setModelParameters
+import static org.gradle.kotlin.dsl.tooling.fixtures.KotlinScriptModelParameters.setModelParameters
 
 @TargetGradleVersion(">=6.0")
 @LeaksFileHandles("Kotlin Compiler Daemon taking time to shut down")

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r68/KotlinDslDefaultScriptsModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r68/KotlinDslDefaultScriptsModelCrossVersionSpec.groovy
@@ -21,7 +21,7 @@ import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptsModel
 
-import static org.gradle.kotlin.dsl.tooling.builders.KotlinScriptModelParameters.setModelParameters
+import static org.gradle.kotlin.dsl.tooling.fixtures.KotlinScriptModelParameters.setModelParameters
 
 @TargetGradleVersion(">=6.8")
 @Flaky(because = 'https://github.com/gradle/gradle-private/issues/3414')

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r68/KotlinDslGivenScriptsModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r68/KotlinDslGivenScriptsModelCrossVersionSpec.groovy
@@ -20,7 +20,7 @@ import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptsModel
 
-import static org.gradle.kotlin.dsl.tooling.builders.KotlinScriptModelParameters.setModelParameters
+import static org.gradle.kotlin.dsl.tooling.fixtures.KotlinScriptModelParameters.setModelParameters
 
 @TargetGradleVersion(">=6.8")
 @LeaksFileHandles("Kotlin Compiler Daemon taking time to shut down")

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r68/KotlinDslScriptsModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r68/KotlinDslScriptsModelCrossVersionSpec.groovy
@@ -22,7 +22,7 @@ import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptModel
 import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptsModel
 
-import static org.gradle.kotlin.dsl.tooling.builders.KotlinScriptModelParameters.setModelParameters
+import static org.gradle.kotlin.dsl.tooling.fixtures.KotlinScriptModelParameters.setModelParameters
 
 @TargetGradleVersion(">=6.8")
 @LeaksFileHandles("Kotlin Compiler Daemon taking time to shut down")

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r71/KotlinDslScriptsModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r71/KotlinDslScriptsModelCrossVersionSpec.groovy
@@ -21,7 +21,7 @@ import org.gradle.kotlin.dsl.tooling.builders.AbstractKotlinScriptModelCrossVers
 import org.gradle.test.fixtures.Flaky
 import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptsModel
 
-import static org.gradle.kotlin.dsl.tooling.builders.KotlinScriptModelParameters.setModelParameters
+import static org.gradle.kotlin.dsl.tooling.fixtures.KotlinScriptModelParameters.setModelParameters
 
 @TargetGradleVersion(">=7.1")
 class KotlinDslScriptsModelCrossVersionSpec extends AbstractKotlinScriptModelCrossVersionTest {

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/integTest/groovy/org/gradle/kotlin/dsl/tooling/builders/KotlinDslScriptsModelSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/integTest/groovy/org/gradle/kotlin/dsl/tooling/builders/KotlinDslScriptsModelSpec.groovy
@@ -20,6 +20,7 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.build.KotlinDslTestProjectInitiation
 import org.gradle.integtests.tooling.fixture.TestOutputStream
 import org.gradle.integtests.tooling.fixture.ToolingApi
+import org.gradle.kotlin.dsl.tooling.fixtures.KotlinScriptModelParameters
 import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptsModel
 import org.junit.Rule
 import org.junit.rules.RuleChain

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/testFixtures/groovy/org/gradle/kotlin/dsl/tooling/fixtures/KotlinScriptModelParameters.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/testFixtures/groovy/org/gradle/kotlin/dsl/tooling/fixtures/KotlinScriptModelParameters.groovy
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.kotlin.dsl.tooling.builders
+package org.gradle.kotlin.dsl.tooling.fixtures
 
 
 import org.gradle.tooling.model.kotlin.dsl.KotlinDslModelsParameters

--- a/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiClassLoaderProvider.groovy
+++ b/platforms/ide/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiClassLoaderProvider.groovy
@@ -87,7 +87,7 @@ class ToolingApiClassLoaderProvider {
         sharedSpec.allowPackage('org.gradle.workers.fixtures')
         sharedSpec.allowPackage('org.gradle.launcher.daemon.testing')
         sharedSpec.allowPackage('org.gradle.tooling')
-        sharedSpec.allowPackage('org.gradle.kotlin.dsl.tooling.builders')
+        sharedSpec.allowPackage('org.gradle.kotlin.dsl.tooling.fixtures')
         sharedSpec.allowClass(OperatingSystem)
         sharedSpec.allowClass(Requires)
         sharedSpec.allowClass(TestPrecondition)


### PR DESCRIPTION
Broken since 
* gradle/gradle#24261

This scan shows the wrongly unrolled tests:
https://ge.gradle.org/s/dptxj7cu5pq54/tests/overview

Fixed with this commit:
https://ge.gradle.org/s/rlqvckva2ynq6/tests/overview

The fixtures added in the PR mentioned above were in the same package as the actual builders. This package was added to the filter spec of one of the classloader used for loading the previous version of the TAPI client in the tests. Because the builders have dependency on the current TAPI the TAPI client loaded the wrong version. 

This PR moves the fixtures to their own package and fixes the classloading.