### PR TITLE
Require since-annotation on Java public API members

### DIFF
--- a/build-logic/binary-compatibility/src/main/kotlin/gradlebuild/binarycompatibility/sources/JavaSourceQueries.kt
+++ b/build-logic/binary-compatibility/src/main/kotlin/gradlebuild/binarycompatibility/sources/JavaSourceQueries.kt
@@ -36,13 +36,17 @@ import japicmp.model.JApiField
 import japicmp.model.JApiMethod
 
 
+private
+typealias PredicateVisitor = GenericVisitorAdapter<Boolean, Unit?>
+
+
 internal
 object JavaSourceQueries {
 
     fun isOverrideMethod(method: JApiMethod): JavaSourceQuery<Boolean> =
         JavaSourceQuery(
             false,
-            object : GenericVisitorAdapter<Boolean, Unit?>() {
+            object : PredicateVisitor() {
                 override fun visit(declaration: MethodDeclaration, arg: Unit?): Boolean? {
                     if (declaration.name?.asString() == method.name && declaration.hasOverrideAnnotation) {
                         return true
@@ -58,9 +62,9 @@ object JavaSourceQueries {
                 false,
                 when (member) {
                     is JApiClass -> isSinceJavaClassVisitorFor(declaringClassSimpleName, version)
-                    is JApiField -> isSinceJavaFieldVisitorFor(member, declaringClassSimpleName, version)
-                    is JApiConstructor -> isSinceJavaConstructorVisitorFor(member, declaringClassSimpleName, version)
-                    is JApiMethod -> isSinceJavaMethodVisitorFor(member, declaringClassSimpleName, version)
+                    is JApiField -> isSinceJavaFieldVisitorFor(member, version)
+                    is JApiConstructor -> isSinceJavaConstructorVisitorFor(declaringClassSimpleName, version)
+                    is JApiMethod -> isSinceJavaMethodVisitorFor(declaringClassSimpleName, member, version)
                     else -> throw IllegalStateException("Unsupported japicmp member type ${member::class}")
                 }
             )
@@ -75,12 +79,25 @@ val MethodDeclaration.hasOverrideAnnotation: Boolean
 
 private
 fun isSinceJavaClassVisitorFor(classSimpleName: String, version: String) =
-    NameAndSinceMatchingVisitor(classSimpleName, version)
+    object : PredicateVisitor() {
+
+        override fun visit(declaration: ClassOrInterfaceDeclaration, arg: Unit?): Boolean? =
+            if (declaration.matchesNameAndIsSince(classSimpleName, version)) true
+            else super.visit(declaration, arg)
+
+        override fun visit(declaration: AnnotationDeclaration, arg: Unit?): Boolean? =
+            if (declaration.matchesNameAndIsSince(classSimpleName, version)) true
+            else super.visit(declaration, arg)
+
+        override fun visit(declaration: EnumDeclaration, arg: Unit?): Boolean? =
+            if (declaration.matchesNameAndIsSince(classSimpleName, version)) true
+            else super.visit(declaration, arg)
+    }
 
 
 private
-fun isSinceJavaFieldVisitorFor(field: JApiField, classSimpleName: String, version: String) =
-    object : NameAndSinceMatchingVisitor(classSimpleName, version) {
+fun isSinceJavaFieldVisitorFor(field: JApiField, version: String) =
+    object : PredicateVisitor() {
 
         override fun visit(declaration: FieldDeclaration, arg: Unit?): Boolean? =
             if (matchesName(declaration.fieldName, field.name) && declaration.isSince(version)) true
@@ -93,26 +110,18 @@ fun isSinceJavaFieldVisitorFor(field: JApiField, classSimpleName: String, versio
 
 
 private
-fun isSinceJavaConstructorVisitorFor(constructor: JApiConstructor, classSimpleName: String, version: String) =
-    object : NameAndSinceMatchingVisitor(classSimpleName, version) {
+fun isSinceJavaConstructorVisitorFor(classSimpleName: String, version: String) =
+    object : PredicateVisitor() {
 
         override fun visit(declaration: ConstructorDeclaration, arg: Unit?): Boolean? =
             if (declaration.matchesNameAndIsSince(classSimpleName, version)) true
             else super.visit(declaration, arg)
-
-        override fun visit(declaration: FieldDeclaration, arg: Unit?): Boolean? =
-            if (matchesName(declaration.fieldName, constructor.name) && declaration.isSince(version)) true
-            else null
-
-        override fun visit(declaration: EnumConstantDeclaration, arg: Unit?): Boolean? =
-            if (declaration.matchesNameAndIsSince(constructor.name, version)) true
-            else null
     }
 
 
 private
-fun isSinceJavaMethodVisitorFor(method: JApiMethod, classSimpleName: String, version: String) =
-    object : NameAndSinceMatchingVisitor(classSimpleName, version) {
+fun isSinceJavaMethodVisitorFor(classSimpleName: String, method: JApiMethod, version: String) =
+    object : PredicateVisitor() {
 
         override fun visit(declaration: AnnotationMemberDeclaration, arg: Unit?): Boolean? =
             if (declaration.matchesNameAndIsSince(method.name, version)) true
@@ -121,32 +130,22 @@ fun isSinceJavaMethodVisitorFor(method: JApiMethod, classSimpleName: String, ver
         override fun visit(declaration: MethodDeclaration, arg: Unit?): Boolean? =
             if (declaration.matchesNameAndIsSince(method.name, version)) true
             else null
+
+        override fun visit(declaration: EnumDeclaration, arg: Unit?): Boolean? {
+            return if (declaration.matchesName(classSimpleName) && method.isEnumImplicitMethod()) true
+            else super.visit(declaration, arg)
+        }
     }
 
 
 private
-open class NameAndSinceMatchingVisitor(
-    val classSimpleName: String,
-    val version: String
-) : GenericVisitorAdapter<Boolean, Unit?>() {
-
-    override fun visit(declaration: ClassOrInterfaceDeclaration, arg: Unit?): Boolean? =
-        if (declaration.matchesNameAndIsSince(classSimpleName, version)) true
-        else super.visit(declaration, arg)
-
-    override fun visit(declaration: AnnotationDeclaration, arg: Unit?): Boolean? =
-        if (declaration.matchesNameAndIsSince(classSimpleName, version)) true
-        else super.visit(declaration, arg)
-
-    override fun visit(declaration: EnumDeclaration, arg: Unit?): Boolean? =
-        if (declaration.matchesNameAndIsSince(classSimpleName, version)) true
-        else super.visit(declaration, arg)
-}
+fun <T> T.matchesNameAndIsSince(candidateName: String, version: String): Boolean where T : BodyDeclaration<*>, T : NodeWithSimpleName<*> =
+    takeIf { it.matchesName(candidateName) }?.isSince(version) == true
 
 
 private
-fun <T> T.matchesNameAndIsSince(candidateName: String, version: String): Boolean where T : BodyDeclaration<*>, T : NodeWithSimpleName<*> =
-    takeIf { matchesName(it.name.asString(), candidateName) }?.isSince(version) == true
+fun <T : NodeWithSimpleName<*>> T.matchesName(candidateName: String) =
+    matchesName(name.asString(), candidateName)
 
 
 private
@@ -162,3 +161,21 @@ fun BodyDeclaration<*>.isSince(version: String): Boolean =
 private
 val FieldDeclaration.fieldName: String
     get() = variables.first().name.asString()
+
+
+private
+fun JApiMethod.isEnumImplicitMethod(): Boolean =
+    isEnumImplicitMethodValues() ||
+        isEnumImplicitMethodValueOf()
+
+
+private
+fun JApiMethod.isEnumImplicitMethodValueOf(): Boolean {
+    return name == "valueOf" && parameters.size == 1 && parameters.first().type == "java.lang.String"
+}
+
+
+private
+fun JApiMethod.isEnumImplicitMethodValues(): Boolean {
+    return name == "values" && parameters.size == 0
+}


### PR DESCRIPTION
Partially addresses https://github.com/gradle/gradle/issues/27113 for public API written in Java.

Enforcement for Kotlin APIs will be done in a follow-up.

An example of what is expected to be since-annotated:
```java
/**
 * @since 8.6
 */
public enum NewEnum {

    /**
     * @since 8.6
     */
    VALUE1;

    /**
     * @since 8.6
     */
    public static final String STATIC_FIELD = "";

    /**
     * @since 8.6
     */
    public void publicMethod() {}

    // @since not required for non-public methods
    private void privateMethod() {}

    // @since not required for overridden methods
    @Override
    public String toString() {return super.toString();}
}
```