### PR TITLE
More accurately track cross-project observation

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultBuildModelControllerServices.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultBuildModelControllerServices.kt
@@ -18,8 +18,6 @@ package org.gradle.configurationcache
 
 import org.gradle.api.internal.BuildDefinition
 import org.gradle.api.internal.GradleInternal
-import org.gradle.api.internal.artifacts.ivyservice.projectmodule.BuildTreeLocalComponentProvider
-import org.gradle.api.internal.artifacts.ivyservice.projectmodule.DefaultLocalComponentRegistry
 import org.gradle.api.internal.project.CrossProjectModelAccess
 import org.gradle.api.internal.project.DefaultCrossProjectModelAccess
 import org.gradle.api.internal.project.DefaultDynamicLookupRoutine
@@ -113,10 +111,6 @@ class DefaultBuildModelControllerServices(
 
         fun createBuildLifecycleController(buildLifecycleControllerFactory: BuildLifecycleControllerFactory): BuildLifecycleController {
             return buildLifecycleControllerFactory.newInstance(buildDefinition, buildScopeServices)
-        }
-
-        fun createLocalComponentRegistry(currentBuild: BuildState, componentProvider: BuildTreeLocalComponentProvider): DefaultLocalComponentRegistry {
-            return DefaultLocalComponentRegistry(currentBuild.buildIdentifier, componentProvider)
         }
 
         fun createIntermediateToolingModelProvider(

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -61,6 +61,8 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionP
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.FileStoreAndIndexProvider;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.DefaultRootComponentMetadataBuilder;
+import org.gradle.api.internal.artifacts.ivyservice.projectmodule.DefaultLocalComponentRegistry;
+import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyResolver;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.DefaultComponentResolversFactory;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.DependencyGraphResolver;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSetResolver;
@@ -211,10 +213,13 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             registration.add(DefaultRootComponentMetadataBuilder.Factory.class);
             registration.add(ResolveExceptionContextualizer.class);
             registration.add(ResolutionStrategyFactory.class);
+            registration.add(DefaultLocalComponentRegistry.class);
+            registration.add(ProjectDependencyResolver.class);
             registration.add(DefaultComponentResolversFactory.class);
             registration.add(ConsumerProvidedVariantFinder.class);
             registration.add(DefaultVariantSelectorFactory.class);
             registration.add(DefaultConfigurationFactory.class);
+            registration.add(DefaultComponentSelectorConverter.class);
         }
 
         AttributesSchemaInternal createConfigurationAttributesSchema(InstantiatorFactory instantiatorFactory, IsolatableFactory isolatableFactory, PlatformSupport platformSupport) {
@@ -521,8 +526,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             SelectedVariantSerializer selectedVariantSerializer,
             ResolvedVariantCache resolvedVariantCache,
             GraphVariantSelector graphVariantSelector,
-            ProjectStateRegistry projectStateRegistry,
-            ListenerManager listenerManager
+            ProjectStateRegistry projectStateRegistry
         ) {
             DefaultConfigurationResolver defaultResolver = new DefaultConfigurationResolver(
                 componentResolversFactory,
@@ -548,8 +552,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                 selectedVariantSerializer,
                 resolvedVariantCache,
                 graphVariantSelector,
-                projectStateRegistry,
-                listenerManager
+                projectStateRegistry
             );
 
             return new ShortCircuitEmptyConfigurationResolver(

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -47,7 +47,6 @@ import org.gradle.api.internal.artifacts.ivyservice.modulecache.ModuleRepository
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.ModuleSourcesSerializer;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.SuppliedComponentMetadataSerializer;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.DefaultProjectPublicationRegistry;
-import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyResolver;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.DependencyGraphResolver;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSetResolver;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant;
@@ -181,8 +180,6 @@ class DependencyManagementBuildScopeServices {
         registration.add(TransformStepNodeDependencyResolver.class);
         registration.add(DefaultProjectPublicationRegistry.class);
         registration.add(FileResourceConnector.class);
-        registration.add(DefaultComponentSelectorConverter.class);
-        registration.add(ProjectDependencyResolver.class);
         registration.add(DependencyGraphResolver.class);
         registration.add(ResolvedArtifactSetResolver.class);
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
@@ -37,7 +37,6 @@ import org.gradle.api.internal.artifacts.ResolveExceptionContextualizer;
 import org.gradle.api.internal.artifacts.ResolverResults;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.artifacts.configurations.ConflictResolution;
-import org.gradle.api.internal.artifacts.configurations.ProjectComponentObservationListener;
 import org.gradle.api.internal.artifacts.configurations.ResolutionHost;
 import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ComponentResolvers;
@@ -88,7 +87,6 @@ import org.gradle.cache.internal.BinaryStore;
 import org.gradle.cache.internal.Store;
 import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.GraphVariantSelector;
-import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.locking.DependencyLockingGraphVisitor;
 import org.gradle.internal.model.CalculatedValueContainerFactory;
 import org.gradle.internal.operations.BuildOperationExecutor;
@@ -127,7 +125,6 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
     private final ResolvedVariantCache resolvedVariantCache;
     private final GraphVariantSelector graphVariantSelector;
     private final ProjectStateRegistry projectStateRegistry;
-    private final ListenerManager listenerManager;
 
     public DefaultConfigurationResolver(
         ComponentResolversFactory componentResolversFactory,
@@ -152,8 +149,7 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
         SelectedVariantSerializer selectedVariantSerializer,
         ResolvedVariantCache resolvedVariantCache,
         GraphVariantSelector graphVariantSelector,
-        ProjectStateRegistry projectStateRegistry,
-        ListenerManager listenerManager
+        ProjectStateRegistry projectStateRegistry
     ) {
         this.componentResolversFactory = componentResolversFactory;
         this.dependencyGraphResolver = dependencyGraphResolver;
@@ -179,15 +175,13 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
         this.resolvedVariantCache = resolvedVariantCache;
         this.graphVariantSelector = graphVariantSelector;
         this.projectStateRegistry = projectStateRegistry;
-        this.listenerManager = listenerManager;
     }
 
     @Override
     public ResolverResults resolveBuildDependencies(ResolveContext resolveContext) {
         ResolutionFailureCollector failureCollector = new ResolutionFailureCollector(componentSelectorConverter);
         InMemoryResolutionResultBuilder resolutionResultBuilder = new InMemoryResolutionResultBuilder();
-        ProjectComponentObservationListener projectObservationListener = listenerManager.getBroadcaster(ProjectComponentObservationListener.class);
-        ResolvedLocalComponentsResultGraphVisitor localComponentsVisitor = new ResolvedLocalComponentsResultGraphVisitor(currentBuild, getConsumingProjectIdentityPath(resolveContext), projectStateRegistry, projectObservationListener);
+        ResolvedLocalComponentsResultGraphVisitor localComponentsVisitor = new ResolvedLocalComponentsResultGraphVisitor(currentBuild, projectStateRegistry);
         DefaultResolvedArtifactsBuilder artifactsVisitor = new DefaultResolvedArtifactsBuilder(buildProjectDependencies);
 
         ComponentResolvers resolvers = componentResolversFactory.create(resolveContext, ImmutableList.of(), consumerSchema);
@@ -203,7 +197,7 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
         );
 
         ImmutableList<DependencyGraphVisitor> visitors = ImmutableList.of(failureCollector, resolutionResultBuilder, localComponentsVisitor, artifactsGraphVisitor);
-        dependencyGraphResolver.resolveGraph(resolveContext, resolvers, consumerSchema, metadataHandler, IS_LOCAL_EDGE, false, visitors);
+        dependencyGraphResolver.resolveGraph(resolveContext, resolvers, consumerSchema, metadataHandler, IS_LOCAL_EDGE, false, visitors, componentSelectorConverter);
         localComponentsVisitor.complete(ConfigurationInternal.InternalState.BUILD_DEPENDENCIES_RESOLVED);
 
         Set<UnresolvedDependency> unresolvedDependencies = failureCollector.complete(Collections.emptySet());
@@ -229,8 +223,7 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
         ResolutionStrategyInternal resolutionStrategy = resolveContext.getResolutionStrategy();
         StreamingResolutionResultBuilder newModelBuilder = new StreamingResolutionResultBuilder(newModelStore, newModelCache, attributeContainerSerializer, componentDetailsSerializer, selectedVariantSerializer, attributeDesugaring, componentSelectionDescriptorFactory, resolutionStrategy.getReturnAllVariants());
 
-        ProjectComponentObservationListener projectObservationListener = listenerManager.getBroadcaster(ProjectComponentObservationListener.class);
-        ResolvedLocalComponentsResultGraphVisitor localComponentsVisitor = new ResolvedLocalComponentsResultGraphVisitor(currentBuild, getConsumingProjectIdentityPath(resolveContext), projectStateRegistry, projectObservationListener);
+        ResolvedLocalComponentsResultGraphVisitor localComponentsVisitor = new ResolvedLocalComponentsResultGraphVisitor(currentBuild, projectStateRegistry);
 
         DefaultResolvedArtifactsBuilder artifactsBuilder = new DefaultResolvedArtifactsBuilder(buildProjectDependencies);
         FileDependencyCollectingGraphVisitor fileDependencyVisitor = new FileDependencyCollectingGraphVisitor();
@@ -271,7 +264,7 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
             consumerSchema
         ));
 
-        dependencyGraphResolver.resolveGraph(resolveContext, resolvers, consumerSchema, metadataHandler, Specs.satisfyAll(), true, graphVisitors.build());
+        dependencyGraphResolver.resolveGraph(resolveContext, resolvers, consumerSchema, metadataHandler, Specs.satisfyAll(), true, graphVisitors.build(), componentSelectorConverter);
         localComponentsVisitor.complete(ConfigurationInternal.InternalState.GRAPH_RESOLVED);
 
         VisitedArtifactResults artifactsResults = artifactsBuilder.complete();

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolverProviderFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolverProviderFactory.java
@@ -15,11 +15,13 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
+import org.gradle.api.internal.artifacts.ivyservice.projectmodule.LocalComponentRegistry;
+
 import java.util.Collection;
 
 public interface ResolverProviderFactory {
     /**
      * Create any applicable resolvers and add to the given collection.
      */
-    void create(Collection<ComponentResolvers> resolvers);
+    void create(Collection<ComponentResolvers> resolvers, LocalComponentRegistry localComponentRegistry);
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/BuildTreeLocalComponentProvider.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/BuildTreeLocalComponentProvider.java
@@ -15,9 +15,9 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.projectmodule;
 
-import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.internal.component.local.model.LocalComponentGraphResolveState;
+import org.gradle.util.Path;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -31,7 +31,7 @@ import javax.annotation.concurrent.ThreadSafe;
 public interface BuildTreeLocalComponentProvider {
     /**
      * Get the local component for the project identified by {@code projectIdentifier}. The returned metadata will
-     * use foreign component identifiers for local components originating from builds different from {@code currentBuild}.
+     * use foreign component identifiers for local components originating from builds different from {@code currentBuildPath}.
      */
-    LocalComponentGraphResolveState getComponent(ProjectComponentIdentifier projectIdentifier, BuildIdentifier currentBuild);
+    LocalComponentGraphResolveState getComponent(ProjectComponentIdentifier projectIdentifier, Path currentBuildPath);
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultLocalComponentRegistry.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/DefaultLocalComponentRegistry.java
@@ -29,7 +29,7 @@ import javax.inject.Inject;
 
 /**
  * A simple dependency-management scoped wrapper around {@link BuildTreeLocalComponentProvider} that
- * contextualizes tracks which domain object context makes a given project component request. The primary
+ * tracks which domain object context makes a given project component request. The primary
  * purpose of this class is to track dependencies between projects as they are resolved. By knowing which
  * project is making the request, we can determine which projects depend on which other projects.
  */

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/LocalComponentRegistry.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/LocalComponentRegistry.java
@@ -17,8 +17,6 @@ package org.gradle.api.internal.artifacts.ivyservice.projectmodule;
 
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.internal.component.local.model.LocalComponentGraphResolveState;
-import org.gradle.internal.service.scopes.Scopes;
-import org.gradle.internal.service.scopes.ServiceScope;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -28,7 +26,6 @@ import javax.annotation.concurrent.ThreadSafe;
  * or in another build within a composite.
  */
 @ThreadSafe
-@ServiceScope(Scopes.Build.class)
 public interface LocalComponentRegistry {
     /**
      * @return The component metadata for the supplied identifier.

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyResolver.java
@@ -40,7 +40,7 @@ import org.gradle.internal.service.scopes.ServiceScope;
 
 import javax.annotation.Nullable;
 
-@ServiceScope(Scopes.Build.class)
+@ServiceScope(Scopes.Project.class)
 public class ProjectDependencyResolver implements ComponentMetaDataResolver, DependencyToComponentIdResolver, ArtifactResolver, ComponentResolvers {
     private final LocalComponentRegistry localComponentRegistry;
     private final ProjectArtifactResolver artifactResolver;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultComponentResolversFactory.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultComponentResolversFactory.java
@@ -23,6 +23,7 @@ import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyIntern
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ComponentResolvers;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ResolveIvyFactory;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ResolverProviderFactory;
+import org.gradle.api.internal.artifacts.ivyservice.projectmodule.LocalComponentRegistry;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyResolver;
 import org.gradle.api.internal.artifacts.repositories.ResolutionAwareRepository;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
@@ -44,6 +45,7 @@ public class DefaultComponentResolversFactory implements ComponentResolversFacto
     private final ImmutableAttributesFactory attributesFactory;
     private final ComponentMetadataSupplierRuleExecutor componentMetadataSupplierRuleExecutor;
     private final GlobalDependencyResolutionRules metadataHandler;
+    private final LocalComponentRegistry localComponentRegistry;
 
     @Inject
     public DefaultComponentResolversFactory(
@@ -52,7 +54,8 @@ public class DefaultComponentResolversFactory implements ComponentResolversFacto
         ProjectDependencyResolver projectDependencyResolver,
         ImmutableAttributesFactory attributesFactory,
         ComponentMetadataSupplierRuleExecutor componentMetadataSupplierRuleExecutor,
-        GlobalDependencyResolutionRules metadataHandler
+        GlobalDependencyResolutionRules metadataHandler,
+        LocalComponentRegistry localComponentRegistry
     ) {
         this.resolverFactories = resolverFactories;
         this.moduleDependencyResolverFactory = moduleDependencyResolverFactory;
@@ -60,6 +63,7 @@ public class DefaultComponentResolversFactory implements ComponentResolversFacto
         this.attributesFactory = attributesFactory;
         this.componentMetadataSupplierRuleExecutor = componentMetadataSupplierRuleExecutor;
         this.metadataHandler = metadataHandler;
+        this.localComponentRegistry = localComponentRegistry;
     }
 
     @Override
@@ -72,7 +76,7 @@ public class DefaultComponentResolversFactory implements ComponentResolversFacto
 
         List<ComponentResolvers> resolvers = new ArrayList<>(3);
         for (ResolverProviderFactory factory : resolverFactories) {
-            factory.create(resolvers);
+            factory.create(resolvers, localComponentRegistry);
         }
         resolvers.add(projectDependencyResolver);
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphResolver.java
@@ -74,7 +74,6 @@ public class DependencyGraphResolver {
     private final VersionComparator versionComparator;
     private final ModuleExclusions moduleExclusions;
     private final BuildOperationExecutor buildOperationExecutor;
-    private final ComponentSelectorConverter componentSelectorConverter;
     private final VersionSelectorScheme versionSelectorScheme;
     private final VersionParser versionParser;
     private final Instantiator instantiator;
@@ -91,7 +90,6 @@ public class DependencyGraphResolver {
         DependencyMetadataFactory dependencyMetadataFactory,
         VersionComparator versionComparator,
         ModuleExclusions moduleExclusions,
-        ComponentSelectorConverter componentSelectorConverter,
         VersionSelectorScheme versionSelectorScheme,
         VersionParser versionParser,
         InstantiatorFactory instantiatorFactory,
@@ -106,7 +104,6 @@ public class DependencyGraphResolver {
         this.versionComparator = versionComparator;
         this.moduleExclusions = moduleExclusions;
         this.buildOperationExecutor = buildOperationExecutor;
-        this.componentSelectorConverter = componentSelectorConverter;
         this.versionSelectorScheme = versionSelectorScheme;
         this.versionParser = versionParser;
         this.instantiator = instantiatorFactory.decorateScheme().instantiator();
@@ -128,7 +125,8 @@ public class DependencyGraphResolver {
         GlobalDependencyResolutionRules metadataHandler,
         Spec<? super DependencyMetadata> edgeFilter,
         boolean includeSyntheticDependencies,
-        List<DependencyGraphVisitor> visitors
+        List<DependencyGraphVisitor> visitors,
+        ComponentSelectorConverter componentSelectorConverter
     ) {
         ComponentMetaDataResolver componentMetaDataResolver = new ClientModuleResolver(
             resolvers.getComponentResolver(), dependencyMetadataFactory, moduleResolveStateFactory

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/projectresult/ResolvedLocalComponentsResultGraphVisitor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/projectresult/ResolvedLocalComponentsResultGraphVisitor.java
@@ -20,7 +20,6 @@ import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.artifacts.ProjectComponentIdentifierInternal;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
-import org.gradle.api.internal.artifacts.configurations.ProjectComponentObservationListener;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.RootGraphNode;
@@ -28,34 +27,32 @@ import org.gradle.api.internal.project.ProjectState;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.util.Path;
 
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
 /**
  * Used to track which configurations in other projects a given resolution depends on. This data is
- * used to mark those configurations as observed so that they cannot be mutated later and to notify
- * listeners that the consuming project has observed the target project.
+ * used to mark those configurations as observed so that they cannot be mutated later.
+ *
+ * <strong>Do not build on-top of this visitor. If you want to track cross-project dependencies,
+ * use {@link org.gradle.api.internal.artifacts.configurations.ProjectComponentObservationListener}</strong>
+ *
+ * TODO: The logic in this visitor should be integrated directly into the DefaultLocalConfigurationMetadataBuilder
+ * so that we instantly mark configurations as observed as their metadata is constructed. That would be an improvement
+ * over this visitor, since here we only mark a configuration observed if its metadata is present in the final graph.
+ * There are likely scenarios that this visitor does not cover, where a configuration's metadata is observed but
+ * its component is not present in the final graph.
  */
 public class ResolvedLocalComponentsResultGraphVisitor implements DependencyGraphVisitor {
     private final BuildIdentifier thisBuild;
-    private final Path consumingProjectIdentity;
     private final ProjectStateRegistry projectStateRegistry;
-    private final ProjectComponentObservationListener listener;
 
     private ComponentIdentifier rootId;
     private final List<ResolvedProjectConfiguration> resolvedProjectConfigurations = new ArrayList<>();
 
-    public ResolvedLocalComponentsResultGraphVisitor(
-        BuildIdentifier thisBuild,
-        @Nullable Path consumingProjectIdentity,
-        ProjectStateRegistry projectStateRegistry,
-        ProjectComponentObservationListener listener
-    ) {
+    public ResolvedLocalComponentsResultGraphVisitor(BuildIdentifier thisBuild, ProjectStateRegistry projectStateRegistry) {
         this.thisBuild = thisBuild;
-        this.consumingProjectIdentity = consumingProjectIdentity;
         this.projectStateRegistry = projectStateRegistry;
-        this.listener = listener;
     }
 
     @Override
@@ -69,7 +66,9 @@ public class ResolvedLocalComponentsResultGraphVisitor implements DependencyGrap
         if (!rootId.equals(componentId) && componentId instanceof ProjectComponentIdentifierInternal) {
             ProjectComponentIdentifierInternal projectComponentId = (ProjectComponentIdentifierInternal) componentId;
 
-            // TODO: We should relax this check. Why are we not tracking observations across builds?
+            // We should be tracking cross-build configuration observations, but we are not.
+            // This check is here for historical reasons, as removing it would be a breaking change.
+            // We should just leave this here, since this observation mechanism is being replaced anyway.
             if (projectComponentId.getBuild().equals(thisBuild)) {
                 resolvedProjectConfigurations.add(new ResolvedProjectConfiguration(projectComponentId.getIdentityPath(), node.getResolvedConfigurationId().getConfiguration()));
             }
@@ -77,25 +76,10 @@ public class ResolvedLocalComponentsResultGraphVisitor implements DependencyGrap
     }
 
     /**
-     * Mark all visited project variant nodes as observed.
+     * Mark all configurations corresponding to visited project variant nodes as observed.
      */
     public void complete(ConfigurationInternal.InternalState requestedState) {
         for (ResolvedProjectConfiguration projectResult : resolvedProjectConfigurations) {
-
-            // Notify listeners that this project has observed the target project
-            // TODO: This should be moved to the `LocalComponentRegistry`, so that we
-            // get a more accurate picture of which projects have observed which other projects
-            // as it happens. This only tracks projects that end up in the final graph, and it
-            // could potentially miss cases where project metadata is observed but not included
-            // in the final graph.
-            listener.projectObserved(consumingProjectIdentity, projectResult.projectIdentity);
-
-            // Mark referenced configurations as observed.
-            // TODO: This logic should be integrated directly into the DefaultLocalConfigurationMetadataBuilder so that
-            // we instantly mark configurations as observed as their metadata is constructed. This is an improvement
-            // over this visitor, where we only mark a configuration observed if its metadata is present in the final graph.
-            // There are likely scenarios that this visitor does not cover, where a configuration's metadata is observed but
-            // its component is not present in the final graph, similar to above.
             ProjectState targetState = projectStateRegistry.stateFor(projectResult.projectIdentity);
             ConfigurationInternal targetConfig = (ConfigurationInternal) targetState.getMutableModel().getConfigurations().findByName(projectResult.targetConfiguration);
             if (targetConfig != null) {

--- a/platforms/software/version-control/src/main/java/org/gradle/vcs/internal/services/VersionControlServices.java
+++ b/platforms/software/version-control/src/main/java/org/gradle/vcs/internal/services/VersionControlServices.java
@@ -57,6 +57,7 @@ import org.gradle.vcs.internal.resolver.VcsDependencyResolver;
 import org.gradle.vcs.internal.resolver.VcsVersionSelectionCache;
 import org.gradle.vcs.internal.resolver.VcsVersionWorkingDirResolver;
 
+import javax.inject.Inject;
 import java.util.Collection;
 
 public class VersionControlServices extends AbstractPluginServiceRegistry {
@@ -135,35 +136,52 @@ public class VersionControlServices extends AbstractPluginServiceRegistry {
     }
 
     private static class VersionControlBuildServices {
-        VcsDependencyResolver createVcsDependencyResolver(LocalComponentRegistry localComponentRegistry, VcsResolver vcsResolver, VersionControlRepositoryConnectionFactory versionControlSystemFactory, VersionSelectorScheme versionSelectorScheme, VersionComparator versionComparator, BuildStateRegistry buildRegistry, VersionParser versionParser, VcsVersionSelectionCache versionSelectionCache, PersistentVcsMetadataCache persistentCache, StartParameter startParameter, PublicBuildPath publicBuildPath) {
+
+        void configure(ServiceRegistration registration) {
+            registration.add(VcsResolverFactory.class);
+        }
+
+        VcsVersionWorkingDirResolver createVcsDependencyResolver(VersionSelectorScheme versionSelectorScheme, VersionComparator versionComparator, VersionParser versionParser, VcsVersionSelectionCache versionSelectionCache, PersistentVcsMetadataCache persistentCache, StartParameter startParameter) {
             VcsVersionWorkingDirResolver workingDirResolver;
             if (startParameter.isOffline()) {
                 workingDirResolver = new OfflineVcsVersionWorkingDirResolver(persistentCache);
             } else {
                 workingDirResolver = new DefaultVcsVersionWorkingDirResolver(versionSelectorScheme, versionComparator, versionParser, versionSelectionCache, persistentCache);
             }
-            workingDirResolver = new OncePerBuildInvocationVcsVersionWorkingDirResolver(versionSelectionCache, workingDirResolver);
-            return new VcsDependencyResolver(localComponentRegistry, vcsResolver, versionControlSystemFactory, buildRegistry, workingDirResolver, publicBuildPath);
-        }
-
-        ResolverProviderFactory createVcsResolverProviderFactory(VcsDependencyResolver vcsDependencyResolver, VcsResolver vcsResolver) {
-            return new VcsResolverFactory(vcsDependencyResolver, vcsResolver);
+            return new OncePerBuildInvocationVcsVersionWorkingDirResolver(versionSelectionCache, workingDirResolver);
         }
     }
 
-    private static class VcsResolverFactory implements ResolverProviderFactory {
-        private final VcsDependencyResolver vcsDependencyResolver;
-        private final VcsResolver vcsResolver;
+    protected static class VcsResolverFactory implements ResolverProviderFactory {
 
-        private VcsResolverFactory(VcsDependencyResolver vcsDependencyResolver, VcsResolver vcsResolver) {
-            this.vcsDependencyResolver = vcsDependencyResolver;
+        private final VcsResolver vcsResolver;
+        private final BuildStateRegistry buildRegistry;
+        private final PublicBuildPath publicBuildPath;
+        private final VersionControlRepositoryConnectionFactory versionControlSystemFactory;
+        private final VcsVersionWorkingDirResolver workingDirResolver;
+
+        @Inject
+        public VcsResolverFactory(
+            VcsResolver vcsResolver,
+            BuildStateRegistry buildRegistry,
+            PublicBuildPath publicBuildPath,
+            VersionControlRepositoryConnectionFactory versionControlSystemFactory,
+            VcsVersionWorkingDirResolver workingDirResolver
+        ) {
             this.vcsResolver = vcsResolver;
+            this.buildRegistry = buildRegistry;
+            this.publicBuildPath = publicBuildPath;
+            this.versionControlSystemFactory = versionControlSystemFactory;
+            this.workingDirResolver = workingDirResolver;
         }
 
         @Override
-        public void create(Collection<ComponentResolvers> resolvers) {
+        public void create(Collection<ComponentResolvers> resolvers, LocalComponentRegistry localComponentRegistry) {
             if (vcsResolver.hasRules()) {
-                resolvers.add(vcsDependencyResolver);
+                resolvers.add(new VcsDependencyResolver(
+                    localComponentRegistry, vcsResolver, versionControlSystemFactory,
+                    buildRegistry, workingDirResolver, publicBuildPath
+                ));
             }
         }
     }

--- a/platforms/software/version-control/src/main/java/org/gradle/vcs/internal/services/VersionControlServices.java
+++ b/platforms/software/version-control/src/main/java/org/gradle/vcs/internal/services/VersionControlServices.java
@@ -141,7 +141,7 @@ public class VersionControlServices extends AbstractPluginServiceRegistry {
             registration.add(VcsResolverFactory.class);
         }
 
-        VcsVersionWorkingDirResolver createVcsDependencyResolver(VersionSelectorScheme versionSelectorScheme, VersionComparator versionComparator, VersionParser versionParser, VcsVersionSelectionCache versionSelectionCache, PersistentVcsMetadataCache persistentCache, StartParameter startParameter) {
+        VcsVersionWorkingDirResolver createVcsVersionWorkingDirResolver(VersionSelectorScheme versionSelectorScheme, VersionComparator versionComparator, VersionParser versionParser, VcsVersionSelectionCache versionSelectionCache, PersistentVcsMetadataCache persistentCache, StartParameter startParameter) {
             VcsVersionWorkingDirResolver workingDirResolver;
             if (startParameter.isOffline()) {
                 workingDirResolver = new OfflineVcsVersionWorkingDirResolver(persistentCache);

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultBuildTreeLocalComponentProvider.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultBuildTreeLocalComponentProvider.java
@@ -33,6 +33,7 @@ import org.gradle.internal.component.local.model.LocalComponentGraphResolveState
 import org.gradle.internal.component.local.model.LocalComponentMetadata;
 import org.gradle.internal.model.CalculatedValueContainer;
 import org.gradle.internal.model.CalculatedValueContainerFactory;
+import org.gradle.util.Path;
 
 import java.io.File;
 import java.util.Map;
@@ -76,8 +77,8 @@ public class DefaultBuildTreeLocalComponentProvider implements BuildTreeLocalCom
     }
 
     @Override
-    public LocalComponentGraphResolveState getComponent(ProjectComponentIdentifier projectIdentifier, BuildIdentifier currentBuild) {
-        boolean isLocalProject = projectIdentifier.getBuild().getBuildPath().equals(currentBuild.getBuildPath());
+    public LocalComponentGraphResolveState getComponent(ProjectComponentIdentifier projectIdentifier, Path currentBuildPath) {
+        boolean isLocalProject = projectIdentifier.getBuild().getBuildPath().equals(currentBuildPath.getPath());
         if (isLocalProject) {
             return getLocalComponent(projectIdentifier, projectStateRegistry.stateFor(projectIdentifier));
         } else {


### PR DESCRIPTION
Update DefaultLocalComponentRegistry to be dependency-management scoped, and thus is now able to track
and broadcast all cases where one project requests the component metadata of another. This is more accurate
than the existing ResolvedLocalComponentsGraphVisitor, which only considers one project dependent on another
when a project node is present in the final graph. Module and capability conflict resolutions can cause
differences between these two methods of tracking project dependencies, for example if a project was originally
used to influence the graph state but was later removed from the graph.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
