### PR TITLE
Track project dependencies for intermediate model requests

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsFixture.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsFixture.groovy
@@ -243,7 +243,7 @@ class IsolatedProjectsFixture {
         return result
     }
 
-    trait HasIntermediateDetails {
+    trait HasIntermediateDetails extends HasBuildActions {
         final projects = new HashSet<String>()
         final List<ModelRequestExpectation> models = []
         int buildModelQueries

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultBuildModelControllerServices.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultBuildModelControllerServices.kt
@@ -29,6 +29,7 @@ import org.gradle.api.internal.project.ProjectRegistry
 import org.gradle.configuration.ProjectsPreparer
 import org.gradle.configuration.ScriptPluginFactory
 import org.gradle.configuration.internal.DynamicCallContextTracker
+import org.gradle.configuration.internal.ToolingModelProjectDependencyListener
 import org.gradle.configuration.project.BuildScriptProcessor
 import org.gradle.configuration.project.ConfigureActionsProjectEvaluator
 import org.gradle.configuration.project.DelayedConfigurationActions
@@ -52,6 +53,7 @@ import org.gradle.internal.build.BuildModelController
 import org.gradle.internal.build.BuildModelControllerServices
 import org.gradle.internal.build.BuildState
 import org.gradle.internal.buildtree.BuildModelParameters
+import org.gradle.internal.buildtree.IntermediateBuildActionRunner
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.model.StateTransitionControllerFactory
 import org.gradle.internal.operations.BuildOperationExecutor
@@ -60,6 +62,9 @@ import org.gradle.internal.service.CachingServiceLocator
 import org.gradle.internal.service.scopes.BuildScopeServices
 import org.gradle.internal.service.scopes.ServiceRegistryFactory
 import org.gradle.invocation.DefaultGradle
+import org.gradle.tooling.provider.model.internal.DefaultIntermediateToolingModelProvider
+import org.gradle.tooling.provider.model.internal.IntermediateToolingModelProvider
+import org.gradle.tooling.provider.model.internal.ToolingModelParameterCarrier
 
 
 class DefaultBuildModelControllerServices(
@@ -112,6 +117,15 @@ class DefaultBuildModelControllerServices(
 
         fun createLocalComponentRegistry(currentBuild: BuildState, componentProvider: BuildTreeLocalComponentProvider): DefaultLocalComponentRegistry {
             return DefaultLocalComponentRegistry(currentBuild.buildIdentifier, componentProvider)
+        }
+
+        fun createIntermediateToolingModelProvider(
+            buildOperationExecutor: BuildOperationExecutor,
+            buildModelParameters: BuildModelParameters,
+            parameterCarrierFactory: ToolingModelParameterCarrier.Factory
+        ): IntermediateToolingModelProvider {
+            val runner = IntermediateBuildActionRunner(buildOperationExecutor, buildModelParameters, "Tooling API intermediate model")
+            return DefaultIntermediateToolingModelProvider(runner, parameterCarrierFactory)
         }
     }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultBuildModelControllerServices.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultBuildModelControllerServices.kt
@@ -29,7 +29,6 @@ import org.gradle.api.internal.project.ProjectRegistry
 import org.gradle.configuration.ProjectsPreparer
 import org.gradle.configuration.ScriptPluginFactory
 import org.gradle.configuration.internal.DynamicCallContextTracker
-import org.gradle.configuration.internal.ToolingModelProjectDependencyListener
 import org.gradle.configuration.project.BuildScriptProcessor
 import org.gradle.configuration.project.ConfigureActionsProjectEvaluator
 import org.gradle.configuration.project.DelayedConfigurationActions
@@ -65,6 +64,7 @@ import org.gradle.invocation.DefaultGradle
 import org.gradle.tooling.provider.model.internal.DefaultIntermediateToolingModelProvider
 import org.gradle.tooling.provider.model.internal.IntermediateToolingModelProvider
 import org.gradle.tooling.provider.model.internal.ToolingModelParameterCarrier
+import org.gradle.tooling.provider.model.internal.ToolingModelProjectDependencyListener
 
 
 class DefaultBuildModelControllerServices(
@@ -122,10 +122,12 @@ class DefaultBuildModelControllerServices(
         fun createIntermediateToolingModelProvider(
             buildOperationExecutor: BuildOperationExecutor,
             buildModelParameters: BuildModelParameters,
-            parameterCarrierFactory: ToolingModelParameterCarrier.Factory
+            parameterCarrierFactory: ToolingModelParameterCarrier.Factory,
+            listenerManager: ListenerManager
         ): IntermediateToolingModelProvider {
+            val projectDependencyListener = listenerManager.getBroadcaster(ToolingModelProjectDependencyListener::class.java)
             val runner = IntermediateBuildActionRunner(buildOperationExecutor, buildModelParameters, "Tooling API intermediate model")
-            return DefaultIntermediateToolingModelProvider(runner, parameterCarrierFactory)
+            return DefaultIntermediateToolingModelProvider(runner, parameterCarrierFactory, projectDependencyListener)
         }
     }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultBuildTreeModelControllerServices.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultBuildTreeModelControllerServices.kt
@@ -191,7 +191,6 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
         fun createToolingModelParameterCarrierFactory(valueSnapshotter: ValueSnapshotter): ToolingModelParameterCarrier.Factory {
             return DefaultToolingModelParameterCarrierFactory(valueSnapshotter)
         }
-
     }
 
     private

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultBuildTreeModelControllerServices.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultBuildTreeModelControllerServices.kt
@@ -86,7 +86,17 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
         val configurationCacheLogLevel = if (startParameter.isConfigurationCacheQuiet) LogLevel.INFO else LogLevel.LIFECYCLE
         val modelParameters = if (requirements.isCreatesModel) {
             // When creating a model, disable certain features - only enable configure on demand and configuration cache when isolated projects is enabled
-            BuildModelParameters(parallelProjectExecution, isolatedProjects, isolatedProjects, isolatedProjects, true, isolatedProjects, parallelToolingActions, invalidateCoupledProjects, configurationCacheLogLevel)
+            BuildModelParameters(
+                parallelProjectExecution,
+                isolatedProjects,
+                isolatedProjects,
+                isolatedProjects,
+                true,
+                isolatedProjects,
+                parallelToolingActions,
+                invalidateCoupledProjects,
+                configurationCacheLogLevel
+            )
         } else {
             val configurationCache = isolatedProjects || startParameter.configurationCache.get()
             val configureOnDemand = isolatedProjects || startParameter.isConfigureOnDemand
@@ -99,7 +109,17 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
             when {
                 configurationCache && startParameter.writeDependencyVerifications.isNotEmpty() -> disabledConfigurationCacheBuildModelParameters(StartParameterBuildOptions.DependencyVerificationWriteOption.LONG_OPTION)
                 configurationCache && startParameter.isExportKeys -> disabledConfigurationCacheBuildModelParameters(StartParameterBuildOptions.ExportKeysOption.LONG_OPTION)
-                else -> BuildModelParameters(parallelProjectExecution, configureOnDemand, configurationCache, isolatedProjects, false, false, parallelToolingActions, invalidateCoupledProjects, configurationCacheLogLevel)
+                else -> BuildModelParameters(
+                    parallelProjectExecution,
+                    configureOnDemand,
+                    configurationCache,
+                    isolatedProjects,
+                    false,
+                    false,
+                    parallelToolingActions,
+                    invalidateCoupledProjects,
+                    configurationCacheLogLevel
+                )
             }
         }
 
@@ -125,7 +145,8 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
         return BuildTreeModelControllerServices.Supplier { registration ->
             registration.add(BuildType::class.java, BuildType.TASKS)
             // Configuration cache is not supported for nested build trees
-            val buildModelParameters = BuildModelParameters(startParameter.isParallelProjectExecutionEnabled, startParameter.isConfigureOnDemand, false, false, true, false, false, false, LogLevel.LIFECYCLE)
+            val buildModelParameters =
+                BuildModelParameters(startParameter.isParallelProjectExecutionEnabled, startParameter.isConfigureOnDemand, false, false, true, false, false, false, LogLevel.LIFECYCLE)
             val buildFeatures = DefaultBuildFeatures(startParameter, buildModelParameters)
             val requirements = RunTasksRequirements(startParameter)
             registerServices(registration, buildModelParameters, buildFeatures, requirements)

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultBuildTreeModelControllerServices.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultBuildTreeModelControllerServices.kt
@@ -47,14 +47,10 @@ import org.gradle.internal.buildtree.BuildModelParameters
 import org.gradle.internal.buildtree.BuildTreeModelControllerServices
 import org.gradle.internal.buildtree.BuildTreeWorkGraphPreparer
 import org.gradle.internal.buildtree.DefaultBuildTreeWorkGraphPreparer
-import org.gradle.internal.buildtree.IntermediateBuildActionRunner
 import org.gradle.internal.buildtree.RunTasksRequirements
-import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.scripts.ProjectScopedScriptResolution
 import org.gradle.internal.service.ServiceRegistration
 import org.gradle.internal.snapshot.ValueSnapshotter
-import org.gradle.tooling.provider.model.internal.DefaultIntermediateToolingModelProvider
-import org.gradle.tooling.provider.model.internal.IntermediateToolingModelProvider
 import org.gradle.tooling.provider.model.internal.ToolingModelParameterCarrier
 import org.gradle.util.internal.IncubationLogger
 
@@ -196,14 +192,6 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
             return DefaultToolingModelParameterCarrierFactory(valueSnapshotter)
         }
 
-        fun createIntermediateToolingModelProvider(
-            buildOperationExecutor: BuildOperationExecutor,
-            buildModelParameters: BuildModelParameters,
-            parameterCarrierFactory: ToolingModelParameterCarrier.Factory
-        ): IntermediateToolingModelProvider {
-            val runner = IntermediateBuildActionRunner(buildOperationExecutor, buildModelParameters, "Tooling API intermediate model")
-            return DefaultIntermediateToolingModelProvider(runner, parameterCarrierFactory)
-        }
     }
 
     private

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultBuildTreeModelControllerServices.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultBuildTreeModelControllerServices.kt
@@ -99,7 +99,17 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
 
             fun disabledConfigurationCacheBuildModelParameters(buildOptionReason: String): BuildModelParameters {
                 logger.log(configurationCacheLogLevel, "{} as configuration cache cannot be reused due to --{}", requirements.actionDisplayName.capitalizedDisplayName, buildOptionReason)
-                return BuildModelParameters(parallelProjectExecution, configureOnDemand, false, false, false, false, parallelToolingActions, invalidateCoupledProjects, configurationCacheLogLevel)
+                return BuildModelParameters(
+                    parallelProjectExecution,
+                    configureOnDemand,
+                    false,
+                    false,
+                    false,
+                    false,
+                    parallelToolingActions,
+                    invalidateCoupledProjects,
+                    configurationCacheLogLevel
+                )
             }
 
             when {
@@ -142,7 +152,17 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
             registration.add(BuildType::class.java, BuildType.TASKS)
             // Configuration cache is not supported for nested build trees
             val buildModelParameters =
-                BuildModelParameters(startParameter.isParallelProjectExecutionEnabled, startParameter.isConfigureOnDemand, false, false, true, false, false, false, LogLevel.LIFECYCLE)
+                BuildModelParameters(
+                    startParameter.isParallelProjectExecutionEnabled,
+                    startParameter.isConfigureOnDemand,
+                    false,
+                    false,
+                    true,
+                    false,
+                    false,
+                    false,
+                    LogLevel.LIFECYCLE
+                )
             val buildFeatures = DefaultBuildFeatures(startParameter, buildModelParameters)
             val requirements = RunTasksRequirements(startParameter)
             registerServices(registration, buildModelParameters, buildFeatures, requirements)

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintWriter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintWriter.kt
@@ -46,6 +46,7 @@ import org.gradle.api.internal.provider.sources.process.ProcessOutputValueSource
 import org.gradle.api.provider.ValueSourceParameters
 import org.gradle.api.tasks.util.PatternSet
 import org.gradle.configurationcache.CoupledProjectsListener
+import org.gradle.tooling.provider.model.internal.ToolingModelProjectDependencyListener
 import org.gradle.configurationcache.InputTrackingState
 import org.gradle.configurationcache.UndeclaredBuildInputListener
 import org.gradle.configurationcache.extensions.fileSystemEntryType
@@ -102,6 +103,7 @@ class ConfigurationCacheFingerprintWriter(
     ChangingValueDependencyResolutionListener,
     ProjectDependencyObservedListener,
     CoupledProjectsListener,
+    ToolingModelProjectDependencyListener,
     FileResourceListener,
     ScriptFileResolvedListener,
     FeatureFlagListener,
@@ -537,11 +539,8 @@ class ConfigurationCacheFingerprintWriter(
     }
 
     override fun dependencyObserved(consumingProject: ProjectState?, targetProject: ProjectState, requestedState: ConfigurationInternal.InternalState, target: ResolvedProjectConfiguration) {
-        if (host.cacheIntermediateModels && consumingProject != null) {
-            val dependency = ProjectSpecificFingerprint.ProjectDependency(consumingProject.identityPath, targetProject.identityPath)
-            if (projectDependencies.add(dependency)) {
-                projectScopedWriter.write(dependency)
-            }
+        if (consumingProject != null) {
+            onProjectDependency(consumingProject, targetProject)
         }
     }
 
@@ -551,6 +550,20 @@ class ConfigurationCacheFingerprintWriter(
 
         if (host.cacheIntermediateModels) {
             val dependency = ProjectSpecificFingerprint.CoupledProjects(referrer.identityPath, target.identityPath)
+            if (projectDependencies.add(dependency)) {
+                projectScopedWriter.write(dependency)
+            }
+        }
+    }
+
+    override fun onToolingModelDependency(consumer: ProjectState, target: ProjectState) {
+        onProjectDependency(consumer, target)
+    }
+
+    private
+    fun onProjectDependency(consumer: ProjectState, target: ProjectState) {
+        if (host.cacheIntermediateModels) {
+            val dependency = ProjectSpecificFingerprint.ProjectDependency(consumer.identityPath, target.identityPath)
             if (projectDependencies.add(dependency)) {
                 projectScopedWriter.write(dependency)
             }

--- a/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/internal/tooling/IsolatedProjectsSafeIdeaModelBuilder.java
+++ b/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/internal/tooling/IsolatedProjectsSafeIdeaModelBuilder.java
@@ -101,6 +101,7 @@ public class IsolatedProjectsSafeIdeaModelBuilder implements IdeaModelBuilderInt
 
     private DefaultIdeaProject fetchForRoot(Project root, IdeaModelParameter parameter) {
         return intermediateToolingModelProvider.getModels(
+            root,
             Collections.singletonList(root),
             MODEL_NAME,
             DefaultIdeaProject.class,
@@ -113,7 +114,7 @@ public class IsolatedProjectsSafeIdeaModelBuilder implements IdeaModelBuilderInt
     }
 
     private void applyIdeaPluginToBuildTree(ProjectInternal root, List<GradleInternal> alreadyProcessed) {
-        intermediateToolingModelProvider.applyPlugin(new ArrayList<>(root.getAllprojects()), IdeaPlugin.class);
+        intermediateToolingModelProvider.applyPlugin(root, new ArrayList<>(root.getAllprojects()), IdeaPlugin.class);
 
         for (IncludedBuildInternal reference : root.getGradle().includedBuilds()) {
             BuildState target = reference.getTarget();
@@ -135,7 +136,7 @@ public class IsolatedProjectsSafeIdeaModelBuilder implements IdeaModelBuilderInt
         IdeaProjectInternal ideaProjectExt = (IdeaProjectInternal) ideaModelExt.getProject();
 
         List<Project> allProjects = new ArrayList<>(rootProject.getAllprojects());
-        List<IsolatedIdeaModuleInternal> allIsolatedIdeaModules = getIsolatedIdeaModules(allProjects, parameter);
+        List<IsolatedIdeaModuleInternal> allIsolatedIdeaModules = getIsolatedIdeaModules(rootProject, allProjects, parameter);
 
         IdeaLanguageLevel languageLevel = resolveRootLanguageLevel(ideaProjectExt, allIsolatedIdeaModules);
         JavaVersion targetBytecodeVersion = resolveRootTargetBytecodeVersion(ideaProjectExt, allIsolatedIdeaModules);
@@ -184,9 +185,9 @@ public class IsolatedProjectsSafeIdeaModelBuilder implements IdeaModelBuilderInt
         return getMaxCompatibility(isolatedModules, IsolatedIdeaModuleInternal::getJavaTargetCompatibility);
     }
 
-    private List<IsolatedIdeaModuleInternal> getIsolatedIdeaModules(List<Project> allProjects, IdeaModelParameter parameter) {
+    private List<IsolatedIdeaModuleInternal> getIsolatedIdeaModules(Project rootProject, List<Project> allProjects, IdeaModelParameter parameter) {
         return intermediateToolingModelProvider
-            .getModels(allProjects, IsolatedIdeaModuleInternal.class, parameter);
+            .getModels(rootProject, allProjects, IsolatedIdeaModuleInternal.class, parameter);
     }
 
     private static List<DefaultIdeaModule> createIdeaModules(

--- a/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/IntermediateToolingModelProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/IntermediateToolingModelProvider.java
@@ -35,27 +35,22 @@ import java.util.List;
 public interface IntermediateToolingModelProvider {
 
     /**
-     * Fetches models of a given type for the given projects.
-     * <p>
-     * Model name to find the underlying builder is derived from the binary name of the {@code modelType}.
+     * Fetches models of a given type for the given projects passing a parameter to the underlying builder.
      */
-    <T> List<T> getModels(List<Project> targets, Class<T> modelType);
+    <T> List<T> getModels(Project requester, List<Project> targets, String modelName, Class<T> modelType, Object modelBuilderParameter);
 
     /**
      * Fetches models of a given type for the given projects passing a parameter to the underlying builder.
      * <p>
      * Model name to find the underlying builder is derived from the binary name of the {@code modelType}.
      */
-    <T> List<T> getModels(List<Project> targets, Class<T> modelType, Object modelBuilderParameter);
-
-    /**
-     * Fetches models of a given type for the given projects passing a parameter to the underlying builder.
-     */
-    <T> List<T> getModels(List<Project> targets, String modelName, Class<T> modelType, Object modelBuilderParameter);
+    default <T> List<T> getModels(Project requester, List<Project> targets, Class<T> modelType, Object modelBuilderParameter) {
+        return getModels(requester, targets, modelType.getName(), modelType, modelBuilderParameter);
+    }
 
     /**
      * Applies a plugin of a given type to the given projects.
      */
-    <P extends Plugin<Project>> void applyPlugin(List<Project> targets, Class<P> pluginClass);
+    <P extends Plugin<Project>> void applyPlugin(Project requester, List<Project> targets, Class<P> pluginClass);
 
 }

--- a/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/IntermediateToolingModelProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/IntermediateToolingModelProvider.java
@@ -31,7 +31,7 @@ import java.util.List;
  * from <b>multiple projects of the same build</b>.
  */
 @NonNullApi
-@ServiceScope(Scopes.BuildTree.class)
+@ServiceScope(Scopes.Build.class)
 public interface IntermediateToolingModelProvider {
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/ToolingModelProjectDependencyListener.java
+++ b/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/ToolingModelProjectDependencyListener.java
@@ -16,10 +16,12 @@
 
 package org.gradle.tooling.provider.model.internal;
 
+import org.gradle.api.NonNullApi;
 import org.gradle.api.internal.project.ProjectState;
 import org.gradle.internal.service.scopes.EventScope;
 import org.gradle.internal.service.scopes.Scopes;
 
+@NonNullApi
 @EventScope(Scopes.Build.class)
 public interface ToolingModelProjectDependencyListener {
 

--- a/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/ToolingModelProjectDependencyListener.java
+++ b/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/ToolingModelProjectDependencyListener.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.provider.model.internal;
+
+import org.gradle.api.internal.project.ProjectState;
+import org.gradle.internal.service.scopes.EventScope;
+import org.gradle.internal.service.scopes.Scopes;
+
+@EventScope(Scopes.Build.class)
+public interface ToolingModelProjectDependencyListener {
+
+    /**
+     * Notified when model builders for a {@code consumer} project requests an intermediate model of some other {@code target} project.
+     * <p>
+     * The {@code consumer} and {@code target} might represent the same project, and the listener implementation
+     * should handle this specifically, probably ignoring such calls.
+     */
+    void onToolingModelDependency(ProjectState consumer, ProjectState target);
+
+}


### PR DESCRIPTION
When a top-level model is aggregated from intermediate models of other projects, the top-level model must be invalidated if the configuration of any of these projects changes in the case of an incremental reconfiguration.

A specific example is the IP-safe model building for the `GradleProject` that is done through fetching isolated models for individual projects. Another example is the `IdeaProject` model that aggregates all projects into individual `IdeaModule` models.