### PR TITLE
Adopt ValueState in DefaultConfigurableFileCollection

### DIFF
--- a/platforms/core-configuration/file-collections/src/integTest/groovy/org/gradle/api/file/FileCollectionLifecycleIntegrationTest.groovy
+++ b/platforms/core-configuration/file-collections/src/integTest/groovy/org/gradle/api/file/FileCollectionLifecycleIntegrationTest.groovy
@@ -140,7 +140,7 @@ class FileCollectionLifecycleIntegrationTest extends AbstractIntegrationSpec imp
         fails('broken')
 
         then:
-        failure.assertHasCause("The value for this file collection is final and cannot be changed.")
+        failure.assertHasCause("The value for this file collection is final and cannot be changed any further.")
     }
 
     def "can disallow changes to file collection without finalizing value"() {
@@ -165,7 +165,7 @@ class FileCollectionLifecycleIntegrationTest extends AbstractIntegrationSpec imp
         fails('broken')
 
         then:
-        failure.assertHasCause("The value for this file collection cannot be changed.")
+        failure.assertHasCause("The value for this file collection cannot be changed any further.")
     }
 
     def "can write but cannot read strict project file collection instance before project configuration completes"() {
@@ -233,11 +233,11 @@ class FileCollectionLifecycleIntegrationTest extends AbstractIntegrationSpec imp
         run("show")
 
         then:
-        outputContains("get files failed with: Cannot query the value for this file collection because configuration of root project 'broken' has not completed yet.")
-        outputContains("get elements failed with: Cannot query the value for this file collection because configuration of root project 'broken' has not completed yet.")
-        outputContains("get files in afterEvaluate failed with: Cannot query the value for this file collection because configuration of root project 'broken' has not completed yet.")
-        outputContains("get elements in afterEvaluate failed with: Cannot query the value for this file collection because configuration of root project 'broken' has not completed yet.")
-        outputContains("set after read failed with: The value for this file collection is final and cannot be changed.")
+        outputContains("get files failed with: Cannot query the value of this file collection because configuration of root project 'broken' has not completed yet.")
+        outputContains("get elements failed with: Cannot query the value of this file collection because configuration of root project 'broken' has not completed yet.")
+        outputContains("get files in afterEvaluate failed with: Cannot query the value of this file collection because configuration of root project 'broken' has not completed yet.")
+        outputContains("get elements in afterEvaluate failed with: Cannot query the value of this file collection because configuration of root project 'broken' has not completed yet.")
+        outputContains("set after read failed with: The value for this file collection is final and cannot be changed any further.")
         output.count("value = [${file('some-file-2')}]") == 2
         output.count("elements = [${file('some-file-2')}]") == 2
     }
@@ -274,7 +274,7 @@ class FileCollectionLifecycleIntegrationTest extends AbstractIntegrationSpec imp
         run("show")
 
         then:
-        outputContains("set failed with: The value for this file collection is final and cannot be changed.")
+        outputContains("set failed with: The value for this file collection is final and cannot be changed any further.")
         output.count("value = [${file('some-file')}]") == 2
     }
 
@@ -313,7 +313,7 @@ class FileCollectionLifecycleIntegrationTest extends AbstractIntegrationSpec imp
         run("show")
 
         then:
-        outputContains("finalize failed with: Cannot finalize the value for this file collection because configuration of root project 'broken' has not completed yet.")
+        outputContains("finalize failed with: Cannot finalize the value of this file collection because configuration of root project 'broken' has not completed yet.")
         output.count("value = [${file('some-file')}]") == 2
     }
 

--- a/platforms/core-configuration/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollectionSpec.groovy
+++ b/platforms/core-configuration/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollectionSpec.groovy
@@ -598,21 +598,21 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
 
         then:
         def e = thrown(IllegalStateException)
-        e.message == 'The value for <display> is final and cannot be changed.'
+        e.message == 'The value for <display> is final and cannot be changed any further.'
 
         when:
         collection.setFrom()
 
         then:
         def e2 = thrown(IllegalStateException)
-        e2.message == 'The value for <display> is final and cannot be changed.'
+        e2.message == 'The value for <display> is final and cannot be changed any further.'
 
         when:
         collection.setFrom(['some', 'more'])
 
         then:
         def e3 = thrown(IllegalStateException)
