### PR TITLE
Patching documentation post-release  - fix in Gradle 8.5 docs - undo 26201

### DIFF
--- a/subprojects/docs/src/docs/userguide/optimizing-performance/file_system_watching.adoc
+++ b/subprojects/docs/src/docs/userguide/optimizing-performance/file_system_watching.adoc
@@ -75,7 +75,7 @@ Network file systems like Samba and NFS are not supported.
 ====
 
 File system watching is not compatible with symlinks.
-If your project files include symlinks, you must disable `vfs.watch` by setting `org.gradle.vfs.watch=false` in `gradle.properties`.
+If your project files include symlinks, symlinked files do not benefit from file system-watching optimizations.
 
 ====
 


### PR DESCRIPTION
### Details
Patch Gradle 8.5 Documentation (post-release)

### Context
Undo doc change for @lptr : https://github.com/gradle/gradle/issues/26201

### Reviewers:  
1 min review