### PR TITLE
Deprecate legacy URI handling & return valid ASCII-safe URIs

### DIFF
--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/FileOrUriNotationConverter.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/FileOrUriNotationConverter.java
@@ -148,14 +148,6 @@ public class FileOrUriNotationConverter implements NotationConverter<Object, Obj
         }
     }
 
-    private static String uriDecode(String path) {
-        try {
-            return new URI(path).getSchemeSpecificPart();
-        } catch (URISyntaxException e) {
-            return fallbackUrlDecode(path);
-        }
-    }
-
     /**
      * Lenient legacy behavior to fall back to when URI cannot be normally parsed.
      */

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/FileOrUriNotationConverter.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/FileOrUriNotationConverter.java
@@ -160,7 +160,7 @@ public class FileOrUriNotationConverter implements NotationConverter<Object, Obj
      * Lenient legacy behavior to fall back to when URI cannot be normally parsed.
      */
     private static String fallbackUrlDecode(String path) {
-        DeprecationLogger.deprecateBehaviour("legacy URL decoding for invalid URLs")
+        DeprecationLogger.deprecateBehaviour("Passing invalid URIs to URI or File converting methods.")
             .withAdvice("Use a valid URL or a file path instead.")
             .willBecomeAnErrorInGradle9()
             .withUpgradeGuideSection(8, "deprecated_legacy_url_decoding")

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/FileOrUriNotationConverter.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/FileOrUriNotationConverter.java
@@ -155,7 +155,7 @@ public class FileOrUriNotationConverter implements NotationConverter<Object, Obj
         DeprecationLogger.deprecateBehaviour("Passing invalid URIs to URI or File converting methods.")
             .withAdvice("Use a valid URL or a file path instead.")
             .willBecomeAnErrorInGradle9()
-            .withUpgradeGuideSection(8, "deprecated_legacy_url_decoding")
+            .withUpgradeGuideSection(8, "deprecated_invalid_url_decoding")
             .nagUser();
         StringBuffer builder = new StringBuffer();
         Matcher matcher = ENCODED_URI.matcher(path);

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/FileOrUriNotationConverter.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/FileOrUriNotationConverter.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.file;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.api.file.FileSystemLocation;
 import org.gradle.api.resources.TextResource;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.exceptions.DiagnosticsVisitor;
 import org.gradle.internal.os.OperatingSystem;
 import org.gradle.internal.typeconversion.NotationConvertResult;
@@ -84,17 +85,33 @@ public class FileOrUriNotationConverter implements NotationConverter<Object, Obj
         }
         if (notation instanceof URI) {
             URI uri = (URI) notation;
-            if ("file".equals(uri.getScheme()) && uri.getPath() != null) {
-                result.converted(new File(uri.getPath()));
-            } else {
-                result.converted(uri);
+            if ("file".equals(uri.getScheme())) {
+                try {
+                    result.converted(new File(uri));
+                    return;
+                } catch (IllegalArgumentException ignored) {
+                    // Bad file URI, return URI as-is
+                }
             }
+            result.converted(uri);
             return;
         }
         if (notation instanceof CharSequence) {
             String notationString = notation.toString();
             if (notationString.startsWith("file:")) {
-                result.converted(new File(uriDecode(notationString.substring(5))));
+                try {
+                    URI uri = new URI(notationString);
+                    try {
+                        result.converted(new File(uri));
+                        return;
+                    } catch (IllegalArgumentException ignored) {
+                        // Bad file URI, use old logic
+                    }
+                } catch (URISyntaxException ignored) {
+                    // Unparsable, use old logic
+                }
+                // Fallback if relative or unparsable
+                result.converted(new File(fallbackUrlDecode(notationString.substring(5))));
                 return;
             }
             if (notationString.startsWith("http:") || notationString.startsWith("https:")) {
@@ -141,10 +158,13 @@ public class FileOrUriNotationConverter implements NotationConverter<Object, Obj
 
     /**
      * Lenient legacy behavior to fall back to when URI cannot be normally parsed.
-     *
-     * TODO: Deprecate this
      */
     private static String fallbackUrlDecode(String path) {
+        DeprecationLogger.deprecateBehaviour("legacy URL decoding for invalid URLs")
+            .withAdvice("Use a valid URL or a file path instead.")
+            .willBecomeAnErrorInGradle9()
+            .withUpgradeGuideSection(8, "deprecated_legacy_url_decoding")
+            .nagUser();
         StringBuffer builder = new StringBuffer();
         Matcher matcher = ENCODED_URI.matcher(path);
         while (matcher.find()) {

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -35,6 +35,33 @@ The previous step will help you identify potential problems by issuing deprecati
 . Run `gradle wrapper --gradle-version {gradleVersion}` to update the project to {gradleVersion}.
 . Try to run the project and debug any errors using the <<troubleshooting.adoc#troubleshooting, Troubleshooting Guide>>.
 
+[[changes_8.7]]
+== Upgrade from 8.6 and earlier
+
+=== Potential breaking changes
+
+=== Deprecations
+
+[[deprecated_legacy_url_decoding]]
+==== Deprecated legacy URL decoding behavior
+Prior to Gradle 8.3, Gradle would decode a `CharSequence` given to `link:{groovyDslPath}/org.gradle.api.Project.html#org.gradle.api.Project:uri(java.lang.Object)[Project.uri(Object)]`
+using a flawed algorithm that accepted invalid URLs and improperly decoded others. Gradle now uses the `URI` class to parse and decode URLs,
+but with a fallback to the legacy behavior in the event of an error.
+
+Starting in Gradle 9.0, the fallback will be removed, and the error will be thrown instead.
+
+To fix a deprecation warning, invalid URLs that require the legacy behavior should be re-encoded to be valid URLs, such as in the following examples:
+
+.Legacy URL Conversions
+|===
+| Original Input | New Input | Reasoning
+
+| `file:relative/path` | `relative/path` | The `file` scheme does not support relative paths.
+| `file:relative/path%21` | `relative/path!` | Without a scheme, the path is taken as-is, without decoding.
+| `https://example.com/my folder/` | `https://example.com/my%20folder/` | Spaces are not valid in URLs.
+| `https://example.com/my%%badly%encoded%path` | `https://example.com/my%25%25badly%25encoded%25path` | `%` must be encoded as `%25` in URLs, and no `%`-escapes should be invalid.
+|===
+
 [[changes_8.6]]
 == Upgrading from 8.5 and earlier
 
@@ -212,13 +239,6 @@ dependencies {
 [[deprecated_artifact_identifier]]
 ==== Deprecated `ArtifactIdentifier`
 The `ArtifactIdentifier` class has been deprecated for removal in Gradle 9.0.
-
-[[deprecated_legacy_url_decoding]]
-==== Deprecated legacy URL decoding behavior
-Prior to Gradle 8.3, Gradle would decode a `CharSequence` given to `link:{groovyDslPath}/org.gradle.api.Project.html#org.gradle.api.Project:uri(java.lang.Object)[Project.uri(Object)]`
-using a flawed algorithm that accepted invalid URLs and improperly decoded others. Gradle now uses the `URI` class to parse and decode URLs,
-but with a fallback to the legacy behavior in the event of an error. This fallback will be removed in Gradle 9.0. Invalid URLs that require the legacy
-behavior should be re-encoded to be valid URLs.
 
 [[changes_8.5]]
 == Upgrading from 8.4 and earlier

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -44,11 +44,10 @@ The previous step will help you identify potential problems by issuing deprecati
 
 [[deprecated_legacy_url_decoding]]
 ==== Deprecated legacy URL decoding behavior
-Prior to Gradle 8.3, Gradle would decode a `CharSequence` given to `link:{groovyDslPath}/org.gradle.api.Project.html#org.gradle.api.Project:uri(java.lang.Object)[Project.uri(Object)]`
-using a flawed algorithm that accepted invalid URLs and improperly decoded others. Gradle now uses the `URI` class to parse and decode URLs,
-but with a fallback to the legacy behavior in the event of an error.
+Prior to Gradle 8.3, Gradle would decode a `CharSequence` given to `link:{groovyDslPath}/org.gradle.api.Project.html#org.gradle.api.Project:uri(java.lang.Object)[Project.uri(Object)]` using an algorithm that accepted invalid URLs and improperly decoded others. 
+Gradle now uses the `URI` class to parse and decode URLs, but with a fallback to the legacy behavior in the event of an error.
 
-Starting in Gradle 9.0, the fallback will be removed, and the error will be thrown instead.
+Starting in Gradle 9.0, the fallback will be removed, and an error will be thrown instead.
 
 To fix a deprecation warning, invalid URLs that require the legacy behavior should be re-encoded to be valid URLs, such as in the following examples:
 

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -213,6 +213,13 @@ dependencies {
 ==== Deprecated `ArtifactIdentifier`
 The `ArtifactIdentifier` class has been deprecated for removal in Gradle 9.0.
 
+[[deprecated_legacy_url_decoding]]
+==== Deprecated legacy URL decoding behavior
+Prior to Gradle 8.3, Gradle would decode a `CharSequence` given to `link:{groovyDslPath}/org.gradle.api.Project.html#org.gradle.api.Project:uri(java.lang.Object)[Project.uri(Object)]`
+using a flawed algorithm that accepted invalid URLs and improperly decoded others. Gradle now uses the `URI` class to parse and decode URLs,
+but with a fallback to the legacy behavior in the event of an error. This fallback will be removed in Gradle 9.0. Invalid URLs that require the legacy
+behavior should be re-encoded to be valid URLs.
+
 [[changes_8.5]]
 == Upgrading from 8.4 and earlier
 

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -36,15 +36,15 @@ The previous step will help you identify potential problems by issuing deprecati
 . Try to run the project and debug any errors using the <<troubleshooting.adoc#troubleshooting, Troubleshooting Guide>>.
 
 [[changes_8.7]]
-== Upgrade from 8.6 and earlier
+== Upgrading from 8.6 and earlier
 
 === Potential breaking changes
 
 === Deprecations
 
-[[deprecated_legacy_url_decoding]]
-==== Deprecated legacy URL decoding behavior
-Prior to Gradle 8.3, Gradle would decode a `CharSequence` given to `link:{groovyDslPath}/org.gradle.api.Project.html#org.gradle.api.Project:uri(java.lang.Object)[Project.uri(Object)]` using an algorithm that accepted invalid URLs and improperly decoded others. 
+[[deprecated_invalid_url_decoding]]
+==== Deprecated invalid URL decoding behavior
+Prior to Gradle 8.3, Gradle would decode a `CharSequence` given to `link:{groovyDslPath}/org.gradle.api.Project.html#org.gradle.api.Project:uri(java.lang.Object)[Project.uri(Object)]` using an algorithm that accepted invalid URLs and improperly decoded others.
 Gradle now uses the `URI` class to parse and decode URLs, but with a fallback to the legacy behavior in the event of an error.
 
 Starting in Gradle 9.0, the fallback will be removed, and an error will be thrown instead.

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-conditionalSubstitutionRule/groovy/buildSrc/src/main/groovy/myproject.java-library-conventions.gradle
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-conditionalSubstitutionRule/groovy/buildSrc/src/main/groovy/myproject.java-library-conventions.gradle
@@ -3,5 +3,5 @@ plugins {
 }
 
 repositories {
-    ivy { url "${rootProject.projectDir.toURI().toASCIIString()}/repo" }
+    ivy { url rootProject.layout.projectDirectory.dir("repo") }
 }

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-conditionalSubstitutionRule/groovy/buildSrc/src/main/groovy/myproject.java-library-conventions.gradle
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-conditionalSubstitutionRule/groovy/buildSrc/src/main/groovy/myproject.java-library-conventions.gradle
@@ -3,5 +3,5 @@ plugins {
 }
 
 repositories {
-    ivy { url "file://${rootProject.projectDir}/repo" }
+    ivy { url "${rootProject.projectDir.toURI().toASCIIString()}/repo" }
 }

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-conditionalSubstitutionRule/kotlin/buildSrc/src/main/kotlin/myproject.java-library-conventions.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-conditionalSubstitutionRule/kotlin/buildSrc/src/main/kotlin/myproject.java-library-conventions.gradle.kts
@@ -3,5 +3,5 @@ plugins {
 }
 
 repositories {
-    ivy { url = uri("file://${rootProject.projectDir}/repo") }
+    ivy { url = uri("${rootProject.projectDir.toURI().toASCIIString()}repo") }
 }

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-conditionalSubstitutionRule/kotlin/buildSrc/src/main/kotlin/myproject.java-library-conventions.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-conditionalSubstitutionRule/kotlin/buildSrc/src/main/kotlin/myproject.java-library-conventions.gradle.kts
@@ -3,5 +3,5 @@ plugins {
 }
 
 repositories {
-    ivy { url = uri("${rootProject.projectDir.toURI().toASCIIString()}repo") }
+    ivy { url = uri(rootProject.layout.projectDirectory.dir("repo")) }
 }

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-selectionRule/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-selectionRule/groovy/build.gradle
@@ -1,6 +1,6 @@
 repositories {
     ivy {
-        url "file://${projectDir}/repo"
+        url "${projectDir.toURI().toASCIIString()}repo"
     }
 }
 

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-selectionRule/groovy/build.gradle
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-selectionRule/groovy/build.gradle
@@ -1,6 +1,6 @@
 repositories {
     ivy {
-        url "${projectDir.toURI().toASCIIString()}repo"
+        url layout.projectDirectory.dir("repo")
     }
 }
 

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-selectionRule/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-selectionRule/kotlin/build.gradle.kts
@@ -1,6 +1,6 @@
 repositories {
     ivy {
-        url = uri("file://${projectDir}/repo")
+        url = uri("${projectDir.toURI().toASCIIString()}/repo")
     }
 }
 

--- a/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-selectionRule/kotlin/build.gradle.kts
+++ b/platforms/documentation/docs/src/snippets/dependencyManagement/customizingResolution-selectionRule/kotlin/build.gradle.kts
@@ -1,6 +1,6 @@
 repositories {
     ivy {
-        url = uri("${projectDir.toURI().toASCIIString()}/repo")
+        url = uri(layout.projectDirectory.dir("repo"))
     }
 }
 

--- a/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/RepositoryOrderingIntegrationSpec.groovy
+++ b/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/RepositoryOrderingIntegrationSpec.groovy
@@ -61,7 +61,7 @@ class RepositoryOrderingIntegrationSpec extends AbstractIntegrationSpec {
         when:
         settingsFile << """
             pluginManagement {
-                repositories { maven { url = "$pluginManagementRepoUri" } }
+                repositories { maven { url = "pluginManagementRepo" } }
             }
         """.stripIndent()
 
@@ -79,7 +79,7 @@ class RepositoryOrderingIntegrationSpec extends AbstractIntegrationSpec {
     }
 
     private String normalizedUriOf(String path) {
-        file(path).toURI().toString().replace("%20", " ")
+        file(path).toURI().toASCIIString()
     }
 
     private void overridePluginPortalUri(String uri) {

--- a/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/RepositoryOrderingIntegrationSpec.groovy
+++ b/platforms/extensibility/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/RepositoryOrderingIntegrationSpec.groovy
@@ -27,9 +27,9 @@ class RepositoryOrderingIntegrationSpec extends AbstractIntegrationSpec {
     def "buildscript repositories searched before plugin management repositories"() {
 
         given:
-        def pluginPortalUri = normalizedUriOf("pluginPortalRepo")
-        def buildscriptRepoUri = normalizedUriOf("buildscriptRepo")
-        def pluginManagementRepoUri = normalizedUriOf("pluginManagementRepo")
+        def pluginPortalUri = file("pluginPortalRepo").displayUri
+        def buildscriptRepoUri = file("buildscriptRepo").displayUri
+        def pluginManagementRepoUri = file("pluginManagementRepo").displayUri
         overridePluginPortalUri(pluginPortalUri)
 
         and:
@@ -61,7 +61,7 @@ class RepositoryOrderingIntegrationSpec extends AbstractIntegrationSpec {
         when:
         settingsFile << """
             pluginManagement {
-                repositories { maven { url = "pluginManagementRepo" } }
+                repositories { maven { url = "$pluginManagementRepoUri" } }
             }
         """.stripIndent()
 
@@ -78,9 +78,6 @@ class RepositoryOrderingIntegrationSpec extends AbstractIntegrationSpec {
         """.stripIndent().trim()
     }
 
-    private String normalizedUriOf(String path) {
-        file(path).toURI().toASCIIString()
-    }
 
     private void overridePluginPortalUri(String uri) {
         executer.withArgument("-D${PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY}=$uri")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactDependenciesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactDependenciesIntegrationTest.groovy
@@ -244,7 +244,7 @@ task listMissingClassifier {
 
         failure.assertHasCause("""Could not find lib-1.0.zip (org.gradle.test:lib:1.0).
 Searched in the following locations:
-    ${module.artifactFile(type: 'zip').toURL()}""")
+    ${module.artifactFile(type: 'zip').toURI().toASCIIString()}""")
 
         when:
         fails('listMissingClassifier')
@@ -252,7 +252,7 @@ Searched in the following locations:
         then:
         failure.assertHasCause("""Could not find lib-1.0-classifier1.jar (org.gradle.test:lib:1.0).
 Searched in the following locations:
-    ${module.artifactFile(classifier: 'classifier1').toURL()}""")
+    ${module.artifactFile(classifier: 'classifier1').toURI().toASCIIString()}""")
     }
 
     @Issue("GRADLE-1342")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactDependenciesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactDependenciesIntegrationTest.groovy
@@ -244,7 +244,7 @@ task listMissingClassifier {
 
         failure.assertHasCause("""Could not find lib-1.0.zip (org.gradle.test:lib:1.0).
 Searched in the following locations:
-    ${module.artifactFile(type: 'zip').toURI().toASCIIString()}""")
+    ${module.artifactFile(type: 'zip').displayUri}""")
 
         when:
         fails('listMissingClassifier')
@@ -252,7 +252,7 @@ Searched in the following locations:
         then:
         failure.assertHasCause("""Could not find lib-1.0-classifier1.jar (org.gradle.test:lib:1.0).
 Searched in the following locations:
-    ${module.artifactFile(classifier: 'classifier1').toURI().toASCIIString()}""")
+    ${module.artifactFile(classifier: 'classifier1').displayUri}""")
     }
 
     @Issue("GRADLE-1342")

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/FlatDirJvmLibraryArtifactResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/FlatDirJvmLibraryArtifactResolutionIntegrationTest.groovy
@@ -50,8 +50,8 @@ repositories {
     }
 
     def "resolves artifacts of non-existing component"() {
-        def location1 = file("repo/some-artifact-1.0.jar").toURI().toASCIIString()
-        def location2 = file("repo/some-artifact.jar").toURI().toASCIIString()
+        def location1 = file("repo/some-artifact-1.0.jar").displayUri
+        def location2 = file("repo/some-artifact.jar").displayUri
 
         fixture.expectComponentNotFound().prepare()
 
@@ -86,8 +86,8 @@ Searched in the following locations:
     def "can only resolve component if main artifact exists"() {
         file("repo/some-artifact-1.0-sources.jar").createFile()
         file("repo/some-artifact-1.0-javadoc.jar").createFile()
-        def location1 = file("repo/some-artifact-1.0.jar").toURI().toASCIIString()
-        def location2 = file("repo/some-artifact.jar").toURI().toASCIIString()
+        def location1 = file("repo/some-artifact-1.0.jar").displayUri
+        def location2 = file("repo/some-artifact.jar").displayUri
 
         fixture.expectComponentNotFound().prepare()
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/FlatDirJvmLibraryArtifactResolutionIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/FlatDirJvmLibraryArtifactResolutionIntegrationTest.groovy
@@ -50,8 +50,8 @@ repositories {
     }
 
     def "resolves artifacts of non-existing component"() {
-        def location1 = file("repo/some-artifact-1.0.jar").toURL()
-        def location2 = file("repo/some-artifact.jar").toURL()
+        def location1 = file("repo/some-artifact-1.0.jar").toURI().toASCIIString()
+        def location2 = file("repo/some-artifact.jar").toURI().toASCIIString()
 
         fixture.expectComponentNotFound().prepare()
 
@@ -86,8 +86,8 @@ Searched in the following locations:
     def "can only resolve component if main artifact exists"() {
         file("repo/some-artifact-1.0-sources.jar").createFile()
         file("repo/some-artifact-1.0-javadoc.jar").createFile()
-        def location1 = file("repo/some-artifact-1.0.jar").toURL().toString()
-        def location2 = file("repo/some-artifact.jar").toURL().toString()
+        def location1 = file("repo/some-artifact-1.0.jar").toURI().toASCIIString()
+        def location2 = file("repo/some-artifact.jar").toURI().toASCIIString()
 
         fixture.expectComponentNotFound().prepare()
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/DependencyConstraintsBugsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/DependencyConstraintsBugsIntegrationTest.groovy
@@ -49,7 +49,7 @@ class DependencyConstraintsBugsIntegrationTest extends AbstractHttpDependencyRes
             repositories {
                 ${mavenCentralRepository()}
                 maven {
-                   url(uri("file:ktor-repo/"))
+                   url(uri("./ktor-repo/"))
                 }
             }
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalRepoResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalRepoResolveIntegrationTest.groovy
@@ -180,7 +180,7 @@ class MavenLocalRepoResolveIntegrationTest extends AbstractDependencyResolutionT
         then:
         failure.assertHasCause("""Could not find group:projectA:1.2.
 Searched in the following locations:
-  - ${module.pomFile.toURI().toASCIIString()}
+  - ${module.pomFile.displayUri}
 Required by:
 """)
         failure.assertHasResolutions(repositoryHint("Maven POM"),

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalRepoResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalRepoResolveIntegrationTest.groovy
@@ -180,7 +180,7 @@ class MavenLocalRepoResolveIntegrationTest extends AbstractDependencyResolutionT
         then:
         failure.assertHasCause("""Could not find group:projectA:1.2.
 Searched in the following locations:
-  - ${module.pomFile.toURL()}
+  - ${module.pomFile.toURI().toASCIIString()}
 Required by:
 """)
         failure.assertHasResolutions(repositoryHint("Maven POM"),

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractResourcePattern.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractResourcePattern.java
@@ -61,7 +61,7 @@ abstract class AbstractResourcePattern implements ResourcePattern {
     public String getPattern() {
         // Replace encoded [] with plain variants, since we are using them with a special meaning here.
         // Inefficient but easy to read, I don't think this method is hot.
-        return pattern.getDecoded().replace("%5B", "[").replace("%5D", "]");
+        return pattern.getDisplayable().replace("%5B", "[").replace("%5D", "]");
     }
 
     protected ExternalResourceName getBase() {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractResourcePattern.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractResourcePattern.java
@@ -59,7 +59,9 @@ abstract class AbstractResourcePattern implements ResourcePattern {
 
     @Override
     public String getPattern() {
-        return pattern.getDecoded();
+        // Replace encoded [] with plain variants, since we are using them with a special meaning here.
+        // Inefficient but easy to read, I don't think this method is hot.
+        return pattern.getDecoded().replace("%5B", "[").replace("%5D", "]");
     }
 
     protected ExternalResourceName getBase() {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractResourcePattern.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractResourcePattern.java
@@ -60,7 +60,6 @@ abstract class AbstractResourcePattern implements ResourcePattern {
     @Override
     public String getPattern() {
         // Replace encoded [] with plain variants, since we are using them with a special meaning here.
-        // Inefficient but easy to read, I don't think this method is hot.
         return pattern.getDisplayable().replace("%5B", "[").replace("%5D", "]");
     }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/ArtifactNotFoundException.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/resolve/ArtifactNotFoundException.java
@@ -30,7 +30,7 @@ public class ArtifactNotFoundException extends ArtifactResolveException {
         if (!locations.isEmpty()) {
             builder.append(String.format("%nSearched in the following locations:"));
             for (String location : locations) {
-                builder.append(String.format("%n    %s", location.replace("%", "%%")));
+                builder.append(String.format("%n    %s", location));
             }
         }
         return builder.toString();

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/IvyResourcePatternTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/IvyResourcePatternTest.groovy
@@ -37,7 +37,7 @@ class IvyResourcePatternTest extends Specification {
         "http://host/"     | ""                 | "http://host/"
         "http://host"      | ""                 | "http://host"
         "http://host/"     | "/"                | "http://host/"
-        "http://host/repo" | "query?[revision]" | "http://host/repo/query?[revision]"
+        "http://host/repo" | "query?[revision]" | "http://host/repo/query%3F[revision]"
     }
 
     def "substitutes artifact attributes into pattern"() {

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/resource/transfer/DefaultCacheAwareExternalResourceAccessorTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/resource/transfer/DefaultCacheAwareExternalResourceAccessorTest.groovy
@@ -138,7 +138,7 @@ class DefaultCacheAwareExternalResourceAccessorTest extends Specification {
     }
 
     def "reuses cached resource if it has not expired"() {
-        def location = new ExternalResourceName("scheme:thing")
+        def location = new ExternalResourceName("thing")
         def fileStore = Mock(CacheAwareExternalResourceAccessor.ResourceFileStore)
         def localCandidates = Mock(LocallyAvailableResourceCandidates)
         def metaData = Mock(ExternalResourceMetaData)
@@ -152,7 +152,7 @@ class DefaultCacheAwareExternalResourceAccessorTest extends Specification {
         result == resultResource
 
         and:
-        1 * index.lookup("scheme:thing") >> cachedResource
+        1 * index.lookup("thing") >> cachedResource
         _ * timeProvider.currentTime >> 24000L
         _ * cachedResource.cachedAt >> 24000L
         _ * cachedResource.cachedFile >> cachedFile

--- a/platforms/software/resources/src/integTest/groovy/org/gradle/internal/resource/ExternalResourceNameIntegrationTest.groovy
+++ b/platforms/software/resources/src/integTest/groovy/org/gradle/internal/resource/ExternalResourceNameIntegrationTest.groovy
@@ -50,6 +50,6 @@ Searched in the following locations:
   - file:${expectLeadingSlashes}MISSING/folder/ivy/org/name/1.0/ivy-1.0.xml
 """
          where:
-         hostPrefix << ['//', 'file://', 'file:////']
+         hostPrefix << ['//', 'file:/', 'file:////']
     }
 }

--- a/platforms/software/resources/src/main/java/org/gradle/internal/resource/ExternalResourceName.java
+++ b/platforms/software/resources/src/main/java/org/gradle/internal/resource/ExternalResourceName.java
@@ -62,12 +62,12 @@ public class ExternalResourceName implements Describable {
     }
 
     public String getDisplayName() {
-        return getDecoded();
+        return getDisplayable();
     }
 
     public String getShortDisplayName() {
         int lastSlash = path.lastIndexOf('/');
-        return lastSlash == -1 ? getDecoded() : path.substring(lastSlash + 1);
+        return lastSlash == -1 ? getDisplayable() : path.substring(lastSlash + 1);
     }
 
     @Override
@@ -90,9 +90,9 @@ public class ExternalResourceName implements Describable {
     }
 
     /**
-     * Returns the 'decoded' name, which is the opaque root + the path of the name.
+     * Returns the 'displayable' name, which is the opaque root + the encoded path of the name.
      */
-    public String getDecoded() {
+    public String getDisplayable() {
         if (encodedRoot == null) {
             return encode(path, false);
         }

--- a/platforms/software/resources/src/main/java/org/gradle/internal/resource/ExternalResourceName.java
+++ b/platforms/software/resources/src/main/java/org/gradle/internal/resource/ExternalResourceName.java
@@ -94,9 +94,9 @@ public class ExternalResourceName implements Describable {
      */
     public String getDecoded() {
         if (encodedRoot == null) {
-            return path;
+            return encode(path, false);
         }
-        return encodedRoot + path;
+        return encodedRoot + encode(path, true);
     }
 
     /**

--- a/platforms/software/resources/src/test/groovy/org/gradle/internal/resource/ExternalResourceNameTest.groovy
+++ b/platforms/software/resources/src/test/groovy/org/gradle/internal/resource/ExternalResourceNameTest.groovy
@@ -116,14 +116,14 @@ class ExternalResourceNameTest extends Specification {
         ""       | ""          | ""
     }
 
-    def "decoded name is base uri plus path"() {
+    def "displayable name is base uri plus the encoded path"() {
         expect:
         def name = new ExternalResourceName(URI.create(uri))
-        name.decoded == expectedDecoded
+        name.displayable == expectedDisplayable
 
         where:
-        uri                          | expectedDecoded
-        "http://host:80/a/%5B123%5D" | "http://host:80/a/[123]"
+        uri                          | expectedDisplayable
+        "http://host:80/a/%5B123%5D" | "http://host:80/a/%5B123%5D"
         "http://host/a/b"            | "http://host/a/b"
         "http://host"                | "http://host"
         "a/b/c"                      | "a/b/c"
@@ -148,8 +148,8 @@ class ExternalResourceNameTest extends Specification {
     def "can handle UNC paths"() {
         expect:
         def name = new ExternalResourceName(uri)
-        name.decoded == expectedDecoded
-        name.resolve("").decoded == expectedDecoded
+        name.displayable == expectedDecoded
+        name.resolve("").displayable == expectedDecoded
 
         where:
         uri                              | expectedDecoded

--- a/platforms/software/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningPublicationsIntegrationSpec.groovy
+++ b/platforms/software/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningPublicationsIntegrationSpec.groovy
@@ -276,7 +276,7 @@ class SigningPublicationsIntegrationSpec extends SigningIntegrationSpec {
                 repositories {
                     maven {
                         name "m2"
-                        url "\$buildDir/m2Repo/"
+                        url layout.buildDirectory.dir("m2Repo")
                     }
                 }
             }
@@ -328,7 +328,7 @@ class SigningPublicationsIntegrationSpec extends SigningIntegrationSpec {
                 }
                 repositories {
                     ivy {
-                        url "\$buildDir/ivyRepo/"
+                        url layout.buildDirectory.dir("ivyRepo")
                         $declaration
                     }
                 }
@@ -455,7 +455,7 @@ class SigningPublicationsIntegrationSpec extends SigningIntegrationSpec {
                 repositories {
                     maven {
                         name "m2"
-                        url "\$buildDir/m2Repo/"
+                        url layout.buildDirectory.dir("m2Repo")
                     }
                 }
             }
@@ -573,10 +573,10 @@ class SigningPublicationsIntegrationSpec extends SigningIntegrationSpec {
                 }
                 repositories {
                     maven {
-                        url "\$buildDir/m2Repo/"
+                        url layout.buildDirectory.dir("m2Repo")
                     }
                     ivy {
-                        url "\$buildDir/ivyRepo/"
+                        url layout.buildDirectory.dir("ivyRepo")
                         patternLayout {
                             artifact "[artifact]-[revision](-[classifier])(.[ext])"
                             ivy "[artifact]-[revision](-[classifier])(.[ext])"
@@ -637,10 +637,10 @@ class SigningPublicationsIntegrationSpec extends SigningIntegrationSpec {
                 }
                 repositories {
                     maven {
-                        url "\$buildDir/m2Repo/"
+                        url layout.buildDirectory.dir("m2Repo")
                     }
                     ivy {
-                        url "\$buildDir/ivyRepo/"
+                        url layout.buildDirectory.dir("ivyRepo")
                         patternLayout {
                             artifact "[artifact]-[revision](-[classifier])(.[ext])"
                             ivy "[artifact]-[revision](-[classifier])(.[ext])"
@@ -655,10 +655,11 @@ class SigningPublicationsIntegrationSpec extends SigningIntegrationSpec {
             }
 
             tasks.register("cleanRepo") {
-                def buildDir = project.buildDir
+                def m2Repo = layout.buildDirectory.dir("m2Repo").get().asFile
+                def ivyRepo = layout.buildDirectory.dir("ivyRepo").get().asFile
                 doLast {
-                    new File("\${buildDir}/m2Repo").deleteDir()
-                    new File("\${buildDir}/ivyRepo").deleteDir()
+                    m2Repo.deleteDir()
+                    ivyRepo.deleteDir()
                 }
             }
             def sign = project.getProperty("sign")
@@ -784,7 +785,7 @@ class SigningPublicationsIntegrationSpec extends SigningIntegrationSpec {
                 repositories {
                     maven {
                         name "m2"
-                        url "\$buildDir/m2Repo/"
+                        url layout.buildDirectory.dir("m2Repo")
                     }
                 }
             }

--- a/platforms/software/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningPublicationsIntegrationSpec.groovy
+++ b/platforms/software/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningPublicationsIntegrationSpec.groovy
@@ -276,7 +276,7 @@ class SigningPublicationsIntegrationSpec extends SigningIntegrationSpec {
                 repositories {
                     maven {
                         name "m2"
-                        url "file://\$buildDir/m2Repo/"
+                        url "\$buildDir/m2Repo/"
                     }
                 }
             }
@@ -328,7 +328,7 @@ class SigningPublicationsIntegrationSpec extends SigningIntegrationSpec {
                 }
                 repositories {
                     ivy {
-                        url "file://\$buildDir/ivyRepo/"
+                        url "\$buildDir/ivyRepo/"
                         $declaration
                     }
                 }
@@ -455,7 +455,7 @@ class SigningPublicationsIntegrationSpec extends SigningIntegrationSpec {
                 repositories {
                     maven {
                         name "m2"
-                        url "file://\$buildDir/m2Repo/"
+                        url "\$buildDir/m2Repo/"
                     }
                 }
             }
@@ -573,10 +573,10 @@ class SigningPublicationsIntegrationSpec extends SigningIntegrationSpec {
                 }
                 repositories {
                     maven {
-                        url "file://\$buildDir/m2Repo/"
+                        url "\$buildDir/m2Repo/"
                     }
                     ivy {
-                        url "file://\$buildDir/ivyRepo/"
+                        url "\$buildDir/ivyRepo/"
                         patternLayout {
                             artifact "[artifact]-[revision](-[classifier])(.[ext])"
                             ivy "[artifact]-[revision](-[classifier])(.[ext])"
@@ -637,10 +637,10 @@ class SigningPublicationsIntegrationSpec extends SigningIntegrationSpec {
                 }
                 repositories {
                     maven {
-                        url "file://\$buildDir/m2Repo/"
+                        url "\$buildDir/m2Repo/"
                     }
                     ivy {
-                        url "file://\$buildDir/ivyRepo/"
+                        url "\$buildDir/ivyRepo/"
                         patternLayout {
                             artifact "[artifact]-[revision](-[classifier])(.[ext])"
                             ivy "[artifact]-[revision](-[classifier])(.[ext])"
@@ -784,7 +784,7 @@ class SigningPublicationsIntegrationSpec extends SigningIntegrationSpec {
                 repositories {
                     maven {
                         name "m2"
-                        url "file://\$buildDir/m2Repo/"
+                        url "\$buildDir/m2Repo/"
                     }
                 }
             }

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyGraphIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyGraphIntegrationTest.groovy
@@ -750,7 +750,7 @@ class CompositeBuildDependencyGraphIntegrationTest extends AbstractCompositeBuil
         failure.assertHasCause("Could not resolve all task dependencies for configuration ':buildC:buildInputs'.")
         failure.assertHasCause("""Could not find org.test:test:1.2.
 Searched in the following locations:
-  - ${m.pom.file.toURI().toASCIIString()}
+  - ${m.pom.file.displayUri}
 Required by:
     project :buildC""")
         failure.assertHasResolutions(REPOSITORY_HINT,

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyGraphIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyGraphIntegrationTest.groovy
@@ -750,7 +750,7 @@ class CompositeBuildDependencyGraphIntegrationTest extends AbstractCompositeBuil
         failure.assertHasCause("Could not resolve all task dependencies for configuration ':buildC:buildInputs'.")
         failure.assertHasCause("""Could not find org.test:test:1.2.
 Searched in the following locations:
-  - ${m.pom.file.toURL()}
+  - ${m.pom.file.toURI().toASCIIString()}
 Required by:
     project :buildC""")
         failure.assertHasResolutions(REPOSITORY_HINT,

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileResolutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileResolutionIntegrationTest.groovy
@@ -67,6 +67,38 @@ The following types/formats are supported:
   - A URI or URL instance.""")
     }
 
+    def "produces deprecation warning for relative file URLs"() {
+        buildFile """
+def f = file("file:testdir")
+assert f == project.layout.projectDirectory.dir("testdir").asFile
+"""
+
+        expect:
+        executer.expectDocumentedDeprecationWarning("Passing invalid URIs to URI or File converting methods. This behavior has been deprecated. This will fail with an error in Gradle 9.0. Use a valid URL or a file path instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_legacy_url_decoding")
+        succeeds()
+    }
+
+    def "produces deprecation warning for invalid URLs"() {
+        buildFile """
+def f = file("file:///home/user/test%%20dir")
+assert f == new File("/home/user/test% dir")
+"""
+
+        expect:
+        executer.expectDocumentedDeprecationWarning("Passing invalid URIs to URI or File converting methods. This behavior has been deprecated. This will fail with an error in Gradle 9.0. Use a valid URL or a file path instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_legacy_url_decoding")
+        succeeds()
+    }
+
+    def "produces no deprecation warning for valid URLs"() {
+        buildFile """
+def f = file("file:///home/user/test%25%20dir")
+assert f == new File("/home/user/test% dir")
+"""
+
+        expect:
+        succeeds()
+    }
+
     def "can construct file collection using java.nio.file.Path"() {
         buildFile """
 java.nio.file.Path fAsPath = buildDir.toPath().resolve('testdir').toAbsolutePath()

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileResolutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileResolutionIntegrationTest.groovy
@@ -80,8 +80,10 @@ assert f == project.layout.projectDirectory.dir("testdir").asFile
 
     def "produces deprecation warning for invalid URLs"() {
         buildFile """
-def f = file("file:///home/user/test%%20dir")
-assert f == new File("/home/user/test% dir")
+def originalFile = layout.projectDirectory.dir("test% dir").asFile
+def fileURI = layout.projectDirectory.dir("test% dir").asFile.toURI().toString().replaceFirst("%25", "%")
+def f = file(fileURI)
+assert f == originalFile
 """
 
         expect:
@@ -91,8 +93,10 @@ assert f == new File("/home/user/test% dir")
 
     def "produces no deprecation warning for valid URLs"() {
         buildFile """
-def f = file("file:///home/user/test%25%20dir")
-assert f == new File("/home/user/test% dir")
+def originalFile = layout.projectDirectory.dir("test% dir").asFile
+def fileURI = layout.projectDirectory.dir("test% dir").asFile.toURI().toString()
+def f = file(fileURI)
+assert f == originalFile
 """
 
         expect:

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileResolutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileResolutionIntegrationTest.groovy
@@ -74,7 +74,7 @@ assert f == project.layout.projectDirectory.dir("testdir").asFile
 """
 
         expect:
-        executer.expectDocumentedDeprecationWarning("Passing invalid URIs to URI or File converting methods. This behavior has been deprecated. This will fail with an error in Gradle 9.0. Use a valid URL or a file path instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_legacy_url_decoding")
+        executer.expectDocumentedDeprecationWarning("Passing invalid URIs to URI or File converting methods. This behavior has been deprecated. This will fail with an error in Gradle 9.0. Use a valid URL or a file path instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_invalid_url_decoding")
         succeeds()
     }
 
@@ -85,7 +85,7 @@ assert f == new File("/home/user/test% dir")
 """
 
         expect:
-        executer.expectDocumentedDeprecationWarning("Passing invalid URIs to URI or File converting methods. This behavior has been deprecated. This will fail with an error in Gradle 9.0. Use a valid URL or a file path instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_legacy_url_decoding")
+        executer.expectDocumentedDeprecationWarning("Passing invalid URIs to URI or File converting methods. This behavior has been deprecated. This will fail with an error in Gradle 9.0. Use a valid URL or a file path instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_invalid_url_decoding")
         succeeds()
     }
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcIdentityIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcIdentityIntegrationTest.groovy
@@ -102,7 +102,7 @@ runtimeClasspath - Runtime classpath of source set 'main'.
         failure.assertHasCause("Could not resolve all files for configuration ':buildSrc:compileClasspath'.")
         failure.assertHasCause("""Could not find org.test:test:1.2.
 Searched in the following locations:
-  - ${m.pom.file.toURI().toASCIIString()}
+  - ${m.pom.file.displayUri}
 Required by:
     project :buildSrc""")
         failure.assertHasResolutions(repositoryHint("Maven POM"),

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcIdentityIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcIdentityIntegrationTest.groovy
@@ -102,7 +102,7 @@ runtimeClasspath - Runtime classpath of source set 'main'.
         failure.assertHasCause("Could not resolve all files for configuration ':buildSrc:compileClasspath'.")
         failure.assertHasCause("""Could not find org.test:test:1.2.
 Searched in the following locations:
-  - ${m.pom.file.toURL()}
+  - ${m.pom.file.toURI().toASCIIString()}
 Required by:
     project :buildSrc""")
         failure.assertHasResolutions(repositoryHint("Maven POM"),

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/BaseDirFileResolverTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/BaseDirFileResolverTest.groovy
@@ -28,6 +28,7 @@ import java.util.concurrent.Callable
 import static org.hamcrest.CoreMatchers.equalTo
 import static org.hamcrest.MatcherAssert.assertThat
 import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertThrows
 import static org.junit.Assert.fail
 
 class BaseDirFileResolverTest {
@@ -151,6 +152,18 @@ class BaseDirFileResolverTest {
     @Test public void testResolveFileWithRelativePath() {
         File relativeFile = new File('relative')
         assertEquals(new File(baseDir, 'relative'), baseDirConverter.resolve(relativeFile))
+    }
+
+    @Test public void testResolveRelativeFileURI() {
+        // Relative URIs were never supported when passed as a URI. They were only supported when passed as a String.
+        def ex = assertThrows(InvalidUserDataException, {
+            baseDirConverter.resolve(URI.create('file:relative'))
+        })
+        assertThat(ex.message, equalTo('Cannot convert URL \'file:relative\' to a file.'))
+        ex = assertThrows(InvalidUserDataException, {
+            baseDirConverter.resolve(URI.create('file:../relative'))
+        })
+        assertThat(ex.message, equalTo('Cannot convert URL \'file:../relative\' to a file.'))
     }
 
     @Test public void testResolveRelativeFileURIString() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/BasicFileResolverTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/BasicFileResolverTest.groovy
@@ -44,6 +44,7 @@ class BasicFileResolverTest extends Specification {
         def target = tmpDir.file("some-file")
 
         expect:
+        resolver.transform(target.toURI().toString()) == target
         resolver.transform(target.toURI().toASCIIString()) == target
     }
 

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -1358,7 +1358,7 @@ org:middle:1.0 FAILED
    Failures:
       - Could not find org:middle:2.0.
         Searched in the following locations:
-          - ${mavenRepoURL}/org/middle/2.0/middle-2.0.pom
+          - ${mavenRepoURL}org/middle/2.0/middle-2.0.pom
         ${repositoryHint("Maven POM")}
 
 org:middle:1.0 -> 2.0 FAILED
@@ -1440,7 +1440,7 @@ org:middle:2.0+ (selected by rule) FAILED
       - Could not find any version that matches org:middle:2.0+.
         Versions that do not match: 1.0
         Searched in the following locations:
-          - ${mavenRepoURL}/org/middle/maven-metadata.xml
+          - ${mavenRepoURL}org/middle/maven-metadata.xml
 
 org:middle:1.0 -> 2.0+ FAILED
 \\--- org:top:1.0
@@ -1482,7 +1482,7 @@ org:leaf:1.0 FAILED
    Failures:
       - Could not find org:leaf:1.0.
         Searched in the following locations:
-          - ${ivyRepoURL}/org/leaf/1.0/ivy-1.0.xml
+          - ${ivyRepoURL}org/leaf/1.0/ivy-1.0.xml
         ${repositoryHint("ivy.xml")}
 
 org:leaf:1.0 FAILED
@@ -1501,7 +1501,7 @@ org:leaf:[1.5,2.0] FAILED
    Failures:
       - Could not find any matches for org:leaf:[1.5,2.0] as no versions of org:leaf are available.
         Searched in the following locations:
-          - ${ivyRepoURL}/org/leaf/
+          - ${ivyRepoURL}org/leaf/
 
 org:leaf:[1.5,2.0] FAILED
 \\--- org:top:1.0
@@ -3079,23 +3079,13 @@ org:foo:1.2 -> 1.5
 """)
     }
 
-
-    @CompileStatic
-    static String decodeURI(URI uri) {
-        def url = URLDecoder.decode(uri.toASCIIString(), 'utf-8')
-        if (url.endsWith('/')) {
-            url = url.substring(0, url.length() - 1)
-        }
-        url
-    }
-
     @CompileStatic
     String getMavenRepoURL() {
-        decodeURI(mavenRepo.uri)
+        mavenRepo.uri.toASCIIString()
     }
 
     @CompileStatic
     String getIvyRepoURL() {
-        decodeURI(ivyRepo.uri)
+        ivyRepo.uri.toASCIIString()
     }
 }

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.api.tasks.diagnostics
 
-import groovy.transform.CompileStatic
+
 import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
@@ -1328,6 +1328,7 @@ org:middle:1.0 FAILED
         given:
         mavenRepo.module("org", "top").dependsOn("org", "middle", "1.0").publish()
         mavenRepo.module("org", "middle", "1.0").publish()
+        def middleModule2 = mavenRepo.module("org", "middle", "2.0")
 
         buildFile << """
             repositories {
@@ -1358,7 +1359,7 @@ org:middle:1.0 FAILED
    Failures:
       - Could not find org:middle:2.0.
         Searched in the following locations:
-          - ${mavenRepoURL}org/middle/2.0/middle-2.0.pom
+          - ${middleModule2.pomFile.displayUri}
         ${repositoryHint("Maven POM")}
 
 org:middle:1.0 -> 2.0 FAILED
@@ -1407,7 +1408,7 @@ org:middle:1.0 -> 2.0 FAILED
     def "marks modules that can't be resolved after substitution as 'FAILED'"() {
         given:
         mavenRepo.module("org", "top").dependsOn("org", "middle", "1.0").publish()
-        mavenRepo.module("org", "middle", "1.0").publish()
+        def middleModule = mavenRepo.module("org", "middle", "1.0").publish()
 
         buildFile << """
             repositories {
@@ -1440,7 +1441,7 @@ org:middle:2.0+ (selected by rule) FAILED
       - Could not find any version that matches org:middle:2.0+.
         Versions that do not match: 1.0
         Searched in the following locations:
-          - ${mavenRepoURL}org/middle/maven-metadata.xml
+          - ${middleModule.rootMetaData.file.displayUri}
 
 org:middle:1.0 -> 2.0+ FAILED
 \\--- org:top:1.0
@@ -1455,6 +1456,7 @@ org:middle:1.0 -> 2.0+ FAILED
             .dependsOn("org", "leaf", "[1.5,2.0]")
             .dependsOn("org", "leaf", "1.6+")
             .publish()
+        def leafModule = ivyRepo.module("org", "leaf", "1.0")
 
         buildFile << """
             repositories {
@@ -1482,7 +1484,7 @@ org:leaf:1.0 FAILED
    Failures:
       - Could not find org:leaf:1.0.
         Searched in the following locations:
-          - ${ivyRepoURL}org/leaf/1.0/ivy-1.0.xml
+          - ${leafModule.ivyFile.displayUri}
         ${repositoryHint("ivy.xml")}
 
 org:leaf:1.0 FAILED
@@ -1501,7 +1503,7 @@ org:leaf:[1.5,2.0] FAILED
    Failures:
       - Could not find any matches for org:leaf:[1.5,2.0] as no versions of org:leaf are available.
         Searched in the following locations:
-          - ${ivyRepoURL}org/leaf/
+          - ${leafModule.moduleDir.parentFile.displayUriForDir}
 
 org:leaf:[1.5,2.0] FAILED
 \\--- org:top:1.0
@@ -3077,15 +3079,5 @@ org:foo:1.2 -> 1.5
 \\--- org:bar:1.0
      \\--- compileClasspath
 """)
-    }
-
-    @CompileStatic
-    String getMavenRepoURL() {
-        mavenRepo.uri.toASCIIString()
-    }
-
-    @CompileStatic
-    String getIvyRepoURL() {
-        ivyRepo.uri.toASCIIString()
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileRepository.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileRepository.groovy
@@ -36,12 +36,20 @@ class IvyFileRepository implements IvyRepository {
         return rootDir.toURI()
     }
 
+    private String getUriWithoutTrailingSlash() {
+        String uri = getUri().toASCIIString()
+        if (uri.endsWith('/')) {
+            uri = uri.substring(0, uri.length() - 1)
+        }
+        return uri
+    }
+
     String getIvyPattern() {
-        return "${uri}${baseIvyPattern}"
+        return "${uriWithoutTrailingSlash}/${baseIvyPattern}"
     }
 
     String getArtifactPattern() {
-        return "${uri}${baseArtifactPattern}"
+        return "${uriWithoutTrailingSlash}/${baseArtifactPattern}"
     }
 
     String getBaseIvyPattern() {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileRepository.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileRepository.groovy
@@ -37,11 +37,11 @@ class IvyFileRepository implements IvyRepository {
     }
 
     String getIvyPattern() {
-        return "${uri}/${baseIvyPattern}"
+        return "${uri}${baseIvyPattern}"
     }
 
     String getArtifactPattern() {
-        return "${uri}/${baseArtifactPattern}"
+        return "${uri}${baseArtifactPattern}"
     }
 
     String getBaseIvyPattern() {

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFile.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFile.java
@@ -902,6 +902,28 @@ public class TestFile extends File {
         return relativeBase.toPath().relativize(this.toPath()).toString();
     }
 
+    /**
+     * Return a string corresponding to how Gradle will display the file URI for this file.
+     *
+     * @return a string corresponding to how Gradle will display the file URI for this file.
+     */
+    public String getDisplayUri() {
+        return toURI().toASCIIString();
+    }
+
+    /**
+     * Return a string corresponding to how Gradle will display the file URI for this file, assuming it is a directory.
+     *
+     * @return a string corresponding to how Gradle will display the file URI for this file, assuming it is a directory.
+     */
+    public String getDisplayUriForDir() {
+        String uri = getDisplayUri();
+        if (!uri.endsWith("/")) {
+            uri += "/";
+        }
+        return uri;
+    }
+
     public static class Snapshot {
         private final long modTime;
         private final HashCode hash;


### PR DESCRIPTION
Fixes #27475 

This attempts to provide consistency between the inputs accepted and the outputs emitted by Gradle in terms of URIs, and to be stricter about what can be provided as input to prevent ambiguity about how certain URIs should be handled.