### PR TITLE
Print more helpful error message when given bad version argument for wrapper upgrade

### DIFF
--- a/platforms/core-runtime/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperUpgradeIntegrationTest.groovy
+++ b/platforms/core-runtime/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperUpgradeIntegrationTest.groovy
@@ -40,9 +40,10 @@ class WrapperUpgradeIntegrationTest extends AbstractWrapperIntegrationSpec {
         and:
         failure.assertHasDescription("Invalid version specified for argument '--gradle-version'")
         failure.assertHasCause("'$badVersion' is not a valid Gradle version string (examples: '1.0', '1.0-rc-1')")
-        failure.assertHasResolution("Please specify a valid Gradle version or use one of the following available dynamic version specifications: 'latest', 'release-candidate', 'release-nightly', 'nightly'")
+        failure.assertHasResolution("Specify a valid Gradle release listed on https://gradle.org/releases/.")
+        failure.assertHasResolution("Use one of the following dynamic version specifications: 'latest', 'release-candidate', 'release-nightly', 'nightly'.")
 
         where:
-        badVersion << ["bad-version", "next", "new", "5.x", "x.3", "x+1", "8.5.x", "8.5.latest", "later", "prerelease", "nightly-release", "latest-release", "rc"]
+        badVersion << ["bad-version", "next", "new", "5.x", "x.3", "x+1", "8.5.x", "8.5.latest", "later", "prerelease", "nightly-release", "latest-release", "rc", "current"]
     }
 }

--- a/platforms/core-runtime/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperUpgradeIntegrationTest.groovy
+++ b/platforms/core-runtime/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperUpgradeIntegrationTest.groovy
@@ -29,4 +29,20 @@ class WrapperUpgradeIntegrationTest extends AbstractWrapperIntegrationSpec {
         expect:
         wrapperExecuter.withTasks('wrapper').run()
     }
+
+    def "prints helpful error message on invalid version argument format: #badVersion"() {
+        given:
+        prepareWrapper()
+
+        expect:
+        def failure = wrapperExecuter.withTasks("wrapper", "--gradle-version", badVersion).runWithFailure()
+
+        and:
+        failure.assertHasDescription("Invalid version specified for argument '--gradle-version'")
+        failure.assertHasCause("'$badVersion' is not a valid Gradle version string (examples: '1.0', '1.0-rc-1')")
+        failure.assertHasResolution("Please specify a valid Gradle version or use one of the following available dynamic version specifications: 'latest', 'release-candidate', 'release-nightly', 'nightly'")
+
+        where:
+        badVersion << ["bad-version", "next", "new", "5.x", "x.3", "x+1", "8.5.x", "8.5.latest", "later", "prerelease", "nightly-release", "latest-release", "rc"]
+    }
 }

--- a/platforms/software/build-init/src/main/java/org/gradle/api/tasks/wrapper/GradleVersionResolver.java
+++ b/platforms/software/build-init/src/main/java/org/gradle/api/tasks/wrapper/GradleVersionResolver.java
@@ -21,6 +21,7 @@ import com.google.gson.reflect.TypeToken;
 import org.gradle.api.GradleException;
 import org.gradle.api.resources.TextResource;
 import org.gradle.api.tasks.wrapper.internal.DefaultWrapperVersionsResources;
+import org.gradle.api.tasks.wrapper.internal.DefaultWrapperVersionsResources.WrapperVersionException;
 import org.gradle.util.GradleVersion;
 
 import java.lang.reflect.Type;
