### PR TITLE
Fix issue with buildscript classpath state being discarded

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/DeprecatedConfigurationUsageIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/DeprecatedConfigurationUsageIntegrationTest.groovy
@@ -100,18 +100,18 @@ class DeprecatedConfigurationUsageIntegrationTest extends AbstractIntegrationSpe
         succeeds('help')
 
         where:
-        methodName                         | role              | methodCall                         || allowed
-        'setExcludeRules(Set)'             | 'consumable'      | "setExcludeRules([] as Set)"       || [ProperMethodUsage.DECLARABLE_AGAINST, ProperMethodUsage.RESOLVABLE]
-        'getConsistentResolutionSource()'  | 'consumable'      | "getConsistentResolutionSource()"  || [ProperMethodUsage.RESOLVABLE]
-        'getConsistentResolutionSource()'  | 'dependencyScope' | "getConsistentResolutionSource()"  || [ProperMethodUsage.RESOLVABLE]
-        'getDependenciesResolverFactory()' | 'consumable'      | "getDependenciesResolverFactory()" || [ProperMethodUsage.RESOLVABLE]
-        'getDependenciesResolverFactory()' | 'dependencyScope' | "getDependenciesResolverFactory()" || [ProperMethodUsage.RESOLVABLE]
-        'getSyntheticDependencies()'       | 'consumable'      | "getSyntheticDependencies()"       || [ProperMethodUsage.RESOLVABLE]
-        'getSyntheticDependencies()'       | 'dependencyScope' | "getSyntheticDependencies()"       || [ProperMethodUsage.RESOLVABLE]
-        'resetResolutionState()'           | 'consumable'      | "resetResolutionState()"           || [ProperMethodUsage.RESOLVABLE]
-        'resetResolutionState()'           | 'dependencyScope' | "resetResolutionState()"           || [ProperMethodUsage.RESOLVABLE]
-        'toRootComponent()'                | 'consumable'      | "toRootComponent()"                || [ProperMethodUsage.RESOLVABLE]
-        'toRootComponent()'                | 'dependencyScope' | "toRootComponent()"                || [ProperMethodUsage.RESOLVABLE]
+        methodName                         | role              | methodCall                           || allowed
+        'setExcludeRules(Set)'             | 'consumable'      | "setExcludeRules([] as Set)"         || [ProperMethodUsage.DECLARABLE_AGAINST, ProperMethodUsage.RESOLVABLE]
+        'getConsistentResolutionSource()'  | 'consumable'      | "getConsistentResolutionSource()"    || [ProperMethodUsage.RESOLVABLE]
+        'getConsistentResolutionSource()'  | 'dependencyScope' | "getConsistentResolutionSource()"    || [ProperMethodUsage.RESOLVABLE]
+        'getDependenciesResolverFactory()' | 'consumable'      | "getDependenciesResolverFactory()"   || [ProperMethodUsage.RESOLVABLE]
+        'getDependenciesResolverFactory()' | 'dependencyScope' | "getDependenciesResolverFactory()"   || [ProperMethodUsage.RESOLVABLE]
+        'getSyntheticDependencies()'       | 'consumable'      | "getSyntheticDependencies()"         || [ProperMethodUsage.RESOLVABLE]
+        'getSyntheticDependencies()'       | 'dependencyScope' | "getSyntheticDependencies()"         || [ProperMethodUsage.RESOLVABLE]
+        'resetResolutionState()'           | 'consumable'      | "withResetResolutionState { 'foo' }" || [ProperMethodUsage.RESOLVABLE]
+        'resetResolutionState()'           | 'dependencyScope' | "withResetResolutionState { 'foo' }" || [ProperMethodUsage.RESOLVABLE]
+        'toRootComponent()'                | 'consumable'      | "toRootComponent()"                  || [ProperMethodUsage.RESOLVABLE]
+        'toRootComponent()'                | 'dependencyScope' | "toRootComponent()"                  || [ProperMethodUsage.RESOLVABLE]
     }
 
     def "forcing resolve of a non-resolvable configuration via calling invalid internal API method #methodName for role #role warns and then throws an exception"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/DeprecatedConfigurationUsageIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/DeprecatedConfigurationUsageIntegrationTest.groovy
@@ -100,18 +100,18 @@ class DeprecatedConfigurationUsageIntegrationTest extends AbstractIntegrationSpe
         succeeds('help')
 
         where:
