### PR TITLE
fix(pmd): make PMD 7 dependency calculation working for RC releases

### DIFF
--- a/platforms/jvm/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdPlugin.java
+++ b/platforms/jvm/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdPlugin.java
@@ -195,7 +195,7 @@ public abstract class PmdPlugin extends AbstractCodeQualityPlugin<Pmd> {
             return Collections.singleton("pmd:pmd:" + versionString);
         } else if (toolVersion.compareTo(VersionNumber.parse("5.2.0")) < 0) {
             return Collections.singleton("net.sourceforge.pmd:pmd:" + versionString);
-        } else if (toolVersion.compareTo(VersionNumber.version(7)) < 0) {
+        } else if (toolVersion.getMajor() < 7) {
             return Collections.singleton("net.sourceforge.pmd:pmd-java:" + versionString);
         }
 

--- a/platforms/jvm/code-quality/src/test/groovy/org/gradle/api/plugins/quality/PmdPluginTest.groovy
+++ b/platforms/jvm/code-quality/src/test/groovy/org/gradle/api/plugins/quality/PmdPluginTest.groovy
@@ -48,6 +48,11 @@ class PmdPluginTest extends AbstractProjectBuilderSpec {
         PmdPlugin.calculateDefaultDependencyNotation("7.0.0") == ImmutableSet.of("net.sourceforge.pmd:pmd-java:7.0.0", "net.sourceforge.pmd:pmd-ant:7.0.0")
     }
 
+    def "pmd 7.0.0-rc4 is loading the right dependencies"() {
+        expect:
+        PmdPlugin.calculateDefaultDependencyNotation("7.0.0-rc4") == ImmutableSet.of("net.sourceforge.pmd:pmd-java:7.0.0-rc4", "net.sourceforge.pmd:pmd-ant:7.0.0-rc4")
+    }
+
     def "pmd 6.55.0 is loading the right dependencies"() {
         expect:
         PmdPlugin.calculateDefaultDependencyNotation("6.55.0") == Collections.singleton("net.sourceforge.pmd:pmd-java:6.55.0")


### PR DESCRIPTION
Previous implementation was not working properly for Release Candidates. This is because [VersionNumber](https://github.com/gradle/gradle/blob/master/platforms/core-runtime/base-services/src/main/java/org/gradle/util/internal/VersionNumber.java) when comparing version "7.0.0" with "7.0.0-rc4" returns that "7.0.0-rc4" is lower than "7.0.0" which is actually true.

<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
