### PR TITLE
Add TAPI model builder parameter contract to javadocs

### DIFF
--- a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/ToolingParameterProxy.java
+++ b/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/ToolingParameterProxy.java
@@ -41,6 +41,8 @@ public class ToolingParameterProxy implements InvocationHandler {
 
     /**
      * Check if the given interface can be instantiated by this proxy.
+     * <p>
+     * If this validation is modified, also update the javadocs for {@link org.gradle.tooling.provider.model.ParameterizedToolingModelBuilder}.
      */
     static void validateParameter(Class<?> clazz) {
         if (!clazz.isInterface()) {

--- a/subprojects/core-api/src/main/java/org/gradle/tooling/provider/model/ParameterizedToolingModelBuilder.java
+++ b/subprojects/core-api/src/main/java/org/gradle/tooling/provider/model/ParameterizedToolingModelBuilder.java
@@ -21,6 +21,9 @@ import org.gradle.api.Project;
 /**
  * A {@link ToolingModelBuilder} which can be parameterized by the client.
  *
+ * <p>The parameter type {@code T} must be an interface and must follow a contract described in {@link #getParameterType()}.
+ * </p>
+ *
  * <p>The parameter type {@code T} does not need to implement the interface defined in the client side, but it does need to have the same structure.
  * The Tooling API will create a view from the client side parameter type to the one defined in this model builder, and deal automatically with
  * missing methods in order to allow evolution of the models.
@@ -32,13 +35,49 @@ import org.gradle.api.Project;
  * </p>
  *
  * @param <T> The type of parameter used by this model builder.
- * @since 4.4
  * @see ToolingModelBuilder
+ * @since 4.4
  */
 public interface ParameterizedToolingModelBuilder<T> extends ToolingModelBuilder {
+
     /**
      * Returns the expected type of the parameter.
-     * It should be an interface with only getters and setters.
+     * <p>
+     * <b>Contract</b>
+     * <p>
+     * The parameter type must conform to the following rules:
+     * <ul>
+     *     <li>It must be an interface.</li>
+     *     <li>It must contain only getter-like and setter-like methods.</li>
+     *     <li>There must be one getter corresponding to exactly one setter, with matching value types.</li>
+     * </ul>
+     * <p>
+     * For each getter-like method:
+     * <ul>
+     *     <li>The name must start with {@code "get"} or {@code "is"}, followed by an uppercase letter.</li>
+     *     <li>It must have no parameters.</li>
+     *     <li>The return type must not be {@code void}.</li>
+     * </ul>
+     * <p>
+     * For each setter-like method:
+     * <ul>
+     *     <li>The name must start with {@code "set"}, followed by an uppercase letter.</li>
+     *     <li>It must have exactly one parameter.</li>
+     *     <li>The return type must be {@code void}.</li>
+     * </ul>
+     * <p>
+     * <b>Example</b>
+     * <p>
+     * Here is an example of a valid parameter type declaration:
+     * <pre>{@code
+     * public interface MyParameter {
+     *     String getValue();
+     *     void setValue(String value);
+     *
+     *     boolean isFlag();
+     *     void setFlag(boolean value);
+     * }
+     * }</pre>
      *
      * @return The type of the parameter.
      */


### PR DESCRIPTION
This is a javadoc-only PR that adds an explicit contract for the types allowed to be parameters of a `ParameterizedToolingModelBuilder`.

The contract is validated by the parameter proxy class:
https://github.com/gradle/gradle/blob/866060514f01806785b1aef1c029dc402175f41a/platforms/ide/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/ToolingParameterProxy.java#L45