### PR TITLE
Make `JacocoReportAggregationPlugin` artifact views cc compatible

### DIFF
--- a/platforms/jvm/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoConfigurationCacheIntegrationTest.groovy
+++ b/platforms/jvm/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoConfigurationCacheIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.testing.jacoco.plugins
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.test.fixtures.dsl.GradleDsl
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.IntegTestPreconditions
 import spock.lang.Issue
@@ -32,12 +33,12 @@ class JacocoConfigurationCacheIntegrationTest extends AbstractIntegrationSpec {
     @Issue('https://github.com/gradle/gradle/issues/26922')
     def 'can aggregate with `kotlin-dsl` subproject'() {
         given:
-        file('settings.gradle.kts') << '''
+        file('settings.gradle.kts') << """
             include(":plugin")
             dependencyResolutionManagement {
-                repositories { mavenCentral() }
+                ${mavenCentralRepository(GradleDsl.KOTLIN)}
             }
-        '''
+        """
         file('build.gradle.kts') << '''
             plugins { id("jacoco-report-aggregation") }
 

--- a/platforms/jvm/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoConfigurationCacheIntegrationTest.groovy
+++ b/platforms/jvm/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoConfigurationCacheIntegrationTest.groovy
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing.jacoco.plugins
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.test.precondition.Requires
+import org.gradle.test.preconditions.IntegTestPreconditions
+import spock.lang.Issue
+
+@Requires(value = IntegTestPreconditions.NotConfigCached, reason = 'Test explicitly enables the configuration cache')
+class JacocoConfigurationCacheIntegrationTest extends AbstractIntegrationSpec {
+
+    def setup() {
+        // run all tests with configuration caching
+        file('gradle.properties') << 'org.gradle.configuration-cache=true'
+    }
+
+    @Issue('https://github.com/gradle/gradle/issues/26922')
+    def 'can aggregate with `kotlin-dsl` subproject'() {
+        given:
+        file('settings.gradle.kts') << '''
+            include(":plugin")
+            dependencyResolutionManagement {
+                repositories { mavenCentral() }
+            }
+        '''
+        file('build.gradle.kts') << '''
+            plugins { id("jacoco-report-aggregation") }
+
+            reporting {
+                reports {
+                    val testCodeCoverageReport by creating(JacocoCoverageReport::class) {
+                        testType = TestSuiteType.UNIT_TEST
+                    }
+                }
+            }
+
+            dependencies {
+                jacocoAggregation(project(":plugin"))
+            }
+        '''
+        createDir('plugin') {
+            file('build.gradle.kts') << '''
+                plugins { `kotlin-dsl` }
+            '''
+            file('src/main/kotlin/plugin.gradle.kts').touch()
+        }
+
+        expect:
+        succeeds ':testCodeCoverageReport'
+    }
+}

--- a/platforms/jvm/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoConfigurationCacheIntegrationTest.groovy
+++ b/platforms/jvm/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoConfigurationCacheIntegrationTest.groovy
@@ -31,7 +31,7 @@ class JacocoConfigurationCacheIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Issue('https://github.com/gradle/gradle/issues/26922')
-    def 'can aggregate with `kotlin-dsl` subproject'() {
+    def 'can aggregate with `java-gradle-plugin` subproject'() {
         given:
         file('settings.gradle.kts') << """
             include(":plugin")
@@ -56,9 +56,8 @@ class JacocoConfigurationCacheIntegrationTest extends AbstractIntegrationSpec {
         '''
         createDir('plugin') {
             file('build.gradle.kts') << '''
-                plugins { `kotlin-dsl` }
+                plugins { id("java-gradle-plugin") }
             '''
-            file('src/main/kotlin/plugin.gradle.kts').touch()
         }
 
         expect:


### PR DESCRIPTION
By making the given component filter specs are serializable.

Fixes #26922