### PR TITLE
Rebaseline performance tests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,4 +18,4 @@ gradle.internal.testdistribution.writeTraceFile=false
 systemProp.gradle.internal.testdistribution.writeTraceFile=false
 systemProp.gradle.internal.testdistribution.queryResponseTimeout=PT20S
 # Default performance baseline
-defaultPerformanceBaselines=8.6-commit-5e42e9f58ae9
+defaultPerformanceBaselines=8.6-commit-e3546027baca8


### PR DESCRIPTION
I've seen a few pre-tested commit builds failing because of performance failures. Let's rebaseline performance tests.