### PR TITLE
Add clearer toString implementations to elements of Properties

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
@@ -295,6 +295,11 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
         public ValueProducer getProducer() {
             return ValueProducer.unknown();
         }
+
+        @Override
+        public String toString() {
+            return value.toString();
+        }
     }
 
     private class EmptySupplier implements CollectionSupplier<T, C> {
@@ -322,6 +327,11 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
         @Override
         public ValueProducer getProducer() {
             return ValueProducer.noProducer();
+        }
+
+        @Override
+        public String toString() {
+            return "[]";
         }
     }
 
@@ -357,6 +367,11 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
         @Override
         public ValueProducer getProducer() {
             return ValueProducer.unknown();
+        }
+
+        @Override
+        public String toString() {
+            return value.toString();
         }
     }
 
@@ -432,6 +447,11 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
         @Override
         public ValueProducer getProducer() {
             return value.getProducer();
+        }
+
+        @Override
+        public String toString() {
+            return value.toString();
         }
     }
 
@@ -519,6 +539,11 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
         @Override
         public ValueProducer getProducer() {
             return left.getProducer().plus(right.getProducer());
+        }
+
+        @Override
+        public String toString() {
+            return left + " + " + right;
         }
     }
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/Collectors.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/Collectors.java
@@ -25,6 +25,8 @@ import org.gradle.api.provider.Provider;
 
 import javax.annotation.Nullable;
 
+import java.util.Arrays;
+
 import static org.gradle.api.internal.lambdas.SerializableLambdas.transformer;
 
 public class Collectors {
@@ -80,6 +82,11 @@ public class Collectors {
         @Override
         public int size() {
             return 1;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("[%s]", element);
         }
     }
 
@@ -150,6 +157,11 @@ public class Collectors {
         public int size() {
             return 1;
         }
+
+        @Override
+        public String toString() {
+            return String.format("item(%s)", provider);
+        }
     }
 
     public static class ElementsFromCollection<T> implements Collector<T> {
@@ -200,6 +212,11 @@ public class Collectors {
         @Override
         public int size() {
             return Iterables.size(value);
+        }
+
+        @Override
+        public String toString() {
+            return value.toString();
         }
     }
 
@@ -266,6 +283,11 @@ public class Collectors {
                 throw new UnsupportedOperationException();
             }
         }
+
+        @Override
+        public String toString() {
+            return String.valueOf(provider);
+        }
     }
 
     public static class ElementsFromArray<T> implements Collector<T> {
@@ -301,6 +323,11 @@ public class Collectors {
         @Override
         public int size() {
             return value.length;
+        }
+
+        @Override
+        public String toString() {
+            return Arrays.toString(value);
         }
     }
 
@@ -370,6 +397,11 @@ public class Collectors {
         @Override
         public int hashCode() {
             return Objects.hashCode(type, delegate);
+        }
+
+        @Override
+        public String toString() {
+            return String.format("(%s as %s)", delegate, type);
         }
     }
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
@@ -385,6 +385,11 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
         public ValueProducer getProducer() {
             return ValueProducer.unknown();
         }
+
+        @Override
+        public String toString() {
+            return value.toString();
+        }
     }
 
     private class EmptySupplier implements MapSupplier<K, V> {
@@ -417,6 +422,11 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
         @Override
         public ValueProducer getProducer() {
             return ValueProducer.noProducer();
+        }
+
+        @Override
+        public String toString() {
+            return "{}";
         }
     }
 
@@ -457,6 +467,11 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
         @Override
         public ValueProducer getProducer() {
             return ValueProducer.unknown();
+        }
+
+        @Override
+        public String toString() {
+            return entries.toString();
         }
     }
 
@@ -559,6 +574,11 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
         @Override
         public ValueProducer getProducer() {
             return collector.getProducer();
+        }
+
+        @Override
+        public String toString() {
+            return collector.toString();
         }
     }
 