-        e3.message == 'The value for <display> is final and cannot be changed.'
+        e3.message == 'The value for <display> is final and cannot be changed any further.'
     }
 
     def "cannot mutate from set when finalized"() {
@@ -627,28 +627,28 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
 
         then:
         def e = thrown(IllegalStateException)
-        e.message == 'The value for <display> is final and cannot be changed.'
+        e.message == 'The value for <display> is final and cannot be changed any further.'
 
         when:
         collection.from.add('b')
 
         then:
         def e2 = thrown(IllegalStateException)
-        e2.message == 'The value for <display> is final and cannot be changed.'
+        e2.message == 'The value for <display> is final and cannot be changed any further.'
 
         when:
         collection.from.remove('a')
 
         then:
         def e3 = thrown(IllegalStateException)
-        e3.message == 'The value for <display> is final and cannot be changed.'
+        e3.message == 'The value for <display> is final and cannot be changed any further.'
 
         when:
         collection.from.iterator().remove()
 
         then:
         def e4 = thrown(IllegalStateException)
-        e4.message == 'The value for <display> is final and cannot be changed.'
+        e4.message == 'The value for <display> is final and cannot be changed any further.'
     }
 
     def "cannot add paths when finalized"() {
@@ -663,7 +663,7 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
 
         then:
         def e = thrown(IllegalStateException)
-        e.message == 'The value for <display> is final and cannot be changed.'
+        e.message == 'The value for <display> is final and cannot be changed any further.'
     }
 
     def "resolves path to file when queried after implicitly finalized"() {
@@ -1112,14 +1112,14 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
 
         then:
         def e = thrown(IllegalStateException)
-        e.message == 'The value for <display> is final and cannot be changed.'
+        e.message == 'The value for <display> is final and cannot be changed any further.'
 
         when:
         collection.setFrom(['some', 'more'])
 
         then:
         def e2 = thrown(IllegalStateException)
-        e2.message == 'The value for <display> is final and cannot be changed.'
+        e2.message == 'The value for <display> is final and cannot be changed any further.'
     }
 
     def "cannot add paths when queried after finalize on read"() {
@@ -1135,14 +1135,14 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
 
         then:
         def e = thrown(IllegalStateException)
-        e.message == 'The value for <display> is final and cannot be changed.'
+        e.message == 'The value for <display> is final and cannot be changed any further.'
 
         when:
         collection.from()
 
         then:
         def e2 = thrown(IllegalStateException)
-        e2.message == 'The value for <display> is final and cannot be changed.'
+        e2.message == 'The value for <display> is final and cannot be changed any further.'
     }
 
     def "cannot mutate from set when queried after finalize on read"() {
@@ -1158,28 +1158,28 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
 
         then:
         def e = thrown(IllegalStateException)
-        e.message == 'The value for <display> is final and cannot be changed.'
+        e.message == 'The value for <display> is final and cannot be changed any further.'
 
         when:
         collection.from.add('b')
 
         then:
         def e2 = thrown(IllegalStateException)
-        e2.message == 'The value for <display> is final and cannot be changed.'
+        e2.message == 'The value for <display> is final and cannot be changed any further.'
 
         when:
         collection.from.remove('a')
 
         then:
         def e3 = thrown(IllegalStateException)
-        e3.message == 'The value for <display> is final and cannot be changed.'
+        e3.message == 'The value for <display> is final and cannot be changed any further.'
 
         when:
         collection.from.iterator().remove()
 
         then:
         def e4 = thrown(IllegalStateException)
-        e4.message == 'The value for <display> is final and cannot be changed.'
+        e4.message == 'The value for <display> is final and cannot be changed any further.'
     }
 
     def "cannot specify paths when changes disallowed"() {
@@ -1193,14 +1193,14 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
 
         then:
         def e = thrown(IllegalStateException)
-        e.message == 'The value for <display> cannot be changed.'
+        e.message == 'The value for <display> cannot be changed any further.'
 
         when:
         collection.setFrom(['some', 'more'])
 
         then:
         def e2 = thrown(IllegalStateException)
-        e2.message == 'The value for <display> cannot be changed.'
+        e2.message == 'The value for <display> cannot be changed any further.'
     }
 
     def "cannot mutate from set when changes disallowed"() {
@@ -1214,28 +1214,28 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
 
         then:
         def e = thrown(IllegalStateException)
-        e.message == 'The value for <display> cannot be changed.'
+        e.message == 'The value for <display> cannot be changed any further.'
 
         when:
         collection.from.add('b')
 
         then:
         def e2 = thrown(IllegalStateException)
-        e2.message == 'The value for <display> cannot be changed.'
+        e2.message == 'The value for <display> cannot be changed any further.'
 
         when:
         collection.from.remove('a')
 
         then:
         def e3 = thrown(IllegalStateException)
-        e3.message == 'The value for <display> cannot be changed.'
+        e3.message == 'The value for <display> cannot be changed any further.'
 
         when:
         collection.from.iterator().remove()
 
         then:
         def e4 = thrown(IllegalStateException)
-        e4.message == 'The value for <display> cannot be changed.'
+        e4.message == 'The value for <display> cannot be changed any further.'
     }
 
     def "cannot add paths when changes disallowed"() {
@@ -1249,7 +1249,7 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
 
         then:
         def e = thrown(IllegalStateException)
-        e.message == 'The value for <display> cannot be changed.'
+        e.message == 'The value for <display> cannot be changed any further.'
     }
 
     def "cannot specify paths when changes disallowed and implicitly finalized"() {
@@ -1264,14 +1264,14 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
 
         then:
         def e = thrown(IllegalStateException)
-        e.message == 'The value for <display> cannot be changed.'
+        e.message == 'The value for <display> cannot be changed any further.'
 
         when:
         collection.setFrom(['some', 'more'])
 
         then:
         def e2 = thrown(IllegalStateException)
-        e2.message == 'The value for <display> cannot be changed.'
+        e2.message == 'The value for <display> cannot be changed any further.'
     }
 
     def "resolves closure to files when changes disallowed"() {
@@ -1395,7 +1395,7 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
 
         then:
         def e = thrown(IllegalStateException)
-        e.message == "Cannot query the value for <display> because <reason>."
+        e.message == "Cannot query the value of <display> because <reason>."
 
         and:
         1 * host.beforeRead(null) >> "<reason>"
@@ -1430,7 +1430,7 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
 
         then:
         def e = thrown(IllegalStateException)
-        e.message == "Cannot query the value for <display> because <reason>."
+        e.message == "Cannot query the value of <display> because <reason>."
 
         and:
         1 * host.beforeRead(null) >> "<reason>"
@@ -1459,7 +1459,7 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
 
         then:
         def e = thrown(IllegalStateException)
-        e.message == "Cannot finalize the value for <display> because <reason>."
+        e.message == "Cannot finalize the value of <display> because <reason>."
 
         and:
         1 * host.beforeRead(null) >> "<reason>"


### PR DESCRIPTION
Now that the value management behavior originally in `AbstractProperty` is available as a top-level class (via #27155), leverage that to replace `ConfigurableFileCollection`'s  own custom implementation.  

This will be useful so we can later support conventions in CFCs.
