### PR TITLE
Fix the :architecture-test:extractGradleApiInfo task on Windows

### DIFF
--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/ExtractGradleApiInfoTask.java
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/ExtractGradleApiInfoTask.java
@@ -75,7 +75,7 @@ public abstract class ExtractGradleApiInfoTask extends DefaultTask {
     private void extractUpgradedProperties(FileCollection from, RegularFileProperty to) {
         String gradleApiInfoJarPrefix = getGradleApiInfoJarPrefix().get();
         File gradleRuntimeApiInfoJar = from.filter(file -> file.getName().startsWith(gradleApiInfoJarPrefix)).getSingleFile();
-        URI uri = URI.create("jar:file:" + gradleRuntimeApiInfoJar.getAbsolutePath());
+        URI uri = URI.create("jar:" + gradleRuntimeApiInfoJar.getAbsoluteFile().toURI());
         try (FileSystem fs = FileSystems.newFileSystem(uri, Collections.emptyMap())) {
             Path upgradedPropertiesJson = fs.getPath(UPGRADED_PROPERTIES_FILE);
             if (Files.exists(upgradedPropertiesJson)) {


### PR DESCRIPTION
Fixes one of the issues in #27120

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- n/a Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- n/a Provide unit tests (under `<subproject>/src/test`) to verify logic
- n/a Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
