### PR TITLE
Let Kotlin DSL source path calculation properly look into `platforms/`

### DIFF
--- a/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/resolver/SourceDistributionResolverIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/resolver/SourceDistributionResolverIntegrationTest.kt
@@ -19,8 +19,23 @@ class SourceDistributionResolverIntegrationTest : AbstractKotlinIntegrationTest(
                 ${SourceDistributionResolver::class.qualifiedName}(project).run {
                     sourceDirs()
                 }
+
             require(sourceDirs.isNotEmpty()) {
                 "Expected source directories but got none"
+            }
+
+            val subprojectSourcePath = "org/gradle/StartParameter.java"
+            val subprojectFound = sourceDirs.find { it.resolve(subprojectSourcePath).isFile }
+            require(subprojectFound != null) {
+                "Source directories do not contain subproject file '${'$'}subprojectSourcePath'. Searched in:\n  " +
+                    sourceDirs.joinToString("  \n")
+            }
+
+            val platformSourcePath = "org/gradle/api/Action.java"
+            val platformFound = sourceDirs.find { it.resolve(platformSourcePath).isFile }
+            require(platformFound != null) {
+                "Source directories do not contain platform file '${'$'}platformSourcePath'. Searched in:\n  " +
+                    sourceDirs.joinToString("\n  ")
             }
 
             """

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/FindGradleSources.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/FindGradleSources.kt
@@ -49,18 +49,25 @@ abstract class FindGradleSources : TransformAction<TransformParameters.None> {
 
     private
     fun registerSourceDirectories(outputs: TransformOutputs) {
-        unzippedSubProjectsDir()?.let {
-            subDirsOf(it).flatMap { subProject ->
-                subDirsOf(File(subProject, "src/main"))
-            }.forEach { outputs.dir(it) }
-        }
+        unzippedProjectDirectories()
+            .flatMap { projectDir -> subDirsOf(projectDir.resolve("src/main")) }
+            .forEach { outputs.dir(it) }
     }
 
     private
-    fun unzippedSubProjectsDir(): File? =
-        unzippedDistroDir()?.let {
-            File(it, "subprojects")
-        }
+    fun unzippedProjectDirectories(): Collection<File> =
+        unzippedDistroDir()?.let { distroDir ->
+            unzippedSubprojectsDirectories(distroDir) + unzippedPlatformProjectsDirectories(distroDir)
+        } ?: emptyList()
+
+    private
+    fun unzippedSubprojectsDirectories(distroDir: File): Collection<File> =
+        subDirsOf(distroDir.resolve("subprojects"))
+
+    private
+    fun unzippedPlatformProjectsDirectories(distroDir: File): Collection<File> =
+        subDirsOf(distroDir.resolve("platforms"))
+            .flatMap { platform -> subDirsOf(platform) }
 
     private
     fun unzippedDistroDir(): File? =


### PR DESCRIPTION
* Fixes https://github.com/gradle/gradle/issues/27405
