### PR TITLE
Fix cache relocatability in GenerateKotlinExtensionsForGradleApiSources

### DIFF
--- a/build-logic/kotlin-dsl/src/main/kotlin/gradlebuild/kotlindsl/generator/tasks/GenerateKotlinExtensionsForGradleApi.kt
+++ b/build-logic/kotlin-dsl/src/main/kotlin/gradlebuild/kotlindsl/generator/tasks/GenerateKotlinExtensionsForGradleApi.kt
@@ -55,7 +55,7 @@ abstract class GenerateKotlinExtensionsForGradleApi : DefaultTask() {
 
     @get:InputFiles
     @get:IgnoreEmptyDirectories
-    @get:PathSensitive(PathSensitivity.ABSOLUTE)
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val sources: ConfigurableFileCollection
 
     @get:OutputDirectory


### PR DESCRIPTION
### Context
This [commit](https://github.com/gradle/gradle/commit/8a34f3f47990b67d859b0eeaff5525e47ef2435d) (_Add @since to generated Kotlin extensions_) and more specifically [this line](https://github.com/gradle/gradle/commit/8a34f3f47990b67d859b0eeaff5525e47ef2435d#diff-8dcf6e6e4756b4683d3cadbab58abc54259cb5fb99d88c5221b0426f8500c28eR58) makes the `gradleApiKotlinExtensions` task cache non relocatable.

Here is the screenshot demonstrating the cost in such scenario
![Screenshot 2023-11-27 at 4 14 45 PM](https://github.com/gradle/gradle/assets/10243934/dc884e88-e065-45ad-91d4-b10ba558e24d)

### Fix
Using `PathSensitive.RELATIVE` fixes the cache misses, but I could be missing @eskatos why this was explicitly set to `ABSOLUTE` in the first place.