### PR TITLE
Make plugin version optional in version catalogs

### DIFF
--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -224,6 +224,25 @@ Previously, extensions registered in `Plugin<Settings>` weren't available in `se
 Now, type-safe accessors for these extensions are generated.
 
 This fixes https://github.com/gradle/gradle/issues/11210.
+
+#### Allow version catalog plugin aliases without a version
+
+Previously, a version catalog plugin alias could be defined without a version, but attempting to use it would result in an exception.
+It is now explicitly allowed to have a plugin alias with no version, and no exception will be thrown when using it:
+
+```toml
+# In libs.versions.toml
+[plugins]
+myPlugin = { id = "my.plugin.id" }
+```
+
+```kotlin
+// In build.gradle(.kts)
+plugins {
+    alias(libs.plugins.myPlugin)
+}
+```
+
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ADD RELEASE FEATURES ABOVE
 ==========================================================

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/management/internal/DefaultPluginManagementSpec.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/management/internal/DefaultPluginManagementSpec.java
@@ -20,14 +20,11 @@ import org.gradle.api.Action;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.initialization.ConfigurableIncludedPluginBuild;
 import org.gradle.api.internal.file.FileResolver;
-import org.gradle.api.provider.Provider;
-import org.gradle.api.provider.ProviderConvertible;
 import org.gradle.initialization.IncludedBuildSpec;
 import org.gradle.internal.Actions;
 import org.gradle.internal.build.BuildIncluder;
 import org.gradle.plugin.management.PluginResolutionStrategy;
 import org.gradle.plugin.use.PluginDependenciesSpec;
-import org.gradle.plugin.use.PluginDependency;
 import org.gradle.plugin.use.PluginDependencySpec;
 import org.gradle.plugin.use.PluginId;
 import org.gradle.plugin.use.internal.DefaultPluginId;
@@ -107,17 +104,6 @@ public class DefaultPluginManagementSpec implements PluginManagementSpecInternal
         @Override
         public PluginDependencySpec id(String id) {
             return new PluginDependencySpecImpl(DefaultPluginId.of(id));
-        }
-
-        @Override
-        public PluginDependencySpec alias(Provider<PluginDependency> notation) {
-            PluginDependency pluginDependency = notation.get();
-            return id(pluginDependency.getPluginId()).version(pluginDependency.getVersion().getRequiredVersion());
-        }
-
-        @Override
-        public PluginDependencySpec alias(ProviderConvertible<PluginDependency> notation) {
-            return alias(notation.asProvider());
         }
     }
 

