### PR TITLE
Fix cross version output expectation

### DIFF
--- a/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerConventionalPluginClasspathInjectionIntegrationTest.groovy
+++ b/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerConventionalPluginClasspathInjectionIntegrationTest.groovy
@@ -53,13 +53,7 @@ class GradleRunnerConventionalPluginClasspathInjectionIntegrationTest extends Ba
         }
 
         then:
-        execFailure(result).assertHasDescription("""
-            |Plugin [id: 'com.company.helloworld'] was not found in any of the following sources:
-            |
-            |- Gradle Core Plugins (plugin is not in 'org.gradle' namespace)
-            |- Included Builds (No included builds contain this plugin)
-            |- $pluginRepositoriesDisplayName (plugin dependency must include a version number for this source)
-        """.stripMargin().trim())
+        !execFailure(result).error.contains("Gradle TestKit (classpath:")
     }
 
     @InspectsBuildOutput
@@ -76,14 +70,7 @@ class GradleRunnerConventionalPluginClasspathInjectionIntegrationTest extends Ba
         }
 
         then:
-        execFailure(result).assertHasDescription("""
-            |Plugin [id: 'com.company.helloworld'] was not found in any of the following sources:
-            |
-            |- Gradle Core Plugins (plugin is not in 'org.gradle' namespace)
-            |- Gradle TestKit (classpath: ${explicitClasspath*.absolutePath.join(File.pathSeparator)})
-            |- Included Builds (No included builds contain this plugin)
-            |- $pluginRepositoriesDisplayName (plugin dependency must include a version number for this source)
-        """.stripMargin().trim())
+        execFailure(result).assertHasErrorOutput("Gradle TestKit (classpath: ${explicitClasspath*.absolutePath.join(File.pathSeparator)})")
     }
 
     def "throws if conventional classpath is requested and metadata cannot be found"() {

--- a/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerPluginClasspathInjectionIntegrationTest.groovy
+++ b/platforms/extensibility/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerPluginClasspathInjectionIntegrationTest.groovy
@@ -49,13 +49,7 @@ class GradleRunnerPluginClasspathInjectionIntegrationTest extends BaseGradleRunn
             .buildAndFail()
 
         then:
-        execFailure(result).assertHasDescription("""
-            |Plugin [id: '$plugin.id'] was not found in any of the following sources:
-            |
-            |- Gradle Core Plugins (plugin is not in 'org.gradle' namespace)
-            |- Included Builds (No included builds contain this plugin)
-            |- $pluginRepositoriesDisplayName (plugin dependency must include a version number for this source)
-        """.stripMargin().trim())
+        !execFailure(result).error.contains("Gradle TestKit (classpath:")
     }
 
     def "injected classpath is indicated in error message if plugin not found"() {
@@ -67,14 +61,7 @@ class GradleRunnerPluginClasspathInjectionIntegrationTest extends BaseGradleRunn
             .buildAndFail()
 
         then:
-        execFailure(result).assertHasDescription("""
-            |Plugin [id: '$plugin.id'] was not found in any of the following sources:
-            |
-            |- Gradle Core Plugins (plugin is not in 'org.gradle' namespace)
-            |- Gradle TestKit (classpath: ${expectedClasspath*.absolutePath.join(File.pathSeparator)})
-            |- Included Builds (No included builds contain this plugin)
-            |- $pluginRepositoriesDisplayName (plugin dependency must include a version number for this source)
-        """.stripMargin().trim())
+        execFailure(result).assertHasErrorOutput("Gradle TestKit (classpath: ${expectedClasspath*.absolutePath.join(File.pathSeparator)})")
     }
 
     def "can inject plugin classpath and use in build"() {


### PR DESCRIPTION
The output changed between versions to include the fact that included builds are checked for plugins We make the error output checking less strict in the cross version tests to avoid needing to check for both old and new output The full output is still verified in other tests

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
