### PR TITLE
Deprecate publishing maven dependency with differing artifact name

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -140,6 +140,71 @@ java {
 ======
 =====
 
+[[publishing_artifact_name_different_from_artifact_id_maven]]
+==== Deprecated publishing artifact dependencies with explicit name to Maven repositories
+
+Publishing dependencies with an explicit artifact with name different from the dependency's artifactId to Maven repositories has been deprecated.
+This behavior will still be permitted when publishing to Ivy repositories.
+This will become an error in Gradle 9.0.
+
+Currently, when publishing to Maven repositories, Gradle will interpret the below dependency as if it were declared with coordinates `org:notfoo:1.0`.
+
+=====
+[.multi-language-sample]
+======
+.build.gradle.kts
+[source,kotlin]
+----
+dependencies {
+    implementation("org:foo:1.0") {
+        artifact {
+            name = "notfoo"
+        }
+    }
+}
+----
+======
+[.multi-language-sample]
+======
+.build.gradle
+[source,groovy]
+----
+dependencies {
+    implementation("org:foo:1.0") {
+        artifact {
+            name = "notfoo"
+        }
+    }
+}
+----
+======
+=====
+
+Instead, this dependency should be declared as:
+
+=====
+[.multi-language-sample]
+======
+.build.gradle.kts
+[source,kotlin]
+----
+dependencies {
+    implementation("org:notfoo:1.0")
+}
+----
+======
+[.multi-language-sample]
+======
+.build.gradle
+[source,groovy]
+----
+dependencies {
+    implementation("org:notfoo:1.0")
+}
+----
+======
+=====
+
 [[deprecated_artifact_identifier]]
 ==== Deprecated `ArtifactIdentifier`
 The `ArtifactIdentifier` class has been deprecated for removal in Gradle 9.0.

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -143,11 +143,11 @@ java {
 [[publishing_artifact_name_different_from_artifact_id_maven]]
 ==== Deprecated publishing artifact dependencies with explicit name to Maven repositories
 
-Publishing dependencies with an explicit artifact with name different from the dependency's artifactId to Maven repositories has been deprecated.
-This behavior will still be permitted when publishing to Ivy repositories.
-This will become an error in Gradle 9.0.
+Publishing dependencies with an explicit artifact with a name different from the dependency's `artifactId` to Maven repositories has been deprecated.
+This behavior is still permitted when publishing to Ivy repositories.
+It will result in an error in Gradle 9.0.
 
-Currently, when publishing to Maven repositories, Gradle will interpret the below dependency as if it were declared with coordinates `org:notfoo:1.0`.
+Currently, when publishing to Maven repositories, Gradle will interpret the dependency below as if it were declared with coordinates `org:notfoo:1.0`.
 
 =====
 [.multi-language-sample]

--- a/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishDependenciesIntegTest.groovy
+++ b/platforms/software/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishDependenciesIntegTest.groovy
@@ -27,8 +27,10 @@ class MavenPublishDependenciesIntegTest extends AbstractMavenPublishIntegTest {
         given:
         settingsFile << "rootProject.name = 'root'"
         buildFile << """
-            apply plugin: 'maven-publish'
-            apply plugin: 'java-library'
+            plugins {
+                id("java-library")
+                id("maven-publish")
+            }
 
             group = 'group'
             version = '1.0'
@@ -75,8 +77,10 @@ class MavenPublishDependenciesIntegTest extends AbstractMavenPublishIntegTest {
         given:
         settingsFile << "rootProject.name = 'root'"
         buildFile << """
-            apply plugin: 'maven-publish'
-            apply plugin: 'java-library'
+            plugins {
+                id("java-library")
+                id("maven-publish")
+            }
 
             group = 'group'
             version = '1.0'
@@ -124,8 +128,10 @@ class MavenPublishDependenciesIntegTest extends AbstractMavenPublishIntegTest {
         given:
         settingsFile << "rootProject.name = 'root'"
         buildFile << """
-            apply plugin: "java-library"
-            apply plugin: "maven-publish"
+            plugins {
+                id("java-library")
+                id("maven-publish")
+            }
 
             group = 'group'
             version = '1.0'
@@ -169,8 +175,10 @@ class MavenPublishDependenciesIntegTest extends AbstractMavenPublishIntegTest {
         given:
         settingsFile << "rootProject.name = 'root'"
         buildFile << """
-            apply plugin: "java-library"
-            apply plugin: "maven-publish"
+            plugins {
+                id("java-library")
+                id("maven-publish")
+            }
 
             group = 'group'
             version = '1.0'
@@ -213,8 +221,10 @@ class MavenPublishDependenciesIntegTest extends AbstractMavenPublishIntegTest {
         given:
         settingsFile << "rootProject.name = 'root'"
         buildFile << """
-            apply plugin: "java-library"
-            apply plugin: "maven-publish"
+            plugins {
+                id("java-library")
+                id("maven-publish")
+            }
 
             group = 'group'
             version = '1.0'
@@ -330,8 +340,10 @@ class MavenPublishDependenciesIntegTest extends AbstractMavenPublishIntegTest {
         given:
         settingsFile << "rootProject.name = 'root'"
         buildFile << """
-            apply plugin: "java-library"
-            apply plugin: "maven-publish"
+            plugins {
+                id("java-library")
+                id("maven-publish")
+            }
 
             group = 'group'
             version = '1.0'
@@ -344,7 +356,6 @@ class MavenPublishDependenciesIntegTest extends AbstractMavenPublishIntegTest {
                 implementation "org:foo:1.0"
                 implementation("org:foo:1.0:classy") {
                     artifact {
-                        name = "tarified"
                         type = "tarfile"
                         extension = "tar"
                         classifier = "ctar"
@@ -401,6 +412,61 @@ class MavenPublishDependenciesIntegTest extends AbstractMavenPublishIntegTest {
                 artifactSelector.classifier == 'ctar'
                 isLast()
             }
+        }
+    }
+
+    def "publishing a dependency to with name different than the artifactId is deprecated"() {
+        given:
+        settingsFile << "rootProject.name = 'root'"
+        buildFile << """
+            plugins {
+                id("java-library")
+                id("maven-publish")
+            }
+
+            group = 'group'
+            version = '1.0'
+
+            tasks.compileJava {
+                // Avoid resolving the classpath when caching the configuration
+                classpath = files()
+            }
+            dependencies {
+                implementation("org:foo:1.0") {
+                    artifact {
+                        name = "notfoo"
+                    }
+                }
+            }
+
+            publishing {
+                repositories {
+                    maven { url "${mavenRepo.uri}" }
+                }
+                publications {
+                    maven(MavenPublication) {
+                        from components.java
+                    }
+                }
+            }
+        """
+
+        when:
+        executer.expectDocumentedDeprecationWarning("Publishing a dependency with an artifact name different from the dependency's artifactId. This behavior has been deprecated. This will fail with an error in Gradle 9.0. This functionality is only supported by Ivy repositories. Declare a dependency with artifactId 'notfoo' instead of 'foo'. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#publishing_artifact_name_different_from_artifact_id_maven")
+        succeeds "publish"
+
+        then:
+        repoModule.assertPublished()
+        repoModule.assertApiDependencies()
+        repoModule.parsedPom.scope("runtime") {
+            def deps = dependencies.values()
+            assert deps.size() == 1
+            def dep = deps[0]
+            assert dep.groupId == "org"
+            assert dep.artifactId == "notfoo"
+            assert dep.version == "1.0"
+            assert dep.classifier == null
+            assert dep.type == null
         }
     }
 

--- a/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/MavenComponentParser.java
+++ b/platforms/software/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/MavenComponentParser.java
@@ -55,6 +55,7 @@ import org.gradle.api.publish.maven.internal.dependencies.MavenDependency;
 import org.gradle.api.publish.maven.internal.dependencies.MavenPomDependencies;
 import org.gradle.api.publish.maven.internal.dependencies.VersionRangeMapper;
 import org.gradle.api.publish.maven.internal.validation.MavenPublicationErrorChecker;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.typeconversion.NotationParser;
 
 import javax.annotation.Nullable;
@@ -302,9 +303,13 @@ public class MavenComponentParser {
             for (DependencyArtifact artifact : dependency.getArtifacts()) {
                 ResolvedCoordinates artifactCoordinates = coordinates;
                 if (!artifact.getName().equals(dependency.getName())) {
-                    // TODO: We should not allow the artifact name to change the coordinates.
-                    //  Artifacts with name different from the coordinate name is not supported in Maven.
-                    //  This behavior should be deprecated.
+                    DeprecationLogger.deprecateBehaviour("Publishing a dependency with an artifact name different from the dependency's artifactId.")
+                        .withContext("This functionality is only supported by Ivy repositories.")
+                        .withAdvice(String.format("Declare a dependency with artifactId '%s' instead of '%s'.", artifact.getName(), dependency.getName()))
+                        .willBecomeAnErrorInGradle9()
+                        .withUpgradeGuideSection(8, "publishing_artifact_name_different_from_artifact_id_maven")
+                        .nagUser();
+
                     artifactCoordinates = ResolvedCoordinates.create(
                         coordinates.getGroup(),
                         artifact.getName(),


### PR DESCRIPTION
Currently, when publishing to maven, Gradle interprets an artifact with an explicit name as a dependency on a module name equal to that artifact name. This is an incorrect interpretation, as this changes the original declared coordinates.

This ability to declare artifacts with name different than the module's name is a feature only supported by Ivy. This should always have been an error.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
