### PR TITLE
Add flag for disabling models-as-project-dependencies behavior

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultBuildTreeModelControllerServices.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultBuildTreeModelControllerServices.kt
@@ -62,6 +62,13 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
 
         private
         val invalidateCoupledProjects = InternalFlag("org.gradle.internal.invalidate-coupled-projects", true)
+
+        /**
+         * If model dependencies between projects should be treated as project dependencies.
+         * Model dependency is observed when a project requests a model from another project.
+         */
+        private
+        val modelProjectDependencies = InternalFlag("org.gradle.internal.model-project-dependencies", true)
     }
 
     override fun servicesForBuildTree(requirements: BuildActionModelRequirements): BuildTreeModelControllerServices.Supplier {
@@ -79,6 +86,7 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
         val parallelProjectExecution = isolatedProjects || requirements.startParameter.isParallelProjectExecutionEnabled
         val parallelToolingActions = parallelProjectExecution && options.getOption(parallelBuilding).get()
         val invalidateCoupledProjects = isolatedProjects && options.getOption(invalidateCoupledProjects).get()
+        val modelAsProjectDependency = isolatedProjects && options.getOption(modelProjectDependencies).get()
         val configurationCacheLogLevel = if (startParameter.isConfigurationCacheQuiet) LogLevel.INFO else LogLevel.LIFECYCLE
         val modelParameters = if (requirements.isCreatesModel) {
             // When creating a model, disable certain features - only enable configure on demand and configuration cache when isolated projects is enabled
@@ -91,6 +99,7 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
                 isolatedProjects,
                 parallelToolingActions,
                 invalidateCoupledProjects,
+                modelAsProjectDependency,
                 configurationCacheLogLevel
             )
         } else {
@@ -108,6 +117,7 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
                     false,
                     parallelToolingActions,
                     invalidateCoupledProjects,
+                    modelAsProjectDependency,
                     configurationCacheLogLevel
                 )
             }
@@ -124,6 +134,7 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
                     false,
                     parallelToolingActions,
                     invalidateCoupledProjects,
+                    modelAsProjectDependency,
                     configurationCacheLogLevel
                 )
             }
@@ -158,6 +169,7 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
                     false,
                     false,
                     true,
+                    false,
                     false,
                     false,
                     false,

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintController.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintController.kt
@@ -331,6 +331,9 @@ class ConfigurationCacheFingerprintController internal constructor(
         override val cacheIntermediateModels: Boolean
             get() = modelParameters.isIntermediateModelCache
 
+        override val modelAsProjectDependency: Boolean
+            get() = modelParameters.isModelAsProjectDependency
+
         override val ignoreInputsInConfigurationCacheTaskGraphWriting: Boolean
             get() = startParameter.isIgnoreInputsInTaskGraphSerialization
 

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintWriter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintWriter.kt
@@ -119,6 +119,7 @@ class ConfigurationCacheFingerprintWriter(
         val startParameterProperties: Map<String, Any?>
         val buildStartTime: Long
         val cacheIntermediateModels: Boolean
+        val modelAsProjectDependency: Boolean
         val ignoreInputsInConfigurationCacheTaskGraphWriting: Boolean
         val instrumentationAgentUsed: Boolean
         val ignoredFileSystemCheckInputs: String?
@@ -557,7 +558,9 @@ class ConfigurationCacheFingerprintWriter(
     }
 
     override fun onToolingModelDependency(consumer: ProjectState, target: ProjectState) {
-        onProjectDependency(consumer, target)
+        if (host.modelAsProjectDependency) {
+            onProjectDependency(consumer, target)
+        }
     }
 
     private

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/configurationcache/ConfigurationCacheKeyTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/configurationcache/ConfigurationCacheKeyTest.kt
@@ -169,7 +169,7 @@ class ConfigurationCacheKeyTest {
                 ),
                 startParameter,
                 DefaultInternalOptions(mapOf()),
-                BuildModelParameters(false, false, true, startParameter.isolatedProjects.get(), false, false, false, false, LogLevel.LIFECYCLE)
+                BuildModelParameters(false, false, true, startParameter.isolatedProjects.get(), false, false, false, false, false, LogLevel.LIFECYCLE)
             ),
             RunTasksRequirements(startParameter),
             object : EncryptionConfiguration {

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildModelParameters.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildModelParameters.java
@@ -22,6 +22,7 @@ import org.gradle.internal.service.scopes.ServiceScope;
 
 @ServiceScope(Scopes.BuildTree.class)
 public class BuildModelParameters {
+
     private final boolean parallelProjectExecution;
     private final boolean configureOnDemand;
     private final boolean configurationCache;
@@ -30,6 +31,7 @@ public class BuildModelParameters {
     private final boolean intermediateModelCache;
     private final boolean parallelToolingApiActions;
     private final boolean invalidateCoupledProjects;
+    private final boolean modelAsProjectDependency;
     private final LogLevel configurationCacheLogLevel;
 
     public BuildModelParameters(
@@ -41,6 +43,7 @@ public class BuildModelParameters {
         boolean intermediateModelCache,
         boolean parallelToolingApiActions,
         boolean invalidateCoupledProjects,
+        boolean modelAsProjectDependency,
         LogLevel configurationCacheLogLevel
     ) {
         this.parallelProjectExecution = parallelProjectExecution;
@@ -51,6 +54,7 @@ public class BuildModelParameters {
         this.intermediateModelCache = intermediateModelCache;
         this.parallelToolingApiActions = parallelToolingApiActions;
         this.invalidateCoupledProjects = invalidateCoupledProjects;
+        this.modelAsProjectDependency = modelAsProjectDependency;
         this.configurationCacheLogLevel = configurationCacheLogLevel;
     }
 
@@ -104,5 +108,14 @@ public class BuildModelParameters {
      */
     public boolean isInvalidateCoupledProjects() {
         return invalidateCoupledProjects;
+    }
+
+    /**
+     * Should model dependencies between projects be treated as project dependencies with respect to invalidation?
+     * <p>
+     * This parameter is only used for benchmarking purposes.
+     */
+    public boolean isModelAsProjectDependency() {
+        return modelAsProjectDependency;
     }
 }


### PR DESCRIPTION
Adding a new internal flag that controls whether model dependencies between projects should be treated as project dependencies with respect to intermediate model cache invalidation.

 Model dependency is observed when a project requests a model from another project.