### PR TITLE
Use gradle init flag for defaults in basic tutorials

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/tutorial/partr1_gradle_init.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/tutorial/partr1_gradle_init.adoc
@@ -48,47 +48,10 @@ $ mkdir authoring-tutorial
 $ cd authoring-tutorial
 ----
 
-Run `gradle init` and continue with the prompt as indicated below:
-
+Run `gradle init` with parameters to generate a Java application:
 [source]
 ----
-$ gradle init
-
-Select type of project to generate:
-  1: basic
-  2: application
-  3: library
-  4: Gradle plugin
-Enter selection (default: basic) [1..4] 2
-
-Select implementation language:
-  1: C++
-  2: Groovy
-  3: Java
-  4: Kotlin
-  5: Scala
-  6: Swift
-Enter selection (default: Java) [1..6] 3
-
-Generate multiple subprojects for application? (default: no) [yes, no] no
-
-Select build script DSL:
-  1: Kotlin
-  2: Groovy
-Enter selection (default: Kotlin) [1..2] 1
-
-Select test framework:
-  1: JUnit 4
-  2: TestNG
-  3: Spock
-  4: JUnit Jupiter
-Enter selection (default: JUnit Jupiter) [1..4] 4
-
-Project name (default: authoring-tutorial):
-Source package (default: authoring.tutorial):
-
-Enter target version of Java (min. 7) (default: 19):
-Generate build using new APIs and behavior (some features may change in the next minor release)? (default: no) [yes, no]
+$ gradle init --use-defaults --type java-application
 ----
 
 NOTE: In this tutorial, Kotlin DSL is used to build a simple Java project (as it is the default DSL starting in Gradle 8.2). All examples are macOS based.
@@ -170,12 +133,12 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(19))             // <5>
+        languageVersion = JavaLanguageVersion.of(11)                // <5>
     }
 }
 
 application {
-    mainClass.set("authoring.tutorial.App")                         // <6>
+    mainClass = "org.example.App"                                   // <6>
 }
 
 tasks.named<Test>("test") {

--- a/platforms/documentation/docs/src/docs/userguide/running-builds/tutorial/part1_gradle_init.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/running-builds/tutorial/part1_gradle_init.adoc
@@ -42,7 +42,7 @@ To test the Gradle installation, run Gradle from the command-line:
 ----
 $ gradle
 
-Welcome to Gradle 8.2.
+Welcome to Gradle 8.6.
 
 Directory '/' does not contain a Gradle build.
 
@@ -61,44 +61,10 @@ $ mkdir tutorial
 $ cd tutorial
 ----
 
-Run `gradle init` and continue with the prompt as indicated below:
+Run `gradle init` with parameters to generate a Java application:
 [source]
 ----
-$ gradle init
-
-Select type of project to generate:
-  1: basic
-  2: application
-  3: library
-  4: Gradle plugin
-Enter selection (default: basic) [1..4] 2
-
-Select implementation language:
-  1: C++
-  2: Groovy
-  3: Java
-  4: Kotlin
-  5: Scala
-  6: Swift
-Enter selection (default: Java) [1..6] 3
-
-Generate multiple subprojects for application? (default: no) [yes, no] no
-Select build script DSL:
-  1: Kotlin
-  2: Groovy
-Enter selection (default: Kotlin) [1..2] 1
-
-Select test framework:
-  1: JUnit 4
-  2: TestNG
-  3: Spock
-  4: JUnit Jupiter
-Enter selection (default: JUnit Jupiter) [1..4] 4
-
-Project name (default: tutorial): tutorial
-Source package (default: tutorial): com.gradle.tutorial
-Enter target version of Java (min. 7) (default: 17): 17
-Generate build using new APIs and behavior (some features may change in the next minor release)? (default: no) [yes, no] no
+$ gradle init --use-defaults --type java-application
 ----
 
 NOTE: In this tutorial, Kotlin DSL is used to build a simple Java project (as it is the default DSL starting in Gradle 8.2). All examples are macOS based.
@@ -266,13 +232,13 @@ dependencies {
 // Apply a specific Java toolchain to ease working on different environments.
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
+        languageVersion = JavaLanguageVersion.of(11)
     }
 }
 
 application {
     // Define the main class for the application.
-    mainClass.set("com.gradle.tutorial.App")
+    mainClass = "org.example.App"
 }
 
 tasks.named<Test>("test") {


### PR DESCRIPTION
In Gradle 8.6, there is a new `gradle init --use-defaults` flag that allows to avoid interactive dialogs, which may be destructive in the introductory tutorials