### PR TITLE
Improve locking failures output

### DIFF
--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -52,7 +52,7 @@ vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv -->
 
 ### Public API improvements
 
-### Enhanced name-based filtering on NamedDomainObject containers
+#### Enhanced name-based filtering on NamedDomainObject containers
 
 A new [`named(Spec<String>)` method](javadoc/org/gradle/api/NamedDomainObjectCollection.html#named-org.gradle.api.specs.Spec-) has been added to all NamedDomainObject containers, which simplifies name-based filtering and eliminates the need to touch any of the values, may they be realized or unrealized.
 
@@ -62,6 +62,32 @@ A new [`named(Spec<String>)` method](javadoc/org/gradle/api/NamedDomainObjectCol
 [`ConfigurationPublications#capability(Object)`](javadoc/org/gradle/api/artifacts/ConfigurationPublications.html#capability-java.lang.Object-),
 [`ModuleDependencyCapabilitiesHandler#requireCapability(Object)`](javadoc/org/gradle/api/artifacts/ModuleDependencyCapabilitiesHandler.html#requireCapability-java.lang.Object-),
 and [`CapabilitiesResolution#withCapability(Object, Action)`](javadoc/org/gradle/api/artifacts/CapabilitiesResolution.html#withCapability-java.lang.Object-org.gradle.api.Action-).
+
+### Error and warning reporting improvements
+
+Gradle provides a rich set of error and warning messages to help you understand and resolve problems in your build.
+
+#### Dependency locking now separates the error from the possible action to try
+
+[Dependency locking](userguide/dependency_locking.html) is a mechanism for ensuring reproducible builds when using dynamic dependency versions.
+
+This release improves error messages by separating the error from the possible action to fix the issue in the console output.
+Errors from invalid [lock file format](userguide/dependency_locking.html#lock_state_location_and_format) or [missing lock state when strict mode is enabled](userguide/dependency_locking.html#fine_tuning_dependency_locking_behaviour_with_lock_mode) are now displayed as illustrated below:
+
+```
+FAILURE: Build failed with an exception.
+
+* What went wrong:
+Execution failed for task ':dependencies'.
+> Could not resolve all dependencies for configuration ':lockedConf'.
+   > Invalid lock state for lock file specified in '<project>/lock.file'. Line: '<<<<<<< HEAD'
+
+* Try:
+> Verify the lockfile content. For more information on lock file format, please refer to https://docs.gradle.org/@version@/userguide/dependency_locking.html#lock_state_location_and_format in the Gradle documentation.
+> Run with --info or --debug option to get more log output.
+> Run with --scan to get full insights.
+> Get more help at https://help.gradle.org.
+```
 
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ADD RELEASE FEATURES ABOVE

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingStrictModeIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingStrictModeIntegrationTest.groovy
@@ -54,6 +54,8 @@ dependencies {
 
         then:
         failureHasCause("Locking strict mode: Configuration ':lockedConf' is locked but does not have lock state.")
+        failure.assertHasResolution("To create the lock state, run a task that will resolve that configuration and add '--write-locks' to the command line.")
+        failure.assertHasResolution("For more information on generating lock state")
         lockfileFixture.expectLockStateMissing('unlockedConf')
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingProvider.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingProvider.java
@@ -157,7 +157,7 @@ public class DefaultDependencyLockingProvider implements DependencyLockingProvid
                 allLockState = lockFileReaderWriter.readUniqueLockFile();
                 uniqueLockStateLoaded = true;
             } catch (IllegalStateException e) {
-                throw new InvalidLockFileException("project '" + context.getProjectPath().getPath() + "'", e);
+                throw new InvalidLockFileException("project '" + context.getProjectPath().getPath() + "'", e, LockFileReaderWriter.FORMATTING_DOC_LINK);
             }
         }
     }
@@ -182,7 +182,7 @@ public class DefaultDependencyLockingProvider implements DependencyLockingProvid
         try {
             lockedIdentifier = converter.convertFromLockNotation(module);
         } catch (IllegalArgumentException e) {
-            throw new InvalidLockFileException("configuration '" + context.identityPath(configurationName).getPath() + "'", e);
+            throw new InvalidLockFileException("configuration '" + context.identityPath(configurationName).getPath() + "'", e, LockFileReaderWriter.FORMATTING_DOC_LINK);
         }
         return lockedIdentifier;
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/locking/InvalidLockFileException.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/locking/InvalidLockFileException.java
@@ -16,8 +16,25 @@
 
 package org.gradle.internal.locking;
 
-public class InvalidLockFileException extends RuntimeException {
-    public InvalidLockFileException(String name, Exception cause) {
+import org.gradle.internal.exceptions.ResolutionProvider;
+
+import java.util.Collections;
+import java.util.List;
+
+public class InvalidLockFileException extends RuntimeException implements ResolutionProvider {
+    private final String resolutionMessage;
+
+    public InvalidLockFileException(String name, Exception cause, String resolutionMessage) {
         super("Invalid lock state for " + name, cause);
+        this.resolutionMessage = resolutionMessage;
+    }
+    public InvalidLockFileException(String name, String resolutionMessage) {
+        super("Invalid lock state for " + name);
+        this.resolutionMessage = resolutionMessage;
+    }
+
+    @Override
+    public List<String> getResolutions() {
+        return Collections.singletonList(resolutionMessage);
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/locking/LockFileReaderWriter.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/locking/LockFileReaderWriter.java
@@ -47,7 +47,7 @@ public class LockFileReaderWriter {
 
     private static final Logger LOGGER = Logging.getLogger(LockFileReaderWriter.class);
     private static final String LIMITATIONS_DOC_LINK = " " + new DocumentationRegistry().getDocumentationRecommendationFor("information on limitations", "dependency_locking", "locking_limitations");
-    private static final String FORMATTING_DOC_LINK = " " + new DocumentationRegistry().getDocumentationRecommendationFor("information on formatting", "dependency_locking", "lock_state_location_and_format");
+    static final String FORMATTING_DOC_LINK = "Verify the lockfile content. " + new DocumentationRegistry().getDocumentationRecommendationFor("information on lock file format", "dependency_locking", "lock_state_location_and_format");
 
     static final String UNIQUE_LOCKFILE_NAME = "gradle.lockfile";
     static final String FILE_SUFFIX = ".lockfile";
@@ -179,8 +179,7 @@ public class LockFileReaderWriter {
     private void parseLine(String line, Map<String, List<String>> result) {
         String[] split = line.split("=");
         if (split.length != 2) {
-            throw new InvalidLockFileException("lock file specified in '" + getUniqueLockfilePath().toString() + "'. Line: " + line +
-                FORMATTING_DOC_LINK, null);
+            throw new InvalidLockFileException("lock file specified in '" + getUniqueLockfilePath().toString() + "'. Line: '" + line + "'", FORMATTING_DOC_LINK);
         }
         String[] configurations = split[1].split(",");
         for (String configuration : configurations) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/locking/LockOutOfDateException.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/locking/LockOutOfDateException.java
@@ -16,9 +16,7 @@
 
 package org.gradle.internal.locking;
 
-import com.google.common.collect.ImmutableList;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.GraphValidationException;
-import org.gradle.internal.logging.text.TreeFormatter;
 
 import java.util.List;
 
@@ -28,25 +26,9 @@ public class LockOutOfDateException extends GraphValidationException {
 
     private final List<String> errors;
 
-    public static LockOutOfDateException createLockOutOfDateException(String configurationName, Iterable<String> errors) {
-        TreeFormatter treeFormatter = new TreeFormatter();
-        treeFormatter.node("Dependency lock state for configuration '" + configurationName + "' is out of date");
-        treeFormatter.startChildren();
-        for (String error : errors) {
-            treeFormatter.node(error);
-        }
-        treeFormatter.endChildren();
-        return new LockOutOfDateException(treeFormatter.toString(), ImmutableList.copyOf(errors));
-    }
-
     public LockOutOfDateException(String message) {
         super(message);
         this.errors = emptyList();
-    }
-
-    private LockOutOfDateException(String message, List<String> errors) {
-        super(message);
-        this.errors = errors;
     }
 
     public List<String> getErrors() {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/locking/MissingLockStateException.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/locking/MissingLockStateException.java
@@ -16,9 +16,26 @@
 
 package org.gradle.internal.locking;
 
-public class MissingLockStateException extends RuntimeException {
+import com.google.common.collect.ImmutableList;
+import org.gradle.api.internal.DocumentationRegistry;
+import org.gradle.internal.exceptions.ResolutionProvider;
+
+import java.util.List;
+
+public class MissingLockStateException extends RuntimeException implements ResolutionProvider {
+
+    private static final List<String> RESOLUTIONS;
+    static {
+        RESOLUTIONS = ImmutableList.of(
+            "To create the lock state, run a task that will resolve that configuration and add '--write-locks' to the command line.",
+            new DocumentationRegistry().getDocumentationRecommendationFor("information on generating lock state", "dependency_locking", "generating_and_updating_dependency_locks"));
+    }
     public MissingLockStateException(String configurationName) {
-        super("Locking strict mode: Configuration '" + configurationName + "' is locked but does not have lock state. " +
-        "To create the lock state, run a task that will resolve that configuration and add --write-locks");
+        super("Locking strict mode: Configuration '" + configurationName + "' is locked but does not have lock state.");
+    }
+
+    @Override
+    public List<String> getResolutions() {
+        return RESOLUTIONS;
     }
 }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingProviderTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingProviderTest.groovy
@@ -34,6 +34,7 @@ import org.gradle.internal.component.external.model.DefaultModuleComponentIdenti
 import org.gradle.internal.resource.local.FileResourceListener
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.util.GradleVersion
 import org.gradle.util.Path
 import org.junit.Rule
 import spock.lang.Specification
@@ -222,7 +223,11 @@ empty=
         then:
         def ex = thrown(MissingLockStateException)
         1 * context.identityPath('conf') >> Path.path(':conf')
-        ex.message == 'Locking strict mode: Configuration \':conf\' is locked but does not have lock state. To create the lock state, run a task that will resolve that configuration and add --write-locks'
+        ex.message == 'Locking strict mode: Configuration \':conf\' is locked but does not have lock state.'
+        ex.resolutions == ["To create the lock state, run a task that will resolve that configuration and add '--write-locks' to the command line.",
+                            "For more information on generating lock state, please refer to https://docs.gradle.org/${GradleVersion.current().version}/userguide/dependency_locking.html#generating_and_updating_dependency_locks in the Gradle documentation."]
+
+        where:
 
         where:
         unique << [true, false]

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/locking/LockFileReaderWriterTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/locking/LockFileReaderWriterTest.groovy
@@ -159,7 +159,8 @@ empty=d
 
         then:
         def ex = thrown(InvalidLockFileException)
-        ex.message == "Invalid lock state for lock file specified in '${lockFile.path}'. Line: <<<<<<< HEAD For more information on formatting, please refer to https://docs.gradle.org/${GradleVersion.current().version}/userguide/dependency_locking.html#lock_state_location_and_format in the Gradle documentation."
+        ex.message == "Invalid lock state for lock file specified in '${lockFile.path}'. Line: '<<<<<<< HEAD'"
+        ex.resolutions == ["Verify the lockfile content. For more information on lock file format, please refer to https://docs.gradle.org/${GradleVersion.current().version}/userguide/dependency_locking.html#lock_state_location_and_format in the Gradle documentation."]
     }
 
     def 'reads a unique lock file from a custom location'() {
@@ -228,7 +229,7 @@ empty=d
         then:
         result == [a: ['bar', 'foo'], b: ['foo'], c: ['bar', 'foo'], d: []]
     }
-    
+
     def 'reads an invalid unique lock file with prefix'() {
         given:
         context.isScript() >> true
@@ -248,7 +249,8 @@ empty=d
 
         then:
         def ex = thrown(InvalidLockFileException)
-        ex.message == "Invalid lock state for lock file specified in '${lockFile.path}'. Line: <<<<<<< HEAD For more information on formatting, please refer to https://docs.gradle.org/${GradleVersion.current().version}/userguide/dependency_locking.html#lock_state_location_and_format in the Gradle documentation."
+        ex.message == "Invalid lock state for lock file specified in '${lockFile.path}'. Line: '<<<<<<< HEAD'"
+        ex.resolutions == ["Verify the lockfile content. For more information on lock file format, please refer to https://docs.gradle.org/${GradleVersion.current().version}/userguide/dependency_locking.html#lock_state_location_and_format in the Gradle documentation."]
     }
 
     def 'fails to read a unique lockfile if root could not be determined'() {


### PR DESCRIPTION
By using `ResolutionProvider`, advice and documentation link properly appear in the
Try section on the console output.

~~Still plan to add a release not entry, in parallel of CI confirming I did not break anything.~~ Release note added

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
