### PR TITLE
Add aspirational test for parametrized model fetching with IP

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/fixtures/SomeToolingModel.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/fixtures/SomeToolingModel.groovy
@@ -23,6 +23,11 @@ interface SomeToolingModel {
     String getMessage()
 }
 
+interface SomeToolingModelParameter {
+    String getMessagePrefix()
+    void setMessagePrefix(String value)
+}
+
 class SomeToolingModelBuildAction implements BuildAction<SomeToolingModel> {
     @Override
     SomeToolingModel execute(BuildController controller) {

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/FetchParameterizedCustomModelForEachProject.java
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/FetchParameterizedCustomModelForEachProject.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache.isolated;
+
+import org.gradle.api.Action;
+import org.gradle.configurationcache.fixtures.SomeToolingModel;
+import org.gradle.configurationcache.fixtures.SomeToolingModelParameter;
+import org.gradle.tooling.BuildAction;
+import org.gradle.tooling.BuildController;
+import org.gradle.tooling.model.gradle.BasicGradleProject;
+import org.gradle.tooling.model.gradle.GradleBuild;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class FetchParameterizedCustomModelForEachProject implements BuildAction<Map<String, List<SomeToolingModel>>> {
+
+    private final List<String> parameters;
+
+    public FetchParameterizedCustomModelForEachProject(List<String> parameters) {
+        this.parameters = parameters;
+    }
+
+    @Override
+    public Map<String, List<SomeToolingModel>> execute(BuildController controller) {
+        GradleBuild buildModel = controller.getBuildModel();
+        Map<String, List<SomeToolingModel>> result = new LinkedHashMap<>();
+        for (String parameter : parameters) {
+            Map<String, SomeToolingModel> model = fetchSomeModelForAllProjects(controller, buildModel, parameter);
+            for (Map.Entry<String, SomeToolingModel> entry : model.entrySet()) {
+                result.computeIfAbsent(entry.getKey(), k -> new ArrayList<>()).add(entry.getValue());
+            }
+        }
+
+        return result;
+    }
+
+    private static Map<String, SomeToolingModel> fetchSomeModelForAllProjects(BuildController controller, GradleBuild buildModel, final String parameterValue) {
+        Map<String, SomeToolingModel> result = new LinkedHashMap<>();
+        for (BasicGradleProject project : buildModel.getProjects()) {
+            SomeToolingModel model = fetchSomeModel(controller, project, parameterValue);
+            if (model != null) {
+                result.put(project.getBuildTreePath(), model);
+            }
+        }
+        return result;
+    }
+
+    @SuppressWarnings({"Convert2Lambda", "NullableProblems"})
+    private static SomeToolingModel fetchSomeModel(BuildController controller, BasicGradleProject project, String parameter) {
+        return controller.findModel(project, SomeToolingModel.class, SomeToolingModelParameter.class, new Action<SomeToolingModelParameter>() {
+            @Override
+            public void execute(SomeToolingModelParameter customParameter) {
+                customParameter.setMessagePrefix(parameter);
+            }
+        });
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiParametrizedModelQueryIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiParametrizedModelQueryIntegrationTest.groovy
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache.isolated
+
+import org.gradle.util.internal.ToBeImplemented
+
+class IsolatedProjectsToolingApiParametrizedModelQueryIntegrationTest extends AbstractIsolatedProjectsToolingApiIntegrationTest {
+    def setup() {
+        settingsFile << """
+            rootProject.name = 'root'
+        """
+    }
+
+    @ToBeImplemented
+    def "can query and cache parametrized models in the same build action"() {
+        withParameterizedSomeToolingModelBuilderPluginInChildBuild("buildSrc")
+        buildFile << """
+            plugins.apply(my.MyPlugin)
+            println("configuring build")
+        """
+
+        when:
+        executer.withArguments(ENABLE_CLI)
+        def models = runBuildAction(new FetchParameterizedCustomModelForEachProject(["fetch1", "fetch2"]))
+
+        then:
+        fixture.assertStateStored {
+            buildModelCreated()
+            projectConfigured(":buildSrc")
+            modelsCreated(":")
+        }
+        outputContains("configuring build")
+        outputContains("creating model with parameter='fetch1' for root project 'root'")
+        // TODO: this line should be present when the functionality is fixed
+//        outputContains("creating model with parameter='fetch2' for root project 'root'")
+
+        and:
+        models.keySet() ==~ [":"]
+        models.values().every { it.size() == 2 }
+
+        models[":"][0].message == "fetch1 It works from project :"
+        // TODO: this should be prefixed with `fetch2` when the functionality is fixed
+        models[":"][1].message == "fetch1 It works from project :"
+
+        when:
+        executer.withArguments(ENABLE_CLI)
+        runBuildAction(new FetchParameterizedCustomModelForEachProject(["fetch1", "fetch2"]))
+
+        then:
+        fixture.assertStateLoaded()
+        outputDoesNotContain("configuring build")
+        outputDoesNotContain("creating model")
+    }
+
+}


### PR DESCRIPTION
Current implementation of intermediate model caching for Isolated Projects (`ConfigurationCacheAwareBuildToolingModelController`) **does not take model builder parametrization into account** (`ParameterizedToolingModelBuilder`).

Due to this fetching the same model with different parameters in the same build action leads to false positive cache hits. This effectively means that the cache returns the wrong value.