### PR TITLE
Verify variant uniqueness outside of Configuration

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/OutgoingVariantsMutationIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/OutgoingVariantsMutationIntegrationTest.groovy
@@ -87,7 +87,7 @@ class OutgoingVariantsMutationIntegrationTest extends AbstractIntegrationSpec {
         fails("mutateAfterResolve")
 
         then:
-        failure.assertHasCause "Cannot change attributes of dependency configuration ':compile' after it has been resolved"
+        failure.assertHasCause "Cannot change attributes of configuration ':compile' after it has been locked for mutation"
     }
 
     @ToBeFixedForConfigurationCache(because = "Task uses the Configuration API")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/UnsupportedConfigurationMutationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/UnsupportedConfigurationMutationTest.groovy
@@ -475,8 +475,11 @@ task resolveChildFirst {
             configurations.a.resolve()
             configurations.a.attributes { attribute(Attribute.of('foo', String), 'bar') }
         """
-        when: fails()
-        then: failure.assertHasCause("Cannot change attributes of dependency configuration ':a' after it has been resolved")
+        when:
+        fails()
+
+        then:
+        failure.assertHasCause("Cannot change attributes of configuration ':a' after it has been locked for mutation")
     }
 
     def "cannot change the configuration role (#code) after it has been resolved"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/ExclusiveVariantsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/ExclusiveVariantsIntegrationTest.groovy
@@ -76,7 +76,7 @@ class ExclusiveVariantsIntegrationTest extends AbstractIntegrationSpec {
 
         expect:
         fails("resolveSample")
-        failure.assertHasDocumentedCause("Consumable configurations with identical capabilities within a project (other than the default configuration) must have unique attributes, but configuration ':sample2' and [configuration ':sample1'] contain identical attribute sets. " +
+        failure.assertHasDocumentedCause("Consumable configurations with identical capabilities within a project (other than the default configuration) must have unique attributes, but configuration ':sample1' and [configuration ':sample2'] contain identical attribute sets. " +
             "Consider adding an additional attribute to one of the configurations to disambiguate them.  " +
             "Run the 'outgoingVariants' task for more details. ${documentationRegistry.getDocumentationRecommendationFor("information", "upgrading_version_7", "unique_attribute_sets")}")
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationContainerInternal.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationContainerInternal.java
@@ -18,7 +18,7 @@ package org.gradle.api.internal.artifacts.configurations;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.UnknownConfigurationException;
 
-public interface ConfigurationContainerInternal extends RoleBasedConfigurationContainerInternal {
+public interface ConfigurationContainerInternal extends RoleBasedConfigurationContainerInternal, ConfigurationsProvider {
     @Override
     ConfigurationInternal getByName(String name) throws UnknownConfigurationException;
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.internal.artifacts.configurations;
 
-import org.gradle.api.GradleException;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ExcludeRule;
 import org.gradle.api.artifacts.PublishArtifact;
@@ -28,7 +27,6 @@ import org.gradle.internal.deprecation.DeprecatableConfiguration;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
-import java.util.List;
 import java.util.Set;
 
 public interface ConfigurationInternal extends ResolveContext, DeprecatableConfiguration, FinalizableValue, Configuration {
@@ -65,16 +63,6 @@ public interface ConfigurationInternal extends ResolveContext, DeprecatableConfi
     void collectVariants(VariantVisitor visitor);
 
     boolean isCanBeMutated();
-
-    /**
-     * Locks the configuration for mutation
-     * <p>
-     * Any invalid state at this point will be added to the returned list of exceptions.
-     * Handling these becomes the responsibility of the caller.
-     *
-     * @return a list of validation failures when not empty
-     */
-    List<? extends GradleException> preventFromFurtherMutationLenient();
 
     /**
      * Gets the complete set of exclude rules including those contributed by

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -27,7 +27,6 @@ import org.gradle.api.DomainObjectSet;
 import org.gradle.api.GradleException;
 import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.InvalidUserDataException;
-import org.gradle.api.Project;
 import org.gradle.api.artifacts.ArtifactCollection;
 import org.gradle.api.artifacts.ArtifactView;
 import org.gradle.api.artifacts.ConfigurablePublishArtifact;
@@ -66,7 +65,6 @@ import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.DefaultPublishArtifactSet;
 import org.gradle.api.internal.artifacts.ExcludeRuleNotationConverter;
 import org.gradle.api.internal.artifacts.Module;
-import org.gradle.api.internal.artifacts.ResolveContext;
 import org.gradle.api.internal.artifacts.ResolveExceptionContextualizer;
 import org.gradle.api.internal.artifacts.ResolverResults;
 import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory;
@@ -86,7 +84,7 @@ import org.gradle.api.internal.artifacts.result.MinimalResolutionResult;
 import org.gradle.api.internal.artifacts.transform.DefaultTransformUpstreamDependenciesResolverFactory;
 import org.gradle.api.internal.artifacts.transform.TransformUpstreamDependenciesResolverFactory;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
-import org.gradle.api.internal.attributes.ImmutableAttributeContainerWithErrorMessage;
+import org.gradle.api.internal.attributes.FreezableAttributeContainer;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
@@ -110,11 +108,9 @@ import org.gradle.internal.Factory;
 import org.gradle.internal.ImmutableActionSet;
 import org.gradle.internal.code.UserCodeApplicationContext;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
-import org.gradle.internal.component.external.model.ProjectDerivedCapability;
 import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.LocalComponentDependencyMetadata;
 import org.gradle.internal.deprecation.DeprecationLogger;
-import org.gradle.internal.deprecation.DocumentedFailure;
 import org.gradle.internal.event.ListenerBroadcast;
 import org.gradle.internal.lazy.Lazy;
 import org.gradle.internal.logging.text.TreeFormatter;
@@ -147,7 +143,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -229,7 +224,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
     private final ConfigurationRole roleAtCreation;
 
     private boolean canBeMutated = true;
-    private AttributeContainerInternal configurationAttributes;
+    private final FreezableAttributeContainer configurationAttributes;
     private final DomainObjectContext domainObjectContext;
     private final ImmutableAttributesFactory attributesFactory;
     private final ResolutionBackedFileCollection intrinsicFiles;
@@ -305,13 +300,14 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
         this.buildOperationExecutor = buildOperationExecutor;
         this.instantiator = instantiator;
         this.attributesFactory = attributesFactory;
-        this.configurationAttributes = attributesFactory.mutable();
         this.domainObjectContext = domainObjectContext;
-        this.intrinsicFiles = fileCollectionFromSpec(Specs.satisfyAll());
         this.exceptionContextualizer = exceptionContextualizer;
-        this.resolvableDependencies = instantiator.newInstance(ConfigurationResolvableDependencies.class, this);
 
-        displayName = Describables.memoize(new ConfigurationDescription(identityPath));
+        this.displayName = Describables.memoize(new ConfigurationDescription(identityPath));
+        this.configurationAttributes = new FreezableAttributeContainer(attributesFactory.mutable(), this.displayName);
+
+        this.intrinsicFiles = fileCollectionFromSpec(Specs.satisfyAll());
+        this.resolvableDependencies = instantiator.newInstance(ConfigurationResolvableDependencies.class, this);
 
         this.ownDependencies = (DefaultDomainObjectSet<Dependency>) domainObjectCollectionFactory.newDomainObjectSet(Dependency.class);
         this.ownDependencies.beforeCollectionChanges(validateMutationType(this, MutationType.DEPENDENCIES));
@@ -714,7 +710,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
                 // TODO: Currently afterResolve runs if there is not an non-unresolved-dependency failure
                 //       We should either _always_ run afterResolve, or only run it if _no_ failure occurred
                 if (!results.getVisitedGraph().getResolutionFailure().isPresent()) {
-                    dependencyResolutionListeners.getSource().afterResolve(incoming);
+                    dependencyResolutionListeners.getSource().afterResolve(getIncoming());
                 }
 
                 // Discard State
@@ -819,7 +815,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
         DependencyResolutionListener dependencyResolutionListener = dependencyResolutionListeners.getSource();
         insideBeforeResolve = true;
         try {
-            dependencyResolutionListener.beforeResolve(incoming);
+            dependencyResolutionListener.beforeResolve(getIncoming());
         } finally {
             insideBeforeResolve = false;
         }
@@ -1106,102 +1102,21 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
 
     @Override
     public void preventFromFurtherMutation() {
-        preventFromFurtherMutation(false);
-    }
+        if (!canBeMutated) {
+            return;
+        }
 
-    @Override
-    public List<? extends GradleException> preventFromFurtherMutationLenient() {
-        return preventFromFurtherMutation(true);
-    }
-
-    private List<? extends GradleException> preventFromFurtherMutation(boolean lenient) {
         // TODO This should use the same `MutationValidator` infrastructure that we use for other mutation types
-        if (canBeMutated) {
-            AttributeContainerInternal delegatee = configurationAttributes.asImmutable();
-            configurationAttributes = new ImmutableAttributeContainerWithErrorMessage(delegatee, this.displayName);
-            outgoing.preventFromFurtherMutation();
-            canBeMutated = false;
 
-            preventUsageMutation();
-
-            // We will only check unique attributes if this configuration is consumable, not resolvable, and has attributes itself
-            if (mustHaveUniqueAttributes(this) && !this.getAttributes().isEmpty()) {
-                return ensureUniqueAttributes(lenient);
-            }
-
-        }
-        return Collections.emptyList();
-    }
-
-    private List<? extends GradleException> ensureUniqueAttributes(boolean lenient) {
-        final Set<? extends ConfigurationInternal> all = (configurationsProvider != null) ? configurationsProvider.getAll() : null;
-        if (all != null) {
-            final Collection<? extends Capability> allCapabilities = allCapabilitiesIncludingDefault(this);
-
-            final Predicate<ConfigurationInternal> isDuplicate = otherConfiguration -> hasSameCapabilitiesAs(allCapabilities, otherConfiguration) && hasSameAttributesAs(otherConfiguration);
-            List<String> collisions = all.stream()
-                .filter(c -> c != this)
-                .filter(this::mustHaveUniqueAttributes)
-                .filter(c -> !c.isCanBeMutated())
-                .filter(isDuplicate)
-                .map(ResolveContext::getDisplayName)
-                .collect(Collectors.toList());
-            if (!collisions.isEmpty()) {
-                DocumentedFailure.Builder builder = DocumentedFailure.builder();
-                String advice = "Consider adding an additional attribute to one of the configurations to disambiguate them.";
-                if (!lenient) {
-                    advice += "  Run the 'outgoingVariants' task for more details.";
-                }
-                GradleException gradleException = builder.withSummary("Consumable configurations with identical capabilities within a project (other than the default configuration) must have unique attributes, but " + getDisplayName() + " and " + collisions + " contain identical attribute sets.")
-                    .withAdvice(advice)
-                    .withUserManual("upgrading_version_7", "unique_attribute_sets")
-                    .build();
-                if (lenient) {
-                    return Collections.singletonList(gradleException);
-                } else {
-                    throw gradleException;
-                }
-            }
-        }
-        return Collections.emptyList();
-    }
-
-    /**
-     * The only configurations which must have unique attributes are those which are consumable (and not also resolvable, legacy configurations),
-     * excluding the default configuration.
-     *
-     * @param configuration the configuration to inspect
-     * @return {@code true} if the given configuration must have unique attributes; {@code false} otherwise
-     */
-    private boolean mustHaveUniqueAttributes(Configuration configuration) {
-        return configuration.isCanBeConsumed() && !configuration.isCanBeResolved() && !Dependency.DEFAULT_CONFIGURATION.equals(configuration.getName());
-    }
-
-    private Collection<? extends Capability> allCapabilitiesIncludingDefault(Configuration conf) {
-        if (conf.getOutgoing().getCapabilities().isEmpty()) {
-            Project project = domainObjectContext.getProject();
-            if (project == null) {
-                throw new IllegalStateException("Project is null for configuration '" + conf.getName() + "'.");
-            }
-            return Collections.singleton(new ProjectDerivedCapability(project));
-        } else {
-            return conf.getOutgoing().getCapabilities();
-        }
-    }
-
-    private boolean hasSameCapabilitiesAs(final Collection<? extends Capability> allMyCapabilities, ConfigurationInternal other) {
-        final Collection<? extends Capability> allOtherCapabilities = allCapabilitiesIncludingDefault(other);
-        //noinspection SuspiciousMethodCalls
-        return allMyCapabilities.size() == allOtherCapabilities.size() && allMyCapabilities.containsAll(allOtherCapabilities);
-    }
-
-    private boolean hasSameAttributesAs(ConfigurationInternal other) {
-        return other.getAttributes().asMap().equals(getAttributes().asMap());
+        configurationAttributes.freeze();
+        outgoing.preventFromFurtherMutation();
+        preventUsageMutation();
+        canBeMutated = false;
     }
 
     @Override
     public void outgoing(Action<? super ConfigurationPublications> action) {
-        action.execute(outgoing);
+        action.execute(getOutgoing());
     }
 
     @Override
@@ -1425,6 +1340,9 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
         childMutationValidators.remove(validator);
     }
 
+    /**
+     * Called when a parent configuration is mutated.
+     */
     private void validateParentMutation(MutationType type) {
         // Strategy changes in a parent configuration do not affect this configuration, or any of its children, in any way
         if (type == MutationType.STRATEGY) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -710,7 +710,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
                 // TODO: Currently afterResolve runs if there is not an non-unresolved-dependency failure
                 //       We should either _always_ run afterResolve, or only run it if _no_ failure occurred
                 if (!results.getVisitedGraph().getResolutionFailure().isPresent()) {
-                    dependencyResolutionListeners.getSource().afterResolve(getIncoming());
+                    dependencyResolutionListeners.getSource().afterResolve(incoming);
                 }
 
                 // Discard State
@@ -815,7 +815,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
         DependencyResolutionListener dependencyResolutionListener = dependencyResolutionListeners.getSource();
         insideBeforeResolve = true;
         try {
-            dependencyResolutionListener.beforeResolve(getIncoming());
+            dependencyResolutionListener.beforeResolve(incoming);
         } finally {
             insideBeforeResolve = false;
         }
@@ -1116,7 +1116,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
 
     @Override
     public void outgoing(Action<? super ConfigurationPublications> action) {
-        action.execute(getOutgoing());
+        action.execute(outgoing);
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
@@ -51,7 +51,7 @@ import java.util.function.Function;
 import java.util.regex.Pattern;
 
 // TODO: We should eventually consider making the DefaultConfigurationContainer extend DefaultPolymorphicDomainObjectContainer
-public class DefaultConfigurationContainer extends AbstractValidatingNamedDomainObjectContainer<Configuration> implements ConfigurationContainerInternal, ConfigurationsProvider {
+public class DefaultConfigurationContainer extends AbstractValidatingNamedDomainObjectContainer<Configuration> implements ConfigurationContainerInternal {
     public static final String DETACHED_CONFIGURATION_DEFAULT_NAME = "detachedConfiguration";
     private static final Pattern RESERVED_NAMES_FOR_DETACHED_CONFS = Pattern.compile(DETACHED_CONFIGURATION_DEFAULT_NAME + "\\d*");
     @SuppressWarnings("deprecation")

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultVariant.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultVariant.java
@@ -26,7 +26,7 @@ import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.ConfigurationVariantInternal;
 import org.gradle.api.internal.artifacts.DefaultPublishArtifactSet;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
-import org.gradle.api.internal.attributes.ImmutableAttributeContainerWithErrorMessage;
+import org.gradle.api.internal.attributes.FreezableAttributeContainer;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
@@ -43,7 +43,7 @@ import java.util.Optional;
 public class DefaultVariant implements ConfigurationVariantInternal {
     private final Describable parentDisplayName;
     private final String name;
-    private AttributeContainerInternal attributes;
+    private final FreezableAttributeContainer attributes;
     private final NotationParser<Object, ConfigurablePublishArtifact> artifactNotationParser;
     private final PublishArtifactSet artifacts;
     private Factory<List<PublishArtifact>> lazyArtifacts;
@@ -59,7 +59,7 @@ public class DefaultVariant implements ConfigurationVariantInternal {
                           TaskDependencyFactory taskDependencyFactory) {
         this.parentDisplayName = parentDisplayName;
         this.name = name;
-        attributes = cache.mutable(parentAttributes);
+        this.attributes = new FreezableAttributeContainer(cache.mutable(parentAttributes), parentDisplayName);
         this.artifactNotationParser = artifactNotationParser;
         artifacts = new DefaultPublishArtifactSet(getDisplayName(), domainObjectCollectionFactory.newDomainObjectSet(PublishArtifact.class), fileCollectionFactory, taskDependencyFactory);
     }
@@ -132,6 +132,6 @@ public class DefaultVariant implements ConfigurationVariantInternal {
 
     @Override
     public void preventFurtherMutation() {
-        attributes = new ImmutableAttributeContainerWithErrorMessage(attributes.asImmutable(), parentDisplayName);
+        attributes.freeze();
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/VariantIdentityUniquenessVerifier.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/VariantIdentityUniquenessVerifier.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.configurations;
+
+import com.google.common.collect.ListMultimap;
+import com.google.common.collect.MultimapBuilder;
+import org.gradle.api.GradleException;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.capabilities.Capability;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.internal.component.external.model.ImmutableCapabilities;
+import org.gradle.internal.component.external.model.ProjectDerivedCapability;
+import org.gradle.internal.deprecation.DocumentedFailure;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Static utility to verify a set of variants each have a unique identity in terms of attributes and capabilities.
+ */
+public class VariantIdentityUniquenessVerifier {
+
+    /**
+     * Build a report of all possible variant uniqueness failures for the given configurations.
+     */
+    public static VerificationReport buildReport(ConfigurationsProvider configurations) {
+        ListMultimap<VariantIdentity, ConfigurationInternal> byIdentity =
+            MultimapBuilder.linkedHashKeys().arrayListValues().build();
+
+        configurations.visitAll(configuration -> {
+            if (!mustHaveUniqueAttributes(configuration)) {
+                return;
+            }
+
+            byIdentity.put(VariantIdentity.from(configuration), configuration);
+        });
+
+        return new VerificationReport(byIdentity);
+    }
+
+    /**
+     * Consumable, non-resolvable, non-default configurations with attributes must have unique attributes.
+     */
+    private static boolean mustHaveUniqueAttributes(Configuration configuration) {
+        return configuration.isCanBeConsumed() &&
+            !configuration.isCanBeResolved() &&
+            !Dependency.DEFAULT_CONFIGURATION.equals(configuration.getName()) &&
+            !configuration.getAttributes().isEmpty();
+    }
+
+    /**
+     * A report tracking all possible variant uniqueness failures for a component.
+     */
+    public static class VerificationReport {
+
+        private final ListMultimap<VariantIdentity, ConfigurationInternal> byIdentity;
+
+        private VerificationReport(ListMultimap<VariantIdentity, ConfigurationInternal> byIdentity) {
+            this.byIdentity = byIdentity;
+        }
+
+        /**
+         * Get a failure that only checks variant uniqueness for the given configuration.
+         */
+        @Nullable
+        public GradleException failureFor(ConfigurationInternal configuration, boolean withTaskAdvice) {
+            List<ConfigurationInternal> collisions =
+                byIdentity.get(VariantIdentity.from(configuration)).stream()
+                    .filter(it -> it != configuration)
+                    .collect(Collectors.toList());
+
+            if (collisions.isEmpty()) {
+                return null;
+            }
+
+            DocumentedFailure.Builder builder = DocumentedFailure.builder();
+            String advice = "Consider adding an additional attribute to one of the configurations to disambiguate them.";
+            if (withTaskAdvice) {
+                advice += "  Run the 'outgoingVariants' task for more details.";
+            }
+
+            String message = "Consumable configurations with identical capabilities within a project (other than the default configuration) " +
+                "must have unique attributes, but " + configuration.getDisplayName() + " and " + collisions + " contain identical attribute sets.";
+
+            return builder.withSummary(message)
+                .withAdvice(advice)
+                .withUserManual("upgrading_version_7", "unique_attribute_sets")
+                .build();
+        }
+
+        /**
+         * Get a failure that encompasses all configurations.
+         */
+        @Nullable
+        public GradleException aggregateFailure() {
+            for (VariantIdentity identity : byIdentity.keySet()) {
+                List<ConfigurationInternal> collisions = byIdentity.get(identity);
+                if (collisions.size() > 1) {
+                    return failureFor(collisions.get(0), true);
+                }
+            }
+
+            return null;
+        }
+    }
+
+    /**
+     * The identity of a variant -- its attributes and capabilities.
+     */
+    private static class VariantIdentity {
+        private final ImmutableAttributes attributes;
+        private final ImmutableCapabilities capabilities;
+
+        private VariantIdentity(ImmutableAttributes attributes, ImmutableCapabilities capabilities) {
+            this.attributes = attributes;
+            this.capabilities = capabilities;
+        }
+
+        public static VariantIdentity from(ConfigurationInternal configuration) {
+            return new VariantIdentity(
+                configuration.getAttributes().asImmutable(),
+                allCapabilitiesIncludingDefault(configuration)
+            );
+        }
+
+        private static ImmutableCapabilities allCapabilitiesIncludingDefault(ConfigurationInternal conf) {
+            Collection<? extends Capability> declaredCapabilities = conf.getOutgoing().getCapabilities();
+            if (!declaredCapabilities.isEmpty()) {
+                return ImmutableCapabilities.of(declaredCapabilities);
+            }
+
+            // If no capabilities are declared, use the implicit capability.
+            Project project = conf.getDomainObjectContext().getProject();
+            if (project == null) {
+                return ImmutableCapabilities.EMPTY;
+            }
+            return ImmutableCapabilities.of(new ProjectDerivedCapability(project));
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            VariantIdentity that = (VariantIdentity) o;
+            return Objects.equals(attributes, that.attributes) &&
+                   Objects.equals(capabilities, that.capabilities);
+        }
+
+        @Override
+        public int hashCode() {
+            return attributes.hashCode() ^ capabilities.hashCode();
+        }
+    }
+
+}

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/FreezableAttributeContainer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/attributes/FreezableAttributeContainer.java
@@ -67,18 +67,14 @@ public class FreezableAttributeContainer implements AttributeContainerInternal {
 
     @Override
     public <T> AttributeContainer attribute(Attribute<T> key, T value) {
-        if (delegate instanceof ImmutableAttributes) {
-            throw new IllegalArgumentException(String.format("Cannot change attributes of dependency %s after it has been resolved", owner.getDisplayName()));
-        }
+        assertMutable();
         delegate.attribute(key, value);
         return this;
     }
 
     @Override
     public <T> AttributeContainer attributeProvider(Attribute<T> key, Provider<? extends T> provider) {
-        if (delegate instanceof ImmutableAttributes) {
-            throw new IllegalArgumentException(String.format("Cannot change attributes of dependency %s after it has been resolved", owner.getDisplayName()));
-        }
+        assertMutable();
         delegate.attributeProvider(key, provider);
         return this;
     }
@@ -102,5 +98,11 @@ public class FreezableAttributeContainer implements AttributeContainerInternal {
     @Override
     public AttributeContainer getAttributes() {
         return this;
+    }
+
+    private void assertMutable() {
+        if (delegate instanceof ImmutableAttributes) {
+            throw new IllegalStateException(String.format("Cannot change attributes of %s after it has been locked for mutation", owner.getDisplayName()));
+        }
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
@@ -18,7 +18,6 @@ package org.gradle.internal.component.local.model;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import org.gradle.api.GradleException;
 import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
@@ -329,10 +328,7 @@ public final class DefaultLocalComponentMetadata implements LocalComponentMetada
 
         @Override
         public void visitConfigurations(Consumer<Candidate> visitor) {
-            GradleException failure = VariantIdentityUniquenessVerifier.buildReport(configurationsProvider).aggregateFailure();
-            if (failure != null) {
-                throw failure;
-            }
+            VariantIdentityUniquenessVerifier.buildReport(configurationsProvider).assertNoConflicts();
 
             configurationsProvider.visitAll(configuration -> {
                 visitor.accept(new Candidate() {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
@@ -18,11 +18,13 @@ package org.gradle.internal.component.local.model;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import org.gradle.api.GradleException;
 import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationsProvider;
+import org.gradle.api.internal.artifacts.configurations.VariantIdentityUniquenessVerifier;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.DefaultLocalConfigurationMetadataBuilder;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.LocalConfigurationMetadataBuilder;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
@@ -327,6 +329,11 @@ public final class DefaultLocalComponentMetadata implements LocalComponentMetada
 
         @Override
         public void visitConfigurations(Consumer<Candidate> visitor) {
+            GradleException failure = VariantIdentityUniquenessVerifier.buildReport(configurationsProvider).aggregateFailure();
+            if (failure != null) {
+                throw failure;
+            }
+
             configurationsProvider.visitAll(configuration -> {
                 visitor.accept(new Candidate() {
                     @Override

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -1531,8 +1531,8 @@ class DefaultConfigurationSpec extends Specification implements InspectableConfi
         conf.getAttributes().attribute(a1, "a1")
 
         then:
-        IllegalArgumentException t = thrown()
-        t.message == "Cannot change attributes of dependency configuration ':conf' after it has been resolved"
+        IllegalStateException t = thrown()
+        t.message == "Cannot change attributes of configuration ':conf' after it has been locked for mutation"
     }
 
     def "wrapper attribute container behaves similar to the delegatee"() {


### PR DESCRIPTION
The preventFromFurtherMutation method did a lot more than the name implied. It also checked all other configurations to ensure they had separate attributes and capabilities than the current configuration being frozen. There are a few reasons we want to avoid doing this check in this method:

1. The configuration should not need a reference to the configurations provider. We are deprecating the getAll method because of this. This change is needed to avoid that reference
2. The method is more true to its name.

Furthermore, we create a FreezeableAttributeContainer which allows the attribute container to maintain the same attribute container reference before and after preventFromFurtherMutation is called. Previously, users who called getAttributes on the configuration before it was prevented from mutation would keep having the mutable reference after mutation was prevented. Now, those same callers will not be able to mutate their attribute container reference after the owning configuration is frozen.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
