### PR TITLE
Do not treat `project.buildFile` as an Isolated Projects violation

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ProblemReportingCrossProjectModelAccess.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ProblemReportingCrossProjectModelAccess.kt
@@ -251,7 +251,6 @@ class ProblemReportingCrossProjectModelAccess(
         }
 
         override fun getBuildFile(): File {
-            onAccess()
             return delegate.buildFile
         }
 

--- a/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/internal/tooling/ToolingModelServices.java
+++ b/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/internal/tooling/ToolingModelServices.java
@@ -30,6 +30,7 @@ import org.gradle.plugins.ide.internal.configurer.DefaultUniqueProjectNameProvid
 import org.gradle.plugins.ide.internal.configurer.UniqueProjectNameProvider;
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry;
 import org.gradle.tooling.provider.model.internal.BuildScopeToolingModelBuilderRegistryAction;
+import org.gradle.tooling.provider.model.internal.DefaultIntermediateToolingModelProvider;
 import org.gradle.tooling.provider.model.internal.IntermediateToolingModelProvider;
 
 public class ToolingModelServices extends AbstractPluginServiceRegistry {

--- a/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/DefaultIntermediateToolingModelProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/DefaultIntermediateToolingModelProvider.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.plugins.ide.internal.tooling;
+package org.gradle.tooling.provider.model.internal;
 
 import org.gradle.api.NonNullApi;
 import org.gradle.api.Project;
@@ -24,8 +24,6 @@ import org.gradle.internal.Cast;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.build.BuildToolingModelController;
 import org.gradle.internal.buildtree.IntermediateBuildActionRunner;
-import org.gradle.tooling.provider.model.internal.IntermediateToolingModelProvider;
-import org.gradle.tooling.provider.model.internal.ToolingModelScope;
 
 import javax.annotation.Nullable;
 import java.util.Collections;


### PR DESCRIPTION
The `project.projectDir` access is not a violation, and the `buildFile` field on `DefaultProject` is final, same as `projectDir`.

Accessing the `buildFile` is also required for making Kotlin DSL model builders IP-compatible.