-        methodName                         | role              | methodCall                           || allowed
-        'setExcludeRules(Set)'             | 'consumable'      | "setExcludeRules([] as Set)"         || [ProperMethodUsage.DECLARABLE_AGAINST, ProperMethodUsage.RESOLVABLE]
-        'getConsistentResolutionSource()'  | 'consumable'      | "getConsistentResolutionSource()"    || [ProperMethodUsage.RESOLVABLE]
-        'getConsistentResolutionSource()'  | 'dependencyScope' | "getConsistentResolutionSource()"    || [ProperMethodUsage.RESOLVABLE]
-        'getDependenciesResolverFactory()' | 'consumable'      | "getDependenciesResolverFactory()"   || [ProperMethodUsage.RESOLVABLE]
-        'getDependenciesResolverFactory()' | 'dependencyScope' | "getDependenciesResolverFactory()"   || [ProperMethodUsage.RESOLVABLE]
-        'getSyntheticDependencies()'       | 'consumable'      | "getSyntheticDependencies()"         || [ProperMethodUsage.RESOLVABLE]
-        'getSyntheticDependencies()'       | 'dependencyScope' | "getSyntheticDependencies()"         || [ProperMethodUsage.RESOLVABLE]
-        'resetResolutionState()'           | 'consumable'      | "withResetResolutionState { 'foo' }" || [ProperMethodUsage.RESOLVABLE]
-        'resetResolutionState()'           | 'dependencyScope' | "withResetResolutionState { 'foo' }" || [ProperMethodUsage.RESOLVABLE]
-        'toRootComponent()'                | 'consumable'      | "toRootComponent()"                  || [ProperMethodUsage.RESOLVABLE]
-        'toRootComponent()'                | 'dependencyScope' | "toRootComponent()"                  || [ProperMethodUsage.RESOLVABLE]
+        methodName                         | role              | methodCall                              || allowed
+        'setExcludeRules(Set)'             | 'consumable'      | "setExcludeRules([] as Set)"            || [ProperMethodUsage.DECLARABLE_AGAINST, ProperMethodUsage.RESOLVABLE]
+        'getConsistentResolutionSource()'  | 'consumable'      | "getConsistentResolutionSource()"       || [ProperMethodUsage.RESOLVABLE]
+        'getConsistentResolutionSource()'  | 'dependencyScope' | "getConsistentResolutionSource()"       || [ProperMethodUsage.RESOLVABLE]
+        'getDependenciesResolverFactory()' | 'consumable'      | "getDependenciesResolverFactory()"      || [ProperMethodUsage.RESOLVABLE]
+        'getDependenciesResolverFactory()' | 'dependencyScope' | "getDependenciesResolverFactory()"      || [ProperMethodUsage.RESOLVABLE]
+        'getSyntheticDependencies()'       | 'consumable'      | "getSyntheticDependencies()"            || [ProperMethodUsage.RESOLVABLE]
+        'getSyntheticDependencies()'       | 'dependencyScope' | "getSyntheticDependencies()"            || [ProperMethodUsage.RESOLVABLE]
+        'callAndResetResolutionState()'    | 'consumable'      | "callAndResetResolutionState { 'foo' }" || [ProperMethodUsage.RESOLVABLE]
+        'callAndResetResolutionState()'    | 'dependencyScope' | "callAndResetResolutionState { 'foo' }" || [ProperMethodUsage.RESOLVABLE]
+        'toRootComponent()'                | 'consumable'      | "toRootComponent()"                     || [ProperMethodUsage.RESOLVABLE]
+        'toRootComponent()'                | 'dependencyScope' | "toRootComponent()"                     || [ProperMethodUsage.RESOLVABLE]
     }
 
     def "forcing resolve of a non-resolvable configuration via calling invalid internal API method #methodName for role #role warns and then throws an exception"() {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -865,7 +865,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
 
     @Override
     public <T> T withResetResolutionState(Factory<T> factory) {
-        warnOnInvalidInternalAPIUsage("resetResolutionState()", ProperMethodUsage.RESOLVABLE);
+        warnOnInvalidInternalAPIUsage("withResetResolutionState()", ProperMethodUsage.RESOLVABLE);
         try {
             // Prevent the state required for resolution from being discarded if anything in the
             // factory resolves this configuration

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -869,12 +869,12 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
         try {
             // Prevent the state required for resolution from being discarded if anything in the
             // factory resolves this configuration
-            getResolutionStrategy().setKeepStateRequiredForGraphResolution(false);
+            getResolutionStrategy().setKeepStateRequiredForGraphResolution(true);
 
             return factory.create();
         } finally {
             // Reset this configuration to an unresolved state
-            getResolutionStrategy().setKeepStateRequiredForGraphResolution(true);
+            getResolutionStrategy().setKeepStateRequiredForGraphResolution(false);
             currentResolveState.set(ResolveState.NOT_RESOLVED);
         }
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -732,7 +732,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
                 // Discard State
                 dependencyResolutionListeners.removeAll();
                 if (resolutionStrategy != null) {
-                    resolutionStrategy.discardStateRequiredForGraphResolution();
+                    resolutionStrategy.maybeDiscardStateRequiredForGraphResolution();
                 }
 
                 captureBuildOperationResult(context, results);
@@ -864,17 +864,17 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
     }
 
     @Override
-    public <T> T withResetResolutionState(Factory<T> factory) {
-        warnOnInvalidInternalAPIUsage("withResetResolutionState()", ProperMethodUsage.RESOLVABLE);
+    public <T> T callAndResetResolutionState(Factory<T> factory) {
+        warnOnInvalidInternalAPIUsage("callAndResetResolutionState()", ProperMethodUsage.RESOLVABLE);
         try {
             // Prevent the state required for resolution from being discarded if anything in the
             // factory resolves this configuration
-            getResolutionStrategy().setResolutionShouldBeFinal(false);
+            getResolutionStrategy().setKeepStateRequiredForGraphResolution(false);
 
             return factory.create();
         } finally {
             // Reset this configuration to an unresolved state
-            getResolutionStrategy().setResolutionShouldBeFinal(true);
+            getResolutionStrategy().setKeepStateRequiredForGraphResolution(true);
             currentResolveState.set(ResolveState.NOT_RESOLVED);
         }
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionStrategyInternal.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionStrategyInternal.java
@@ -32,9 +32,9 @@ public interface ResolutionStrategyInternal extends ResolutionStrategy {
 
     /**
      * Sets whether or not any configuration resolution is final and the state required for resolution can be
-     * discarded.  Setting this to false implies that the configuration may be re-resolved again in the future.
+     * discarded.  Setting this to true implies that the configuration may be re-resolved again in the future.
      *
-     * Defaults to true.
+     * Defaults to false.
      */
     void setKeepStateRequiredForGraphResolution(boolean keepStateRequiredForGraphResolution);
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionStrategyInternal.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionStrategyInternal.java
@@ -31,6 +31,14 @@ public interface ResolutionStrategyInternal extends ResolutionStrategy {
     void discardStateRequiredForGraphResolution();
 
     /**
+     * Sets whether or not any configuration resolution is final and the state required for resolution can be
+     * discarded.  Setting this to false implies that the configuration may be re-resolved again in the future.
+     *
+     * Defaults to true.
+     */
+    void setResolutionShouldBeFinal(boolean resolutionShouldBeFinal);
+
+    /**
      * Gets the current expiry policy for dynamic revisions.
      *
      * @return the expiry policy

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionStrategyInternal.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionStrategyInternal.java
@@ -28,7 +28,7 @@ public interface ResolutionStrategyInternal extends ResolutionStrategy {
     /**
      * Discard any configuration state that is not required after graph resolution has been attempted.
      */
-    void discardStateRequiredForGraphResolution();
+    void maybeDiscardStateRequiredForGraphResolution();
 
     /**
      * Sets whether or not any configuration resolution is final and the state required for resolution can be
@@ -36,7 +36,7 @@ public interface ResolutionStrategyInternal extends ResolutionStrategy {
      *
      * Defaults to true.
      */
-    void setResolutionShouldBeFinal(boolean resolutionShouldBeFinal);
+    void setKeepStateRequiredForGraphResolution(boolean keepStateRequiredForGraphResolution);
 
     /**
      * Gets the current expiry policy for dynamic revisions.

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
@@ -81,7 +81,7 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
     private boolean verifyDependencies = true;
     private final Property<Boolean> useGlobalDependencySubstitutionRules;
     private boolean returnAllVariants = false;
-    private boolean keepStateRequiredForGraphResolution = true;
+    private boolean keepStateRequiredForGraphResolution = false;
 
     public DefaultResolutionStrategy(
         DependencySubstitutionRules globalDependencySubstitutionRules,
@@ -124,7 +124,7 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
 
     @Override
     public void maybeDiscardStateRequiredForGraphResolution() {
-        if (keepStateRequiredForGraphResolution) {
+        if (!keepStateRequiredForGraphResolution) {
             dependencySubstitutions.discard();
         }
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
@@ -81,7 +81,7 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
     private boolean verifyDependencies = true;
     private final Property<Boolean> useGlobalDependencySubstitutionRules;
     private boolean returnAllVariants = false;
-    private boolean resolutionShouldBeFinal = true;
+    private boolean keepStateRequiredForGraphResolution = true;
 
     public DefaultResolutionStrategy(
         DependencySubstitutionRules globalDependencySubstitutionRules,
@@ -123,8 +123,8 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
     }
 
     @Override
-    public void discardStateRequiredForGraphResolution() {
-        if (resolutionShouldBeFinal) {
+    public void maybeDiscardStateRequiredForGraphResolution() {
+        if (keepStateRequiredForGraphResolution) {
             dependencySubstitutions.discard();
         }
     }
@@ -415,7 +415,7 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
     }
 
     @Override
-    public void setResolutionShouldBeFinal(boolean resolutionShouldBeFinal) {
-        this.resolutionShouldBeFinal = resolutionShouldBeFinal;
+    public void setKeepStateRequiredForGraphResolution(boolean keepStateRequiredForGraphResolution) {
+        this.keepStateRequiredForGraphResolution = keepStateRequiredForGraphResolution;
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
@@ -81,6 +81,7 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
     private boolean verifyDependencies = true;
     private final Property<Boolean> useGlobalDependencySubstitutionRules;
     private boolean returnAllVariants = false;
+    private boolean resolutionShouldBeFinal = true;
 
     public DefaultResolutionStrategy(
         DependencySubstitutionRules globalDependencySubstitutionRules,
@@ -123,7 +124,9 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
 
     @Override
     public void discardStateRequiredForGraphResolution() {
-        dependencySubstitutions.discard();
+        if (resolutionShouldBeFinal) {
+            dependencySubstitutions.discard();
+        }
     }
 
     @Override
@@ -409,5 +412,10 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
     @Override
     public boolean getReturnAllVariants() {
         return this.returnAllVariants;
+    }
+
+    @Override
+    public void setResolutionShouldBeFinal(boolean resolutionShouldBeFinal) {
+        this.resolutionShouldBeFinal = resolutionShouldBeFinal;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
@@ -105,7 +105,7 @@ public class DefaultScriptHandler implements ScriptHandler, ScriptHandlerInterna
                 if (getBoolean(DISABLE_RESET_CONFIGURATION_SYSTEM_PROPERTY)) {
                     resolvedClasspath = classPathFactory.create();
                 } else {
-                    resolvedClasspath = ((ResettableConfiguration) classpathConfiguration).withResetResolutionState(classPathFactory);
+                    resolvedClasspath = ((ResettableConfiguration) classpathConfiguration).callAndResetResolutionState(classPathFactory);
                 }
             } else {
                 resolvedClasspath = ClassPath.EMPTY;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
@@ -31,6 +31,7 @@ import org.gradle.api.internal.artifacts.configurations.RoleBasedConfigurationCo
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.groovy.scripts.ScriptSource;
+import org.gradle.internal.Factory;
 import org.gradle.internal.classloader.ClasspathUtil;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.resource.ResourceLocation;
@@ -99,9 +100,12 @@ public class DefaultScriptHandler implements ScriptHandler, ScriptHandlerInterna
     public ClassPath getInstrumentedScriptClassPath() {
         if (resolvedClasspath == null) {
             if (classpathConfiguration != null) {
-                resolvedClasspath = buildLogicBuilder.resolveClassPath(classpathConfiguration, dependencyHandler, configContainer);
-                if (!getBoolean(DISABLE_RESET_CONFIGURATION_SYSTEM_PROPERTY)) {
-                    ((ResettableConfiguration) classpathConfiguration).resetResolutionState();
+
+                Factory<ClassPath> classPathFactory = () -> buildLogicBuilder.resolveClassPath(classpathConfiguration, dependencyHandler, configContainer);
+                if (getBoolean(DISABLE_RESET_CONFIGURATION_SYSTEM_PROPERTY)) {
+                    resolvedClasspath = classPathFactory.create();
+                } else {
+                    resolvedClasspath = ((ResettableConfiguration) classpathConfiguration).withResetResolutionState(classPathFactory);
                 }
             } else {
                 resolvedClasspath = ClassPath.EMPTY;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/ResettableConfiguration.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/ResettableConfiguration.java
@@ -17,6 +17,9 @@
 package org.gradle.api.internal.initialization;
 
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.internal.Factory;
+
+import javax.annotation.Nullable;
 
 /**
  * A {@link Configuration} which can reset its resolution state. This interface is
@@ -26,12 +29,14 @@ import org.gradle.api.artifacts.Configuration;
 public interface ResettableConfiguration extends Configuration {
 
     /**
-     * Reset this Configuration's resolution state to the unresolved state, discarding any
-     * cached resolution results. No other state is reconfigured. The configuration remains
-     * immutable if resolution has already occurred. Any hooks or actions which ran when the
-     * configuration was originally resolved may or may not run again if this configuration
+     * Call this factory (which presumably resolves this Configuration) and then reset the resolution state
+     * to the unresolved state, discarding any cached resolution results. No other state is reconfigured.
+     * The configuration remains immutable if resolution has already occurred. Any hooks or actions which
+     * ran when the configuration was originally resolved may or may not run again if this configuration
      * is resolved again. Any side-effects or external caching which occur as a part of or
-     * after this configuration's resolution are not reversed or invalidated.
+     * after this configuration's resolution are not reversed or invalidated.  Note that calling this method
+     * will discard the resolution <i>results</i> but will prevent any state required to resolve the
+     * configuration again from being discarded.
      * <p>
      * <strong>This method should be avoided if at all possible, and should only be used as a last resort.</strong>
      * This method was originally added in order to release the resources of the {@code classpath}
@@ -47,6 +52,7 @@ public interface ResettableConfiguration extends Configuration {
      * @implSpec Usage: This method should only be called on resolvable configurations and should throw an exception if
      * called on a configuration that does not permit this usage.
      */
-    void resetResolutionState();
+    @Nullable
+    <T> T withResetResolutionState(Factory<T> factory);
 
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/ResettableConfiguration.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/ResettableConfiguration.java
@@ -53,6 +53,6 @@ public interface ResettableConfiguration extends Configuration {
      * called on a configuration that does not permit this usage.
      */
     @Nullable
-    <T> T withResetResolutionState(Factory<T> factory);
+    <T> T callAndResetResolutionState(Factory<T> factory);
 
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultScriptHandlerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultScriptHandlerTest.groovy
@@ -105,7 +105,7 @@ class DefaultScriptHandlerTest extends Specification {
         1 * depMgmtServices.configurationContainer >> configurationContainer
         1 * depMgmtServices.dependencyHandler >> dependencyHandler
         1 * configurationContainer.migratingUnlocked('classpath', ConfigurationRolesForMigration.LEGACY_TO_RESOLVABLE_DEPENDENCY_SCOPE) >> configuration
-        1 * configuration.withResetResolutionState(_) >> { args -> args[0].create() }
+        1 * configuration.callAndResetResolutionState(_) >> { args -> args[0].create() }
         1 * buildLogicBuilder.prepareClassPath(configuration, dependencyHandler)
         1 * buildLogicBuilder.resolveClassPath(configuration, dependencyHandler, configurationContainer) >> classpath
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultScriptHandlerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultScriptHandlerTest.groovy
@@ -105,6 +105,7 @@ class DefaultScriptHandlerTest extends Specification {
         1 * depMgmtServices.configurationContainer >> configurationContainer
         1 * depMgmtServices.dependencyHandler >> dependencyHandler
         1 * configurationContainer.migratingUnlocked('classpath', ConfigurationRolesForMigration.LEGACY_TO_RESOLVABLE_DEPENDENCY_SCOPE) >> configuration
+        1 * configuration.withResetResolutionState(_) >> { args -> args[0].create() }
         1 * buildLogicBuilder.prepareClassPath(configuration, dependencyHandler)
         1 * buildLogicBuilder.resolveClassPath(configuration, dependencyHandler, configurationContainer) >> classpath
     }


### PR DESCRIPTION
This prevents the state required for resolving the buildscript classpath from being discarded when we discard the resolution results.  This allows the `buildEnvironment` task to correctly re-resolve the buildscript classpath later.

Fixes #27521 

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
