### PR TITLE
Add 'CaptureStateBeforeExecutionStep$Operation$Details' class to removed-types.txt

### DIFF
--- a/subprojects/core/src/main/resources/org/gradle/initialization/removed-types.txt
+++ b/subprojects/core/src/main/resources/org/gradle/initialization/removed-types.txt
@@ -24,3 +24,4 @@ org.gradle.api.artifacts.transform.ArtifactTransformException
 org.gradle.api.artifacts.transform.VariantTransform
 org.gradle.api.tasks.incremental.IncrementalTaskInputs
 org.gradle.workers.WorkerConfiguration
+org.gradle.internal.execution.steps.CaptureStateBeforeExecutionStep$Operation$Details

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -35,6 +35,7 @@ import org.gradle.test.fixtures.dsl.GradleDsl
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.internal.DefaultGradleRunner
+import org.gradle.util.internal.TextUtil
 import spock.lang.Specification
 import spock.lang.TempDir
 
@@ -218,8 +219,9 @@ abstract class AbstractSmokeTest extends Specification {
     @TempDir
     File testProjectDir
     File buildFile
-
     File settingsFile
+    @TempDir
+    File buildCacheDir
 
     def setup() {
         buildFile = new File(testProjectDir, defaultBuildFileName)
@@ -355,6 +357,16 @@ abstract class AbstractSmokeTest extends Specification {
             text = text.replaceAll("\\\$${var}".toString(), value)
         }
         file.text = text
+    }
+
+    protected void setupLocalBuildCache() {
+        settingsFile << """
+            buildCache {
+                local {
+                    directory = new File("${TextUtil.normaliseFileSeparators(buildCacheDir.absolutePath)}")
+                }
+            }
+        """
     }
 
     protected static String jcenterRepository(GradleDsl dsl = GROOVY) {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
@@ -23,18 +23,13 @@ import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.util.GradleVersion
-import org.gradle.util.internal.TextUtil
 import org.gradle.util.internal.VersionNumber
-import spock.lang.TempDir
 
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.ConcurrentHashMap
 
 // https://plugins.gradle.org/plugin/com.gradle.enterprise
 class BuildScanPluginSmokeTest extends AbstractSmokeTest {
-
-    @TempDir
-    File buildCacheDir
 
     enum CI {
         TEAM_CITY(
@@ -369,16 +364,6 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
 
         setupLocalBuildCache()
         setupJavaProject()
-    }
-
-    private void setupLocalBuildCache() {
-        settingsFile << """
-            buildCache {
-                local {
-                    directory = new File("${TextUtil.normaliseFileSeparators(buildCacheDir.absolutePath)}")
-                }
-            }
-        """
     }
 
     private setupJavaProject() {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
@@ -293,6 +293,7 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
             systemProp.${ci.propPrefix}.gradle-enterprise.url=http://localhost:5086
         """.stripIndent()
 
+        setupLocalBuildCache()
         setupJavaProject()
         if (doesNotBundleTestRetryPluginOrSupportsSafeMode(versionNumber)) {
             new TestFile(buildFile).with {
@@ -366,6 +367,11 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
             """
         }
 
+        setupLocalBuildCache()
+        setupJavaProject()
+    }
+
+    private void setupLocalBuildCache() {
         settingsFile << """
             buildCache {
                 local {
@@ -373,8 +379,6 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
                 }
             }
         """
-
-        setupJavaProject()
     }
 
     private setupJavaProject() {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
@@ -23,13 +23,18 @@ import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.util.GradleVersion
+import org.gradle.util.internal.TextUtil
 import org.gradle.util.internal.VersionNumber
+import spock.lang.TempDir
 
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.ConcurrentHashMap
 
 // https://plugins.gradle.org/plugin/com.gradle.enterprise
 class BuildScanPluginSmokeTest extends AbstractSmokeTest {
+
+    @TempDir
+    File buildCacheDir
 
     enum CI {
         TEAM_CITY(
@@ -360,6 +365,14 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
                 }
             """
         }
+
+        settingsFile << """
+            buildCache {
+                local {
+                    directory = new File("${TextUtil.normaliseFileSeparators(buildCacheDir.absolutePath)}")
+                }
+            }
+        """
 
         setupJavaProject()
     }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
@@ -329,7 +329,8 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
     }
 
     SmokeTestGradleRunner scanRunner(String... args) {
-        runner("build", "-Dscan.dump", *args).forwardOutput()
+        // Run with --build-cache to test also build-cache events
+        runner("build", "-Dscan.dump", "--build-cache", *args).forwardOutput()
     }
 
     void usePluginVersion(String version) {


### PR DESCRIPTION
Develocity plugin references that class in versions `3.13` and up, and by removing that class we broke the plugin. This fixes it.
Also, now we test Develocity plugin with `--build-cache` that reproduces the issue.