### PR TITLE
Ignore test until #27213 is fixed

### DIFF
--- a/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorProblemsApiIntegrationTest.groovy
+++ b/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorProblemsApiIntegrationTest.groovy
@@ -18,7 +18,9 @@ package org.gradle.workers.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.workers.fixtures.WorkerExecutorFixture
+import spock.lang.Ignore
 
+@Ignore("https://github.com/gradle/gradle/issues/27213")
 class WorkerExecutorProblemsApiIntegrationTest extends AbstractIntegrationSpec {
 
     def setup() {


### PR DESCRIPTION
Fix to relieve CI from our flaky tests, which are going to fixed by #27213