### PR TITLE
Don't run artifact transform in place in integration tests

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIncrementalIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIncrementalIntegrationTest.groovy
@@ -18,6 +18,9 @@ package org.gradle.integtests.resolve.transform
 
 import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
 
+import static org.gradle.api.internal.initialization.DefaultScriptClassPathResolver.INSTRUMENTED_ATTRIBUTE
+import static org.gradle.api.internal.initialization.DefaultScriptClassPathResolver.NOT_INSTRUMENTED_ATTRIBUTE_VALUE
+
 class ArtifactTransformIncrementalIntegrationTest extends AbstractDependencyResolutionTest implements ArtifactTransformTestFixture {
 
     def "incremental artifact transform in buildscript block for included build runs without exception"() {
@@ -32,18 +35,19 @@ class ArtifactTransformIncrementalIntegrationTest extends AbstractDependencyReso
         """
         file("a/build.gradle") << """
             buildscript {
+                // Build script classpath is resolved via ${INSTRUMENTED_ATTRIBUTE.name} attribute,
+                // so we have to set that attribute too to make transform run
                 def artifactType = Attribute.of('artifactType', String)
+                def instrumented = Attribute.of('${INSTRUMENTED_ATTRIBUTE.name}', String.class)
                 dependencies {
                     classpath "com.test:lib:1.0"
                     registerTransform(MakeColor) {
-                        from.attribute(artifactType, 'jar')
-                        to.attribute(artifactType, 'green')
+                        from.attribute(artifactType, 'jar').attribute(instrumented, '${NOT_INSTRUMENTED_ATTRIBUTE_VALUE}')
+                        to.attribute(artifactType, 'green').attribute(instrumented, '${NOT_INSTRUMENTED_ATTRIBUTE_VALUE}')
                         parameters.targetColor.set('green')
                     }
                 }
-                configurations.classpath.incoming.artifactView {
-                    attributes.attribute(artifactType, 'green')
-                }.files.files
+                configurations.classpath.attributes.attribute(artifactType, 'green')
             }
         """
         file("included/b/build.gradle") << """

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptClassPathResolver.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptClassPathResolver.java
@@ -57,8 +57,8 @@ public class DefaultScriptClassPathResolver implements ScriptClassPathResolver {
     );
 
     private static final Attribute<Boolean> HIERARCHY_COLLECTED_ATTRIBUTE = Attribute.of("org.gradle.internal.hierarchy-collected", Boolean.class);
-    private static final Attribute<String> INSTRUMENTED_ATTRIBUTE = Attribute.of("org.gradle.internal.instrumented", String.class);
-    private static final String NOT_INSTRUMENTED_ATTRIBUTE = "not-instrumented";
+    public static final Attribute<String> INSTRUMENTED_ATTRIBUTE = Attribute.of("org.gradle.internal.instrumented", String.class);
+    public static final String NOT_INSTRUMENTED_ATTRIBUTE_VALUE = "not-instrumented";
     private static final String INSTRUMENTED_EXTERNAL_DEPENDENCY_ATTRIBUTE = "instrumented-external-dependency";
     private static final String INSTRUMENTED_PROJECT_DEPENDENCY_ATTRIBUTE = "instrumented-project-dependency";
     private final NamedObjectInstantiator instantiator;
@@ -76,7 +76,7 @@ public class DefaultScriptClassPathResolver implements ScriptClassPathResolver {
     public void prepareDependencyHandler(DependencyHandler dependencyHandler) {
         // We use `maybeCreate`, since buildSrc already has JAR_TYPE defined from the JavaBase plugin
         dependencyHandler.getArtifactTypes().maybeCreate(ArtifactTypeDefinition.JAR_TYPE).getAttributes()
-            .attribute(INSTRUMENTED_ATTRIBUTE, NOT_INSTRUMENTED_ATTRIBUTE)
+            .attribute(INSTRUMENTED_ATTRIBUTE, NOT_INSTRUMENTED_ATTRIBUTE_VALUE)
             .attribute(HIERARCHY_COLLECTED_ATTRIBUTE, false);
 
         // Register instrumentation transforms
@@ -88,7 +88,7 @@ public class DefaultScriptClassPathResolver implements ScriptClassPathResolver {
         dependencyHandler.registerTransform(
             transform,
             spec -> {
-                spec.getFrom().attribute(INSTRUMENTED_ATTRIBUTE, NOT_INSTRUMENTED_ATTRIBUTE);
+                spec.getFrom().attribute(INSTRUMENTED_ATTRIBUTE, NOT_INSTRUMENTED_ATTRIBUTE_VALUE);
                 spec.getTo().attribute(INSTRUMENTED_ATTRIBUTE, instrumentedAttribute);
                 spec.parameters(parameters -> parameters.getAgentSupported().set(agentStatus.isAgentInstrumentationEnabled()));
             }


### PR DESCRIPTION
For ArtifactTransformBuildOperationIntegrationTest and ArtifactTransformIncrementalIntegrationTest tests.

A change was introduced in https://github.com/gradle/gradle/pull/26045. With this fix a test won't resolve artifact transform in place.