### PR TITLE
Add more data for CC load/store build operations

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildOperationsIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildOperationsIntegrationTest.groovy
@@ -74,11 +74,11 @@ class ConfigurationCacheBuildOperationsIntegrationTest extends AbstractConfigura
         when:
         inDirectory 'lib'
         configurationCacheRun 'assemble'
-        loadOp = operations.only(ConfigurationCacheLoadBuildOperationType)
 
         then:
+        def loadOpInCcHitBuild = operations.only(ConfigurationCacheLoadBuildOperationType)
         workGraphLoaded()
-        loadOp.result.originBuildInvocationId == buildInvocationId
+        loadOpInCcHitBuild.result.originBuildInvocationId == buildInvocationId
     }
 
     def "emits relevant build operations when configuration cache is used - included build dependency"() {

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildOperationsIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildOperationsIntegrationTest.groovy
@@ -61,13 +61,24 @@ class ConfigurationCacheBuildOperationsIntegrationTest extends AbstractConfigura
 
         then:
         workGraphStoredAndLoaded()
+        def loadOp = operations.only(ConfigurationCacheLoadBuildOperationType)
+        def storeOp = operations.only(ConfigurationCacheStoreBuildOperationType)
+        with(storeOp.result) {
+            cacheEntrySize > 0
+        }
+        with(loadOp.result) {
+            cacheEntrySize == storeOp.result.cacheEntrySize
+        }
+        def buildInvocationId = loadOp.result.originBuildInvocationId
 
         when:
         inDirectory 'lib'
         configurationCacheRun 'assemble'
+        loadOp = operations.only(ConfigurationCacheLoadBuildOperationType)
 
         then:
         workGraphLoaded()
+        loadOp.result.originBuildInvocationId == buildInvocationId
     }
 
     def "emits relevant build operations when configuration cache is used - included build dependency"() {

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheBuildOperations.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheBuildOperations.kt
@@ -61,7 +61,8 @@ object LoadDetails : ConfigurationCacheLoadBuildOperationType.Details
 
 
 internal
-data class LoadResult(val originInvocationId: String?) : ConfigurationCacheLoadBuildOperationType.Result {
+data class LoadResult(val stateFile: File, val originInvocationId: String? = null) : ConfigurationCacheLoadBuildOperationType.Result {
+    override fun getCacheEntrySize(): Long = stateFile.length()
     override fun getOriginBuildInvocationId(): String? = originInvocationId
 }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheIO.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheIO.kt
@@ -154,7 +154,7 @@ class ConfigurationCacheIO internal constructor(
         }
 
     internal
-    fun readRootBuildStateFrom(stateFile: ConfigurationCacheStateFile, loadAfterStore: Boolean, graph: BuildTreeWorkGraph, graphBuilder: BuildTreeWorkGraphBuilder?): BuildTreeWorkGraph.FinalizedGraph {
+    fun readRootBuildStateFrom(stateFile: ConfigurationCacheStateFile, loadAfterStore: Boolean, graph: BuildTreeWorkGraph, graphBuilder: BuildTreeWorkGraphBuilder?): Pair<String, BuildTreeWorkGraph.FinalizedGraph> {
         return readConfigurationCacheState(stateFile) { state ->
             state.run {
                 readRootBuildState(graph, graphBuilder, loadAfterStore)

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheRepository.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheRepository.kt
@@ -180,7 +180,7 @@ class ConfigurationCacheRepository(
             }
         }
 
-        override fun useForStore(action: (Layout) -> Unit) {
+        override fun <T> useForStore(action: (Layout) -> T): T =
             withExclusiveAccessToCache(baseDir) { cacheDir ->
                 // TODO GlobalCache require(!cacheDir.isDirectory)
                 Files.createDirectories(cacheDir.toPath())
@@ -198,7 +198,6 @@ class ConfigurationCacheRepository(
                         }
                 }
             }
-        }
     }
 
     private

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheStateStore.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheStateStore.kt
@@ -40,7 +40,7 @@ interface ConfigurationCacheStateStore {
     /**
      * Writes some value to zero or more state files.
      */
-    fun useForStore(action: (ConfigurationCacheRepository.Layout) -> Unit)
+    fun <T> useForStore(action: (ConfigurationCacheRepository.Layout) -> T): T
 
     /**
      * Creates a new [ValueStore] that can be used to load and store multiple values.

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
@@ -369,7 +369,7 @@ class DefaultConfigurationCache internal constructor(
     private
     fun loadModel(): Any {
         return loadFromCache(StateType.Model) { stateFile ->
-            LoadResult(originInvocationId = null) to cacheIO.readModelFrom(stateFile)
+            LoadResult(stateFile.stateFile.file) to cacheIO.readModelFrom(stateFile)
         }
     }
 
@@ -377,7 +377,7 @@ class DefaultConfigurationCache internal constructor(
     fun loadWorkGraph(graph: BuildTreeWorkGraph, graphBuilder: BuildTreeWorkGraphBuilder?, loadAfterStore: Boolean): BuildTreeWorkGraph.FinalizedGraph {
         return loadFromCache(StateType.Work) { stateFile ->
             val (buildInvocationId, workGraph) = cacheIO.readRootBuildStateFrom(stateFile, loadAfterStore, graph, graphBuilder)
-            LoadResult(buildInvocationId) to workGraph
+            LoadResult(stateFile.stateFile.file, buildInvocationId) to workGraph
         }
     }
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
@@ -352,7 +352,9 @@ class DefaultConfigurationCache internal constructor(
         buildOperationExecutor.withStoreOperation(cacheKey.string) {
             store.useForStore { layout ->
                 try {
-                    action(layout.fileFor(stateType))
+                    val stateFile = layout.fileFor(stateType)
+                    action(stateFile)
+                    StoreResult(stateFile.stateFile.file)
                 } catch (error: ConfigurationCacheError) {
                     // Invalidate state on serialization errors
                     problems.failingBuildDueToSerializationError()

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
@@ -369,19 +369,20 @@ class DefaultConfigurationCache internal constructor(
     private
     fun loadModel(): Any {
         return loadFromCache(StateType.Model) { stateFile ->
-            cacheIO.readModelFrom(stateFile)
+            LoadResult(originInvocationId = null) to cacheIO.readModelFrom(stateFile)
         }
     }
 
     private
     fun loadWorkGraph(graph: BuildTreeWorkGraph, graphBuilder: BuildTreeWorkGraphBuilder?, loadAfterStore: Boolean): BuildTreeWorkGraph.FinalizedGraph {
         return loadFromCache(StateType.Work) { stateFile ->
-            cacheIO.readRootBuildStateFrom(stateFile, loadAfterStore, graph, graphBuilder)
+            val (buildInvocationId, workGraph) = cacheIO.readRootBuildStateFrom(stateFile, loadAfterStore, graph, graphBuilder)
+            LoadResult(buildInvocationId) to workGraph
         }
     }
 
     private
-    fun <T : Any> loadFromCache(stateType: StateType, action: (ConfigurationCacheStateFile) -> T): T {
+    fun <T : Any> loadFromCache(stateType: StateType, action: (ConfigurationCacheStateFile) -> Pair<LoadResult, T>): T {
         prepareConfigurationTimeBarrier()
 
         // No need to record the `ClassLoaderScope` tree

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/configurationcache/ConfigurationCacheBuildOperationsTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/configurationcache/ConfigurationCacheBuildOperationsTest.kt
@@ -68,7 +68,6 @@ class ConfigurationCacheBuildOperationsTest {
             on { call<Unit>(any()) } doReturn Unit
         }
         val stateFile = testDirectoryProvider.file("stateFile")
-        stateFile.text = "CC content"
 
         // when:
         buildOperationExecutor.withLoadOperation {

--- a/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/internal/configurationcache/ConfigurationCacheLoadBuildOperationType.java
+++ b/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/internal/configurationcache/ConfigurationCacheLoadBuildOperationType.java
@@ -18,6 +18,8 @@ package org.gradle.internal.configurationcache;
 
 import org.gradle.internal.operations.BuildOperationType;
 
+import javax.annotation.Nullable;
+
 /**
  * Details about a configuration cache load build operation.
  *
@@ -29,6 +31,16 @@ public class ConfigurationCacheLoadBuildOperationType implements BuildOperationT
     }
 
     public interface Result {
+        /**
+         * If work was UP_TO_DATE or FROM_CACHE, this will convey the ID of the build that produced the outputs being reused.
+         * Value will be null for any other outcome.
+         *
+         * This value may also be null for an UP_TO_DATE outcome where the work executed, but then decided it was UP_TO_DATE.
+         * That is, it was not UP_TO_DATE due to Gradle's core input/output incremental build mechanism.
+         * This is not necessarily ideal behaviour, but it is the current.
+         */
+        @Nullable
+        String getOriginBuildInvocationId();
     }
 
 }

--- a/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/internal/configurationcache/ConfigurationCacheLoadBuildOperationType.java
+++ b/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/internal/configurationcache/ConfigurationCacheLoadBuildOperationType.java
@@ -32,18 +32,18 @@ public class ConfigurationCacheLoadBuildOperationType implements BuildOperationT
 
     public interface Result {
         /**
-         * The number of bytes of the loaded cache artifact if it was a hit.
-         * Else undetermined.
+         * The number of bytes of the stored configuration cache entry.
+         *
+         * @since 8.6
          */
         long getCacheEntrySize();
 
         /**
-         * If work was UP_TO_DATE or FROM_CACHE, this will convey the ID of the build that produced the outputs being reused.
-         * Value will be null for any other outcome.
+         * The ID of the build that store the configuration cache entry.
          *
-         * This value may also be null for an UP_TO_DATE outcome where the work executed, but then decided it was UP_TO_DATE.
-         * That is, it was not UP_TO_DATE due to Gradle's core input/output incremental build mechanism.
-         * This is not necessarily ideal behaviour, but it is the current.
+         * Is currently `null` when unknown, e.g. when loading models and not a task graph.
+         *
+         * @since 8.6
          */
         @Nullable
         String getOriginBuildInvocationId();

--- a/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/internal/configurationcache/ConfigurationCacheLoadBuildOperationType.java
+++ b/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/internal/configurationcache/ConfigurationCacheLoadBuildOperationType.java
@@ -32,6 +32,12 @@ public class ConfigurationCacheLoadBuildOperationType implements BuildOperationT
 
     public interface Result {
         /**
+         * The number of bytes of the loaded cache artifact if it was a hit.
+         * Else undetermined.
+         */
+        long getCacheEntrySize();
+
+        /**
          * If work was UP_TO_DATE or FROM_CACHE, this will convey the ID of the build that produced the outputs being reused.
          * Value will be null for any other outcome.
          *

--- a/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/internal/configurationcache/ConfigurationCacheLoadBuildOperationType.java
+++ b/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/internal/configurationcache/ConfigurationCacheLoadBuildOperationType.java
@@ -41,7 +41,7 @@ public class ConfigurationCacheLoadBuildOperationType implements BuildOperationT
         /**
          * The ID of the build that store the configuration cache entry.
          *
-         * Is currently `null` when unknown, e.g. when loading models and not a task graph.
+         * `null` when unknown, e.g. when loading models and not a task graph.
          *
          * @since 8.6
          */

--- a/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/internal/configurationcache/ConfigurationCacheStoreBuildOperationType.java
+++ b/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/internal/configurationcache/ConfigurationCacheStoreBuildOperationType.java
@@ -29,6 +29,11 @@ public class ConfigurationCacheStoreBuildOperationType implements BuildOperation
     }
 
     public interface Result {
+        /**
+         * The number of bytes of the loaded cache artifact if it was a hit.
+         * Else undetermined.
+         */
+        long getCacheEntrySize();
     }
 
 }

--- a/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/internal/configurationcache/ConfigurationCacheStoreBuildOperationType.java
+++ b/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/internal/configurationcache/ConfigurationCacheStoreBuildOperationType.java
@@ -30,8 +30,9 @@ public class ConfigurationCacheStoreBuildOperationType implements BuildOperation
 
     public interface Result {
         /**
-         * The number of bytes of the loaded cache artifact if it was a hit.
-         * Else undetermined.
+         * The number of bytes of the loaded configuration cache entry.
+         *
+         * @since 8.6
          */
         long getCacheEntrySize();
     }


### PR DESCRIPTION
The PR adds the `cacheEntrySize` for CC load and store operation results, and the `originBuildInvocationId` for the load operation result.