### PR TITLE
Use lightweight alias existence check

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/DefaultVersionCatalog.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/DefaultVersionCatalog.java
@@ -100,6 +100,22 @@ public class DefaultVersionCatalog implements Serializable {
         return plugins.get(normalize(name));
     }
 
+    public boolean hasDependency(String alias) {
+        return libraries.containsKey(normalize(alias));
+    }
+
+    public boolean hasBundle(String alias) {
+        return bundles.containsKey(normalize(alias));
+    }
+
+    public boolean hasVersion(String alias) {
+        return versions.containsKey(normalize(alias));
+    }
+
+    public boolean hasPlugin(String alias) {
+        return plugins.containsKey(normalize(alias));
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/VersionCatalogView.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/VersionCatalogView.java
@@ -59,7 +59,7 @@ public class VersionCatalogView implements VersionCatalog {
     @Override
     public final Optional<Provider<MinimalExternalModuleDependency>> findLibrary(String alias) {
         String normalizedAlias = normalize(alias);
-        if (config.getLibraryAliases().contains(normalizedAlias)) {
+        if (config.hasDependency(normalizedAlias)) {
             return Optional.of(dependencyFactory.create(normalizedAlias));
         }
         return Optional.empty();
@@ -68,7 +68,7 @@ public class VersionCatalogView implements VersionCatalog {
     @Override
     public final Optional<Provider<ExternalModuleDependencyBundle>> findBundle(String alias) {
         String normalizedBundle = normalize(alias);
-        if (config.getBundleAliases().contains(normalizedBundle)) {
+        if (config.hasBundle(normalizedBundle)) {
             return Optional.of(bundleFactory.createBundle(normalizedBundle));
         }
         return Optional.empty();
@@ -77,7 +77,7 @@ public class VersionCatalogView implements VersionCatalog {
     @Override
     public final Optional<VersionConstraint> findVersion(String alias) {
         String normalizedName = normalize(alias);
-        if (config.getVersionAliases().contains(normalizedName)) {
+        if (config.hasVersion(normalizedName)) {
             return Optional.of(new VersionFactory(providerFactory, config).findVersionConstraint(normalizedName));
         }
         return Optional.empty();
@@ -86,7 +86,7 @@ public class VersionCatalogView implements VersionCatalog {
     @Override
     public Optional<Provider<PluginDependency>> findPlugin(String alias) {
         String normalizedAlias = normalize(alias);
-        if (config.getPluginAliases().contains(normalizedAlias)) {
+        if (config.hasPlugin(normalizedAlias)) {
             return Optional.of(new PluginFactory(providerFactory, config).createPlugin(normalizedAlias));
         }
         return Optional.empty();

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/catalog/DefaultVersionCatalogBuilderTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/catalog/DefaultVersionCatalogBuilderTest.groovy
@@ -379,4 +379,22 @@ class DefaultVersionCatalogBuilderTest extends AbstractVersionCatalogTest implem
             existing('v1', 'v2')
         })
     }
+
+    def "has all defined aliases"() {
+        builder.library("foo-lib1", "org", "foo").version("lib-version")
+        builder.library("foo-lib2", "org", "foo").version("lib-version2")
+        builder.bundle("foo-bundle", ["foo-lib1", "foo-lib2"])
+        builder.plugin("foo-plugin", "foo.bar").version("plugin-version")
+        builder.version("foo-version", "1.0.0")
+
+        when:
+        def model = builder.build()
+
+        then:
+        model.hasDependency("foo-lib1")
+        model.hasDependency("foo-lib2")
+        model.hasBundle("foo-bundle")
+        model.hasPlugin("foo-plugin")
+        model.hasVersion("foo-version")
+    }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/catalog/parser/TomlCatalogFileParserTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/catalog/parser/TomlCatalogFileParserTest.groovy
@@ -396,6 +396,7 @@ class TomlCatalogFileParserTest extends Specification implements VersionCatalogE
     }
 
     void hasDependency(String name, @DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = DependencySpec) Closure<Void> spec) {
+        assert model.hasDependency(name)
         def data = model.getDependencyData(name)
         assert data != null: "Expected a dependency with alias $name but it wasn't found"
         def dependencySpec = new DependencySpec(data)
@@ -405,12 +406,14 @@ class TomlCatalogFileParserTest extends Specification implements VersionCatalogE
     }
 
     void hasBundle(String id, List<String> expectedElements) {
+        assert model.hasBundle(id)
         def bundle = model.getBundle(id)?.components
         assert bundle != null: "Expected a bundle with name $id but it wasn't found"
         assert bundle == expectedElements
     }
 
     void hasVersion(String id, String version) {
+        assert model.hasVersion(id)
         def versionConstraint = model.getVersion(id)?.version
         assert versionConstraint != null: "Expected a version constraint with name $id but didn't find one"
         def actual = versionConstraint.toString()
@@ -418,6 +421,7 @@ class TomlCatalogFileParserTest extends Specification implements VersionCatalogE
     }
 
     void hasPlugin(String alias, String id, String version) {
+        assert model.hasPlugin(alias)
         def plugin = model.getPlugin(alias)
         assert plugin != null : "Expected a plugin with alias '$alias' but it wasn't found"
         assert plugin.id == id
@@ -425,6 +429,7 @@ class TomlCatalogFileParserTest extends Specification implements VersionCatalogE
     }
 
     void hasPlugin(String alias, @DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = PluginSpec) Closure<Void> spec) {
+        assert model.hasPlugin(alias)
         def plugin = model.getPlugin(alias)
         assert plugin != null : "Expected a plugin with alias '$alias' but it wasn't found"
         def pluginSpec = new PluginSpec(plugin)


### PR DESCRIPTION
`DefaultVersionCatalog#get*Aliases()` methods sort all aliases on each method call which is not required in case of checking existence. Replace these methods usages with simple Map.containsKey check.

Fixes #25226 

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
