### PR TITLE
Fix InclusiveRepositoryContentDescriptor.includeGroupAndSubgroups

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultRepositoryHandler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultRepositoryHandler.java
@@ -199,7 +199,7 @@ public class DefaultRepositoryHandler extends DefaultArtifactRepositoryContainer
 
             @Override
             public void includeGroupAndSubgroups(String groupPrefix) {
-                desc.includeGroupAndSubgroups(groupPrefix);
+                desc.excludeGroupAndSubgroups(groupPrefix);
             }
 
             @Override


### PR DESCRIPTION
Using `includeGroupAndSubgroups` in `exclusiveContent` blocks breaks dependency resolution as upcall to other repositories not negated properly.

Fixes #26569
