### PR TITLE
Fix native build failures on Ubuntu 22.04

### DIFF
--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationIntegrationTest.groovy
@@ -137,14 +137,16 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         result.assertTasksExecuted(tasks.release.allToInstall, tasks.release.extract, tasks.release.assemble)
 
         executable("build/exe/main/release/app").assertExists()
-        executable("build/exe/main/release/app").assertHasStrippedDebugSymbolsFor(app.sourceFileNamesWithoutHeaders)
+        // clang 11: build/exe/main/release/app: ['greeter.cpp', 'main.cpp']
+        // clang 14: build/exe/main/release/app: ['greeter.cpp', 'std', '__ioinit', 'ios_base', 'Init', '_Ios_Iostate', '_S_goodbit', ... ]
+        executable("build/exe/main/release/app").assertHasStrippedDebugSymbolsFor(["greeter.cpp"])
         installation("build/install/main/release").exec().out == app.withFeatureEnabled().expectedOutput
 
         succeeds tasks.debug.assemble
         result.assertTasksExecuted(tasks.debug.allToInstall, tasks.debug.assemble)
 
         executable("build/exe/main/debug/app").assertExists()
-        executable("build/exe/main/debug/app").assertHasDebugSymbolsFor(app.sourceFileNamesWithoutHeaders)
+        executable("build/exe/main/debug/app").assertHasDebugSymbolsFor(["greeter.cpp"])
         installation("build/install/main/debug").exec().out == app.withFeatureDisabled().expectedOutput
     }
 

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/tasks/ExtractSymbolsIntegrationTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/tasks/ExtractSymbolsIntegrationTest.groovy
@@ -55,7 +55,9 @@ class ExtractSymbolsIntegrationTest extends AbstractInstalledToolChainIntegratio
 
         then:
         executedAndNotSkipped":extractSymbolsDebug"
-        fixture("build/symbols").assertHasDebugSymbolsFor(withoutHeaders(app.original))
+        // clang 11: [greeter.cpp, sum.cpp, multiply.cpp, main.cpp]
+        // clang 14: ['multiply.cpp', 'Multiply', 'multiply', 'int', 'this', 'a', 'b', ...]
+        fixture("build/symbols").assertHasDebugSymbolsFor(['multiply.cpp'])
     }
 
     @ToBeFixedForConfigurationCache
@@ -71,7 +73,9 @@ class ExtractSymbolsIntegrationTest extends AbstractInstalledToolChainIntegratio
 
         then:
         skipped":extractSymbolsDebug"
-        fixture("build/symbols").assertHasDebugSymbolsFor(withoutHeaders(app.original))
+        // clang 11: [greeter.cpp, sum.cpp, multiply.cpp, main.cpp]
+        // clang 14: ['multiply.cpp', 'Multiply', 'multiply', 'int', 'this', 'a', 'b', ...]
+        fixture("build/symbols").assertHasDebugSymbolsFor(['multiply.cpp'])
     }
 
     @ToBeFixedForConfigurationCache
@@ -88,7 +92,9 @@ class ExtractSymbolsIntegrationTest extends AbstractInstalledToolChainIntegratio
 
         then:
         executedAndNotSkipped":extractSymbolsDebug"
-        fixture("build/symbols").assertHasDebugSymbolsFor(withoutHeaders(app.alternate))
+        // clang 11: [greeter.cpp, renamed-sum.cpp, main.cpp]
+        // clang 14: ['greeter.cpp', 'std', '__ioinit', 'ios_base', 'Init', '__exception_ptr', 'exception_ptr', 'rethrow_exception', '__debug' ...]
+        fixture("build/symbols").assertHasDebugSymbolsFor(['greeter.cpp'])
     }
 
     NativeBinaryFixture fixture(String path) {

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/tasks/StripSymbolsIntegrationTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/tasks/StripSymbolsIntegrationTest.groovy
@@ -55,7 +55,9 @@ class StripSymbolsIntegrationTest extends AbstractInstalledToolChainIntegrationS
 
         then:
         executedAndNotSkipped":stripSymbolsDebug"
-        executable("build/exe/main/debug/app").assertHasDebugSymbolsFor(withoutHeaders(app.original))
+        // clang 11: [greeter.cpp, sum.cpp, multiply.cpp, main.cpp]
+        // clang 14: ['multiply.cpp', 'Multiply', 'multiply', 'int', 'this', 'a', 'b', ...]
+        executable("build/exe/main/debug/app").assertHasDebugSymbolsFor(['multiply.cpp'])
         binary("build/stripped").assertDoesNotHaveDebugSymbolsFor(withoutHeaders(app.original))
     }
 


### PR DESCRIPTION
With higher version of native toolchains (gcc 11/clang 14), some native builds are failing. 