### PR TITLE
Require root project target for IdeaProject and GradleProject with Isolated Projects

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/FailingBuildAction.java
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/FailingBuildAction.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache.isolated;
+
+import org.gradle.configurationcache.fixtures.SomeToolingModel;
+import org.gradle.tooling.BuildAction;
+import org.gradle.tooling.BuildController;
+
+public class FailingBuildAction implements BuildAction<SomeToolingModel> {
+    @Override
+    public SomeToolingModel execute(BuildController controller) {
+        controller.getBuildModel();
+        throw new RuntimeException("Build action expectedly failed");
+    }
+}

--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiBuildActionIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiBuildActionIntegrationTest.groovy
@@ -621,4 +621,17 @@ class IsolatedProjectsToolingApiBuildActionIntegrationTest extends AbstractIsola
         model4.message == "It works from project :a"
     }
 
+    def "does not cache execution of BuildAction when it fails"() {
+        when:
+        withIsolatedProjects()
+        runBuildActionFails(new FailingBuildAction())
+
+        then:
+        fixture.assertNoConfigurationCache()
+        failureDescriptionContains("Build action expectedly failed")
+
+        // TODO:isolated should not contain this output https://github.com/gradle/gradle/issues/27476
+        failure.assertOutputContains("Configuration cache entry stored.")
+    }
+
 }

--- a/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinDslScriptsModelBuilder.kt
+++ b/platforms/core-configuration/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinDslScriptsModelBuilder.kt
@@ -160,7 +160,7 @@ abstract class AbstractKotlinDslScriptsModelBuilder : ToolingModelBuilder {
     private
     fun requireRootProject(project: Project) =
         require(project == project.rootProject) {
-            "$MODEL_NAME can only be requested on the root project, got '$project'"
+            "$MODEL_NAME can only be requested on the root project, got $project"
         }
 }
 


### PR DESCRIPTION
Historically, models `IdeaProject` and `GradleProject` are allowed to be requested with a non-root project target. However, the model builder silently falls back to building a model for the root.

Since model builders for these models are separate with Isolated Projects, in that mode we can already require users to target only the root project.

This should not be a problem in practice. So this is more of a precautionary measure.
In the future, we want to deprecate this behavior for the non-Isolated Projects mode as well.