### PR TITLE
Remove closure taking methods from configurable value subtypes

### DIFF
--- a/platforms/core-configuration/file-collections/src/integTest/groovy/org/gradle/api/file/FileCollectionIntegrationTest.groovy
+++ b/platforms/core-configuration/file-collections/src/integTest/groovy/org/gradle/api/file/FileCollectionIntegrationTest.groovy
@@ -44,7 +44,7 @@ class FileCollectionIntegrationTest extends AbstractIntegrationSpec implements T
             def elements = files.elements
 
             def name = 'a'
-            files.withActualValue { from(name) }
+            files.withActualValue { it.from(name) }
 
             assert elements.get().asFile == [file('b'), file('a')]
         """

--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
@@ -19,7 +19,6 @@ package org.gradle.api.internal.file.collections;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.Transformer;
 import org.gradle.api.file.ConfigurableFileCollection;
@@ -45,7 +44,6 @@ import org.gradle.internal.Factory;
 import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.internal.logging.text.TreeFormatter;
 import org.gradle.internal.state.Managed;
-import org.gradle.util.internal.ConfigureUtil;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -96,13 +94,6 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
     public ConfigurableFileCollection withActualValue(Action<FileCollectionConfigurer> action) {
         setToConventionIfUnset();
         action.execute(getExplicitValue());
-        return this;
-    }
-
-    @Override
-    public ConfigurableFileCollection withActualValue(Closure<Void> action) {
-        setToConventionIfUnset();
-        ConfigureUtil.configure(action, getExplicitValue());
         return this;
     }
 

--- a/platforms/core-configuration/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollectionSpec.groovy
+++ b/platforms/core-configuration/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollectionSpec.groovy
@@ -1838,8 +1838,8 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
     def "can incrementally set paths using closure"() {
         when:
         collection.withActualValue {
-            from("src1", "src2")
-            from("src3")
+            it.from("src1", "src2")
+            it.from("src3")
         }
         then:
         collection.from as List == ["src1", "src2", "src3"]
@@ -1849,8 +1849,8 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
         when:
         collection.convention("src0")
         collection.withActualValue {
-            from("src1", "src2")
-            from("src3")
+            it.from("src1", "src2")
+            it.from("src3")
         }
         then:
         collection.from as List == ["src0", "src1", "src2", "src3"]
@@ -1862,8 +1862,8 @@ class DefaultConfigurableFileCollectionSpec extends FileCollectionSpec {
         collection.setFrom("src1")
         collection.convention("unused-src")
         collection.withActualValue {
-            from("src3")
-            from("src4")
+            it.from("src3")
+            it.from("src4")
         }
         then:
         collection.from as List == ["src1", "src3", "src4"]

--- a/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/CollectionPropertyIntegrationTest.groovy
+++ b/platforms/core-configuration/model-core/src/integTest/groovy/org/gradle/api/provider/CollectionPropertyIntegrationTest.groovy
@@ -404,6 +404,22 @@ task wrongPropertyElementTypeApi(type: MyTask) {
         succeeds("verify")
     }
 
+    def "can leverage convention in list property"() {
+        buildFile """
+            verify {
+                prop.convention(project.provider { [ 'a', 'b' ] })
+                assert !prop.explicit
+                prop.withActualValue {
+                    it.addAll(project.provider { [ 'c', 'd' ] })
+                }
+                expected = [ 'a', 'b', 'c', 'd' ]
+                assert prop.explicit
+            }
+        """
+        expect:
+        succeeds("verify")
+    }
+
     def "adds to non-defined property does nothing"() {
         buildFile << """
             verify {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
@@ -18,8 +18,6 @@ package org.gradle.api.internal.provider;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableCollection;
-import groovy.lang.Closure;
-import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
 import org.gradle.api.Transformer;
 import org.gradle.api.internal.provider.Collectors.ElementFromProvider;
@@ -32,7 +30,6 @@ import org.gradle.api.provider.HasMultipleValues;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.SupportsConvention;
 import org.gradle.internal.Cast;
-import org.gradle.util.internal.ConfigureUtil;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -94,13 +91,6 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>>
     public HasMultipleValues<T> withActualValue(Action<CollectionPropertyConfigurer<T>> action) {
         setToConventionIfUnset();
         action.execute(getExplicitValue());
-        return this;
-    }
-
-    @Override
-    public HasMultipleValues<T> withActualValue(@DelegatesTo(CollectionPropertyConfigurer.class) Closure<Void> action) {
-        setToConventionIfUnset();
-        ConfigureUtil.configure(action, getExplicitValue());
         return this;
     }
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultListProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultListProperty.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.provider;
 
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
-import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.provider.CollectionPropertyConfigurer;
 import org.gradle.api.provider.ListProperty;
@@ -89,11 +88,6 @@ public class DefaultListProperty<T> extends AbstractCollectionProperty<T, List<T
 
     @Override
     public ListProperty<T> withActualValue(Action<CollectionPropertyConfigurer<T>> action) {
-        return uncheckedNonnullCast(super.withActualValue(action));
-    }
-
-    @Override
-    public ListProperty<T> withActualValue(Closure<Void> action) {
         return uncheckedNonnullCast(super.withActualValue(action));
     }
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
@@ -20,8 +20,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import groovy.lang.Closure;
-import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
 import org.gradle.api.Transformer;
 import org.gradle.api.internal.provider.MapCollectors.EntriesFromMap;
@@ -31,7 +29,6 @@ import org.gradle.api.internal.provider.MapCollectors.SingleEntry;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.MapPropertyConfigurer;
 import org.gradle.api.provider.Provider;
-import org.gradle.util.internal.ConfigureUtil;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -204,13 +201,6 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, Defaul
     public MapProperty<K, V> withActualValue(Action<MapPropertyConfigurer<K, V>> action) {
         setToConventionIfUnset();
         action.execute(getExplicitValue());
-        return this;
-    }
-
-    @Override
-    public MapProperty<K, V> withActualValue(@DelegatesTo(MapPropertyConfigurer.class) Closure<Void> action) {
-        setToConventionIfUnset();
-        ConfigureUtil.configure(action, getExplicitValue());
         return this;
     }
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultSetProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultSetProperty.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.provider;
 
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableSet;
-import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.provider.CollectionPropertyConfigurer;
 import org.gradle.api.provider.Provider;
@@ -89,11 +88,6 @@ public class DefaultSetProperty<T> extends AbstractCollectionProperty<T, Set<T>>
 
     @Override
     public SetProperty<T> withActualValue(Action<CollectionPropertyConfigurer<T>> action) {
-        return uncheckedNonnullCast(super.withActualValue(action));
-    }
-
-    @Override
-    public SetProperty<T> withActualValue(Closure<Void> action) {
         return uncheckedNonnullCast(super.withActualValue(action));
     }
 

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
@@ -1270,8 +1270,8 @@ The value of this property is derived from: <source>""")
         given:
         property.convention(Providers.of(["1"]))
         property.withActualValue {
-            addAll(Providers.of(["2"]))
-            addAll(Providers.of(["3", "4"]))
+            it.addAll(Providers.of(["2"]))
+            it.addAll(Providers.of(["3", "4"]))
         }
         expect:
         assertValueIs toImmutable(["1", "2", "3", "4"])
@@ -1282,8 +1282,8 @@ The value of this property is derived from: <source>""")
         given:
         property.set([])
         property.withActualValue {
-            addAll(Providers.of(["1", "2"]))
-            addAll(Providers.of(["3", "4"]))
+            it.addAll(Providers.of(["1", "2"]))
+            it.addAll(Providers.of(["3", "4"]))
         }
 
         expect:
