### PR TITLE
Adopt architecture decision records (ADR)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,7 +30,7 @@ subprojects/internal-testing/               @gradle/bt-developer-productivity
 subprojects/precondition-tester/            @gradle/bt-developer-productivity
 
 # Architecture Decision Records
-architecture-standards                      @gradle/bt-architecture-council
+architecture-standards/                     @gradle/bt-architecture-council
 
 # Core automation platform (core/configuration)
 platforms/core-configuration/               @gradle/bt-configuration

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,6 +29,9 @@ subprojects/internal-performance-testing/   @gradle/bt-developer-productivity
 subprojects/internal-testing/               @gradle/bt-developer-productivity
 subprojects/precondition-tester/            @gradle/bt-developer-productivity
 
+# Architecture Decision Records
+architecture-standards                      @gradle/bt-architecture-council
+
 # Core automation platform (core/configuration)
 platforms/core-configuration/               @gradle/bt-configuration
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,8 @@ Your code needs to run on [all versions of Java that Gradle supports](platforms/
 * Be careful when using features introduced in Java 1.7 or later. Some parts of Gradle still need to run on Java 6.
 * Normalize file paths in tests. The `org.gradle.util.internal.TextUtil` class has some useful functions for this purpose.
 
+You can consult the [Architecture Decision Records](architecture-standards) to learn about some of the architectural decisions the team took.
+
 ### Creating commits and writing commit messages
 
 The commit messages that accompany your code changes are an important piece of documentation. Please follow these guidelines when creating commits:

--- a/architecture-standards/0001-use-architectural-decision-records.md
+++ b/architecture-standards/0001-use-architectural-decision-records.md
@@ -4,10 +4,6 @@
 
 2023-12-01
 
-## Decision makers
-
-* Build tool team
-
 ## Context
 
 In a distributed team with many subteams, the best solution to communicate decisions is to use a format accessible by everyone in charge of development.
@@ -43,11 +39,6 @@ The format for ADR in this module should follow this template:
 ## Date
 
 20XY-AB-CD
-
-## Decision makers
-
-* XXX
-* YYY
 
 ## Context
 

--- a/architecture-standards/0001-use-architectural-decision-records.md
+++ b/architecture-standards/0001-use-architectural-decision-records.md
@@ -1,0 +1,87 @@
+# ADR-0001 - Use Architectural Decision Records
+
+## Date
+
+2023-12-01
+
+## Decision makers
+
+* Build tool team
+
+## Context
+
+In a distributed team with many subteams, the best solution to communicate decisions is to use a format accessible by everyone in charge of development.
+
+We use *Specification* and *Discovery* documents stored in Google Drive, but they present some downsides:
+
+* They are not updated after edition and then are hard to follow, especially after decision-making
+* They are not synced with the code
+* Google Docs is not a "code oriented" tool, like asciidoc can be
+* Review in Google Doc is not as simple as a PR code review in GitHub
+
+## Decision
+
+The *Build Tool Team* has decided to use Architectural Decision Records (aka ADR) to track decisions we want to follow.
+
+The main logic with ADRs is to describe (architectural) decisions made:
+
+* To provide best practices and solutions we (as *build tool* team) want to promote.
+* To avoid asking the same thing multiple times during code review.
+* To explain *rejected solutions*, for now and future development, in case of re-visit.
+
+ADRs can be written by any team, like code, it has to be reviewed by any other relevant teams.
+The goal is not to *own*, but to *share* with other teams, to improve the build tool conjointly.
+
+
+### Format
+
+The format for ADR in this module should follow this template:
+
+```markdown
+# ADR-000X - Title
+
+## Date
+
+20XY-AB-CD
+
+## Decision makers
+
+* XXX
+* YYY
+
+## Context
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+## Decision
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
+aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+## Status
+
+[PROPOSED, ACCEPTED, REJECTED, DEPRECATED, REPLACED]
+
+## Consequences
+
+* X
+* Y
+* Z
+```
+
+## Status
+
+PROPOSED
+
+## Consequences
+
+* We start to use Architectural Decision Records
+* We use the proposed template from this ADR
+* We locate `.md` files in the folder `/architecture-standards`
+* We highly encourage usage of ADR to communicate decisions
+* We use links to ADRs in *Specifications*, *Discoveries* and *Pull-Requests* to simplify communication

--- a/architecture-standards/0002-avoid-java-serialization.md
+++ b/architecture-standards/0002-avoid-java-serialization.md
@@ -1,0 +1,41 @@
+# ADR-0002 - Avoid Java serialization
+
+## Date
+
+2012-12-01
+
+## Context
+
+In Gradle we often need to serialize in-memory objects for caching, or to transmit them across process barriers etc.
+Java serialization is one way to implement this, however despite it's simplicity of implementation, it has several drawbacks:
+
+- **Performance:** Java's built-in serialization mechanism is often slower compared to other serialization solutions. This is due to Java's use of reflection and the need to maintain a lot of metadata.
+
+- **Size of Serialized Data:** Java serialization tends to produce larger serialized objects because it includes class metadata and other overhead.
+
+- **Flexibility and Control:** Java serialization offers limited control over the serialization process, such as excluding certain fields, customizing naming conventions, and handling complex data structures more gracefully.
+
+- **Security:** Java serialization poses security risks, especially related to deserialization vulnerabilities.
+
+- **Version Compatibility:** With Java serialization, even minor changes to a class (like adding a field) can break compatibility.
+
+- **Cross-Language Compatibility:** Java serialization is inherently Java-centric and does not support cross-language scenarios well.
+
+- **Type Safety:** Java serialization does not enforce type safety as strictly as some alternatives, potentially leading to runtime errors.
+
+## Decision
+
+We do not use Java serialization. Instead, we use custom serialization where we explicitly describe how data objects should be serialized and deserialized.
+
+For internal purposes we use binary formats for their brevity.
+We use the `Serializer` abstraction to separate the actual implementation of serialization from its uses.
+
+When sharing data with external tools, we use JSON.
+
+## Status
+
+PROPOSED
+
+## Consequences
+
+* We use the `Serializer`s based on the Kryo framework for most serialization needs.

--- a/architecture-standards/0002-avoid-using-java-serialization.md
+++ b/architecture-standards/0002-avoid-using-java-serialization.md
@@ -1,4 +1,4 @@
-# ADR-0002 - Avoid Java serialization
+# ADR-0002 - Avoid using Java serialization
 
 ## Date
 

--- a/architecture-standards/README.md
+++ b/architecture-standards/README.md
@@ -8,4 +8,4 @@ If we see fit, we can break these out to per-platform ones, or keep a hybrid app
 
 Our aim is to keep the process lightweight and approachable.
 
-For this reason we adopt a [Light Markdown ADR template](0001-use-architectural-decision-records.md#format).
+For this reason we adopt a [lightweight Markdown ADR template](0001-use-architectural-decision-records.md#format).

--- a/architecture-standards/README.md
+++ b/architecture-standards/README.md
@@ -1,0 +1,10 @@
+## Architecture Standards
+
+**Experimental!**
+
+We'd like to capture our architectural decisions about the build tool as [Architectural Decision Records (ADRs)](https://adr.github.io/).
+For now we just have this global repository of ADRs.
+If we see fit, we can break these out to per-platform ones, or keep a hybrid approach to having global and platform-specific ADSs.
+
+Our aim is to keep the process lightweight and approachable.
+For this reason we adopt the Light Markdown ADR template.

--- a/architecture-standards/README.md
+++ b/architecture-standards/README.md
@@ -7,4 +7,5 @@ For now we just have this global repository of ADRs.
 If we see fit, we can break these out to per-platform ones, or keep a hybrid approach to having global and platform-specific ADSs.
 
 Our aim is to keep the process lightweight and approachable.
-For this reason we adopt the Light Markdown ADR template.
+
+For this reason we adopt a [Light Markdown ADR template](0001-use-architectural-decision-records.md#format).


### PR DESCRIPTION
Introduce a place to keep ADSs (see https://adr.github.io/) and add a first ADR to describe our approach to data serialization.
