### PR TITLE
Support chaining Hasher calls

### DIFF
--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/caching/impl/DefaultCachingStateFactory.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/caching/impl/DefaultCachingStateFactory.java
@@ -49,10 +49,8 @@ public class DefaultCachingStateFactory implements CachingStateFactory {
 
         beforeExecutionState.getInputProperties().forEach((propertyName, valueSnapshot) -> {
             if (logger.isWarnEnabled()) {
-                Hasher valueHasher = Hashing.newHasher();
-                valueSnapshot.appendToHasher(valueHasher);
                 logger.warn("Appending input value fingerprint for '{}' to build cache key: {}",
-                    propertyName, valueHasher.hash());
+                    propertyName, Hashing.hashHashable(valueSnapshot));
             }
             cacheKeyHasher.putString(propertyName);
             valueSnapshot.appendToHasher(cacheKeyHasher);

--- a/platforms/core-execution/hashing/src/main/java/org/gradle/internal/hash/Hasher.java
+++ b/platforms/core-execution/hashing/src/main/java/org/gradle/internal/hash/Hasher.java
@@ -18,64 +18,65 @@ package org.gradle.internal.hash;
 
 /**
  * A safe hasher that can be marked as invalid.
- *
- * In order to avoid collisions we prepend the length of the next bytes to the underlying hasher (see this <a href="http://crypto.stackexchange.com/a/10065">answer</a> on stackexchange).
+ * <p>
+ * In order to avoid collisions we prepend the length of the next bytes to the underlying hasher
+ * (see this <a href="http://crypto.stackexchange.com/a/10065">answer</a> on stackexchange).
  */
 public interface Hasher {
     /**
      * Feed a bunch of bytes into the hasher.
      */
-    void putBytes(byte[] bytes);
+    Hasher putBytes(byte[] bytes);
 
     /**
      * Feed a given number of bytes into the hasher from the given offset.
      */
-    void putBytes(byte[] bytes, int off, int len);
+    Hasher putBytes(byte[] bytes, int off, int len);
 
     /**
      * Feed a single byte into the hasher.
      */
-    void putByte(byte value);
+    Hasher putByte(byte value);
 
     /**
      * Feed an integer byte into the hasher.
      */
-    void putInt(int value);
+    Hasher putInt(int value);
 
     /**
      * Feed a long value byte into the hasher.
      */
-    void putLong(long value);
+    Hasher putLong(long value);
 
     /**
      * Feed a double value into the hasher.
      */
-    void putDouble(double value);
+    Hasher putDouble(double value);
 
     /**
      * Feed a boolean value into the hasher.
      */
-    void putBoolean(boolean value);
+    Hasher putBoolean(boolean value);
 
     /**
      * Feed a string into the hasher.
      */
-    void putString(CharSequence value);
+    Hasher putString(CharSequence value);
 
     /**
      * Feed a hash code into the hasher.
      */
-    void putHash(HashCode hashCode);
+    Hasher putHash(HashCode hashCode);
 
     /**
      * Puts a hashable value into the hasher.
      */
-    void put(Hashable hashable);
+    Hasher put(Hashable hashable);
 
     /**
      * Feed a {@code null} value into the hasher.
      */
-    void putNull();
+    Hasher putNull();
 
     /**
      * Returns the combined hash.

--- a/platforms/core-execution/hashing/src/main/java/org/gradle/internal/hash/Hashing.java
+++ b/platforms/core-execution/hashing/src/main/java/org/gradle/internal/hash/Hashing.java
@@ -370,67 +370,78 @@ public class Hashing {
         }
 
         @Override
-        public void putByte(byte value) {
+        public Hasher putByte(byte value) {
             hasher.putInt(1);
             hasher.putByte(value);
+            return this;
         }
 
         @Override
-        public void putBytes(byte[] bytes) {
+        public Hasher putBytes(byte[] bytes) {
             hasher.putInt(bytes.length);
             hasher.putBytes(bytes);
+            return this;
         }
 
         @Override
-        public void putBytes(byte[] bytes, int off, int len) {
+        public Hasher putBytes(byte[] bytes, int off, int len) {
             hasher.putInt(len);
             hasher.putBytes(bytes, off, len);
+            return this;
         }
 
         @Override
-        public void putHash(HashCode hashCode) {
+        public Hasher putHash(HashCode hashCode) {
             hasher.putInt(hashCode.length());
             hasher.putHash(hashCode);
+            return this;
         }
 
         @Override
-        public void putInt(int value) {
+        public Hasher putInt(int value) {
             hasher.putInt(4);
             hasher.putInt(value);
+            return this;
         }
 
         @Override
-        public void putLong(long value) {
+        public Hasher putLong(long value) {
             hasher.putInt(8);
             hasher.putLong(value);
+            return this;
         }
 
         @Override
-        public void putDouble(double value) {
+        public Hasher putDouble(double value) {
             hasher.putInt(8);
             hasher.putDouble(value);
+            return this;
         }
 
         @Override
-        public void putBoolean(boolean value) {
+        public Hasher putBoolean(boolean value) {
             hasher.putInt(1);
             hasher.putBoolean(value);
+            return this;
         }
 
         @Override
-        public void putString(CharSequence value) {
+        public Hasher putString(CharSequence value) {
             hasher.putInt(value.length());
             hasher.putString(value);
+            return this;
         }
 
         @Override
-        public void put(Hashable hashable) {
+        public Hasher put(Hashable hashable) {
             hashable.appendToHasher(this);
+            return this;
         }
 
         @Override
-        public void putNull() {
+        public Hasher putNull() {
             this.putInt(0);
+            return this;
         }
 
         @Override

--- a/platforms/core-execution/hashing/src/main/java/org/gradle/internal/hash/Hashing.java
+++ b/platforms/core-execution/hashing/src/main/java/org/gradle/internal/hash/Hashing.java
@@ -112,9 +112,7 @@ public class Hashing {
      * Hash the given {@code hashable} instance with the default hash function.
      */
     public static HashCode hashHashable(Hashable hashable) {
-        Hasher hasher = newHasher();
-        hasher.put(hashable);
-        return hasher.hash();
+        return newHasher().put(hashable).hash();
     }
 
     /**

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AbstractTransformExecution.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AbstractTransformExecution.java
@@ -34,7 +34,6 @@ import org.gradle.internal.execution.history.OverlappingOutputs;
 import org.gradle.internal.execution.history.changes.InputChangesInternal;
 import org.gradle.internal.execution.model.InputNormalizer;
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
-import org.gradle.internal.hash.Hasher;
 import org.gradle.internal.hash.Hashing;
 import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationDescriptor;
@@ -353,9 +352,7 @@ abstract class AbstractTransformExecution implements UnitOfWork {
 
         @Override
         public byte[] getSecondaryInputValueHashBytes() {
-            Hasher hasher = Hashing.newHasher();
-            transformWorkspaceIdentity.getSecondaryInputsSnapshot().appendToHasher(hasher);
-            return hasher.hash().toByteArray();
+            return Hashing.hashHashable(transformWorkspaceIdentity.getSecondaryInputsSnapshot()).toByteArray();
         }
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformWorkspaceIdentity.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformWorkspaceIdentity.java
@@ -69,7 +69,7 @@ class TransformWorkspaceIdentity implements UnitOfWork.Identity {
         Hasher hasher = Hashing.newHasher();
         hasher.putString(normalizedInputArtifactPath);
         hasher.putString(producerBuildTreePath);
-        secondaryInputsSnapshot.appendToHasher(hasher);
+        hasher.put(secondaryInputsSnapshot);
         hasher.putHash(dependenciesHash);
         return new TransformWorkspaceIdentity(secondaryInputsSnapshot, hasher.hash());
     }
@@ -81,9 +81,9 @@ class TransformWorkspaceIdentity implements UnitOfWork.Identity {
         HashCode dependenciesHash
     ) {
         Hasher hasher = Hashing.newHasher();
-        inputArtifactPath.appendToHasher(hasher);
+        hasher.put(inputArtifactPath);
         hasher.putHash(inputArtifactSnapshot);
-        secondaryInputsSnapshot.appendToHasher(hasher);
+        hasher.put(secondaryInputsSnapshot);
         hasher.putHash(dependenciesHash);
         return new TransformWorkspaceIdentity(secondaryInputsSnapshot, hasher.hash());
     }
@@ -95,9 +95,9 @@ class TransformWorkspaceIdentity implements UnitOfWork.Identity {
         HashCode dependenciesHash
     ) {
         Hasher hasher = Hashing.newHasher();
-        inputArtifactPath.appendToHasher(hasher);
+        hasher.put(inputArtifactPath);
         hasher.putHash(inputArtifactFingerprint.getHash());
-        secondaryInputsSnapshot.appendToHasher(hasher);
+        hasher.put(secondaryInputsSnapshot);
         hasher.putHash(dependenciesHash);
         return new TransformWorkspaceIdentity(secondaryInputsSnapshot, hasher.hash());
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/caching/CrossBuildCachingRuleExecutor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/caching/CrossBuildCachingRuleExecutor.java
@@ -35,7 +35,6 @@ import org.gradle.internal.action.ConfigurableRule;
 import org.gradle.internal.action.ConfigurableRules;
 import org.gradle.internal.action.InstantiatingAction;
 import org.gradle.internal.hash.HashCode;
-import org.gradle.internal.hash.Hasher;
 import org.gradle.internal.hash.Hashing;
 import org.gradle.internal.isolation.Isolatable;
 import org.gradle.internal.reflect.Instantiator;
@@ -66,14 +65,16 @@ public class CrossBuildCachingRuleExecutor<KEY, DETAILS, RESULT> implements Cach
     private final BuildCommencedTimeProvider timeProvider;
     private final EntryValidator<RESULT> validator;
 
-    public CrossBuildCachingRuleExecutor(String name,
-                                         GlobalScopedCacheBuilderFactory cacheBuilderFactory,
-                                         InMemoryCacheDecoratorFactory cacheDecoratorFactory,
-                                         ValueSnapshotter snapshotter,
-                                         BuildCommencedTimeProvider timeProvider,
-                                         EntryValidator<RESULT> validator,
-                                         Transformer<?, KEY> keyToSnapshottable,
-                                         Serializer<RESULT> resultSerializer) {
+    public CrossBuildCachingRuleExecutor(
+        String name,
+        GlobalScopedCacheBuilderFactory cacheBuilderFactory,
+        InMemoryCacheDecoratorFactory cacheDecoratorFactory,
+        ValueSnapshotter snapshotter,
+        BuildCommencedTimeProvider timeProvider,
+        EntryValidator<RESULT> validator,
+        Transformer<?, KEY> keyToSnapshottable,
+        Serializer<RESULT> resultSerializer
+    ) {
         this.snapshotter = snapshotter;
         this.validator = validator;
         this.keyToSnapshottable = keyToSnapshottable;
@@ -144,6 +145,7 @@ public class CrossBuildCachingRuleExecutor<KEY, DETAILS, RESULT> implements Cach
     /**
      * This method computes a snapshot of the explicit inputs of the rule, which consist of the rule implementation,
      * the rule key (for example, a module identifier) and the optional rule parameters.
+     *
      * @param key the primary key
      * @param rules the rules to be snapshotted
      * @return a snapshot of the inputs
@@ -157,9 +159,8 @@ public class CrossBuildCachingRuleExecutor<KEY, DETAILS, RESULT> implements Cach
             toBeSnapshotted.add(ruleClass);
             toBeSnapshotted.add(ruleParams);
         }
-        Hasher hasher = Hashing.newHasher();
-        snapshotter.snapshot(toBeSnapshotted).appendToHasher(hasher);
-        return hasher.hash();
+
+        return Hashing.hashHashable(snapshotter.snapshot(toBeSnapshotted));
     }
 
     private ImplicitInputsCapturingInstantiator findInputCapturingInstantiator(InstantiatingAction<DETAILS> action) {
@@ -324,7 +325,7 @@ public class CrossBuildCachingRuleExecutor<KEY, DETAILS, RESULT> implements Cach
     private static class AnySerializer implements Serializer<Object> {
         private static final BaseSerializerFactory SERIALIZER_FACTORY = new BaseSerializerFactory();
 
-        private static final Class<?>[] USUAL_TYPES = new Class<?>[] {
+        private static final Class<?>[] USUAL_TYPES = new Class<?>[]{
             String.class,
             Boolean.class,
             Long.class,

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/BaseSnapshotInputsBuildOperationResult.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/BaseSnapshotInputsBuildOperationResult.java
@@ -31,7 +31,6 @@ import org.gradle.internal.fingerprint.DirectorySensitivity;
 import org.gradle.internal.fingerprint.FileNormalizer;
 import org.gradle.internal.fingerprint.LineEndingSensitivity;
 import org.gradle.internal.hash.HashCode;
-import org.gradle.internal.hash.Hasher;
 import org.gradle.internal.hash.Hashing;
 import org.gradle.internal.operations.trace.CustomOperationTraceSerialization;
 import org.gradle.internal.scan.UsedByScanPlugin;
@@ -71,11 +70,7 @@ public abstract class BaseSnapshotInputsBuildOperationResult implements CustomOp
             .map(ExecutionInputState::getInputProperties)
             .filter(inputValueFingerprints -> !inputValueFingerprints.isEmpty())
             .map(inputValueFingerprints -> inputValueFingerprints.entrySet().stream()
-                .collect(toLinkedHashMap(valueSnapshot -> {
-                    Hasher hasher = Hashing.newHasher();
-                    valueSnapshot.appendToHasher(hasher);
-                    return hasher.hash().toByteArray();
-                })))
+                .collect(toLinkedHashMap(valueSnapshot -> Hashing.hashHashable(valueSnapshot).toByteArray())))
             .orElse(null);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingClasspathFileTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingClasspathFileTransformer.java
@@ -72,12 +72,10 @@ public class InstrumentingClasspathFileTransformer implements ClasspathFileTrans
     }
 
     private static ClasspathFileHasher createFileHasherWithConfig(HashCode configHash, ClasspathFileHasher fileHasher) {
-        return sourceSnapshot -> {
-            Hasher hasher = Hashing.defaultFunction().newHasher();
-            hasher.putHash(configHash);
-            hasher.putHash(fileHasher.hashOf(sourceSnapshot));
-            return hasher.hash();
-        };
+        return sourceSnapshot -> Hashing.newHasher()
+            .putHash(configHash)
+            .putHash(fileHasher.hashOf(sourceSnapshot))
+            .hash();
     }
 
     @Override


### PR DESCRIPTION
Creating a hash is now possible via an expression in Java:
```
return Hashing.newHasher().putInt(42).hash();
```