### PR TITLE
Make it possible to override POM name and description

### DIFF
--- a/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/MavenPluginPublishPlugin.java
+++ b/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/MavenPluginPublishPlugin.java
@@ -110,7 +110,13 @@ abstract class MavenPluginPublishPlugin implements Plugin<Project> {
                 version.setTextContent(versionProvider.get());
             }
         });
-        publication.getPom().getName().set(declaration.getDisplayName());
-        publication.getPom().getDescription().set(declaration.getDescription());
+        String displayName = declaration.getDisplayName();
+        if (displayName != null) {
+            publication.getPom().getName().set(displayName);
+        }
+        String description = declaration.getDescription();
+        if (description != null && !description.isEmpty()) {
+            publication.getPom().getDescription().set(description);
+        }
     }
 }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #12259

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
This fixed the problem that a "custom pom declaration" via the `publishing.publication` configuration will be ignored for the `name` and `description` property in the POM file.

The problem right now is, that the `java-gradle-plugin` sets the `name` and `description` (of the POM) to the value of the `gradlePlugin.displayName` and `gradlePlugin.description` respectively.
If the latter properties are *not*  set, your custom POM declaration will be overriden by `null`. So basically the `name` and `description` will be removed from the POM.

This is confusing in my opinion.

The fix is the straight forward.
It will only set (or override) the POM `name` and `description` in case the `gradlePlugin.displayName` or `gradlePlugin.description` are *set*. In case they are not set (and are not empty) it will don't do anything. 
In case you don't have a custom POM declaration this is the default behaviour anyways.

So what would work now that wasn't the case before?
This didn't worked:
```kotlin
gradlePlugin {
    plugins {
        register("some.thing") {
            id = "some.thing"
            implementationClass = "some.thing.Klass"
        }
    }
}

publishing {
    publications.withType<MavenPublication> {
        pom {
            name = "Something"
            description = "SomeDesc"
        }
    }
}
```
The POM `name` and `description` where empty!
Now it works and will be respected.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
