### PR TITLE
Internal flag for compact CC problem identifiers

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheReport.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheReport.kt
@@ -44,7 +44,7 @@ class ConfigurationCacheReport(
 
     companion object {
         private
-        val problemHashing = InternalFlag("org.gradle.configuration-cache.internal.report.problem-hashing", false)
+        val stacktraceHashes = InternalFlag("org.gradle.configuration-cache.internal.report.stacktrace-hashes", false)
     }
 
     private
@@ -189,7 +189,7 @@ class ConfigurationCacheReport(
     }
 
     private
-    val isProblemHashing = internalOptions.getOption(problemHashing).get()
+    val isStacktraceHashes = internalOptions.getOption(stacktraceHashes).get()
 
     private
     var state: State = State.Idle { kind, problem ->
@@ -197,7 +197,7 @@ class ConfigurationCacheReport(
             temporaryFileProvider.createTemporaryFile("configuration-cache-report", "html"),
             executorFactory.create("Configuration cache report writer", 1),
             CharBuf::class.java.classLoader,
-            if (isProblemHashing) ::decorateProblemWithHash else null
+            if (isStacktraceHashes) ::decorateProblemWithHash else null
         ).onDiagnostic(kind, problem)
     }
 


### PR DESCRIPTION
Introduces a new internal flag `org.gradle.configuration-cache.internal.report.stacktrace-hashes` that enables displaying compact identifiers before the CC problems in the report.

It allows to quickly understand if multiple instances of the same problem are contained in the report. For each problem it prepends a hash of the stacktrace like `[fb7f3cd46a9234897h]` without including the instance-sensitive exception message into it.

Here is an example of running IntelliJ Sync with Isolated Projects:
<img width="1401" alt="image" src="https://github.com/gradle/gradle/assets/2759152/e09101cc-f339-4557-a66c-fb7f3cd46a92">
