### PR TITLE
doc: amend reserved alias names in version catalogs

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/troubleshooting/version_catalog_problems.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/troubleshooting/version_catalog_problems.adoc
@@ -39,7 +39,7 @@ To fix this problem, if you need more entries, it's probably best to split the c
 == Use of a reserved alias name
 
 This error indicates that you chose an alias which is a reserved name.
-Typically this happens if you choose an alias which ends with `version`, `bundle`, or `plugin`, as it may clash with generated accessors.
+Typically this happens if you choose an alias which starts with `versions`, `bundles`, or `plugins` or contains `extensions`, `convention`, `class`, as it may clash with generated accessors.
 
 To fix this problem, you must choose a different alias.
 


### PR DESCRIPTION
Issue: #27590 

Amend reserved alias names in version catalogs based on 

https://github.com/gradle/gradle/blob/6f6bbb327b94f57a823c51e57ce7e221ac906322/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/DefaultVersionCatalogBuilder.java#L106-L111


https://github.com/gradle/gradle/blob/6f6bbb327b94f57a823c51e57ce7e221ac906322/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/catalog/DefaultVersionCatalogBuilder.java#L382-L406