@@ -89,8 +90,13 @@ class GradleVersionResolver {
 
     void setGradleVersionString(String gradleVersionString) {
         if (!isPlaceHolder(gradleVersionString)) {
-            this.gradleVersion = GradleVersion.version(gradleVersionString);
+            try {
+                this.gradleVersion = GradleVersion.version(gradleVersionString);
+            } catch (Exception e) {
+                throw new WrapperVersionException("Invalid version specified for argument '--gradle-version'", e);
+            }
         }
+
         if (this.gradleVersionString != gradleVersionString) {
             this.gradleVersionString = gradleVersionString;
             this.gradleVersion = null;

--- a/platforms/software/build-init/src/main/java/org/gradle/api/tasks/wrapper/internal/DefaultWrapperVersionsResources.java
+++ b/platforms/software/build-init/src/main/java/org/gradle/api/tasks/wrapper/internal/DefaultWrapperVersionsResources.java
@@ -16,18 +16,23 @@
 
 package org.gradle.api.tasks.wrapper.internal;
 
+import org.gradle.api.GradleException;
 import org.gradle.api.resources.TextResource;
 import org.gradle.api.tasks.wrapper.WrapperVersionsResources;
+import org.gradle.internal.exceptions.ResolutionProvider;
 
+import javax.annotation.Nullable;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class DefaultWrapperVersionsResources implements WrapperVersionsResources {
     public static final String LATEST = "latest";
     public static final String NIGHTLY = "nightly";
     public static final String RELEASE_NIGHTLY = "release-nightly";
     public static final String RELEASE_CANDIDATE = "release-candidate";
-    public static final List<String> PLACE_HOLDERS = Arrays.asList(LATEST, NIGHTLY, RELEASE_NIGHTLY, RELEASE_CANDIDATE);
+    public static final List<String> PLACE_HOLDERS = Arrays.asList(LATEST, RELEASE_CANDIDATE, RELEASE_NIGHTLY, NIGHTLY); // order these from most to least stable
     private final TextResource latest;
     private final TextResource releaseCandidate;
     private final TextResource nightly;
@@ -57,4 +62,25 @@ public class DefaultWrapperVersionsResources implements WrapperVersionsResources
         return releaseNightly;
     }
 
+    /**
+     * This exception is thrown when the wrapper task is run in an attempt to update the wrapper version and
+     * an invalid version is specified.
+     */
+    public static final class WrapperVersionException extends GradleException implements ResolutionProvider {
+        public WrapperVersionException(String message) {
+            super(message);
+        }
+
+        public WrapperVersionException(String message, @Nullable Throwable cause) {
+            super(message, cause);
+        }
+
+        @Override
+        public List<String> getResolutions() {
+            String validStrings = DefaultWrapperVersionsResources.PLACE_HOLDERS.stream()
+                .map(s -> String.format("'%s'", s))
+                .collect(Collectors.joining(", "));
+            return Collections.singletonList("Please specify a valid Gradle version or use one of the following available dynamic version specifications: " + validStrings);
+        }
+    }
 }

--- a/platforms/software/build-init/src/main/java/org/gradle/api/tasks/wrapper/internal/DefaultWrapperVersionsResources.java
+++ b/platforms/software/build-init/src/main/java/org/gradle/api/tasks/wrapper/internal/DefaultWrapperVersionsResources.java
@@ -23,7 +23,6 @@ import org.gradle.internal.exceptions.ResolutionProvider;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -77,10 +76,18 @@ public class DefaultWrapperVersionsResources implements WrapperVersionsResources
 
         @Override
         public List<String> getResolutions() {
+            return Arrays.asList(suggestActualVersion(), suggestDynamicVersions());
+        }
+
+        private String suggestActualVersion() {
+            return "Specify a valid Gradle release listed on https://gradle.org/releases/.";
+        }
+
+        private String suggestDynamicVersions() {
             String validStrings = DefaultWrapperVersionsResources.PLACE_HOLDERS.stream()
                 .map(s -> String.format("'%s'", s))
                 .collect(Collectors.joining(", "));
-            return Collections.singletonList("Please specify a valid Gradle version or use one of the following available dynamic version specifications: " + validStrings);
+            return String.format("Use one of the following dynamic version specifications: %s.", validStrings);
         }
     }
 }


### PR DESCRIPTION
The previous message:
- Only said "X is not a valid Gradle version string", not where X was being used
- Didn't mention the new dynamic version specs

The new message:
- Says that the bad version in question is the one provided to the wrapper task
- Links to the releases page in a suggestion so you can find the latest version
- Suggests using the dynamic version specs and lists them
- Uses a new custom exception class rather than `IllegalArgumentException` (necessary to carry resolutions, but more specific and better in general)
- Helps when you keep trying "current" as your dynamic version spec, and forgetting it's not a thing

## New Message:

For `gradlew wrapper --gradle-version bad-version`:

```
FAILURE: Build failed with an exception.

* What went wrong:
Invalid version specified for argument '--gradle-version'
> 'bad-version' is not a valid Gradle version string (examples: '1.0', '1.0-rc-1')

* Try:
> Specify a valid Gradle release listed on https://gradle.org/releases/.
> Use one of the following dynamic version specifications: 'latest', 'release-candidate', 'release-nightly', 'nightly'.
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

BUILD FAILED in 2s
```