### PR TITLE
Wire dependency resolution for dependency mapping

### DIFF
--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/MergeProviderIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/MergeProviderIntegrationTest.groovy
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.provider
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+/**
+ * Tests {@link org.gradle.api.internal.provider.MergeProvider}.
+ */
+class MergeProviderIntegrationTest extends AbstractIntegrationSpec {
+
+    def "carries task dependencies"() {
+        buildFile << """
+            tasks.register('myTask1', StringTask) {
+                string.set('Hello')
+            }
+            tasks.register('myTask2', StringTask) {
+                string.set('World')
+            }
+
+            tasks.register('combined', StringListTask) {
+                strings.set(new org.gradle.api.internal.provider.MergeProvider([
+                    tasks.named('myTask1').map { it.string.get() },
+                    tasks.named('myTask2').map { it.string.get() }
+                ]))
+            }
+
+            abstract class StringTask extends DefaultTask {
+                @Input
+                abstract Property<String> getString()
+
+                @TaskAction
+                void printText() {
+                    println getString().get()
+                }
+            }
+
+            abstract class StringListTask extends DefaultTask {
+                @Input
+                abstract ListProperty<String> getStrings()
+
+                @TaskAction
+                void printText() {
+                    println getStrings().get()
+                }
+            }
+        """
+
+        when:
+        succeeds 'combined'
+
+        then:
+        executedAndNotSkipped(':myTask1', ':myTask2', ':combined')
+        outputContains('[Hello, World]')
+    }
+}

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/MergeProvider.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/MergeProvider.java
@@ -38,7 +38,7 @@ public class MergeProvider<R> extends AbstractMinimalProvider<List<R>> {
     private final List<Provider<R>> items;
 
     public MergeProvider(List<Provider<R>> items) {
-        this.items = items;
+        this.items = ImmutableList.copyOf(items);
     }
 
     @Override
@@ -110,14 +110,14 @@ public class MergeProvider<R> extends AbstractMinimalProvider<List<R>> {
         for (Provider<R> item : items) {
             producers.add(Providers.internal(item).getProducer());
         }
-        return new ZipValueProvider(producers.build());
+        return new MergeValueProducer(producers.build());
     }
 
-    private static class ZipValueProvider implements ValueProducer {
+    private static class MergeValueProducer implements ValueProducer {
 
         private final List<ValueProducer> items;
 
-        public ZipValueProvider(List<ValueProducer> items) {
+        public MergeValueProducer(List<ValueProducer> items) {
             this.items = items;
         }
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/MergeProvider.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/MergeProvider.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.provider;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import org.gradle.api.Action;
+import org.gradle.api.Task;
+import org.gradle.api.provider.Provider;
+import org.gradle.internal.Cast;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A provider that takes a list of providers of values and provides a list of those values.
+ *
+ * This effectively converts a {@code List<Provider<T>>} to a {@code Provider<List<T>>}.
+ *
+ * @param <R> The type of the values that all source providers must share.
+ */
+public class MergeProvider<R> extends AbstractMinimalProvider<List<R>> {
+
+    private final List<Provider<R>> items;
+
+    public MergeProvider(List<Provider<R>> items) {
+        this.items = items;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("merge([%s])", Joiner.on(", ").join(items));
+    }
+
+    @Override
+    public boolean calculatePresence(ValueConsumer consumer) {
+        for (Provider<R> provider : items) {
+            if (!Providers.internal(provider).calculatePresence(consumer)) {
+                return false;
+            }
+        }
+
+        // Purposefully only calculate full value if all items are present, to save time
+        return super.calculatePresence(consumer);
+    }
+
+    @Override
+    public ExecutionTimeValue<? extends List<R>> calculateExecutionTimeValue() {
+        for (Provider<R> provider : items) {
+            if (isChangingValue(Providers.internal(provider))) {
+                return ExecutionTimeValue.changingValue(this);
+            }
+        }
+
+        return super.calculateExecutionTimeValue();
+    }
+
+    private boolean isChangingValue(ProviderInternal<?> provider) {
+        return provider.calculateExecutionTimeValue().isChangingValue();
+    }
+
+    @Override
+    protected Value<List<R>> calculateOwnValue(ValueConsumer consumer) {
+
+        List<Value<? extends R>> values = new ArrayList<>(items.size());
+        for (Provider<R> provider : items) {
+            Value<? extends R> value = Providers.internal(provider).calculateValue(consumer);
+            if (value.isMissing()) {
+                return value.asType();
+            }
+            values.add(value);
+        }
+
+        ImmutableList.Builder<R> result = ImmutableList.builderWithExpectedSize(values.size());
+        for (Value<? extends R> value : values) {
+            result.add(value.getWithoutSideEffect());
+        }
+
+        Value<List<R>> finalValue = Value.ofNullable(result.build());
+        for (Value<? extends R> value : values) {
+            finalValue = finalValue.withSideEffect(SideEffect.fixedFrom(value));
+        }
+
+        return finalValue;
+    }
+
+    @Nullable
+    @Override
+    public Class<List<R>> getType() {
+        return Cast.uncheckedCast(List.class);
+    }
+
+    @Override
+    public ValueProducer getProducer() {
+        ImmutableList.Builder<ValueProducer> producers = ImmutableList.builderWithExpectedSize(items.size());
+        for (Provider<R> item : items) {
+            producers.add(Providers.internal(item).getProducer());
+        }
+        return new ZipValueProvider(producers.build());
+    }
+
+    private static class ZipValueProvider implements ValueProducer {
+
+        private final List<ValueProducer> items;
+
+        public ZipValueProvider(List<ValueProducer> items) {
+            this.items = items;
+        }
+
+        @Override
+        public boolean isKnown() {
+            for (ValueProducer item : items) {
+                if (item.isKnown()) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public boolean isProducesDifferentValueOverTime() {
+            for (ValueProducer item : items) {
+                if (item.isProducesDifferentValueOverTime()) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public void visitProducerTasks(Action<? super Task> visitor) {
+            for (ValueProducer item : items) {
+                item.visitProducerTasks(visitor);
+            }
+        }
+    }
+}

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/MergeProviderTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/MergeProviderTest.groovy
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider
+
+import org.gradle.util.TestUtil
+import spock.lang.Specification
+
+class MergeProviderTest extends Specification {
+
+    def objects = TestUtil.objectFactory()
+    def providers = TestUtil.providerFactory()
+
+    def "provides all values"() {
+        given:
+        def provider1 = new MergeProvider([providers.provider { "a" }])
+        def provider2 = new MergeProvider([providers.provider { "a" }, providers.provider { "b" }])
+
+        expect:
+        provider1.get() == ["a"]
+        provider2.get() == ["a", "b"]
+    }
+
+    def "isPresent is true if all sources are present"() {
+        given:
+        def provider1 = new MergeProvider([providers.provider { new Object() }])
+        def provider2 = new MergeProvider([providers.provider { new Object() }, providers.provider { new Object() }])
+
+        expect:
+        provider1.isPresent()
+        provider2.isPresent()
+    }
+
+    def "isPresent is false if any source is not present"() {
+        given:
+        def provider1 = new MergeProvider([providers.provider { null }])
+        def provider2 = new MergeProvider([providers.provider { null }, providers.provider { new Object() }])
+
+        expect:
+        !provider1.isPresent()
+        !provider2.isPresent()
+    }
+
+    def "runs side effects"() {
+        given:
+        def leftSideEffect = Mock(ValueSupplier.SideEffect)
+        def rightSideEffect = Mock(ValueSupplier.SideEffect)
+        def mergedSideEffect = Mock(ValueSupplier.SideEffect)
+
+        def left = Providers.of("left").withSideEffect(leftSideEffect)
+        def right = Providers.of("right").withSideEffect(rightSideEffect)
+
+        def provider = new MergeProvider([left, right]).withSideEffect(mergedSideEffect)
+
+        when:
+        provider.calculateValue(ValueSupplier.ValueConsumer.IgnoreUnsafeRead)
+        provider.calculateExecutionTimeValue()
+
+        then:
+        0 * _ // no side effects when values are not unpacked
+
+        when:
+        def result = provider.getOrNull()
+
+        then:
+        result == ["left", "right"]
+        1 * leftSideEffect.execute("left")
+
+        then: // ensure ordering
+        1 * rightSideEffect.execute("right")
+
+        then: // ensure ordering
+        1 * mergedSideEffect.execute(["left", "right"])
+    }
+
+    def "provider is live"() {
+        given:
+        def first = objects.property(String)
+        def second = objects.property(String)
+
+        def provider = new MergeProvider([first, second])
+
+        when:
+        first.set("1")
+        second.set("2")
+
+        then:
+        provider.get() == ["1", "2"]
+
+        when:
+        first.set("3")
+        second.set("4")
+
+        then:
+        provider.get() == ["3", "4"]
+
+    }
+}

--- a/platforms/software/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/IvyComponentParser.java
+++ b/platforms/software/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/IvyComponentParser.java
@@ -17,6 +17,7 @@
 package org.gradle.api.publish.ivy.internal.publication;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.GradleException;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.DependencyConstraint;
@@ -32,8 +33,10 @@ import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.ExactVersionSelector;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
+import org.gradle.api.internal.provider.MergeProvider;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.publish.internal.component.IvyPublishingAwareVariant;
 import org.gradle.api.publish.internal.mapping.DependencyCoordinateResolverFactory;
 import org.gradle.api.publish.internal.mapping.ResolvedCoordinates;
@@ -55,8 +58,10 @@ import org.gradle.internal.typeconversion.NotationParser;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -174,45 +179,63 @@ public class IvyComponentParser {
         return publishArtifact.getName() + ":" + publishArtifact.getType() + ":" + publishArtifact.getExtension() + ":" + publishArtifact.getClassifier();
     }
 
-    public ParsedDependencyResult parseDependencies(SoftwareComponentInternal component, VersionMappingStrategyInternal versionMappingStrategy) {
+    public Provider<ParsedDependencyResult> parseDependencies(SoftwareComponentInternal component, VersionMappingStrategyInternal versionMappingStrategy) {
         PublicationErrorChecker.checkForUnpublishableAttributes(component, documentationRegistry);
 
-        DefaultIvyDependencySet ivyDependencies = instantiator.newInstance(DefaultIvyDependencySet.class, collectionCallbackActionDecorator);
+        List<Provider<ParsedVariantDependencyResult>> parsedVariants = component.getUsages().stream()
+            .map(variant -> dependencyCoordinateResolverFactory
+                .createCoordinateResolvers(variant, versionMappingStrategy)
+                .map(resolvers -> getDependenciesForVariant(variant, resolvers.getVariantResolver(), platformSupport))
+            )
+            .collect(ImmutableList.toImmutableList());
 
-        PublicationWarningsCollector publicationWarningsCollector =
-            new PublicationWarningsCollector(LOG, UNSUPPORTED_FEATURE, "", PUBLICATION_WARNING_FOOTER, "suppressIvyMetadataWarningsFor");
+        return new MergeProvider<>(parsedVariants).map(variants -> {
+            DefaultIvyDependencySet ivyDependencies = instantiator.newInstance(DefaultIvyDependencySet.class, collectionCallbackActionDecorator);
+            Map<String, VariantWarningCollector> warnings = new HashMap<>();
 
-        for (SoftwareComponentVariant variant : component.getUsages()) {
-            VariantWarningCollector warnings = publicationWarningsCollector.warningCollectorFor(variant.getName());
-
-            VariantDependencyResolver dependencyResolver = dependencyCoordinateResolverFactory.createCoordinateResolvers(variant, versionMappingStrategy).getVariantResolver();
-
-            VariantDependencyFactory dependencyFactory = new VariantDependencyFactory(dependencyResolver, warnings);
-
-            for (ModuleDependency dependency : variant.getDependencies()) {
-                String confMapping = confMappingFor(variant, dependency);
-                if (platformSupport.isTargetingPlatform(dependency)) {
-                    warnings.addUnsupported(String.format("%s:%s:%s declared as platform", dependency.getGroup(), dependency.getName(), dependency.getVersion()));
-                }
-                ivyDependencies.add(dependencyFactory.convertDependency(dependency, confMapping));
+            for (ParsedVariantDependencyResult variant : variants) {
+                ivyDependencies.addAll(variant.dependencies);
+                warnings.put(variant.name, variant.warnings);
             }
 
-            if (!variant.getDependencyConstraints().isEmpty()) {
-                for (DependencyConstraint constraint : variant.getDependencyConstraints()) {
-                    warnings.addUnsupported(String.format("%s:%s:%s declared as a dependency constraint", constraint.getGroup(), constraint.getName(), constraint.getVersion()));
-                }
+            return new ParsedDependencyResult(
+                ivyDependencies,
+                new PublicationWarningsCollector(warnings, LOG, UNSUPPORTED_FEATURE, "", PUBLICATION_WARNING_FOOTER, "suppressIvyMetadataWarningsFor")
+            );
+        });
+    }
+
+    private static ParsedVariantDependencyResult getDependenciesForVariant(
+        SoftwareComponentVariant variant,
+        VariantDependencyResolver dependencyResolver,
+        PlatformSupport platformSupport
+    ) {
+        VariantWarningCollector warnings = new VariantWarningCollector();
+        Set<? extends ModuleDependency> dependencies = variant.getDependencies();
+        List<IvyDependency> ivyDependencies = new ArrayList<>(dependencies.size());
+
+        VariantDependencyFactory dependencyFactory = new VariantDependencyFactory(dependencyResolver, warnings);
+
+        for (ModuleDependency dependency : dependencies) {
+            String confMapping = confMappingFor(variant, dependency);
+            if (platformSupport.isTargetingPlatform(dependency)) {
+                warnings.addUnsupported(String.format("%s:%s:%s declared as platform", dependency.getGroup(), dependency.getName(), dependency.getVersion()));
             }
-            if (!variant.getCapabilities().isEmpty()) {
-                for (Capability capability : variant.getCapabilities()) {
-                    warnings.addVariantUnsupported(String.format("Declares capability %s:%s:%s which cannot be mapped to Ivy", capability.getGroup(), capability.getName(), capability.getVersion()));
-                }
+            ivyDependencies.add(dependencyFactory.convertDependency(dependency, confMapping));
+        }
+
+        if (!variant.getDependencyConstraints().isEmpty()) {
+            for (DependencyConstraint constraint : variant.getDependencyConstraints()) {
+                warnings.addUnsupported(String.format("%s:%s:%s declared as a dependency constraint", constraint.getGroup(), constraint.getName(), constraint.getVersion()));
+            }
+        }
+        if (!variant.getCapabilities().isEmpty()) {
+            for (Capability capability : variant.getCapabilities()) {
+                warnings.addVariantUnsupported(String.format("Declares capability %s:%s:%s which cannot be mapped to Ivy", capability.getGroup(), capability.getName(), capability.getVersion()));
             }
         }
 
-        return new ParsedDependencyResult(
-            ivyDependencies,
-            publicationWarningsCollector
-        );
+        return new ParsedVariantDependencyResult(variant.getName(), ivyDependencies, warnings);
     }
 
     public Set<IvyExcludeRule> parseGlobalExcludes(SoftwareComponentInternal component) {
@@ -338,6 +361,9 @@ public class IvyComponentParser {
         }
     }
 
+    /**
+     * Parsed dependencies for all variants.
+     */
     public static class ParsedDependencyResult {
         private final DefaultIvyDependencySet dependencies;
         private final PublicationWarningsCollector warnings;
@@ -356,6 +382,25 @@ public class IvyComponentParser {
 
         public PublicationWarningsCollector getWarnings() {
             return warnings;
+        }
+    }
+
+    /**
+     * Parsed dependencies for a single variant.
+     */
+    private static class ParsedVariantDependencyResult {
+        private final String name;
+        private final List<IvyDependency> dependencies;
+        private final VariantWarningCollector warnings;
+
+        public ParsedVariantDependencyResult(
+            String name,
+            List<IvyDependency> dependencies,
+            VariantWarningCollector warnings
+        ) {
+            this.name = name;
+            this.dependencies = dependencies;
+            this.warnings = warnings;
         }
     }
 }

--- a/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/AbstractMavenPublishJavaIntegTest.groovy
+++ b/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/AbstractMavenPublishJavaIntegTest.groovy
@@ -289,7 +289,7 @@ abstract class AbstractMavenPublishJavaIntegTest extends AbstractMavenPublishInt
         javaLibrary.parsedPom.scopes.compile.assertDependsOn("org.springframework:spring-core:1.2.9")
 
         javaLibrary.parsedPom.scopes.runtime.assertDependsOn("org.apache.commons:commons-compress:1.5")
-        javaLibrary.parsedPom.scopes.no_scope.assertDependencyManagement("commons-logging:commons-logging:1.1", "commons-logging:commons-logging:1.2", "org.tukaani:xz:1.6")
+        javaLibrary.parsedPom.scopes.no_scope.assertDependencyManagement("commons-logging:commons-logging:1.1", "org.tukaani:xz:1.6")
 
         and:
         javaLibrary.parsedModuleMetadata.variant("apiElements") {

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/MavenComponentParser.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/MavenComponentParser.java
@@ -38,8 +38,10 @@ import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.MavenVersionSelectorScheme;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
+import org.gradle.api.internal.provider.MergeProvider;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.publish.internal.component.MavenPublishingAwareVariant;
 import org.gradle.api.publish.internal.mapping.ComponentDependencyResolver;
 import org.gradle.api.publish.internal.mapping.DependencyCoordinateResolverFactory;
@@ -63,8 +65,10 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -131,92 +135,116 @@ public class MavenComponentParser {
             .collect(Collectors.toSet());
     }
 
-    public ParsedDependencyResult parseDependencies(
+    public Provider<ParsedDependencyResult> parseDependencies(
         SoftwareComponentInternal component,
         VersionMappingStrategyInternal versionMappingStrategy,
         ModuleVersionIdentifier coordinates
     ) {
         MavenPublicationErrorChecker.checkForUnpublishableAttributes(component, documentationRegistry);
 
-        PublicationWarningsCollector publicationWarningsCollector = new PublicationWarningsCollector(
-            LOG, UNSUPPORTED_FEATURE, INCOMPATIBLE_FEATURE, PUBLICATION_WARNING_FOOTER, "suppressPomMetadataWarningsFor");
+        List<Provider<ParsedVariantDependencyResult>> parsedVariants = createSortedVariantsStream(component)
+            .map(variant -> dependencyCoordinateResolverFactory
+                .createCoordinateResolvers(variant, versionMappingStrategy)
+                .map(resolvers -> getDependenciesForVariant(variant, resolvers, coordinates))
+            ).collect(Collectors.toList());
 
-        Set<MavenDependencyKey> seenDependencies = new HashSet<>();
-        Set<MavenDependencyKey> seenPlatforms = new HashSet<>();
-        Set<DependencyConstraint> seenConstraints = new HashSet<>();
+        return new MergeProvider<>(parsedVariants).map(variants -> {
+            List<MavenDependency> dependencies = new ArrayList<>();
+            List<MavenDependency> constraints = new ArrayList<>();
+            List<MavenDependency> platforms = new ArrayList<>();
+
+            Set<MavenDependencyKey> seenDependencies = new HashSet<>();
+            Set<MavenDependencyKey> seenPlatforms = new HashSet<>();
+            Set<MavenDependencyKey> seenConstraints = new HashSet<>();
+
+            Map<String, VariantWarningCollector> warnings = new HashMap<>();
+
+            for (ParsedVariantDependencyResult variant : variants) {
+                for (MavenDependency dependency : variant.dependencies) {
+                    if (seenDependencies.add(MavenDependencyKey.of(dependency))) {
+                        dependencies.add(dependency);
+                    }
+                }
+                for (MavenDependency platform : variant.platforms) {
+                    if (seenPlatforms.add(MavenDependencyKey.of(platform))) {
+                        platforms.add(platform);
+                    }
+                }
+                for (MavenDependency dep : variant.constraints) {
+                    if (seenConstraints.add(MavenDependencyKey.of(dep))) {
+                        constraints.add(dep);
+                    }
+                }
+
+                warnings.put(variant.name, variant.warnings);
+            }
+
+            return new ParsedDependencyResult(
+                new DefaultMavenPomDependencies(
+                    ImmutableList.copyOf(dependencies),
+                    ImmutableList.<MavenDependency>builder().addAll(constraints).addAll(platforms).build()
+                ),
+                new PublicationWarningsCollector(warnings, LOG, UNSUPPORTED_FEATURE, INCOMPATIBLE_FEATURE, PUBLICATION_WARNING_FOOTER, "suppressPomMetadataWarningsFor")
+            );
+        });
+    }
+
+    private ParsedVariantDependencyResult getDependenciesForVariant(
+        SoftwareComponentVariant variant,
+        DependencyCoordinateResolverFactory.DependencyResolvers resolvers,
+        ModuleVersionIdentifier coordinates
+    ) {
+        VariantWarningCollector warnings = new VariantWarningCollector();
 
         List<MavenDependency> dependencies = new ArrayList<>();
         List<MavenDependency> constraints = new ArrayList<>();
         List<MavenDependency> platforms = new ArrayList<>();
 
-        createSortedVariantsStream(component).forEach(variant -> {
-            VariantWarningCollector warnings = publicationWarningsCollector.warningCollectorFor(variant.getName());
-            MavenPublishingAwareVariant.ScopeMapping scopeMapping = MavenPublishingAwareVariant.scopeForVariant(variant);
-            String scope = scopeMapping.getScope();
-            boolean optional = scopeMapping.isOptional();
-            Set<ExcludeRule> globalExcludes = variant.getGlobalExcludes();
+        MavenPublishingAwareVariant.ScopeMapping scopeMapping = MavenPublishingAwareVariant.scopeForVariant(variant);
+        String scope = scopeMapping.getScope();
+        boolean optional = scopeMapping.isOptional();
+        Set<ExcludeRule> globalExcludes = variant.getGlobalExcludes();
 
-            DependencyCoordinateResolverFactory.DependencyResolvers resolvers = dependencyCoordinateResolverFactory.createCoordinateResolvers(variant, versionMappingStrategy);
-            MavenDependencyFactory dependencyFactory = new MavenDependencyFactory(
-                warnings,
-                resolvers.getVariantResolver(),
-                resolvers.getComponentResolver(),
-                versionRangeMapper,
-                scope,
-                optional,
-                globalExcludes
-            );
-
-            Consumer<MavenDependency> dependencyAdder = dep -> {
-                if (seenDependencies.add(MavenDependencyKey.of(dep))) {
-                    dependencies.add(dep);
-                }
-            };
-            Consumer<MavenDependency> platformsAdder = dep -> {
-                if (seenPlatforms.add(MavenDependencyKey.of(dep))) {
-                    platforms.add(dep);
-                }
-            };
-
-            for (ModuleDependency dependency : variant.getDependencies()) {
-                if (isDependencyWithDefaultArtifact(dependency) && dependencyMatchesProject(dependency, coordinates)) {
-                    // We skip all self referencing dependency declarations, unless they have custom artifact information
-                    continue;
-                }
-                if (platformSupport.isTargetingPlatform(dependency)) {
-                    dependencyFactory.convertImportDependencyConstraint(dependency, platformsAdder);
-                } else {
-                    dependencyFactory.convertDependency(dependency, dependencyAdder);
-                }
-            }
-
-            for (DependencyConstraint dependency : variant.getDependencyConstraints()) {
-                if (seenConstraints.add(dependency)) { // TODO: De-duplicate constraints like we do with MavenDependencyKey
-                    if (dependency instanceof DefaultProjectDependencyConstraint || dependency.getVersion() != null) {
-                        dependencyFactory.convertDependencyConstraint(dependency, constraints::add);
-                    } else {
-                        // Some dependency constraints, like those with rejectAll() have no version and do not map to Maven.
-                        warnings.addIncompatible(String.format("constraint %s:%s declared with a Maven incompatible version notation", dependency.getGroup(), dependency.getName()));
-                    }
-                }
-            }
-
-            if (!variant.getCapabilities().isEmpty()) {
-                for (Capability capability : variant.getCapabilities()) {
-                    if (isNotDefaultCapability(capability, coordinates)) {
-                        warnings.addVariantUnsupported(String.format("Declares capability %s:%s:%s which cannot be mapped to Maven", capability.getGroup(), capability.getName(), capability.getVersion()));
-                    }
-                }
-            }
-        });
-
-        return new ParsedDependencyResult(
-            new DefaultMavenPomDependencies(
-                ImmutableList.copyOf(dependencies),
-                ImmutableList.<MavenDependency>builder().addAll(constraints).addAll(platforms).build()
-            ),
-            publicationWarningsCollector
+        MavenDependencyFactory dependencyFactory = new MavenDependencyFactory(
+            warnings,
+            resolvers.getVariantResolver(),
+            resolvers.getComponentResolver(),
+            versionRangeMapper,
+            scope,
+            optional,
+            globalExcludes
         );
+
+        for (ModuleDependency dependency : variant.getDependencies()) {
+            if (isDependencyWithDefaultArtifact(dependency) && dependencyMatchesProject(dependency, coordinates)) {
+                // We skip all self referencing dependency declarations, unless they have custom artifact information
+                continue;
+            }
+            if (platformSupport.isTargetingPlatform(dependency)) {
+                dependencyFactory.convertImportDependencyConstraint(dependency, platforms::add);
+            } else {
+                dependencyFactory.convertDependency(dependency, dependencies::add);
+            }
+        }
+
+        for (DependencyConstraint dependency : variant.getDependencyConstraints()) {
+            if (dependency instanceof DefaultProjectDependencyConstraint || dependency.getVersion() != null) {
+                dependencyFactory.convertDependencyConstraint(dependency, constraints::add);
+            } else {
+                // Some dependency constraints, like those with rejectAll() have no version and do not map to Maven.
+                warnings.addIncompatible(String.format("constraint %s:%s declared with a Maven incompatible version notation", dependency.getGroup(), dependency.getName()));
+            }
+        }
+
+        if (!variant.getCapabilities().isEmpty()) {
+            for (Capability capability : variant.getCapabilities()) {
+                if (isNotDefaultCapability(capability, coordinates)) {
+                    warnings.addVariantUnsupported(String.format("Declares capability %s:%s:%s which cannot be mapped to Maven", capability.getGroup(), capability.getName(), capability.getVersion()));
+                }
+            }
+        }
+
+        return new ParsedVariantDependencyResult(variant.getName(), dependencies, platforms, constraints, warnings);
     }
 
     private static boolean isNotDefaultCapability(Capability capability, ModuleVersionIdentifier coordinates) {
@@ -410,6 +438,9 @@ public class MavenComponentParser {
         }
     }
 
+    /**
+     * Parsed dependencies for all variants.
+     */
     public static class ParsedDependencyResult {
         private final MavenPomDependencies dependencies;
         private final PublicationWarningsCollector warnings;
@@ -428,6 +459,31 @@ public class MavenComponentParser {
 
         public PublicationWarningsCollector getWarnings() {
             return warnings;
+        }
+    }
+
+    /**
+     * Parsed dependencies for a single variant.
+     */
+    private static class ParsedVariantDependencyResult {
+        private final String name;
+        private final List<MavenDependency> dependencies;
+        private final List<MavenDependency> platforms;
+        private final List<MavenDependency> constraints;
+        private final VariantWarningCollector warnings;
+
+        public ParsedVariantDependencyResult(
+            String name,
+            List<MavenDependency> dependencies,
+            List<MavenDependency> platforms,
+            List<MavenDependency> constraints,
+            VariantWarningCollector warnings
+        ) {
+            this.name = name;
+            this.dependencies = dependencies;
+            this.platforms = platforms;
+            this.constraints = constraints;
+            this.warnings = warnings;
         }
     }
 

--- a/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/mapping/DependencyCoordinateResolverFactory.java
+++ b/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/mapping/DependencyCoordinateResolverFactory.java
@@ -17,6 +17,7 @@
 package org.gradle.api.publish.internal.mapping;
 
 import org.gradle.api.component.SoftwareComponentVariant;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.publish.internal.versionmapping.VersionMappingStrategyInternal;
 
 /**
@@ -28,7 +29,7 @@ public interface DependencyCoordinateResolverFactory {
     /**
      * Create coordinate resolvers for the given variant.
      */
-    DependencyResolvers createCoordinateResolvers(SoftwareComponentVariant variant, VersionMappingStrategyInternal versionMappingStrategy);
+    Provider<DependencyResolvers> createCoordinateResolvers(SoftwareComponentVariant variant, VersionMappingStrategyInternal versionMappingStrategy);
 
     /**
      * Contains the variant and component coordinate resolver for a given variant.

--- a/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/validation/PublicationWarningsCollector.java
+++ b/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/validation/PublicationWarningsCollector.java
@@ -34,10 +34,17 @@ public class PublicationWarningsCollector {
     private final String disableMethod;
     private final Map<String, VariantWarningCollector> variantToWarnings;
 
-    public PublicationWarningsCollector(Logger logger, String unsupportedFeature, String incompatibleFeature, String footer, String disableMethod) {
+    public PublicationWarningsCollector(
+        Map<String, VariantWarningCollector> variantToWarnings,
+        Logger logger,
+        String unsupportedFeature,
+        String incompatibleFeature,
+        String footer,
+        String disableMethod
+    ) {
         this.footer = footer;
         this.disableMethod = disableMethod;
-        this.variantToWarnings = new TreeMap<>();
+        this.variantToWarnings = new TreeMap<>(variantToWarnings);
         this.logger = logger;
         this.unsupportedFeature = unsupportedFeature;
         this.incompatibleFeature = incompatibleFeature;
@@ -74,9 +81,5 @@ public class PublicationWarningsCollector {
             treeFormatter.node(footer);
             logger.lifecycle(treeFormatter.toString());
         }
-    }
-
-    public VariantWarningCollector warningCollectorFor(String name) {
-        return variantToWarnings.computeIfAbsent(name, k -> new VariantWarningCollector());
     }
 }

--- a/platforms/software/publish/src/main/java/org/gradle/api/publish/tasks/GenerateModuleMetadata.java
+++ b/platforms/software/publish/src/main/java/org/gradle/api/publish/tasks/GenerateModuleMetadata.java
@@ -268,7 +268,7 @@ public abstract class GenerateModuleMetadata extends DefaultTask {
             checker,
             dependencyCoordinateResolverFactory,
             dependencyAttributeValidators()
-        ).build();
+        ).build().get();
         checker.validate();
         return spec;
     }

--- a/platforms/software/publish/src/test/groovy/org/gradle/api/publish/internal/metadata/GradleModuleMetadataWriterTest.groovy
+++ b/platforms/software/publish/src/test/groovy/org/gradle/api/publish/internal/metadata/GradleModuleMetadataWriterTest.groovy
@@ -39,6 +39,7 @@ import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.component.SoftwareComponentInternal
 import org.gradle.api.internal.component.UsageContext
 import org.gradle.api.internal.provider.Providers
+import org.gradle.api.provider.Provider
 import org.gradle.api.publish.internal.PublicationInternal
 import org.gradle.api.publish.internal.mapping.ComponentDependencyResolver
 import org.gradle.api.publish.internal.mapping.DependencyCoordinateResolverFactory
@@ -87,7 +88,7 @@ class GradleModuleMetadataWriterTest extends Specification {
             checker,
             resolverFactory,
             []
-        ).build()
+        ).build().get()
         checker.validate()
 
         new GradleModuleMetadataWriter(
@@ -1327,8 +1328,8 @@ class GradleModuleMetadataWriterTest extends Specification {
         String resolvedVersion
 
         @Override
-        DependencyResolvers createCoordinateResolvers(SoftwareComponentVariant variant, VersionMappingStrategyInternal versionMappingStrategy) {
-            return new DependencyResolvers(null, new TestVariantDependencyResolver(resolvedVersion))
+        Provider<DependencyResolvers> createCoordinateResolvers(SoftwareComponentVariant variant, VersionMappingStrategyInternal versionMappingStrategy) {
+            return Providers.of(new DependencyResolvers(null, new TestVariantDependencyResolver(resolvedVersion)))
         }
 
         void resolveToVersion(String resolvedVersion) {


### PR DESCRIPTION
Version mapping and dependency mapping previously did not properly wire dependency resolution. Instead, they resolved configurations eagerly instead of through providers.

This properly uses providers to wire resolution results all the way down to the dependency mapping resolvers.

This does not yet actually declare resolution properly, as that is blocked by #27255

This change primarily relies on a new provider, MergeProvider, which can accept a list of providers and provides a list of the resolved provider values


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
