### PR TITLE
Add missing uuid for GitHubMergeQueueCheckPass

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/GitHubMergeQueueCheckPass.kt
+++ b/.teamcity/src/main/kotlin/configurations/GitHubMergeQueueCheckPass.kt
@@ -1,8 +1,10 @@
 package configurations
 
 import common.VersionedSettingsBranch
+import common.uuidPrefix
 import jetbrains.buildServer.configs.kotlin.AbsoluteId
 import jetbrains.buildServer.configs.kotlin.CheckoutMode
+import jetbrains.buildServer.configs.kotlin.DslContext
 import jetbrains.buildServer.configs.kotlin.FailureAction
 import jetbrains.buildServer.configs.kotlin.RelativeId
 import jetbrains.buildServer.configs.kotlin.triggers.VcsTrigger
@@ -11,7 +13,8 @@ import model.CIBuildModel
 import model.StageName
 
 class GitHubMergeQueueCheckPass(model: CIBuildModel) : BaseGradleBuildType(init = {
-    id("Check_GitHubMergeQueueCheckPass")
+    id("${model.projectId}_GitHubMergeQueueCheckPass")
+    uuid = "${DslContext.uuidPrefix}_${model.projectId}_GitHubMergeQueueCheckPass"
     name = "GitHub Merge Queue Check Pass"
     type = Type.COMPOSITE
 


### PR DESCRIPTION
Otherwise, there'd weird issues, like:

The build is triggered on `Master` pipeline but the build url points to `Experimental` pipeline:

![image](https://github.com/gradle/gradle/assets/12689835/ae01f944-cdea-4df7-be0b-e222a50865f4)

And it redirects to `Master` pipeline.

![image](https://github.com/gradle/gradle/assets/12689835/69f0d068-9282-49bb-b3da-f8229d70d443)
