### PR TITLE
Clean up checkout dir before AdHocPerformanceTest

### DIFF
--- a/.teamcity/src/main/kotlin/util/AdHocPerformanceScenario.kt
+++ b/.teamcity/src/main/kotlin/util/AdHocPerformanceScenario.kt
@@ -7,6 +7,7 @@ import common.Os
 import common.applyPerformanceTestSettings
 import common.buildToolGradleParameters
 import common.checkCleanM2AndAndroidUserHome
+import common.cleanUpReadOnlyDir
 import common.gradleWrapper
 import common.individualPerformanceTestArtifactRules
 import common.killProcessStep
@@ -80,6 +81,7 @@ abstract class AdHocPerformanceScenario(os: Os, arch: Arch = Arch.AMD64) : Build
     val buildTypeThis = this
     steps {
         killProcessStep(buildTypeThis, KILL_ALL_GRADLE_PROCESSES, os)
+        cleanUpReadOnlyDir(os)
         substDirOnWindows(os)
         gradleWrapper {
             name = "GRADLE_RUNNER"


### PR DESCRIPTION
Otherwise some undeleteable files may cause build failures.