### PR TITLE
Separate DefaultLenientConfiguration from ResolveContext

### DIFF
--- a/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/api/internal/artifacts/ResolveArtifactsBuildOperationType.java
+++ b/platforms/enterprise/enterprise-operations/src/main/java/org/gradle/api/internal/artifacts/ResolveArtifactsBuildOperationType.java
@@ -27,6 +27,14 @@ public final class ResolveArtifactsBuildOperationType implements BuildOperationT
 
     public interface Details {
 
+        /**
+         * This method is not called on the Develocity side, at least in DV plugin >= 3.0.
+         *
+         * @return An empty string.
+         *
+         * @deprecated This method will be removed in Gradle 9.0
+         */
+        @Deprecated
         String getConfigurationPath();
 
     }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r40/ArtifactDownloadProgressCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r40/ArtifactDownloadProgressCrossVersionSpec.groovy
@@ -53,7 +53,7 @@ class ArtifactDownloadProgressCrossVersionSpec extends AbstractHttpCrossVersionS
         def applyRootBuildScript = configureBuild.child("Configure project :").child(applyRootProjectBuildScript())
 
         def resolveCompileDependencies = events.operation("Resolve dependencies :compileClasspath", "Resolve dependencies of :compileClasspath")
-        def resolveCompileFiles = events.operation("Resolve files :compileClasspath", "Resolve files of :compileClasspath")
+        def resolveCompileFiles = events.operation(resolveConfigurationFiles(":compileClasspath"), resolveConfigurationFiles(":compileClasspath"))
         def resolveB = events.operation("Resolve group:projectB:1.0")
         def resolveD = events.operation("Resolve group:projectD:2.0-SNAPSHOT")
         def resolveArtifactB = events.operation("Resolve projectB-1.0.jar (group:projectB:1.0)")
@@ -95,6 +95,14 @@ class ArtifactDownloadProgressCrossVersionSpec extends AbstractHttpCrossVersionS
             return "Apply build file 'build.gradle' to root project 'root'"
         } else {
             return "Apply script build.gradle to root project 'root'"
+        }
+    }
+
+    private String resolveConfigurationFiles(String path) {
+        if (targetVersion.baseVersion >= GradleVersion.version("8.7")) {
+            return "Resolve files of configuration '" + path + "'"
+        } else {
+            return "Resolve files of " + path
         }
     }
 }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r40/ProjectConfigurationChildrenProgressCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r40/ProjectConfigurationChildrenProgressCrossVersionSpec.groovy
@@ -290,7 +290,7 @@ class ProjectConfigurationChildrenProgressCrossVersionSpec extends AbstractProgr
             it.descendant "Download ${server.uri}${projectD.pomPath}"
         }
 
-        def resolveArtifacts = applyBuildScript.child("Resolve files of :compileClasspath")
+        def resolveArtifacts = applyBuildScript.child(resolveConfigurationFiles(':compileClasspath'))
 
         resolveArtifacts.child("Resolve ${expectedDisplayName('projectB', 'jar', '1.0')} (group:projectB:1.0)")
             .child "Download ${server.uri}${projectB.artifactPath}"
@@ -340,11 +340,11 @@ class ProjectConfigurationChildrenProgressCrossVersionSpec extends AbstractProgr
 
         def applyRootBuildScript = configureRoot.child(applyBuildScriptRootProject("multi"))
         def resolveCompile = applyRootBuildScript.child("Resolve dependencies of :compileClasspath")
-        applyRootBuildScript.child("Resolve files of :compileClasspath")
+        applyRootBuildScript.child(resolveConfigurationFiles(':compileClasspath'))
 
         def applyProjectABuildScript = resolveCompile.child("Configure project :a").child(applyBuildScript(aBuildfile, ':a'))
         def resolveCompileA = applyProjectABuildScript.child("Resolve dependencies of :a:compileClasspath")
-        applyProjectABuildScript.child("Resolve files of :a:compileClasspath")
+        applyProjectABuildScript.child(resolveConfigurationFiles(':a:compileClasspath'))
 
         resolveCompileA.child("Configure project :b")
     }
@@ -391,4 +391,11 @@ class ProjectConfigurationChildrenProgressCrossVersionSpec extends AbstractProgr
         return new MavenFileRepository(file(name))
     }
 
