### PR TITLE
Let `GenerateKotlinExtensionsForGradleApi` properly handle nested classes

### DIFF
--- a/build-logic/kotlin-dsl/src/main/kotlin/gradlebuild/kotlindsl/generator/codegen/FunctionSinceRepository.kt
+++ b/build-logic/kotlin-dsl/src/main/kotlin/gradlebuild/kotlindsl/generator/codegen/FunctionSinceRepository.kt
@@ -20,6 +20,7 @@ import com.thoughtworks.qdox.JavaProjectBuilder
 import com.thoughtworks.qdox.library.OrderedClassLibraryBuilder
 import com.thoughtworks.qdox.model.JavaAnnotatedElement
 import com.thoughtworks.qdox.model.JavaClass
+import com.thoughtworks.qdox.model.JavaSource
 import org.gradle.internal.classloader.DefaultClassLoaderFactory
 import org.gradle.internal.classpath.DefaultClassPath
 import java.io.File
@@ -55,8 +56,7 @@ class FunctionSinceRepository(classPath: Set<File>, sourcePath: Set<File>) : Aut
 
         val javaFunction = parsedJavaFunctionOf(functionSignature)
 
-        val matchingType = builder.sources
-            .flatMap { it.classes }
+        val matchingType = builder.allSourceClasses()
             .singleOrNull { javaFunction.typeName == it.binaryName }
             ?: throw IllegalArgumentException("Class for function '$functionSignature' not found in since repository! See FunctionSinceRepository.kt")
 
@@ -67,6 +67,12 @@ class FunctionSinceRepository(classPath: Set<File>, sourcePath: Set<File>) : Aut
 
         return matchingFunction.since ?: matchingType.since
     }
+
+    private
+    fun JavaProjectBuilder.allSourceClasses() = sources.asSequence().flatMap { it.allClasses() }
+
+    private
+    fun JavaSource.allClasses() = classes.asSequence().flatMap { sequenceOf(it) + it.nestedClasses }
 
     private
     fun parsedJavaFunctionOf(functionSignature: String): JavaFunction<JavaClass> =

--- a/build-logic/kotlin-dsl/src/main/kotlin/gradlebuild/kotlindsl/generator/codegen/FunctionSinceRepository.kt
+++ b/build-logic/kotlin-dsl/src/main/kotlin/gradlebuild/kotlindsl/generator/codegen/FunctionSinceRepository.kt
@@ -20,7 +20,6 @@ import com.thoughtworks.qdox.JavaProjectBuilder
 import com.thoughtworks.qdox.library.OrderedClassLibraryBuilder
 import com.thoughtworks.qdox.model.JavaAnnotatedElement
 import com.thoughtworks.qdox.model.JavaClass
-import com.thoughtworks.qdox.model.JavaSource
 import org.gradle.internal.classloader.DefaultClassLoaderFactory
 import org.gradle.internal.classpath.DefaultClassPath
 import java.io.File
@@ -56,7 +55,7 @@ class FunctionSinceRepository(classPath: Set<File>, sourcePath: Set<File>) : Aut
 
         val javaFunction = parsedJavaFunctionOf(functionSignature)
 
-        val matchingType = builder.allSourceClasses()
+        val matchingType = builder.allSourceClasses
             .singleOrNull { javaFunction.typeName == it.binaryName }
             ?: throw IllegalArgumentException("Class for function '$functionSignature' not found in since repository! See FunctionSinceRepository.kt")
 
@@ -69,10 +68,10 @@ class FunctionSinceRepository(classPath: Set<File>, sourcePath: Set<File>) : Aut
     }
 
     private
-    fun JavaProjectBuilder.allSourceClasses() = sources.asSequence().flatMap { it.allClasses() }
-
-    private
-    fun JavaSource.allClasses() = classes.asSequence().flatMap { sequenceOf(it) + it.nestedClasses }
+    val JavaProjectBuilder.allSourceClasses
+        get() = sources.asSequence()
+            .flatMap { it.classes }
+            .flatMap { sequenceOf(it) + it.nestedClasses }
 
     private
     fun parsedJavaFunctionOf(functionSignature: String): JavaFunction<JavaClass> =


### PR DESCRIPTION
By adjusting `FunctionsSinceRepository` to also look for `@since` annotations in nested classes and adding nested class methods to the parameter name index.

### Context

I discovered this limitation while spiking a new API that involved a nested public interface.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
