### PR TITLE
Revert support for chaining Hasher calls

### DIFF
--- a/platforms/core-execution/hashing/src/main/java/org/gradle/internal/hash/Hasher.java
+++ b/platforms/core-execution/hashing/src/main/java/org/gradle/internal/hash/Hasher.java
@@ -26,57 +26,57 @@ public interface Hasher {
     /**
      * Feed a bunch of bytes into the hasher.
      */
-    Hasher putBytes(byte[] bytes);
+    void putBytes(byte[] bytes);
 
     /**
      * Feed a given number of bytes into the hasher from the given offset.
      */
-    Hasher putBytes(byte[] bytes, int off, int len);
+    void putBytes(byte[] bytes, int off, int len);
 
     /**
      * Feed a single byte into the hasher.
      */
-    Hasher putByte(byte value);
+    void putByte(byte value);
 
     /**
      * Feed an integer byte into the hasher.
      */
-    Hasher putInt(int value);
+    void putInt(int value);
 
     /**
      * Feed a long value byte into the hasher.
      */
-    Hasher putLong(long value);
+    void putLong(long value);
 
     /**
      * Feed a double value into the hasher.
      */
-    Hasher putDouble(double value);
+    void putDouble(double value);
 
     /**
      * Feed a boolean value into the hasher.
      */
-    Hasher putBoolean(boolean value);
+    void putBoolean(boolean value);
 
     /**
      * Feed a string into the hasher.
      */
-    Hasher putString(CharSequence value);
+    void putString(CharSequence value);
 
     /**
      * Feed a hash code into the hasher.
      */
-    Hasher putHash(HashCode hashCode);
+    void putHash(HashCode hashCode);
 
     /**
      * Puts a hashable value into the hasher.
      */
-    Hasher put(Hashable hashable);
+    void put(Hashable hashable);
 
     /**
      * Feed a {@code null} value into the hasher.
      */
-    Hasher putNull();
+    void putNull();
 
     /**
      * Returns the combined hash.

--- a/platforms/core-execution/hashing/src/main/java/org/gradle/internal/hash/Hashing.java
+++ b/platforms/core-execution/hashing/src/main/java/org/gradle/internal/hash/Hashing.java
@@ -112,7 +112,9 @@ public class Hashing {
      * Hash the given {@code hashable} instance with the default hash function.
      */
     public static HashCode hashHashable(Hashable hashable) {
-        return newHasher().put(hashable).hash();
+        Hasher hasher = newHasher();
+        hasher.put(hashable);
+        return hasher.hash();
     }
 
     /**
@@ -368,78 +370,67 @@ public class Hashing {
         }
 
         @Override
-        public Hasher putByte(byte value) {
+        public void putByte(byte value) {
             hasher.putInt(1);
             hasher.putByte(value);
-            return this;
         }
 
         @Override
-        public Hasher putBytes(byte[] bytes) {
+        public void putBytes(byte[] bytes) {
             hasher.putInt(bytes.length);
             hasher.putBytes(bytes);
-            return this;
         }
 
         @Override
-        public Hasher putBytes(byte[] bytes, int off, int len) {
+        public void putBytes(byte[] bytes, int off, int len) {
             hasher.putInt(len);
             hasher.putBytes(bytes, off, len);
-            return this;
         }
 
         @Override
-        public Hasher putHash(HashCode hashCode) {
+        public void putHash(HashCode hashCode) {
             hasher.putInt(hashCode.length());
             hasher.putHash(hashCode);
-            return this;
         }
 
         @Override
-        public Hasher putInt(int value) {
+        public void putInt(int value) {
             hasher.putInt(4);
             hasher.putInt(value);
-            return this;
         }
 
         @Override
-        public Hasher putLong(long value) {
+        public void putLong(long value) {
             hasher.putInt(8);
             hasher.putLong(value);
-            return this;
         }
 
         @Override
-        public Hasher putDouble(double value) {
+        public void putDouble(double value) {
             hasher.putInt(8);
             hasher.putDouble(value);
-            return this;
         }
 
         @Override
-        public Hasher putBoolean(boolean value) {
+        public void putBoolean(boolean value) {
             hasher.putInt(1);
             hasher.putBoolean(value);
-            return this;
         }
 
         @Override
-        public Hasher putString(CharSequence value) {
+        public void putString(CharSequence value) {
             hasher.putInt(value.length());
             hasher.putString(value);
-            return this;
         }
 
         @Override
-        public Hasher put(Hashable hashable) {
+        public void put(Hashable hashable) {
             hashable.appendToHasher(this);
-            return this;
         }
 
         @Override
-        public Hasher putNull() {
+        public void putNull() {
             this.putInt(0);
-            return this;
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingClasspathFileTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingClasspathFileTransformer.java
@@ -72,10 +72,12 @@ public class InstrumentingClasspathFileTransformer implements ClasspathFileTrans
     }
 
     private static ClasspathFileHasher createFileHasherWithConfig(HashCode configHash, ClasspathFileHasher fileHasher) {
-        return sourceSnapshot -> Hashing.newHasher()
-            .putHash(configHash)
-            .putHash(fileHasher.hashOf(sourceSnapshot))
-            .hash();
+        return sourceSnapshot -> {
+            Hasher hasher = Hashing.newHasher();
+            hasher.putHash(configHash);
+            hasher.putHash(fileHasher.hashOf(sourceSnapshot));
+            return hasher.hash();
+        };
     }
 
     @Override


### PR DESCRIPTION
This partly reverts #27341, since KGP uses that class.
