### PR TITLE
Make BuildAction part of the Configuration Cache key

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/FetchCustomModelForTargetProject.java
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/FetchCustomModelForTargetProject.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache.isolated;
+
+import org.gradle.configurationcache.fixtures.SomeToolingModel;
+import org.gradle.tooling.BuildAction;
+import org.gradle.tooling.BuildController;
+import org.gradle.tooling.model.gradle.BasicGradleProject;
+import org.gradle.tooling.model.gradle.GradleBuild;
+
+public class FetchCustomModelForTargetProject implements BuildAction<SomeToolingModel> {
+
+    private final String targetProject;
+
+    public FetchCustomModelForTargetProject(String targetProject) {
+        this.targetProject = targetProject;
+    }
+
+    @Override
+    public SomeToolingModel execute(BuildController controller) {
+        GradleBuild buildModel = controller.getBuildModel();
+        for (BasicGradleProject project : buildModel.getProjects()) {
+            if (targetProject.equals(project.getBuildTreePath())) {
+                return controller.getModel(project, SomeToolingModel.class);
+            }
+        }
+        for (GradleBuild editableBuild : buildModel.getEditableBuilds()) {
+            for (BasicGradleProject project : editableBuild.getProjects()) {
+                if (targetProject.equals(project.getBuildTreePath())) {
+                    return controller.getModel(project, SomeToolingModel.class);
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiBuildActionIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiBuildActionIntegrationTest.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.configurationcache.isolated
 
+import org.gradle.configurationcache.fixtures.SomeToolingModel
+
 class IsolatedProjectsToolingApiBuildActionIntegrationTest extends AbstractIsolatedProjectsToolingApiIntegrationTest {
     def setup() {
         settingsFile << """
@@ -550,6 +552,73 @@ class IsolatedProjectsToolingApiBuildActionIntegrationTest extends AbstractIsola
         and:
         model4.size() == 2
         model4[0].message == "It works from project :"
+    }
+
+    def "caches execution of BuildAction of same type with different state"() {
+        given:
+        withSomeToolingModelBuilderPluginInBuildSrc()
+        settingsFile << """
+            include("a")
+        """
+        buildFile << """
+            plugins.apply(my.MyPlugin)
+        """
+        file("a/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+        """
+
+        when:
+        executer.withArguments(ENABLE_CLI)
+        def model = runBuildAction(new FetchCustomModelForTargetProject(":"))
+
+        then:
+        fixture.assertStateStored {
+            projectsConfigured(":buildSrc", ":")
+            buildModelCreated()
+            modelsCreated(":", SomeToolingModel)
+        }
+        outputContains("creating model for root project 'root'")
+
+        and:
+        model.message == "It works from project :"
+
+
+        when:
+        executer.withArguments(ENABLE_CLI)
+        def model2 = runBuildAction(new FetchCustomModelForTargetProject(":a"))
+
+        then:
+        fixture.assertStateStored {
+            projectsConfigured(":buildSrc", ":", ":a")
+            buildModelCreated()
+            modelsCreated(":a", SomeToolingModel)
+        }
+        outputContains("creating model for project ':a'")
+
+        and:
+        model2.message == "It works from project :a"
+
+
+        when:
+        executer.withArguments(ENABLE_CLI)
+        def model3 = runBuildAction(new FetchCustomModelForTargetProject(":"))
+
+        then:
+        fixture.assertStateLoaded()
+
+        and:
+        model3.message == "It works from project :"
+
+
+        when:
+        executer.withArguments(ENABLE_CLI)
+        def model4 = runBuildAction(new FetchCustomModelForTargetProject(":a"))
+
+        then:
+        fixture.assertStateLoaded()
+
+        and:
+        model4.message == "It works from project :a"
     }
 
 }

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiParameterizedModelQueryIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiParameterizedModelQueryIntegrationTest.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.configurationcache.isolated
 
+import org.gradle.configurationcache.fixtures.SomeToolingModel
+
 class IsolatedProjectsToolingApiParameterizedModelQueryIntegrationTest extends AbstractIsolatedProjectsToolingApiIntegrationTest {
 
     def setup() {
@@ -40,7 +42,7 @@ class IsolatedProjectsToolingApiParameterizedModelQueryIntegrationTest extends A
         fixture.assertStateStored {
             projectConfigured(":buildSrc")
             buildModelCreated()
-            modelsCreated(":", 2) // only 2 intermediate models are created for 2 unique parameters
+            modelsCreated(":", SomeToolingModel, SomeToolingModel) // only 2 models are created for 2 unique parameters of 4 requests
         }
         outputContains("configuring root")
         outputContains("creating model with parameter='fetch1' for root project 'root'")
@@ -54,6 +56,7 @@ class IsolatedProjectsToolingApiParameterizedModelQueryIntegrationTest extends A
         models[":"][1].message == "fetch2 It works from project :"
         models[":"][2].message == "fetch1 It works from project :"
         models[":"][3].message == "fetch2 It works from project :"
+
 
         when:
         executer.withArguments(ENABLE_CLI)
@@ -82,8 +85,8 @@ class IsolatedProjectsToolingApiParameterizedModelQueryIntegrationTest extends A
         fixture.assertStateStored {
             projectConfigured(":buildSrc")
             buildModelCreated()
-            modelsCreated(":", 2)
-            modelsCreated(":a", 2)
+            modelsCreated(":", SomeToolingModel, SomeToolingModel)
+            modelsCreated(":a", SomeToolingModel, SomeToolingModel)
         }
         outputContains("configuring root")
         outputContains("creating model with parameter='fetch1' for root project 'root'")
@@ -101,6 +104,7 @@ class IsolatedProjectsToolingApiParameterizedModelQueryIntegrationTest extends A
         model1[":a"][0].message == "fetch1 It works from project :a"
         model1[":a"][1].message == "fetch2 It works from project :a"
 
+
         when:
         executer.withArguments(ENABLE_CLI)
         def model2 = runBuildAction(new FetchParameterizedCustomModelForEachProject(["fetch2", "fetch1"]))
@@ -109,8 +113,8 @@ class IsolatedProjectsToolingApiParameterizedModelQueryIntegrationTest extends A
         fixture.assertStateStored {
             projectConfigured(":buildSrc")
             buildModelCreated()
-            modelsCreated(":", 2)
-            modelsCreated(":a", 2)
+            modelsCreated(":", SomeToolingModel, SomeToolingModel)
+            modelsCreated(":a", SomeToolingModel, SomeToolingModel)
         }
         outputContains("configuring root")
         outputContains("creating model with parameter='fetch1' for root project 'root'")
@@ -138,7 +142,7 @@ class IsolatedProjectsToolingApiParameterizedModelQueryIntegrationTest extends A
         fixture.assertStateStored {
             projectConfigured(":buildSrc")
             buildModelCreated()
-            modelsCreated(":", 1)
+            modelsCreated(":", SomeToolingModel)
         }
         outputContains("configuring root")
         outputContains("creating model with parameter='fetch1' for root project 'root'")
@@ -160,7 +164,7 @@ class IsolatedProjectsToolingApiParameterizedModelQueryIntegrationTest extends A
         fixture.assertStateStored {
             projectConfigured(":buildSrc")
             buildModelCreated()
-            modelsCreated(":", 1)
+            modelsCreated(":", SomeToolingModel)
         }
         outputContains("configuring changed settings")
         outputContains("configuring root")
@@ -191,7 +195,7 @@ class IsolatedProjectsToolingApiParameterizedModelQueryIntegrationTest extends A
         fixture.assertStateStored {
             projectConfigured(":buildSrc")
             buildModelCreated()
-            modelsCreated(":", ":a", ":b")
+            modelsCreated(SomeToolingModel, ":", ":a", ":b")
         }
         outputContains("configuring root")
         outputContains("configuring project ':a'")
@@ -220,7 +224,7 @@ class IsolatedProjectsToolingApiParameterizedModelQueryIntegrationTest extends A
         fixture.assertStateUpdated {
             fileChanged("a/build.gradle")
             projectsConfigured(":buildSrc", ":")
-            modelsCreated(":a")
+            modelsCreated(":a", SomeToolingModel)
             modelsReused(":buildSrc", ":", ":b")
         }
 

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiPhasedBuildActionIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiPhasedBuildActionIntegrationTest.groovy
@@ -235,4 +235,6 @@ class IsolatedProjectsToolingApiPhasedBuildActionIntegrationTest extends Abstrac
         outputDoesNotContain("creating model")
         result.ignoreBuildSrc.assertTasksExecuted(":a:thing")
     }
+
+    // TODO: add test for caching
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/models/DefaultToolingModelParameterCarrierFactory.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/models/DefaultToolingModelParameterCarrierFactory.kt
@@ -17,7 +17,6 @@
 package org.gradle.configurationcache.models
 
 import org.gradle.internal.hash.HashCode
-import org.gradle.internal.hash.Hasher
 import org.gradle.internal.hash.Hashing
 import org.gradle.internal.snapshot.ValueSnapshotter
 import org.gradle.tooling.internal.adapter.ProtocolToModelAdapter
@@ -46,9 +45,7 @@ class DefaultToolingModelParameterCarrierFactory(
 
         override fun getHash(): HashCode {
             val unpacked = ToolingParameterProxy.unpackProperties(parameter)
-            val hasher: Hasher = Hashing.newHasher()
-            hasher.put(valueSnapshotter.snapshot(unpacked))
-            return hasher.hash()
+            return Hashing.hashHashable(valueSnapshotter.snapshot(unpacked))
         }
     }
 }

--- a/platforms/core-execution/hashing/src/main/java/org/gradle/internal/hash/Hashing.java
+++ b/platforms/core-execution/hashing/src/main/java/org/gradle/internal/hash/Hashing.java
@@ -109,6 +109,15 @@ public class Hashing {
     }
 
     /**
+     * Hash the given {@code hashable} instance with the default hash function.
+     */
+    public static HashCode hashHashable(Hashable hashable) {
+        Hasher hasher = newHasher();
+        hasher.put(hashable);
+        return hasher.hash();
+    }
+
+    /**
      * The default hashing function.
      */
     public static HashFunction defaultFunction() {

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/AbstractToolingModelRequirements.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/AbstractToolingModelRequirements.java
@@ -21,6 +21,7 @@ import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.buildtree.BuildActionModelRequirements;
 import org.gradle.internal.hash.HashCode;
+import org.gradle.internal.hash.Hasher;
 
 import java.util.function.Supplier;
 
@@ -65,7 +66,14 @@ public abstract class AbstractToolingModelRequirements implements BuildActionMod
         return Describables.of("the requested model");
     }
 
-    protected HashCode getPayloadHash() {
-        return payloadHashProvider.get();
+    @Override
+    public void appendKeyTo(Hasher hasher) {
+        hasher.putByte(getActionTypeId());
+        hasher.putHash(payloadHashProvider.get());
     }
+
+    /**
+     * Each inheriting action must provide a unique value.
+     */
+    protected abstract byte getActionTypeId();
 }

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/AbstractToolingModelRequirements.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/AbstractToolingModelRequirements.java
@@ -20,15 +20,24 @@ import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.buildtree.BuildActionModelRequirements;
+import org.gradle.internal.hash.HashCode;
+
+import java.util.function.Supplier;
 
 public abstract class AbstractToolingModelRequirements implements BuildActionModelRequirements {
+
     private final StartParameterInternal startParameter;
     private final boolean runsTasks;
+    private final Supplier<HashCode> payloadHashProvider;
 
-    public AbstractToolingModelRequirements(StartParameterInternal startParameter,
-                                            boolean runsTasks) {
+    public AbstractToolingModelRequirements(
+        StartParameterInternal startParameter,
+        boolean runsTasks,
+        Supplier<HashCode> payloadHashProvider
+    ) {
         this.startParameter = startParameter;
         this.runsTasks = runsTasks;
+        this.payloadHashProvider = payloadHashProvider;
     }
 
     @Override
@@ -54,5 +63,9 @@ public abstract class AbstractToolingModelRequirements implements BuildActionMod
     @Override
     public DisplayName getConfigurationCacheKeyDisplayName() {
         return Describables.of("the requested model");
+    }
+
+    protected HashCode getPayloadHash() {
+        return payloadHashProvider.get();
     }
 }

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/BuildTreeLifecycleBuildActionExecutor.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/BuildTreeLifecycleBuildActionExecutor.java
@@ -24,7 +24,6 @@ import org.gradle.internal.buildtree.BuildTreeModelControllerServices;
 import org.gradle.internal.buildtree.BuildTreeState;
 import org.gradle.internal.buildtree.RunTasksRequirements;
 import org.gradle.internal.hash.HashCode;
-import org.gradle.internal.hash.Hasher;
 import org.gradle.internal.hash.Hashing;
 import org.gradle.internal.id.UniqueId;
 import org.gradle.internal.invocation.BuildAction;
@@ -107,10 +106,6 @@ public class BuildTreeLifecycleBuildActionExecutor implements BuildSessionAction
 
     private Supplier<HashCode> payloadHashProvider(Object payload) {
         ValueSnapshotter valueSnapshotter = this.valueSnapshotter;
-        return () -> {
-            Hasher hasher = Hashing.newHasher();
-            hasher.put(valueSnapshotter.snapshot(payload));
-            return hasher.hash();
-        };
+        return () -> Hashing.hashHashable(valueSnapshotter.snapshot(payload));
     }
 }

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/QueryModelRequirements.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/QueryModelRequirements.java
@@ -17,22 +17,25 @@
 package org.gradle.launcher.exec;
 
 import org.gradle.api.internal.StartParameterInternal;
+import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.hash.Hasher;
 
-public class QueryModelRequirements extends AbstractToolingModelRequirements {
-    private final String modelName;
+import java.util.function.Supplier;
 
-    public QueryModelRequirements(StartParameterInternal startParameter,
-                                  boolean runsTasks,
-                                  String modelName) {
-        super(startParameter, runsTasks);
-        this.modelName = modelName;
+public class QueryModelRequirements extends AbstractToolingModelRequirements {
+
+    public QueryModelRequirements(
+        StartParameterInternal startParameter,
+        boolean runsTasks,
+        Supplier<HashCode> payloadHashProvider
+    ) {
+        super(startParameter, runsTasks, payloadHashProvider);
     }
 
     @Override
     public void appendKeyTo(Hasher hasher) {
         // Identify the type of action
         hasher.putByte((byte) 2);
-        hasher.putString(modelName);
+        hasher.putHash(getPayloadHash());
     }
 }

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/QueryModelRequirements.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/QueryModelRequirements.java
@@ -18,7 +18,6 @@ package org.gradle.launcher.exec;
 
 import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.internal.hash.HashCode;
-import org.gradle.internal.hash.Hasher;
 
 import java.util.function.Supplier;
 
@@ -33,9 +32,7 @@ public class QueryModelRequirements extends AbstractToolingModelRequirements {
     }
 
     @Override
-    public void appendKeyTo(Hasher hasher) {
-        // Identify the type of action
-        hasher.putByte((byte) 2);
-        hasher.putHash(getPayloadHash());
+    protected byte getActionTypeId() {
+        return 2;
     }
 }

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/RunActionRequirements.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/RunActionRequirements.java
@@ -18,7 +18,6 @@ package org.gradle.launcher.exec;
 
 import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.internal.hash.HashCode;
-import org.gradle.internal.hash.Hasher;
 
 import java.util.function.Supplier;
 
@@ -33,9 +32,7 @@ public class RunActionRequirements extends AbstractToolingModelRequirements {
     }
 
     @Override
-    public void appendKeyTo(Hasher hasher) {
-        // Identify the type of action
-        hasher.putByte((byte) 3);
-        hasher.putHash(getPayloadHash());
+    protected byte getActionTypeId() {
+        return 3;
     }
 }

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/RunActionRequirements.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/RunActionRequirements.java
@@ -17,17 +17,25 @@
 package org.gradle.launcher.exec;
 
 import org.gradle.api.internal.StartParameterInternal;
+import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.hash.Hasher;
 
+import java.util.function.Supplier;
+
 public class RunActionRequirements extends AbstractToolingModelRequirements {
-    public RunActionRequirements(StartParameterInternal startParameter,
-                                 boolean runsTasks) {
-        super(startParameter, runsTasks);
+
+    public RunActionRequirements(
+        StartParameterInternal startParameter,
+        boolean runsTasks,
+        Supplier<HashCode> payloadHashProvider
+    ) {
+        super(startParameter, runsTasks, payloadHashProvider);
     }
 
     @Override
     public void appendKeyTo(Hasher hasher) {
         // Identify the type of action
         hasher.putByte((byte) 3);
+        hasher.putHash(getPayloadHash());
     }
 }

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/RunPhasedActionRequirements.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/RunPhasedActionRequirements.java
@@ -17,17 +17,25 @@
 package org.gradle.launcher.exec;
 
 import org.gradle.api.internal.StartParameterInternal;
+import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.hash.Hasher;
 
+import java.util.function.Supplier;
+
 public class RunPhasedActionRequirements extends AbstractToolingModelRequirements {
-    public RunPhasedActionRequirements(StartParameterInternal startParameter,
-                                       boolean runsTasks) {
-        super(startParameter, runsTasks);
+
+    public RunPhasedActionRequirements(
+        StartParameterInternal startParameter,
+        boolean runsTasks,
+        Supplier<HashCode> payloadHashProvider
+    ) {
+        super(startParameter, runsTasks, payloadHashProvider);
     }
 
     @Override
     public void appendKeyTo(Hasher hasher) {
         // Identify the type of action
         hasher.putByte((byte) 4);
+        hasher.putHash(getPayloadHash());
     }
 }

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/RunPhasedActionRequirements.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/launcher/exec/RunPhasedActionRequirements.java
@@ -18,7 +18,6 @@ package org.gradle.launcher.exec;
 
 import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.internal.hash.HashCode;
-import org.gradle.internal.hash.Hasher;
 
 import java.util.function.Supplier;
 
@@ -33,9 +32,7 @@ public class RunPhasedActionRequirements extends AbstractToolingModelRequirement
     }
 
     @Override
-    public void appendKeyTo(Hasher hasher) {
-        // Identify the type of action
-        hasher.putByte((byte) 4);
-        hasher.putHash(getPayloadHash());
+    protected byte getActionTypeId() {
+        return 4;
     }
 }

--- a/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/LauncherServices.java
+++ b/platforms/core-runtime/launcher/src/main/java/org/gradle/tooling/internal/provider/LauncherServices.java
@@ -59,6 +59,7 @@ import org.gradle.internal.service.scopes.AbstractPluginServiceRegistry;
 import org.gradle.internal.service.scopes.GradleUserHomeScopeServiceRegistry;
 import org.gradle.internal.session.BuildSessionActionExecutor;
 import org.gradle.internal.snapshot.CaseSensitivity;
+import org.gradle.internal.snapshot.ValueSnapshotter;
 import org.gradle.internal.snapshot.impl.DirectorySnapshotterStatistics;
 import org.gradle.internal.time.Clock;
 import org.gradle.internal.time.Time;
@@ -180,7 +181,8 @@ public class LauncherServices extends AbstractPluginServiceRegistry {
             WorkerLeaseService workerLeaseService,
             BuildLayoutValidator buildLayoutValidator,
             FileSystem fileSystem,
-            FileSystemWatchingInformation fileSystemWatchingInformation
+            FileSystemWatchingInformation fileSystemWatchingInformation,
+            ValueSnapshotter valueSnapshotter
         ) {
             CaseSensitivity caseSensitivity = fileSystem.isCaseSensitive() ? CASE_SENSITIVE : CASE_INSENSITIVE;
             return new SubscribableBuildActionExecutor(
@@ -204,7 +206,7 @@ public class LauncherServices extends AbstractPluginServiceRegistry {
                     new RunAsWorkerThreadBuildActionExecutor(
                         workerLeaseService,
                         new RunAsBuildOperationBuildActionExecutor(
-                            new BuildTreeLifecycleBuildActionExecutor(buildModelServices, buildLayoutValidator),
+                            new BuildTreeLifecycleBuildActionExecutor(buildModelServices, buildLayoutValidator, valueSnapshotter),
                             buildOperationExecutor,
                             loggingBuildOperationProgressBroadcaster,
                             buildOperationNotificationValve))));


### PR DESCRIPTION
It includes the payload of the client-provided build action and the phased build action into the CC key. This makes sure that build actions of different types or with different state do not get a false cache hit.