### PR TITLE
Run native related builds on Intel macs only

### DIFF
--- a/.teamcity/src/main/kotlin/model/CIBuildModel.kt
+++ b/.teamcity/src/main/kotlin/model/CIBuildModel.kt
@@ -115,7 +115,7 @@ data class CIBuildModel(
                 SpecificBuild.TestPerformanceTest,
                 SpecificBuild.FlakyTestQuarantineLinux,
                 SpecificBuild.FlakyTestQuarantineMacOs,
-                SpecificBuild.FlakyTestQuarantineMacOsM1,
+                SpecificBuild.FlakyTestQuarantineMacOsAppleSilicon,
                 SpecificBuild.FlakyTestQuarantineWindows,
                 SpecificBuild.GradleceptionWithMaxLtsJdk,
             ),
@@ -128,7 +128,7 @@ data class CIBuildModel(
                 TestCoverage(11, TestType.allVersionsCrossVersion, Os.WINDOWS, JvmCategory.MIN_VERSION_WINDOWS, ALL_CROSS_VERSION_BUCKETS.size),
                 TestCoverage(12, TestType.noDaemon, Os.LINUX, JvmCategory.MIN_VERSION, DEFAULT_LINUX_FUNCTIONAL_TEST_BUCKET_SIZE),
                 TestCoverage(13, TestType.noDaemon, Os.WINDOWS, JvmCategory.MAX_LTS_VERSION),
-                TestCoverage(14, TestType.platform, Os.MACOS, JvmCategory.MIN_VERSION, expectedBucketNumber = 20, arch = Arch.AMD64),
+                TestCoverage(14, TestType.platform, Os.MACOS, JvmCategory.MIN_VERSION, expectedBucketNumber = 5, arch = Arch.AMD64),
                 TestCoverage(15, TestType.forceRealizeDependencyManagement, Os.LINUX, JvmCategory.MIN_VERSION, DEFAULT_LINUX_FUNCTIONAL_TEST_BUCKET_SIZE),
                 TestCoverage(33, TestType.allVersionsIntegMultiVersion, Os.LINUX, JvmCategory.MIN_VERSION, ALL_CROSS_VERSION_BUCKETS.size),
                 TestCoverage(34, TestType.allVersionsIntegMultiVersion, Os.WINDOWS, JvmCategory.MIN_VERSION_WINDOWS, ALL_CROSS_VERSION_BUCKETS.size),
@@ -431,7 +431,7 @@ enum class SpecificBuild {
             return FlakyTestQuarantine(model, stage, Os.MACOS)
         }
     },
