### PR TITLE
Use assign operator for Kotlin DSL generated with `gradle init`

### DIFF
--- a/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionIntegrationTest.groovy
+++ b/platforms/software/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionIntegrationTest.groovy
@@ -438,7 +438,7 @@ ${TextUtil.indent(configLines.join("\n"), "                    ")}
             }
             '''.stripIndent().trim())) || rootBuildFile.text.contains(TextUtil.toPlatformLineSeparators('''
             val testsJar by tasks.registering(Jar::class) {
-                archiveClassifier.set("tests")
+                archiveClassifier = "tests"
                 from(sourceSets["test"].output)
             }
             '''.stripIndent().trim()))

--- a/platforms/software/build-init/src/main/java/org/gradle/buildinit/plugins/internal/BuildScriptBuilder.java
+++ b/platforms/software/build-init/src/main/java/org/gradle/buildinit/plugins/internal/BuildScriptBuilder.java
@@ -363,7 +363,7 @@ public class BuildScriptBuilder {
             t.block(null, "toolchain", t1 -> {
                 t1.propertyAssignment(null, "languageVersion",
                     new MethodInvocationExpression(null, "JavaLanguageVersion.of", singletonList(new LiteralValue(languageVersion.asInt()))),
-                false);
+                true);
             });
         });
     }
@@ -1036,13 +1036,13 @@ public class BuildScriptBuilder {
 
         final String propertyName;
         final ExpressionValue propertyValue;
-        final boolean legacyProperty;
+        final boolean assignOperator;
 
-        private PropertyAssignment(String comment, String propertyName, ExpressionValue propertyValue, boolean legacyProperty) {
+        private PropertyAssignment(String comment, String propertyName, ExpressionValue propertyValue, boolean assignOperator) {
             super(comment);
             this.propertyName = propertyName;
             this.propertyValue = propertyValue;
-            this.legacyProperty = legacyProperty;
+            this.assignOperator = assignOperator;
         }
 
         @Override
@@ -1558,8 +1558,8 @@ public class BuildScriptBuilder {
         }
 
         @Override
-        public void propertyAssignment(String comment, String propertyName, Object propertyValue, boolean legacyProperty) {
-            statements.add(new PropertyAssignment(comment, propertyName, expressionValue(propertyValue), legacyProperty));
+        public void propertyAssignment(String comment, String propertyName, Object propertyValue, boolean assignOperator) {
+            statements.add(new PropertyAssignment(comment, propertyName, expressionValue(propertyValue), assignOperator));
         }
 
         @Override
@@ -2095,12 +2095,11 @@ public class BuildScriptBuilder {
             return config + "(" + notation + ")";
         }
 
-
         @Override
         public String propertyAssignment(PropertyAssignment expression) {
             String propertyName = expression.propertyName;
             ExpressionValue propertyValue = expression.propertyValue;
-            if (expression.legacyProperty) {
+            if (expression.assignOperator) {
                 if (propertyValue.isBooleanType()) {
                     return booleanPropertyNameFor(propertyName) + " = " + propertyValue.with(this);
                 }

--- a/platforms/software/build-init/src/main/java/org/gradle/buildinit/plugins/internal/JvmApplicationProjectInitDescriptor.java
+++ b/platforms/software/build-init/src/main/java/org/gradle/buildinit/plugins/internal/JvmApplicationProjectInitDescriptor.java
@@ -56,7 +56,7 @@ public class JvmApplicationProjectInitDescriptor extends JvmProjectInitDescripto
                 if (!isSingleProject(settings)) {
                     mainClass = "app." + mainClass;
                 }
-                b.propertyAssignment("Define the main class for the application.", "mainClass", withPackage(settings, mainClass), false);
+                b.propertyAssignment("Define the main class for the application.", "mainClass", withPackage(settings, mainClass), true);
             });
         }
 

--- a/platforms/software/build-init/src/main/java/org/gradle/buildinit/plugins/internal/ScriptBlockBuilder.java
+++ b/platforms/software/build-init/src/main/java/org/gradle/buildinit/plugins/internal/ScriptBlockBuilder.java
@@ -24,7 +24,7 @@ public interface ScriptBlockBuilder {
     /**
      * Adds a property assignment statement to this block
      */
-    void propertyAssignment(@Nullable String comment, String propertyName, Object propertyValue, boolean legacyProperty);
+    void propertyAssignment(@Nullable String comment, String propertyName, Object propertyValue, boolean assignOperator);
 
     /**
      * Adds a method invocation statement to this block

--- a/platforms/software/build-init/src/main/java/org/gradleinternal/buildinit/plugins/internal/maven/Maven2Gradle.java
+++ b/platforms/software/build-init/src/main/java/org/gradleinternal/buildinit/plugins/internal/maven/Maven2Gradle.java
@@ -472,7 +472,7 @@ public class Maven2Gradle {
         Plugin jarPlugin = plugin("maven-jar-plugin", project);
         if (pluginGoal("test-jar", jarPlugin) != null) {
             builder.taskRegistration(null, "testsJar", "Jar", task -> {
-                task.propertyAssignment(null, "archiveClassifier", "tests", false);
+                task.propertyAssignment(null, "archiveClassifier", "tests", true);
                 task.methodInvocation(null, "from", builder.propertyExpression(builder.containerElementExpression("sourceSets", "test"), "output"));
             });
             return true;


### PR DESCRIPTION
Because assignment operator `=` has been promoted to stable in 8.4 and supported by a variety of property types