@@ -1294,8 +1294,8 @@ The value of this property is derived from: <source>""")
     def "can add to actual value without previous configuration"() {
         given:
         property.withActualValue {
-            addAll(Providers.of(["1", "2"]))
-            addAll(Providers.of(["3", "4"]))
+            it.addAll(Providers.of(["1", "2"]))
+            it.addAll(Providers.of(["3", "4"]))
         }
 
         expect:

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
@@ -1206,8 +1206,8 @@ The value of this property is derived from: <source>""")
         given:
         property.convention(['k0': '1'])
         property.withActualValue {
-            putAll(['k1': '2', 'k2': '3'])
-            put('k2', '4')
+            it.putAll(['k1': '2', 'k2': '3'])
+            it.put('k2', '4')
         }
         expect:
         assertValueIs(['k0': '1', 'k1': '2', 'k2': '4'])
@@ -1218,9 +1218,9 @@ The value of this property is derived from: <source>""")
         given:
         property.set([:])
         property.withActualValue {
-            put('k0', '1')
-            putAll(['k1': '2', 'k2': '3'])
-            put('k2', '4')
+            it.put('k0', '1')
+            it.putAll(['k1': '2', 'k2': '3'])
+            it.put('k2', '4')
         }
         expect:
         assertValueIs(['k0': '1', 'k1': '2', 'k2': '4'])
@@ -1230,9 +1230,9 @@ The value of this property is derived from: <source>""")
     def "may configure actual value incrementally"() {
         given:
         property.withActualValue {
-            put('k0', '1')
-            putAll(['k1': '2', 'k2': '3'])
-            put('k2', '4')
+            it.put('k0', '1')
+            it.putAll(['k1': '2', 'k2': '3'])
+            it.put('k2', '4')
         }
         expect:
         assertValueIs(['k0': '1', 'k1': '2', 'k2': '4'])
@@ -1243,7 +1243,7 @@ The value of this property is derived from: <source>""")
         given:
         property.convention(['k0': '1', 'k1': '2', 'k2': '3'])
         property.withActualValue {
-            put('k1', '4')
+            it.put('k1', '4')
         }
         expect:
         assertValueIs(['k0': '1', 'k1': '4', 'k2': '3'])

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/ConfigurableFileCollection.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/ConfigurableFileCollection.java
@@ -16,7 +16,6 @@
 package org.gradle.api.file;
 
 import groovy.lang.Closure;
-import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.SupportsKotlinAssignmentOverloading;
@@ -131,23 +130,6 @@ public interface ConfigurableFileCollection extends FileCollection, HasConfigura
     @Override
     @Incubating
     ConfigurableFileCollection withActualValue(Action<FileCollectionConfigurer> action);
-
-    /**
-     * Performs incremental updates to the actual value of this file collection.
-     *
-     * This is a Groovy closure-compatible version of
-     * {@link ConfigurableFileCollection#withActualValue(Action)},
-     * having this file collection's actual value (and not the file collection itself)
-     * as the target object.
-     *
-     * @param action a Groovy closure to incrementally configure this object actual value
-     * via the {@link FileCollectionConfigurer} protocol.
-     *
-     * @see #withActualValue(Action)
-     * @since 8.7
-     */
-    @Incubating
-    ConfigurableFileCollection withActualValue(@DelegatesTo(FileCollectionConfigurer.class) Closure<Void> action);
 
     /**
      * Applies an eager transformation to the current contents of this file collection, without explicitly resolving it.

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/HasMultipleValues.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/HasMultipleValues.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.provider;
 
-import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.SupportsKotlinAssignmentOverloading;
 
@@ -157,20 +156,4 @@ public interface HasMultipleValues<T> extends HasConfigurableValue, CollectionPr
      */
     @Override
     HasMultipleValues<T> withActualValue(Action<CollectionPropertyConfigurer<T>> action);
-
-    /**
-     * Performs incremental updates to the actual value of this property.
-     *
-     * This is a Groovy closure-compatible version of
-     * {@link HasMultipleValues#withActualValue(Action)},
-     * having this property's actual value (and not the property itself)
-     * as the target object.
-     *
-     * @param action a Groovy closure to incrementally configure this object's actual value
-     * via the {@link CollectionPropertyConfigurer} protocol.
-     *
-     * @see #withActualValue(Action)
-     * @since 8.7
-     */
-    HasMultipleValues<T> withActualValue(Closure<Void> action);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ListProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ListProperty.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.provider;
 
-import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.Transformer;
@@ -92,12 +91,6 @@ public interface ListProperty<T> extends Provider<List<T>>, HasMultipleValues<T>
      */
     @Override
     ListProperty<T> withActualValue(Action<CollectionPropertyConfigurer<T>> action);
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    ListProperty<T> withActualValue(Closure<Void> action);
 
     /**
      * Applies an eager transformation to the current value of the property "in place", without explicitly obtaining it.

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/MapProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/MapProperty.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.provider;
 
-import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.SupportsKotlinAssignmentOverloading;
@@ -144,23 +143,6 @@ public interface MapProperty<K, V> extends Provider<Map<K, V>>, HasConfigurableV
      */
     @Override
     MapProperty<K, V> withActualValue(Action<MapPropertyConfigurer<K, V>> action);
-
-    /**
-     * Performs incremental updates to the actual value of this property.
-     *
-     * This is a Groovy closure-compatible version of
-     * {@link MapProperty#withActualValue(Action)},
-     * having this property's actual value (and not the property itself)
-     * as the target object.
-     *
-     * @param action a Groovy closure to incrementally configure this object's actual value
-     * via the {@link MapPropertyConfigurer} protocol.
-     *
-     * @see #withActualValue(Action)
-     * @since 8.7
-     */
-    @Incubating
-    MapProperty<K, V> withActualValue(Closure<Void> action);
 
     /**
      * Specifies the value to use as the convention for this property. The convention is used when no value has been set for this property.

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/SetProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/SetProperty.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.provider;
 
-import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.Transformer;
@@ -91,12 +90,6 @@ public interface SetProperty<T> extends Provider<Set<T>>, HasMultipleValues<T> {
      */
     @Override
     SetProperty<T> withActualValue(Action<CollectionPropertyConfigurer<T>> action);
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    SetProperty<T> withActualValue(Closure<Void> action);
 
     /**
      * Applies an eager transformation to the current value of the property "in place", without explicitly obtaining it.


### PR DESCRIPTION
...as those should be supported automatically instead via explicit API.