### PR TITLE
Add support for conventions to ConfigurableFileCollection

### DIFF
--- a/platforms/core-configuration/file-collections/src/integTest/groovy/org/gradle/api/file/FileCollectionIntegrationTest.groovy
+++ b/platforms/core-configuration/file-collections/src/integTest/groovy/org/gradle/api/file/FileCollectionIntegrationTest.groovy
@@ -38,6 +38,21 @@ class FileCollectionIntegrationTest extends AbstractIntegrationSpec implements T
         type << ["Object", "Object[]", "Set", "LinkedHashSet", "List", "LinkedList", "Collection", "FileCollection"]
     }
 
+    def "can set elements as convention of file collection"() {
+        buildFile """
+            def files = objects.fileCollection().convention('b')
+            def elements = files.elements
+
+            def name = 'a'
+            files.configure { it.from(name) }
+
+            assert elements.get().asFile == [file('b'), file('a')]
+        """
+
+        expect:
+        succeeds()
+    }
+
     @Issue("https://github.com/gradle/gradle/issues/10322")
     def "can construct file collection from the elements of a source directory set"() {
         buildFile """

--- a/platforms/core-configuration/file-collections/src/integTest/groovy/org/gradle/api/file/FileCollectionIntegrationTest.groovy
+++ b/platforms/core-configuration/file-collections/src/integTest/groovy/org/gradle/api/file/FileCollectionIntegrationTest.groovy
@@ -44,7 +44,7 @@ class FileCollectionIntegrationTest extends AbstractIntegrationSpec implements T
             def elements = files.elements
 
             def name = 'a'
-            files.configure { it.from(name) }
+            files.configure { from(name) }
 
             assert elements.get().asFile == [file('b'), file('a')]
         """

--- a/platforms/core-configuration/file-collections/src/integTest/groovy/org/gradle/api/file/FileCollectionIntegrationTest.groovy
+++ b/platforms/core-configuration/file-collections/src/integTest/groovy/org/gradle/api/file/FileCollectionIntegrationTest.groovy
@@ -44,7 +44,7 @@ class FileCollectionIntegrationTest extends AbstractIntegrationSpec implements T
             def elements = files.elements
 
             def name = 'a'
-            files.configure { from(name) }
+            files.withActualValue { from(name) }
 
             assert elements.get().asFile == [file('b'), file('a')]
         """

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.file.collections;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.Transformer;
 import org.gradle.api.file.ConfigurableFileCollection;
@@ -44,6 +45,7 @@ import org.gradle.internal.Factory;
 import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.internal.logging.text.TreeFormatter;
 import org.gradle.internal.state.Managed;
+import org.gradle.util.internal.ConfigureUtil;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -96,9 +98,9 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
         return this;
     }
 
-    @VisibleForTesting
-    public ConfigurableFileCollection configureConvention(Action<FileCollectionConfigurer> action) {
-        action.execute(getConventionValue());
+    @Override
+    public ConfigurableFileCollection configure(Closure<FileCollectionConfigurer> action) {
+        ConfigureUtil.configure(action, getActualValue());
         return this;
     }
 

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
@@ -93,13 +93,13 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
     }
 
     @Override
-    public ConfigurableFileCollection configure(Action<FileCollectionConfigurer> action) {
+    public ConfigurableFileCollection withActualValue(Action<FileCollectionConfigurer> action) {
         action.execute(getActualValue());
         return this;
     }
 
     @Override
-    public ConfigurableFileCollection configure(Closure<FileCollectionConfigurer> action) {
+    public ConfigurableFileCollection withActualValue(Closure<Void> action) {
         ConfigureUtil.configure(action, getActualValue());
         return this;
     }

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
@@ -16,10 +16,13 @@
 
 package org.gradle.api.internal.file.collections;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import org.gradle.api.Action;
 import org.gradle.api.Transformer;
 import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.FileCollectionConfigurer;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.CompositeFileCollection;
 import org.gradle.api.internal.file.FileCollectionInternal;
@@ -34,6 +37,7 @@ import org.gradle.api.internal.provider.support.LazyGroovySupport;
 import org.gradle.api.internal.tasks.DefaultTaskDependency;
 import org.gradle.api.internal.tasks.TaskDependencyFactory;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
+import org.gradle.api.provider.SupportsConvention;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.internal.Cast;
 import org.gradle.internal.Factory;
@@ -65,8 +69,9 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
     private final TaskDependencyFactory dependencyFactory;
     private final PropertyHost host;
     private final DefaultTaskDependency buildDependency;
-    private ValueCollector value = EMPTY_COLLECTOR;
+    private ValueCollector value;
     private ValueState<ValueCollector> valueState;
+    private ValueCollector defaultValue = new EmptyCollector();
 
     public DefaultConfigurableFileCollection(@Nullable String displayName, PathToFileResolver fileResolver, TaskDependencyFactory dependencyFactory, Factory<PatternSet> patternSetFactory, PropertyHost host) {
         super(dependencyFactory, patternSetFactory);
@@ -75,8 +80,26 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
         this.dependencyFactory = dependencyFactory;
         this.host = host;
         this.valueState = ValueState.newState(host);
+        init(EMPTY_COLLECTOR, EMPTY_COLLECTOR);
         filesWrapper = new PathSet();
         buildDependency = dependencyFactory.configurableDependency();
+    }
+
+    private void init(ValueCollector initialValue, ValueCollector convention) {
+        this.valueState.setConvention(convention);
+        this.value = initialValue;
+    }
+
+    @Override
+    public ConfigurableFileCollection configure(Action<FileCollectionConfigurer> action) {
+        action.execute(getActualValue());
+        return this;
+    }
+
+    @VisibleForTesting
+    public ConfigurableFileCollection configureConvention(Action<FileCollectionConfigurer> action) {
+        action.execute(getConventionValue());
+        return this;
     }
 
     @Override
@@ -211,23 +234,78 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
     @Override
     public void setFrom(Iterable<?> path) {
         assertMutable();
-        value = value.setFrom(this, resolver, patternSetFactory, dependencyFactory, host, path);
+        setExplicitCollector(newValue(value, path));
+    }
+
+    @Override
+    public ConfigurableFileCollection convention(Iterable<?> paths) {
+        assertMutable();
+        setConventionCollector(newValue(EMPTY_COLLECTOR, paths));
+        return this;
+    }
+
+    @Override
+    public ConfigurableFileCollection convention(Object... paths) {
+        assertMutable();
+        setConventionCollector(newValue(EMPTY_COLLECTOR, paths));
+        return this;
+    }
+
+    @Override
+    public ConfigurableFileCollection setToConventionIfUnset() {
+        assertMutable();
+        value = valueState.setToConventionIfUnset(value);
+        return this;
+    }
+
+    @Override
+    public SupportsConvention setToConvention() {
+        assertMutable();
+        value = valueState.setToConvention();
+        return this;
+    }
+
+    private void setConventionCollector(ValueCollector convention) {
+        value = valueState.applyConvention(value, convention);
+    }
+
+    private void setExplicitCollector(ValueCollector valueCollector) {
+        value = valueState.explicitValue(valueCollector);
+    }
+
+    @Override
+    public ConfigurableFileCollection unsetConvention() {
+        assertMutable();
+        setConventionCollector(EMPTY_COLLECTOR);
+        return this;
+    }
+
+    @Override
+    public ConfigurableFileCollection unset() {
+        assertMutable();
+        value = valueState.implicitValue();
+        return this;
     }
 
     @Override
     public void setFrom(Object... paths) {
         assertMutable();
-        value = paths.length > 0
-            ? value.setFrom(this, resolver, patternSetFactory, dependencyFactory, host, paths)
-            : EMPTY_COLLECTOR;
+        setExplicitCollector(paths.length > 0
+            ? newValue(value, paths)
+            : EMPTY_COLLECTOR);
+    }
+
+    private ValueCollector newValue(ValueCollector baseValue, Object[] paths) {
+        return baseValue.setFrom(this, resolver, patternSetFactory, dependencyFactory, host, paths);
+    }
+
+    private ValueCollector newValue(ValueCollector baseValue, Iterable<?> paths) {
+        return baseValue.setFrom(this, resolver, patternSetFactory, dependencyFactory, host, paths);
     }
 
     @Override
     public ConfigurableFileCollection from(Object... paths) {
-        assertMutable();
-        if (paths.length > 0) {
-            value = value.plus(this, resolver, patternSetFactory, dependencyFactory, host, paths);
-        }
+        getExplicitValue().from(paths);
         return this;
     }
 
@@ -291,7 +369,7 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
                 builder.add(fileTree);
             }
         }));
-        value = new ResolvedItemsCollector(builder.build());
+        setExplicitCollector(new ResolvedItemsCollector(builder.build()));
     }
 
     @Override
@@ -304,6 +382,37 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
     public void visitDependencies(TaskDependencyResolveContext context) {
         context.add(buildDependency);
         super.visitDependencies(context);
+    }
+
+    private ValueCollector getConventionCollector() {
+        return valueState.convention();
+    }
+
+    /**
+     * Returns the current value of this property, if explicitly defined, otherwise the given default. Does not apply the convention.
+     */
+    private ValueCollector getExplicitCollector() {
+        return valueState.explicitValue(value, defaultValue);
+    }
+
+    private FileCollectionConfigurer getActualValue() {
+        if (valueState.isExplicit()) {
+            return getExplicitValue();
+        }
+        return getConventionValue();
+    }
+
+    private FileCollectionConfigurer getExplicitValue() {
+        return new ExplicitValueConfigurer();
+    }
+
+    private FileCollectionConfigurer getConventionValue() {
+        return new ConventionValueConfigurer();
+    }
+
+    @VisibleForTesting
+    protected boolean isExplicit() {
+        return valueState.isExplicit();
     }
 
     /**
@@ -586,7 +695,7 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
         public boolean add(Object o) {
             assertMutable();
             if (!delegate().contains(o)) {
-                value = value.plus(DefaultConfigurableFileCollection.this, resolver, patternSetFactory, dependencyFactory, host, o);
+                setExplicitCollector(value.plus(DefaultConfigurableFileCollection.this, resolver, patternSetFactory, dependencyFactory, host, o));
                 return true;
             } else {
                 return false;
@@ -602,7 +711,47 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
         @Override
         public void clear() {
             assertMutable();
-            value = EMPTY_COLLECTOR;
+            setExplicitCollector(EMPTY_COLLECTOR);
+        }
+    }
+
+    private abstract class Configurer implements FileCollectionConfigurer {
+
+        protected abstract ValueCollector getValue();
+
+        protected abstract void setValue(ValueCollector newValue);
+
+        @Override
+        public FileCollectionConfigurer from(Object... paths) {
+            assertMutable();
+            if (paths.length > 0) {
+                setValue(getValue().plus(DefaultConfigurableFileCollection.this, resolver, patternSetFactory, dependencyFactory, host, paths));
+            }
+            return this;
+        }
+    }
+
+    private class ExplicitValueConfigurer extends Configurer {
+        @Override
+        protected ValueCollector getValue() {
+            return getExplicitCollector();
+        }
+
+        @Override
+        protected void setValue(ValueCollector newValue) {
+            setExplicitCollector(newValue);
+        }
+    }
+
+    private class ConventionValueConfigurer extends Configurer {
+        @Override
+        protected ValueCollector getValue() {
+            return getConventionCollector();
+        }
+
+        @Override
+        protected void setValue(ValueCollector newValue) {
+            setConventionCollector(newValue);
         }
     }
 }

--- a/platforms/core-configuration/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollectionSpec.groovy
+++ b/platforms/core-configuration/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollectionSpec.groovy
@@ -15,9 +15,11 @@
  */
 package org.gradle.api.internal.file.collections
 
+import org.gradle.api.Action
 import org.gradle.api.Task
 import org.gradle.api.Transformer
 import org.gradle.api.file.FileCollection
+import org.gradle.api.file.FileCollectionConfigurer
 import org.gradle.api.internal.file.AbstractFileCollection
 import org.gradle.api.internal.file.FileCollectionInternal
 import org.gradle.api.internal.file.FileCollectionSpec
@@ -1807,12 +1809,32 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
         !collection.explicit
     }
 
+    def "can incrementally set paths using action"() {
+        when:
+        collection.withActualValue({
+            it.from("src1", "src2")
+            it.from("src3")
+        } as Action<FileCollectionConfigurer>)
+        then:
+        collection.from as List == ["src1", "src2", "src3"]
+    }
+
+    def "can incrementally set paths using closure"() {
+        when:
+        collection.withActualValue {
+            from("src1", "src2")
+            from("src3")
+        }
+        then:
+        collection.from as List == ["src1", "src2", "src3"]
+    }
+
     def "can incrementally set paths as convention to the collection"() {
         when:
         collection.convention("src0")
         collection.withActualValue {
-            it.from("src1", "src2")
-            it.from("src3")
+            from("src1", "src2")
+            from("src3")
         }
         then:
         collection.from as List == ["src0", "src1", "src2", "src3"]
@@ -1824,8 +1846,8 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
         collection.setFrom("src1")
         collection.convention("unused-src")
         collection.withActualValue {
-            it.from("src3")
-            it.from("src4")
+            from("src3")
+            from("src4")
         }
         then:
         collection.from as List == ["src1", "src3", "src4"]
@@ -1835,7 +1857,7 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
         given:
         collection.convention("src0")
         collection.withActualValue {
-            it.from("src1")
+            from("src1")
         }
 
         when:

--- a/platforms/core-configuration/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollectionSpec.groovy
+++ b/platforms/core-configuration/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollectionSpec.groovy
@@ -1810,7 +1810,7 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
     def "can incrementally set paths as convention to the collection"() {
         when:
         collection.convention("src0")
-        collection.configure {
+        collection.withActualValue {
             it.from("src1", "src2")
             it.from("src3")
         }
@@ -1823,7 +1823,7 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
         when:
         collection.setFrom("src1")
         collection.convention("unused-src")
-        collection.configure {
+        collection.withActualValue {
             it.from("src3")
             it.from("src4")
         }
@@ -1834,7 +1834,7 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
     def "can unset convention"() {
         given:
         collection.convention("src0")
-        collection.configure {
+        collection.withActualValue {
             it.from("src1")
         }
 

--- a/platforms/core-configuration/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollectionSpec.groovy
+++ b/platforms/core-configuration/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollectionSpec.groovy
@@ -264,6 +264,29 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
         files == [file1, file2] as LinkedHashSet
     }
 
+    def "can set another collection as convention to the collection"() {
+        given:
+        def file1 = new File("1")
+        def file2 = new File("2")
+        def src = Mock(MinimalFileSet)
+        def srcCollection = TestFiles.fileCollectionFactory().create(src)
+
+        when:
+        collection.convention(srcCollection)
+        def files = collection.files
+
+        then:
+        1 * src.getFiles() >> ([file1] as Set)
+        files as List == [file1]
+
+        when:
+        files = collection.files
+
+        then:
+        1 * src.getFiles() >> ([file1, file2] as LinkedHashSet)
+        files == [file1, file2] as LinkedHashSet
+    }
+
     def "can use a callable to specify the contents of the collection"() {
         given:
         def file1 = new File("1")
@@ -272,6 +295,23 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
 
         when:
         collection.from(callable)
+        def files = collection.files
+
+        then:
+        1 * callable.call() >> ["src1", "src2"]
+        _ * fileResolver.resolve("src1") >> file1
+        _ * fileResolver.resolve("src2") >> file2
+        files as List == [file1, file2]
+    }
+
+    def "can use a callable to specify the convention contents of the collection"() {
+        given:
+        def file1 = new File("1")
+        def file2 = new File("2")
+        def callable = Mock(Callable)
+
+        when:
+        collection.convention(callable)
         def files = collection.files
 
         then:
@@ -1757,5 +1797,100 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
 
         then:
         0 * filterSpec._
+    }
+
+    def "can set paths as convention to the collection"() {
+        when:
+        collection.convention("src1", "src2")
+        then:
+        collection.from as List == ["src1", "src2"]
+        !collection.explicit
+    }
+
+    def "can incrementally set paths as convention to the collection"() {
+        when:
+        collection.convention("src0")
+        collection.configure {
+            it.from("src1", "src2")
+            it.from("src3")
+        }
+        then:
+        collection.from as List == ["src0", "src1", "src2", "src3"]
+        !collection.explicit
+    }
+
+    def "can incrementally set explicit value"() {
+        when:
+        collection.setFrom("src1")
+        collection.convention("unused-src")
+        collection.configure {
+            it.from("src3")
+            it.from("src4")
+        }
+        then:
+        collection.from as List == ["src1", "src3", "src4"]
+    }
+
+    def "can unset convention"() {
+        given:
+        collection.convention("src0")
+        collection.configure {
+            it.from("src1")
+        }
+
+        when:
+        collection.unsetConvention()
+
+        then:
+        collection.from as List == []
+    }
+
+    def "conventions are ignored if a value is already explicitly set using #setFrom"() {
+        when:
+        collection.setFrom("src3")
+        collection.convention("src1", "src2")
+        then:
+        collection.from as List == ["src3"]
+    }
+
+    def "conventions are ignored if a value is already explicitly set using #from"() {
+        when:
+        collection.from("src3")
+        collection.convention("src1", "src2")
+        then:
+        collection.from as List == ["src3"]
+    }
+
+    def "conventions can be overridden with an explicit value using #setFrom"() {
+        when:
+        collection.convention("src1", "src2")
+        collection.setFrom("src3")
+        then:
+        collection.from as List == ["src3"]
+        collection.explicit
+    }
+
+    def "conventions can be overridden with an explicit value using #from"() {
+        when:
+        collection.convention("src1", "src2")
+        collection.from("src3")
+        then:
+        collection.explicit
+        collection.from as List == ["src3"]
+    }
+
+    def "conventions are brought back if explicit value is unset"() {
+        when:
+        collection.from("src3")
+        collection.convention("src1", "src2")
+        then:
+        collection.from as List == ["src3"]
+
+        when:
+        collection.unset()
+
+        then:
+        collection.from as List == ["src1", "src2"]
+        !collection.explicit
     }
 }

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/FileCollectionConventionMappingIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/FileCollectionConventionMappingIntegrationTest.groovy
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.provider
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class FileCollectionConventionMappingIntegrationTest extends AbstractIntegrationSpec {
+    def "convention mapping can be used with Configurable File Collection and an actual value"() {
+        buildFile << """
+            abstract class MyTask extends DefaultTask {
+                @Internal abstract ConfigurableFileCollection getFoo()
+                @Internal abstract ConfigurableFileCollection getBar()
+                @Inject abstract ProjectLayout getLayout()
+
+                @TaskAction
+                void useIt() {
+                    assert foo.files == layout.files("file1", "file2").files
+                    assert foo.files.size() == 2
+                }
+            }
+            tasks.register("mytask", MyTask) {
+                conventionMapping.map("foo") { bar }
+                bar.setFrom("file1", "file2")
+            }
+        """
+
+        expect:
+        succeeds 'mytask'
+    }
+
+    def "convention mapping works with FileCollection in a ConventionTask"() {
+        buildFile << """
+            abstract class MyTask extends org.gradle.api.internal.ConventionTask {
+                @Internal abstract ConfigurableFileCollection getFoo()
+                @Inject abstract ProjectLayout getLayout()
+
+                @TaskAction
+                void useIt() {
+                    // convention mapping for FileCollection is already ignored
+                    assert foo.files == layout.files("file1", "file2").files
+                    assert foo.files.size() == 2
+                }
+            }
+            tasks.register("mytask", MyTask) {
+                conventionMapping.map("foo", { project.objects.fileCollection().from("file1") })
+                foo.convention("file1", "file2")
+            }
+        """
+
+        expect:
+        succeeds 'mytask'
+    }
+}

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/ProviderConventionMappingIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/ProviderConventionMappingIntegrationTest.groovy
@@ -19,7 +19,10 @@ package org.gradle.api.provider
 import org.gradle.api.internal.provider.DefaultProvider
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 
-// TODO: Also do this for FileCollection types eventually
+/**
+ * See {@link FileCollectionConventionMappingIntegrationTest} for similar coverage for
+ * file collections.
+ */
 class ProviderConventionMappingIntegrationTest extends AbstractIntegrationSpec {
     private void expectDocumentedFailure() {
         failure.assertHasDocumentedCause('Using internal convention mapping with a Provider backed property. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#convention_mapping')

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ValueState.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/ValueState.java
@@ -85,6 +85,26 @@ public abstract class ValueState<S> {
         finalizeOnNextGet();
     }
 
+    public abstract boolean isExplicit();
+
+    /**
+     * Retrieves the current convention.
+     */
+    public abstract S convention();
+
+    /**
+     * Marks this value as being explicitly set with
+     * the current value assigned to the convention.
+     */
+    public abstract S setToConvention();
+
+    /**
+     * Marks this value as being explicitly set with
+     * the current value assigned to the convention,
+     * unless it is already an explicit value.
+     */
+    public abstract S setToConventionIfUnset(S value);
+
     private static class NonFinalizedValue<S> extends ValueState<S> {
         private final PropertyHost host;
         private boolean explicitValue;
@@ -159,6 +179,30 @@ public abstract class ValueState<S> {
         @Override
         public boolean isFinalizing() {
             return finalizeOnNextGet;
+        }
+
+        @Override
+        public boolean isExplicit() {
+            return explicitValue;
+        }
+
+        @Override
+        public S convention() {
+            return convention;
+        }
+
+        @Override
+        public S setToConvention() {
+            explicitValue = true;
+            return convention;
+        }
+
+        @Override
+        public S setToConventionIfUnset(S value) {
+            if (!explicitValue) {
+                return setToConvention();
+            }
+            return value;
         }
 
         @Override
@@ -275,6 +319,26 @@ public abstract class ValueState<S> {
         @Override
         public boolean isFinalizing() {
             return true;
+        }
+
+        @Override
+        public boolean isExplicit() {
+            return true;
+        }
+
+        @Override
+        public S convention() {
+            return null;
+        }
+
+        @Override
+        public S setToConvention() {
+            throw unexpected();
+        }
+
+        @Override
+        public S setToConventionIfUnset(S value) {
+            throw unexpected();
         }
 
         @Override

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/extensibility/ConventionAwareHelper.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/extensibility/ConventionAwareHelper.java
@@ -19,10 +19,12 @@ package org.gradle.internal.extensibility;
 import groovy.lang.Closure;
 import groovy.lang.MissingPropertyException;
 import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.internal.ConventionMapping;
 import org.gradle.api.internal.IConventionAware;
 import org.gradle.api.internal.provider.DefaultProvider;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.SupportsConvention;
 import org.gradle.internal.Cast;
 import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.deprecation.DocumentedFailure;
@@ -66,19 +68,21 @@ public class ConventionAwareHelper implements ConventionMapping, org.gradle.api.
         }
 
         if (_ineligiblePropertyNames.contains(propertyName)) {
-            // When there's a Property, use its `.convention()` method instead
+            // When there's a convention-supporting object, use its `.convention()` method instead
             // This is something we added to support properties migrated in the future from
             // Java bean to Property where old code uses ConventionMapping to set conventions.
             Class<? extends IConventionAware> sourceType = _source.getClass();
             Method getter = JavaPropertyReflectionUtil.findGetterMethod(sourceType, propertyName);
-            if (getter != null && Property.class.isAssignableFrom(getter.getReturnType())) {
-                Property<Object> property;
+            if (getter != null && (Property.class.isAssignableFrom(getter.getReturnType()) || SupportsConvention.class.isAssignableFrom(getter.getReturnType()))) {
+                Object target;
                 try {
-                    property = Cast.uncheckedNonnullCast(getter.invoke(_source));
-                } catch (InvocationTargetException | IllegalAccessException e) {
+                    target = Cast.uncheckedNonnullCast(getter.invoke(_source));
+                } catch (IllegalAccessException | InvocationTargetException e) {
                     throw new IllegalStateException(String.format("Could not access property %s.%s", sourceType.getSimpleName(), propertyName), e);
                 }
-                property.convention(new DefaultProvider<>(() -> mapping.getValue(_convention, _source)));
+                if (!mapConventionOn(target, mapping)) {
+                    throw new IllegalStateException(String.format("Unexpected convention-supporting type used in property %s.%s", sourceType.getSimpleName(), propertyName, getter.getReturnType().getName()));
+                }
             } else {
                 throw DocumentedFailure.builder()
                     .withSummary("Using internal convention mapping with a Provider backed property.")
@@ -89,6 +93,19 @@ public class ConventionAwareHelper implements ConventionMapping, org.gradle.api.
             _mappings.put(propertyName, mapping);
         }
         return mapping;
+    }
+
+    private boolean mapConventionOn(Object target, MappedPropertyImpl mapping) {
+        if (target instanceof Property) {
+            Property<Object> asProperty = Cast.uncheckedNonnullCast(target);
+            asProperty.convention(new DefaultProvider<>(() -> mapping.getValue(_convention, _source)));
+        } else if (target instanceof ConfigurableFileCollection) {
+            ConfigurableFileCollection asFileCollection = Cast.uncheckedNonnullCast(target);
+            asFileCollection.convention((Callable) () -> mapping.getValue(_convention, _source));
+        } else {
+            return false;
+        }
+        return true;
     }
 
     @Override

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
@@ -49,6 +49,7 @@ import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.SetProperty;
+import org.gradle.api.provider.SupportsConvention;
 import org.gradle.api.reflect.InjectionPointQualifier;
 import org.gradle.api.tasks.Nested;
 import org.gradle.cache.internal.CrossBuildInMemoryCache;
@@ -412,9 +413,9 @@ abstract class AbstractClassGenerator implements ClassGenerator {
     }
 
     private static boolean isIneligibleForConventionMapping(PropertyMetadata property) {
-        // Provider API types should have conventions set through convention() instead of
+        // Provider API types and convention-supporting types in general should have conventions set through convention() instead of
         // using convention mapping.
-        return Provider.class.isAssignableFrom(property.getType());
+        return Provider.class.isAssignableFrom(property.getType()) || SupportsConvention.class.isAssignableFrom(property.getType());
     }
 
     private static boolean isLazyAttachProperty(PropertyMetadata property) {

--- a/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
+++ b/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
@@ -1,3 +1,14 @@
 {
-    "acceptedApiChanges": []
+    "acceptedApiChanges": [
+        {
+            "type": "org.gradle.api.file.ConfigurableFileCollection",
+            "member": "Class org.gradle.api.file.ConfigurableFileCollection",
+            "acceptation": "ConfigurableFileCollection now supports conventions",
+            "changes": [
+                "org.gradle.api.file.FileCollectionConfigurer",
+                "org.gradle.api.provider.ConfigurableValue",
+                "org.gradle.api.provider.SupportsConvention"
+            ]
+        }
+    ]
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/ConfigurableFileCollection.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/ConfigurableFileCollection.java
@@ -129,24 +129,24 @@ public interface ConfigurableFileCollection extends FileCollection, HasConfigura
      */
     @Override
     @Incubating
-    ConfigurableFileCollection configure(Action<FileCollectionConfigurer> action);
+    ConfigurableFileCollection withActualValue(Action<FileCollectionConfigurer> action);
 
     /**
      * Performs incremental updates to the actual value of this file collection.
      *
      * This is a Groovy closure-compatible version of
-     * {@link ConfigurableFileCollection#configure(Action)},
+     * {@link ConfigurableFileCollection#withActualValue(Action)},
      * having this file collection's actual value (and not the file collection itself)
      * as the target object.
      *
      * @param action a Groovy closure to incrementally configure this object actual value
      * via the {@link FileCollectionConfigurer} protocol.
      *
-     * @see #configure(Action)
+     * @see #withActualValue(Action)
      * @since 8.7
      */
     @Incubating
-    ConfigurableFileCollection configure(Closure<FileCollectionConfigurer> action);
+    ConfigurableFileCollection withActualValue(Closure<Void> action);
 
     /**
      * Applies an eager transformation to the current contents of this file collection, without explicitly resolving it.

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/ConfigurableFileCollection.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/ConfigurableFileCollection.java
@@ -16,11 +16,14 @@
 package org.gradle.api.file;
 
 import groovy.lang.Closure;
+import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.SupportsKotlinAssignmentOverloading;
 import org.gradle.api.Transformer;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ConfigurableValue;
 import org.gradle.api.provider.HasConfigurableValue;
+import org.gradle.api.provider.SupportsConvention;
 
 import java.util.Set;
 
@@ -32,7 +35,7 @@ import java.util.Set;
  * <p><b>Note:</b> This interface is not intended for implementation by build script or plugin authors.</p>
  */
 @SupportsKotlinAssignmentOverloading
-public interface ConfigurableFileCollection extends FileCollection, HasConfigurableValue {
+public interface ConfigurableFileCollection extends FileCollection, HasConfigurableValue, ConfigurableValue<FileCollectionConfigurer>, SupportsConvention, FileCollectionConfigurer {
     /**
      * Returns the set of source paths for this collection. The paths are evaluated as per {@link org.gradle.api.Project#files(Object...)}.
      *
@@ -55,11 +58,39 @@ public interface ConfigurableFileCollection extends FileCollection, HasConfigura
     void setFrom(Object... paths);
 
     /**
-     * Adds a set of source paths to this collection. The given paths are evaluated as per {@link org.gradle.api.Project#files(Object...)}.
+     * Specifies the value to use as the convention (default value) to be used when resolving this file collection,
+     * if no source paths are explicitly defined.
      *
-     * @param paths The files to add.
-     * @return this
+     * If, at the time this method is invoked, the set of source paths for this collection is empty, the convention will be used
+     * to resolve this file collection.
+     *
+     * @param paths The paths.
+     * @return this collection
+     *
+     * @since 8.7
      */
+    @Incubating
+    ConfigurableFileCollection convention(Iterable<?> paths);
+
+    /**
+     * Specifies the value to use as the convention (default value) to be used when resolving this file collection,
+     * if no source paths are explicitly defined.
+     *
+     * If, at the time this method is invoked, the set of source paths for this collection is empty, the convention will be used
+     * to resolve this file collection.
+     *
+     * @param paths The paths.
+     * @return this collection
+     *
+     * @since 8.7
+     */
+    @Incubating
+    ConfigurableFileCollection convention(Object... paths);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     ConfigurableFileCollection from(Object... paths);
 
     /**
@@ -84,6 +115,38 @@ public interface ConfigurableFileCollection extends FileCollection, HasConfigura
      * @return this
      */
     ConfigurableFileCollection builtBy(Object... tasks);
+
+    /**
+     * Performs incremental updates to the actual value of this file collection.
+     *
+     * {@inheritDoc}
+     *
+     * For wholesale updates to the explicit value, use
+     * {@link #setFrom(Object...)}, {@link #setFrom(Iterable)} or {@link #update(Transformer)}.
+     *
+     * For wholesale updates to the convention value, use
+     * {@link #convention(Object...)} or {@link #convention(Iterable)}.
+     */
+    @Override
+    @Incubating
+    ConfigurableFileCollection configure(Action<FileCollectionConfigurer> action);
+
+    /**
+     * Performs incremental updates to the actual value of this file collection.
+     *
+     * This is a Groovy closure-compatible version of
+     * {@link ConfigurableFileCollection#configure(Action)},
+     * having this file collection's actual value (and not the file collection itself)
+     * as the target object.
+     *
+     * @param action a Groovy closure to incrementally configure this object actual value
+     * via the {@link FileCollectionConfigurer} protocol.
+     *
+     * @see #configure(Action)
+     * @since 8.7
+     */
+    @Incubating
+    ConfigurableFileCollection configure(Closure<FileCollectionConfigurer> action);
 
     /**
      * Applies an eager transformation to the current contents of this file collection, without explicitly resolving it.

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/FileCollectionConfigurer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/FileCollectionConfigurer.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.file;
+
+import org.gradle.api.Incubating;
+import org.gradle.api.provider.ConfigurableValue;
+
+/**
+ * The configuration protocol for incremental updates to ConfigurableFileCollections.
+ *
+ * @since 8.7
+ */
+@Incubating
+public interface FileCollectionConfigurer extends ConfigurableValue.Configurer {
+    /**
+     * Adds a set of source paths to this collection. The given paths are evaluated as per {@link org.gradle.api.Project#files(Object...)}.
+     *
+     * @param paths The files to add.
+     * @return this
+     *
+     * @since 8.7
+     */
+    FileCollectionConfigurer from(Object... paths);
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ConfigurableValue.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ConfigurableValue.java
@@ -48,5 +48,5 @@ public interface ConfigurableValue<C extends ConfigurableValue.Configurer> {
      *
      * @since 8.7
      */
-    ConfigurableValue<C> configure(Action<C> action);
+    ConfigurableValue<C> withActualValue(Action<C> action);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ConfigurableValue.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ConfigurableValue.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.provider;
+
+import org.gradle.api.Action;
+import org.gradle.api.Incubating;
+
+/**
+ * A protocol for objects that can be incrementally updated in a lazy way.
+ *
+ * @param <C> the configurer type, the type that models the configuration protocol
+ *
+ * @since 8.7
+ */
+@Incubating
+public interface ConfigurableValue<C extends ConfigurableValue.Configurer> {
+    /**
+     * A base interface for incrementally mutating configurable objects.
+     *
+     * Implementations are supposed to provide only (incremental) mutating methods,
+     * with no return values, and no querying methods.
+     *
+     * @since 8.7
+     */
+    @Incubating
+    interface Configurer {
+    }
+
+    /**
+     * Applies the action to the current value of the property, be it defined via convention,
+     * or as an explicit value.
+     *
+     * @param action an action to incrementally configure this object
+     *
+     * @since 8.7
+     */
+    ConfigurableValue<C> configure(Action<C> action);
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/SupportsConvention.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/SupportsConvention.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.provider;
+
+import org.gradle.api.Incubating;
+
+/**
+ * Marks a Gradle API custom type as supporting conventions.
+ *
+ * <p>
+ * <b>Note:</b> This interface is not intended for implementation by build script or plugin authors.
+ * </p>
+ *
+ * @since 8.7
+ */
+@Incubating
+public interface SupportsConvention {
+    /**
+     * Unsets this object's explicit value, allowing the convention to be
+     * selected when evaluating this object's value.
+     *
+     * @since 8.7
+     */
+    SupportsConvention unset();
+
+    /**
+     * Unsets this object's convention value.
+     *
+     * @since 8.7
+     */
+    SupportsConvention unsetConvention();
+
+    /**
+     * Sets the value of the property to the current convention value, replacing whatever explicit value the property already had.
+     *
+     * If the property has no convention set at the time this method is invoked,
+     * the effect of invoking it is similar to invoking {@link SupportsConvention#unset()}.
+     *
+     * @since 8.7
+     */
+    SupportsConvention setToConvention();
+
+    /**
+     * Sets the value of the property to the current convention value, if an explicit
+     * value has not been set yet.
+     *
+     * If the property has no convention set at the time this method is invoked,
+     * or if an explicit value has already been set, it has no effect.
+     *
+     * @since 8.7
+     */
+    SupportsConvention setToConventionIfUnset();
+}


### PR DESCRIPTION
Also allows convention mapping to work with CFCs.

See [spec](https://docs.google.com/document/d/1KHCCzNeNAIkpedH9fUcNUe_vgZAWHxCODzxVW_7NzLw/edit#heading=h.qutvq8vpnt95) for design discussions.

Fixes: #21752, #25509 