### PR TITLE
Fix flaky AbstractDirectorySensitivityIntegrationSpec test

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/AbstractDirectorySensitivityIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/AbstractDirectorySensitivityIntegrationSpec.groovy
@@ -212,6 +212,8 @@ abstract class AbstractDirectorySensitivityIntegrationSpec extends AbstractInteg
     }
 
     def "artifact transforms are sensitive to empty directories by default"() {
+        requireOwnGradleUserHomeDir()
+
         createParameterizedTransformWithSensitivity(DirectorySensitivity.DEFAULT)
         file('augmented').mkdir()
         file('augmented/a').mkdir()
@@ -251,6 +253,8 @@ abstract class AbstractDirectorySensitivityIntegrationSpec extends AbstractInteg
     }
 
     def "artifact transforms ignore empty directories when specified"() {
+        requireOwnGradleUserHomeDir()
+
         createParameterizedTransformWithSensitivity(DirectorySensitivity.IGNORE_DIRECTORIES)
         file('augmented').mkdir()
         file('augmented/a').mkdir()


### PR DESCRIPTION
Without a separate user home these tests could fail, because they could load the results of a previous execution from the shared user home.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
