### PR TITLE
Extract `AndroidStudioProvisioningPlugin` from `PerformanceTestPlugin`

### DIFF
--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/ide/AndroidStudioProvisioningPlugin.kt
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/ide/AndroidStudioProvisioningPlugin.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gradlebuild.integrationtests.ide/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import gradlebuild.basics.BuildEnvironment
+import gradlebuild.basics.androidStudioHome
+import gradlebuild.basics.autoDownloadAndroidStudio
+import gradlebuild.basics.runAndroidStudioInHeadlessMode
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.file.RelativePath
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Copy
+import org.gradle.internal.os.OperatingSystem
+import org.gradle.kotlin.dsl.*
+import org.gradle.process.CommandLineArgumentProvider
+import java.util.concurrent.Callable
+
+// Android Studio Iguana 2023.2.1.16 Canary 16
+private const val defaultAndroidStudioVersion = "2023.2.1.16"
+
+class AndroidStudioProvisioningPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            val androidStudioProvisioningExtension = extensions
+                .create("androidStudioProvisioning", AndroidStudioProvisioningExtension::class)
+                .apply {
+                    androidStudioVersion.convention(defaultAndroidStudioVersion)
+                }
+
+            repositories {
+                ivy {
+                    // Url of Android Studio archive
+                    url = uri("https://redirector.gvt1.com/edgedl/android/studio/ide-zips")
+                    patternLayout {
+                        artifact("[revision]/[artifact]-[revision]-[ext]")
+                    }
+                    metadataSources { artifact() }
+                    content {
+                        includeGroup("android-studio")
+                    }
+                }
+            }
+
+            val androidStudioRuntime by configurations.creating
+            dependencies {
+                val extension = when {
+                    BuildEnvironment.isWindows -> "windows.zip"
+                    BuildEnvironment.isMacOsX && BuildEnvironment.isIntel -> "mac.zip"
+                    BuildEnvironment.isMacOsX && !BuildEnvironment.isIntel -> "mac_arm.zip"
+                    BuildEnvironment.isLinux -> "linux.tar.gz"
+                    else -> throw IllegalStateException("Unsupported OS: ${OperatingSystem.current()}")
+                }
+                val androidStudioDependencyProvider =
+                    androidStudioProvisioningExtension.androidStudioVersion.map { "android-studio:android-studio:$it@$extension" }
+
+                androidStudioRuntime(androidStudioDependencyProvider)
+            }
+
+            tasks.register<Copy>("unpackAndroidStudio") {
+                from(
+                    Callable {
+                        val singleFile = androidStudioRuntime.singleFile
+                        when {
+                            singleFile.name.endsWith(".tar.gz") -> tarTree(singleFile)
+                            else -> zipTree(singleFile)
+                        }
+                    }
+                ) {
+                    eachFile {
+                        // Remove top folder when unzipping, that way we get rid of Android Studio.app folder that can cause issues on Mac
+                        // where MacOS would kill the Android Studio process right after start, issue: https://github.com/gradle/gradle-profiler/issues/469
+                        relativePath = RelativePath(true, *relativePath.segments.drop(1).toTypedArray())
+                    }
+                }
+                into(layout.buildDirectory.dir("android-studio"))
+            }
+        }
+    }
+}
+
+abstract class AndroidStudioProvisioningExtension {
+
+    abstract val androidStudioVersion: Property<String>
+
+    fun androidStudioSystemProperties(project: Project, androidStudioJvmArgs: List<String>): CommandLineArgumentProvider {
+        val unpackAndroidStudio = project.tasks.named("unpackAndroidStudio", Copy::class.java)
+        val androidStudioInstallation = project.objects.newInstance<AndroidStudioInstallation>().apply {
+            studioInstallLocation.fileProvider(unpackAndroidStudio.map { it.destinationDir })
+        }
+        return AndroidStudioSystemProperties(
+            androidStudioInstallation,
+            project.autoDownloadAndroidStudio,
+            project.runAndroidStudioInHeadlessMode,
+            project.androidStudioHome,
+            androidStudioJvmArgs,
+            project.providers
+        )
+    }
+}
+
+
+
+

--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/ide/AndroidStudioProvisioningPlugin.kt
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/ide/AndroidStudioProvisioningPlugin.kt
@@ -44,8 +44,11 @@ import org.gradle.kotlin.dsl.*
 import org.gradle.process.CommandLineArgumentProvider
 import java.util.concurrent.Callable
 
