### PR TITLE
Fix merge queue branch matching

### DIFF
--- a/.teamcity/src/main/kotlin/common/extensions.kt
+++ b/.teamcity/src/main/kotlin/common/extensions.kt
@@ -195,7 +195,7 @@ fun BuildSteps.checkCleanM2AndAndroidUserHome(os: Os = Os.LINUX, buildType: Buil
 
 fun BuildStep.onlyRunOnGitHubMergeQueueBranch() {
     conditions {
-        matches("teamcity.build.branch", "(pre-test/)|(gh-readonly-queue/)")
+        matches("teamcity.build.branch", "(pre-test/.*)|(gh-readonly-queue/.*)")
     }
 }
 


### PR DESCRIPTION
When we switched to GitHub merge queue we changed the merge queue matching rule, which seems not working.

Now the new pattern is tested on experimental pipeline.