### PR TITLE
Make ParentDirectoryStub public for backward compatibility with Spring Boot 2.x.

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/NormalizingCopyActionDecorator.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/NormalizingCopyActionDecorator.java
@@ -108,7 +108,9 @@ public class NormalizingCopyActionDecorator implements CopyAction {
         delegateAction.processFile(dir);
     }
 
-    private static class ParentDirectoryStub extends AbstractFileTreeElement implements FileCopyDetailsInternal {
+    // should be private, but it is used by Spring.
+    // see https://github.com/gradle/gradle/issues/27635
+    public static class ParentDirectoryStub extends AbstractFileTreeElement implements FileCopyDetailsInternal {
         private final RelativePath path;
 
         private final long lastModified = System.currentTimeMillis();


### PR DESCRIPTION
Fixes #27635

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