-    FlakyTestQuarantineMacOsM1 {
+    FlakyTestQuarantineMacOsAppleSilicon {
         override fun create(model: CIBuildModel, stage: Stage): BaseGradleBuildType {
             return FlakyTestQuarantine(model, stage, Os.MACOS, Arch.AARCH64)
         }

--- a/.teamcity/src/main/kotlin/model/FunctionalTestBucketGenerator.kt
+++ b/.teamcity/src/main/kotlin/model/FunctionalTestBucketGenerator.kt
@@ -4,6 +4,7 @@ import com.alibaba.fastjson.JSON
 import com.alibaba.fastjson.JSONArray
 import com.alibaba.fastjson.JSONObject
 import com.alibaba.fastjson.serializer.SerializerFeature
+import common.Arch
 import common.Os
 import common.VersionedSettingsBranch
 import configurations.ParallelizationMethod
@@ -131,6 +132,7 @@ class FunctionalTestBucketGenerator(private val model: CIBuildModel, testTimeDat
             .filter { model.subprojects.getSubprojectByName(it.key) != null }
             .map { SubprojectTestClassTime(model.subprojects.getSubprojectByName(it.key)!!, it.value.filter { it.testClassAndSourceSet.sourceSet != "test" }) }
             .sortedBy { -it.totalTime }
+            .filter { onlyNativeSubprojectsForIntelMacs(testCoverage, it.subProject.name) }
 
         return parallelize(subProjectTestClassTimes, testCoverage) { numberOfBatches ->
             if (testCoverage.os == Os.LINUX)
@@ -180,5 +182,17 @@ class FunctionalTestBucketGenerator(private val model: CIBuildModel, testTimeDat
                 println("No test statistics found for ${testCoverage.asName()} (${testCoverage.uuid}), re-using the data from ${foundTestCoverage.asName()} (${foundTestCoverage.uuid})")
             }
         }
+    }
+}
+
+fun onlyNativeSubprojectsForIntelMacs(
+    testCoverage: TestCoverage,
+    subprojectName: String
+): Boolean {
+    return if (testCoverage.os == Os.MACOS && testCoverage.arch == Arch.AMD64) {
+        subprojectName.contains("native") ||
+            subprojectName in listOf("file-watching", "snapshots", "workers", "logging")
+    } else {
+        true
     }
 }

--- a/.teamcity/src/main/kotlin/model/FunctionalTestBucketProvider.kt
+++ b/.teamcity/src/main/kotlin/model/FunctionalTestBucketProvider.kt
@@ -92,7 +92,9 @@ class StatisticBasedFunctionalTestBucketProvider(val model: CIBuildModel, testBu
             // in this case we have no historical test running time, so we simply add these subprojects into first available bucket
             val allSubprojectsInBucketJson = buckets.flatMap { it.subprojects.map { it.name } }.toSet()
 
-            val allSubprojectsInModel = model.subprojects.getSubprojectsForFunctionalTest(testCoverage).map { it.name }
+            val allSubprojectsInModel = model.subprojects.getSubprojectsForFunctionalTest(testCoverage)
+                .filter { onlyNativeSubprojectsForIntelMacs(testCoverage, it.name) }
+                .map { it.name }
             val subprojectsInModelButNotInBucketJson = allSubprojectsInModel.toMutableList().apply { removeAll(allSubprojectsInBucketJson) }
 
             if (subprojectsInModelButNotInBucketJson.isEmpty()) {

--- a/.teamcity/src/main/kotlin/util/AdHocPerformanceScenario.kt
+++ b/.teamcity/src/main/kotlin/util/AdHocPerformanceScenario.kt
@@ -116,4 +116,4 @@ fun ParametrizedWithType.profilerParam(defaultProfiler: String) {
 object AdHocPerformanceScenarioLinux : AdHocPerformanceScenario(Os.LINUX)
 object AdHocPerformanceScenarioWindows : AdHocPerformanceScenario(Os.WINDOWS)
 object AdHocPerformanceScenarioMacOS : AdHocPerformanceScenario(Os.MACOS, Arch.AMD64)
-object AdHocPerformanceScenarioMacM1 : AdHocPerformanceScenario(Os.MACOS, Arch.AARCH64)
+object AdHocPerformanceScenarioMacAppleSilicon : AdHocPerformanceScenario(Os.MACOS, Arch.AARCH64)

--- a/.teamcity/src/main/kotlin/util/UtilPerformanceProject.kt
+++ b/.teamcity/src/main/kotlin/util/UtilPerformanceProject.kt
@@ -9,7 +9,7 @@ object UtilPerformanceProject : Project({
     buildType(AdHocPerformanceScenarioLinux)
     buildType(AdHocPerformanceScenarioWindows)
     buildType(AdHocPerformanceScenarioMacOS)
-    buildType(AdHocPerformanceScenarioMacM1)
+    buildType(AdHocPerformanceScenarioMacAppleSilicon)
 
     params {
         param("env.GRADLE_ENTERPRISE_ACCESS_KEY", "%ge.gradle.org.access.key%")

--- a/.teamcity/test-buckets.json
+++ b/.teamcity/test-buckets.json
@@ -1893,46 +1893,10 @@
 			{
 				"parallelizationMethod":{
 					"name":"TeamCityParallelTests",
-					"numberOfBatches":3
-				},
-				"subprojects":[
-					"core"
-				]
-			},
-			{
-				"parallelizationMethod":{
-					"name":"TeamCityParallelTests",
-					"numberOfBatches":3
-				},
-				"subprojects":[
-					"dependency-management"
-				]
-			},
-			{
-				"parallelizationMethod":{
-					"name":"TeamCityParallelTests",
 					"numberOfBatches":2
 				},
 				"subprojects":[
-					"configuration-cache"
-				]
-			},
-			{
-				"parallelizationMethod":{
-					"name":"TeamCityParallelTests",
-					"numberOfBatches":2
-				},
-				"subprojects":[
-					"testing-jvm"
-				]
-			},
-			{
-				"parallelizationMethod":{
-					"name":"TeamCityParallelTests",
-					"numberOfBatches":2
-				},
-				"subprojects":[
-					"build-init"
+					"logging"
 				]
 			},
 			{
@@ -1941,167 +1905,31 @@
 					"numberOfBatches":1
 				},
 				"subprojects":[
-					"tooling-api",
-					"wrapper",
-					"tooling-api-builders",
-					"samples",
-					"native",
-					"java-compiler-plugin",
-					"hashing",
-					"functional",
-					"file-temp",
-					"base-services-groovy",
-					"logging-api"
-				]
-			},
-			{
-				"parallelizationMethod":{
-					"name":"TeamCityParallelTests",
-					"numberOfBatches":1
-				},
-				"subprojects":[
-					"composite-builds",
-					"kotlin-dsl-plugins",
-					"docs-asciidoctor-extensions-base",
-					"internal-instrumentation-processor",
-					"security",
-					"input-tracking",
-					"base-ide-plugins",
-					"worker-processes",
-					"files",
-					"build-cache-packaging",
-					"build-operations"
-				]
-			},
-			{
-				"parallelizationMethod":{
-					"name":"TeamCityParallelTests",
-					"numberOfBatches":1
-				},
-				"subprojects":[
-					"scala",
-					"precondition-tester",
-					"kotlin-dsl-provider-plugins",
-					"test-suites-base",
-					"internal-testing",
-					"testing-jvm-infrastructure",
-					"cli",
-					"normalization-java",
-					"docs",
-					"build-option",
-					"execution"
-				]
-			},
-			{
-				"parallelizationMethod":{
-					"name":"TeamCityParallelTests",
-					"numberOfBatches":1
-				},
-				"subprojects":[
-					"language-java",
-					"toolchains-jvm",
-					"resources-http",
-					"internal-performance-testing",
-					"internal-integ-testing",
-					"platform-jvm",
-					"snapshots",
-					"wrapper-shared",
-					"resources",
-					"publish",
-					"process-services"
-				]
-			},
-			{
-				"parallelizationMethod":{
-					"name":"TeamCityParallelTests",
-					"numberOfBatches":1
-				},
-				"subprojects":[
-					"launcher",
-					"messaging",
-					"build-profile",
-					"base-services",
-					"jvm-services",
-					"problems-api",
-					"problems",
-					"ivy",
-					"war",
-					"plugins-java-base",
-					"plugins-test-report-aggregation"
-				]
-			},
-			{
-				"parallelizationMethod":{
-					"name":"TeamCityParallelTests",
-					"numberOfBatches":1
-				},
-				"subprojects":[
-					"plugin-use",
-					"resources-gcs",
-					"testing-base",
-					"tooling-native",
-					"java-platform",
-					"plugins-version-catalog",
-					"ear",
-					"plugins-distribution",
-					"platform-native",
-					"resources-s3",
-					"plugins-jvm-test-fixtures"
-				]
-			},
-			{
-				"parallelizationMethod":{
-					"name":"TeamCityParallelTests",
-					"numberOfBatches":1
-				},
-				"subprojects":[
-					"code-quality",
-					"testing-native",
-					"language-jvm",
-					"signing",
-					"model-groovy",
-					"core-api",
-					"build-cache-http",
-					"build-events",
-					"resources-sftp",
-					"persistent-cache",
-					"plugins-jvm-test-suite"
-				]
-			},
-			{
-				"parallelizationMethod":{
-					"name":"TeamCityParallelTests",
-					"numberOfBatches":1
-				},
-				"subprojects":[
-					"kotlin-dsl-integ-tests",
-					"kotlin-dsl-tooling-builders",
-					"integ-test",
-					"language-groovy",
-					"model-core",
-					"maven",
-					"logging",
-					"plugin-development",
 					"language-native",
-					"test-kit",
-					"plugins-java",
-					"plugins-groovy",
+					"native",
+					"snapshots",
+					"tooling-native",
+					"platform-native",
+					"testing-native"
+				]
+			},
+			{
+				"parallelizationMethod":{
+					"name":"TeamCityParallelTests",
+					"numberOfBatches":1
+				},
+				"subprojects":[
 					"ide-native",
-					"platform-base",
-					"workers",
-					"enterprise",
-					"kotlin-dsl",
-					"jacoco",
-					"plugins",
-					"antlr",
-					"version-control",
-					"file-watching",
-					"build-cache",
-					"diagnostics",
-					"ide",
-					"ide-plugins",
-					"file-collections",
-					"reporting"
+					"file-watching"
+				]
+			},
+			{
+				"parallelizationMethod":{
+					"name":"TeamCityParallelTests",
+					"numberOfBatches":1
+				},
+				"subprojects":[
+					"workers"
 				]
 			}
 		],
@@ -2392,7 +2220,6 @@
 					"jvm-services",
 					"kotlin-dsl",
 					"kotlin-dsl-integ-tests",
-					"kotlin-dsl-tooling-builders",
 					"language-java",
 					"language-jvm",
 					"logging",
@@ -2538,7 +2365,6 @@
 					"jvm-services",
 					"kotlin-dsl",
 					"kotlin-dsl-integ-tests",
-					"kotlin-dsl-tooling-builders",
 					"language-java",
 					"language-jvm",
 					"logging",


### PR DESCRIPTION
Since 2024 there will be only 2 Intel Mac build agents. Because only native builds are architecture-dependent, this PR only executes native subprojects on Intel Macs.