### PR TITLE
Proper variant support in artifact collections

### DIFF
--- a/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
+++ b/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
@@ -110,6 +110,7 @@ public class EclipseDependenciesCreator {
         }
 
         @Override
+        @SuppressWarnings("deprecation")
         public void visitProjectDependency(ResolvedArtifactResult artifact, boolean testDependency, boolean asJavaModule) {
             ProjectComponentIdentifier componentIdentifier = (ProjectComponentIdentifier) artifact.getId().getComponentIdentifier();
             if (componentIdentifier.equals(currentProjectId)) {

--- a/platforms/native/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftBinary.java
+++ b/platforms/native/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftBinary.java
@@ -233,6 +233,7 @@ public class DefaultSwiftBinary extends DefaultNativeBinary implements SwiftBina
         }
 
         @Override
+        @SuppressWarnings("deprecation")
         public Set<File> getFiles() {
             if (result == null) {
                 result = Sets.newLinkedHashSet();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/ChecksumAndSignatureVerificationOverride.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/ChecksumAndSignatureVerificationOverride.java
@@ -203,9 +203,11 @@ public class ChecksumAndSignatureVerificationOverride implements DependencyVerif
     public ResolvedArtifactResult verifiedArtifact(ResolvedArtifactResult artifact) {
         return new ResolvedArtifactResult() {
             @Override
-            @SuppressWarnings("deprecation")
             public File getFile() {
-                artifactsAccessed(artifact.getVariant().getDisplayName());
+                String displayName = artifact.getVariants().stream()
+                    .map(ResolvedVariantResult::getDisplayName).findFirst() // There will always be at least one variant
+                    .orElseThrow(() -> new IllegalStateException("No variant found for artifact " + artifact.getId()));
+                artifactsAccessed(displayName);
                 return artifact.getFile();
             }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/ChecksumAndSignatureVerificationOverride.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/ChecksumAndSignatureVerificationOverride.java
@@ -203,12 +203,14 @@ public class ChecksumAndSignatureVerificationOverride implements DependencyVerif
     public ResolvedArtifactResult verifiedArtifact(ResolvedArtifactResult artifact) {
         return new ResolvedArtifactResult() {
             @Override
+            @SuppressWarnings("deprecation")
             public File getFile() {
                 artifactsAccessed(artifact.getVariant().getDisplayName());
                 return artifact.getFile();
             }
 
             @Override
+            @Deprecated
             public ResolvedVariantResult getVariant() {
                 return artifact.getVariant();
             }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/ChecksumAndSignatureVerificationOverride.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/ChecksumAndSignatureVerificationOverride.java
@@ -214,6 +214,11 @@ public class ChecksumAndSignatureVerificationOverride implements DependencyVerif
             }
 
             @Override
+            public Set<ResolvedVariantResult> getVariants() {
+                return artifact.getVariants();
+            }
+
+            @Override
             public ComponentArtifactIdentifier getId() {
                 return artifact.getId();
             }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedArtifactResult.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedArtifactResult.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.artifacts.result;
 
+import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
@@ -24,13 +25,16 @@ import org.gradle.api.component.Artifact;
 import org.gradle.internal.DisplayName;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 public class DefaultResolvedArtifactResult implements ResolvedArtifactResult {
     private final ComponentArtifactIdentifier identifier;
     private final ResolvedVariantResult variant;
     private final Class<? extends Artifact> type;
     private final File file;
+    private final Set<ResolvedVariantResult> variants;
 
     public DefaultResolvedArtifactResult(ComponentArtifactIdentifier identifier,
                                          AttributeContainer variantAttributes,
@@ -40,8 +44,20 @@ public class DefaultResolvedArtifactResult implements ResolvedArtifactResult {
                                          File file) {
         this.identifier = identifier;
         this.variant = new DefaultResolvedVariantResult(identifier.getComponentIdentifier(), variantDisplayName, variantAttributes, capabilities, null);
+        this.variants = Collections.singleton(variant);
         this.type = type;
         this.file = file;
+    }
+
+    private DefaultResolvedArtifactResult(DefaultResolvedArtifactResult result, DefaultResolvedVariantResult additionalVariantResult) {
+        this.identifier = result.identifier;
+        this.variant = result.variant;
+        this.variants = ImmutableSet.<ResolvedVariantResult>builder()
+            .addAll(result.variants)
+            .add(additionalVariantResult)
+            .build();
+        this.type = result.type;
+        this.file = result.file;
     }
 
     @Override
@@ -67,5 +83,14 @@ public class DefaultResolvedArtifactResult implements ResolvedArtifactResult {
     @Override
     public ResolvedVariantResult getVariant() {
         return variant;
+    }
+
+    @Override
+    public Set<ResolvedVariantResult> getVariants() {
+        return variants;
+    }
+
+    public DefaultResolvedArtifactResult withAddedVariant(AttributeContainer variantAttributes, List<? extends Capability> capabilities, DisplayName variantName) {
+        return new DefaultResolvedArtifactResult(this, new DefaultResolvedVariantResult(identifier.getComponentIdentifier(), variantName, variantAttributes, capabilities, null));
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedArtifactResult.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedArtifactResult.java
@@ -81,6 +81,7 @@ public class DefaultResolvedArtifactResult implements ResolvedArtifactResult {
     }
 
     @Override
+    @Deprecated
     public ResolvedVariantResult getVariant() {
         return variant;
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/DefaultVersionCatalogBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/DefaultVersionCatalogBuilder.java
@@ -230,6 +230,7 @@ public abstract class DefaultVersionCatalogBuilder implements VersionCatalogBuil
         return DefaultCatalogProblemBuilder.getProblemInVersionCatalog(name) + ", ";
     }
 
+    @SuppressWarnings("deprecation")
     private void maybeImportCatalogs() {
         if (importedCatalog == null) {
             return;

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ResolvedArtifactCollectingVisitorTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ResolvedArtifactCollectingVisitorTest.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice
+
+import org.gradle.api.artifacts.component.ComponentIdentifier
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact
+import org.gradle.api.internal.attributes.ImmutableAttributes
+import org.gradle.internal.DisplayName
+import org.gradle.internal.component.external.model.ImmutableCapability
+import org.gradle.internal.component.local.model.ComponentFileArtifactIdentifier
+import spock.lang.Specification
+
+class ResolvedArtifactCollectingVisitorTest extends Specification {
+
+    def "variants with different capabilities are collected"() {
+        given:
+        def visitor = new ResolvedArtifactCollectingVisitor()
+        def componentIdentifier = Mock(ComponentIdentifier) {
+            getDisplayName() >> "example"
+        }
+        def variantName = Mock(DisplayName) {
+            getDisplayName() >> "variant"
+            getCapitalizedDisplayName() >> "Variant"
+        }
+        def artifactIdentifier = new ComponentFileArtifactIdentifier(componentIdentifier, "out")
+        def projectCapability = new ImmutableCapability("group", "project", "1.0")
+        def testFixturesCapability = new ImmutableCapability("group", "project-test-fixtures", "1.0")
+        def artifact = Mock(ResolvableArtifact) {
+            getId() >> artifactIdentifier
+        }
+
+        when:
+        visitor.visitArtifact(variantName, ImmutableAttributes.EMPTY, [projectCapability], artifact)
+        visitor.visitArtifact(variantName, ImmutableAttributes.EMPTY, [testFixturesCapability], artifact)
+
+        then:
+        visitor.getArtifacts().size() == 1
+        visitor.getArtifacts().first().variants.size() == 2
+    }
+}

--- a/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
+++ b/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
@@ -1,3 +1,12 @@
 {
-    "acceptedApiChanges": []
+    "acceptedApiChanges": [
+        {
+            "type": "org.gradle.api.artifacts.result.ResolvedArtifactResult",
+            "member": "Method org.gradle.api.artifacts.result.ResolvedArtifactResult.getVariants()",
+            "acceptation": "Promoting the new method directly as this is really a bug fix.",
+            "changes": [
+                "Method added to interface"
+            ]
+        }
+    ]
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ResolvedArtifactResult.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ResolvedArtifactResult.java
@@ -15,7 +15,10 @@
  */
 package org.gradle.api.artifacts.result;
 
+import org.apache.groovy.lang.annotation.Incubating;
+
 import java.io.File;
+import java.util.Set;
 
 /**
  * The result of successfully resolving an artifact.
@@ -30,6 +33,20 @@ public interface ResolvedArtifactResult extends ArtifactResult {
 
     /**
      * The variant that included this artifact.
+     * Note that this will only expose the first variant.
+     * See {@link #getVariants()} for a complete view.
+     *
+     * @return the variant that included this artifact
      */
     ResolvedVariantResult getVariant();
+
+    /**
+     * Returns all the variants that included this artifact.
+     *
+     * @return the different variants that included this artifact, never {@code null} or empty.
+     *
+     * @since 8.6
+     */
+    @Incubating
+    Set<ResolvedVariantResult> getVariants();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ResolvedArtifactResult.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ResolvedArtifactResult.java
@@ -15,8 +15,6 @@
  */
 package org.gradle.api.artifacts.result;
 
-import org.apache.groovy.lang.annotation.Incubating;
-
 import java.io.File;
 import java.util.Set;
 
@@ -37,7 +35,10 @@ public interface ResolvedArtifactResult extends ArtifactResult {
      * See {@link #getVariants()} for a complete view.
      *
      * @return the variant that included this artifact
+     *
+     * @deprecated Use {@link #getVariants()} instead.
      */
+    @Deprecated
     ResolvedVariantResult getVariant();
 
     /**
@@ -47,6 +48,5 @@ public interface ResolvedArtifactResult extends ArtifactResult {
      *
      * @since 8.6
      */
-    @Incubating
     Set<ResolvedVariantResult> getVariants();
 }


### PR DESCRIPTION
This fix adds support for having multiple artifacts with the same name
that are selected as part of dependency resolution.
It also enables recording that a single artifact has been selected by
multiple variants.

Fixes #17213
Fixes #18458

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
