### PR TITLE
Unwrap `InvocationTargetException` from `ApiExtensionGeneratorFacade`

### DIFF
--- a/build-logic/kotlin-dsl/src/main/kotlin/gradlebuild/kotlindsl/generator/codegen/KotlinExtensionsForGradleApiFacade.kt
+++ b/build-logic/kotlin-dsl/src/main/kotlin/gradlebuild/kotlindsl/generator/codegen/KotlinExtensionsForGradleApiFacade.kt
@@ -19,6 +19,7 @@ package gradlebuild.kotlindsl.generator.codegen
 import org.gradle.internal.classloader.DefaultClassLoaderFactory
 import org.gradle.internal.classpath.ClassPath
 import java.io.File
+import java.lang.reflect.InvocationTargetException
 import java.net.URLClassLoader
 
 
@@ -103,7 +104,11 @@ class KotlinExtensionsForGradleApiFacade(classPath: ClassPath) : AutoCloseable {
         val facadeClass = loader.loadClass(className)
         val facade = facadeClass.getConstructor().newInstance()
         val function = facadeClass.methods.single { it.name == "generate" }
-        function.invoke(facade, parameters)
+        try {
+            function.invoke(facade, parameters)
+        } catch (e: InvocationTargetException) {
+            throw e.targetException
+        }
     }
 
     override fun close() {


### PR DESCRIPTION
Currently, build failures caused by `ApiExtensionsGeneratorFacade` report no useful information:
```
* What went wrong:
Execution failed for task ':distributions-core:gradleApiKotlinExtensions'.
> java.lang.reflect.InvocationTargetException
```

This change makes Gradle report the actual error:
```
* What went wrong:
Execution failed for task ':distributions-core:gradleApiKotlinExtensions'.
> Class for function 'org.gradle.api.shareddata.ProjectSharedData.register(java.lang.Class,java.lang.String,org.gradle.api.provider.Provider)' not found in since repository!
```