### PR TITLE
Update out-of-date TeamCity links

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/reference/ci-systems/teamcity.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/ci-systems/teamcity.adoc
@@ -169,19 +169,19 @@ Otherwise, the link to the link:https://scans.gradle.com[build scan] for the giv
 image::ci-systems/teamcity-log-link.png[]
 
 There are various options to trigger TeamCity builds continuously:
-from link:https://confluence.jetbrains.com/display/TCDL/Configuring+Build+Triggers[polling the repository] periodically,
-to link:https://confluence.jetbrains.com/display/TCDL/Configuring+Schedule+Triggers[building on a set schedule],
-or via link:https://confluence.jetbrains.com/display/TCDL/Configuring+VCS+Post-Commit+Hooks+for+TeamCity[post-commit hook].
+from link:https://www.jetbrains.com/help/teamcity/configuring-build-triggers.html[polling the repository] periodically,
+to link:https://www.jetbrains.com/help/teamcity/configuring-schedule-triggers.html[building on a set schedule],
+or via link:https://www.jetbrains.com/help/teamcity/configuring-vcs-post-commit-hooks-for-teamcity.html[post-commit hook].
 
 
 == Further reading
 
 You can learn more about advanced TeamCity usage through these resources:
 
-* https://confluence.jetbrains.com/display/TCD18/Build+Dependencies+Setup[Build chains and dependencies]
-* https://confluence.jetbrains.com/display/TCD18/Pre-Tested+%28Delayed%29+Commit[Remote run and pre-tested commit]
+* https://www.jetbrains.com/help/teamcity/build-dependencies-setup.html[Build chains and dependencies]
+* https://www.jetbrains.com/help/teamcity/pre-tested-delayed-commit.html[Remote run and pre-tested commit]
 
-More information is available in https://confluence.jetbrains.com/display/TCD18/TeamCity+Documentation[TeamCity documentation].
+More information is available in https://www.jetbrains.com/help/teamcity/teamcity-documentation.html[TeamCity documentation].
 Follow the https://blog.jetbrains.com/teamcity/[TeamCity blog] for the latest news.
 
 


### PR DESCRIPTION
The links in teamcity documentation are quite out-of-date.