### PR TITLE
Consider capabilities when reselecting artifact variants

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactVariantReselectionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactVariantReselectionIntegrationTest.groovy
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+/**
+ * Tests variant reselection. i.e. anything of the form:
+ * <pre>
+ *     someConf.incoming.artifactView {
+ *         withVariantReselection()
+ *     }
+ * </pre>
+ */
+class ArtifactVariantReselectionIntegrationTest extends AbstractIntegrationSpec {
+
+    def "variant reselection excludes artifacts for dependency with explicit artifact"() {
+        mavenRepo.module("com", "foo").artifact(classifier: "sources").artifact(classifier: "cls").publish()
+        buildFile << """
+            plugins {
+                id("java-library")
+            }
+
+            repositories { maven { url "${mavenRepo.uri}" } }
+
+            dependencies {
+                implementation 'com:foo:1.0'
+                implementation 'com:foo:1.0:cls'
+            }
+
+            task resolve {
+                def normal = configurations.runtimeClasspath.incoming.files
+                def reselected = configurations.runtimeClasspath.incoming.artifactView {
+                    withVariantReselection()
+                    attributes {
+                        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+                        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.DOCUMENTATION))
+                        attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
+                        attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType, DocsType.SOURCES))
+                    }
+                }.files
+                doLast {
+                    assert normal*.name == ["foo-1.0.jar", "foo-1.0-cls.jar"]
+
+                    // Does not include artifacts from dependency with explicit artifact request.
+                    assert reselected*.name == ["foo-1.0-sources.jar"]
+                }
+            }
+        """
+
+        expect:
+        succeeds(":resolve")
+    }
+
+    def "variant reselection selects among variants with same attributes and different capabilities"() {
+        given:
+        settingsFile << "include 'producer'"
+        file("producer/build.gradle") << multiFeatureProducer()
+
+        buildFile << """
+            plugins {
+                id("java-library")
+            }
+
+            dependencies {
+                implementation(project(":producer")) {
+                    capabilities {
+                        requireCapability("com.example:producer-${featureName}:1.0")
+                    }
+                }
+            }
+
+            task resolve {
+                def normal = configurations.runtimeClasspath.incoming.files
+                def reselected = configurations.runtimeClasspath.incoming.artifactView {
+                    withVariantReselection()
+                    attributes {
+                        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+                        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.DOCUMENTATION))
+                        attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
+                        attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType, DocsType.SOURCES))
+                    }
+                }.files
+                doLast {
+                    assert normal*.name == ["producer-1.0-${featureName}.jar"]
+                    assert reselected*.name == ${expectedArtifacts}
+                }
+            }
+        """
+
+        expect:
+        succeeds(":resolve")
+
+        where:
+        featureName      | expectedArtifacts
+        // We request sources for a variant that does not have sources.
+        // We should not fail, since variant reselection allows no matching variants.
+        "without-sources" | "[]"
+        // We request sources for a variant that has sources and expect those sources to be reselected.
+        "with-sources"    | "[\"producer-1.0-with-sources-sources.jar\"]"
+    }
+
+    def "variant reselection selects multiple dependencies from the same project with differing capabilities"() {
+        given:
+        settingsFile << "include 'producer'"
+        file("producer/build.gradle") << multiFeatureProducer()
+
+        buildFile << """
+            plugins {
+                id("java-library")
+            }
+
+            dependencies {
+                implementation(project(":producer")) {
+                    capabilities {
+                        requireCapability("com.example:producer-without-sources:1.0")
+                    }
+                }
+                implementation(project(":producer")) {
+                    capabilities {
+                        requireCapability("com.example:producer-with-sources:1.0")
+                    }
+                }
+                implementation(project(":producer")) {
+                    capabilities {
+                        requireCapability("com.example:producer-with-sources2:1.0")
+                    }
+                }
+            }
+
+            task resolve {
+                def normal = configurations.runtimeClasspath.incoming.files
+                def reselected = configurations.runtimeClasspath.incoming.artifactView {
+                    withVariantReselection()
+                    attributes {
+                        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+                        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.DOCUMENTATION))
+                        attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
+                        attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType, DocsType.SOURCES))
+                    }
+                }.files
+                doLast {
+                    assert normal*.name == ["producer-1.0-without-sources.jar", "producer-1.0-with-sources.jar", "producer-1.0-with-sources2.jar"]
+                    assert reselected*.name == ["producer-1.0-with-sources-sources.jar", "producer-1.0-with-sources2-sources.jar"]
+                }
+            }
+        """
+
+        expect:
+        succeeds(":resolve")
+    }
+
+    private static String multiFeatureProducer() {
+        """
+            plugins {
+                id 'java-library'
+            }
+
+            group = "com.example"
+            version = "1.0"
+
+            java {
+                withSourcesJar()
+            }
+
+            java {
+                sourceSets {
+                    withoutSources
+                }
+                registerFeature("withoutSources") {
+                    usingSourceSet(sourceSets.withoutSources)
+                }
+            }
+
+            java {
+                sourceSets {
+                    withSources
+                }
+                registerFeature("withSources") {
+                    usingSourceSet(sourceSets.withSources)
+                    withSourcesJar()
+                }
+            }
+
+            java {
+                sourceSets {
+                    withSources2
+                }
+                registerFeature("withSources2") {
+                    usingSourceSet(sourceSets.withSources2)
+                    withSourcesJar()
+                }
+            }
+        """
+    }
+}

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/derived/JvmDerivedVariantsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/derived/JvmDerivedVariantsIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.integtests.resolve.derived
 
