### PR TITLE
Write primitive `short`, `float` and `double` values more efficiently

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/Combinators.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/Combinators.kt
@@ -428,33 +428,6 @@ inline fun <reified E : Enum<E>> Decoder.readEnum(): E =
     readSmallInt().let { ordinal -> enumValues<E>()[ordinal] }
 
 
-fun Encoder.writeShort(value: Short) {
-    BaseSerializerFactory.SHORT_SERIALIZER.write(this, value)
-}
-
-
-fun Decoder.readShort(): Short =
-    BaseSerializerFactory.SHORT_SERIALIZER.read(this)
-
-
-fun Encoder.writeFloat(value: Float) {
-    BaseSerializerFactory.FLOAT_SERIALIZER.write(this, value)
-}
-
-
-fun Decoder.readFloat(): Float =
-    BaseSerializerFactory.FLOAT_SERIALIZER.read(this)
-
-
-fun Encoder.writeDouble(value: Double) {
-    BaseSerializerFactory.DOUBLE_SERIALIZER.write(this, value)
-}
-
-
-fun Decoder.readDouble(): Double =
-    BaseSerializerFactory.DOUBLE_SERIALIZER.read(this)
-
-
 inline
 fun <reified T : Any> ReadContext.readClassOf(): Class<out T> =
     readClass().asSubclass(T::class.java)

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/ArrayCodecs.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/ArrayCodecs.kt
@@ -22,13 +22,7 @@ import org.gradle.configurationcache.serialization.Codec
 import org.gradle.configurationcache.serialization.ReadContext
 import org.gradle.configurationcache.serialization.WriteContext
 import org.gradle.configurationcache.serialization.readArray
-import org.gradle.configurationcache.serialization.readDouble
-import org.gradle.configurationcache.serialization.readFloat
-import org.gradle.configurationcache.serialization.readShort
 import org.gradle.configurationcache.serialization.writeArray