@@ -686,6 +706,11 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
         @Override
         public ValueProducer getProducer() {
             return left.getProducer().plus(right.getProducer());
+        }
+
+        @Override
+        public String toString() {
+            return left + " + " + right;
         }
     }
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/MapCollectors.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/MapCollectors.java
@@ -79,6 +79,11 @@ public class MapCollectors {
         public int hashCode() {
             return Objects.hashCode(key, value);
         }
+
+        @Override
+        public String toString() {
+            return String.format("{%s=%s}", key, value);
+        }
     }
 
     public static class EntryWithValueFromProvider<K, V> implements MapCollector<K, V> {
@@ -133,6 +138,11 @@ public class MapCollectors {
         public ValueProducer getProducer() {
             return providerOfValue.getProducer();
         }
+
+        @Override
+        public String toString() {
+            return String.format("entry{%s=%s}", key, providerOfValue);
+        }
     }
 
     public static class EntriesFromMap<K, V> implements MapCollector<K, V> {
@@ -168,6 +178,11 @@ public class MapCollectors {
         @Override
         public ValueProducer getProducer() {
             return ValueProducer.unknown();
+        }
+
+        @Override
+        public String toString() {
+            return entries.toString();
         }
     }
 
@@ -212,6 +227,11 @@ public class MapCollectors {
         @Override
         public ValueProducer getProducer() {
             return providerOfEntries.getProducer();
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(providerOfEntries);
         }
     }
 }

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultListPropertyTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultListPropertyTest.groovy
@@ -38,6 +38,11 @@ class DefaultListPropertyTest extends CollectionPropertySpec<List<String>> {
     }
 
     @Override
+    String getCollectionName() {
+        return "list"
+    }
+
+    @Override
     protected Class<? extends ImmutableCollection<?>> getImmutableCollectionType() {
         return ImmutableList.class
     }

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultSetPropertyTest.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultSetPropertyTest.groovy
@@ -33,6 +33,11 @@ class DefaultSetPropertyTest extends CollectionPropertySpec<Set<String>> {
     }
 
     @Override
+    String getCollectionName() {
+        return "set"
+    }
+
+    @Override
     protected Class<? extends ImmutableCollection<?>> getImmutableCollectionType() {
         return ImmutableSet.class
     }

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
@@ -1578,4 +1578,26 @@ The value of this property is derived from: <source>""")
             }
         }
     }
+
+    def "has meaningful toString for #valueDescription"(Closure<MapProperty<String, String>> initializer, String stringValue) {
+        given:
+        def p = initializer.call()
+
+        expect:
+        p.toString() == stringValue
+
+        where:
+        valueDescription             | initializer                                             || stringValue
+        "default"                    | { property() }                                          || "Map(string->String, {})"
+        "empty"                      | { property().value([:]) }                               || "Map(string->String, {})"
+        "unset"                      | { propertyWithNoValue() }                               || "Map(string->String, missing)"
+        "[k: v]"                     | { property().value(k: "v") }                            || "Map(string->String, {k=v})"
+        "[k1: v1, k2: v2]"           | { property().value(k1: "v1", k2: "v2") }                || "Map(string->String, {k1=v1, k2=v2})"
+        "[k1: v1] + [k2: v2]"        | { property().tap { put("k1", "v1"); put("k2", "v2") } } || "Map(string->String, {k1=v1} + {k2=v2})"
+        "provider {k: v}"            | { property().value(Providers.of([k: "v"])) }            || "Map(string->String, fixed(class ${LinkedHashMap.name}, {k=v}))"
+        "[k: provider {v}]"          | { property().tap { put("k", Providers.of("v")) } }      || "Map(string->String, entry{k=fixed(class ${String.name}, v)})"
+
+        // The following case abuses Groovy lax type-checking to put an invalid value into the property.
+        "[k: (Object) provider {v}]" | { property().value(k: Providers.of("v")) }              || "Map(string->String, {k=fixed(class ${String.name}, v)})"
+    }
 }

--- a/platforms/core-configuration/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/AbstractPropertySpec.groovy
+++ b/platforms/core-configuration/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/AbstractPropertySpec.groovy
@@ -256,7 +256,7 @@ abstract class AbstractPropertySpec<T> extends PropertySpec<T> {
         copy.orNull == someValue()
     }
 
-    def "obtaining value of the shadow copy does not finalize property"() {
+    def "obtaining value of the shallow copy does not finalize property"() {
         given:
         def property = propertyWithValue(someValue())
         property.finalizeValueOnRead()


### PR DESCRIPTION
These may be shown to the users as part of the circular evaluation reporting. Having default toString implementations is not very helpful in these cases.

The convention for `toString` of collectors is the following:
1. List and Sets (and arrays) are enclosed in `[]`, to follow JDK's own implementations
2. Maps are enclosed in `{}`, with keys and values separated with `=` - again, to follow the JDK
3. Single-element collectors have the element enclosed.  These makes them indistinguishable to collection-based collectors with only one element, but it is unlikely anyone needs to distinguish between the two cases.
4. For provider-based collectors, the provider representation is prefixed with `*`, a bit C-like. This helps to highlight the cases where the provider itself is the collection value and not its value. The former is also unlikely to happen, but would be tricky to debug otherwise
5. Collectors that contribute a single element are enclosed in `[]` or `{}`. Collectors that contribute several elements are not enclosed, though fixed-value ones just delegate to the respective collection's `toString` anyway.

For example `provider { 1 }` as part of the ListProperty would be represented as `[*provider(?)]`. `provider { listOf(1, 2, 3)}` would be just `*provider(?)`. 

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
