### PR TITLE
Use simpler name for the `build-logic` included build created with `init`

### DIFF
--- a/platforms/software/build-init/src/main/java/org/gradle/buildinit/plugins/internal/LanguageSpecificAdaptor.java
+++ b/platforms/software/build-init/src/main/java/org/gradle/buildinit/plugins/internal/LanguageSpecificAdaptor.java
@@ -146,13 +146,7 @@ public class LanguageSpecificAdaptor implements ProjectGenerator {
         BuildScriptBuilder builder = scriptBuilderFactory.scriptForNewProjectsWithoutVersionCatalog(settings.getDsl(), buildContentGenerationContext, pluginsBuildLocation(settings) + "/settings", settings.isUseIncubatingAPIs());
         builder.withComments(settings.isWithComments() ? BuildInitComments.ON : BuildInitComments.OFF);
         builder.fileComment("This settings file is used to specify which projects to include in your build-logic build.");
-        String rootProjectName;
-        if (settings.isUseIncubatingAPIs()) {
-            rootProjectName = settings.getProjectName() + "-build-logic";
-        } else {
-            rootProjectName = "buildSrc";
-        }
-        builder.propertyAssignment(null, "rootProject.name", rootProjectName);
+        builder.propertyAssignment(null, "rootProject.name", settings.isUseIncubatingAPIs() ? "build-logic" : "buildSrc");
         builder.useVersionCatalogFromOuterBuild("Reuse version catalog from the main build.");
         return builder;
     }


### PR DESCRIPTION
There is no need for a build logic included build to be more unique than a `build-logic`.

Otherwise, freshly generated `gradle init` projects look confusing:
![image](https://github.com/gradle/gradle/assets/2759152/f2e290d0-70b3-440f-bf19-b847a32b70d2)

### Change

This PR changes the name from `<project_name>-build-logic` to just `build-logic`
