### PR TITLE
Improve readability of inferred version catalog values in javadocs

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/DefaultVersionCatalogBuilder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/DefaultVersionCatalogBuilder.java
@@ -145,7 +145,7 @@ public abstract class DefaultVersionCatalogBuilder implements VersionCatalogBuil
         this.objects = objects;
         this.dependencyResolutionServicesSupplier = dependencyResolutionServicesSupplier;
         this.strictVersionParser = new StrictVersionParser(strings);
-        this.description = objects.property(String.class).convention("A catalog of dependencies accessible via the `" + name + "` extension.");
+        this.description = objects.property(String.class).convention("A catalog of dependencies accessible via the {@code " + name + "} extension.");
     }
 
     @Inject

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/catalog/LibrariesSourceGeneratorTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/catalog/LibrariesSourceGeneratorTest.groovy
@@ -166,14 +166,14 @@ class LibrariesSourceGeneratorTest extends AbstractVersionCatalogTest implements
         }
 
         then:
-        sources.hasDependencyAlias('foo', 'getFoo', "with version '1.0'")
-        sources.hasDependencyAlias('fooBaz', 'getFooBaz', "with version '{strictly [1.0, 2.0[; prefer 1.2}'")
-        sources.hasDependencyAlias('bar', 'getBar', "with versionRef 'barVersion'")
-        sources.hasDependencyAlias('boo', 'getBoo', "with no version specified")
+        sources.hasDependencyAlias('foo', 'getFoo', "with version <b>1.0</b>")
+        sources.hasDependencyAlias('fooBaz', 'getFooBaz', "with version <b>{strictly [1.0, 2.0[; prefer 1.2}</b>")
+        sources.hasDependencyAlias('bar', 'getBar', "with version reference <b>barVersion</b>")
+        sources.hasDependencyAlias('boo', 'getBoo', "with <b>no version specified</b>")
 
-        sources.hasPlugin('fooPlugin', 'getFooPlugin', "with version '1.0'")
-        sources.hasPlugin('barPlugin', 'getBarPlugin', "with versionRef 'barVersion'")
-        sources.hasPlugin('bazPlugin', 'getBazPlugin', "with no version specified")
+        sources.hasPlugin('fooPlugin', 'getFooPlugin', "with version <b>1.0</b>")
+        sources.hasPlugin('barPlugin', 'getBarPlugin', "with version reference <b>barVersion</b>")
+        sources.hasPlugin('bazPlugin', 'getBazPlugin', "with <b>no version specified</b>")
     }
 
     @VersionCatalogProblemTestFor(


### PR DESCRIPTION
Current javadocs generated for version catalog accessors are rendered as a monotone single paragraph text, making it hard to get a value out of looking at them. At the same time, they already contain useful information inferred from the values in the actual version catalog.

This PR improves the generated javadocs by
- consistently marking all inferred values as bold
- rewording the scaffolding sentences to make them more concise and clear
- splitting each javadoc into multiple paragraphs, keeping different information visually separated
- provides a sensible javadoc for empty bundles
- fixes the indentation of the generated accessor sources

## Before

Versions
<img width="700" alt="image" src="https://github.com/gradle/gradle/assets/2759152/912966bd-a51c-41cd-9b1f-8af3c825cc35">

Libraries
<img width="700" alt="image" src="https://github.com/gradle/gradle/assets/2759152/ed482c55-9150-4417-ab10-bf8a0bec3d87">

Plugins
<img width="700" alt="image" src="https://github.com/gradle/gradle/assets/2759152/61070cea-7600-4827-938d-1282f4bf373d">


## After

Versions
<img width="699" alt="image" src="https://github.com/gradle/gradle/assets/2759152/de0db4d9-e414-41a2-a0ac-33160476d57c">


Libraries
<img width="700" alt="image" src="https://github.com/gradle/gradle/assets/2759152/5f7c34b0-4eac-47bd-93a4-0fb5e8eea015">

Plugins
<img width="700" alt="image" src="https://github.com/gradle/gradle/assets/2759152/b8eda2b6-97ac-4ef0-aa0e-4547245c792b">

