### PR TITLE
Support conventions and incremental updates on composite properties

### DIFF
--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
@@ -255,15 +255,26 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
         return this;
     }
 
-    @Override
-    public ConfigurableFileCollection setToConventionIfUnset() {
+    /**
+     * Sets the value of the property to the current convention value, if an explicit
+     * value has not been set yet.
+     *
+     * If the property has no convention set at the time this method is invoked,
+     * or if an explicit value has already been set, it has no effect.
+     */
+    protected ConfigurableFileCollection setToConventionIfUnset() {
         assertMutable();
         value = valueState.setToConventionIfUnset(value);
         return this;
     }
 
-    @Override
-    public SupportsConvention setToConvention() {
+    /**
+     * Sets the value of the property to the current convention value, replacing whatever explicit value the property already had.
+     *
+     * If the property has no convention set at the time this method is invoked,
+     * the effect of invoking it is similar to invoking {@link #unset()}.
+     */
+    protected SupportsConvention setToConvention() {
         assertMutable();
         value = valueState.setToConvention();
         return this;

--- a/platforms/core-configuration/model-core/build.gradle.kts
+++ b/platforms/core-configuration/model-core/build.gradle.kts
@@ -77,4 +77,7 @@ packageCycles {
     excludePatterns.add("org/gradle/model/internal/manage/schema/**")
     excludePatterns.add("org/gradle/model/internal/type/**")
     excludePatterns.add("org/gradle/api/internal/plugins/*")
+    // cycle between org.gradle.api.internal.provider and org.gradle.util.internal
+    // (api.internal.provider -> ConfigureUtil, DeferredUtil -> api.internal.provider)
+    excludePatterns.add("org/gradle/util/internal/*")
 }

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/ProviderConventionMappingIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/ProviderConventionMappingIntegrationTest.groovy
@@ -96,7 +96,7 @@ class ProviderConventionMappingIntegrationTest extends AbstractIntegrationSpec {
         failureHasCause("Cannot get the value of task ':mytask' property 'bar' of type $String.name as the provider associated with this property returned a value of type $DefaultProvider.name.")
     }
 
-    def "emits deprecation warning when convention mapping is used with MapProperty"() {
+    def "convention mapping can be used with MapProperty"() {
         buildFile << """
             abstract class MyTask extends DefaultTask {
                 @Internal abstract MapProperty<String, String> getFoo()
@@ -114,11 +114,10 @@ class ProviderConventionMappingIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
-        runAndFail 'mytask'
-        expectDocumentedFailure()
+        succeeds 'mytask'
     }
 
-    def "emits deprecation warning when convention mapping is used with ListProperty"() {
+    def "convention mapping can be used with ListProperty"() {
         buildFile << """
             abstract class MyTask extends DefaultTask {
                 @Internal abstract ListProperty<String> getFoo()
@@ -136,8 +135,7 @@ class ProviderConventionMappingIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
-        runAndFail 'mytask'
-        expectDocumentedFailure()
+        succeeds 'mytask'
     }
 
     def "convention mapping works with Property in a ConventionTask"() {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
@@ -30,6 +30,7 @@ import org.gradle.api.internal.provider.Collectors.SingleElement;
 import org.gradle.api.provider.CollectionPropertyConfigurer;
 import org.gradle.api.provider.HasMultipleValues;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.SupportsConvention;
 import org.gradle.internal.Cast;
 import org.gradle.util.internal.ConfigureUtil;
 
@@ -38,8 +39,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Supplier;
-
-import static org.gradle.internal.Cast.uncheckedNonnullCast;
 
 public abstract class AbstractCollectionProperty<T, C extends Collection<T>>
     extends AbstractProperty<C, AbstractCollectionProperty.CollectionSupplierGuard<T, C>>
@@ -190,8 +189,7 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>>
     @Override
     public void set(@Nullable final Iterable<? extends T> elements) {
         if (elements == null) {
-            discardValue();
-            defaultValue = noValueSupplier();
+            unset();
         } else {
             setSupplier(new CollectingSupplier(new ElementsFromCollection<>(elements)));
         }
@@ -213,6 +211,13 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>>
             }
         }
         setSupplier(new CollectingSupplier(new ElementsFromCollectionProvider<>(p)));
+    }
+
+    @Override
+    public SupportsConvention unset() {
+        discardValue();
+        defaultValue = noValueSupplier();
+        return this;
     }
 
     @Override
@@ -258,7 +263,7 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>>
     @Override
     public HasMultipleValues<T> convention(@Nullable Iterable<? extends T> elements) {
         if (elements == null) {
-            setConvention(noValueSupplier());
+            unsetConvention();
         } else {
             setConvention(new CollectingSupplier(new ElementsFromCollection<>(elements)));
         }
@@ -269,26 +274,6 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>>
     public HasMultipleValues<T> convention(Provider<? extends Iterable<? extends T>> provider) {
         setConvention(new CollectingSupplier(new ElementsFromCollectionProvider<>(Providers.internal(provider))));
         return this;
-    }
-
-    @Override
-    public HasMultipleValues<T> unsetConvention() {
-        return convention((Iterable<? extends T>) null);
-    }
-
-    @Override
-    public HasMultipleValues<T> unset() {
-        return value((Iterable<? extends T>) null);
-    }
-
-    @Override
-    public HasMultipleValues<T> setToConvention() {
-        return uncheckedNonnullCast(super.setToConvention());
-    }
-
-    @Override
-    public HasMultipleValues<T> setToConventionIfUnset() {
-        return uncheckedNonnullCast(super.setToConventionIfUnset());
     }
 
     @Override

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
@@ -213,6 +213,7 @@ public abstract class AbstractProperty<T, S extends AbstractMinimalProvider.Guar
         state.disallowChangesAndFinalizeOnNextGet();
     }
 
+    @Override
     public void disallowUnsafeRead() {
         state.disallowUnsafeRead();
     }
@@ -280,12 +281,39 @@ public abstract class AbstractProperty<T, S extends AbstractMinimalProvider.Guar
         value = state.applyConvention(value, getDefaultConvention());
     }
 
-    public SupportsConvention setToConvention() {
+    @Override
+    public SupportsConvention unsetConvention() {
+        discardConvention();
+        return this;
+    }
+
+    @Override
+    public SupportsConvention unset() {
+        discardValue();
+        return this;
+    }
+
+    /**
+     * Sets the value of the property to the current convention value, replacing whatever explicit value the property already had.
+     *
+     * If the property has no convention set at the time this method is invoked,
+     * the effect of invoking it is similar to invoking {@link #unset()}.
+     */
+    protected SupportsConvention setToConvention() {
+        assertCanMutate();
         this.value = state.setToConvention();
         return this;
     }
 
-    public SupportsConvention setToConventionIfUnset() {
+    /**
+     * Sets the value of the property to the current convention value, if an explicit
+     * value has not been set yet.
+     *
+     * If the property has no convention set at the time this method is invoked,
+     * or if an explicit value has already been set, it has no effect.
+     */
+    protected SupportsConvention setToConventionIfUnset() {
+        assertCanMutate();
         if (!isDefaultConvention()) {
             this.value = state.setToConventionIfUnset(value);
         }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.provider;
 
 import org.gradle.api.Task;
+import org.gradle.api.provider.SupportsConvention;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.UncheckedException;
@@ -52,6 +53,10 @@ public abstract class AbstractProperty<T, S extends AbstractMinimalProvider.Guar
     @Override
     public boolean isFinalized() {
         return state.isFinalized();
+    }
+
+    protected boolean isExplicit() {
+        return state.isExplicit();
     }
 
     @Override
@@ -117,6 +122,10 @@ public abstract class AbstractProperty<T, S extends AbstractMinimalProvider.Guar
 
     protected S getSupplier() {
         return value;
+    }
+
+    protected S getConventionSupplier() {
+        return state.convention();
     }
 
     protected Value<? extends T> calculateOwnValueNoProducer(ValueConsumer consumer) {
@@ -262,6 +271,26 @@ public abstract class AbstractProperty<T, S extends AbstractMinimalProvider.Guar
         assertCanMutate();
         value = state.implicitValue();
     }
+
+    /**
+     * Discards the convention of this property.
+     */
+    protected void discardConvention() {
+        assertCanMutate();
+        value = state.applyConvention(value, getDefaultConvention());
+    }
+
+    public SupportsConvention setToConvention() {
+        this.value = state.setToConvention();
+        return this;
+    }
+
+    public SupportsConvention setToConventionIfUnset() {
+        this.value = state.setToConventionIfUnset(value);
+        return this;
+    }
+
+    protected abstract S getDefaultConvention();
 
     protected void assertCanMutate() {
         state.beforeMutate(this.getDisplayName());

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
@@ -286,11 +286,18 @@ public abstract class AbstractProperty<T, S extends AbstractMinimalProvider.Guar
     }
 
     public SupportsConvention setToConventionIfUnset() {
-        this.value = state.setToConventionIfUnset(value);
+        if (!isDefaultConvention()) {
+            this.value = state.setToConventionIfUnset(value);
+        }
         return this;
     }
 
     protected abstract S getDefaultConvention();
+
+    /**
+     * Is convention set to the initial convention value?
+     */
+    protected abstract boolean isDefaultConvention();
 
     protected void assertCanMutate() {
         state.beforeMutate(this.getDisplayName());

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultListProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultListProperty.java
@@ -106,14 +106,4 @@ public class DefaultListProperty<T> extends AbstractCollectionProperty<T, List<T
     public ListProperty<T> unsetConvention() {
         return uncheckedNonnullCast(super.unsetConvention());
     }
-
-    @Override
-    public ListProperty<T> setToConvention() {
-        return uncheckedNonnullCast(super.setToConvention());
-    }
-
-    @Override
-    public ListProperty<T> setToConventionIfUnset() {
-        return uncheckedNonnullCast(super.setToConventionIfUnset());
-    }
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultListProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultListProperty.java
@@ -18,6 +18,9 @@ package org.gradle.api.internal.provider;
 
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
+import org.gradle.api.Action;
+import org.gradle.api.provider.CollectionPropertyConfigurer;
+import org.gradle.api.provider.HasMultipleValues;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.Cast;
@@ -25,6 +28,8 @@ import org.gradle.internal.Cast;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.function.Supplier;
+
+import static org.gradle.internal.Cast.uncheckedNonnullCast;
 
 public class DefaultListProperty<T> extends AbstractCollectionProperty<T, List<T>> implements ListProperty<T> {
     private static final Supplier<ImmutableCollection.Builder<Object>> FACTORY = new Supplier<ImmutableCollection.Builder<Object>>() {
@@ -80,5 +85,30 @@ public class DefaultListProperty<T> extends AbstractCollectionProperty<T, List<T
     public ListProperty<T> convention(Provider<? extends Iterable<? extends T>> provider) {
         super.convention(provider);
         return this;
+    }
+
+    @Override
+    public HasMultipleValues<T> withActualValue(Action<CollectionPropertyConfigurer<T>> action) {
+        return uncheckedNonnullCast(super.withActualValue(action));
+    }
+
+    @Override
+    public ListProperty<T> unset() {
+        return uncheckedNonnullCast(super.unset());
+    }
+
+    @Override
+    public ListProperty<T> unsetConvention() {
+        return uncheckedNonnullCast(super.unsetConvention());
+    }
+
+    @Override
+    public ListProperty<T> setToConvention() {
+        return uncheckedNonnullCast(super.setToConvention());
+    }
+
+    @Override
+    public ListProperty<T> setToConventionIfUnset() {
+        return uncheckedNonnullCast(super.setToConventionIfUnset());
     }
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultListProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultListProperty.java
@@ -18,9 +18,9 @@ package org.gradle.api.internal.provider;
 
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
+import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.provider.CollectionPropertyConfigurer;
-import org.gradle.api.provider.HasMultipleValues;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.Cast;
@@ -88,7 +88,12 @@ public class DefaultListProperty<T> extends AbstractCollectionProperty<T, List<T
     }
 
     @Override
-    public HasMultipleValues<T> withActualValue(Action<CollectionPropertyConfigurer<T>> action) {
+    public ListProperty<T> withActualValue(Action<CollectionPropertyConfigurer<T>> action) {
+        return uncheckedNonnullCast(super.withActualValue(action));
+    }
+
+    @Override
+    public ListProperty<T> withActualValue(Closure<Void> action) {
         return uncheckedNonnullCast(super.withActualValue(action));
     }
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
@@ -47,6 +47,8 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, Defaul
     private static final String NULL_KEY_FORBIDDEN_MESSAGE = String.format("Cannot add an entry with a null key to a property of type %s.", Map.class.getSimpleName());
     private static final String NULL_VALUE_FORBIDDEN_MESSAGE = String.format("Cannot add an entry with a null value to a property of type %s.", Map.class.getSimpleName());
 
+    private static final MapSupplier<Object, Object> NO_VALUE = new NoValueSupplier<>(Value.missing());
+
     private final Class<K> keyType;
     private final Class<V> valueType;
     private final ValueCollector<K> keyCollector;
@@ -77,7 +79,7 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, Defaul
     }
 
     private MapSupplierGuard<K, V> noValueSupplier() {
-        return guard(uncheckedCast(new NoValueSupplier<>(Value.missing())));
+        return guard(uncheckedCast(NO_VALUE));
     }
 
     private void setConvention(MapSupplier<K, V> unguardedConvention) {
@@ -157,7 +159,6 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, Defaul
         setSupplier(new CollectingSupplier(new MapCollectors.EntriesFromMapProvider<>(p)));
     }
 
-
     @Override
     public MapProperty<K, V> value(@Nullable Map<? extends K, ? extends V> entries) {
         set(entries);
@@ -211,11 +212,6 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, Defaul
         setToConventionIfUnset();
         ConfigureUtil.configure(action, getExplicitValue());
         return this;
-    }
-
-    @Override
-    public ProviderInternal<Map<K, V>> withFinalValue(ValueConsumer consumer) {
-        return super.withFinalValue(consumer);
     }
 
     private boolean isNoValueSupplier(MapSupplierGuard<K, V> valueSupplier) {
@@ -276,17 +272,6 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, Defaul
         discardValue();
         return this;
     }
-
-    @Override
-    public MapProperty<K, V> setToConvention() {
-        return uncheckedNonnullCast(super.setToConvention());
-    }
-
-    @Override
-    public MapProperty<K, V> setToConventionIfUnset() {
-        return uncheckedNonnullCast(super.setToConventionIfUnset());
-    }
-
 
     public void fromState(ExecutionTimeValue<? extends Map<? extends K, ? extends V>> value) {
         if (value.isMissing()) {
@@ -668,10 +653,6 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, Defaul
         void addCollector(MapCollector<K, V> collector) {
             addExplicitCollector(collector);
         }
-    }
-
-    private Provider<Map<K, V>> frozen() {
-        return Providers.of(get());
     }
 
     private static class PlusCollector<K, V> implements MapCollector<K, V> {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
@@ -155,6 +155,11 @@ public class DefaultProperty<T> extends AbstractProperty<T, AbstractMinimalProvi
     }
 
     @Override
+    protected boolean isDefaultConvention() {
+        return getConventionSupplier() == NOT_DEFINED;
+    }
+
+    @Override
     protected String describeContents() {
         // NOTE: Do not realize the value of the Provider in toString().  The debugger will try to call this method and make debugging really frustrating.
         return String.format("property(%s, %s)", type.getName(), getSupplier());

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
@@ -27,6 +27,7 @@ import javax.annotation.Nullable;
 public class DefaultProperty<T> extends AbstractProperty<T, AbstractMinimalProvider.ProviderGuard<? extends T>> implements Property<T> {
     private final Class<T> type;
     private final ValueSanitizer<T> sanitizer;
+    private final static ProviderGuard<?> NOT_DEFINED = Cast.uncheckedCast(GuardedData.of(Providers.notDefined(), Providers.notDefined()));
 
     public DefaultProperty(PropertyHost propertyHost, Class<T> type) {
         super(propertyHost);
@@ -121,6 +122,18 @@ public class DefaultProperty<T> extends AbstractProperty<T, AbstractMinimalProvi
     }
 
     @Override
+    public Property<T> unset() {
+        discardValue();
+        return this;
+    }
+
+    @Override
+    public Property<T> unsetConvention() {
+        discardConvention();
+        return this;
+    }
+
+    @Override
     protected ExecutionTimeValue<? extends T> calculateOwnExecutionTimeValue(ProviderGuard<? extends T> value) {
         // Discard this property from a provider chain, as it does not contribute anything to the calculation.
         return value.calculateExecutionTimeValue();
@@ -134,6 +147,11 @@ public class DefaultProperty<T> extends AbstractProperty<T, AbstractMinimalProvi
     @Override
     protected ProviderGuard<? extends T> finalValue(ProviderGuard<? extends T> value, ValueConsumer consumer) {
         return guardProvider(value.withFinalValue(consumer));
+    }
+
+    @Override
+    protected ProviderGuard<? extends T> getDefaultConvention() {
+        return Cast.uncheckedCast(NOT_DEFINED);
     }
 
     @Override

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultSetProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultSetProperty.java
@@ -106,14 +106,4 @@ public class DefaultSetProperty<T> extends AbstractCollectionProperty<T, Set<T>>
     public SetProperty<T> unsetConvention() {
         return uncheckedNonnullCast(super.unsetConvention());
     }
-
-    @Override
-    public SetProperty<T> setToConvention() {
-        return uncheckedNonnullCast(super.setToConvention());
-    }
-
-    @Override
-    public SetProperty<T>  setToConventionIfUnset() {
-        return uncheckedNonnullCast(super.setToConventionIfUnset());
-    }
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultSetProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultSetProperty.java
@@ -18,6 +18,9 @@ package org.gradle.api.internal.provider;
 
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableSet;
+import groovy.lang.Closure;
+import org.gradle.api.Action;
+import org.gradle.api.provider.CollectionPropertyConfigurer;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.internal.Cast;
@@ -83,6 +86,17 @@ public class DefaultSetProperty<T> extends AbstractCollectionProperty<T, Set<T>>
         super.convention(provider);
         return this;
     }
+
+    @Override
+    public SetProperty<T> withActualValue(Action<CollectionPropertyConfigurer<T>> action) {
+        return uncheckedNonnullCast(super.withActualValue(action));
+    }
+
+    @Override
+    public SetProperty<T> withActualValue(Closure<Void> action) {
+        return uncheckedNonnullCast(super.withActualValue(action));
+    }
+
     @Override
     public SetProperty<T> unset() {
         return uncheckedNonnullCast(super.unset());

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultSetProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultSetProperty.java
@@ -26,6 +26,8 @@ import javax.annotation.Nullable;
 import java.util.Set;
 import java.util.function.Supplier;
 
+import static org.gradle.internal.Cast.uncheckedNonnullCast;
+
 public class DefaultSetProperty<T> extends AbstractCollectionProperty<T, Set<T>> implements SetProperty<T> {
     private static final Supplier<ImmutableCollection.Builder<Object>> FACTORY = new Supplier<ImmutableCollection.Builder<Object>>() {
         @Override
@@ -80,5 +82,24 @@ public class DefaultSetProperty<T> extends AbstractCollectionProperty<T, Set<T>>
     public SetProperty<T> convention(Provider<? extends Iterable<? extends T>> provider) {
         super.convention(provider);
         return this;
+    }
+    @Override
+    public SetProperty<T> unset() {
+        return uncheckedNonnullCast(super.unset());
+    }
+
+    @Override
+    public SetProperty<T> unsetConvention() {
+        return uncheckedNonnullCast(super.unsetConvention());
+    }
+
+    @Override
+    public SetProperty<T> setToConvention() {
+        return uncheckedNonnullCast(super.setToConvention());
+    }
+
+    @Override
+    public SetProperty<T>  setToConventionIfUnset() {
+        return uncheckedNonnullCast(super.setToConventionIfUnset());
     }
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/PropertyInternal.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/PropertyInternal.java
@@ -17,10 +17,11 @@
 package org.gradle.api.internal.provider;
 
 import org.gradle.api.internal.provider.support.LazyGroovySupport;
+import org.gradle.api.provider.SupportsConvention;
 import org.gradle.internal.state.ModelObject;
 import org.gradle.internal.state.OwnerAware;
 
-public interface PropertyInternal<T> extends ProviderInternal<T>, HasConfigurableValueInternal, OwnerAware, LazyGroovySupport {
+public interface PropertyInternal<T> extends ProviderInternal<T>, HasConfigurableValueInternal, OwnerAware, LazyGroovySupport, SupportsConvention {
     /**
      * Associates this property with the task that produces its value.
      */

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
@@ -36,7 +36,7 @@ abstract class CollectionPropertySpec<C extends Collection<String>> extends Prop
     @Override
     AbstractCollectionProperty<String, C> propertyWithNoValue() {
         def p = property()
-        p.set((Iterable) null)
+        p.unset()
         return p
     }
 
@@ -95,6 +95,7 @@ abstract class CollectionPropertySpec<C extends Collection<String>> extends Prop
     def "has empty collection as value by default"() {
         expect:
         assertValueIs([])
+        !property.explicit
     }
 
     def "can change value to empty collection"() {
@@ -103,6 +104,7 @@ abstract class CollectionPropertySpec<C extends Collection<String>> extends Prop
 
         expect:
         assertValueIs([])
+        property.explicit
     }
 
     def "can set value using empty collection"() {
@@ -1262,5 +1264,42 @@ The value of this property is derived from: <source>""")
             where:
             consumer << safeConsumers()
         }
+    }
+
+    def "can add to convention value"() {
+        given:
+        property.convention([])
+        property.withActualValue {
+            it.addAll(Providers.of(["1", "2"]))
+            it.addAll(Providers.of(["3", "4"]))
+        }
+        expect:
+        assertValueIs toImmutable(["1", "2", "3", "4"])
+        !property.explicit
+    }
+
+    def "can add to explicit value"() {
+        given:
+        property.set([])
+        property.withActualValue {
+            it.addAll(Providers.of(["1", "2"]))
+            it.addAll(Providers.of(["3", "4"]))
+        }
+
+        expect:
+        assertValueIs toImmutable(["1", "2", "3", "4"])
+        property.explicit
+    }
+
+    def "can add to actual value without previous configuration"() {
+        given:
+        property.withActualValue {
+            it.addAll(Providers.of(["1", "2"]))
+            it.addAll(Providers.of(["3", "4"]))
+        }
+
+        expect:
+        assertValueIs toImmutable(["1", "2", "3", "4"])
+        property.explicit
     }
 }

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
@@ -1270,8 +1270,8 @@ The value of this property is derived from: <source>""")
         given:
         property.convention([])
         property.withActualValue {
-            it.addAll(Providers.of(["1", "2"]))
-            it.addAll(Providers.of(["3", "4"]))
+            addAll(Providers.of(["1", "2"]))
+            addAll(Providers.of(["3", "4"]))
         }
         expect:
         assertValueIs toImmutable(["1", "2", "3", "4"])
@@ -1282,8 +1282,8 @@ The value of this property is derived from: <source>""")
         given:
         property.set([])
         property.withActualValue {
-            it.addAll(Providers.of(["1", "2"]))
-            it.addAll(Providers.of(["3", "4"]))
+            addAll(Providers.of(["1", "2"]))
+            addAll(Providers.of(["3", "4"]))
         }
 
         expect:
@@ -1294,8 +1294,8 @@ The value of this property is derived from: <source>""")
     def "can add to actual value without previous configuration"() {
         given:
         property.withActualValue {
-            it.addAll(Providers.of(["1", "2"]))
-            it.addAll(Providers.of(["3", "4"]))
+            addAll(Providers.of(["1", "2"]))
+            addAll(Providers.of(["3", "4"]))
         }
 
         expect:

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
@@ -1268,14 +1268,14 @@ The value of this property is derived from: <source>""")
 
     def "can add to convention value"() {
         given:
-        property.convention([])
+        property.convention(Providers.of(["1"]))
         property.withActualValue {
-            addAll(Providers.of(["1", "2"]))
+            addAll(Providers.of(["2"]))
             addAll(Providers.of(["3", "4"]))
         }
         expect:
         assertValueIs toImmutable(["1", "2", "3", "4"])
-        !property.explicit
+        property.explicit
     }
 
     def "can add to explicit value"() {

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
@@ -1206,9 +1206,9 @@ The value of this property is derived from: <source>""")
         given:
         property.convention([:])
         property.withActualValue {
-            it.put('k0', '1')
-            it.putAll(['k1': '2', 'k2': '3'])
-            it.put('k2', '4')
+            put('k0', '1')
+            putAll(['k1': '2', 'k2': '3'])
+            put('k2', '4')
         }
         expect:
         assertValueIs(['k0': '1', 'k1': '2', 'k2': '4'])
@@ -1219,9 +1219,9 @@ The value of this property is derived from: <source>""")
         given:
         property.set([:])
         property.withActualValue {
-            it.put('k0', '1')
-            it.putAll(['k1': '2', 'k2': '3'])
-            it.put('k2', '4')
+            put('k0', '1')
+            putAll(['k1': '2', 'k2': '3'])
+            put('k2', '4')
         }
         expect:
         assertValueIs(['k0': '1', 'k1': '2', 'k2': '4'])
@@ -1231,9 +1231,9 @@ The value of this property is derived from: <source>""")
     def "may configure actual value incrementally"() {
         given:
         property.withActualValue {
-            it.put('k0', '1')
-            it.putAll(['k1': '2', 'k2': '3'])
-            it.put('k2', '4')
+            put('k0', '1')
+            putAll(['k1': '2', 'k2': '3'])
+            put('k2', '4')
         }
         expect:
         assertValueIs(['k0': '1', 'k1': '2', 'k2': '4'])
@@ -1244,7 +1244,7 @@ The value of this property is derived from: <source>""")
         given:
         property.convention(['k0': '1', 'k1': '2', 'k2': '3'])
         property.withActualValue {
-            it.put('k1', '4')
+            put('k1', '4')
         }
         expect:
         assertValueIs(['k0': '1', 'k1': '4', 'k2': '3'])

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
@@ -1202,6 +1202,55 @@ The value of this property is derived from: <source>""")
         "getOrElse" | _
     }
 
+    def "may configure convention value incrementally"() {
+        given:
+        property.convention([:])
+        property.withActualValue {
+            it.put('k0', '1')
+            it.putAll(['k1': '2', 'k2': '3'])
+            it.put('k2', '4')
+        }
+        expect:
+        assertValueIs(['k0': '1', 'k1': '2', 'k2': '4'])
+        assert !property.explicit
+    }
+
+    def "may configure explicit value incrementally"() {
+        given:
+        property.set([:])
+        property.withActualValue {
+            it.put('k0', '1')
+            it.putAll(['k1': '2', 'k2': '3'])
+            it.put('k2', '4')
+        }
+        expect:
+        assertValueIs(['k0': '1', 'k1': '2', 'k2': '4'])
+        assert property.explicit
+    }
+
+    def "may configure actual value incrementally"() {
+        given:
+        property.withActualValue {
+            it.put('k0', '1')
+            it.putAll(['k1': '2', 'k2': '3'])
+            it.put('k2', '4')
+        }
+        expect:
+        assertValueIs(['k0': '1', 'k1': '2', 'k2': '4'])
+        assert property.explicit
+    }
+
+    def "may replace convention values"() {
+        given:
+        property.convention(['k0': '1', 'k1': '2', 'k2': '3'])
+        property.withActualValue {
+            it.put('k1', '4')
+        }
+        expect:
+        assertValueIs(['k0': '1', 'k1': '4', 'k2': '3'])
+        !property.explicit
+    }
+
     private ProviderInternal<String> brokenValueSupplier() {
         return brokenSupplier(String)
     }

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
@@ -1204,15 +1204,14 @@ The value of this property is derived from: <source>""")
 
     def "may configure convention value incrementally"() {
         given:
-        property.convention([:])
+        property.convention(['k0': '1'])
         property.withActualValue {
-            put('k0', '1')
             putAll(['k1': '2', 'k2': '3'])
             put('k2', '4')
         }
         expect:
         assertValueIs(['k0': '1', 'k1': '2', 'k2': '4'])
-        assert !property.explicit
+        assert property.explicit
     }
 
     def "may configure explicit value incrementally"() {
@@ -1248,7 +1247,53 @@ The value of this property is derived from: <source>""")
         }
         expect:
         assertValueIs(['k0': '1', 'k1': '4', 'k2': '3'])
+        property.explicit
+    }
+
+    def "can set explicit value to convention"() {
+        given:
+        property.convention(['k0': '1'])
+        property.value(['k1': '4'])
+
+        when:
+        property.setToConvention()
+
+        then:
+        assertValueIs(['k0': '1'])
+        property.explicit
+
+        when:
+        property.put('k2', '3')
+
+        then:
+        assertValueIs(['k0': '1', 'k2': '3'])
+
+        when:
+        property.unset()
+
+        then:
+        assertValueIs(['k0': '1'])
         !property.explicit
+    }
+
+    def "can set explicit value to convention if not set yet"() {
+        given:
+        property.convention(['k0': '1'])
+        property.value(['k1': '4'])
+
+        when:
+        property.setToConventionIfUnset()
+
+        then:
+        assertValueIs(['k1': '4'])
+
+        when:
+        property.unset()
+        property.setToConventionIfUnset()
+
+        then:
+        assertValueIs(['k0': '1'])
+        property.explicit
     }
 
     private ProviderInternal<String> brokenValueSupplier() {

--- a/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
+++ b/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
@@ -99,6 +99,14 @@
             "changes": [
                 "Method now provides default implementation"
             ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.GradleApiKotlinDslExtensions_4xzlmchnjfhf5wwk67zexqao1Kt",
+            "member": "Method org.gradle.kotlin.dsl.GradleApiKotlinDslExtensions_4xzlmchnjfhf5wwk67zexqao1Kt.registerIfAbsent(org.gradle.api.services.BuildServiceRegistry,java.lang.String,kotlin.reflect.KClass)",
+            "acceptation": "Add new default method without action",
+            "changes": [
+                "Method added to public class"
+            ]
         }
     ]
 }

--- a/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
+++ b/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
@@ -3,10 +3,92 @@
         {
             "type": "org.gradle.api.file.ConfigurableFileCollection",
             "member": "Class org.gradle.api.file.ConfigurableFileCollection",
-            "acceptation": "ConfigurableFileCollection now supports conventions",
+            "acceptation": "Introduce SupportsConvention/ConfigurableValue to collection properties",
             "changes": [
                 "org.gradle.api.file.FileCollectionConfigurer",
                 "org.gradle.api.provider.ConfigurableValue",
+                "org.gradle.api.provider.SupportsConvention"
+            ]
+        },
+        {
+            "type": "org.gradle.api.provider.CollectionPropertyConfigurer",
+            "member": "Method org.gradle.api.provider.CollectionPropertyConfigurer.add(java.lang.Object)",
+            "acceptation": "Introduce SupportsConvention/ConfigurableValue to collection properties",
+            "changes": []
+        },
+        {
+            "type": "org.gradle.api.provider.CollectionPropertyConfigurer",
+            "member": "Method org.gradle.api.provider.CollectionPropertyConfigurer.add(org.gradle.api.provider.Provider)",
+            "acceptation": "Introduce SupportsConvention/ConfigurableValue to collection properties",
+            "changes": []
+        },
+        {
+            "type": "org.gradle.api.provider.CollectionPropertyConfigurer",
+            "member": "Method org.gradle.api.provider.CollectionPropertyConfigurer.addAll(java.lang.Iterable)",
+            "acceptation": "Introduce SupportsConvention/ConfigurableValue to collection properties",
+            "changes": []
+        },
+        {
+            "type": "org.gradle.api.provider.CollectionPropertyConfigurer",
+            "member": "Method org.gradle.api.provider.CollectionPropertyConfigurer.addAll(java.lang.Object[])",
+            "acceptation": "Introduce SupportsConvention/ConfigurableValue to collection properties",
+            "changes": []
+        },
+        {
+            "type": "org.gradle.api.provider.CollectionPropertyConfigurer",
+            "member": "Method org.gradle.api.provider.CollectionPropertyConfigurer.addAll(org.gradle.api.provider.Provider)",
+            "acceptation": "Introduce SupportsConvention/ConfigurableValue to collection properties",
+            "changes": []
+        },
+        {
+            "type": "org.gradle.api.provider.HasMultipleValues",
+            "member": "Class org.gradle.api.provider.HasMultipleValues",
+            "acceptation": "Introduce SupportsConvention/ConfigurableValue to collection properties",
+            "changes": [
+                "org.gradle.api.provider.CollectionPropertyConfigurer",
+                "org.gradle.api.provider.ConfigurableValue",
+                "org.gradle.api.provider.SupportsConvention"
+            ]
+        },
+        {
+            "type": "org.gradle.api.provider.MapProperty",
+            "member": "Class org.gradle.api.provider.MapProperty",
+            "acceptation": "Introduce SupportsConvention/ConfigurableValue to collection properties",
+            "changes": [
+                "org.gradle.api.provider.ConfigurableValue",
+                "org.gradle.api.provider.MapPropertyConfigurer",
+                "org.gradle.api.provider.SupportsConvention"
+            ]
+        },
+        {
+            "type": "org.gradle.api.provider.MapPropertyConfigurer",
+            "member": "Method org.gradle.api.provider.MapPropertyConfigurer.put(java.lang.Object,java.lang.Object)",
+            "acceptation": "Introduce SupportsConvention/ConfigurableValue to collection properties",
+            "changes": []
+        },
+        {
+            "type": "org.gradle.api.provider.MapPropertyConfigurer",
+            "member": "Method org.gradle.api.provider.MapPropertyConfigurer.put(java.lang.Object,org.gradle.api.provider.Provider)",
+            "acceptation": "Introduce SupportsConvention/ConfigurableValue to collection properties",
+            "changes": []
+        },
+        {
+            "type": "org.gradle.api.provider.MapPropertyConfigurer",
+            "member": "Method org.gradle.api.provider.MapPropertyConfigurer.putAll(java.util.Map)",
+            "acceptation": "Introduce SupportsConvention/ConfigurableValue to collection properties",
+            "changes": []
+        },
+        {
+            "type": "org.gradle.api.provider.MapPropertyConfigurer",
+            "member": "Method org.gradle.api.provider.MapPropertyConfigurer.putAll(org.gradle.api.provider.Provider)",
+            "acceptation": "Introduce SupportsConvention/ConfigurableValue to collection properties",
+            "changes": []
+        },
+        {
+            "type": "org.gradle.api.provider.Property",
+            "member": "Class org.gradle.api.provider.Property",
+            "acceptation": "Introduce SupportsConvention/ConfigurableValue to collection properties",
+            "changes": [
                 "org.gradle.api.provider.SupportsConvention"
             ]
         },
@@ -16,14 +98,6 @@
             "acceptation": "Add new default method without action",
             "changes": [
                 "Method now provides default implementation"
-            ]
-        },
-        {
-            "type": "org.gradle.kotlin.dsl.GradleApiKotlinDslExtensions_4xzlmchnjfhf5wwk67zexqao1Kt",
-            "member": "Method org.gradle.kotlin.dsl.GradleApiKotlinDslExtensions_4xzlmchnjfhf5wwk67zexqao1Kt.registerIfAbsent(org.gradle.api.services.BuildServiceRegistry,java.lang.String,kotlin.reflect.KClass)",
-            "acceptation": "Add generated Kotlin DSL extension for new method",
-            "changes": [
-                "Method added to public class"
             ]
         }
     ]

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/ConfigurableFileCollection.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/ConfigurableFileCollection.java
@@ -16,6 +16,7 @@
 package org.gradle.api.file;
 
 import groovy.lang.Closure;
+import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.SupportsKotlinAssignmentOverloading;
@@ -146,7 +147,7 @@ public interface ConfigurableFileCollection extends FileCollection, HasConfigura
      * @since 8.7
      */
     @Incubating
-    ConfigurableFileCollection withActualValue(Closure<Void> action);
+    ConfigurableFileCollection withActualValue(@DelegatesTo(FileCollectionConfigurer.class) Closure<Void> action);
 
     /**
      * Applies an eager transformation to the current contents of this file collection, without explicitly resolving it.

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/CollectionPropertyConfigurer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/CollectionPropertyConfigurer.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.provider;
+
+import org.gradle.api.Incubating;
+
+/**
+ * Allows configuring collection-based properties, namely {@link ListProperty} and {@link SetProperty}.
+ *
+ * @param <T>
+ *
+ * @since 8.7
+ */
+@Incubating
+public interface CollectionPropertyConfigurer<T> extends ConfigurableValue.Configurer {
+    /**
+     * Adds an element to the property value.
+     *
+     * @param element The element
+     */
+    void add(T element);
+
+    /**
+     * Adds an element to the property value.
+     *
+     * <p>The given provider will be queried when the value of this property is queried.
+     * This property will have no value when the given provider has no value.
+     *
+     * @param provider The provider of an element
+     */
+    void add(Provider<? extends T> provider);
+
+    /**
+     * Adds zero or more elements to the property value.
+     *
+     * @param elements The elements to add
+     * @since 4.10
+     */
+    @SuppressWarnings("unchecked")
+    void addAll(T... elements);
+
+    /**
+     * Adds zero or more elements to the property value.
+     *
+     * <p>The given iterable will be queried when the value of this property is queried.
+     *
+     * @param elements The elements to add.
+     * @since 4.10
+     */
+    void addAll(Iterable<? extends T> elements);
+
+    /**
+     * Adds zero or more elements to the property value.
+     *
+     * <p>The given provider will be queried when the value of this property is queried.
+     * This property will have no value when the given provider has no value.
+     *
+     * @param provider Provider of elements
+     */
+    void addAll(Provider<? extends Iterable<? extends T>> provider);
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/CollectionPropertyConfigurer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/CollectionPropertyConfigurer.java
@@ -48,7 +48,6 @@ public interface CollectionPropertyConfigurer<T> extends ConfigurableValue.Confi
      * Adds zero or more elements to the property value.
      *
      * @param elements The elements to add
-     * @since 4.10
      */
     @SuppressWarnings("unchecked")
     void addAll(T... elements);
@@ -59,7 +58,6 @@ public interface CollectionPropertyConfigurer<T> extends ConfigurableValue.Confi
      * <p>The given iterable will be queried when the value of this property is queried.
      *
      * @param elements The elements to add.
-     * @since 4.10
      */
     void addAll(Iterable<? extends T> elements);
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ConfigurableValue.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ConfigurableValue.java
@@ -42,7 +42,7 @@ public interface ConfigurableValue<C extends ConfigurableValue.Configurer> {
 
     /**
      * Applies the action to the current value of the property, be it defined via convention,
-     * or as an explicit value.
+     * or as an explicit value, committing the resulting value as the new explicit value.
      *
      * @param action an action to incrementally configure this object
      *

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/HasMultipleValues.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/HasMultipleValues.java
@@ -80,6 +80,41 @@ public interface HasMultipleValues<T> extends HasConfigurableValue, CollectionPr
     HasMultipleValues<T> empty();
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    void add(T element);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    void add(Provider<? extends T> provider);
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 4.10
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    void addAll(T... elements);
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 4.10
+     */
+    @Override
+    void addAll(Iterable<? extends T> elements);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    void addAll(Provider<? extends Iterable<? extends T>> provider);
+
+    /**
      * Specifies the value to use as the convention for this property. The convention is used when no value has been set for this property.
      *
      * @param elements The elements, or {@code null} when the convention is that the property has no value.

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/HasMultipleValues.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/HasMultipleValues.java
@@ -16,6 +16,8 @@
 
 package org.gradle.api.provider;
 
+import groovy.lang.Closure;
+import org.gradle.api.Action;
 import org.gradle.api.SupportsKotlinAssignmentOverloading;
 
 import javax.annotation.Nullable;
@@ -29,7 +31,7 @@ import javax.annotation.Nullable;
  * @since 4.5
  */
 @SupportsKotlinAssignmentOverloading
-public interface HasMultipleValues<T> extends HasConfigurableValue {
+public interface HasMultipleValues<T> extends HasConfigurableValue, CollectionPropertyConfigurer<T>, ConfigurableValue<CollectionPropertyConfigurer<T>>, SupportsConvention {
     /**
      * Sets the value of the property to the elements of the given iterable, and replaces any existing value. This property will query the elements of the iterable each time the value of this property is queried.
      *
@@ -78,52 +80,6 @@ public interface HasMultipleValues<T> extends HasConfigurableValue {
     HasMultipleValues<T> empty();
 
     /**
-     * Adds an element to the property value.
-     *
-     * @param element The element
-     */
-    void add(T element);
-
-    /**
-     * Adds an element to the property value.
-     *
-     * <p>The given provider will be queried when the value of this property is queried.
-     * This property will have no value when the given provider has no value.
-     *
-     * @param provider The provider of an element
-     */
-    void add(Provider<? extends T> provider);
-
-    /**
-     * Adds zero or more elements to the property value.
-     *
-     * @param elements The elements to add
-     * @since 4.10
-     */
-    @SuppressWarnings("unchecked")
-    void addAll(T... elements);
-
-    /**
-     * Adds zero or more elements to the property value.
-     *
-     * <p>The given iterable will be queried when the value of this property is queried.
-     *
-     * @param elements The elements to add.
-     * @since 4.10
-     */
-    void addAll(Iterable<? extends T> elements);
-
-    /**
-     * Adds zero or more elements to the property value.
-     *
-     * <p>The given provider will be queried when the value of this property is queried.
-     * This property will have no value when the given provider has no value.
-     *
-     * @param provider Provider of elements
-     */
-    void addAll(Provider<? extends Iterable<? extends T>> provider);
-
-    /**
      * Specifies the value to use as the convention for this property. The convention is used when no value has been set for this property.
      *
      * @param elements The elements, or {@code null} when the convention is that the property has no value.
@@ -152,4 +108,34 @@ public interface HasMultipleValues<T> extends HasConfigurableValue {
      */
     @Override
     void finalizeValue();
+
+    /**
+     * Performs incremental updates to the actual value of this property.
+     *
+     * {@inheritDoc}
+     *
+     * For wholesale updates to the explicit value, use
+     * or {@link #set(Iterable)}, {@link #set(Provider)} .
+     *
+     * For wholesale updates to the convention value, use
+     * {@link #convention(Iterable)} or {@link #convention(Provider)}.
+     */
+    @Override
+    HasMultipleValues<T> withActualValue(Action<CollectionPropertyConfigurer<T>> action);
+
+    /**
+     * Performs incremental updates to the actual value of this property.
+     *
+     * This is a Groovy closure-compatible version of
+     * {@link HasMultipleValues#withActualValue(Action)},
+     * having this property's actual value (and not the property itself)
+     * as the target object.
+     *
+     * @param action a Groovy closure to incrementally configure this object's actual value
+     * via the {@link CollectionPropertyConfigurer} protocol.
+     *
+     * @see #withActualValue(Action)
+     * @since 8.7
+     */
+    HasMultipleValues<T> withActualValue(Closure<Void> action);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ListProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ListProperty.java
@@ -16,6 +16,8 @@
 
 package org.gradle.api.provider;
 
+import groovy.lang.Closure;
+import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.Transformer;
 
@@ -88,6 +90,18 @@ public interface ListProperty<T> extends Provider<List<T>>, HasMultipleValues<T>
      */
     @Override
     ListProperty<T> setToConventionIfUnset();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    ListProperty<T> withActualValue(Action<CollectionPropertyConfigurer<T>> action);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    ListProperty<T> withActualValue(Closure<Void> action);
 
     /**
      * Applies an eager transformation to the current value of the property "in place", without explicitly obtaining it.

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ListProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ListProperty.java
@@ -69,27 +69,23 @@ public interface ListProperty<T> extends Provider<List<T>>, HasMultipleValues<T>
 
     /**
      * {@inheritDoc}
+     *
+     * <p>
+     * This is similar to calling {@link #value(Iterable)} with a <code>null</code> argument.
+     * </p>
      */
     @Override
     ListProperty<T> unset();
 
     /**
      * {@inheritDoc}
+     *
+     * <p>
+     * This is similar to calling {@link #convention(Iterable)} with a <code>null</code> argument.
+     * </p>
      */
     @Override
     ListProperty<T> unsetConvention();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    ListProperty<T> setToConvention();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    ListProperty<T> setToConventionIfUnset();
 
     /**
      * {@inheritDoc}

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ListProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ListProperty.java
@@ -66,6 +66,30 @@ public interface ListProperty<T> extends Provider<List<T>>, HasMultipleValues<T>
     ListProperty<T> convention(Provider<? extends Iterable<? extends T>> provider);
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    ListProperty<T> unset();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    ListProperty<T> unsetConvention();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    ListProperty<T> setToConvention();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    ListProperty<T> setToConventionIfUnset();
+
+    /**
      * Applies an eager transformation to the current value of the property "in place", without explicitly obtaining it.
      * The provided transformer is applied to the provider of the current value, and the returned provider is used as a new value.
      * The provider of the value can be used to derive the new value, but doesn't have to.

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/MapProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/MapProperty.java
@@ -223,6 +223,10 @@ public interface MapProperty<K, V> extends Provider<Map<K, V>>, HasConfigurableV
 
     /**
      * {@inheritDoc}
+     *
+     * <p>
+     * This is similar to calling {@link #value(Map)} with a <code>null</code> argument.
+     * </p>
      */
     @Incubating
     @Override
@@ -230,6 +234,10 @@ public interface MapProperty<K, V> extends Provider<Map<K, V>>, HasConfigurableV
 
     /**
      * {@inheritDoc}
+     *
+     * <p>
+     * This is similar to calling {@link #convention(Map)} with a <code>null</code> argument.
+     * </p>
      */
     @Incubating
     @Override

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/MapProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/MapProperty.java
@@ -16,6 +16,8 @@
 
 package org.gradle.api.provider;
 
+import groovy.lang.Closure;
+import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.SupportsKotlinAssignmentOverloading;
 import org.gradle.api.Transformer;
@@ -38,7 +40,7 @@ import java.util.Set;
  * @since 5.1
  */
 @SupportsKotlinAssignmentOverloading
-public interface MapProperty<K, V> extends Provider<Map<K, V>>, HasConfigurableValue {
+public interface MapProperty<K, V> extends Provider<Map<K, V>>, HasConfigurableValue, MapPropertyConfigurer<K, V>, ConfigurableValue<MapPropertyConfigurer<K, V>>, SupportsConvention {
 
     /**
      * Sets the value of this property to an empty map, and replaces any existing value.
@@ -113,42 +115,6 @@ public interface MapProperty<K, V> extends Provider<Map<K, V>>, HasConfigurableV
     MapProperty<K, V> value(Provider<? extends Map<? extends K, ? extends V>> provider);
 
     /**
-     * Adds a map entry to the property value.
-     *
-     * @param key the key
-     * @param value the value
-     */
-    void put(K key, V value);
-
-    /**
-     * Adds a map entry to the property value.
-     *
-     * <p>The given provider will be queried when the value of this property is queried.
-     * This property will have no value when the given provider has no value.
-     *
-     * @param key the key
-     * @param providerOfValue the provider of the value
-     */
-    void put(K key, Provider<? extends V> providerOfValue);
-
-    /**
-     * Adds all entries from another {@link Map} to the property value.
-     *
-     * @param entries a {@link Map} containing the entries to add
-     */
-    void putAll(Map<? extends K, ? extends V> entries);
-
-    /**
-     * Adds all entries from another {@link Map} to the property value.
-     *
-     * <p>The given provider will be queried when the value of this property is queried.
-     * This property will have no value when the given provider has no value.
-     *
-     * @param provider the provider of the entries
-     */
-    void putAll(Provider<? extends Map<? extends K, ? extends V>> provider);
-
-    /**
      * Returns a {@link Provider} that returns the set of keys for the map that is the property value.
      *
      * <p>The returned provider will track the value of this property and query its value when it is queried.</p>
@@ -164,6 +130,37 @@ public interface MapProperty<K, V> extends Provider<Map<K, V>>, HasConfigurableV
      * @return a {@link Provider} that provides the set of keys for the map
      */
     Provider<Set<K>> keySet();
+
+    /**
+     * Performs incremental updates to the actual value of this property.
+     *
+     * {@inheritDoc}
+     *
+     * For wholesale updates to the explicit value, use
+     * {@link #set(Map)} or {@link #set(Provider)}.
+     *
+     * For wholesale updates to the convention value, use
+     * {@link #convention(Map)} or {@link #convention(Provider)}.
+     */
+    @Override
+    MapProperty<K, V> withActualValue(Action<MapPropertyConfigurer<K, V>> action);
+
+    /**
+     * Performs incremental updates to the actual value of this property.
+     *
+     * This is a Groovy closure-compatible version of
+     * {@link MapProperty#withActualValue(Action)},
+     * having this property's actual value (and not the property itself)
+     * as the target object.
+     *
+     * @param action a Groovy closure to incrementally configure this object's actual value
+     * via the {@link MapPropertyConfigurer} protocol.
+     *
+     * @see #withActualValue(Action)
+     * @since 8.7
+     */
+    @Incubating
+    MapProperty<K, V> withActualValue(Closure<Void> action);
 
     /**
      * Specifies the value to use as the convention for this property. The convention is used when no value has been set for this property.
@@ -223,6 +220,20 @@ public interface MapProperty<K, V> extends Provider<Map<K, V>>, HasConfigurableV
      */
     @Incubating
     void update(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends Map<? extends K, ? extends V>>, ? super Provider<Map<K, V>>> transform);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Incubating
+    @Override
+    MapProperty<K, V> unset();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Incubating
+    @Override
+    MapProperty<K, V> unsetConvention();
 
     /**
      * Disallows further changes to the value of this property. Calls to methods that change the value of this property, such as {@link #set(Map)} or {@link #put(Object, Object)} will fail.

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/MapPropertyConfigurer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/MapPropertyConfigurer.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.provider;
+
+import org.gradle.api.Incubating;
+
+import java.util.Map;
+
+/**
+ * Allows configuring a {@link MapProperty}.
+ *
+ * @param <K>
+ * @param <V>
+ * @since 8.7
+ */
+@Incubating
+public interface MapPropertyConfigurer<K, V>  extends ConfigurableValue.Configurer {
+    /**
+     * Adds a map entry to the property value.
+     *
+     * @param key the key
+     * @param value the value
+     */
+    void put(K key, V value);
+
+    /**
+     * Adds a map entry to the property value.
+     *
+     * <p>The given provider will be queried when the value of this property is queried.
+     * This property will have no value when the given provider has no value.
+     *
+     * @param key the key
+     * @param providerOfValue the provider of the value
+     */
+    void put(K key, Provider<? extends V> providerOfValue);
+
+    /**
+     * Adds all entries from another {@link Map} to the property value.
+     *
+     * @param entries a {@link Map} containing the entries to add
+     */
+    void putAll(Map<? extends K, ? extends V> entries);
+
+    /**
+     * Adds all entries from another {@link Map} to the property value.
+     *
+     * <p>The given provider will be queried when the value of this property is queried.
+     * This property will have no value when the given provider has no value.
+     *
+     * @param provider the provider of the entries
+     */
+    void putAll(Provider<? extends Map<? extends K, ? extends V>> provider);
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/Property.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/Property.java
@@ -123,6 +123,15 @@ public interface Property<T> extends Provider<T>, HasConfigurableValue, Supports
     Property<T> value(Provider<? extends T> provider);
 
     /**
+     * {@inheritDoc}
+     * <p>
+     * This is similar to calling {@link #value(Object)} with a <code>null</code> argument.
+     * </p>
+     */
+    @Override
+    Property<T> unset();
+
+    /**
      * Specifies the value to use as the convention (default value) for this property. If the convention is set and
      * no explicit value or value provider has been specified, then the convention will be returned as the value of
      * the property (when queried).
@@ -159,6 +168,16 @@ public interface Property<T> extends Provider<T>, HasConfigurableValue, Supports
      * @since 5.1
      */
     Property<T> convention(Provider<? extends T> provider);
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>
+     * This is similar to calling {@link #convention(Object)} with a <code>null</code> argument.
+     * </p>
+     */
+    @Override
+    Property<T> unsetConvention();
 
     /**
      * Disallows further changes to the value of this property. Calls to methods that change the value of this property,

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/Property.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/Property.java
@@ -49,7 +49,7 @@ import javax.annotation.Nullable;
  * @since 4.3
  */
 @SupportsKotlinAssignmentOverloading
-public interface Property<T> extends Provider<T>, HasConfigurableValue {
+public interface Property<T> extends Provider<T>, HasConfigurableValue, SupportsConvention {
     /**
      * Sets the value of the property to the given value, replacing whatever value the property already had.
      *

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/SetProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/SetProperty.java
@@ -16,6 +16,8 @@
 
 package org.gradle.api.provider;
 
+import groovy.lang.Closure;
+import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.Transformer;
 
@@ -88,6 +90,19 @@ public interface SetProperty<T> extends Provider<Set<T>>, HasMultipleValues<T> {
      */
     @Override
     SetProperty<T> setToConventionIfUnset();
+
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    SetProperty<T> withActualValue(Action<CollectionPropertyConfigurer<T>> action);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    SetProperty<T> withActualValue(Closure<Void> action);
 
     /**
      * Applies an eager transformation to the current value of the property "in place", without explicitly obtaining it.

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/SetProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/SetProperty.java
@@ -66,6 +66,30 @@ public interface SetProperty<T> extends Provider<Set<T>>, HasMultipleValues<T> {
     SetProperty<T> convention(Provider<? extends Iterable<? extends T>> provider);
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    SetProperty<T> unset();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    SetProperty<T> unsetConvention();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    SetProperty<T> setToConvention();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    SetProperty<T> setToConventionIfUnset();
+
+    /**
      * Applies an eager transformation to the current value of the property "in place", without explicitly obtaining it.
      * The provided transformer is applied to the provider of the current value, and the returned provider is used as a new value.
      * The provider of the value can be used to derive the new value, but doesn't have to.

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/SetProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/SetProperty.java
@@ -69,28 +69,22 @@ public interface SetProperty<T> extends Provider<Set<T>>, HasMultipleValues<T> {
 
     /**
      * {@inheritDoc}
+     *
+     * <p>
+     * This is similar to calling {@link #value(Iterable)} with a <code>null</code> argument.
+     * </p>
      */
     @Override
     SetProperty<T> unset();
 
     /**
      * {@inheritDoc}
+     * <p>
+     * This is similar to calling {@link #convention(Iterable)} with a <code>null</code> argument.
+     * </p>
      */
     @Override
     SetProperty<T> unsetConvention();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    SetProperty<T> setToConvention();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    SetProperty<T> setToConventionIfUnset();
-
 
     /**
      * {@inheritDoc}

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/SupportsConvention.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/SupportsConvention.java
@@ -43,25 +43,4 @@ public interface SupportsConvention {
      * @since 8.7
      */
     SupportsConvention unsetConvention();
-
-    /**
-     * Sets the value of the property to the current convention value, replacing whatever explicit value the property already had.
-     *
-     * If the property has no convention set at the time this method is invoked,
-     * the effect of invoking it is similar to invoking {@link SupportsConvention#unset()}.
-     *
-     * @since 8.7
-     */
-    SupportsConvention setToConvention();
-
-    /**
-     * Sets the value of the property to the current convention value, if an explicit
-     * value has not been set yet.
-     *
-     * If the property has no convention set at the time this method is invoked,
-     * or if an explicit value has already been set, it has no effect.
-     *
-     * @since 8.7
-     */
-    SupportsConvention setToConventionIfUnset();
 }


### PR DESCRIPTION
Fixes: #18352 

This is a follow-up to #27414, now introducing standard support for conventions and incremental updates for collection properties.

This was originally spiked here: #26564.