-import groovy.test.NotYetImplemented
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 
 class JvmDerivedVariantsIntegrationTest extends AbstractIntegrationSpec {
@@ -37,15 +36,6 @@ version = "1.0"
 java {
     withJavadocJar()
     withSourcesJar()
-}
-
-java {
-    sourceSets {
-        foo
-    }
-    registerFeature("foo") {
-        usingSourceSet(sourceSets.foo)
-    }
 }
 
 publishing {
@@ -175,77 +165,6 @@ task resolve {
         when:
         removeGMM()
         and:
-        succeeds(":consumer:resolve")
-        then:
-        noExceptionThrown()
-    }
-
-    def "can re-select artifacts if dependency has explicit artifact when"() {
-        file("consumer/build.gradle") << """
-dependencies {
-    implementation 'com.example:test'
-    implementation 'com.example:test:1.0:foo'
-}
-
-task resolve {
-    def normal = configurations.runtimeClasspath.incoming.files
-    def reselected = configurations.runtimeClasspath.incoming.artifactView {
-        withVariantReselection()
-        attributes {
-            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
-            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.DOCUMENTATION))
-            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
-            attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType, DocsType.SOURCES))
-        }
-    }.files
-    doLast {
-        assert normal*.name == ["test-1.0.jar", "test-1.0-foo.jar"]
-        assert reselected*.name == ["test-1.0-sources.jar"]
-    }
-}
-"""
-        when:
-        succeeds(":consumer:resolve")
-        then:
-        noExceptionThrown()
-
-        when:
-        removeGMM()
-        and:
-        succeeds(":consumer:resolve")
-        then:
-        noExceptionThrown()
-    }
-
-    @NotYetImplemented // Currently we throw an exception since we can't decide between the production and foo sources
-    def "variant reselection only re-selects among variants with the same capabilities"() {
-        file("consumer/build.gradle") << """
-dependencies {
-    implementation('com.example:test:1.0') {
-        capabilities {
-            requireCapability("com.example:test-foo:1.0")
-        }
-    }
-}
-
-task resolve {
-    def normal = configurations.runtimeClasspath.incoming.files
-    def reselected = configurations.runtimeClasspath.incoming.artifactView {
-        withVariantReselection()
-        attributes {
-            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
-            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.DOCUMENTATION))
-            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
-            attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType, DocsType.SOURCES))
-        }
-    }.files
-    doLast {
-        assert normal*.name == ["test-1.0-foo.jar"]
-        assert reselected*.name == ["test-1.0-foo-sources.jar"]
-    }
-}
-"""
-        when:
         succeeds(":consumer:resolve")
         then:
         noExceptionThrown()

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -550,7 +550,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             ResolveExceptionContextualizer resolveExceptionContextualizer,
             ComponentDetailsSerializer componentDetailsSerializer,
             SelectedVariantSerializer selectedVariantSerializer,
-            ResolvedVariantCache resolvedVariantCache
+            ResolvedVariantCache resolvedVariantCache,
+            GraphVariantSelector graphVariantSelector
         ) {
             DefaultConfigurationResolver defaultResolver = new DefaultConfigurationResolver(
                 componentResolversFactory,
@@ -575,7 +576,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                 resolveExceptionContextualizer,
                 componentDetailsSerializer,
                 selectedVariantSerializer,
-                resolvedVariantCache
+                resolvedVariantCache,
+                graphVariantSelector
             );
 
             return new ErrorHandlingConfigurationResolver(

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/VariantResolvingArtifactSet.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/VariantResolvingArtifactSet.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.ExcludeSpec;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphEdge;
 import org.gradle.api.internal.artifacts.transform.ArtifactVariantSelector;
@@ -28,8 +29,9 @@ import org.gradle.api.internal.artifacts.transform.VariantDefinition;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.model.ComponentArtifactResolveMetadata;
-import org.gradle.internal.component.model.ComponentArtifactResolveState;
 import org.gradle.internal.component.model.ComponentGraphResolveState;
+import org.gradle.internal.component.model.GraphVariantSelectionResult;
+import org.gradle.internal.component.model.GraphVariantSelector;
 import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.component.model.VariantArtifactResolveState;
 import org.gradle.internal.component.model.VariantGraphResolveState;
@@ -37,23 +39,27 @@ import org.gradle.internal.component.model.VariantResolveMetadata;
 import org.gradle.internal.lazy.Lazy;
 import org.gradle.internal.resolve.resolver.VariantArtifactResolver;
 
+import java.util.Collections;
 import java.util.List;
-import java.util.function.Consumer;
+import java.util.Set;
 
 /**
  * An {@link ArtifactSet} representing the artifacts contributed by a single variant in a dependency
  * graph, in the context of the dependency referencing it.
  */
-public class VariantResolvingArtifactSet implements ArtifactSet, ArtifactVariantSelector.ResolvedArtifactTransformer {
+public class VariantResolvingArtifactSet implements ArtifactSet {
 
     private final VariantArtifactResolver variantResolver;
     private final ComponentGraphResolveState component;
     private final VariantGraphResolveState variant;
     private final ComponentIdentifier componentId;
-    private final AttributesSchemaInternal schema;
+    private final AttributesSchemaInternal producerSchema;
     private final ImmutableAttributes overriddenAttributes;
     private final List<IvyArtifactName> artifacts;
     private final ExcludeSpec exclusions;
+    private final List<Capability> capabilities;
+    private final GraphVariantSelector graphVariantSelector;
+    private final AttributesSchemaInternal consumerSchema;
 
     private final Lazy<ImmutableSet<ResolvedVariant>> ownArtifacts = Lazy.locking().of(this::calculateOwnArtifacts);
 
@@ -61,16 +67,21 @@ public class VariantResolvingArtifactSet implements ArtifactSet, ArtifactVariant
         VariantArtifactResolver variantResolver,
         ComponentGraphResolveState component,
         VariantGraphResolveState variant,
-        DependencyGraphEdge dependency
+        DependencyGraphEdge dependency,
+        GraphVariantSelector graphVariantSelector,
+        AttributesSchemaInternal consumerSchema
     ) {
         this.variantResolver = variantResolver;
         this.component = component;
         this.variant = variant;
         this.componentId = component.getId();
-        this.schema = component.getMetadata().getAttributesSchema();
+        this.producerSchema = component.getMetadata().getAttributesSchema();
         this.overriddenAttributes = dependency.getAttributes();
         this.artifacts = dependency.getDependencyMetadata().getArtifacts();
         this.exclusions = dependency.getExclusions();
+        this.capabilities = dependency.getSelector().getRequested().getRequestedCapabilities();
+        this.graphVariantSelector = graphVariantSelector;
+        this.consumerSchema = consumerSchema;
     }
 
     @Override
@@ -88,19 +99,27 @@ public class VariantResolvingArtifactSet implements ArtifactSet, ArtifactVariant
                 return ResolvedArtifactSet.EMPTY;
             }
 
-            ResolvedVariantSet variants;
+            ImmutableSet<ResolvedVariant> variants;
             try {
-                variants = getVariants(spec.getSelectFromAllVariants());
+                if (!spec.getSelectFromAllVariants()) {
+                    variants = ownArtifacts.get();
+                } else {
+                    variants = getArtifactVariantsForReselection(spec.getRequestAttributes());
+                }
             } catch (Exception e) {
                 return new BrokenResolvedArtifactSet(e);
             }
 
-            return variantSelector.select(variants, spec.getRequestAttributes(), spec.getAllowNoMatchingVariants(), this);
+            if (variants.isEmpty() && spec.getAllowNoMatchingVariants()) {
+                return ResolvedArtifactSet.EMPTY;
+            }
+
+            ResolvedVariantSet variantSet = new DefaultResolvedVariantSet(componentId, producerSchema, overriddenAttributes, variants);
+            return variantSelector.select(variantSet, spec.getRequestAttributes(), spec.getAllowNoMatchingVariants(), this::asTransformed);
         }
     }
 
-    @Override
-    public ResolvedArtifactSet asTransformed(ResolvedVariant sourceVariant, VariantDefinition variantDefinition, TransformUpstreamDependenciesResolverFactory dependenciesResolverFactory, TransformedVariantFactory transformedVariantFactory) {
+    private ResolvedArtifactSet asTransformed(ResolvedVariant sourceVariant, VariantDefinition variantDefinition, TransformUpstreamDependenciesResolverFactory dependenciesResolverFactory, TransformedVariantFactory transformedVariantFactory) {
         if (componentId instanceof ProjectComponentIdentifier) {
             return transformedVariantFactory.transformedProjectArtifacts(componentId, sourceVariant, variantDefinition, dependenciesResolverFactory);
         } else {
@@ -108,78 +127,66 @@ public class VariantResolvingArtifactSet implements ArtifactSet, ArtifactVariant
         }
     }
 
-    public ResolvedVariantSet getVariants(boolean selectFromAllVariants) {
-        ImmutableSet<ResolvedVariant> variants;
-        if (!selectFromAllVariants) {
-            variants = ownArtifacts.get();
-        } else {
-            variants = getComponentVariants();
-        }
-
-        return new DefaultResolvedVariantSet(
-            componentId,
-            schema,
-            overriddenAttributes,
-            variants
-        );
-    }
-
     public ImmutableSet<ResolvedVariant> calculateOwnArtifacts() {
-        VariantArtifactResolveState variantState = variant.prepareForArtifactResolution();
-
         if (artifacts.isEmpty()) {
-            ComponentArtifactResolveMetadata componentMetadata = component.prepareForArtifactResolution().getResolveMetadata();
-
-            ImmutableSet.Builder<ResolvedVariant> ownArtifacts = ImmutableSet.builder();
-            visitResolvedArtifacts(componentMetadata, variantState, ownArtifacts::add, exclusions.mayExcludeArtifacts());
-            return ownArtifacts.build();
+            return getArtifactsForGraphVariant(variant);
         } else {
-            return ImmutableSet.of(variantState.resolveAdhocVariant(variantResolver, artifacts));
+            return ImmutableSet.of(variant.prepareForArtifactResolution().resolveAdhocVariant(variantResolver, artifacts));
         }
     }
 
     /**
-     * Gets all artifact variants ("sub-variants") for the component. This is used when
-     * artifact view variant-reselection is enabled.
+     * Gets all artifact variants that should be considered for artifact selection.
      *
-     * TODO: Currently, this contains all variants in the entire component,
-     * however in practice when using withVariantReselection the user likely
-     * does not want to select from variants with a different capability than
-     * the current variant.
+     * <p>This emulates the normal variant selection process where graph variants are first
+     * considered, then artifact variants. We first consider graph variants, which leverages the
+     * same algorithm used during graph variant selection. This considers requested and declared
+     * capabilities.</p>
      */
-    private ImmutableSet<ResolvedVariant> getComponentVariants() {
-        ComponentArtifactResolveState componentState = component.prepareForArtifactResolution();
-        List<VariantArtifactResolveState> componentVariants = componentState.getVariantsForArtifactSelection().orElse(null);
+    private ImmutableSet<ResolvedVariant> getArtifactVariantsForReselection(ImmutableAttributes requestAttributes) {
+        // First, find the graph variant containing the artifact variants to select among.
+        GraphVariantSelectionResult selectedGraphVariants = graphVariantSelector.selectVariantsLenient(
+            requestAttributes,
+            capabilities,
+            component,
+            consumerSchema,
+            Collections.emptyList()
+        );
 
-        if (componentVariants == null) {
-            return ownArtifacts.get();
+        // It is fine if no graph variants satisfy our request.
+        // Variant reselection allows no target variants to be found.
+        if (selectedGraphVariants.getVariants().isEmpty()) {
+            return ImmutableSet.of();
         }
 
-        boolean applyExclusions = exclusions.mayExcludeArtifacts();
-        ImmutableSet.Builder<ResolvedVariant> builder = ImmutableSet.builder();
-        ComponentArtifactResolveMetadata componentMetadata = componentState.getResolveMetadata();
+        // The graphVariantSelector will always select a single variant.
+        // However, the interface does not reflect that since the type used here is shared with Ivy, which can select multiple variants.
+        assert selectedGraphVariants.getVariants().size() == 1;
+        VariantGraphResolveState graphVariant = selectedGraphVariants.getVariants().get(0);
 
-        for (VariantArtifactResolveState componentVariant : componentVariants) {
-            visitResolvedArtifacts(componentMetadata, componentVariant, builder::add, applyExclusions);
-        }
-
-        return builder.build();
+        // Next, return all artifact variants for the selected graph variant.
+        return getArtifactsForGraphVariant(graphVariant);
     }
 
-    private void visitResolvedArtifacts(
-        ComponentArtifactResolveMetadata component,
-        VariantArtifactResolveState variant,
-        Consumer<ResolvedVariant> visitor,
-        boolean applyExclusions
-    ) {
-        if (applyExclusions) {
-            for (VariantResolveMetadata subvariant : variant.getArtifactVariants()) {
-                visitor.accept(variantResolver.resolveVariant(component, subvariant, exclusions));
+    /**
+     * Resolve all artifact variants for the given graph variant.
+     */
+    private ImmutableSet<ResolvedVariant> getArtifactsForGraphVariant(VariantGraphResolveState graphVariant) {
+        VariantArtifactResolveState variantState = graphVariant.prepareForArtifactResolution();
+        Set<? extends VariantResolveMetadata> artifactVariants = variantState.getArtifactVariants();
+        ImmutableSet.Builder<ResolvedVariant> resolved = ImmutableSet.builderWithExpectedSize(artifactVariants.size());
+
+        ComponentArtifactResolveMetadata componentMetadata = component.prepareForArtifactResolution().getResolveMetadata();
+        if (exclusions.mayExcludeArtifacts()) {
+            for (VariantResolveMetadata artifactVariant : artifactVariants) {
+                resolved.add(variantResolver.resolveVariant(componentMetadata, artifactVariant, exclusions));
             }
         } else {
-            for (VariantResolveMetadata subvariant : variant.getArtifactVariants()) {
-                visitor.accept(variantResolver.resolveVariant(component, subvariant));
+            for (VariantResolveMetadata artifactVariant : artifactVariants) {
+                resolved.add(variantResolver.resolveVariant(componentMetadata, artifactVariant));
             }
         }
+
+        return resolved.build();
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentGraphResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentGraphResolveState.java
@@ -68,9 +68,6 @@ public class DefaultLocalComponentGraphResolveState extends AbstractComponentGra
     // The variants to use for variant selection during graph resolution
     private final Lazy<Optional<List<? extends VariantGraphResolveState>>> allVariantsForGraphResolution;
 
-    // The variants of this component to use for artifact selection when variant reselection is enabled
-    private final Lazy<Optional<List<VariantArtifactResolveState>>> allVariantsForArtifactSelection;
-
     // The public view of all selectable variants of this component
     private final Lazy<List<ResolvedVariantResult>> selectableVariantResults;
 
@@ -79,11 +76,6 @@ public class DefaultLocalComponentGraphResolveState extends AbstractComponentGra
         allVariantsForGraphResolution = Lazy.locking().of(() -> metadata.getVariantsForGraphTraversal().map(variants ->
             variants.stream()
                 .map(variant -> getConfiguration(variant.getName()).asVariant())
-                .collect(Collectors.toList())
-        ));
-        allVariantsForArtifactSelection = Lazy.locking().of(() -> metadata.getVariantsForGraphTraversal().map(variants ->
-            variants.stream()
-                .map(variant -> getConfiguration(variant.getName()).asVariant().prepareForArtifactResolution())
                 .collect(Collectors.toList())
         ));
         this.idGenerator = idGenerator;
@@ -141,11 +133,6 @@ public class DefaultLocalComponentGraphResolveState extends AbstractComponentGra
     @Override
     protected Optional<List<? extends VariantGraphResolveState>> getVariantsForGraphTraversal() {
         return allVariantsForGraphResolution.get();
-    }
-
-    @Override
-    public Optional<List<VariantArtifactResolveState>> getVariantsForArtifactSelection() {
-        return allVariantsForArtifactSelection.get();
     }
 
     @Nullable

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentArtifactResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentArtifactResolveState.java
@@ -21,9 +21,6 @@ import org.gradle.api.internal.component.ArtifactType;
 import org.gradle.internal.resolve.resolver.ArtifactResolver;
 import org.gradle.internal.resolve.result.BuildableArtifactSetResolveResult;
 
-import java.util.List;
-import java.util.Optional;
-
 /**
  * State for a component instance that is used to perform artifact resolution.
  *
@@ -48,9 +45,4 @@ public interface ComponentArtifactResolveState {
      * Discovers the set of artifacts belonging to this component, with the type specified. Does not download the artifacts. Any failures are packaged up in the result.
      */
     void resolveArtifactsWithType(ArtifactResolver artifactResolver, ArtifactType artifactType, BuildableArtifactSetResolveResult result);
-
-    /**
-     * Return the artifact resolution state for each variant in this component, used for selecting artifacts.
-     */
-    Optional<List<VariantArtifactResolveState>> getVariantsForArtifactSelection();
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultComponentGraphResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultComponentGraphResolveState.java
@@ -52,9 +52,6 @@ public class DefaultComponentGraphResolveState<T extends ComponentGraphResolveMe
     // The variants to use for variant selection during graph resolution
     private final Lazy<Optional<List<? extends VariantGraphResolveState>>> allVariantsForGraphResolution;
 
-    // The variants of this component to use when variant reselection is enabled
-    private final Lazy<Optional<List<VariantArtifactResolveState>>> allVariantsForArtifactSelection;
-
     // The public view of all selectable variants of this component
     private final List<ResolvedVariantResult> selectableVariantResults;
 
@@ -64,12 +61,6 @@ public class DefaultComponentGraphResolveState<T extends ComponentGraphResolveMe
             variants.stream()
                 .map(ModuleConfigurationMetadata.class::cast)
                 .map(variant -> resolveStateFor(variant).asVariant())
-                .collect(Collectors.toList())
-        ));
-        allVariantsForArtifactSelection = Lazy.locking().of(() -> graphMetadata.getVariantsForGraphTraversal().map(variants ->
-            variants.stream()
-                .map(ModuleConfigurationMetadata.class::cast)
-                .map(variant -> resolveStateFor(variant).asVariant().prepareForArtifactResolution())
                 .collect(Collectors.toList())
         ));
         this.idGenerator = idGenerator;
@@ -103,11 +94,6 @@ public class DefaultComponentGraphResolveState<T extends ComponentGraphResolveMe
     @Override
     protected Optional<List<? extends VariantGraphResolveState>> getVariantsForGraphTraversal() {
         return allVariantsForGraphResolution.get();
-    }
-
-    @Override
-    public Optional<List<VariantArtifactResolveState>> getVariantsForArtifactSelection() {
-        return allVariantsForArtifactSelection.get();
     }
 
     @Nullable

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/VariantResolvingArtifactSetTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/VariantResolvingArtifactSetTest.groovy
@@ -16,14 +16,18 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact
 
+import org.gradle.api.artifacts.component.ComponentSelector
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.ExcludeSpec
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphEdge
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphSelector
 import org.gradle.api.internal.artifacts.transform.ArtifactVariantSelector
+import org.gradle.api.internal.attributes.AttributesSchemaInternal
 import org.gradle.api.internal.attributes.ImmutableAttributes
-import org.gradle.internal.component.model.ComponentArtifactResolveState
 import org.gradle.internal.component.model.ComponentGraphResolveMetadata
 import org.gradle.internal.component.model.ComponentGraphResolveState
 import org.gradle.internal.component.model.DependencyMetadata
+import org.gradle.internal.component.model.GraphVariantSelectionResult
+import org.gradle.internal.component.model.GraphVariantSelector
 import org.gradle.internal.component.model.VariantArtifactResolveState
 import org.gradle.internal.component.model.VariantGraphResolveState
 import org.gradle.internal.component.model.VariantResolveMetadata
@@ -36,12 +40,14 @@ class VariantResolvingArtifactSetTest extends Specification {
     ComponentGraphResolveState component
     VariantGraphResolveState variant
     DependencyGraphEdge dependency
+    GraphVariantSelector graphSelector
+    AttributesSchemaInternal consumerSchema
 
     def selector = Mock(ArtifactVariantSelector)
 
     def setup() {
         variantResolver = Mock(VariantArtifactResolver)
-        component = Mock(ComponentGraphResolveState) {
+        component = Stub(ComponentGraphResolveState) {
             getMetadata() >> Mock(ComponentGraphResolveMetadata)
         }
         variant = Mock(VariantGraphResolveState)
@@ -51,12 +57,23 @@ class VariantResolvingArtifactSetTest extends Specification {
             }
             getExclusions() >> Mock(ExcludeSpec)
             getAttributes() >> ImmutableAttributes.EMPTY
+            getSelector() >> Mock(DependencyGraphSelector) {
+                getRequested() >> Mock(ComponentSelector) {
+                    getRequestedCapabilities() >> []
+                }
+            }
         }
+        graphSelector = Mock(GraphVariantSelector) {
+            selectVariantsLenient(_, _, _, _, _) >> Mock(GraphVariantSelectionResult) {
+                getVariants() >> [variant]
+            }
+        }
+        consumerSchema = Mock(AttributesSchemaInternal)
     }
 
     def "returns empty set when component id does not match spec"() {
         when:
-        def artifactSet = new VariantResolvingArtifactSet(variantResolver, component, variant, dependency)
+        def artifactSet = new VariantResolvingArtifactSet(variantResolver, component, variant, dependency, graphSelector, consumerSchema)
         def spec = new ArtifactSelectionSpec(ImmutableAttributes.EMPTY, { false }, selectFromAll, false)
         def selected = artifactSet.select(selector, spec)
 
@@ -71,25 +88,14 @@ class VariantResolvingArtifactSetTest extends Specification {
     def "does not access all artifacts when selecting one variant"() {
         def subvariant1 = Mock(VariantResolveMetadata)
         def subvariant2 = Mock(VariantResolveMetadata)
-        def subvariant3 = Mock(VariantResolveMetadata)
 
         variant.prepareForArtifactResolution() >> Mock(VariantArtifactResolveState) {
             getArtifactVariants() >> ([subvariant1, subvariant2] as Set)
         }
 
-        def variant2 = Mock(VariantGraphResolveState) {
-            prepareForArtifactResolution() >> Mock(VariantArtifactResolveState) {
-                getArtifactVariants() >> ([subvariant3] as Set)
-            }
-        }
-
-        component.prepareForArtifactResolution() >> Mock(ComponentArtifactResolveState) {
-            getVariantsForArtifactSelection() >> Optional.of([variant, variant2])
-        }
-
         when:
         def spec = new ArtifactSelectionSpec(ImmutableAttributes.EMPTY, { true }, false, false)
-        def artifactSet = new VariantResolvingArtifactSet(variantResolver, component, variant, dependency)
+        def artifactSet = new VariantResolvingArtifactSet(variantResolver, component, variant, dependency, graphSelector, consumerSchema)
         artifactSet.select(new ArtifactVariantSelector() {
             @Override
             ResolvedArtifactSet select(ResolvedVariantSet candidates, ImmutableAttributes requestAttributes, boolean allowNoMatchingVariants, ArtifactVariantSelector.ResolvedArtifactTransformer factory) {
@@ -114,15 +120,11 @@ class VariantResolvingArtifactSetTest extends Specification {
             getArtifactVariants() >> ([subvariant1, subvariant2] as Set)
         }
 
-        component.prepareForArtifactResolution() >> Mock(ComponentArtifactResolveState) {
-            getVariantsForArtifactSelection() >> Optional.of([variant.prepareForArtifactResolution()])
-        }
-
         def artifacts = Stub(ResolvedArtifactSet)
-        def artifactSet = new VariantResolvingArtifactSet(variantResolver, component, variant, dependency)
+        def artifactSet = new VariantResolvingArtifactSet(variantResolver, component, variant, dependency, graphSelector, consumerSchema)
 
         when:
-        def spec = new ArtifactSelectionSpec(ImmutableAttributes.EMPTY, { true }, false, false)
+        def spec = new ArtifactSelectionSpec(ImmutableAttributes.EMPTY, { true }, selectFromAll, false)
         def selected = artifactSet.select(selector, spec)
 
         then:


### PR DESCRIPTION
Previously, ArtifactView#withVariantReselection did not consider capabilities when reselecting variants. This means that we would get ambiguous attribute matching failures when selecting among multiple variants with the same attributes but different capabilities. This aligns the artifact selection process used by normal artifact selection with reselction by first filtering artifact variants with the graph variant selector and then selecting the selected graph variant's artifact variants. This allows us to consider capabilities in the same manner that the normal algorithm does

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
