### PR TITLE
docs: Fix unclear and partly wrong description of task dependencies

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/reference/command_line_interface.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/command_line_interface.adoc
@@ -183,7 +183,7 @@ include::{snippetsPath}/tutorial/excludeTasks/tests/excludeTask.out[]
 .Simple Task Graph
 image::commandLineTutorialTasks.png[]
 
-You can see that the `test` task is not executed, even though it depends on the `dist` task. The `test` task's dependencies, such as `compileTest`, are not executed either. Those dependencies of `test` that another task requires, such as `compile`, are still executed.
+You can see that the `test` task is not executed, even though the `dist` task depends on it. The `test` task's dependencies, such as `compileTest`, are not executed either. Those dependencies of `test` that another task also depends upon, such as `compile`, are still executed.
 
 [[sec:rerun_tasks]]
 === Forcing tasks to execute

--- a/platforms/documentation/docs/src/docs/userguide/reference/command_line_interface.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/reference/command_line_interface.adoc
@@ -183,7 +183,8 @@ include::{snippetsPath}/tutorial/excludeTasks/tests/excludeTask.out[]
 .Simple Task Graph
 image::commandLineTutorialTasks.png[]
 
-You can see that the `test` task is not executed, even though the `dist` task depends on it. The `test` task's dependencies, such as `compileTest`, are not executed either. Those dependencies of `test` that another task also depends upon, such as `compile`, are still executed.
+You can see that the `test` task is not executed, even though it is a dependency of the `dist` task. The `test` task’s dependencies, such as `compileTest`, are not executed either. 
+The dependencies of `test` that other tasks depend on, such as `compile`, are still executed.
 
 [[sec:rerun_tasks]]
 === Forcing tasks to execute


### PR DESCRIPTION
Changes the text to describe dependencies shown in Figure 1 correctly. Also use consistent wording by using the word "depends" in the whole paragraph.

Fixes #27684

### Context
The text under Figure 1 in [this paragraph](https://docs.gradle.org/current/userguide/command_line_interface.html#sec:excluding_tasks_from_the_command_line) says: "You can see that the test task is not executed, even though it depends on the dist task.".
This sentence trips me up and I think it might be wrong. Following the arrows in the picture I would argue that it is the dist task that depends on the test task, not the other way around.

In addition, the last sentence of the paragraph says: "Those dependencies of test that another task requires, such as compile, are still executed."
This sentence uses the word "requires" instead of "depends" event though I think the meaning is the same as when the word "depends" is used in the first sentence. I think it is better to consistently use one word, in this case "depends".

The paragraph was a bit hard to read and understand due to these two problems pointed out above.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [N/A] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [N/A] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [N/A] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [N/A] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [N/A] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
