### PR TITLE
Fix encryption key instructions

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheEncryptionIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheEncryptionIntegrationTest.groovy
@@ -284,7 +284,9 @@ class ConfigurationCacheEncryptionIntegrationTest extends AbstractConfigurationC
     def "new configuration cache entry if env var key changes"() {
         given:
         def configurationCache = newConfigurationCacheFixture()
-        def differentKey = "O6lTi7qNmAAIookBZGqHqyDph882NPQOXW5P5K2yupM="
+        // Obtained via:
+        // openssl enc -aes-128-cbc -P -pbkdf2 -nosalt -k YOUR-OWN-PASSPHRASE-HERE | grep key | cut -f 2 -d = | xxd  -r -ps | base64
+        def differentKey = "yqqfx9gxQY0n9W7PQGl/zA=="
 
         when:
         runWithEncryption(EncryptionKind.ENV_VAR, ["help"], [], [(GRADLE_ENCRYPTION_KEY_ENV_KEY): this.encryptionKeyAsBase64])

--- a/platforms/documentation/docs/src/docs/userguide/optimizing-performance/configuration_cache.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/optimizing-performance/configuration_cache.adoc
@@ -1120,12 +1120,12 @@ or else Gradle will not be able to reuse existing cached configurations.
 === Generating an encryption key that is compatible with GRADLE_ENCRYPTION_KEY
 
 For Gradle to encrypt the configuration cache using a user-specified encryption key,
-you must run Gradle while having the GRADLE_ENCRYPTION_KEY environment variable set with a valid AES 128-bit key, encoded as a Base64 string.
+you must run Gradle while having the GRADLE_ENCRYPTION_KEY environment variable set with a valid AES key, encoded as a Base64 string.
 
-One way of generating a Base64-encoded AES-128 key is by using a command like this:
+One way of generating a Base64-encoded AES-compatible key is by using a command like this:
 
 ```
-❯ openssl enc -aes-128-cbc -P -base64 -pbkdf2 -nosalt -k YOUR-PASSPHRASE | grep key | cut -f 2 -d =
+❯ openssl enc -aes-128-cbc -P -pbkdf2 -nosalt -k YOUR-OWN-PASSPHRASE-HERE | grep key | cut -f 2 -d = | xxd -r -ps | base64
 ```
 
 This command should work on Linux, Mac OS, or on Windows, if using a tool like Cygwin.


### PR DESCRIPTION
Documentation fix. We now convert the hex-based key generated by `openssl` into Base64 format properly (via `xxd` and `base64` utils).