### PR TITLE
Make ProxyAuthenticator static class

### DIFF
--- a/platforms/core-runtime/wrapper-shared/src/main/java/org/gradle/wrapper/Download.java
+++ b/platforms/core-runtime/wrapper-shared/src/main/java/org/gradle/wrapper/Download.java
@@ -81,7 +81,7 @@ public class Download implements IDownload {
     private void configureProxyAuthentication() {
         if (systemProperties.get("http.proxyUser") != null || systemProperties.get("https.proxyUser") != null) {
             // Only an authenticator for proxies needs to be set. Basic authentication is supported by directly setting the request header field.
-            Authenticator.setDefault(new ProxyAuthenticator());
+            Authenticator.setDefault(new ProxyAuthenticator(systemProperties));
         }
     }
 
@@ -232,7 +232,13 @@ public class Download implements IDownload {
         return String.format("%s/%s (%s;%s;%s) (%s;%s;%s)", appName, appVersion, osName, osVersion, osArch, javaVendor, javaVersion, javaVendorVersion);
     }
 
-    private class ProxyAuthenticator extends Authenticator {
+    private static class ProxyAuthenticator extends Authenticator {
+        private final Map<String, String> systemProperties;
+
+        private ProxyAuthenticator(Map<String, String> systemProperties) {
+            this.systemProperties = systemProperties;
+        }
+
         @Override
         protected PasswordAuthentication getPasswordAuthentication() {
             if (getRequestorType() == RequestorType.PROXY) {

--- a/platforms/core-runtime/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
+++ b/platforms/core-runtime/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
@@ -95,7 +95,7 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
         executer.inDirectory(file("second")).withTasks("wrapper").run()
 
         then: "the checksum should be constant (unless there are code changes)"
-        Hashing.sha256().hashFile(file("first/gradle/wrapper/gradle-wrapper.jar")) == HashCode.fromString("5fddf0b3537808484e196a0a3924f27ce669210fd11c88d4250b49ddf3c06a6b")
+        Hashing.sha256().hashFile(file("first/gradle/wrapper/gradle-wrapper.jar")) == HashCode.fromString("cb0da6751c2b753a16ac168bb354870ebb1e162e9083f116729cec9c781156b8")
 
         and:
         file("first/gradle/wrapper/gradle-wrapper.jar").md5Hash == file("second/gradle/wrapper/gradle-wrapper.jar").md5Hash


### PR DESCRIPTION
... in order to avoid memory leaks when
using proxy setup. IDEA injects a listener
that is kept around through Authenticator,
ProxyAuthenticator, Download, DownloadProgressListener etc. causing eventually larger objects to be kept around as they are not GC'ed.

Here is an example for one of the leaks:
```
34.0MB          1          (root): java.lang.Class(java.net.Authenticator)
34.0MB          1          (static): org.gradle.wrapper.Download$ProxyAuthenticator
34.0MB          1          this$0: org.gradle.wrapper.Download
34.0MB          1          progressListener: org.gradle.wrapper.Download$DefaultDownloadProgressListener
34.0MB          1          delegate: org.gradle.tooling.internal.consumer.DistributionInstaller$ForwardingDownloadProgressListener
34.0MB          1          this$0: org.gradle.tooling.internal.consumer.DistributionInstaller
34.0MB          1          buildProgressListener: org.gradle.tooling.internal.consumer.parameters.FailsafeBuildProgressListenerAdapter
34.0MB          1          delegate: org.gradle.tooling.internal.consumer.parameters.BuildProgressListenerAdapter
34.0MB          1          fileDownloadListeners: org.gradle.internal.event.ListenerBroadcast
34.0MB          1          broadcast: org.gradle.internal.event.BroadcastDispatch$CompositeDispatch
34.0MB          1          dispatchers: java.util.ArrayList
34.0MB          1          elementData: [Ljava.lang.Object;
34.0MB          1          []: org.gradle.internal.event.BroadcastDispatch$SingletonDispatch
34.0MB          1          handler: org.jetbrains.plugins.gradle.service.execution.GradleProgressListener
34.0MB          1          myListener: com.android.tools.idea.gradle.project.build.invoker.GradleTasksExecutorImpl$TaskImpl$invokeGradleTasks$executeTasksFunction$1$listener$1
34.0MB          1          this$0: com.android.tools.idea.gradle.project.build.invoker.GradleTasksExecutorImpl$TaskImpl
33.7MB          1          myProject: com.intellij.openapi.project.impl.ProjectImpl (disposedRoot)
```