### PR TITLE
Remove unused Groovy assumes from `AbstractIntegrationSpec`

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -744,14 +744,6 @@ tmpdir is currently ${System.getProperty("java.io.tmpdir")}""")
         recreateExecuter()
     }
 
-    void assumeGroovy3() {
-        Assume.assumeFalse('Requires Groovy 3', isAtLeastGroovy4)
-    }
-
-    void assumeGroovy4() {
-        Assume.assumeTrue('Requires Groovy 4', isAtLeastGroovy4)
-    }
-
     def enableProblemsApiCheck() {
         enableProblemsApiCheck = true
         buildOperationsFixture = new BuildOperationsFixture(executer, temporaryFolder)


### PR DESCRIPTION
I remembered removing these, but eventually not.

These were moved to here:
https://github.com/gradle/gradle/blob/ef6a429b1c630053333680434d823a769354f08d/subprojects/internal-testing/src/main/groovy/org/gradle/test/preconditions/UnitTestPreconditions.groovy#L533-L545