### PR TITLE
IDE sync smoke test

### DIFF
--- a/platforms/core-configuration/configuration-cache/build.gradle.kts
+++ b/platforms/core-configuration/configuration-cache/build.gradle.kts
@@ -101,6 +101,7 @@ dependencies {
     integTestImplementation(libs.guava)
     integTestImplementation(libs.ant)
     integTestImplementation(libs.inject)
+    integTestImplementation((libs.gradleProfiler))
     integTestImplementation("com.microsoft.playwright:playwright:1.20.1")
 
     integTestImplementation(testFixtures(project(":tooling-api")))

--- a/platforms/core-configuration/configuration-cache/build.gradle.kts
+++ b/platforms/core-configuration/configuration-cache/build.gradle.kts
@@ -101,7 +101,7 @@ dependencies {
     integTestImplementation(libs.guava)
     integTestImplementation(libs.ant)
     integTestImplementation(libs.inject)
-    integTestImplementation((libs.gradleProfiler))
+    integTestImplementation(libs.gradleProfiler)
     integTestImplementation("com.microsoft.playwright:playwright:1.20.1")
 
     integTestImplementation(testFixtures(project(":tooling-api")))

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/fixtures/AbstractConfigurationCacheOptInFeatureIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/fixtures/AbstractConfigurationCacheOptInFeatureIntegrationTest.groovy
@@ -29,7 +29,7 @@ abstract class AbstractConfigurationCacheOptInFeatureIntegrationTest extends Abs
         // Verify that the previous test cleaned up state correctly
         assert System.getProperty(StartParameterBuildOptions.ConfigurationCacheOption.PROPERTY_NAME) == null
         assert System.getProperty(StartParameterBuildOptions.IsolatedProjectsOption.PROPERTY_NAME) == null
-        problems = new ConfigurationCacheProblemsFixture(executer, testDirectory)
+        problems = new ConfigurationCacheProblemsFixture(testDirectory)
     }
 
     def cleanup() {

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/AbstractIdeSyncSmokeTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/AbstractIdeSyncSmokeTest.groovy
@@ -53,7 +53,7 @@ abstract class AbstractIdeSyncSmokeTest extends AbstractIntegrationSpec {
                 .build()
 
         sync(
-            "Android studio sync",
+            "Android Studio sync",
             invocationSettings,
             [new LocalPropertiesMutator(invocationSettings, "/Users/sopivalov/Library/Android/sdk")] // TODO configure SDK_ROOT
         )

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/AbstractIdeSyncSmokeTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/AbstractIdeSyncSmokeTest.groovy
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache.isolated
+
+import com.google.common.collect.ImmutableList
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.internal.UncheckedException
+import org.gradle.internal.jvm.Jvm
+import org.gradle.profiler.BuildAction
+import org.gradle.profiler.BuildMutator
+import org.gradle.profiler.GradleBuildConfiguration
+import org.gradle.profiler.InvocationSettings
+import org.gradle.profiler.Logging
+import org.gradle.profiler.Profiler
+import org.gradle.profiler.ScenarioContext
+import org.gradle.profiler.gradle.DaemonControl
+import org.gradle.profiler.gradle.GradleBuildInvoker
+import org.gradle.profiler.gradle.GradleScenarioDefinition
+import org.gradle.profiler.gradle.GradleScenarioInvoker
+import org.gradle.profiler.instrument.PidInstrumentation
+import org.gradle.profiler.studio.AndroidStudioSyncAction
+import org.gradle.profiler.studio.invoker.StudioBuildInvocationResult
+import org.gradle.profiler.studio.invoker.StudioGradleScenarioDefinition
+import org.gradle.profiler.studio.invoker.StudioGradleScenarioInvoker
+import org.gradle.profiler.studio.tools.StudioFinder
+
+import java.util.function.Consumer
+
+abstract class AbstractIdeSyncSmokeTest extends AbstractIntegrationSpec {
+
+    protected IdeSyncFixture fixture = new IdeSyncFixture(testDirectory)
+
+    protected StudioBuildInvocationResult syncResult
+
+    protected void androidStudioSync() {
+        def invocationSettings =
+            syncInvocationSettingsBuilder()
+                .setStudioInstallDir(StudioFinder.findStudioHome())
+                .build()
+
+        sync(
+            "Android studio sync",
+            invocationSettings,
+            [new LocalPropertiesMutator(invocationSettings, "/Users/sopivalov/Library/Android/sdk")] // TODO configure SDK_ROOT
+        )
+    }
+
+    protected void ideaSync(String ideaHome) {
+        def invocationSettings =
+            syncInvocationSettingsBuilder()
+                .setStudioInstallDir(new File(ideaHome))
+                .build()
+
+        sync(
+            "IDEA sync",
+            invocationSettings,
+            Collections.emptyList()
+        )
+    }
+
+    private InvocationSettings.InvocationSettingsBuilder syncInvocationSettingsBuilder() {
+        // TODO it would be nice not to have it in test dir, to avoid it's indexing during a sync
+        def gradleUserHome = file("gradle-user-home")
+        def ideSandbox = file("ide-sandbox")
+        def profilerOutput = file('profiler-output')
+
+        // TODO -Dstudio.tests.headless=true check headless mode possibility
+        return new InvocationSettings.InvocationSettingsBuilder()
+            .setProjectDir(testDirectory)
+            .setProfiler(Profiler.NONE)
+            .setStudioSandboxDir(ideSandbox)
+            .setGradleUserHome(gradleUserHome)
+            .setVersions(ImmutableList.of(distribution.version.version))
+            .setScenarioFile(null)
+            .setBenchmark(true)
+            .setOutputDir(profilerOutput)
+            .setWarmupCount(1)
+            .setIterations(1)
+    }
+
+    private void sync(
+        String scenarioName,
+        InvocationSettings invocationSettings,
+        List<BuildMutator> buildMutators
+    ) {
+        // TODO consider passing jvmArgs where it's sane
+        def syncScenario = new StudioGradleScenarioDefinition(
+            new GradleScenarioDefinition(
+                scenarioName,
+                scenarioName,
+                GradleBuildInvoker.AndroidStudio,
+                new GradleBuildConfiguration(
+                    distribution.getVersion(),
+                    distribution.gradleHomeDir,
+                    Jvm.current().getJavaHome(),
+                    Collections.emptyList(), // daemon args
+                    false,
+                    Collections.emptyList() // client args
+                ),
+                new AndroidStudioSyncAction(),
+                BuildAction.NO_OP,
+                Collections.emptyList(),
+                new HashMap<String, String>(),
+                buildMutators,
+                invocationSettings.warmUpCount,
+                invocationSettings.buildCount,
+                invocationSettings.outputDir,
+                Collections.emptyList(),
+                Collections.emptyList()
+            ),
+            Collections.emptyList(),
+            Collections.emptyList()
+        )
+
+        def scenarioInvoker = new StudioGradleScenarioInvoker(
+            new GradleScenarioInvoker(
+                new DaemonControl(invocationSettings.getGradleUserHome()),
+                createPidInstrumentation()
+            )
+        )
+
+        Logging.setupLogging(invocationSettings.outputDir)
+
+        try {
+            scenarioInvoker.run(
+                syncScenario,
+                invocationSettings,
+                new Consumer<StudioBuildInvocationResult>() {
+                    @Override
+                    void accept(StudioBuildInvocationResult studioBuildInvocationResult) {
+                        syncResult = studioBuildInvocationResult
+                    }
+                })
+        } catch (IOException | InterruptedException e) {
+            throw UncheckedException.throwAsUncheckedException(e)
+        } finally {
+            try {
+                Logging.resetLogging()
+            } catch (IOException e) {
+                e.printStackTrace()
+            }
+        }
+    }
+
+    private PidInstrumentation createPidInstrumentation() {
+        try {
+            return new PidInstrumentation()
+        } catch (IOException e) {
+            throw new RuntimeException(e)
+        }
+    }
+
+    private static class LocalPropertiesMutator implements BuildMutator {
+        private final String androidSdkRootPath
+        private final InvocationSettings invocation
+
+        LocalPropertiesMutator(InvocationSettings invocation, String androidSdkRootPath) {
+            this.invocation = invocation
+            this.androidSdkRootPath = androidSdkRootPath
+        }
+
+        @Override
+        void beforeScenario(ScenarioContext context) {
+            def localProperties = new File(invocation.projectDir, "local.properties")
+            localProperties << "\nsdk.dir=$androidSdkRootPath\n"
+        }
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IdeSyncFixture.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IdeSyncFixture.groovy
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache.isolated
+
+
+import org.gradle.integtests.fixtures.configurationcache.ConfigurationCacheProblemsFixture
+import org.gradle.integtests.fixtures.configurationcache.HasConfigurationCacheProblemsSpec
+import org.gradle.test.fixtures.file.TestFile
+
+import java.nio.file.FileVisitResult
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.attribute.BasicFileAttributes
+
+class IdeSyncFixture {
+
+    private final ConfigurationCacheProblemsFixture configurationCacheProblemsFixture
+    private final TestFile rootDir
+
+    IdeSyncFixture(TestFile rootDir) {
+        this.configurationCacheProblemsFixture = new ConfigurationCacheProblemsFixture(rootDir)
+        this.rootDir = rootDir
+    }
+
+    void assertHtmlReportHasProblems(
+        @DelegatesTo(value = HasConfigurationCacheProblemsSpec, strategy = Closure.DELEGATE_FIRST) Closure<?> specClosure
+    ) {
+        def reportDir = resolveFirstConfigurationCacheReportDir(rootDir)
+        configurationCacheProblemsFixture.assertHtmlReportHasProblems(
+            reportDir,
+            configurationCacheProblemsFixture.newProblemsSpec(specClosure)
+        )
+    }
+
+    private static TestFile resolveFirstConfigurationCacheReportDir(TestFile rootDir) {
+        def reportsDir = rootDir.file("build/reports/configuration-cache")
+        TestFile reportDir = null
+        Files.walkFileTree(reportsDir.toPath(), new SimpleFileVisitor<Path>() {
+            @Override
+            FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                if (file.getFileName().toString() == "configuration-cache-report.html") {
+                    reportDir = new TestFile(file.parent.toString())
+                    return FileVisitResult.TERMINATE;
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        })
+
+        if (reportDir == null) {
+            throw new RuntimeException()
+        }
+
+        return reportDir
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsJavaProjectSyncTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsJavaProjectSyncTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.configurationcache.isolated
 
+import org.hamcrest.core.StringContains
 import spock.lang.Ignore
 
 
@@ -32,7 +33,16 @@ class IsolatedProjectsJavaProjectSyncTest extends AbstractIdeSyncSmokeTest {
         then:
         fixture.assertHtmlReportHasProblems {
             totalProblemsCount = 78
-            problemsWithStackTraceCount = 50
+            withLocatedProblem(new StringContains("sync.studio.tooling"), "Cannot access project ':app' from project ':'")
+            withLocatedProblem(new StringContains("sync.studio.tooling"), "Cannot access project ':lib' from project ':'")
+            withLocatedProblem("Plugin class 'JetGradlePlugin'", "Cannot access project ':app' from project ':'")
+            withLocatedProblem("Plugin class 'JetGradlePlugin'", "Cannot access project ':lib' from project ':'")
+            withLocatedProblem("Plugin class 'JetGradlePlugin'", "Cannot access project ':' from project ':app'")
+            withLocatedProblem("Plugin class 'JetGradlePlugin'", "Cannot access project ':lib' from project ':app'")
+            withLocatedProblem("Plugin class 'JetGradlePlugin'", "Cannot access project ':' from project ':lib'")
+            withLocatedProblem("Plugin class 'JetGradlePlugin'", "Cannot access project ':app' from project ':lib'")
+            withLocatedProblem("Plugin class 'JetGradlePlugin'", "Cannot access project ':app' from project ':'. 'Project.evaluationDependsOn' must be used to establish a dependency between project ':app' and project ':' evaluation")
+            withLocatedProblem("Plugin class 'JetGradlePlugin'", "Cannot access project ':lib' from project ':'. 'Project.evaluationDependsOn' must be used to establish a dependency between project ':lib' and project ':' evaluation")
         }
     }
 

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsJavaProjectSyncTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsJavaProjectSyncTest.groovy
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache.isolated
+
+import spock.lang.Ignore
+
+
+class IsolatedProjectsJavaProjectSyncTest extends AbstractIdeSyncSmokeTest {
+
+    @Ignore // not yet implemented
+    def "vanilla Java project is IP compatible"() {
+        given:
+        simpleJavaProject()
+
+        when:
+        ideaSync("/Applications/IntelliJ IDEA.app")
+
+        then:
+        fixture.assertHtmlReportHasProblems {
+            totalProblemsCount = 78
+            problemsWithStackTraceCount = 50
+        }
+    }
+
+    private void simpleJavaProject() {
+        settingsFile << """
+            rootProject.name = 'project-under-test'
+            include ':app'
+            include ':lib'
+        """
+
+        file("gradle.properties") << """
+            org.gradle.configuration-cache.problems=warn
+            org.gradle.unsafe.isolated-projects=true
+        """
+
+        file("app/build.gradle") << """
+            plugins {
+                id 'java'
+            }
+
+            dependencies {
+                implementation(project(':lib'))
+            }
+        """
+
+        file("lib/build.gradle") << """
+            plugins {
+                id 'java'
+            }
+        """
+    }
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheFixture.groovy
@@ -36,7 +36,7 @@ class ConfigurationCacheFixture {
         this.spec = spec
         buildOperations = new BuildOperationsFixture(spec.executer, spec.temporaryFolder)
         configurationCacheBuildOperations = new ConfigurationCacheBuildOperationsFixture(buildOperations)
-        problems = new ConfigurationCacheProblemsFixture(spec.executer, spec.testDirectory)
+        problems = new ConfigurationCacheProblemsFixture(spec.testDirectory)
     }
 
     /**


### PR DESCRIPTION
Part of #27364

Still WIP

The idea of this PR is to have an integration test setup that would allow to run IDE sync on arbitrary project and check Isolated Projects violations in resulting CC report.

For running a sync, it's leveraging the pieces of Gradle Profiler in the same manner as `AbstractPerformanceTest`s are doing. It's using current Gradle distribution as a Gradle version, so such tests are not going to work in `embedded` mode.

There are difficulties with validating of resulting CC report for problems:
originally, `ConfigurationCacheProblemsFixture` relies on two things in problems validation:
- `System.out`/`System.err` of Gradle build
- `configuration-cache.html`
The first thing is allowing to have fine-grained validation with checking of problem message.
The second one is doing coarse grained validation, focused on check of total problems count.

There is a problem with accessing to output of the Gradle build, that happening during sync. IDEA is doesn't storing this output on disk(checked with JB guys), so `idea.log` or any other `.log` is doesn't contain it. So we can't do fine-grained validation of problems currently in this PR. 

However, this can be worked around by parsing `jsModel` of the report (can it?).

There are a bunch of things, that will be improved as well:
1. API for sync with AS. Some extra environment should be provided.
2. IDE provisioning
3. Headless mode (seems like it's supported, just need to test it)

Alternatively, there is a [toolkit](https://github.com/JetBrains/intellij-ide-starter/tree/master) for e2e tests that could be used. However, I don't see much sense in it now, considering that it has same limitation of having Gradle build output.
