### PR TITLE
Improve logging around file system watching intiialization

### DIFF
--- a/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
+++ b/platforms/core-runtime/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
@@ -97,7 +97,7 @@ public class NativeServices extends DefaultServiceRegistry implements ServiceReg
                         LOGGER.info("Initialized file system watching services in: {}", nativeBaseDir);
                         return true;
                     } catch (NativeIntegrationUnavailableException ex) {
-                        LOGGER.debug("Native file system watching is not available for this operating system.", ex);
+                        logFileSystemWatchingUnavailable(ex);
                         return false;
                     }
                 }
@@ -143,6 +143,14 @@ public class NativeServices extends DefaultServiceRegistry implements ServiceReg
      */
     public static void initializeOnWorker(File userHomeDir) {
         INSTANCE.initialize(userHomeDir, EnumSet.noneOf(NativeFeatures.class));
+    }
+
+    public static void logFileSystemWatchingUnavailable(NativeIntegrationUnavailableException ex) {
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("File system watching is not available", ex);
+        } else {
+            LOGGER.info("File system watching is not available: {}", ex.getMessage());
+        }
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
@@ -71,6 +71,7 @@ import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.hash.StreamHasher;
 import org.gradle.internal.nativeintegration.NativeCapabilities;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
+import org.gradle.internal.nativeintegration.services.NativeServices;
 import org.gradle.internal.os.OperatingSystem;
 import org.gradle.internal.serialize.HashCodeSerializer;
 import org.gradle.internal.service.ServiceRegistration;
@@ -263,7 +264,7 @@ public class VirtualFileSystemServices extends AbstractPluginServiceRegistry {
                         return Optional.of(new LinuxFileWatcherRegistryFactory(immutableLocationsFilter));
                     }
                 } catch (NativeIntegrationUnavailableException e) {
-                    LOGGER.debug("Native file system watching is not available for this operating system.", e);
+                    NativeServices.logFileSystemWatchingUnavailable(e);
                 }
             }
             return Optional.empty();


### PR DESCRIPTION
We now report on `INFO` level if/why file system watching was unavailable when the native library reports a problem.