-import org.gradle.configurationcache.serialization.writeDouble
-import org.gradle.configurationcache.serialization.writeFloat
-import org.gradle.configurationcache.serialization.writeShort
 
 
 object NonPrimitiveArrayCodec : Codec<Array<*>> {

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/jos/ObjectInputStreamAdapter.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/jos/ObjectInputStreamAdapter.kt
@@ -21,9 +21,6 @@ import org.gradle.configurationcache.extensions.documentationLinkFor
 import org.gradle.configurationcache.problems.DocumentationSection
 import org.gradle.configurationcache.serialization.ReadContext
 import org.gradle.configurationcache.serialization.beans.BeanStateReader
-import org.gradle.configurationcache.serialization.readDouble
-import org.gradle.configurationcache.serialization.readFloat
-import org.gradle.configurationcache.serialization.readShort
 import org.gradle.configurationcache.serialization.runReadOperation
 import java.io.InputStream
 import java.io.ObjectInputStream

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/jos/RecordingObjectOutputStream.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/jos/RecordingObjectOutputStream.kt
@@ -18,9 +18,6 @@ package org.gradle.configurationcache.serialization.codecs.jos
 
 import org.gradle.configurationcache.serialization.WriteContext
 import org.gradle.configurationcache.serialization.withBeanTrace
-import org.gradle.configurationcache.serialization.writeDouble
-import org.gradle.configurationcache.serialization.writeFloat
-import org.gradle.configurationcache.serialization.writeShort
 import java.io.ObjectOutputStream
 
 

--- a/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintCheckerTest.kt
+++ b/platforms/core-configuration/configuration-cache/src/test/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintCheckerTest.kt
@@ -263,6 +263,7 @@ class ConfigurationCacheFingerprintCheckerTest {
      * The written state can then be read from the [ReadContext] returned
      * by [toReadContext].
      */
+    private
     class RecordingWriteContext : WriteContext {
 
         private
@@ -334,6 +335,15 @@ class ConfigurationCacheFingerprintCheckerTest {
         override fun writeLong(value: Long): Unit =
             undefined()
 
+        override fun writeShort(value: Short) =
+            undefined()
+
+        override fun writeFloat(value: Float) =
+            undefined()
+
+        override fun writeDouble(value: Double) =
+            undefined()
+
         override fun writeString(value: CharSequence?): Unit =
             undefined()
 
@@ -368,6 +378,7 @@ class ConfigurationCacheFingerprintCheckerTest {
             undefined()
     }
 
+    private
     class PlaybackReadContext(values: Iterable<Any?>) : ReadContext {
 
         private
@@ -438,6 +449,15 @@ class ConfigurationCacheFingerprintCheckerTest {
             undefined()
 
         override fun readNullableSmallInt(): Int? =
+            undefined()
+
+        override fun readShort(): Short =
+            undefined()
+
+        override fun readFloat(): Float =
+            undefined()
+
+        override fun readDouble(): Double =
             undefined()
 
         override fun readNullableString(): String? =

--- a/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/IsolatableSerializerRegistry.java
+++ b/platforms/core-execution/workers/src/main/java/org/gradle/workers/internal/IsolatableSerializerRegistry.java
@@ -287,11 +287,13 @@ public class IsolatableSerializerRegistry extends DefaultSerializerRegistry {
     private static class ShortValueSnapshotSerializer extends IsolatableSerializer<ShortValueSnapshot> {
         @Override
         protected void serialize(Encoder encoder, ShortValueSnapshot value) throws Exception {
+            // TODO: consider changing to `encoder.writeShort`
             encoder.writeInt(value.getValue());
         }
 
         @Override
         protected ShortValueSnapshot deserialize(Decoder decoder) throws Exception {
+            // TODO: consider changing to `decoder.readShort`
             return new ShortValueSnapshot((short) decoder.readInt());
         }
 

--- a/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/serialize/BaseSerializerFactory.java
+++ b/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/serialize/BaseSerializerFactory.java
@@ -24,7 +24,6 @@ import org.gradle.internal.hash.HashCode;
 import java.io.File;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
@@ -220,12 +219,12 @@ public class BaseSerializerFactory {
     private static class ShortSerializer extends AbstractSerializer<Short> {
         @Override
         public Short read(Decoder decoder) throws Exception {
-            return (short) decoder.readInt();
+            return decoder.readShort();
         }
 
         @Override
         public void write(Encoder encoder, Short value) throws Exception {
-            encoder.writeInt(value);
+            encoder.writeShort(value);
         }
     }
 
@@ -256,30 +255,24 @@ public class BaseSerializerFactory {
     private static class FloatSerializer extends AbstractSerializer<Float> {
         @Override
         public Float read(Decoder decoder) throws Exception {
-            byte[] bytes = new byte[4];
-            decoder.readBytes(bytes);
-            return ByteBuffer.wrap(bytes).getFloat();
+            return decoder.readFloat();
         }
 
         @Override
         public void write(Encoder encoder, Float value) throws Exception {
-            byte[] b = ByteBuffer.allocate(4).putFloat(value).array();
-            encoder.writeBytes(b);
+            encoder.writeFloat(value);
         }
     }
 
     private static class DoubleSerializer extends AbstractSerializer<Double> {
         @Override
         public Double read(Decoder decoder) throws Exception {
-            byte[] bytes = new byte[8];
-            decoder.readBytes(bytes);
-            return ByteBuffer.wrap(bytes).getDouble();
+            return decoder.readDouble();
         }
 
         @Override
         public void write(Encoder encoder, Double value) throws Exception {
-            byte[] b = ByteBuffer.allocate(8).putDouble(value).array();
-            encoder.writeBytes(b);
+            encoder.writeDouble(value);
         }
     }
 

--- a/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/serialize/Decoder.java
+++ b/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/serialize/Decoder.java
@@ -68,6 +68,30 @@ public interface Decoder {
     Integer readNullableSmallInt() throws EOFException, IOException;
 
     /**
+     * Reads a short value that was written with {@link Encoder#writeShort(short)}
+     *
+     * @throws EOFException when the end of the byte stream is reached before the short value can be fully read.
+     * @since 8.7
+     */
+    short readShort() throws EOFException, IOException;
+
+    /**
+     * Reads a float value that was written with {@link Encoder#writeFloat(float)}
+     *
+     * @throws EOFException when the end of the byte stream is reached before the float value can be fully read.
+     * @since 8.7
+     */
+    float readFloat() throws EOFException, IOException;
+
+    /**
+     * Reads a double value that was written with {@link Encoder#writeDouble(double)}
+     *
+     * @throws EOFException when the end of the byte stream is reached before the double value can be fully read.
+     * @since 8.7
+     */
+    double readDouble() throws EOFException, IOException;
+
+    /**
      * Reads a boolean value. Can read any value that was written using {@link Encoder#writeBoolean(boolean)}.
      *
      * @throws EOFException when the end of the byte stream is reached before the boolean value can be fully read.

--- a/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/serialize/Encoder.java
+++ b/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/serialize/Encoder.java
@@ -83,6 +83,27 @@ public interface Encoder {
     void writeSmallInt(int value) throws IOException;
 
     /**
+     * Writes a short value.
+     *
+     * @since 8.7
+     */
+    void writeShort(short value) throws IOException;
+
+    /**
+     * Writes a float value.
+     *
+     * @since 8.7
+     */
+    void writeFloat(float value) throws IOException;
+
+    /**
+     * Writes a double value.
+     *
+     * @since 8.7
+     */
+    void writeDouble(double value) throws IOException;
+
+    /**
      * Writes a nullable signed 32 bit int value whose value is likely to be small and positive but may not be.
      *
      * @see #writeSmallInt(int)

--- a/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/serialize/InputStreamBackedDecoder.java
+++ b/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/serialize/InputStreamBackedDecoder.java
@@ -16,7 +16,11 @@
 
 package org.gradle.internal.serialize;
 
-import java.io.*;
+import java.io.Closeable;
+import java.io.DataInputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
 
 public class InputStreamBackedDecoder extends AbstractDecoder implements Decoder, Closeable {
     private final DataInputStream inputStream;
@@ -50,6 +54,21 @@ public class InputStreamBackedDecoder extends AbstractDecoder implements Decoder
     }
 
     @Override
+    public short readShort() throws EOFException, IOException {
+        return inputStream.readShort();
+    }
+
+    @Override
+    public float readFloat() throws EOFException, IOException {
+        return inputStream.readFloat();
+    }
+
+    @Override
+    public double readDouble() throws EOFException, IOException {
+        return inputStream.readDouble();
+    }
+
+    @Override
     public boolean readBoolean() throws EOFException, IOException {
         return inputStream.readBoolean();
     }
@@ -61,7 +80,7 @@ public class InputStreamBackedDecoder extends AbstractDecoder implements Decoder
 
     @Override
     public byte readByte() throws IOException {
-        return (byte)(inputStream.readByte() & 0xff);
+        return (byte) (inputStream.readByte() & 0xff);
     }
 
     @Override

--- a/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/serialize/OutputStreamBackedEncoder.java
+++ b/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/serialize/OutputStreamBackedEncoder.java
@@ -39,6 +39,21 @@ public class OutputStreamBackedEncoder extends AbstractEncoder implements Closea
     }
 
     @Override
+    public void writeShort(short value) throws IOException {
+        outputStream.writeShort(value);
+    }
+
+    @Override
+    public void writeFloat(float value) throws IOException {
+        outputStream.writeFloat(value);
+    }
+
+    @Override
+    public void writeDouble(double value) throws IOException {
+        outputStream.writeDouble(value);
+    }
+
+    @Override
     public void writeBoolean(boolean value) throws IOException {
         outputStream.writeBoolean(value);
     }

--- a/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/serialize/kryo/KryoBackedDecoder.java
+++ b/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/serialize/kryo/KryoBackedDecoder.java
@@ -137,6 +137,33 @@ public class KryoBackedDecoder extends AbstractDecoder implements Decoder, Close
     }
 
     @Override
+    public short readShort() throws EOFException, IOException {
+        try {
+            return input.readShort();
+        } catch (KryoException e) {
+            throw maybeEndOfStream(e);
+        }
+    }
+
+    @Override
+    public float readFloat() throws EOFException, IOException {
+        try {
+            return input.readFloat();
+        } catch (KryoException e) {
+            throw maybeEndOfStream(e);
+        }
+    }
+
+    @Override
+    public double readDouble() throws EOFException, IOException {
+        try {
+            return input.readDouble();
+        } catch (KryoException e) {
+            throw maybeEndOfStream(e);
+        }
+    }
+
+    @Override
     public boolean readBoolean() throws EOFException {
         try {
             return input.readBoolean();

--- a/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/serialize/kryo/KryoBackedEncoder.java
+++ b/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/serialize/kryo/KryoBackedEncoder.java
@@ -69,6 +69,21 @@ public class KryoBackedEncoder extends AbstractEncoder implements FlushableEncod
     }
 
     @Override
+    public void writeShort(short value) throws IOException {
+        output.writeShort(value);
+    }
+
+    @Override
+    public void writeFloat(float value) throws IOException {
+        output.writeFloat(value);
+    }
+
+    @Override
+    public void writeDouble(double value) throws IOException {
+        output.writeDouble(value);
+    }
+
+    @Override
     public void writeBoolean(boolean value) {
         output.writeBoolean(value);
     }

--- a/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/serialize/kryo/StringDeduplicatingKryoBackedDecoder.java
+++ b/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/serialize/kryo/StringDeduplicatingKryoBackedDecoder.java
@@ -132,6 +132,33 @@ public class StringDeduplicatingKryoBackedDecoder extends AbstractDecoder implem
     }
 
     @Override
+    public short readShort() throws EOFException, IOException {
+        try {
+            return input.readShort();
+        } catch (KryoException e) {
+            throw maybeEndOfStream(e);
+        }
+    }
+
+    @Override
+    public float readFloat() throws EOFException, IOException {
+        try {
+            return input.readFloat();
+        } catch (KryoException e) {
+            throw maybeEndOfStream(e);
+        }
+    }
+
+    @Override
+    public double readDouble() throws EOFException, IOException {
+        try {
+            return input.readDouble();
+        } catch (KryoException e) {
+            throw maybeEndOfStream(e);
+        }
+    }
+
+    @Override
     public boolean readBoolean() throws EOFException {
         try {
             return input.readBoolean();

--- a/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/serialize/kryo/StringDeduplicatingKryoBackedEncoder.java
+++ b/platforms/core-runtime/messaging/src/main/java/org/gradle/internal/serialize/kryo/StringDeduplicatingKryoBackedEncoder.java
@@ -23,6 +23,7 @@ import org.gradle.internal.serialize.FlushableEncoder;
 
 import javax.annotation.Nullable;
 import java.io.Closeable;
+import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Map;
 
@@ -67,6 +68,21 @@ public class StringDeduplicatingKryoBackedEncoder extends AbstractEncoder implem
     @Override
     public void writeSmallInt(int value) {
         output.writeInt(value, true);
+    }
+
+    @Override
+    public void writeShort(short value) throws IOException {
+        output.writeShort(value);
+    }
+
+    @Override
+    public void writeFloat(float value) throws IOException {
+        output.writeFloat(value);
+    }
+
+    @Override
+    public void writeDouble(double value) throws IOException {
+        output.writeDouble(value);
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/StringDeduplicatingDecoder.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/StringDeduplicatingDecoder.java
@@ -65,6 +65,21 @@ class StringDeduplicatingDecoder implements Decoder, Closeable {
     }
 
     @Override
+    public short readShort() throws EOFException, IOException {
+        return delegate.readShort();
+    }
+
+    @Override
+    public float readFloat() throws EOFException, IOException {
+        return delegate.readFloat();
+    }
+
+    @Override
+    public double readDouble() throws EOFException, IOException {
+        return delegate.readDouble();
+    }
+
+    @Override
     public boolean readBoolean() throws EOFException, IOException {
         return delegate.readBoolean();
     }
@@ -121,6 +136,6 @@ class StringDeduplicatingDecoder implements Decoder, Closeable {
 
     @Override
     public void close() throws IOException {
-        ((Closeable)delegate).close();
+        ((Closeable) delegate).close();
     }
 }


### PR DESCRIPTION
By introducing specific `Encoder#write(Short|Float|Double)` and `Decoder#read(Short|Float|Double)` methods which can be mapped directly to the kryo implementation.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
