### PR TITLE
Make max test distribution executor number configurable

### DIFF
--- a/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
+++ b/build-logic-commons/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
@@ -39,6 +39,8 @@ import gradlebuild.basics.BuildParams.FLAKY_TEST
 import gradlebuild.basics.BuildParams.GRADLE_INSTALL_PATH
 import gradlebuild.basics.BuildParams.INCLUDE_PERFORMANCE_TEST_SCENARIOS
 import gradlebuild.basics.BuildParams.MAX_PARALLEL_FORKS
+import gradlebuild.basics.BuildParams.MAX_TEST_DISTRIBUTION_LOCAL_EXECUTORS
+import gradlebuild.basics.BuildParams.MAX_TEST_DISTRIBUTION_REMOTE_EXECUTORS
 import gradlebuild.basics.BuildParams.PERFORMANCE_BASELINES
 import gradlebuild.basics.BuildParams.PERFORMANCE_DB_PASSWORD
 import gradlebuild.basics.BuildParams.PERFORMANCE_DB_PASSWORD_ENV
@@ -104,6 +106,8 @@ object BuildParams {
     const val FLAKY_TEST = "flakyTests"
     const val INCLUDE_PERFORMANCE_TEST_SCENARIOS = "includePerformanceTestScenarios"
     const val MAX_PARALLEL_FORKS = "maxParallelForks"
+    const val MAX_TEST_DISTRIBUTION_REMOTE_EXECUTORS = "maxTestDistributionRemoteExecutors"
+    const val MAX_TEST_DISTRIBUTION_LOCAL_EXECUTORS = "maxTestDistributionLocalExecutors"
     const val PERFORMANCE_BASELINES = "performanceBaselines"
     const val PERFORMANCE_TEST_VERBOSE = "performanceTest.verbose"
     const val PERFORMANCE_DB_PASSWORD = "org.gradle.performance.db.password"
@@ -130,6 +134,7 @@ object BuildParams {
      * Run docs tests with the configuration cache enabled.
      */
     const val ENABLE_CONFIGURATION_CACHE_FOR_DOCS_TESTS = "enableConfigurationCacheForDocsTests"
+
     /**
      * Run docs tests that are knowingly broken when running with the configuration cache enabled. Only applied when #ENABLE_CONFIGURATION_CACHE_FOR_DOCS_TESTS is also set.
      */
@@ -250,6 +255,13 @@ val Project.buildVersionQualifier: Provider<String>
 val Project.defaultPerformanceBaselines: Provider<String>
     get() = gradleProperty(DEFAULT_PERFORMANCE_BASELINES)
 
+
+// null means no limit: use all available executors
+val Project.maxTestDistributionRemoteExecutors: Int?
+    get() = gradleProperty(MAX_TEST_DISTRIBUTION_REMOTE_EXECUTORS).orNull?.toInt()
+
+val Project.maxTestDistributionLocalExecutors: Int?
+    get() = gradleProperty(MAX_TEST_DISTRIBUTION_LOCAL_EXECUTORS).orNull?.toInt()
 
 val Project.flakyTestStrategy: FlakyTestStrategy
     get() = gradleProperty(FLAKY_TEST).let {

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -24,6 +24,8 @@ import gradlebuild.basics.FlakyTestStrategy
 import gradlebuild.basics.accessors.kotlin
 import gradlebuild.basics.flakyTestStrategy
 import gradlebuild.basics.maxParallelForks
+import gradlebuild.basics.maxTestDistributionRemoteExecutors
+import gradlebuild.basics.maxTestDistributionLocalExecutors
 import gradlebuild.basics.maxTestDistributionPartitionSecond
 import gradlebuild.basics.predictiveTestSelectionEnabled
 import gradlebuild.basics.rerunAllTests
@@ -276,8 +278,8 @@ fun configureTests() {
                 project.maxTestDistributionPartitionSecond?.apply {
                     preferredMaxDuration = Duration.ofSeconds(this)
                 }
-                // No limit; use all available executors
-                distribution.maxRemoteExecutors = if (project.isPerformanceProject()) 0 else null
+                distribution.maxRemoteExecutors = if (project.isPerformanceProject()) 0 else project.maxTestDistributionRemoteExecutors
+                distribution.maxLocalExecutors = project.maxTestDistributionLocalExecutors
 
                 // Test distribution annotation-class filters
                 // See: https://docs.gradle.com/enterprise/test-distribution/#gradle_executor_restrictions_class_matcher


### PR DESCRIPTION
In many cases, we want the max TD executor number configurable, for example:

- To test a new TD agent image, we'd like to run all tests on remote executors, i.e. `maxLocalExecutors=0`.
- To test new Ubuntu 22.04, we'd like to run all tests locally, i.e. `maxRemoteExecutors=0`.

This PR adds the ability to configure `maxLocalExecutors` and `maxRemoteExecutors`.