### PR TITLE
Decouple configuration repository filtering

### DIFF
--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/use/internal/PluginArtifactRepository.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/use/internal/PluginArtifactRepository.java
@@ -22,6 +22,7 @@ import org.gradle.api.artifacts.repositories.ArtifactRepository;
 import org.gradle.api.artifacts.repositories.RepositoryContentDescriptor;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ConfiguredModuleComponentRepository;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.artifacts.repositories.ArtifactRepositoryInternal;
 import org.gradle.api.internal.artifacts.repositories.ArtifactResolutionDetails;
 import org.gradle.api.internal.artifacts.repositories.ContentFilteringRepository;
@@ -105,8 +106,8 @@ class PluginArtifactRepository implements ArtifactRepositoryInternal, ContentFil
     }
 
     @Override
-    public RepositoryContentDescriptorInternal createRepositoryDescriptor() {
-        return delegate.createRepositoryDescriptor();
+    public RepositoryContentDescriptorInternal createRepositoryDescriptor(VersionParser versionParser) {
+        return delegate.createRepositoryDescriptor(versionParser);
     }
 
     @Override

--- a/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/use/internal/PluginArtifactRepository.java
+++ b/platforms/extensibility/plugin-use/src/main/java/org/gradle/plugin/use/internal/PluginArtifactRepository.java
@@ -20,6 +20,7 @@ import org.gradle.api.Action;
 import org.gradle.api.NamedDomainObjectCollection;
 import org.gradle.api.artifacts.repositories.ArtifactRepository;
 import org.gradle.api.artifacts.repositories.RepositoryContentDescriptor;
+import org.gradle.api.attributes.Attribute;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ConfiguredModuleComponentRepository;
 import org.gradle.api.internal.artifacts.repositories.ArtifactRepositoryInternal;
 import org.gradle.api.internal.artifacts.repositories.ArtifactResolutionDetails;
@@ -27,6 +28,10 @@ import org.gradle.api.internal.artifacts.repositories.ContentFilteringRepository
 import org.gradle.api.internal.artifacts.repositories.RepositoryContentDescriptorInternal;
 import org.gradle.api.internal.artifacts.repositories.ResolutionAwareRepository;
 import org.gradle.api.internal.artifacts.repositories.descriptor.RepositoryDescriptor;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+import java.util.Set;
 
 class PluginArtifactRepository implements ArtifactRepositoryInternal, ContentFilteringRepository, ResolutionAwareRepository {
     private static final String REPOSITORY_NAME_PREFIX = "__plugin_repository__";
@@ -59,6 +64,24 @@ class PluginArtifactRepository implements ArtifactRepositoryInternal, ContentFil
     @Override
     public Action<? super ArtifactResolutionDetails> getContentFilter() {
         return repositoryContentDescriptor.toContentFilter();
+    }
+
+    @Nullable
+    @Override
+    public Set<String> getIncludedConfigurations() {
+        return repositoryContentDescriptor.getIncludedConfigurations();
+    }
+
+    @Nullable
+    @Override
+    public Set<String> getExcludedConfigurations() {
+        return repositoryContentDescriptor.getExcludedConfigurations();
+    }
+
+    @Nullable
+    @Override
+    public Map<Attribute<Object>, Set<Object>> getRequiredAttributes() {
+        return repositoryContentDescriptor.getRequiredAttributes();
     }
 
     @Override

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationIntegrityCheckIntegTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationIntegrityCheckIntegTest.groovy
@@ -910,7 +910,7 @@ This can indicate that a dependency has been compromised. Please carefully verif
         succeeds ":compileJava"
 
         then:
-        outputContains "Dependency verification has been disabled for configuration compileClasspath"
+        outputContains "Dependency verification has been disabled."
 
         when:
         fails ":resolveRuntime"
@@ -1012,7 +1012,7 @@ This can indicate that a dependency has been compromised. Please carefully verif
         succeeds ":resolve", "-PdisableVerification=true"
 
         then:
-        outputContains "Dependency verification has been disabled for configuration detachedConfiguration1"
+        outputContains "Dependency verification has been disabled."
 
         where:
         terse << [true, false]

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationWritingIntegTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationWritingIntegTest.groovy
@@ -1270,7 +1270,7 @@ class DependencyVerificationWritingIntegTest extends AbstractDependencyVerificat
         run ":help"
 
         then:
-        outputContains "Dependency verification has been disabled for configuration runtimeClasspath"
+        outputContains "Dependency verification has been disabled."
         hasModules(["org:foo"])
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultVersionedComponentChooser.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultVersionedComponentChooser.java
@@ -20,7 +20,6 @@ import org.gradle.api.artifacts.ComponentMetadata;
 import org.gradle.api.artifacts.ComponentSelection;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
-import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.AttributesSchema;
 import org.gradle.api.internal.artifacts.ComponentSelectionInternal;
 import org.gradle.api.internal.artifacts.ComponentSelectionRulesInternal;
@@ -91,7 +90,7 @@ class DefaultVersionedComponentChooser implements VersionedComponentChooser {
         Action<? super ArtifactResolutionDetails> contentFilter = result.getContentFilter();
         for (ModuleComponentResolveState candidate : resolveStates) {
             if (contentFilter != null) {
-                DynamicArtifactResolutionDetails details = new DynamicArtifactResolutionDetails(candidate, result.getConfigurationName(), result.getConsumerAttributes());
+                DynamicArtifactResolutionDetails details = new DynamicArtifactResolutionDetails(candidate);
                 contentFilter.execute(details);
                 if (!details.found) {
                     continue;
@@ -227,14 +226,10 @@ class DefaultVersionedComponentChooser implements VersionedComponentChooser {
 
     private static class DynamicArtifactResolutionDetails implements ArtifactResolutionDetails {
         private final ModuleComponentResolveState resolveState;
-        private final String configurationName;
-        private final ImmutableAttributes consumerAttributes;
         boolean found = true;
 
-        public DynamicArtifactResolutionDetails(ModuleComponentResolveState resolveState, String configurationName, ImmutableAttributes consumerAttributes) {
+        public DynamicArtifactResolutionDetails(ModuleComponentResolveState resolveState) {
             this.resolveState = resolveState;
-            this.configurationName = configurationName;
-            this.consumerAttributes = consumerAttributes;
         }
 
         @Override
@@ -246,16 +241,6 @@ class DefaultVersionedComponentChooser implements VersionedComponentChooser {
         @Nullable
         public ModuleComponentIdentifier getComponentId() {
             return resolveState.getId();
-        }
-
-        @Override
-        public AttributeContainer getConsumerAttributes() {
-            return consumerAttributes;
-        }
-
-        @Override
-        public String getConsumerName() {
-            return configurationName;
         }
 
         @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DynamicVersionResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DynamicVersionResolver.java
@@ -349,19 +349,6 @@ public class DynamicVersionResolver {
         }
 
         @Override
-        public String getConfigurationName() {
-            if (repository instanceof FilteredModuleComponentRepository) {
-                return ((FilteredModuleComponentRepository) repository).getConsumerName();
-            }
-            return null;
-        }
-
-        @Override
-        public ImmutableAttributes getConsumerAttributes() {
-            return consumerAttributes;
-        }
-
-        @Override
         public void rejectedBySelector(ModuleComponentIdentifier id, VersionSelector versionSelector) {
             if (firstRejected == null) {
                 firstRejected = id;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactory.java
@@ -150,7 +150,7 @@ public class ResolveIvyFactory {
 
             moduleComponentRepository = new ErrorHandlingModuleComponentRepository(moduleComponentRepository, repositoryBlacklister);
             moduleComponentRepository = filterRepository(repository, moduleComponentRepository);
-            moduleComponentRepository = applyDependencyVerification(moduleComponentRepository, resolutionStrategy.isDependencyVerificationEnabled());
+            moduleComponentRepository = maybeApplyDependencyVerification(moduleComponentRepository, resolutionStrategy.isDependencyVerificationEnabled());
 
             moduleResolver.add(moduleComponentRepository);
             parentModuleResolver.add(moduleComponentRepository);
@@ -175,7 +175,7 @@ public class ResolveIvyFactory {
         return new FilteredModuleComponentRepository(moduleComponentRepository, filter);
     }
 
-    private ModuleComponentRepository<ModuleComponentGraphResolveState> applyDependencyVerification(
+    private ModuleComponentRepository<ModuleComponentGraphResolveState> maybeApplyDependencyVerification(
         ModuleComponentRepository<ModuleComponentGraphResolveState> moduleComponentRepository,
         boolean dependencyVerificationEnabled
     ) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactory.java
@@ -38,6 +38,8 @@ import org.gradle.api.internal.artifacts.repositories.ResolutionAwareRepository;
 import org.gradle.api.internal.artifacts.result.DefaultResolvedArtifactResult;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.component.ArtifactType;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 import org.gradle.internal.Actions;
 import org.gradle.internal.component.external.model.ModuleComponentGraphResolveState;
 import org.gradle.internal.component.external.model.ModuleComponentGraphResolveStateFactory;
@@ -65,6 +67,9 @@ import java.util.Collection;
  * Creates resolver that can resolve module components from repositories.
  */
 public class ResolveIvyFactory {
+
+    private final static Logger LOGGER = Logging.getLogger(ResolveIvyFactory.class);
+
     private final ModuleRepositoryCacheProvider cacheProvider;
     private final StartParameterResolutionOverride startParameterResolutionOverride;
     private final BuildCommencedTimeProvider timeProvider;
@@ -105,7 +110,6 @@ public class ResolveIvyFactory {
     }
 
     public ComponentResolvers create(
-        String resolveContextName,
         ResolutionStrategyInternal resolutionStrategy,
         Collection<? extends ResolutionAwareRepository> repositories,
         ComponentMetadataProcessorFactory metadataProcessor,
@@ -143,9 +147,11 @@ public class ResolveIvyFactory {
             if (baseRepository.isDynamicResolveMode()) {
                 moduleComponentRepository = new IvyDynamicResolveModuleComponentRepository(moduleComponentRepository, moduleResolveStateFactory);
             }
+
             moduleComponentRepository = new ErrorHandlingModuleComponentRepository(moduleComponentRepository, repositoryBlacklister);
-            moduleComponentRepository = filterRepository(repository, moduleComponentRepository, resolveContextName, consumerAttributes);
-            moduleComponentRepository = dependencyVerificationOverride.overrideDependencyVerification(moduleComponentRepository, resolveContextName, resolutionStrategy);
+            moduleComponentRepository = filterRepository(repository, moduleComponentRepository);
+            moduleComponentRepository = applyDependencyVerification(moduleComponentRepository, resolutionStrategy.isDependencyVerificationEnabled());
+
             moduleResolver.add(moduleComponentRepository);
             parentModuleResolver.add(moduleComponentRepository);
         }
@@ -153,12 +159,32 @@ public class ResolveIvyFactory {
         return moduleResolver;
     }
 
-    private ModuleComponentRepository<ModuleComponentGraphResolveState> filterRepository(ResolutionAwareRepository repository, ModuleComponentRepository<ModuleComponentGraphResolveState> moduleComponentRepository, String consumerName, AttributeContainer consumerAttributes) {
+    private static ModuleComponentRepository<ModuleComponentGraphResolveState> filterRepository(
+        ResolutionAwareRepository repository,
+        ModuleComponentRepository<ModuleComponentGraphResolveState> moduleComponentRepository
+    ) {
         Action<? super ArtifactResolutionDetails> filter = Actions.doNothing();
         if (repository instanceof ContentFilteringRepository) {
             filter = ((ContentFilteringRepository) repository).getContentFilter();
         }
-        return FilteredModuleComponentRepository.of(moduleComponentRepository, filter, consumerName, consumerAttributes);
+
+        if (filter == Actions.doNothing()) {
+            return moduleComponentRepository;
+        }
+
+        return new FilteredModuleComponentRepository(moduleComponentRepository, filter);
+    }
+
+    private ModuleComponentRepository<ModuleComponentGraphResolveState> applyDependencyVerification(
+        ModuleComponentRepository<ModuleComponentGraphResolveState> moduleComponentRepository,
+        boolean dependencyVerificationEnabled
+    ) {
+        if (!dependencyVerificationEnabled) {
+            LOGGER.warn("Dependency verification has been disabled.");
+            return moduleComponentRepository;
+        }
+
+        return dependencyVerificationOverride.overrideDependencyVerification(moduleComponentRepository);
     }
 
     public ArtifactResult verifiedArtifact(DefaultResolvedArtifactResult defaultResolvedArtifactResult) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/StartParameterResolutionOverride.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/StartParameterResolutionOverride.java
@@ -17,11 +17,8 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
 import org.gradle.StartParameter;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
-import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.artifacts.verification.DependencyVerificationMode;
 import org.gradle.api.internal.DocumentationRegistry;
-import org.gradle.api.internal.GradleInternal;
-import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal;
 import org.gradle.api.internal.artifacts.configurations.dynamicversion.CachePolicy;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.ChecksumAndSignatureVerificationOverride;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.DependencyVerificationOverride;
@@ -32,8 +29,6 @@ import org.gradle.api.internal.artifacts.verification.exceptions.DependencyVerif
 import org.gradle.api.internal.artifacts.verification.signatures.SignatureVerificationServiceFactory;
 import org.gradle.api.internal.component.ArtifactType;
 import org.gradle.api.internal.properties.GradleProperties;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.gradle.api.resources.ResourceException;
 import org.gradle.internal.Factory;
 import org.gradle.internal.component.external.model.ModuleComponentGraphResolveState;
@@ -43,8 +38,6 @@ import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.ModuleSources;
-import org.gradle.internal.concurrent.CompositeStoppable;
-import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.hash.ChecksumService;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.resolve.ArtifactResolveException;
@@ -104,26 +97,23 @@ public class StartParameterResolutionOverride {
         List<String> checksums = startParameter.getWriteDependencyVerifications();
         File verificationsFile = DependencyVerificationOverride.dependencyVerificationsFile(gradleDir);
         fileResourceListener.fileObserved(verificationsFile);
+
         if (!checksums.isEmpty() || startParameter.isExportKeys()) {
-            return DisablingVerificationOverride.of(
-                new WriteDependencyVerificationFile(verificationsFile, buildOperationExecutor, checksums, checksumService, signatureVerificationServiceFactory, startParameter.isDryRun(), startParameter.isExportKeys())
-            );
-        } else {
-            if (verificationsFile.exists()) {
-                if (startParameter.getDependencyVerificationMode() == DependencyVerificationMode.OFF) {
-                    return DependencyVerificationOverride.NO_VERIFICATION;
-                }
-                try {
-                    File sessionReportDir = computeReportDirectory(timeProvider);
-                    return DisablingVerificationOverride.of(
-                        new ChecksumAndSignatureVerificationOverride(buildOperationExecutor, startParameter.getGradleUserHomeDir(), verificationsFile, checksumService, signatureVerificationServiceFactory, startParameter.getDependencyVerificationMode(), documentationRegistry, sessionReportDir, gradlePropertiesFactory, fileResourceListener)
-                    );
-                } catch (Exception e) {
-                    return new FailureVerificationOverride(e);
-                }
-            }
+            return new WriteDependencyVerificationFile(verificationsFile, buildOperationExecutor, checksums, checksumService, signatureVerificationServiceFactory, startParameter.isDryRun(), startParameter.isExportKeys());
         }
-        return DependencyVerificationOverride.NO_VERIFICATION;
+
+        if (!verificationsFile.exists() ||
+            startParameter.getDependencyVerificationMode() == DependencyVerificationMode.OFF
+        ) {
+            return DependencyVerificationOverride.NO_VERIFICATION;
+        }
+
+        try {
+            File sessionReportDir = computeReportDirectory(timeProvider);
+            return new ChecksumAndSignatureVerificationOverride(buildOperationExecutor, startParameter.getGradleUserHomeDir(), verificationsFile, checksumService, signatureVerificationServiceFactory, startParameter.getDependencyVerificationMode(), documentationRegistry, sessionReportDir, gradlePropertiesFactory, fileResourceListener);
+        } catch (Exception e) {
+            return new FailureVerificationOverride(e);
+        }
     }
 
     private File computeReportDirectory(BuildCommencedTimeProvider timeProvider) {
@@ -233,52 +223,8 @@ public class StartParameterResolutionOverride {
         }
 
         @Override
-        public ModuleComponentRepository<ModuleComponentGraphResolveState> overrideDependencyVerification(ModuleComponentRepository<ModuleComponentGraphResolveState> original, String resolveContextName, ResolutionStrategyInternal resolutionStrategy) {
+        public ModuleComponentRepository<ModuleComponentGraphResolveState> overrideDependencyVerification(ModuleComponentRepository<ModuleComponentGraphResolveState> original) {
             throw new DependencyVerificationException("Dependency verification cannot be performed", error);
-        }
-    }
-
-    public static class DisablingVerificationOverride implements DependencyVerificationOverride, Stoppable {
-        private final static Logger LOGGER = Logging.getLogger(DependencyVerificationOverride.class);
-
-        private final DependencyVerificationOverride delegate;
-
-        public static DisablingVerificationOverride of(DependencyVerificationOverride delegate) {
-            return new DisablingVerificationOverride(delegate);
-        }
-
-        private DisablingVerificationOverride(DependencyVerificationOverride delegate) {
-            this.delegate = delegate;
-        }
-
-        @Override
-        public ModuleComponentRepository<ModuleComponentGraphResolveState> overrideDependencyVerification(ModuleComponentRepository<ModuleComponentGraphResolveState> original, String resolveContextName, ResolutionStrategyInternal resolutionStrategy) {
-            if (resolutionStrategy.isDependencyVerificationEnabled()) {
-                return delegate.overrideDependencyVerification(original, resolveContextName, resolutionStrategy);
-            } else {
-                LOGGER.warn("Dependency verification has been disabled for configuration " + resolveContextName);
-                return original;
-            }
-        }
-
-        @Override
-        public void buildFinished(GradleInternal model) {
-            delegate.buildFinished(model);
-        }
-
-        @Override
-        public void artifactsAccessed(String displayName) {
-            delegate.artifactsAccessed(displayName);
-        }
-
-        @Override
-        public ResolvedArtifactResult verifiedArtifact(ResolvedArtifactResult artifact) {
-            return delegate.verifiedArtifact(artifact);
-        }
-
-        @Override
-        public void stop() {
-            CompositeStoppable.stoppable(delegate).stop();
         }
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/ChecksumAndSignatureVerificationOverride.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/ChecksumAndSignatureVerificationOverride.java
@@ -25,7 +25,6 @@ import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.gradle.api.artifacts.verification.DependencyVerificationMode;
 import org.gradle.api.component.Artifact;
 import org.gradle.api.internal.DocumentationRegistry;
-import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.DependencyVerifyingModuleComponentRepository;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ModuleComponentRepository;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.report.DependencyVerificationReportWriter;
@@ -164,7 +163,7 @@ public class ChecksumAndSignatureVerificationOverride implements DependencyVerif
     }
 
     @Override
-    public ModuleComponentRepository<ModuleComponentGraphResolveState> overrideDependencyVerification(ModuleComponentRepository<ModuleComponentGraphResolveState> original, String resolveContextName, ResolutionStrategyInternal resolutionStrategy) {
+    public ModuleComponentRepository<ModuleComponentGraphResolveState> overrideDependencyVerification(ModuleComponentRepository<ModuleComponentGraphResolveState> original) {
         return new DependencyVerifyingModuleComponentRepository(original, this, verifier.getConfiguration().isVerifySignatures());
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/DependencyVerificationOverride.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/DependencyVerificationOverride.java
@@ -17,21 +17,20 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification;
 
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.internal.GradleInternal;
-import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ModuleComponentRepository;
 import org.gradle.internal.component.external.model.ModuleComponentGraphResolveState;
 
 import java.io.File;
 
 public interface DependencyVerificationOverride {
-    DependencyVerificationOverride NO_VERIFICATION = (original, resolveContextName, resolutionStrategy) -> original;
+    DependencyVerificationOverride NO_VERIFICATION = original -> original;
     String VERIFICATION_METADATA_XML = "verification-metadata.xml";
 
     static File dependencyVerificationsFile(File gradleDirectory) {
         return new File(gradleDirectory, VERIFICATION_METADATA_XML);
     }
 
-    ModuleComponentRepository<ModuleComponentGraphResolveState> overrideDependencyVerification(ModuleComponentRepository<ModuleComponentGraphResolveState> original, String resolveContextName, ResolutionStrategyInternal resolutionStrategy);
+    ModuleComponentRepository<ModuleComponentGraphResolveState> overrideDependencyVerification(ModuleComponentRepository<ModuleComponentGraphResolveState> original);
 
     default void buildFinished(GradleInternal model) {
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFile.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFile.java
@@ -28,7 +28,6 @@ import org.gradle.api.artifacts.ArtifactView;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.GradleInternal;
-import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.DependencyVerifyingModuleComponentRepository;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ModuleComponentRepository;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.ArtifactVerificationOperation;
@@ -176,7 +175,7 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
     }
 
     @Override
-    public ModuleComponentRepository<ModuleComponentGraphResolveState> overrideDependencyVerification(ModuleComponentRepository<ModuleComponentGraphResolveState> original, String resolveContextName, ResolutionStrategyInternal resolutionStrategy) {
+    public ModuleComponentRepository<ModuleComponentGraphResolveState> overrideDependencyVerification(ModuleComponentRepository<ModuleComponentGraphResolveState> original) {
         return new DependencyVerifyingModuleComponentRepository(original, this, generatePgpInfo);
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/ArtifactRepositoryInternal.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/ArtifactRepositoryInternal.java
@@ -18,12 +18,13 @@ package org.gradle.api.internal.artifacts.repositories;
 import org.gradle.api.Describable;
 import org.gradle.api.NamedDomainObjectCollection;
 import org.gradle.api.artifacts.repositories.ArtifactRepository;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 
 public interface ArtifactRepositoryInternal extends ArtifactRepository, Describable {
 
     void onAddToContainer(NamedDomainObjectCollection<ArtifactRepository> container);
 
-    RepositoryContentDescriptorInternal createRepositoryDescriptor();
+    RepositoryContentDescriptorInternal createRepositoryDescriptor(VersionParser versionParser);
 
     RepositoryContentDescriptorInternal getRepositoryDescriptorCopy();
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/ArtifactResolutionDetails.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/ArtifactResolutionDetails.java
@@ -17,7 +17,6 @@ package org.gradle.api.internal.artifacts.repositories;
 
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
-import org.gradle.api.attributes.AttributeContainer;
 
 import javax.annotation.Nullable;
 
@@ -68,19 +67,6 @@ public interface ArtifactResolutionDetails {
      */
     @Nullable
     ModuleComponentIdentifier getComponentId();
-
-    /**
-     * The attributes of the consumer looking for this module
-     * @return the consumer attributes
-     */
-    AttributeContainer getConsumerAttributes();
-
-    /**
-     * The name of the consumer. Usually corresponds to the name of the configuration being
-     * resolved.
-     * @return the consumer name
-     */
-    String getConsumerName();
 
     /**
      * Returns true if this details is created for a version listing.

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/ContentFilteringRepository.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/ContentFilteringRepository.java
@@ -17,8 +17,31 @@
 package org.gradle.api.internal.artifacts.repositories;
 
 import org.gradle.api.Action;
+import org.gradle.api.attributes.Attribute;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+import java.util.Set;
 
 public interface ContentFilteringRepository {
 
     Action<? super ArtifactResolutionDetails> getContentFilter();
+
+    /**
+     * @see RepositoryContentDescriptorInternal#getIncludedConfigurations()
+     */
+    @Nullable
+    Set<String> getIncludedConfigurations();
+
+    /**
+     * @see RepositoryContentDescriptorInternal#getExcludedConfigurations()
+     */
+    @Nullable
+    Set<String> getExcludedConfigurations();
+
+    /**
+     * @see RepositoryContentDescriptorInternal#getRequiredAttributes()
+     */
+    @Nullable
+    Map<Attribute<Object>, Set<Object>> getRequiredAttributes();
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
@@ -98,7 +98,6 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
     private final ChecksumService checksumService;
     private final MavenMetadataSources metadataSources = new MavenMetadataSources();
     private final InstantiatorFactory instantiatorFactory;
-    private final VersionParser versionParser;
 
     public DefaultMavenArtifactRepository(FileResolver fileResolver,
                                           RepositoryTransportFactory transportFactory,
@@ -158,7 +157,6 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
         this.checksumService = checksumService;
         this.metadataSources.setDefaults();
         this.instantiatorFactory = instantiatorFactory;
-        this.versionParser = versionParser;
     }
 
     @Override
@@ -344,13 +342,8 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
     }
 
     @Override
-    public RepositoryContentDescriptorInternal createRepositoryDescriptor() {
+    public RepositoryContentDescriptorInternal createRepositoryDescriptor(VersionParser versionParser) {
         return new DefaultMavenRepositoryContentDescriptor(this::getDisplayName, versionParser);
-    }
-
-    @Override
-    public RepositoryContentDescriptorInternal getRepositoryDescriptorCopy() {
-        return getRepositoryDescriptor().asMutableCopy();
     }
 
     private static class DefaultDescriber implements Transformer<String, MavenArtifactRepository> {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/RepositoryContentDescriptorInternal.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/RepositoryContentDescriptorInternal.java
@@ -17,8 +17,31 @@ package org.gradle.api.internal.artifacts.repositories;
 
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.repositories.RepositoryContentDescriptor;
+import org.gradle.api.attributes.Attribute;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+import java.util.Set;
 
 public interface RepositoryContentDescriptorInternal extends RepositoryContentDescriptor {
     Action<? super ArtifactResolutionDetails> toContentFilter();
     RepositoryContentDescriptorInternal asMutableCopy();
+
+    /**
+     * Returns values added by {@link #onlyForConfigurations}.
+     */
+    @Nullable
+    Set<String> getIncludedConfigurations();
+
+    /**
+     * Returns values added by {@link #notForConfigurations}
+     */
+    @Nullable
+    Set<String> getExcludedConfigurations();
+
+    /**
+     * Returns value added by {@link #onlyForAttribute}
+     */
+    @Nullable
+    Map<Attribute<Object>, Set<Object>> getRequiredAttributes();
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/result/ComponentSelectionContext.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/result/ComponentSelectionContext.java
@@ -20,7 +20,6 @@ import org.gradle.api.Action;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector;
 import org.gradle.api.internal.artifacts.repositories.ArtifactResolutionDetails;
-import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 import org.gradle.internal.resolve.RejectedByAttributesVersion;
 import org.gradle.internal.resolve.RejectedByRuleVersion;
@@ -72,14 +71,4 @@ public interface ComponentSelectionContext {
      */
     @Nullable
     Action<? super ArtifactResolutionDetails> getContentFilter();
-
-    /**
-     * Returns the name of the configuration being resolved
-     */
-    String getConfigurationName();
-
-    /**
-     * Returns the consumer attributes
-     */
-    ImmutableAttributes getConsumerAttributes();
 }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactoryTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolveIvyFactoryTest.groovy
@@ -109,7 +109,7 @@ class ResolveIvyFactoryTest extends Specification {
 
     def "returns an empty resolver when no repositories are configured"() {
         when:
-        def resolver = resolveIvyFactory.create("test", Stub(ResolutionStrategyInternal), Collections.emptyList(), Stub(ComponentMetadataProcessorFactory), ImmutableAttributes.EMPTY, Stub(AttributesSchemaInternal), AttributeTestUtil.attributesFactory(), Stub(ComponentMetadataSupplierRuleExecutor))
+        def resolver = resolveIvyFactory.create(Stub(ResolutionStrategyInternal), Collections.emptyList(), Stub(ComponentMetadataProcessorFactory), ImmutableAttributes.EMPTY, Stub(AttributesSchemaInternal), AttributeTestUtil.attributesFactory(), Stub(ComponentMetadataSupplierRuleExecutor))
 
         then:
         resolver instanceof NoRepositoriesResolver
@@ -128,7 +128,7 @@ class ResolveIvyFactoryTest extends Specification {
         })
 
         when:
-        def resolver = resolveIvyFactory.create("test", resolutionStrategy, repositories, Stub(ComponentMetadataProcessorFactory), ImmutableAttributes.EMPTY, Stub(AttributesSchemaInternal), AttributeTestUtil.attributesFactory(), Stub(ComponentMetadataSupplierRuleExecutor))
+        def resolver = resolveIvyFactory.create(resolutionStrategy, repositories, Stub(ComponentMetadataProcessorFactory), ImmutableAttributes.EMPTY, Stub(AttributesSchemaInternal), AttributeTestUtil.attributesFactory(), Stub(ComponentMetadataSupplierRuleExecutor))
 
         then:
         assert resolver instanceof UserResolverChain

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQueryTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQueryTest.groovy
@@ -136,7 +136,7 @@ class DefaultArtifactResolutionQueryTest extends Specification {
     }
 
     private def withArtifactResolutionInteractions(int numberOfComponentsToResolve = 1) {
-        1 * resolveIvyFactory.create(_, _, _, _, _, _, _, _) >> repositoryChain
+        1 * resolveIvyFactory.create(_, _, _, _, _, _, _) >> repositoryChain
         1 * repositoryChain.artifactResolver >> artifactResolver
         1 * repositoryChain.componentResolver >> componentMetaDataResolver
         def state = Mock(ComponentGraphResolveState)


### PR DESCRIPTION
Allow configurations to themselves choose which repositories to use instead of having the repositories know which configurations to allow. The DSL is still configured on the repository itself, but it is the configuration's reponsibility to filter repositories based on those options.

The biggest advantage is that repositories no longer need to know the name of the configuration being resolved

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