--- a/platforms/software/plugins-version-catalog/src/integTest/groovy/org/gradle/catalog/VersionCatalogPluginApplicationIntegrationTest.groovy
+++ b/platforms/software/plugins-version-catalog/src/integTest/groovy/org/gradle/catalog/VersionCatalogPluginApplicationIntegrationTest.groovy
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.catalog
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.test.fixtures.plugin.PluginBuilder
+
+class VersionCatalogPluginApplicationIntegrationTest extends AbstractIntegrationSpec {
+    def setup() {
+        def pluginBuilder = new PluginBuilder(testDirectory.file("plugin"))
+
+        def message = "from plugin"
+        def taskName = "pluginTask"
+
+        pluginBuilder.addPluginWithPrintlnTask(taskName, message, "org.example.plugin")
+        pluginBuilder.publishAs("org.example.plugin:plugin:1.0.0", mavenRepo, executer)
+    }
+
+    def "can apply a plugin by id and version using version catalog"() {
+        given:
+        versionCatalogFile """
+        [plugins]
+        orgExample = "org.example.plugin:1.0.0"
+        """
+        settingsFile """
+            pluginManagement {
+                repositories {
+                    ${mavenTestRepository()}
+                }
+            }
+            rootProject.name = 'test'
+        """
+        buildFile """
+            plugins {
+                alias(libs.plugins.orgExample)
+            }
+        """
+
+        when:
+        succeeds(":pluginTask")
+
+        then:
+        output.contains("from plugin")
+    }
+
+    def "can apply a plugin by id only using version catalog"() {
+        given:
+        versionCatalogFile """
+        [plugins]
+        javaPlugin = { id = "java-library" }
+        """
+        settingsFile """
+            rootProject.name = 'test'
+        """
+        buildFile """
+            plugins {
+                alias(libs.plugins.javaPlugin)
+            }
+        """
+
+        expect:
+        succeeds(":compileJava")
+    }
+
+    def "can apply a plugin in both root and sub- project using id and version using version catalog"() {
+        given:
+        versionCatalogFile """
+        [plugins]
+        orgExample = "org.example.plugin:1.0.0"
+        """
+        settingsFile """
+            pluginManagement {
+                repositories {
+                    ${mavenTestRepository()}
+                }
+            }
+            rootProject.name = 'test'
+
+            include 'subproject'
+        """
+        buildFile """
+            plugins {
+                alias(libs.plugins.orgExample)
+            }
+        """
+        file("subproject/build.gradle") << """
+            plugins {
+                alias(libs.plugins.orgExample)
+            }
+        """
+
+        when:
+        succeeds(":pluginTask")
+
+        then:
+        output.contains("from plugin")
+
+        when:
+        succeeds(":subproject:pluginTask")
+
+        then:
+        output.contains("from plugin")
+    }
+
+    def "can apply a plugin in both root and sub- project using id only using version catalog"() {
+        given:
+        versionCatalogFile """
+        [plugins]
+        javaPlugin = { id = "java-library" }
+        """
+        settingsFile """
+            rootProject.name = 'test'
+
+            include 'subproject'
+        """
+        buildFile """
+            plugins {
+                alias(libs.plugins.javaPlugin)
+            }
+        """
+        file("subproject/build.gradle") << """
+            plugins {
+                alias(libs.plugins.javaPlugin)
+            }
+        """
+
+        expect:
+        succeeds(":compileJava")
+        succeeds(":subproject:compileJava")
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/plugin/use/internal/PluginRequestCollector.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/use/internal/PluginRequestCollector.java
@@ -18,8 +18,6 @@ package org.gradle.plugin.use.internal;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
-import org.gradle.api.provider.Provider;
-import org.gradle.api.provider.ProviderConvertible;
 import org.gradle.groovy.scripts.ScriptSource;
 import org.gradle.internal.exceptions.LocationAwareException;
 import org.gradle.plugin.internal.InvalidPluginIdException;
@@ -30,7 +28,6 @@ import org.gradle.plugin.management.internal.InvalidPluginRequestException;
 import org.gradle.plugin.management.internal.PluginRequestInternal;
 import org.gradle.plugin.management.internal.PluginRequests;
 import org.gradle.plugin.use.PluginDependenciesSpec;
-import org.gradle.plugin.use.PluginDependency;
 import org.gradle.plugin.use.PluginDependencySpec;
 import org.gradle.plugin.use.PluginId;
 import org.gradle.util.internal.CollectionUtils;
@@ -109,18 +106,6 @@ public class PluginRequestCollector {
             PluginDependencySpecImpl spec = new PluginDependencySpecImpl(id, requestLineNumber);
             specs.add(spec);
             return spec;
-        }
-
-        @Override
-        public PluginDependencySpec alias(Provider<PluginDependency> notation) {
-            PluginDependency pluginDependency = notation.get();
-            // For now we use the _required version_ when a plugin comes from a catalog
-            return id(pluginDependency.getPluginId()).version(pluginDependency.getVersion().getRequiredVersion());
-        }
-
-        @Override
-        public PluginDependencySpec alias(ProviderConvertible<PluginDependency> notation) {
-            return alias(notation.asProvider());
         }
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/catalog/parser/TomlCatalogFileParserTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/catalog/parser/TomlCatalogFileParserTest.groovy
@@ -227,6 +227,7 @@ class TomlCatalogFileParserTest extends Specification implements VersionCatalogE
 
         then:
         hasPlugin('simple', 'org.example', '1.0')
+        hasPlugin('without.version', 'org.example', '')
         hasPlugin('with.id', 'org.example', '1.1')
         hasPlugin('with.ref') {
             withId 'org.example'

--- a/subprojects/core/src/test/resources/org/gradle/api/internal/catalog/parser/plugin-notations.toml
+++ b/subprojects/core/src/test/resources/org/gradle/api/internal/catalog/parser/plugin-notations.toml
@@ -1,5 +1,6 @@
 [plugins]
 simple = "org.example:1.0"
+without-version = { id = "org.example" }
 with-id = { id = "org.example", version = "1.1"}
 with-ref = { id = "org.example", version.ref = "ref"}
 with-rich1 = { id = "org.example", version = { prefer = "1.0" } }


### PR DESCRIPTION
In some cases, one can apply a plugin in `plugin { ... }` block without specifying a version.
However, at the moment it's not possible to leave version unspecified in a version catalog and then apply via `alias`. Under the hood `alias` calls `version` unconditionally and then fails on null or empty value. This commit prevents such a failure.

Use case for not specifying plugin versions in version catalog:
* a plugin may be applied from an included build (incl. `buildSrc`)
* plugin version may be pinned via settings, a settings plugin or an init script via `pluginManagement`
* a plugin may be discovered in build script classpath
* other situations and mechanisms unknown to me

Even if version is not specified, version catalog can be used as a bill of materials or a reference list. Besides, generated DSL accessors work as a typo prevention mechanism.

<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
