### PR TITLE
Populate entry tasks properly when restoring task graph from CC

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildOperationsIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildOperationsIntegrationTest.groovy
@@ -471,6 +471,8 @@ class ConfigurationCacheBuildOperationsIntegrationTest extends AbstractConfigura
 
         def calculateGraphOp2 = calculateGraphOps[1]
         assert calculateGraphOp2.parentId == calculateTreeGraphOp2.id
+
+        assert calculateGraphOp.result.requestedTaskPaths == calculateGraphOp2.result.requestedTaskPaths
     }
 
     private void hasCompositeBuildsWorkGraphPopulated() {

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/CachedBuildState.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/CachedBuildState.kt
@@ -16,7 +16,7 @@
 
 package org.gradle.configurationcache
 
-import org.gradle.execution.plan.Node
+import org.gradle.execution.plan.ScheduledWork
 import org.gradle.normalization.internal.InputNormalizationHandlerInternal
 import org.gradle.util.Path
 import java.io.File
@@ -91,7 +91,7 @@ class BuildWithWork(
     val build: ConfigurationCacheBuild,
     rootProjectName: String,
     projects: List<CachedProjectState>,
-    val workGraph: List<Node>
+    val workGraph: ScheduledWork
 ) : BuildWithProjects(identityPath, rootProjectName, projects)
 
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheHost.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheHost.kt
@@ -24,7 +24,7 @@ import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.api.internal.initialization.ScriptHandlerFactory
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.project.ProjectStateRegistry
-import org.gradle.execution.plan.Node
+import org.gradle.execution.plan.ScheduledWork
 import org.gradle.groovy.scripts.TextResourceScriptSource
 import org.gradle.initialization.ClassLoaderScopeRegistry
 import org.gradle.initialization.DefaultProjectDescriptor
@@ -79,11 +79,11 @@ class ConfigurationCacheHost internal constructor(
         override val hasScheduledWork: Boolean
             get() = gradle.taskGraph.size() > 0
 
-        override val scheduledWork: List<Node>
+        override val scheduledWork: ScheduledWork
             get() {
-                lateinit var nodes: List<Node>
-                gradle.taskGraph.visitScheduledNodes { nodes = it }
-                return nodes
+                lateinit var work: ScheduledWork
+                gradle.taskGraph.visitScheduledNodes { nodes, entryNodes -> work = ScheduledWork(nodes, entryNodes) }
+                return work
             }
     }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/CrossProjectConfigurationReportingTaskExecutionGraph.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/CrossProjectConfigurationReportingTaskExecutionGraph.kt
@@ -33,7 +33,7 @@ import org.gradle.execution.taskgraph.TaskExecutionGraphInternal
 import org.gradle.internal.build.ExecutionResult
 import org.gradle.util.Path
 import java.util.Objects
-import java.util.function.Consumer
+import java.util.function.BiConsumer
 
 
 internal
@@ -202,7 +202,7 @@ class CrossProjectConfigurationReportingTaskExecutionGraph(
     override fun execute(plan: FinalizedExecutionPlan?): ExecutionResult<Void>? =
         delegate.execute(plan)
 
-    override fun visitScheduledNodes(visitor: Consumer<MutableList<Node>>?) =
+    override fun visitScheduledNodes(visitor: BiConsumer<List<Node>, Set<Node>>) =
         delegate.visitScheduledNodes(visitor)
 
     override fun size(): Int = delegate.size()

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/VintageGradleBuild.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/VintageGradleBuild.kt
@@ -17,7 +17,7 @@
 package org.gradle.configurationcache
 
 import org.gradle.api.internal.GradleInternal
-import org.gradle.execution.plan.Node
+import org.gradle.execution.plan.ScheduledWork
 import org.gradle.internal.build.BuildState
 
 
@@ -26,5 +26,5 @@ interface VintageGradleBuild {
     val state: BuildState
     val gradle: GradleInternal
     val hasScheduledWork: Boolean
-    val scheduledWork: List<Node>
+    val scheduledWork: ScheduledWork
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/SelectedTaskExecutionAction.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/SelectedTaskExecutionAction.java
@@ -37,7 +37,7 @@ public class SelectedTaskExecutionAction implements BuildWorkExecutor {
 
     private void bindAllReferencesOfProject(FinalizedExecutionPlan plan) {
         Set<Project> seen = Sets.newHashSet();
-        plan.getContents().getScheduledNodes().visitNodes(nodes -> {
+        plan.getContents().getScheduledNodes().visitNodes((nodes, entryNodes) -> {
             for (Node node : nodes) {
                 if (node instanceof LocalTaskNode) {
                     ProjectInternal taskProject = node.getOwningProject();

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionPlan.java
@@ -36,7 +36,7 @@ public interface ExecutionPlan extends Describable, Closeable {
 
     void setContinueOnFailure(boolean continueOnFailure);
 
-    void setScheduledNodes(Collection<? extends Node> nodes);
+    void setScheduledWork(ScheduledWork work);
 
     /**
      * Adds an entry task to the execution plan. If called multiple times then execution plan follows the method invocation order.

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/QueryableExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/QueryableExecutionPlan.java
@@ -21,7 +21,7 @@ import org.gradle.api.Task;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 
 /**
  * An execution plan that has been finalized and can no longer be mutated.
@@ -52,7 +52,7 @@ public interface QueryableExecutionPlan {
 
         @Override
         public ScheduledNodes getScheduledNodes() {
-            return visitor -> visitor.accept(Collections.emptyList());
+            return visitor -> visitor.accept(Collections.emptyList(), Collections.emptySet());
         }
 
         @Override
@@ -97,6 +97,11 @@ public interface QueryableExecutionPlan {
      * An immutable snapshot of the set of scheduled nodes.
      */
     interface ScheduledNodes {
-        void visitNodes(Consumer<List<Node>> visitor);
+        /**
+         * Invokes the consumer with the list of scheduled nodes and the set of entry nodes. Entry nodes may not be a subset of scheduled nodes.
+         *
+         * @param visitor the consumer of nodes and entry nodes
+         */
+        void visitNodes(BiConsumer<List<Node>, Set<Node>> visitor);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ScheduledWork.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ScheduledWork.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.execution.plan;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.function.BiConsumer;
+
+/**
+ * An immutable snapshot of the currently scheduled nodes, together with the information about which nodes are entry points.
+ */
+public class ScheduledWork implements QueryableExecutionPlan.ScheduledNodes {
+    private final ImmutableList<Node> scheduledNodes;
+    private final ImmutableSet<Node> entryNodes;
+
+    public ScheduledWork(List<? extends Node> scheduledNodes, Collection<? extends Node> entryNodes) {
+        // Checking that entryNodes are a subset of scheduledNodes can be expensive, so it is omitted from here.
+        this.scheduledNodes = ImmutableList.copyOf(scheduledNodes);
+        this.entryNodes = ImmutableSet.copyOf(entryNodes);
+    }
+
+    @Override
+    public void visitNodes(BiConsumer<List<Node>, Set<Node>> visitor) {
+        visitor.accept(scheduledNodes, entryNodes);
+    }
+
+    /**
+     * Returns the list of the scheduled nodes in the scheduling order.
+     *
+     * @return the list of the scheduled nodes
+     */
+    public ImmutableList<Node> getScheduledNodes() {
+        return scheduledNodes;
+    }
+
+    /**
+     * Returns the set of the entry nodes. For example, this set may contain task nodes for the tasks specified in the command line.
+     * The returned set may not be a subset of {@link #getScheduledNodes()}, if some entry tasks are not scheduled.
+     *
+     * @return the set of the entry nodes
+     * @see QueryableExecutionPlan#getRequestedTasks()
+     */
+    public ImmutableSet<Node> getEntryNodes() {
+        return entryNodes;
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionGraph.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionGraph.java
@@ -56,7 +56,7 @@ import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 
 @SuppressWarnings("deprecation")
 @NonNullApi
@@ -272,7 +272,7 @@ public class DefaultTaskExecutionGraph implements TaskExecutionGraphInternal {
     }
 
     @Override
-    public void visitScheduledNodes(Consumer<List<Node>> visitor) {
+    public void visitScheduledNodes(BiConsumer<List<Node>, Set<Node>> visitor) {
         executionPlan.getContents().getScheduledNodes().visitNodes(visitor);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskExecutionGraphInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskExecutionGraphInternal.java
@@ -24,7 +24,7 @@ import org.gradle.internal.build.ExecutionResult;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 
 public interface TaskExecutionGraphInternal extends TaskExecutionGraph {
 
@@ -60,7 +60,7 @@ public interface TaskExecutionGraphInternal extends TaskExecutionGraph {
      * Returns all the work items in this graph scheduled for execution plus all
      * dependencies from other builds.
      */
-    void visitScheduledNodes(Consumer<List<Node>> visitor);
+    void visitScheduledNodes(BiConsumer<List<Node>, Set<Node>> visitor);
 
     /**
      * Resets the lifecycle for this graph.

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildLifecycleController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildLifecycleController.java
@@ -20,7 +20,7 @@ import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.execution.EntryTaskSelector;
 import org.gradle.execution.plan.BuildWorkPlan;
-import org.gradle.execution.plan.Node;
+import org.gradle.execution.plan.ScheduledWork;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -150,6 +150,6 @@ public interface BuildLifecycleController {
         /**
          * Sets the set of scheduled node to the work graph for this build. Short-circuits dependency discovery and any sorting. Nodes must be restored in the same order they were scheduled.
          */
-        void setScheduledNodes(List<? extends Node> nodes);
+        void setScheduledWork(ScheduledWork work);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildOperationFiringBuildWorkPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildOperationFiringBuildWorkPreparer.java
@@ -121,7 +121,7 @@ public class BuildOperationFiringBuildWorkPreparer implements BuildWorkPreparer 
 
         private PlannedNodeGraph computePlannedNodeGraph(QueryableExecutionPlan.ScheduledNodes scheduledWork) {
             PlannedNodeGraph.Collector collector = new PlannedNodeGraph.Collector(converterRegistry);
-            scheduledWork.visitNodes(collector::collectNodes);
+            scheduledWork.visitNodes((nodes, entryNodes) -> collector.collectNodes(nodes));
             return collector.getGraph();
         }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/build/DefaultBuildLifecycleController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/DefaultBuildLifecycleController.java
@@ -34,8 +34,8 @@ import org.gradle.execution.plan.BuildWorkPlan;
 import org.gradle.execution.plan.ExecutionPlan;
 import org.gradle.execution.plan.FinalizedExecutionPlan;
 import org.gradle.execution.plan.LocalTaskNode;
-import org.gradle.execution.plan.Node;
 import org.gradle.execution.plan.QueryableExecutionPlan;
+import org.gradle.execution.plan.ScheduledWork;
 import org.gradle.initialization.exception.ExceptionAnalyser;
 import org.gradle.internal.Describables;
 import org.gradle.internal.Pair;
@@ -412,8 +412,8 @@ public class DefaultBuildLifecycleController implements BuildLifecycleController
         }
 
         @Override
-        public void setScheduledNodes(List<? extends Node> nodes) {
-            plan.setScheduledNodes(nodes);
+        public void setScheduledWork(ScheduledWork work) {
+            plan.setScheduledWork(work);
         }
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanParallelTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanParallelTest.groovy
@@ -2413,7 +2413,7 @@ class DefaultExecutionPlanParallelTest extends AbstractExecutionPlanSpec {
 
     List<Node> getScheduledNodes() {
         def result = []
-        executionPlan.scheduledNodes.visitNodes(nodes -> result.addAll(nodes))
+        executionPlan.scheduledNodes.visitNodes { nodes, entryNodes -> result.addAll(nodes) }
         return result
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanTest.groovy
@@ -986,7 +986,7 @@ class DefaultExecutionPlanTest extends AbstractExecutionPlanSpec {
         def node1 = requiredNode()
         def node2 = requiredNode(node1)
         def node3 = requiredNode(node2)
-        executionPlan.setScheduledNodes([node3, node1, node2])
+        executionPlan.setScheduledWork(scheduledWork(node3, node1, node2))
 
         when:
         populateGraph()
@@ -1182,5 +1182,9 @@ class DefaultExecutionPlanTest extends AbstractExecutionPlanSpec {
         task.getShouldRunAfter() >> brokenDependencies()
         task.getFinalizedBy() >> taskDependencyResolvingTo(task, [])
         return task
+    }
+
+    private ScheduledWork scheduledWork(Node... nodes) {
+        return new ScheduledWork(nodes as List<Node>, nodes as List<Node>)
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/build/BuildOperationFiringBuildWorkPreparerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/build/BuildOperationFiringBuildWorkPreparerTest.groovy
@@ -32,7 +32,7 @@ import org.gradle.internal.taskgraph.NodeIdentity
 import org.gradle.util.Path
 import spock.lang.Specification
 
-import java.util.function.Consumer
+import java.util.function.BiConsumer
 
 class BuildOperationFiringBuildWorkPreparerTest extends Specification {
 
@@ -48,8 +48,8 @@ class BuildOperationFiringBuildWorkPreparerTest extends Specification {
         List<Node> nodes = [t]
 
         def scheduledNodesStub = Stub(QueryableExecutionPlan.ScheduledNodes) {
-            visitNodes(_) >> { Consumer<List<Node>> consumer ->
-                consumer.accept(nodes)
+            visitNodes(_) >> { BiConsumer<List<Node>, Set<Node>> consumer ->
+                consumer.accept(nodes, new HashSet<Node>(nodes))
             }
         }
 


### PR DESCRIPTION
Before this commit, upon restoring from configuration cache, all tasks were considered entry (requested) tasks. This was confusing observability tools.

This commit makes CC to keep the list of the requested tasks in the cache.

Fixes #26987.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
