### PR TITLE
Remove CacheableTransform annotation from InstrumentationMetadataTransform

### DIFF
--- a/build-logic/packaging/src/main/kotlin/gradlebuild/instrumentation/transforms/InstrumentationMetadataTransform.kt
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild/instrumentation/transforms/InstrumentationMetadataTransform.kt
@@ -28,6 +28,7 @@ import org.gradle.api.tasks.Classpath
 import org.gradle.work.ChangeType.ADDED
 import org.gradle.work.ChangeType.MODIFIED
 import org.gradle.work.ChangeType.REMOVED
+import org.gradle.work.DisableCachingByDefault
 import org.gradle.work.FileChange
 import org.gradle.work.InputChanges
 import java.io.File
@@ -35,6 +36,7 @@ import java.util.Properties
 import javax.inject.Inject
 
 
+@DisableCachingByDefault(because = "This transform introduces negative savings when caching is enabled")
 abstract class InstrumentationMetadataTransform : TransformAction<TransformParameters.None> {
 
     companion object {

--- a/build-logic/packaging/src/main/kotlin/gradlebuild/instrumentation/transforms/InstrumentationMetadataTransform.kt
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild/instrumentation/transforms/InstrumentationMetadataTransform.kt
@@ -17,7 +17,6 @@
 package gradlebuild.instrumentation.transforms
 
 import gradlebuild.basics.classanalysis.getClassSuperTypes
-import org.gradle.api.artifacts.transform.CacheableTransform
 import org.gradle.api.artifacts.transform.InputArtifact
 import org.gradle.api.artifacts.transform.TransformAction
 import org.gradle.api.artifacts.transform.TransformOutputs
@@ -35,8 +34,6 @@ import java.io.File
 import java.util.Properties
 import javax.inject.Inject
 
-
-@CacheableTransform
 abstract class InstrumentationMetadataTransform : TransformAction<TransformParameters.None> {
 
     companion object {

--- a/build-logic/packaging/src/main/kotlin/gradlebuild/instrumentation/transforms/InstrumentationMetadataTransform.kt
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild/instrumentation/transforms/InstrumentationMetadataTransform.kt
@@ -34,6 +34,7 @@ import java.io.File
 import java.util.Properties
 import javax.inject.Inject
 
+
 abstract class InstrumentationMetadataTransform : TransformAction<TransformParameters.None> {
 
     companion object {


### PR DESCRIPTION
Since avoidance savings are negative for that transform.