+
 // Android Studio Iguana 2023.2.1.16 Canary 16
-private const val defaultAndroidStudioVersion = "2023.2.1.16"
+private
+const val defaultAndroidStudioVersion = "2023.2.1.16"
+
 
 class AndroidStudioProvisioningPlugin : Plugin<Project> {
     override fun apply(target: Project) {
@@ -107,6 +110,7 @@ class AndroidStudioProvisioningPlugin : Plugin<Project> {
     }
 }
 
+
 abstract class AndroidStudioProvisioningExtension {
 
     abstract val androidStudioVersion: Property<String>
@@ -126,7 +130,3 @@ abstract class AndroidStudioProvisioningExtension {
         )
     }
 }
-
-
-
-

--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/ide/AndroidStudioSystemProperties.kt
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/ide/AndroidStudioSystemProperties.kt
@@ -27,11 +27,14 @@ import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.process.CommandLineArgumentProvider
 
+
 abstract class AndroidStudioInstallation {
     @get:InputFiles
     @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val studioInstallLocation: DirectoryProperty
 }
+
+
 class AndroidStudioSystemProperties(
     @get:Internal
     val studioInstallation: AndroidStudioInstallation,

--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/ide/AndroidStudioSystemProperties.kt
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/ide/AndroidStudioSystemProperties.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gradlebuild.integrationtests.ide
+
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderFactory
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.process.CommandLineArgumentProvider
+
+abstract class AndroidStudioInstallation {
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val studioInstallLocation: DirectoryProperty
+}
+class AndroidStudioSystemProperties(
+    @get:Internal
+    val studioInstallation: AndroidStudioInstallation,
+    @get:Internal
+    val autoDownloadAndroidStudio: Boolean,
+    @get:Internal
+    val runAndroidStudioInHeadlessMode: Boolean,
+    @get:Internal
+    val androidStudioHome: Provider<String>,
+    @get:Internal
+    val androidStudioJvmArgs: List<String>,
+    providers: ProviderFactory
+) : CommandLineArgumentProvider {
+
+    @get:Optional
+    @get:Nested
+    val studioInstallationProvider = providers.provider {
+        if (autoDownloadAndroidStudio) {
+            studioInstallation
+        } else {
+            null
+        }
+    }
+
+    override fun asArguments(): Iterable<String> {
+        val systemProperties = mutableListOf<String>()
+        if (autoDownloadAndroidStudio) {
+            val androidStudioPath = studioInstallation.studioInstallLocation.asFile.get().absolutePath
+            systemProperties.add("-Dstudio.home=$androidStudioPath")
+        } else {
+            if (androidStudioHome.isPresent) {
+                systemProperties.add("-Dstudio.home=${androidStudioHome.get()}")
+            }
+        }
+        if (runAndroidStudioInHeadlessMode) {
+            systemProperties.add("-Dstudio.tests.headless=true")
+        }
+        if (androidStudioJvmArgs.isNotEmpty()) {
+            systemProperties.add("-DstudioJvmArgs=${androidStudioJvmArgs.joinToString(separator = ",")}")
+        }
+        return systemProperties
+    }
+}

--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/ide/AndroidStudioSystemProperties.kt
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/ide/AndroidStudioSystemProperties.kt
@@ -61,14 +61,23 @@ class AndroidStudioSystemProperties(
 
     override fun asArguments(): Iterable<String> {
         val systemProperties = mutableListOf<String>()
+        var isStudioHomeProvided = false
+
         if (autoDownloadAndroidStudio) {
             val androidStudioPath = studioInstallation.studioInstallLocation.asFile.get().absolutePath
             systemProperties.add("-Dstudio.home=$androidStudioPath")
+            isStudioHomeProvided = true
         } else {
             if (androidStudioHome.isPresent) {
                 systemProperties.add("-Dstudio.home=${androidStudioHome.get()}")
+                isStudioHomeProvided = true
             }
         }
+
+        if (!isStudioHomeProvided) {
+            throw IllegalArgumentException("Android Studio home must be provided either auto downloading must be enabled")
+        }
+
         if (runAndroidStudioInHeadlessMode) {
             systemProperties.add("-Dstudio.tests.headless=true")
         }

--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/ide/AndroidStudioSystemProperties.kt
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/ide/AndroidStudioSystemProperties.kt
@@ -61,22 +61,8 @@ class AndroidStudioSystemProperties(
 
     override fun asArguments(): Iterable<String> {
         val systemProperties = mutableListOf<String>()
-        var isStudioHomeProvided = false
 
-        if (autoDownloadAndroidStudio) {
-            val androidStudioPath = studioInstallation.studioInstallLocation.asFile.get().absolutePath
-            systemProperties.add("-Dstudio.home=$androidStudioPath")
-            isStudioHomeProvided = true
-        } else {
-            if (androidStudioHome.isPresent) {
-                systemProperties.add("-Dstudio.home=${androidStudioHome.get()}")
-                isStudioHomeProvided = true
-            }
-        }
-
-        if (!isStudioHomeProvided) {
-            throw IllegalArgumentException("Android Studio home must be provided either auto downloading must be enabled")
-        }
+        systemProperties.add(getStudioHome())
 
         if (runAndroidStudioInHeadlessMode) {
             systemProperties.add("-Dstudio.tests.headless=true")
@@ -85,5 +71,16 @@ class AndroidStudioSystemProperties(
             systemProperties.add("-DstudioJvmArgs=${androidStudioJvmArgs.joinToString(separator = ",")}")
         }
         return systemProperties
+    }
+
+    private
+    fun getStudioHome(): String {
+        if (autoDownloadAndroidStudio) {
+            val androidStudioPath = studioInstallation.studioInstallLocation.asFile.get().absolutePath
+            return "-Dstudio.home=$androidStudioPath"
+        } else if (androidStudioHome.isPresent) {
+            return "-Dstudio.home=${androidStudioHome.get()}"
+        }
+        throw IllegalArgumentException("Android Studio home must be provided either auto downloading must be enabled")
     }
 }

--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
@@ -18,13 +18,7 @@ package gradlebuild.performance
 
 import com.google.common.annotations.VisibleForTesting
 import com.gradle.enterprise.gradleplugin.testretry.TestRetryExtension
-import gradlebuild.basics.BuildEnvironment.isIntel
-import gradlebuild.basics.BuildEnvironment.isLinux
-import gradlebuild.basics.BuildEnvironment.isMacOsX
-import gradlebuild.basics.BuildEnvironment.isWindows
 import gradlebuild.basics.accessors.groovy
-import gradlebuild.basics.androidStudioHome
-import gradlebuild.basics.autoDownloadAndroidStudio
 import gradlebuild.basics.buildBranch
 import gradlebuild.basics.buildCommitId
 import gradlebuild.basics.capitalize
@@ -38,11 +32,12 @@ import gradlebuild.basics.performanceTestVerbose
 import gradlebuild.basics.propertiesForPerformanceDb
 import gradlebuild.basics.releasedVersionsFile
 import gradlebuild.basics.repoRoot
-import gradlebuild.basics.runAndroidStudioInHeadlessMode
 import gradlebuild.basics.toLowerCase
 import gradlebuild.integrationtests.addDependenciesAndConfigurations
-import gradlebuild.performance.Config.androidStudioVersion
-import gradlebuild.performance.Config.defaultAndroidStudioJvmArgs
+import gradlebuild.integrationtests.ide.AndroidStudioProvisioningExtension
+import gradlebuild.integrationtests.ide.AndroidStudioProvisioningPlugin
+import gradlebuild.performance.Config.performanceTestAndroidStudioJvmArgs
+import gradlebuild.performance.Config.performanceTestAndroidStudioVersion
 import gradlebuild.performance.generator.tasks.AbstractProjectGeneratorTask
 import gradlebuild.performance.generator.tasks.JvmProjectGeneratorTask
 import gradlebuild.performance.generator.tasks.ProjectGeneratorTask
@@ -55,22 +50,12 @@ import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.file.RelativePath
 import org.gradle.api.internal.tasks.testing.filter.DefaultTestFilter
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
-import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.ClasspathNormalizer
-import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.Delete
-import org.gradle.api.tasks.InputFiles
-import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.JavaExec
-import org.gradle.api.tasks.Nested
-import org.gradle.api.tasks.Optional
-import org.gradle.api.tasks.PathSensitive
-import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.TaskProvider
@@ -99,8 +84,8 @@ object Config {
     const val performanceTestResultsJson = "performance-tests/$performanceTestResultsJsonName"
 
     // Android Studio Iguana 2023.2.1.16 Canary 16
-    const val androidStudioVersion = "2023.2.1.16"
-    val defaultAndroidStudioJvmArgs = listOf("-Xms256m", "-Xmx4096m")
+    const val performanceTestAndroidStudioVersion = "2023.2.1.16"
+    val performanceTestAndroidStudioJvmArgs = listOf("-Xms256m", "-Xmx4096m")
 }
 
 
@@ -110,19 +95,35 @@ class PerformanceTestPlugin : Plugin<Project> {
         val performanceTestSourceSet = createPerformanceTestSourceSet()
         addPerformanceTestConfigurationAndDependencies()
         configureGeneratorTasks()
+        configureAndroidStudioProvisioning()
         val cleanTestProjectsTask = createCleanTestProjectsTask()
         val performanceTestExtension = createExtension(performanceTestSourceSet, cleanTestProjectsTask)
 
         createAndWireCommitDistributionTask(performanceTestExtension)
         createAdditionalTasks(performanceTestSourceSet)
         configureIdePlugins(performanceTestSourceSet)
-        configureAndroidStudioInstallation()
+    }
+
+    private
+    fun Project.configureAndroidStudioProvisioning() {
+        pluginManager.apply(AndroidStudioProvisioningPlugin::class)
+        extensions.configure(AndroidStudioProvisioningExtension::class) {
+            androidStudioVersion.set(performanceTestAndroidStudioVersion)
+        }
     }
 
     private
     fun Project.createExtension(performanceTestSourceSet: SourceSet, cleanTestProjectsTask: TaskProvider<Delete>): PerformanceTestExtension {
         val buildService = registerBuildService()
-        val performanceTestExtension = extensions.create<PerformanceTestExtension>("performanceTest", this, performanceTestSourceSet, cleanTestProjectsTask, buildService)
+        val androidStudioProvisioningExtension = extensions.getByType(AndroidStudioProvisioningExtension::class)
+        val performanceTestExtension = extensions.create<PerformanceTestExtension>(
+            "performanceTest",
+            this,
+            performanceTestSourceSet,
+            cleanTestProjectsTask,
+            buildService,
+            androidStudioProvisioningExtension.androidStudioSystemProperties(this, performanceTestAndroidStudioJvmArgs)
+        )
         performanceTestExtension.baselines = project.performanceBaselines
         return performanceTestExtension
     }
@@ -277,54 +278,6 @@ class PerformanceTestPlugin : Plugin<Project> {
     }
 
     private
-    fun Project.configureAndroidStudioInstallation() {
-        repositories {
-            ivy {
-                // Url of Android Studio archive
-                url = uri("https://redirector.gvt1.com/edgedl/android/studio/ide-zips")
-                patternLayout {
-                    artifact("[revision]/[artifact]-[revision]-[ext]")
-                }
-                metadataSources { artifact() }
-                content {
-                    includeGroup("android-studio")
-                }
-            }
-        }
-
-        val androidStudioRuntime by configurations.creating
-        dependencies {
-            val extension = when {
-                isWindows -> "windows.zip"
-                isMacOsX && isIntel -> "mac.zip"
-                isMacOsX && !isIntel -> "mac_arm.zip"
-                isLinux -> "linux.tar.gz"
-                else -> throw IllegalStateException("Unsupported OS: ${OperatingSystem.current()}")
-            }
-            androidStudioRuntime("android-studio:android-studio:$androidStudioVersion@$extension")
-        }
-
-        tasks.register<Copy>("unpackAndroidStudio") {
-            from(
-                Callable {
-                    val singleFile = androidStudioRuntime.singleFile
-                    when {
-                        singleFile.name.endsWith(".tar.gz") -> tarTree(singleFile)
-                        else -> zipTree(singleFile)
-                    }
-                }
-            ) {
-                eachFile {
-                    // Remove top folder when unzipping, that way we get rid of Android Studio.app folder that can cause issues on Mac
-                    // where MacOS would kill the Android Studio process right after start, issue: https://github.com/gradle/gradle-profiler/issues/469
-                    relativePath = RelativePath(true, *relativePath.segments.drop(1).toTypedArray())
-                }
-            }
-            into(layout.buildDirectory.dir("android-studio"))
-        }
-    }
-
-    private
     fun Project.registerBuildService(): Provider<PerformanceTestService> =
         gradle.sharedServices.registerIfAbsent("performanceTestService", PerformanceTestService::class) {
             maxParallelUsages = 1
@@ -382,7 +335,8 @@ class PerformanceTestExtension(
     private val project: Project,
     private val performanceSourceSet: SourceSet,
     private val cleanTestProjectsTask: TaskProvider<Delete>,
-    private val buildService: Provider<PerformanceTestService>
+    private val buildService: Provider<PerformanceTestService>,
+    private val androidProjectJvmArguments: CommandLineArgumentProvider
 ) {
     private
     val registeredPerformanceTests: MutableList<TaskProvider<out Task>> = mutableListOf()
@@ -403,25 +357,9 @@ class PerformanceTestExtension(
     fun <T : Task> registerAndroidTestProject(testProject: String, type: Class<T>, configurationAction: Action<in T>): TaskProvider<T> {
         return doRegisterTestProject(testProject, type, configurationAction) {
             // AndroidStudio jvmArgs could be set per project, but at the moment that is not necessary
-            jvmArgumentProviders.add(getAndroidProjectJvmArguments(defaultAndroidStudioJvmArgs))
+            jvmArgumentProviders.add(androidProjectJvmArguments)
             environment("JAVA_HOME", LazyEnvironmentVariable { javaLauncher.get().metadata.installationPath.asFile.absolutePath })
         }
-    }
-
-    private
-    fun getAndroidProjectJvmArguments(androidStudioJvmArgs: List<String>): CommandLineArgumentProvider {
-        val unpackAndroidStudio = project.tasks.named("unpackAndroidStudio", Copy::class.java)
-        val androidStudioInstallation = project.objects.newInstance<AndroidStudioInstallation>().apply {
-            studioInstallLocation.fileProvider(unpackAndroidStudio.map { it.destinationDir })
-        }
-        return AndroidStudioSystemProperties(
-            androidStudioInstallation,
-            project.autoDownloadAndroidStudio,
-            project.runAndroidStudioInHeadlessMode,
-            project.androidStudioHome,
-            androidStudioJvmArgs,
-            project.providers
-        )
     }
 
     private
@@ -545,58 +483,6 @@ class PerformanceTestExtension(
             destinationDirectory = project.layout.buildDirectory
             archiveFileName = "test-results-${junitXmlDir.name}.zip"
         }
-}
-
-
-abstract class AndroidStudioInstallation {
-    @get:InputFiles
-    @get:PathSensitive(PathSensitivity.RELATIVE)
-    abstract val studioInstallLocation: DirectoryProperty
-}
-
-
-class AndroidStudioSystemProperties(
-    @get:Internal
-    val studioInstallation: AndroidStudioInstallation,
-    @get:Internal
-    val autoDownloadAndroidStudio: Boolean,
-    @get:Internal
-    val runAndroidStudioInHeadlessMode: Boolean,
-    @get:Internal
-    val androidStudioHome: Provider<String>,
-    @get:Internal
-    val androidStudioJvmArgs: List<String>,
-    providers: ProviderFactory
-) : CommandLineArgumentProvider {
-
-    @get:Optional
-    @get:Nested
-    val studioInstallationProvider = providers.provider {
-        if (autoDownloadAndroidStudio) {
-            studioInstallation
-        } else {
-            null
-        }
-    }
-
-    override fun asArguments(): Iterable<String> {
-        val systemProperties = mutableListOf<String>()
-        if (autoDownloadAndroidStudio) {
-            val androidStudioPath = studioInstallation.studioInstallLocation.asFile.get().absolutePath
-            systemProperties.add("-Dstudio.home=$androidStudioPath")
-        } else {
-            if (androidStudioHome.isPresent) {
-                systemProperties.add("-Dstudio.home=${androidStudioHome.get()}")
-            }
-        }
-        if (runAndroidStudioInHeadlessMode) {
-            systemProperties.add("-Dstudio.tests.headless=true")
-        }
-        if (androidStudioJvmArgs.isNotEmpty()) {
-            systemProperties.add("-DstudioJvmArgs=${androidStudioJvmArgs.joinToString(separator = ",")}")
-        }
-        return systemProperties
-    }
 }
 
 


### PR DESCRIPTION
Fixes #27499 

We want to reuse PerformanceTest AndroidStudio provisioning infrastructure in a new type of integration tests in CC project. These tests are going to test sync with AndroidStudio (and IDEA in future), so it need to obtain an IDE somehow. 

This PR is extracting logic of AS provisioning from `PerformanceTestPlugin` to `AndroidStudioProvisioningPlugin` as is.
Also, `AndroidStudioProvisioningPlugin` is allowing to configure a version of AndroidStudio that will be provided. 