### PR TITLE
Fix `Class` serialization for reused projects

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsFixture.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsFixture.groovy
@@ -341,18 +341,22 @@ class IsolatedProjectsFixture {
 
         String getUpdatedProjectsString() {
             def updatedProjects = models.size()
-            return updatedProjects == 1 ? "1 project" : "$updatedProjects projects"
+            return getPluralProjectsString(updatedProjects)
         }
 
         String getReusedProjectsString() {
             def reusedProjects = projectsReused.size()
-            switch (reusedProjects) {
+            return getPluralProjectsString(reusedProjects)
+        }
+
+        private static String getPluralProjectsString(int amount) {
+            switch (amount) {
                 case 0:
                     return "no projects"
                 case 1:
                     return "1 project"
                 default:
-                    return "${reusedProjects} projects"
+                    return "${amount} projects"
             }
         }
 

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiModelQueryIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiModelQueryIntegrationTest.groovy
@@ -322,4 +322,69 @@ class IsolatedProjectsToolingApiModelQueryIntegrationTest extends AbstractIsolat
         outputDoesNotContain("configuring build")
         outputDoesNotContain("creating model")
     }
+
+    def "can store fingerprint for reused projects"() {
+        given:
+        withSomeToolingModelBuilderPluginInBuildSrc()
+        settingsFile << """
+            include("a")
+            include("b")
+        """
+        // Materializing of `ValueSource` at configuration time is leading to serializing its `Class`
+        file("a/build.gradle") << """
+            import org.gradle.api.provider.ValueSourceParameters
+
+            plugins.apply(my.MyPlugin)
+
+            abstract class MyValueSource implements ValueSource<String, ValueSourceParameters.None> {
+
+                @Override
+                String obtain() {
+                    return "Foo"
+                }
+            }
+
+            def a = providers.of(MyValueSource) {}
+            println(a.get())
+        """
+
+        file("b/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+        """
+
+        when:
+        executer.withArguments(ENABLE_CLI)
+        runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        fixture.assertStateStored {
+            projectsConfigured(":buildSrc", ":", ":a", ":b")
+            buildModelCreated()
+            modelsCreated(":a", ":b")
+        }
+
+        when:
+        file("buildSrc/build.gradle") << """
+            // change it
+        """
+
+        and:
+        executer.withArguments(ENABLE_CLI)
+        runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        fixture.assertStateUpdated {
+            fileChanged("buildSrc/build.gradle")
+            projectsConfigured(":buildSrc")
+            modelsCreated()
+            modelsReused(":a", ":b", ":")
+        }
+
+        and:
+        executer.withArguments(ENABLE_CLI)
+        runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        fixture.assertStateLoaded()
+    }
 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/BuildTreeConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/BuildTreeConfigurationCache.kt
@@ -34,10 +34,8 @@ interface BuildTreeConfigurationCache {
     /**
      * Loads the scheduled tasks from cache, if available, or else runs the given function to schedule the tasks and then
      * writes the result to the cache.
-     *
-     * @param isModelBuildingRequested True if tasks scheduling was requested as a part of model building process.
      */
-    fun loadOrScheduleRequestedTasks(graph: BuildTreeWorkGraph, graphBuilder: BuildTreeWorkGraphBuilder?, scheduler: (BuildTreeWorkGraph) -> BuildTreeWorkGraph.FinalizedGraph, isModelBuildingRequested: Boolean): WorkGraphResult
+    fun loadOrScheduleRequestedTasks(graph: BuildTreeWorkGraph, graphBuilder: BuildTreeWorkGraphBuilder?, scheduler: (BuildTreeWorkGraph) -> BuildTreeWorkGraph.FinalizedGraph): WorkGraphResult
 
     /**
      * Loads the scheduled tasks from cache.

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheAwareBuildTreeWorkController.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheAwareBuildTreeWorkController.kt
@@ -35,7 +35,7 @@ class ConfigurationCacheAwareBuildTreeWorkController(
     private val startParameter: ConfigurationCacheStartParameter,
 ) : BuildTreeWorkController {
 
-    override fun scheduleAndRunRequestedTasks(taskSelector: EntryTaskSelector?, isModelBuildingRequested: Boolean): ExecutionResult<Void> {
+    override fun scheduleAndRunRequestedTasks(taskSelector: EntryTaskSelector?): ExecutionResult<Void> {
         val scheduleTaskSelectorPostProcessing: BuildTreeWorkGraphBuilder? = taskSelector?.let { selector ->
             { rootBuildState ->
                 addFinalization(rootBuildState, selector::postProcessExecutionPlan)
@@ -44,10 +44,8 @@ class ConfigurationCacheAwareBuildTreeWorkController(
         val executionResult = workGraph.withNewWorkGraph { graph ->
             val result = cache.loadOrScheduleRequestedTasks(
                 graph = graph,
-                scheduler = { workPreparer.scheduleRequestedTasks(graph, taskSelector) },
-                graphBuilder = scheduleTaskSelectorPostProcessing,
-                isModelBuildingRequested = isModelBuildingRequested
-            )
+                graphBuilder = scheduleTaskSelectorPostProcessing
+            ) { workPreparer.scheduleRequestedTasks(graph, taskSelector) }
             if (!result.wasLoadedFromCache && !result.entryDiscarded && startParameter.loadAfterStore) {
                 // Load the work graph from cache instead
                 null

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheStateStore.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheStateStore.kt
@@ -38,7 +38,7 @@ interface ConfigurationCacheStateStore {
     fun <T : Any> useForStateLoad(stateType: StateType, action: (ConfigurationCacheStateFile) -> T): T
 
     /**
-     * Writes some value to zer or more state files.
+     * Writes some value to zero or more state files.
      */
     fun useForStore(action: (ConfigurationCacheRepository.Layout) -> Unit)
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/VintageBuildTreeWorkController.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/VintageBuildTreeWorkController.kt
@@ -31,7 +31,7 @@ class VintageBuildTreeWorkController(
     private val taskGraph: BuildTreeWorkGraphController
 ) : BuildTreeWorkController {
 
-    override fun scheduleAndRunRequestedTasks(taskSelector: EntryTaskSelector?, isModelBuildingRequested: Boolean): ExecutionResult<Void> {
+    override fun scheduleAndRunRequestedTasks(taskSelector: EntryTaskSelector?): ExecutionResult<Void> {
         return taskGraph.withNewWorkGraph { graph: BuildTreeWorkGraph ->
             val finalizedGraph: BuildTreeWorkGraph.FinalizedGraph = workPreparer.scheduleRequestedTasks(graph, taskSelector)
             workExecutor.execute(finalizedGraph)

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeWorkController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeWorkController.java
@@ -28,8 +28,6 @@ public interface BuildTreeWorkController {
 
     /**
      * Schedules and runs requested tasks based on the provided {@code taskSelector}.
-     *
-     * @param isModelBuildingRequested True if tasks run was requested as a part of model building process.
-     * */
-    ExecutionResult<Void> scheduleAndRunRequestedTasks(@Nullable EntryTaskSelector taskSelector, boolean isModelBuildingRequested);
+     */
+    ExecutionResult<Void> scheduleAndRunRequestedTasks(@Nullable EntryTaskSelector taskSelector);
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/DefaultBuildTreeLifecycleController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/DefaultBuildTreeLifecycleController.java
@@ -73,7 +73,7 @@ public class DefaultBuildTreeLifecycleController implements BuildTreeLifecycleCo
 
     @Override
     public void scheduleAndRunTasks(EntryTaskSelector selector) {
-        runBuild(() -> workController.scheduleAndRunRequestedTasks(selector, false));
+        runBuild(() -> workController.scheduleAndRunRequestedTasks(selector));
     }
 
     @Override
@@ -81,7 +81,7 @@ public class DefaultBuildTreeLifecycleController implements BuildTreeLifecycleCo
         return runBuild(() -> {
             modelCreator.beforeTasks(action);
             if (runTasks && isEligibleToRunTasks()) {
-                ExecutionResult<Void> result = workController.scheduleAndRunRequestedTasks(null, true);
+                ExecutionResult<Void> result = workController.scheduleAndRunRequestedTasks(null);
                 if (!result.getFailures().isEmpty()) {
                     return result.asFailure();
                 }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/buildtree/DefaultBuildTreeLifecycleControllerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/buildtree/DefaultBuildTreeLifecycleControllerTest.groovy
@@ -47,7 +47,7 @@ class DefaultBuildTreeLifecycleControllerTest extends Specification {
         controller.scheduleAndRunTasks()
 
         then:
-        1 * workController.scheduleAndRunRequestedTasks(null, false) >> ExecutionResult.succeeded()
+        1 * workController.scheduleAndRunRequestedTasks(null) >> ExecutionResult.succeeded()
 
         and:
         1 * finishExecutor.finishBuildTree([]) >> null
@@ -64,7 +64,7 @@ class DefaultBuildTreeLifecycleControllerTest extends Specification {
         e == reportableFailure
 
         and:
-        1 * workController.scheduleAndRunRequestedTasks(null, false) >> ExecutionResult.failed(failure)
+        1 * workController.scheduleAndRunRequestedTasks(null) >> ExecutionResult.failed(failure)
 
         and:
         1 * finishExecutor.finishBuildTree([failure]) >> reportableFailure
@@ -79,7 +79,7 @@ class DefaultBuildTreeLifecycleControllerTest extends Specification {
         e == reportableFailure
 
         and:
-        1 * workController.scheduleAndRunRequestedTasks(null, false) >> ExecutionResult.succeeded()
+        1 * workController.scheduleAndRunRequestedTasks(null) >> ExecutionResult.succeeded()
 
         and:
         1 * finishExecutor.finishBuildTree([]) >> reportableFailure
@@ -97,7 +97,7 @@ class DefaultBuildTreeLifecycleControllerTest extends Specification {
         result == "result"
 
         and:
-        1 * workController.scheduleAndRunRequestedTasks(null, true) >> ExecutionResult.succeeded()
+        1 * workController.scheduleAndRunRequestedTasks(null) >> ExecutionResult.succeeded()
 
         and:
         1 * modelCreator.fromBuildModel(action) >> "result"
@@ -118,7 +118,7 @@ class DefaultBuildTreeLifecycleControllerTest extends Specification {
         result == "result"
 
         and:
-        0 * workController.scheduleAndRunRequestedTasks(null, true)
+        0 * workController.scheduleAndRunRequestedTasks(null)
 
         and:
         1 * modelCreator.fromBuildModel(action) >> "result"
@@ -146,7 +146,7 @@ class DefaultBuildTreeLifecycleControllerTest extends Specification {
         e == reportableFailure
 
         and:
-        1 * workController.scheduleAndRunRequestedTasks(null, true) >> ExecutionResult.failed(failure)
+        1 * workController.scheduleAndRunRequestedTasks(null) >> ExecutionResult.failed(failure)
         0 * action._
 
         and:


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/27357

This PR is making disposing of `ClassLoaderScopeRegistry` later, during finalization of CC entry
### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