+    private String resolveConfigurationFiles(String path) {
+        if (targetVersion.baseVersion >= GradleVersion.version("8.7")) {
+            return "Resolve files of configuration '" + path + "'"
+        } else {
+            return "Resolve files of " + path
+        }
+    }
 }

--- a/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r40/ResolveArtifactsProgressCrossVersionSpec.groovy
+++ b/platforms/ide/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r40/ResolveArtifactsProgressCrossVersionSpec.groovy
@@ -63,7 +63,7 @@ class ResolveArtifactsProgressCrossVersionSpec extends ToolingApiSpecification {
         events.assertIsABuild()
 
         and:
-        def resolveArtifacts = events.operation('Resolve files of :configurationWithDependency')
+        def resolveArtifacts = events.operation(resolveConfigurationFiles(':configurationWithDependency'))
         resolveArtifacts.parent.descriptor.displayName.matches("Execute .* for :resolve")
         resolveArtifacts.children.size() == 1
         resolveArtifacts.child("Resolve ${expectedDisplayName('provider', 'jar', '1.0')} (test:provider:1.0)")
@@ -85,7 +85,7 @@ class ResolveArtifactsProgressCrossVersionSpec extends ToolingApiSpecification {
         events.assertIsABuild()
 
         and:
-        def resolveArtifacts = events.operation('Resolve files of :configurationWithDependency')
+        def resolveArtifacts = events.operation(resolveConfigurationFiles(':configurationWithDependency'))
         resolveArtifacts.parent.descriptor.displayName.matches("Execute .* for :resolve")
         resolveArtifacts.children.size() == 1
         resolveArtifacts.child("Resolve ${expectedDisplayName('provider', 'jar', '1.0')} (test:provider:1.0)")
@@ -107,7 +107,7 @@ class ResolveArtifactsProgressCrossVersionSpec extends ToolingApiSpecification {
         events.assertIsABuild()
 
         and:
-        def resolveArtifacts = events.operation('Resolve files of :configurationWithDependency')
+        def resolveArtifacts = events.operation(resolveConfigurationFiles(':configurationWithDependency'))
         resolveArtifacts.parent.descriptor.displayName.matches("Execute .* for :resolve")
         resolveArtifacts.children.size() == 1
         resolveArtifacts.child("Resolve ${expectedDisplayName('provider', 'jar', '1.0')} (test:provider:1.0)")
@@ -129,7 +129,7 @@ class ResolveArtifactsProgressCrossVersionSpec extends ToolingApiSpecification {
         events.assertIsABuild()
 
         and:
-        def resolveArtifacts = events.operation('Resolve files of :configurationWithDependency')
+        def resolveArtifacts = events.operation(resolveConfigurationFiles(':configurationWithDependency'))
         resolveArtifacts.parent.descriptor.displayName.matches("Execute .* for :resolve")
         resolveArtifacts.children.size() == 1
         resolveArtifacts.child("Resolve ${expectedDisplayName('provider', 'jar', '1.0')} (test:provider:1.0)")
@@ -151,7 +151,7 @@ class ResolveArtifactsProgressCrossVersionSpec extends ToolingApiSpecification {
         events.assertIsABuild()
 
         and:
-        def resolveArtifacts = events.operation('Resolve files of :configurationWithDependency')
+        def resolveArtifacts = events.operation(resolveConfigurationFiles(':configurationWithDependency'))
         resolveArtifacts.parent.descriptor.displayName.matches("Execute .* for :resolve")
         resolveArtifacts.children.size() == 1
         resolveArtifacts.child("Resolve ${expectedDisplayName('other', 'thing', '1.0')} (test:other:1.0)")
@@ -173,7 +173,7 @@ class ResolveArtifactsProgressCrossVersionSpec extends ToolingApiSpecification {
         events.assertIsABuild()
 
         and:
-        def resolveArtifacts = events.operation('Resolve files of :configurationWithDependency')
+        def resolveArtifacts = events.operation(resolveConfigurationFiles(':configurationWithDependency'))
         resolveArtifacts.parent.descriptor.displayName.matches("Execute .* for :resolve")
         resolveArtifacts.children.size() == 1
         resolveArtifacts.child("Resolve ${expectedDisplayName('other', 'thing', '1.0')} (test:other:1.0)")
@@ -195,7 +195,7 @@ class ResolveArtifactsProgressCrossVersionSpec extends ToolingApiSpecification {
         events.assertIsABuild()
 
         and:
-        def resolveArtifacts = events.operation('Resolve files of :configurationWithDependency')
+        def resolveArtifacts = events.operation(resolveConfigurationFiles(':configurationWithDependency'))
         resolveArtifacts.parent.descriptor.displayName.matches("Execute .* for :resolve")
         resolveArtifacts.children.size() == 0
     }
@@ -216,7 +216,7 @@ class ResolveArtifactsProgressCrossVersionSpec extends ToolingApiSpecification {
         events.assertIsABuild()
 
         and:
-        def resolveArtifacts = events.operation('Resolve files of :configurationWithDependency')
+        def resolveArtifacts = events.operation(resolveConfigurationFiles(':configurationWithDependency'))
         resolveArtifacts.parent.descriptor.displayName.matches("Execute .* for :resolve")
         resolveArtifacts.children.empty
     }
@@ -314,5 +314,13 @@ class ResolveArtifactsProgressCrossVersionSpec extends ToolingApiSpecification {
 
     MavenFileRepository getMavenRepo(String name = "repo") {
         return new MavenFileRepository(file(name))
+    }
+
+    private String resolveConfigurationFiles(String path) {
+        if (targetVersion.baseVersion >= GradleVersion.version("8.7")) {
+            return "Resolve files of configuration '" + path + "'"
+        } else {
+            return "Resolve files of " + path
+        }
     }
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyDownloadBuildOperationsIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyDownloadBuildOperationsIntegrationTest.groovy
@@ -71,7 +71,6 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
 
         def artifactsOps = buildOperations.all(ResolveArtifactsBuildOperationType)
         artifactsOps.size() == 1
-        artifactsOps[0].details.configurationPath == ':path'
 
         def artifactOps = buildOperations.all(DownloadArtifactBuildOperationType)
         artifactOps.size() == 1
@@ -89,7 +88,6 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
 
         def artifactsOps2 = buildOperations.all(ResolveArtifactsBuildOperationType)
         artifactsOps2.size() == 1
-        artifactsOps2[0].details.configurationPath == ':path'
 
         def artifactOps2 = buildOperations.all(DownloadArtifactBuildOperationType)
         artifactOps2.size() == 1
@@ -169,7 +167,6 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
 
         def artifactsOps = buildOperations.all(ResolveArtifactsBuildOperationType)
         artifactsOps.size() == 1
-        artifactsOps[0].details.configurationPath == ':path'
 
         def artifactOps = buildOperations.all(DownloadArtifactBuildOperationType)
         artifactOps.size() == 1
@@ -199,7 +196,6 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
 
         def artifactsOps2 = buildOperations.all(ResolveArtifactsBuildOperationType)
         artifactsOps2.size() == 1
-        artifactsOps2[0].details.configurationPath == ':path'
 
         def artifactOps2 = buildOperations.all(DownloadArtifactBuildOperationType)
         artifactOps2.size() == 1
@@ -260,7 +256,6 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
 
         def artifactsOps = buildOperations.all(ResolveArtifactsBuildOperationType)
         artifactsOps.size() == 1
-        artifactsOps[0].details.configurationPath == ':path'
 
         def artifactOps = buildOperations.all(DownloadArtifactBuildOperationType)
         artifactOps.size() == 1
@@ -287,7 +282,6 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
 
         def artifactsOps2 = buildOperations.all(ResolveArtifactsBuildOperationType)
         artifactsOps2.size() == 1
-        artifactsOps2[0].details.configurationPath == ':path'
 
         def artifactOps2 = buildOperations.all(DownloadArtifactBuildOperationType)
         artifactOps2.size() == 1
@@ -335,9 +329,6 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
 
         def artifactsOps = buildOperations.all(ResolveArtifactsBuildOperationType)
         artifactsOps.size() == 3
-        artifactsOps[0].details.configurationPath == ':primary'
-        artifactsOps[1].details.configurationPath == ':primary'
-        artifactsOps[2].details.configurationPath == ':more'
 
         def artifactOps = buildOperations.all(DownloadArtifactBuildOperationType)
         artifactOps.size() == 1
@@ -357,9 +348,6 @@ class DependencyDownloadBuildOperationsIntegrationTest extends AbstractHttpDepen
 
         def artifactsOps2 = buildOperations.all(ResolveArtifactsBuildOperationType)
         artifactsOps2.size() == 3
-        artifactsOps2[0].details.configurationPath == ':primary'
-        artifactsOps2[1].details.configurationPath == ':primary'
-        artifactsOps2[2].details.configurationPath == ':more'
 
         def artifactOps2 = buildOperations.all(DownloadArtifactBuildOperationType)
         artifactOps2.size() == 1

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RemoteDependencyResolveConsoleIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RemoteDependencyResolveConsoleIntegrationTest.groovy
@@ -99,7 +99,7 @@ class RemoteDependencyResolveConsoleIntegrationTest extends AbstractDependencyRe
         then:
         ConcurrentTestUtil.poll {
             outputContainsProgress(build,
-                "> :resolve > Resolve files of :compile",
+                "> :resolve > Resolve files of configuration ':compile'",
                 "> one-1.2.jar", "> two-1.2.jar"
             )
         }
@@ -112,7 +112,7 @@ class RemoteDependencyResolveConsoleIntegrationTest extends AbstractDependencyRe
         then:
         ConcurrentTestUtil.poll {
             outputContainsProgress(build,
-                "> :resolve > Resolve files of :compile",
+                "> :resolve > Resolve files of configuration ':compile'",
                 "> one-1.2.jar > 1 KiB/2 KiB downloaded", "> two-1.2.jar > 1 KiB/2 KiB downloaded"
             )
         }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolveContext.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolveContext.java
@@ -15,15 +15,14 @@
  */
 package org.gradle.api.internal.artifacts;
 
-import org.gradle.api.Describable;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
+import org.gradle.api.internal.artifacts.configurations.ResolutionHost;
 import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.RootComponentMetadataBuilder;
 import org.gradle.api.internal.artifacts.transform.TransformUpstreamDependenciesResolverFactory;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.internal.component.model.DependencyMetadata;
-import org.gradle.util.Path;
 
 import java.util.List;
 
@@ -34,13 +33,7 @@ public interface ResolveContext extends DependencyMetaDataProvider {
 
     String getName();
 
-    Describable asDescribable();
-
-    String getDisplayName();
-
-    Path getIdentityPath();
-
-    Path getProjectPath();
+    ResolutionHost getResolutionHost();
 
     DomainObjectContext getDomainObjectContext();
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolveExceptionContextualizer.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolveExceptionContextualizer.java
@@ -61,7 +61,7 @@ public class ResolveExceptionContextualizer {
     }
 
     public ResolveException contextualize(Throwable e, ResolveContext resolveContext) {
-        return mapFailure(e, "dependencies", resolveContext.getDisplayName());
+        return mapFailure(e, "dependencies", resolveContext.getResolutionHost().getDisplayName());
     }
 
     private ResolveException mapFailure(Throwable failure, String type, String contextDisplayName) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
@@ -41,6 +41,8 @@ public interface ConfigurationInternal extends ResolveContext, DeprecatableConfi
         ARTIFACTS_RESOLVED
     }
 
+    String getDisplayName();
+
     @Override
     AttributeContainerInternal getAttributes();
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -194,6 +194,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
     private final ConfigurationsProvider configurationsProvider;
 
     private final Path identityPath;
+    private final Path projectPath;
 
     // These fields are not covered by mutation lock
     private final String name;
@@ -283,6 +284,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
         this.domainObjectCollectionFactory = domainObjectCollectionFactory;
         this.calculatedValueContainerFactory = calculatedValueContainerFactory;
         this.identityPath = domainObjectContext.identityPath(name);
+        this.projectPath = domainObjectContext.projectPath(name);
         this.name = name;
         this.configurationsProvider = configurationsProvider;
         this.resolver = resolver;
@@ -1845,7 +1847,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
 
         @Override
         public String getPath() {
-            return domainObjectContext.projectPath(name).getPath();
+            return projectPath.getPath();
         }
 
         @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -1845,7 +1845,7 @@ public abstract class DefaultConfiguration extends AbstractFileCollection implem
 
         @Override
         public String getPath() {
-            return identityPath.getPath();
+            return domainObjectContext.projectPath(name).getPath();
         }
 
         @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionHost.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionHost.java
@@ -21,6 +21,12 @@ import org.gradle.internal.DisplayName;
 import java.util.Collection;
 import java.util.Optional;
 
+/**
+ * The "Host" or owner of a resolution -- the thing in charge of the resolution, or the thing being resolved.
+ *
+ * <p>The purpose of this type is to be a configuration-cache compatible representation of the thing
+ * being resolved. This type should remain as minimal as possible.</p>
+ */
 public interface ResolutionHost {
     String getDisplayName();
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
@@ -36,6 +36,7 @@ import org.gradle.api.internal.artifacts.ResolveContext;
 import org.gradle.api.internal.artifacts.ResolveExceptionContextualizer;
 import org.gradle.api.internal.artifacts.ResolverResults;
 import org.gradle.api.internal.artifacts.configurations.ConflictResolution;
+import org.gradle.api.internal.artifacts.configurations.ResolutionHost;
 import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ComponentResolvers;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.DependencyVerificationOverride;
@@ -282,8 +283,9 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
         Set<Throwable> nonFatalFailures = nonFatalFailuresBuilder.build();
         Set<UnresolvedDependency> resolutionFailures = failureCollector.complete(lockingFailures);
 
+        ResolutionHost resolutionHost = resolveContext.getResolutionHost();
         MinimalResolutionResult resolutionResult = newModelBuilder.complete(lockingFailures);
-        ResolveException failure = exceptionContextualizer.mapFailures(nonFatalFailures, resolveContext.getDisplayName(), "dependencies");
+        ResolveException failure = exceptionContextualizer.mapFailures(nonFatalFailures, resolutionHost.getDisplayName(), "dependencies");
         VisitedGraphResults graphResults = new DefaultVisitedGraphResults(resolutionResult, resolutionFailures, failure);
 
         // Only write dependency locks if resolution completed without failure.
@@ -294,7 +296,8 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
         TransientConfigurationResultsLoader transientConfigurationResultsFactory = new TransientConfigurationResultsLoader(oldTransientModelBuilder, legacyGraphResults);
         ArtifactVariantSelector artifactVariantSelector = variantSelectorFactory.create(resolveContext.getDependenciesResolverFactory());
         DefaultLenientConfiguration lenientConfiguration = new DefaultLenientConfiguration(
-            resolveContext,
+            resolutionHost,
+            resolveContext.getAttributes().asImmutable(),
             graphResults,
             artifactsResults,
             fileDependencyResults,

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice;
 
-import org.gradle.api.Describable;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.FileCollectionDependency;
 import org.gradle.api.artifacts.LenientConfiguration;
@@ -26,7 +25,7 @@ import org.gradle.api.artifacts.UnresolvedDependency;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.DependencyGraphNodeResult;
 import org.gradle.api.internal.artifacts.ResolveArtifactsBuildOperationType;
-import org.gradle.api.internal.artifacts.ResolveContext;
+import org.gradle.api.internal.artifacts.configurations.ResolutionHost;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.DependencyVerificationOverride;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactSelectionSpec;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor;
@@ -45,7 +44,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult.Tran
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.oldresult.TransientConfigurationResultsLoader;
 import org.gradle.api.internal.artifacts.transform.ArtifactVariantSelector;
 import org.gradle.api.internal.artifacts.verification.exceptions.DependencyVerificationException;
-import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.file.FileCollectionStructureVisitor;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
@@ -77,12 +76,12 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
     private final static ResolveArtifactsBuildOperationType.Result RESULT = new ResolveArtifactsBuildOperationType.Result() {
     };
 
-    private final ResolveContext resolveContext;
+    private final ResolutionHost resolutionHost;
+    private final ImmutableAttributes implicitAttributes;
     private final VisitedGraphResults graphResults;
     private final VisitedArtifactsResults artifactResults;
     private final VisitedFileDependencyResults fileDependencyResults;
     private final TransientConfigurationResultsLoader transientConfigurationResultsFactory;
-    private final AttributeContainerInternal implicitAttributes;
     private final BuildOperationExecutor buildOperationExecutor;
     private final DependencyVerificationOverride dependencyVerificationOverride;
     private final WorkerLeaseService workerLeaseService;
@@ -93,7 +92,8 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
     private DependencyVerificationException dependencyVerificationException;
 
     public DefaultLenientConfiguration(
-        ResolveContext resolveContext,
+        ResolutionHost resolutionHost,
+        ImmutableAttributes implicitAttributes,
         VisitedGraphResults graphResults,
         VisitedArtifactsResults artifactResults,
         VisitedFileDependencyResults fileDependencyResults,
@@ -103,8 +103,8 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
         WorkerLeaseService workerLeaseService,
         ArtifactVariantSelector artifactVariantSelector
     ) {
-        this.resolveContext = resolveContext;
-        this.implicitAttributes = resolveContext.getAttributes().asImmutable();
+        this.resolutionHost = resolutionHost;
+        this.implicitAttributes = implicitAttributes;
         this.graphResults = graphResults;
         this.artifactResults = artifactResults;
         this.fileDependencyResults = fileDependencyResults;
@@ -131,7 +131,7 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
     }
 
     private ArtifactSelectionSpec getImplicitSelectionSpec() {
-        return new ArtifactSelectionSpec(implicitAttributes.asImmutable(), Specs.satisfyAll(), false, false);
+        return new ArtifactSelectionSpec(implicitAttributes, Specs.satisfyAll(), false, false);
     }
 
     @Override
@@ -248,7 +248,7 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
                     throw dependencyVerificationException;
                 } else {
                     try {
-                        dependencyVerificationOverride.artifactsAccessed(getDisplayName().toString());
+                        dependencyVerificationOverride.artifactsAccessed(resolutionHost.getDisplayName());
                     } catch (DependencyVerificationException e) {
                         dependencyVerificationException = e;
                         throw e;
@@ -259,27 +259,21 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
 
             @Override
             public BuildOperationDescriptor.Builder description() {
-                String displayName = "Resolve files of " + resolveContext.getIdentityPath();
+                String displayName = "Resolve files of " + resolutionHost.getDisplayName();
                 return BuildOperationDescriptor
                     .displayName(displayName)
                     .progressDisplayName(displayName)
-                    // TODO: Can we update this to use the identity path?
-                    .details(new ResolveArtifactsDetails(resolveContext.getProjectPath().toString()));
+                    .details(new ResolveArtifactsDetails());
             }
         });
     }
 
     private static class ResolveArtifactsDetails implements ResolveArtifactsBuildOperationType.Details {
 
-        private final String configuration;
-
-        public ResolveArtifactsDetails(String configuration) {
-            this.configuration = configuration;
-        }
-
         @Override
+        @Deprecated
         public String getConfigurationPath() {
-            return configuration;
+            return "";
         }
 
     }
@@ -314,8 +308,8 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
         ParallelResolveArtifactSet.wrap(CompositeResolvedArtifactSet.of(artifactSets), buildOperationExecutor).visit(visitor);
     }
 
-    public Describable getDisplayName() {
-        return resolveContext.asDescribable();
+    public String getDisplayName() {
+        return resolutionHost.getDisplayName();
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultResolvedConfiguration.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultResolvedConfiguration.java
@@ -53,7 +53,7 @@ public class DefaultResolvedConfiguration implements ResolvedConfiguration {
 
         List<Throwable> failures = new ArrayList<>();
         graphResults.visitFailures(failures::add);
-        throw new ResolveException(configuration.getDisplayName().toString(), failures);
+        throw new ResolveException(configuration.getDisplayName(), failures);
     }
 
     @Override
@@ -74,7 +74,7 @@ public class DefaultResolvedConfiguration implements ResolvedConfiguration {
         if (!failures.isEmpty()) {
             throw new DefaultLenientConfiguration.ArtifactResolveException(
                 "files",
-                configuration.getDisplayName().toString(),
+                configuration.getDisplayName(),
                 failures
             );
         }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/MinimalResolutionResult.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/MinimalResolutionResult.java
@@ -32,7 +32,7 @@ public interface MinimalResolutionResult {
     Supplier<ResolvedComponentResult> getRootSource();
 
     /**
-     * The request attributes used to initially build the dependency graph.
+     * The desugared request attributes used to initially build the dependency graph.
      */
     ImmutableAttributes getRequestedAttributes();
 }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
@@ -102,6 +102,7 @@ class DefaultConfigurationContainerSpec extends Specification {
 
     def "adds and gets"() {
         1 * domainObjectContext.identityPath("compile") >> Path.path(":build:compile")
+        1 * domainObjectContext.projectPath("compile") >> Path.path(":compile")
         1 * domainObjectContext.model >> RootScriptDomainObjectContext.INSTANCE
 
         when:
@@ -109,7 +110,7 @@ class DefaultConfigurationContainerSpec extends Specification {
 
         then:
         compile.name == "compile"
-        compile.incoming.path == ":build:compile"
+        compile.incoming.path == ":compile"
         compile instanceof DefaultConfiguration
 
         and:
@@ -132,6 +133,7 @@ class DefaultConfigurationContainerSpec extends Specification {
 
     def "configures and finds"() {
         1 * domainObjectContext.identityPath("compile") >> Path.path(":build:compile")
+        1 * domainObjectContext.projectPath("compile") >> Path.path(":compile")
         1 * domainObjectContext.model >> RootScriptDomainObjectContext.INSTANCE
 
         when:
@@ -142,12 +144,12 @@ class DefaultConfigurationContainerSpec extends Specification {
         then:
         configurationContainer.getByName("compile") == compile
         compile.description == "I compile!"
-        compile.incoming.path == ":build:compile"
+        compile.incoming.path == ":compile"
     }
 
     def "creates detached"() {
         given:
-        1 * domainObjectContext.identityPath("detachedConfiguration1") >> Path.path(":build:detachedConfiguration1")
+        1 * domainObjectContext.projectPath("detachedConfiguration1") >> Path.path(":detachedConfiguration1")
         1 * domainObjectContext.model >> RootScriptDomainObjectContext.INSTANCE
 
         def dependency1 = new DefaultExternalModuleDependency("group", "name", "version")
@@ -162,6 +164,6 @@ class DefaultConfigurationContainerSpec extends Specification {
         detached.getHierarchy() == [detached] as Set
         [dependency1, dependency2].each { detached.getDependencies().contains(it) }
         detached.getDependencies().size() == 2
-        detached.incoming.path == ":build:detachedConfiguration1"
+        detached.incoming.path == ":detachedConfiguration1"
     }
 }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
@@ -102,7 +102,6 @@ class DefaultConfigurationContainerSpec extends Specification {
 
     def "adds and gets"() {
         1 * domainObjectContext.identityPath("compile") >> Path.path(":build:compile")
-        1 * domainObjectContext.projectPath("compile") >> Path.path(":compile")
         1 * domainObjectContext.model >> RootScriptDomainObjectContext.INSTANCE
 
         when:
@@ -110,7 +109,7 @@ class DefaultConfigurationContainerSpec extends Specification {
 
         then:
         compile.name == "compile"
-        compile.incoming.path == ":compile"
+        compile.incoming.path == ":build:compile"
         compile instanceof DefaultConfiguration
 
         and:
@@ -133,7 +132,6 @@ class DefaultConfigurationContainerSpec extends Specification {
 
     def "configures and finds"() {
         1 * domainObjectContext.identityPath("compile") >> Path.path(":build:compile")
-        1 * domainObjectContext.projectPath("compile") >> Path.path(":compile")
         1 * domainObjectContext.model >> RootScriptDomainObjectContext.INSTANCE
 
         when:
@@ -144,12 +142,12 @@ class DefaultConfigurationContainerSpec extends Specification {
         then:
         configurationContainer.getByName("compile") == compile
         compile.description == "I compile!"
-        compile.incoming.path == ":compile"
+        compile.incoming.path == ":build:compile"
     }
 
     def "creates detached"() {
         given:
-        1 * domainObjectContext.projectPath("detachedConfiguration1") >> Path.path(":detachedConfiguration1")
+        1 * domainObjectContext.identityPath("detachedConfiguration1") >> Path.path(":build:detachedConfiguration1")
         1 * domainObjectContext.model >> RootScriptDomainObjectContext.INSTANCE
 
         def dependency1 = new DefaultExternalModuleDependency("group", "name", "version")
@@ -164,6 +162,6 @@ class DefaultConfigurationContainerSpec extends Specification {
         detached.getHierarchy() == [detached] as Set
         [dependency1, dependency2].each { detached.getDependencies().contains(it) }
         detached.getDependencies().size() == 2
-        detached.incoming.path == ":detachedConfiguration1"
+        detached.incoming.path == ":build:detachedConfiguration1"
     }
 }

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfigurationTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfigurationTest.groovy
@@ -21,7 +21,7 @@ import org.gradle.api.artifacts.ResolvedArtifact
 import org.gradle.api.artifacts.ResolvedDependency
 import org.gradle.api.artifacts.ResolvedModuleVersion
 import org.gradle.api.internal.artifacts.DependencyGraphNodeResult
-import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal
+import org.gradle.api.internal.artifacts.configurations.ResolutionHost
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.DependencyVerificationOverride
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.VisitedArtifactsResults
@@ -43,13 +43,8 @@ class DefaultLenientConfigurationTest extends Specification {
     def resultsLoader = Mock(TransientConfigurationResultsLoader)
     def artifactsResults = Stub(VisitedArtifactsResults)
     def fileDependencyResults = Stub(VisitedFileDependencyResults)
-    def configuration = Stub(ConfigurationInternal)
     def buildOperationExecutor = Mock(BuildOperationExecutor)
     def dependencyVerificationOverride = DependencyVerificationOverride.NO_VERIFICATION
-
-    def setup() {
-        _ * configuration.attributes >> ImmutableAttributes.EMPTY
-    }
 
     def "should resolve first level dependencies in tree"() {
         given:
@@ -122,7 +117,7 @@ class DefaultLenientConfigurationTest extends Specification {
 
     private DefaultLenientConfiguration newConfiguration() {
         VisitedGraphResults visitedGraphResults = new DefaultVisitedGraphResults(Stub(MinimalResolutionResult), [] as Set, null)
-        new DefaultLenientConfiguration(configuration, visitedGraphResults, artifactsResults, fileDependencyResults, resultsLoader, buildOperationExecutor, dependencyVerificationOverride, new TestWorkerLeaseService(), Mock(ArtifactVariantSelector))
+        new DefaultLenientConfiguration(Stub(ResolutionHost), ImmutableAttributes.EMPTY, visitedGraphResults, artifactsResults, fileDependencyResults, resultsLoader, buildOperationExecutor, dependencyVerificationOverride, new TestWorkerLeaseService(), Mock(ArtifactVariantSelector))
     }
 
     def generateDependenciesWithChildren(Map treeStructure) {

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ErrorHandlingConfigurationResolverTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ErrorHandlingConfigurationResolverTest.groovy
@@ -25,6 +25,7 @@ import org.gradle.api.internal.artifacts.DefaultResolverResults
 import org.gradle.api.internal.artifacts.ResolveExceptionContextualizer
 import org.gradle.api.internal.artifacts.ResolverResults
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal
+import org.gradle.api.internal.artifacts.configurations.ResolutionHost
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.VisitedArtifactSet
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.results.VisitedGraphResults
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.projectresult.ResolvedLocalComponentsResult
@@ -39,16 +40,16 @@ class ErrorHandlingConfigurationResolverTest extends Specification {
     private visitedGraphResults = Mock(VisitedGraphResults)
     private projectConfigResult = Mock(ResolvedLocalComponentsResult)
     private visitedArtifactSet = Mock(VisitedArtifactSet)
-    private context = Mock(ConfigurationInternal)
+    private context = Mock(ConfigurationInternal) {
+        getResolutionHost() >> Mock(ResolutionHost) {
+            getDisplayName() >> "resolve context 'foo'"
+        }
+    }
     private contextualizer =  new ResolveExceptionContextualizer(Mock(DomainObjectContext), Mock(DocumentationRegistry))
     private resolver = new ErrorHandlingConfigurationResolver(delegate, contextualizer);
 
     def delegateResults = Mock(ResolverResults) {
         getResolvedConfiguration() >> resolvedConfiguration
-    }
-
-    def setup() {
-        context.displayName >> "resolve context 'foo'"
     }
 
     void "delegates to backing service to resolve build dependencies"() {


### PR DESCRIPTION
In attempt to reduce the places where ResolveContext is used, we update DefaultLenientConfiguration to only accept a ResolutionHost -- a much weaker counterpart to ResolveContext. To do so, we change the description of the ResolveArtifactsDetails to only use the ResolutionHost display name instead of the configuration path, and deprecate getConfigurationPath method on the build operation. Te deprecated method on this build operation was confirmed to not be in use by Develocity in any supported version.

This allows us to remove several methods from ResolveContext

See this slack thread for context: https://gradle.slack.com/archives/C03PH5M446L/p1704768491492289

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
