### PR TITLE
Fix typos in JavaDoc

### DIFF
--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/BasicProblemBuilder.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/BasicProblemBuilder.java
@@ -29,7 +29,7 @@ import org.gradle.api.Incubating;
  *          .label("test problem")
  *          .undocumented()
  *          .noLocation()
- *          .cotegory("problemCategory")
+ *          .category("problemCategory")
  *          .severity(Severity.ERROR)
  *          .details("this is a test")
  *  }</pre>

--- a/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/ReportableProblemBuilder.java
+++ b/platforms/ide/problems-api/src/main/java/org/gradle/api/problems/ReportableProblemBuilder.java
@@ -29,7 +29,7 @@ import org.gradle.api.Incubating;
  *          .label("test problem")
  *          .undocumented()
  *          .noLocation()
- *          .cotegory("problemCategory")
+ *          .category("problemCategory")
  *          .severity(Severity.ERROR)
  *          .details("this is a test")
  *  }</pre>


### PR DESCRIPTION
This PR fixes a couple of similar typos in JavaDoc as in issue https://github.com/gradle/gradle/issues/27136