### PR TITLE
Allow specifying a source encoding for the jacoco report tasks

### DIFF
--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -52,7 +52,7 @@ Example:
 ADD RELEASE FEATURES BELOW
 vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv -->
 
-## Configuration cache improvements
+### Configuration cache improvements
 
 [Java Record classes](https://docs.oracle.com/en/java/javase/21/language/records.html) are now supported in the configuration cache.
 
@@ -179,6 +179,10 @@ ADD RELEASE FEATURES ABOVE
 ==========================================================
 
 -->
+
+### Allow specifying source encoding for Jacoco report tasks
+
+The source encoding of `JacocoReport` tasks may now be specified via the `sourceEncoding` property.
 
 ## Promoted features
 Promoted features are features that were incubating in previous versions of Gradle but are now supported and subject to backward compatibility.

--- a/platforms/jvm/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginMultiVersionIntegrationTest.groovy
+++ b/platforms/jvm/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginMultiVersionIntegrationTest.groovy
@@ -257,6 +257,32 @@ public class ThingTest {
         htmlReport().numberOfClasses() == 2000
     }
 
+    def "allows specifying a source encoding"() {
+        given:
+        testDirectory.createDir('src/main/java/foo').file('Bar.java').canonicalFile.write('''
+            // öäüß
+            package foo;
+            public class Bar {}
+        ''', 'UTF-8')
+
+        buildFile << """
+            jacocoTestReport {
+                sourceEncoding = '$encoding'
+            }
+        """
+
+        when:
+        succeeds('test', 'jacocoTestReport')
+
+        then:
+        htmlReport().sourceCode('foo', 'Bar.java').contains('öäüß') == match
+
+        where:
+        encoding     || match
+        'UTF-8'      || true
+        'ISO-8859-1' || false
+    }
+
     private JacocoReportFixture htmlReport(String basedir = "${REPORTING_BASE}/jacoco/test/html") {
         return new JacocoReportFixture(file(basedir))
     }

--- a/platforms/jvm/jacoco/src/main/java/org/gradle/internal/jacoco/AbstractAntJacocoReport.java
+++ b/platforms/jvm/jacoco/src/main/java/org/gradle/internal/jacoco/AbstractAntJacocoReport.java
@@ -23,6 +23,7 @@ import org.gradle.api.Action;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.project.IsolatedAntBuilder;
 
+import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.Map;
 
@@ -51,7 +52,7 @@ public abstract class AbstractAntJacocoReport<T> {
 
     protected void invokeJacocoReport(final GroovyObjectSupport antBuilder, final String projectName,
                      final FileCollection allClassesDirs, final FileCollection allSourcesDirs,
-                     final FileCollection executionData, final T t) {
+                     @Nullable final String encoding, final FileCollection executionData, final T t) {
         final Map<String, Object> emptyArgs = Collections.emptyMap();
         antBuilder.invokeMethod("jacocoReport", new Object[]{Collections.emptyMap(), new Closure<Object>(this, this) {
             @SuppressWarnings("UnusedDeclaration")
@@ -71,7 +72,8 @@ public abstract class AbstractAntJacocoReport<T> {
                                 return null;
                             }
                         }});
-                        antBuilder.invokeMethod("sourcefiles", new Object[]{emptyArgs, new Closure<Object>(this, this) {
+                        final Map<String, Object> sourcefilesArgs = encoding == null ? emptyArgs : Collections.singletonMap("encoding", encoding);
+                        antBuilder.invokeMethod("sourcefiles", new Object[]{sourcefilesArgs, new Closure<Object>(this, this) {
                             public Object doCall(Object ignore) {
                                 allSourcesDirs.addToAntBuilder(antBuilder, "resources");
                                 return null;

--- a/platforms/jvm/jacoco/src/main/java/org/gradle/internal/jacoco/AntJacocoCheck.java
+++ b/platforms/jvm/jacoco/src/main/java/org/gradle/internal/jacoco/AntJacocoCheck.java
@@ -29,6 +29,7 @@ import org.gradle.testing.jacoco.tasks.rules.JacocoLimit;
 import org.gradle.testing.jacoco.tasks.rules.JacocoViolationRule;
 import org.gradle.testing.jacoco.tasks.rules.JacocoViolationRulesContainer;
 
+import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Map;
@@ -51,14 +52,14 @@ public class AntJacocoCheck extends AbstractAntJacocoReport<JacocoViolationRules
 
     public JacocoCheckResult execute(FileCollection classpath, final String projectName,
                                      final FileCollection allClassesDirs, final FileCollection allSourcesDirs,
-                                     final FileCollection executionData, final JacocoViolationRulesContainer violationRules) {
+                                     @Nullable final String encoding, final FileCollection executionData, final JacocoViolationRulesContainer violationRules) {
         final JacocoCheckResult jacocoCheckResult = new JacocoCheckResult();
 
         configureAntReportTask(classpath, new Action<GroovyObjectSupport>() {
             @Override
             public void execute(GroovyObjectSupport antBuilder) {
                 try {
-                    invokeJacocoReport(antBuilder, projectName, allClassesDirs, allSourcesDirs, executionData, violationRules);
+                    invokeJacocoReport(antBuilder, projectName, allClassesDirs, allSourcesDirs, encoding, executionData, violationRules);
                 } catch (Exception e) {
                     String violations = getViolations(antBuilder);
                     jacocoCheckResult.setSuccess(false);

--- a/platforms/jvm/jacoco/src/main/java/org/gradle/internal/jacoco/AntJacocoReport.java
+++ b/platforms/jvm/jacoco/src/main/java/org/gradle/internal/jacoco/AntJacocoReport.java
@@ -23,6 +23,8 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.project.IsolatedAntBuilder;
 import org.gradle.testing.jacoco.tasks.JacocoReportsContainer;
 
+import javax.annotation.Nullable;
+
 public class AntJacocoReport extends AbstractAntJacocoReport<JacocoReportsContainer> {
 
     public AntJacocoReport(IsolatedAntBuilder ant) {
@@ -31,11 +33,11 @@ public class AntJacocoReport extends AbstractAntJacocoReport<JacocoReportsContai
 
     public void execute(FileCollection classpath, final String projectName,
                         final FileCollection allClassesDirs, final FileCollection allSourcesDirs,
-                        final FileCollection executionData, final JacocoReportsContainer reports) {
+                        @Nullable final String encoding, final FileCollection executionData, final JacocoReportsContainer reports) {
         configureAntReportTask(classpath, new Action<GroovyObjectSupport>() {
             @Override
             public void execute(GroovyObjectSupport antBuilder) {
-                invokeJacocoReport(antBuilder, projectName, allClassesDirs, allSourcesDirs, executionData, reports);
+                invokeJacocoReport(antBuilder, projectName, allClassesDirs, allSourcesDirs, encoding, executionData, reports);
             }
         });
     }

--- a/platforms/jvm/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoCoverageVerification.java
+++ b/platforms/jvm/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoCoverageVerification.java
@@ -84,6 +84,7 @@ public abstract class JacocoCoverageVerification extends JacocoReportBase {
             projectName,
             getAllClassDirs().filter(File::exists),
             getAllSourceDirs().filter(File::exists),
+            getSourceEncoding().getOrNull(),
             getExecutionData().filter(File::exists),
             getViolationRules()
         );

--- a/platforms/jvm/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoReport.java
+++ b/platforms/jvm/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoReport.java
@@ -85,6 +85,7 @@ public abstract class JacocoReport extends JacocoReportBase implements Reporting
             projectName.get(),
             getAllClassDirs().filter(File::exists),
             getAllSourceDirs().filter(File::exists),
+            getSourceEncoding().getOrNull(),
             getExecutionData().filter(File::exists),
             getReports()
         );

--- a/platforms/jvm/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoReportBase.java
+++ b/platforms/jvm/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoReportBase.java
@@ -19,14 +19,17 @@ package org.gradle.testing.jacoco.tasks;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 import org.gradle.api.Task;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.project.IsolatedAntBuilder;
+import org.gradle.api.provider.Property;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.IgnoreEmptyDirectories;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
@@ -57,6 +60,7 @@ public abstract class JacocoReportBase extends JacocoBase {
     private final ConfigurableFileCollection classDirectories = getProject().files();
     private final ConfigurableFileCollection additionalClassDirs = getProject().files();
     private final ConfigurableFileCollection additionalSourceDirs = getProject().files();
+    private final Property<String> sourceEncoding = getProject().getObjects().property(String.class);
 
     public JacocoReportBase() {
         onlyIf("Any of the execution data files exists", new Spec<Task>() {
@@ -139,6 +143,18 @@ public abstract class JacocoReportBase extends JacocoBase {
     @InputFiles
     public ConfigurableFileCollection getAdditionalSourceDirs() {
         return additionalSourceDirs;
+    }
+
+    /**
+     * The character encoding of the source files.
+     *
+     * @since 8.8
+     */
+    @Incubating
+    @Optional
+    @Input
+    public Property<String> getSourceEncoding() {
+        return sourceEncoding;
     }
 
     /**

--- a/platforms/jvm/jacoco/src/test/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginSpec.groovy
+++ b/platforms/jvm/jacoco/src/test/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginSpec.groovy
@@ -107,4 +107,15 @@ class JacocoPluginSpec extends AbstractProjectBuilderSpec {
         jacocoTestReportTask.description == 'Generates code coverage report for the test task.'
         jacocoTestCoverageVerificationTask.description == 'Verifies code coverage metrics based on specified rules for the test task.'
     }
+
+    def "declares task property values for sourceEncoding without default value"() {
+        given:
+        project.apply plugin: 'java'
+
+        expect:
+        def jacocoTestReportTask = project.tasks.getByName('jacocoTestReport')
+        def jacocoTestCoverageVerificationTask = project.tasks.getByName('jacocoTestCoverageVerification')
+        !jacocoTestReportTask.sourceEncoding.isPresent()
+        !jacocoTestCoverageVerificationTask.sourceEncoding.isPresent()
+    }
 }

--- a/platforms/jvm/jacoco/src/testFixtures/groovy/org/gradle/testing/jacoco/plugins/fixtures/JacocoReportFixture.groovy
+++ b/platforms/jvm/jacoco/src/testFixtures/groovy/org/gradle/testing/jacoco/plugins/fixtures/JacocoReportFixture.groovy
@@ -56,6 +56,10 @@ class JacocoReportFixture {
         return Integer.parseInt(numberOfClasses)
     }
 
+    String sourceCode(String pkg, String file) {
+        return htmlDir.file("${pkg}/${file}.html").getText('UTF-8')
+    }
+
     boolean assertVersion(String version) {
         String jacocoVersion = jacocoVersion()
         // Newer versions of JaCoCo include the timestamp in the rendered report


### PR DESCRIPTION
Use the encoding of the compileJava task by default (if specified), or the default encoding if not specified

Fixes #13666

This is a reanimation of #13687 by @jnizet which got abandoned.
I did not make any changes or tested it manually.
I just rebased the old PR and resolved the conflicts.
But if there are any findings, I'll do my best to resolve them.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
