### PR TITLE
Fail with reasonable error message on primitive array parameters

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/AbstractValueProcessor.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/AbstractValueProcessor.java
@@ -61,7 +61,7 @@ abstract class AbstractValueProcessor {
             return processList((List<?>) value, visitor);
         }
         if (value instanceof Enum) {
-            return visitor.enumValue((Enum) value);
+            return visitor.enumValue((Enum<?>) value);
         }
         if (value instanceof Class<?>) {
             return visitor.classValue((Class<?>) value);
@@ -187,12 +187,12 @@ abstract class AbstractValueProcessor {
         return builder.build();
     }
 
-    private <T> T gradleSerialization(Object value, Serializer serializer, ValueVisitor<T> visitor) {
+    private <T> T gradleSerialization(Object value, Serializer<?> serializer, ValueVisitor<T> visitor) {
         return visitor.gradleSerialized(value, gradleSerialized(value, serializer));
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    private byte[] gradleSerialized(Object value, Serializer serializer) {
+    private static byte[] gradleSerialized(Object value, Serializer serializer) {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         try (KryoBackedEncoder encoder = new KryoBackedEncoder(outputStream)) {
             serializer.write(encoder, Cast.uncheckedCast(value));
@@ -207,7 +207,7 @@ abstract class AbstractValueProcessor {
         return visitor.javaSerialized(value, javaSerialized(value));
     }
 
-    private byte[] javaSerialized(Object value) {
+    private static byte[] javaSerialized(Object value) {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         try (ObjectOutputStream oos = new ObjectOutputStream(outputStream)) {
             oos.writeObject(value);
@@ -218,7 +218,7 @@ abstract class AbstractValueProcessor {
         return outputStream.toByteArray();
     }
 
-    private ValueSnapshottingException newValueSerializationException(Class<?> valueType, Throwable cause) {
+    private static ValueSnapshottingException newValueSerializationException(Class<?> valueType, Throwable cause) {
         TreeFormatter formatter = new TreeFormatter();
         formatter.node("Could not serialize value of type ");
         formatter.appendType(valueType);
@@ -233,7 +233,7 @@ abstract class AbstractValueProcessor {
 
         T booleanValue(Boolean value);
 
-        T enumValue(Enum value);
+        T enumValue(Enum<?> value);
 
         T classValue(Class<?> value);
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/AbstractValueProcessor.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/AbstractValueProcessor.java
@@ -171,9 +171,7 @@ abstract class AbstractValueProcessor {
             return visitor.emptyArray(componentType);
         }
         if (componentType.isPrimitive()) {
-            // Use Java serialization as a simple implementation mechanism to isolate primitive arrays
-            // https://github.com/gradle/gradle/issues/26596
-            return javaSerialization(value, visitor);
+            throw cantSerializePrimitiveArray(valueClass);
         }
         return visitor.array(processArrayElements(value, length, visitor), componentType);
     }
@@ -223,6 +221,13 @@ abstract class AbstractValueProcessor {
         formatter.node("Could not serialize value of type ");
         formatter.appendType(valueType);
         return new ValueSnapshottingException(formatter.toString(), cause);
+    }
+
+    private static ValueSnapshottingException cantSerializePrimitiveArray(Class<?> arrayType) {
+        TreeFormatter formatter = new TreeFormatter();
+        formatter.node("Cannot serialize primitive arrays of type ");
+        formatter.appendType(arrayType);
+        return new ValueSnapshottingException(formatter.toString());
     }
 
     protected interface ValueVisitor<T> {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/AbstractValueProcessor.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/AbstractValueProcessor.java
@@ -171,7 +171,9 @@ abstract class AbstractValueProcessor {
             return visitor.emptyArray(componentType);
         }
         if (componentType.isPrimitive()) {
-            throw new IsolationException(value);
+            // Use Java serialization as a simple implementation mechanism to isolate primitive arrays
+            // https://github.com/gradle/gradle/issues/26596
+            return javaSerialization(value, visitor);
         }
         return visitor.array(processArrayElements(value, length, visitor), componentType);
     }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/AbstractValueProcessor.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/AbstractValueProcessor.java
@@ -58,15 +58,7 @@ abstract class AbstractValueProcessor {
             return visitor.booleanValue((Boolean) value);
         }
         if (value instanceof List) {
-            List<?> list = (List<?>) value;
-            if (list.size() == 0) {
-                return visitor.emptyList();
-            }
-            ImmutableList.Builder<T> builder = ImmutableList.builderWithExpectedSize(list.size());
-            for (Object element : list) {
-                builder.add(processValue(element, visitor));
-            }
-            return visitor.list(builder.build());
+            return processList((List<?>) value, visitor);
         }
         if (value instanceof Enum) {
             return visitor.enumValue((Enum) value);
@@ -91,49 +83,19 @@ abstract class AbstractValueProcessor {
             }
         }
         if (value instanceof Set) {
-            Set<?> set = (Set<?>) value;
-            ImmutableSet.Builder<T> builder = ImmutableSet.builderWithExpectedSize(set.size());
-            for (Object element : set) {
-                builder.add(processValue(element, visitor));
-            }
-            return visitor.set(builder.build());
+            return processSet((Set<?>) value, visitor);
         }
         if (value instanceof Map) {
-            Map<?, ?> map = (Map<?, ?>) value;
-            ImmutableList.Builder<MapEntrySnapshot<T>> builder = ImmutableList.builderWithExpectedSize(map.size());
-            for (Map.Entry<?, ?> entry : map.entrySet()) {
-                builder.add(new MapEntrySnapshot<>(processValue(entry.getKey(), visitor), processValue(entry.getValue(), visitor)));
-            }
-            if (value instanceof Properties) {
-                return visitor.properties(builder.build());
-            } else {
-                return visitor.map(builder.build());
-            }
+            return processMap((Map<?, ?>) value, visitor);
         }
         if (valueClass.isArray()) {
-            int length = Array.getLength(value);
-            if (length == 0) {
-                return visitor.emptyArray(valueClass.getComponentType());
-            }
-            ImmutableList.Builder<T> builder = ImmutableList.builderWithExpectedSize(length);
-            for (int i = 0; i < length; i++) {
-                Object element = Array.get(value, i);
-                builder.add(processValue(element, visitor));
-            }
-            return visitor.array(builder.build(), valueClass.getComponentType());
+            return processArray(valueClass, value, visitor);
         }
         if (value instanceof Attribute) {
             return visitor.attributeValue((Attribute<?>) value);
         }
         if (value instanceof Managed) {
-            Managed managed = (Managed) value;
-            if (managed.isImmutable()) {
-                return visitor.managedImmutableValue(managed);
-            } else {
-                // May (or may not) be mutable - unpack the state
-                T state = processValue(managed.unpackState(), visitor);
-                return visitor.managedValue(managed, state);
-            }
+            return processManaged((Managed) value, visitor);
         }
         if (value instanceof Isolatable) {
             return visitor.fromIsolatable((Isolatable<?>) value);
@@ -157,8 +119,78 @@ abstract class AbstractValueProcessor {
         return javaSerialization(value, visitor);
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    private <T> T processManaged(Managed managed, ValueVisitor<T> visitor) {
+        if (managed.isImmutable()) {
+            return visitor.managedImmutableValue(managed);
+        } else {
+            // May (or may not) be mutable - unpack the state
+            T state = processValue(managed.unpackState(), visitor);
+            return visitor.managedValue(managed, state);
+        }
+    }
+
+    private <T> T processMap(Map<?, ?> map, ValueVisitor<T> visitor) {
+        ImmutableList.Builder<MapEntrySnapshot<T>> builder = ImmutableList.builderWithExpectedSize(map.size());
+        for (Map.Entry<?, ?> entry : map.entrySet()) {
+            builder.add(new MapEntrySnapshot<>(processValue(entry.getKey(), visitor), processValue(entry.getValue(), visitor)));
+        }
+        if (map instanceof Properties) {
+            return visitor.properties(builder.build());
+        } else {
+            return visitor.map(builder.build());
+        }
+    }
+
+    private <T> T processSet(Set<?> set, ValueVisitor<T> visitor) {
+        ImmutableSet.Builder<T> builder = ImmutableSet.builderWithExpectedSize(set.size());
+        for (Object element : set) {
+            builder.add(processValue(element, visitor));
+        }
+        return visitor.set(builder.build());
+    }
+
+    private <T> T processList(List<?> value, ValueVisitor<T> visitor) {
+        if (value.isEmpty()) {
+            return visitor.emptyList();
+        }
+        return visitor.list(processListElements(value, visitor));
+    }
+
+    private <T> ImmutableList<T> processListElements(List<?> list, ValueVisitor<T> visitor) {
+        ImmutableList.Builder<T> builder = ImmutableList.builderWithExpectedSize(list.size());
+        for (Object element : list) {
+            builder.add(processValue(element, visitor));
+        }
+        return builder.build();
+    }
+
+    private <T> T processArray(Class<?> valueClass, Object value, ValueVisitor<T> visitor) {
+        Class<?> componentType = valueClass.getComponentType();
+        int length = Array.getLength(value);
+        if (length == 0) {
+            return visitor.emptyArray(componentType);
+        }
+        if (componentType.isPrimitive()) {
+            throw new IsolationException(value);
+        }
+        return visitor.array(processArrayElements(value, length, visitor), componentType);
+    }
+
+    private <T> ImmutableList<T> processArrayElements(Object array, int length, ValueVisitor<T> visitor) {
+        ImmutableList.Builder<T> builder = ImmutableList.builderWithExpectedSize(length);
+        for (int i = 0; i < length; i++) {
+            Object element = Array.get(array, i);
+            builder.add(processValue(element, visitor));
+        }
+        return builder.build();
+    }
+
     private <T> T gradleSerialization(Object value, Serializer serializer, ValueVisitor<T> visitor) {
+        return visitor.gradleSerialized(value, gradleSerialized(value, serializer));
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private byte[] gradleSerialized(Object value, Serializer serializer) {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         try (KryoBackedEncoder encoder = new KryoBackedEncoder(outputStream)) {
             serializer.write(encoder, Cast.uncheckedCast(value));
@@ -166,18 +198,22 @@ abstract class AbstractValueProcessor {
         } catch (Exception e) {
             throw newValueSerializationException(value.getClass(), e);
         }
-        return visitor.gradleSerialized(value, outputStream.toByteArray());
+        return outputStream.toByteArray();
     }
 
     private <T> T javaSerialization(Object value, ValueVisitor<T> visitor) {
+        return visitor.javaSerialized(value, javaSerialized(value));
+    }
+
+    private byte[] javaSerialized(Object value) {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        try (ObjectOutputStream objectStr = new ObjectOutputStream(outputStream)) {
-            objectStr.writeObject(value);
-            objectStr.flush();
+        try (ObjectOutputStream oos = new ObjectOutputStream(outputStream)) {
+            oos.writeObject(value);
+            oos.flush();
         } catch (IOException e) {
             throw newValueSerializationException(value.getClass(), e);
         }
-        return visitor.javaSerialized(value, outputStream.toByteArray());
+        return outputStream.toByteArray();
     }
 
     private ValueSnapshottingException newValueSerializationException(Class<?> valueType, Throwable cause) {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/DefaultIsolatableFactory.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/DefaultIsolatableFactory.java
@@ -97,7 +97,7 @@ public class DefaultIsolatableFactory extends AbstractValueProcessor implements 
         }
 
         @Override
-        public Isolatable<?> enumValue(Enum value) {
+        public Isolatable<?> enumValue(Enum<?> value) {
             return new IsolatedEnumValueSnapshot(value);
         }
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/DefaultValueSnapshotter.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/internal/snapshot/impl/DefaultValueSnapshotter.java
@@ -95,7 +95,7 @@ public class DefaultValueSnapshotter extends AbstractValueProcessor implements V
         }
 
         @Override
-        public ValueSnapshot enumValue(Enum value) {
+        public ValueSnapshot enumValue(Enum<?> value) {
             return new EnumValueSnapshot(value);
         }
 

--- a/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParametersKotlinIntegrationTest.groovy
+++ b/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParametersKotlinIntegrationTest.groovy
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.workers.internal
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.util.internal.ToBeImplemented
+import org.gradle.workers.fixtures.WorkerExecutorFixture
+
+class WorkerExecutorParametersKotlinIntegrationTest extends AbstractIntegrationSpec {
+
+    @ToBeImplemented('https://github.com/gradle/gradle/issues/26596')
+    def "can provide primitive #type array parameters with isolation mode #isolationMode"() {
+        given:
+        buildKotlinFile << """
+            import org.gradle.workers.WorkAction
+            import org.gradle.workers.WorkParameters
+            import org.gradle.workers.WorkerExecutor
+
+            interface TestParameters : WorkParameters {
+                val array: Property<${type.toString().capitalize()}Array>
+            }
+
+            abstract class ParameterWorkAction : WorkAction<TestParameters> {
+                override fun execute() {
+                    println(parameters.array.get().joinToString(",", "[", "]"))
+                }
+            }
+
+            abstract class ParameterTask : DefaultTask() {
+
+                @get:Inject
+                abstract val workerExecutor: WorkerExecutor
+
+                @TaskAction
+                fun doWork() {
+                    workerExecutor.${isolationMode}().submit(ParameterWorkAction::class) {
+                        array = ${type}ArrayOf(1, 2, 3)
+                    }
+                }
+            }
+
+            tasks {
+                register<ParameterTask>("runWork") {
+                }
+            }
+        """
+
+        when:
+        //succeeds 'runWork'
+        fails 'runWork'
+
+        then:
+        //outputContains '[1,2,3]'
+        failureCauseContains 'Could not isolate value ['
+
+        where:
+        [isolationMode, type] << [
+            WorkerExecutorFixture.IsolationMode.values(),
+            ['byte', 'short', 'int', 'long']
+        ].combinations()
+    }
+}

--- a/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParametersKotlinIntegrationTest.groovy
+++ b/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParametersKotlinIntegrationTest.groovy
@@ -36,7 +36,8 @@ class WorkerExecutorParametersKotlinIntegrationTest extends AbstractIntegrationS
 
             abstract class ParameterWorkAction : WorkAction<TestParameters> {
                 override fun execute() {
-                    println(parameters.array.get().joinToString(",", "[", "]"))
+                    val array = parameters.array.get()
+                    println(array.javaClass.componentType.toString() + "ArrayOf" + array.joinToString(",", "(", ")"))
                 }
             }
 
@@ -60,12 +61,10 @@ class WorkerExecutorParametersKotlinIntegrationTest extends AbstractIntegrationS
         """
 
         when:
-        //succeeds 'runWork'
-        fails 'runWork'
+        succeeds 'runWork'
 
         then:
-        //outputContains '[1,2,3]'
-        failureCauseContains 'Could not isolate value ['
+        outputContains "${type}ArrayOf(1,2,3)"
 
         where:
         [isolationMode, type] << [

--- a/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParametersKotlinIntegrationTest.groovy
+++ b/platforms/core-execution/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParametersKotlinIntegrationTest.groovy
@@ -17,13 +17,13 @@
 package org.gradle.workers.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.util.internal.ToBeImplemented
 import org.gradle.workers.fixtures.WorkerExecutorFixture
+import spock.lang.Issue
 
 class WorkerExecutorParametersKotlinIntegrationTest extends AbstractIntegrationSpec {
 
-    @ToBeImplemented('https://github.com/gradle/gradle/issues/26596')
-    def "can provide primitive #type array parameters with isolation mode #isolationMode"() {
+    @Issue('https://github.com/gradle/gradle/issues/26596')
+    def "can provide primitive #type array parameters with #isolationMode isolation"() {
         given:
         buildKotlinFile << """
             import org.gradle.workers.WorkAction
@@ -48,7 +48,7 @@ class WorkerExecutorParametersKotlinIntegrationTest extends AbstractIntegrationS
 
                 @TaskAction
                 fun doWork() {
-                    workerExecutor.${isolationMode}().submit(ParameterWorkAction::class) {
+                    workerExecutor.${isolationMode.method}().submit(ParameterWorkAction::class) {
                         array = ${type}ArrayOf(1, 2, 3)
                     }
                 }

--- a/platforms/core-execution/workers/src/testFixtures/groovy/org/gradle/workers/fixtures/WorkerExecutorFixture.groovy
+++ b/platforms/core-execution/workers/src/testFixtures/groovy/org/gradle/workers/fixtures/WorkerExecutorFixture.groovy
@@ -20,10 +20,16 @@ import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.internal.TextUtil
 
 class WorkerExecutorFixture {
-    public static final ISOLATION_MODES = ["'noIsolation'", "'classLoaderIsolation'", "'processIsolation'"]
+
+    enum IsolationMode {
+        noIsolation, classLoaderIsolation, processIsolation
+    }
+
+    public static final ISOLATION_MODES = IsolationMode.values().collect { "'$it'" }
+
     def outputFileDir
     def outputFileDirPath
-    def list = [ 1, 2, 3 ]
+    def list = [1, 2, 3]
     private final TestNameTestDirectoryProvider temporaryFolder
     final WorkParameterClass testParameterType
     final WorkActionClass workActionThatCreatesFiles
@@ -37,9 +43,9 @@ class WorkerExecutorFixture {
         testParameterType = workParameterClass("TestParameters", "org.gradle.test")
         testParameterType.imports += ["java.io.File", "java.util.List", "org.gradle.other.Foo"]
         testParameterType.fields += [
-                "files": "List<String>",
-                "outputDir": "File",
-                "bar": "Foo"
+            "files": "List<String>",
+            "outputDir": "File",
+            "bar": "Foo"
         ]
 
         workActionThatCreatesFiles = getWorkActionThatCreatesFiles("TestWorkAction")
@@ -115,7 +121,7 @@ class WorkerExecutorFixture {
     }
 
     WorkActionClass workActionClass(String name, String packageName, WorkParameterClass parameterClass) {
-       return new WorkActionClass(name, packageName, parameterClass)
+        return new WorkActionClass(name, packageName, parameterClass)
     }
 
     WorkParameterClass workParameterClass(String name, String packageName) {
@@ -125,8 +131,8 @@ class WorkerExecutorFixture {
     WorkActionClass getWorkActionThatCreatesFiles(String name) {
         def workerClass = workActionClass(name, "org.gradle.test", testParameterType)
         workerClass.imports += [
-                "java.io.File",
-                "java.util.UUID"
+            "java.io.File",
+            "java.util.UUID"
         ]
         workerClass.extraFields = """
             private static final String id = UUID.randomUUID().toString();

--- a/platforms/core-execution/workers/src/testFixtures/groovy/org/gradle/workers/fixtures/WorkerExecutorFixture.groovy
+++ b/platforms/core-execution/workers/src/testFixtures/groovy/org/gradle/workers/fixtures/WorkerExecutorFixture.groovy
@@ -22,10 +22,27 @@ import org.gradle.util.internal.TextUtil
 class WorkerExecutorFixture {
 
     enum IsolationMode {
-        noIsolation, classLoaderIsolation, processIsolation
+        NO_ISOLATION("no"),
+        CLASSLOADER_ISOLATION("classLoader"),
+        PROCESS_ISOLATION("process");
+
+        private final String prefix
+
+        IsolationMode(String prefix) {
+            this.prefix = prefix
+        }
+
+        String getMethod() {
+            "${prefix}Isolation"
+        }
+
+        @Override
+        String toString() {
+            prefix
+        }
     }
 
-    public static final ISOLATION_MODES = IsolationMode.values().collect { "'$it'" }
+    public static final ISOLATION_MODES = IsolationMode.values().collect { "'${it.method}'" }
 
     def outputFileDir
     def outputFileDirPath

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/classloader/ClassLoaderUtils.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/classloader/ClassLoaderUtils.java
@@ -86,6 +86,20 @@ public abstract class ClassLoaderUtils {
 
     public static Class<?> classFromContextLoader(String className) {
         try {
+            if (className.startsWith("[")) {
+                if (className.equals("[B")) {
+                    return byte[].class;
+                }
+                if (className.equals("[S")) {
+                    return short[].class;
+                }
+                if (className.equals("[I")) {
+                    return int[].class;
+                }
+                if (className.equals("[J")) {
+                    return long[].class;
+                }
+            }
             return Thread.currentThread().getContextClassLoader().loadClass(className);
         } catch (ClassNotFoundException e) {
             throw UncheckedException.throwAsUncheckedException(e);

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/classloader/ClassLoaderUtils.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/classloader/ClassLoaderUtils.java
@@ -86,20 +86,6 @@ public abstract class ClassLoaderUtils {
 
     public static Class<?> classFromContextLoader(String className) {
         try {
-            if (className.startsWith("[")) {
-                if (className.equals("[B")) {
-                    return byte[].class;
-                }
-                if (className.equals("[S")) {
-                    return short[].class;
-                }
-                if (className.equals("[I")) {
-                    return int[].class;
-                }
-                if (className.equals("[J")) {
-                    return long[].class;
-                }
-            }
             return Thread.currentThread().getContextClassLoader().loadClass(className);
         } catch (ClassNotFoundException e) {
             throw UncheckedException.throwAsUncheckedException(e);

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/text/TreeFormatter.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/text/TreeFormatter.java
@@ -24,6 +24,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.Arrays;
 
 /**
  * Constructs a tree of diagnostic messages.
@@ -172,7 +173,12 @@ public class TreeFormatter implements DiagnosticsVisitor {
         if (value == null) {
             append("null");
         } else if (value.getClass().isArray()) {
-            appendValues((Object[]) value);
+            Class<?> componentType = value.getClass().getComponentType();
+            if (componentType.isPrimitive()) {
+                append(value.toString());
+            } else {
+                appendValues((Object[]) value);
+            }
         } else if (value instanceof String) {
             append("'");
             append(value.toString());

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/text/TreeFormatter.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/text/TreeFormatter.java
@@ -24,7 +24,6 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.util.Arrays;
 
 /**
  * Constructs a tree of diagnostic messages.


### PR DESCRIPTION
This is the first step in addressing #26596, failing with a reasonable error message. A follow-up PR should add support for passing primitive array parameters efficiently.