### PR TITLE
Fix wrong baseline version

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/AbstractReportGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/AbstractReportGenerator.java
@@ -45,6 +45,9 @@ import java.util.stream.Collectors;
 import static org.gradle.performance.results.report.PerformanceFlakinessDataProvider.EmptyPerformanceFlakinessDataProvider;
 
 public abstract class AbstractReportGenerator<R extends ResultsStore> {
+    public static Set<String> getDependencyPerformanceTestTeamCityBuildIds() {
+        return new HashSet<>(Arrays.asList(System.getProperty("org.gradle.performance.dependencyBuildIds", "").split(",")));
+    }
 
     protected void generateReport(String... args) {
         File outputDirectory = new File(args[0]);
@@ -54,10 +57,8 @@ public abstract class AbstractReportGenerator<R extends ResultsStore> {
             resultJsons.add(new File(args[i]));
         }
 
-        Set<String> performanceTestBuildIds = new HashSet<>(Arrays.asList(System.getProperty("org.gradle.performance.dependencyBuildIds", "").split(",")));
-
         try (ResultsStore store = getResultsStore()) {
-            PerformanceExecutionDataProvider executionDataProvider = getExecutionDataProvider(store, resultJsons, performanceTestBuildIds);
+            PerformanceExecutionDataProvider executionDataProvider = getExecutionDataProvider(store, resultJsons, getDependencyPerformanceTestTeamCityBuildIds());
             PerformanceFlakinessDataProvider flakinessDataProvider = getFlakinessDataProvider();
             generateReport(store, flakinessDataProvider, executionDataProvider, outputDirectory, projectName);
             checkResult(flakinessDataProvider, executionDataProvider);

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/AbstractTablePageGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/AbstractTablePageGenerator.java
@@ -33,9 +33,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.joining;
+import static org.gradle.performance.results.report.AbstractReportGenerator.getDependencyPerformanceTestTeamCityBuildIds;
 import static org.gradle.performance.results.report.Tag.FixedTag;
 
 public abstract class AbstractTablePageGenerator extends HtmlPageGenerator<ResultsStore> {
+    private static final Set<String> DEPENDENCY_PERFORMANCE_TEST_TEAM_CITY_BUILD_IDS = getDependencyPerformanceTestTeamCityBuildIds();
+
     protected final PerformanceFlakinessDataProvider flakinessDataProvider;
     protected final PerformanceExecutionDataProvider executionDataProvider;
 
@@ -265,8 +268,9 @@ public abstract class AbstractTablePageGenerator extends HtmlPageGenerator<Resul
     private Optional<String> determineBaseline() {
         return executionDataProvider.getReportScenarios().stream()
             .filter(scenario -> !scenario.getCrossBuild())
+            .flatMap(scenario -> scenario.getHistoryExecutions().stream())
+            .filter(execution -> DEPENDENCY_PERFORMANCE_TEST_TEAM_CITY_BUILD_IDS.contains(execution.getTeamCityBuildId()))
             .findFirst()
-            .filter(scenario -> !scenario.getHistoryExecutions().isEmpty())
-            .map(scenario -> scenario.getHistoryExecutions().get(0).getBaseVersion().getName());
+            .map(execution -> execution.getBaseVersion().getName());
     }
 }


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle-private/issues/4047

The "baseline" version rendered to the performance test report is determined in the following way:

1. In the performance trigger build, collect build ids of all dependency builds (the individual performance tests).
2. Select performance test executions from performance database, `where teamcityBuildId in (the list of build ids) or branch=<current branch>`.
3. The "baseline version" is the baseline version of the latest executed performance test execution from step 2).

In [@6hundreds 's case](https://github.com/gradle/gradle-private/issues/4047), he triggered two performance tests with different baseline versions at the same time, one with `8.5-commit-28aca86a718`, another with `8.0.2-commit-7d6581558e2`).

Now the problem happens - the performance test trigger selected the executions that didn't belong to it (which is fine because we need to render a historical execution table). But when we determine the baseline versions, we should only use the baseline version from the executions from current build chain, i.e. the build in the dependency build ids from step 1).

This PR fixes the problem by filtering out the executions that are not in "dependency build id list" when determining baseline version.