### PR TITLE
Deprecate calling getIncoming() on non-resolvable configuration

### DIFF
--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRolesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ConfigurationRolesIntegrationTest.groovy
@@ -122,6 +122,17 @@ This method is only meant to be called on configurations which allow the (non-de
 \tDeclarable - this configuration can have dependencies added to it
 This method is only meant to be called on configurations which allow the (non-deprecated) usage(s): 'Resolvable'. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_configuration_usage""")
             }
+        } else if (method.startsWith('getIncoming()')) {
+            if (role == 'canBeResolved = false') {
+                executer.expectDocumentedDeprecationWarning("""Calling configuration method 'getIncoming()' is deprecated for configuration 'internal', which has permitted usage(s):
+\tConsumable - this configuration can be selected by another project as a dependency
+\tDeclarable - this configuration can have dependencies added to it
+This method is only meant to be called on configurations which allow the (non-deprecated) usage(s): 'Resolvable'. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_configuration_usage""")
+            } else {
+                executer.expectDocumentedDeprecationWarning("""Calling configuration method 'getIncoming()' is deprecated for configuration 'internal', which has permitted usage(s):
+\tDeclarable - this configuration can have dependencies added to it
+This method is only meant to be called on configurations which allow the (non-deprecated) usage(s): 'Resolvable'. This behavior has been deprecated. This behavior is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_configuration_usage""")
+            }
         }
         fails 'checkState'
 

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/DeprecatedConfigurationUsageIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/DeprecatedConfigurationUsageIntegrationTest.groovy
@@ -83,7 +83,8 @@ class DeprecatedConfigurationUsageIntegrationTest extends AbstractIntegrationSpe
         'copy(Spec)'                                   | 'dependencyScope' | 'copy { } as Spec'                                             || [ProperMethodUsage.RESOLVABLE]
         'copyRecursive(Spec)'                          | 'consumable'      | 'copyRecursive { } as Spec'                                    || [ProperMethodUsage.RESOLVABLE]
         'copyRecursive(Spec)'                          | 'dependencyScope' | 'copyRecursive { } as Spec'                                    || [ProperMethodUsage.RESOLVABLE]
-
+        'getIncoming()'                                | 'consumable'      | 'getIncoming()'                                                || [ProperMethodUsage.RESOLVABLE]
+        'getIncoming()'                                | 'dependencyScope' | 'getIncoming()'                                                || [ProperMethodUsage.RESOLVABLE]
     }
 
     def "calling an invalid internal API method #methodName for role #role produces a deprecation warning"() {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -695,8 +695,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
                 runDependencyActions();
                 preventFromFurtherMutation();
 
-                ResolvableDependenciesInternal incoming = (ResolvableDependenciesInternal) getIncoming();
-                performPreResolveActions(incoming);
+                performPreResolveActions(resolvableDependencies);
                 ResolverResults results = resolver.resolveGraph(DefaultConfiguration.this);
                 dependenciesModified = false;
 
@@ -710,7 +709,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
                 // TODO: Currently afterResolve runs if there is not an non-unresolved-dependency failure
                 //       We should either _always_ run afterResolve, or only run it if _no_ failure occurred
                 if (!results.getVisitedGraph().getResolutionFailure().isPresent()) {
-                    dependencyResolutionListeners.getSource().afterResolve(incoming);
+                    dependencyResolutionListeners.getSource().afterResolve(resolvableDependencies);
                 }
 
                 // Discard State
@@ -1082,6 +1081,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
 
     @Override
     public ResolvableDependencies getIncoming() {
+        warnOnDeprecatedUsage("getIncoming()", ProperMethodUsage.RESOLVABLE);
         return resolvableDependencies;
     }
 

--- a/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/component/ConfigurationSoftwareComponentVariant.java
+++ b/platforms/software/publish/src/main/java/org/gradle/api/publish/internal/component/ConfigurationSoftwareComponentVariant.java
@@ -38,7 +38,7 @@ import java.util.Set;
  */
 public class ConfigurationSoftwareComponentVariant extends AbstractSoftwareComponentVariant {
     protected final String name;
-    private final Configuration configuration;
+    private final ConfigurationInternal configuration;
     private DomainObjectSet<ModuleDependency> dependencies;
     private DomainObjectSet<DependencyConstraint> dependencyConstraints;
     private Set<? extends Capability> capabilities;
@@ -50,7 +50,7 @@ public class ConfigurationSoftwareComponentVariant extends AbstractSoftwareCompo
 
     public ConfigurationSoftwareComponentVariant(String name, AttributeContainer attributes, Set<? extends PublishArtifact> artifacts, Configuration configuration) {
         super(((AttributeContainerInternal) attributes).asImmutable(), artifacts);
-        this.configuration = configuration;
+        this.configuration = (ConfigurationInternal) configuration;
         this.name = name;
     }
 
@@ -62,7 +62,8 @@ public class ConfigurationSoftwareComponentVariant extends AbstractSoftwareCompo
     @Override
     public Set<ModuleDependency> getDependencies() {
         if (dependencies == null) {
-            dependencies = configuration.getIncoming().getDependencies().withType(ModuleDependency.class);
+            configuration.runDependencyActions();
+            dependencies = configuration.getAllDependencies().withType(ModuleDependency.class);
         }
         return dependencies;
     }
@@ -70,7 +71,8 @@ public class ConfigurationSoftwareComponentVariant extends AbstractSoftwareCompo
     @Override
     public Set<? extends DependencyConstraint> getDependencyConstraints() {
         if (dependencyConstraints == null) {
-            dependencyConstraints = configuration.getIncoming().getDependencyConstraints();
+            configuration.runDependencyActions();
+            dependencyConstraints = configuration.getAllDependencyConstraints();
         }
         return dependencyConstraints;
     }
@@ -88,7 +90,7 @@ public class ConfigurationSoftwareComponentVariant extends AbstractSoftwareCompo
     @Override
     public Set<ExcludeRule> getGlobalExcludes() {
         if (excludeRules == null) {
-            this.excludeRules = ImmutableSet.copyOf(((ConfigurationInternal) configuration).getAllExcludeRules());
+            this.excludeRules = ImmutableSet.copyOf(configuration.getAllExcludeRules());
         }
         return excludeRules;
     }


### PR DESCRIPTION
This method only exposes resolvable functionality of a configuration.
This should not be called for non-resolvable configurations


### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
