### PR TITLE
Fix binary compatibilty check for generated Kotlin extension functions

### DIFF
--- a/build-logic/binary-compatibility/src/main/kotlin/gradlebuild/binarycompatibility/sources/KotlinSourceQueries.kt
+++ b/build-logic/binary-compatibility/src/main/kotlin/gradlebuild/binarycompatibility/sources/KotlinSourceQueries.kt
@@ -262,11 +262,18 @@ fun CtBehavior.firstParameterMatches(ktTypeReference: KtTypeReference): Boolean 
 
 private
 fun CtClass.isLikelyEquivalentTo(ktTypeReference: KtTypeReference): Boolean {
-    if (ktTypeReference.text.contains(" -> ")) {
+    val ktTypeAsText = ktTypeReference.text
+    if (ktTypeAsText.contains(" -> ")) {
         // This is a function of some sort
         return name.startsWith("kotlin.jvm.functions.Function")
     }
-    return (primitiveTypeStrings[name] ?: name).endsWith(ktTypeReference.text.substringBefore('<'))
+
+    val ktTypeRawName = ktTypeAsText
+        .trimEnd('?') // nullability is not part of JVM types
+        .substringBefore('<') // generics are not part of parameter types in JVM method signatures
+
+    val thisTypeAsKt = primitiveTypeStrings[name] ?: name
+    return thisTypeAsKt.endsWith(ktTypeRawName)
 }
 
 

--- a/build-logic/kotlin-dsl-shared-runtime/src/main/kotlin/org/gradle/kotlin/dsl/internal/sharedruntime/codegen/ApiExtensionsGenerator.kt
+++ b/build-logic/kotlin-dsl-shared-runtime/src/main/kotlin/org/gradle/kotlin/dsl/internal/sharedruntime/codegen/ApiExtensionsGenerator.kt
@@ -334,12 +334,13 @@ data class KotlinExtensionFunction(
 
         appendReproducibleNewLine(
             """
-            /**
-             * $description.
-             *
-             * @see ${targetType.sourceName}.$name${if (since != null) "\n * @since $since" else ""}
-             */
-            """.trimIndent()
+               |/**
+               | * $description.
+               | *
+               | * @see ${targetType.sourceName}.$name
+            ${"| * @since ".appendOrNull(since) ?: ""}
+               | */
+            """.trimMargin().dropBlankLines()
         )
         if (isDeprecated) appendReproducibleNewLine("""@Deprecated("Deprecated Gradle API")""")
         if (isIncubating) appendReproducibleNewLine("@org.gradle.api.Incubating")
@@ -357,6 +358,14 @@ data class KotlinExtensionFunction(
         appendReproducibleNewLine("`$name`(${parameters.toArgumentsString()})".prependIndent())
         appendReproducibleNewLine()
     }.toString()
+
+    private
+    fun String.appendOrNull(s: String?) =
+        if (s == null) null else "$this$s"
+
+    private
+    fun String.dropBlankLines(): String =
+        lineSequence().filter(String::isNotBlank).joinToString("\n")
 
     private
     fun List<MappedApiFunctionParameter>.toDeclarationString(): String =

--- a/build-logic/kotlin-dsl-shared-runtime/src/main/kotlin/org/gradle/kotlin/dsl/internal/sharedruntime/codegen/ApiExtensionsGenerator.kt
+++ b/build-logic/kotlin-dsl-shared-runtime/src/main/kotlin/org/gradle/kotlin/dsl/internal/sharedruntime/codegen/ApiExtensionsGenerator.kt
@@ -408,9 +408,12 @@ fun Boolean.toKotlinNullabilityString(): String =
 
 private
 fun ApiTypeUsage.toTypeParameterString(): String =
-    "$sourceName${
-    bounds.takeIf { it.isNotEmpty() }?.let { " : ${it.single().toTypeParameterString()}" } ?: ""
-    }${typeArguments.toTypeParametersString(type)}${isNullable.toKotlinNullabilityString()}"
+    "$sourceName${bounds.toBoundsString()}${typeArguments.toTypeParametersString(type)}${isNullable.toKotlinNullabilityString()}"
+
+
+private
+fun List<ApiTypeUsage>.toBoundsString() =
+    takeIf { it.isNotEmpty() }?.let { " : ${it.single().toTypeParameterString()}" } ?: ""
 
 
 private


### PR DESCRIPTION
Couple different things are fixed:
- When searching for extension function target during `@since` annotation check, nullability is ignored to get the match
- Implicit class of a Kotlin file holding extension functions is now correctly annotated with `@Incubating` only when all functions the file are annotated
- Generated KDoc formatting is fixed