### PR TITLE
Add default values to Javadoc of isDownloadSources and isDownloadJavadoc in IdeaModule

### DIFF
--- a/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/idea/model/IdeaModule.java
+++ b/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/idea/model/IdeaModule.java
@@ -301,7 +301,7 @@ public abstract class IdeaModule {
     }
 
     /**
-     * Whether to download and add sources associated with the dependency jars. <p> For example see docs for {@link IdeaModule}
+     * Whether to download and add sources associated with the dependency jars. Defaults to true. <p> For example see docs for {@link IdeaModule}
      */
     public boolean isDownloadSources() {
         return downloadSources;
@@ -312,7 +312,7 @@ public abstract class IdeaModule {
     }
 
     /**
-     * Whether to download and add javadoc associated with the dependency jars. <p> For example see docs for {@link IdeaModule}
+     * Whether to download and add javadoc associated with the dependency jars. Defaults to false. <p> For example see docs for {@link IdeaModule}
      */
     public boolean isDownloadJavadoc() {
         return downloadJavadoc;


### PR DESCRIPTION
### Context
To quickly find out the default value via the IDE, just like the users from the Eclipse extension [are used to](https://github.com/gradle/gradle/blob/master/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java#L253-L273).

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
