### PR TITLE
Another refactor before making Kotlin DSL models IP compatible

### DIFF
--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslScriptsModelCrossVersionSpec.groovy
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslScriptsModelCrossVersionSpec.groovy
@@ -22,6 +22,7 @@ import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptModel
 import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptsModel
+import org.gradle.util.GradleVersion
 
 import java.lang.reflect.Proxy
 
@@ -71,11 +72,12 @@ class KotlinDslScriptsModelCrossVersionSpec extends AbstractKotlinDslScriptsMode
         def model = loadValidatedToolingModel(KotlinDslScriptsModel) {
             setModelParameters(it, true, true, [buildFileKts])
         }
-
+        def source = Proxy.getInvocationHandler(model).sourceObject
 
         then:
-        def source = Proxy.getInvocationHandler(model).sourceObject
-        source.scripts == [buildFileKts]
+        if (targetVersion.baseVersion < GradleVersion.version("8.6")) {
+            assert source.scripts == [buildFileKts]
+        }
 
         and:
         def commonModel = source.commonModel

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/EditorReportsBuilder.kt
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/EditorReportsBuilder.kt
@@ -112,6 +112,7 @@ fun Sequence<Exception>.runtimeFailuresLocatedInAndNotCausedScriptCompilation(sc
     mapNotNull { it.runtimeFailureLocatedIn(scriptPath) }.filter { !it.isCausedByScriptCompilationException }
 
 
+internal
 fun Sequence<Exception>.runtimeFailuresLocatedIn(scriptPath: String): Sequence<LocationAwareException> =
     mapNotNull { it.runtimeFailureLocatedIn(scriptPath) }
 

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptModelBuilder.kt
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptModelBuilder.kt
@@ -43,7 +43,7 @@ import org.gradle.kotlin.dsl.precompile.PrecompiledScriptDependenciesResolver
 import org.gradle.kotlin.dsl.provider.ClassPathModeExceptionCollector
 import org.gradle.kotlin.dsl.provider.KotlinScriptClassPathProvider
 import org.gradle.kotlin.dsl.provider.KotlinScriptEvaluator
-import org.gradle.kotlin.dsl.provider.ignoringErrors
+import org.gradle.kotlin.dsl.provider.runCatching
 import org.gradle.kotlin.dsl.resolver.EditorReports
 import org.gradle.kotlin.dsl.resolver.SourceDistributionResolver
 import org.gradle.kotlin.dsl.resolver.SourcePathProvider
@@ -408,12 +408,12 @@ data class KotlinScriptTargetModelBuilder(
         val classpathSources = sourcePathFor(sourceLookupScriptHandlers)
         val classPathModeExceptionCollector = project.serviceOf<ClassPathModeExceptionCollector>()
         val accessorsClassPath =
-            classPathModeExceptionCollector.ignoringErrors {
+            classPathModeExceptionCollector.runCatching {
                 accessorsClassPath(scriptClassPath)
             } ?: AccessorsClassPath.empty
 
         val additionalImports =
-            classPathModeExceptionCollector.ignoringErrors {
+            classPathModeExceptionCollector.runCatching {
                 additionalImports()
             } ?: emptyList()
 

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptModelBuilder.kt
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptModelBuilder.kt
@@ -258,9 +258,9 @@ fun ProjectInternal.accessorsClassPathOf(classPath: ClassPath): AccessorsClassPa
     val stage1BlocksAccessorClassPathGenerator = serviceOf<Stage1BlocksAccessorClassPathGenerator>()
     val projectAccessorClassPathGenerator = serviceOf<ProjectAccessorsClassPathGenerator>()
     val dependenciesAccessors = serviceOf<DependenciesAccessors>()
-    return projectAccessorClassPathGenerator.projectAccessorsClassPath(this, classPath) +
-        stage1BlocksAccessorClassPathGenerator.stage1BlocksAccessorClassPath(this) +
-        AccessorsClassPath(dependenciesAccessors.classes, dependenciesAccessors.sources)
+    return (projectAccessorClassPathGenerator.projectAccessorsClassPath(this, classPath)
+        + stage1BlocksAccessorClassPathGenerator.stage1BlocksAccessorClassPath(this)
+        + AccessorsClassPath(dependenciesAccessors.classes, dependenciesAccessors.sources))
 }
 
 

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinDslScriptsModelBuilder.kt
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinDslScriptsModelBuilder.kt
@@ -109,8 +109,11 @@ data class StandardEditorPosition(
 internal
 object KotlinDslScriptsModelBuilder : ToolingModelBuilder {
 
+    private
+    const val MODEL_NAME = "org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptsModel"
+
     override fun canBuild(modelName: String): Boolean =
-        modelName == "org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptsModel"
+        modelName == MODEL_NAME
 
     override fun buildAll(modelName: String, project: Project): KotlinDslScriptsModel {
         requireRootProject(project)
@@ -135,7 +138,7 @@ object KotlinDslScriptsModelBuilder : ToolingModelBuilder {
     private
     fun requireRootProject(project: Project) =
         require(project == project.rootProject) {
-            "${KotlinDslScriptsModel::class.qualifiedName} can only be requested on the root project, got '$project'"
+            "$MODEL_NAME can only be requested on the root project, got '$project'"
         }
 
     private

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinDslScriptsModelBuilder.kt
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinDslScriptsModelBuilder.kt
@@ -226,27 +226,22 @@ fun Project.resolveExplicitScriptsParameter(): List<File>? =
 
 // TODO:kotlin-dsl naive implementation for now, refine
 private
-fun Project.collectKotlinDslScripts(): List<File> = sequence<File> {
+fun Project.collectKotlinDslScripts(): List<File> = buildList {
 
-    // Init Scripts
-    yieldAll(discoverInitScripts())
+    addAll(discoverInitScripts())
 
-    // Settings Script
     discoverSettingScript()?.let {
-        yield(it)
+        add(it)
     }
 
     allprojects.forEach { p ->
-
-        // Project Scripts
         p.discoverBuildScript()?.let {
-            yield(it)
+            add(it)
         }
 
-        // Precompiled Scripts
-        yieldAll(p.discoverPrecompiledScriptPluginScripts())
+        addAll(p.discoverPrecompiledScriptPluginScripts())
     }
-}.toList()
+}
 
 
 internal

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinDslScriptsModelBuilder.kt
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinDslScriptsModelBuilder.kt
@@ -256,8 +256,8 @@ val Project.precompiledScriptPluginsSupport
 
 private
 data class KotlinDslScriptsParameter(
-    var correlationId: String?,
-    var scriptFiles: List<File>
+    val correlationId: String?,
+    val scriptFiles: List<File>
 )
 
 

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/internal/KotlinScriptingModelBuildersRegistrationAction.kt
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/internal/KotlinScriptingModelBuildersRegistrationAction.kt
@@ -13,13 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.kotlin.dsl.tooling.builders
+package org.gradle.kotlin.dsl.tooling.builders.internal
 
 import org.gradle.api.internal.project.ProjectInternal
 
 import org.gradle.configuration.project.ProjectConfigureAction
 
 import org.gradle.kotlin.dsl.support.serviceOf
+import org.gradle.kotlin.dsl.tooling.builders.KotlinBuildScriptModelBuilder
+import org.gradle.kotlin.dsl.tooling.builders.KotlinBuildScriptTemplateModelBuilder
+import org.gradle.kotlin.dsl.tooling.builders.KotlinDslScriptsModelBuilder
 
 import org.gradle.tooling.model.kotlin.dsl.KotlinDslModelsParameters
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/resources/META-INF/services/org.gradle.configuration.project.ProjectConfigureAction
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/resources/META-INF/services/org.gradle.configuration.project.ProjectConfigureAction
@@ -1,1 +1,1 @@
-org.gradle.kotlin.dsl.tooling.builders.KotlinScriptingModelBuildersRegistrationAction
+org.gradle.kotlin.dsl.tooling.builders.internal.KotlinScriptingModelBuildersRegistrationAction

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/ClassPathModeExceptionCollector.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/ClassPathModeExceptionCollector.kt
@@ -16,15 +16,16 @@
 package org.gradle.kotlin.dsl.provider
 
 import org.gradle.internal.concurrent.Stoppable
+import java.util.Collections.synchronizedList
 
 
 open class ClassPathModeExceptionCollector : Stoppable {
 
     private
-    val collection = mutableListOf<Exception>()
+    val collection: MutableList<Exception> = synchronizedList(mutableListOf<Exception>())
 
     val exceptions: List<Exception>
-        get() = collection
+        get() = collection.toList()
 
     fun collect(error: Exception) {
         collection.add(error)

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/ClassPathModeExceptionCollector.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/ClassPathModeExceptionCollector.kt
@@ -37,7 +37,7 @@ open class ClassPathModeExceptionCollector : Stoppable {
 }
 
 
-inline fun <T> ClassPathModeExceptionCollector.ignoringErrors(f: () -> T): T? =
+inline fun <T> ClassPathModeExceptionCollector.runCatching(f: () -> T): T? =
     try {
         f()
     } catch (e: Exception) {

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptEvaluator.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptEvaluator.kt
@@ -136,7 +136,7 @@ class StandardKotlinScriptEvaluator(
     private
     inline fun withOptions(options: EvalOptions, action: () -> Unit) {
         if (EvalOption.IgnoreErrors in options)
-            classPathModeExceptionCollector.ignoringErrors(action)
+            classPathModeExceptionCollector.runCatching(action)
         else
             action()
     }


### PR DESCRIPTION
This is only clean up and polishing, no changes to public models

Preparation for:
- https://github.com/gradle/gradle/pull/27434

Main changes:
- `StandardKotlinDslScriptsModel` no longer carries a list of scripts, as it is implied by the keys in the dehydrated map
- `ClassPathModeExceptionCollector` is made thread-safe