### PR TITLE
Enable perf monitor on TeamCity

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/FunctionalTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/FunctionalTest.kt
@@ -5,6 +5,7 @@ import com.alibaba.fastjson.annotation.JSONField
 import common.functionalTestExtraParameters
 import jetbrains.buildServer.configs.kotlin.BuildSteps
 import jetbrains.buildServer.configs.kotlin.buildFeatures.parallelTests
+import jetbrains.buildServer.configs.kotlin.buildFeatures.perfmon
 import model.CIBuildModel
 import model.Stage
 import model.StageName
@@ -73,6 +74,11 @@ class FunctionalTest(
             parallelTests {
                 this.numberOfBatches = parallelizationMethod.numberOfBatches
             }
+        }
+    }
+
+    features {
+        perfmon {
         }
     }
 


### PR DESCRIPTION
Example: https://builds.gradle.org/buildConfiguration/Gradle_Experimental_Check_Quick_2_bucket18/76495608?buildTab=perfmon

![image](https://github.com/gradle/gradle/assets/12689835/aaf56a34-f873-4fb1-9722-ab7e5a2b06a2)
