### PR TITLE
Downgrade DependencyCollector assertion to warning

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -213,6 +213,75 @@ dependencies {
 ==== Deprecated `ArtifactIdentifier`
 The `ArtifactIdentifier` class has been deprecated for removal in Gradle 9.0.
 
+[[dependency_mutate_dependency_collector_after_finalize]]
+==== Deprecate mutating `DependencyCollector` dependencies after observation
+
+Starting in Gradle 9.0, mutating dependencies sourced from a link:{javadocPath}/org/gradle/api/artifacts/dsl/DependencyCollector.html[DependencyCollector] after those dependencies have been observed will result in an error.
+The `DependencyCollector` interface is used to declare dependencies within the test suites DSL.
+
+Consider the following example where a test suite's dependency is mutated after it is observed:
+
+=====
+[.multi-language-sample]
+======
+.build.gradle.kts
+[source,kotlin]
+----
+plugins {
+    id("java-library")
+}
+
+testing.suites {
+    named<JvmTestSuite>("test") {
+        dependencies {
+            // Dependency is declared on a `DependencyCollector`
+            implementation("com:foo")
+        }
+    }
+}
+
+configurations.testImplementation {
+    // Calling `all` here realizes/observes all lazy sources, including the `DependencyCollector`
+    // from the test suite block. Operations like resolving a dependency similarly realize lazy sources.
+    dependencies.all {
+        if (this is ExternalDependency && group == "com" && name == "foo" && version == null) {
+            // Dependency is mutated after observation
+            version {
+                require("2.0")
+            }
+        }
+    }
+}
+----
+======
+=====
+
+In the above example, the build logic uses iteration and mutation to try to set a default version for a particular dependency if the version is not already set.
+Build logic like the above example makes it difficult to reason about declared dependencies, as reporting tools will display this dependency as if the user declared the version as "2.0", even though they never did.
+Instead, the build logic can avoid iteration and mutation by declaring a `preferred` version constraint on the dependency's coordinates.
+This allows the dependency management engine to use the version declared on the constraint if no other version is declared.
+
+Consider the following example that replaces the above iteration with an indiscriminate <<rich_versions.adoc#sec:preferred-version,preferred>> version constraint:
+
+=====
+[.multi-language-sample]
+======
+.build.gradle.kts
+[source,kotlin]
+----
+dependencies {
+    constraints {
+        testImplementation("com:foo") {
+            version {
+                prefer("2.0")
+            }
+        }
+    }
+}
+----
+======
+=====
+
 [[changes_8.5]]
 == Upgrading from 8.4 and earlier
 

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -242,7 +242,7 @@ testing.suites {
 
 configurations.testImplementation {
     // Calling `all` here realizes/observes all lazy sources, including the `DependencyCollector`
-    // from the test suite block. Operations like resolving a dependency similarly realize lazy sources.
+    // from the test suite block. Operations like resolving a configuration similarly realize lazy sources.
     dependencies.all {
         if (this is ExternalDependency && group == "com" && name == "foo" && version == null) {
             // Dependency is mutated after observation
@@ -257,7 +257,7 @@ configurations.testImplementation {
 =====
 
 In the above example, the build logic uses iteration and mutation to try to set a default version for a particular dependency if the version is not already set.
-Build logic like the above example makes it difficult to reason about declared dependencies, as reporting tools will display this dependency as if the user declared the version as "2.0", even though they never did.
+Build logic like the above example creates challenges in resolving declared dependencies, as reporting tools will display this dependency as if the user declared the version as "2.0", even though they never did.
 Instead, the build logic can avoid iteration and mutation by declaring a `preferred` version constraint on the dependency's coordinates.
 This allows the dependency management engine to use the version declared on the constraint if no other version is declared.
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyCollector.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyCollector.java
@@ -30,6 +30,7 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderConvertible;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.Nested;
+import org.gradle.internal.deprecation.DeprecationLogger;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -64,8 +65,10 @@ public abstract class DefaultDependencyCollector implements DependencyCollector 
         if (mutable instanceof AbstractModuleDependency) {
             ((AbstractModuleDependency) mutable).addMutationValidator(validator -> {
                 if (((PropertyInternal<?>) getDependencies()).isFinalized()) {
-                    throw new InvalidUserCodeException(
-                        "Cannot mutate '" + mutable + "' after it has been finalized.");
+                    DeprecationLogger.deprecateAction("Mutating dependency " + mutable + " after it has been finalized")
+                        .willBecomeAnErrorInGradle9()
+                        .withUpgradeGuideSection(8, "dependency_mutate_dependency_collector_after_finalize")
+                        .nagUser();
                 }
             });
         }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultDomainObjectCollectionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultDomainObjectCollectionTest.groovy
@@ -16,12 +16,14 @@
 
 package org.gradle.api.internal
 
+import groovy.test.NotYetImplemented
 import org.gradle.api.Action
 import org.gradle.api.internal.collections.IterationOrderRetainingSetElementSource
 import org.gradle.api.internal.provider.ProviderInternal
 import org.gradle.api.internal.provider.ValueSupplier
 import org.gradle.api.specs.Spec
 import org.gradle.internal.code.UserCodeSource
+import org.gradle.util.TestUtil
 
 import static org.gradle.util.internal.WrapUtil.toList
 
@@ -422,5 +424,55 @@ class DefaultDomainObjectCollectionTest extends AbstractDomainObjectCollectionSp
     def canRemoveNonExistentObject() {
         expect:
         !container.remove("a")
+    }
+
+    def "withType works with addLater"() {
+        given:
+        def value = Mock(Subtype)
+
+        when:
+        container.addLater(TestUtil.providerFactory().provider { value })
+        def result = collect(container.withType(Subtype))
+
+        then:
+        result == [value]
+    }
+
+    @NotYetImplemented
+    def "withType works with addAllLater"() {
+        given:
+        def value = Mock(Subtype)
+
+        when:
+        container.addAllLater(TestUtil.providerFactory().provider { [value] })
+        def result = collect(container.withType(Subtype))
+
+        then:
+        result == [value]
+    }
+
+    @NotYetImplemented
+    def "withType works for addAllLater and list property"() {
+        def value = Mock(Subtype)
+        def property = TestUtil.objectFactory().listProperty(CharSequence)
+        property.add(value)
+
+        when:
+        container.addAllLater(property)
+        def result = collect(container.withType(Subtype))
+
+        then:
+        result == [value]
+    }
+
+    interface Subtype extends CharSequence {}
+
+    static <T> Collection<T> collect(Iterable<T> iterable) {
+        def result = []
+        Iterator it = iterable.iterator()
+        while (it.hasNext()) {
+            result.add(it.next())
+        }
+        result
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultDomainObjectSetTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultDomainObjectSetTest.groovy
@@ -15,7 +15,9 @@
  */
 package org.gradle.api.internal
 
+import groovy.test.NotYetImplemented
 import org.gradle.api.Action
+import org.gradle.util.TestUtil
 
 import static org.gradle.util.internal.WrapUtil.toList
 
@@ -192,4 +194,55 @@ class DefaultDomainObjectSetTest extends AbstractDomainObjectCollectionSpec<Char
         1 * action.execute(null)
         0 * _
     }
+
+    def "withType works with addLater"() {
+        given:
+        def value = Mock(Subtype)
+
+        when:
+        container.addLater(TestUtil.providerFactory().provider { value })
+        def result = collect(container.withType(Subtype))
+
+        then:
+        result == [value]
+    }
+
+    @NotYetImplemented
+    def "withType works with addAllLater for list"() {
+        given:
+        def value = Mock(Subtype)
+
+        when:
+        container.addAllLater(TestUtil.providerFactory().provider { [value] })
+        def result = collect(container.withType(Subtype))
+
+        then:
+        result == [value]
+    }
+
+    @NotYetImplemented
+    def "withType works for addAllLater and set property"() {
+        def value = Mock(Subtype)
+        def property = TestUtil.objectFactory().setProperty(CharSequence)
+        property.add(value)
+
+        when:
+        container.addAllLater(property)
+        def result = collect(container.withType(Subtype))
+
+        then:
+        result == [value]
+    }
+
+    interface Subtype extends CharSequence {}
+
+    static <T> Collection<T> collect(Iterable<T> iterable) {
+        def result = []
+        Iterator it = iterable.iterator()
+        while (it.hasNext()) {
+            result.add(it.next())
+        }
+        result
+    }
+
 }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.smoketests
 
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.versions.KotlinGradlePluginVersions
+import org.gradle.util.GradleVersion
 import org.gradle.util.internal.VersionNumber
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
@@ -80,6 +81,65 @@ class KotlinPluginSmokeTest extends AbstractKotlinPluginSmokeTest {
             TestedVersions.kotlin.versions,
             ParallelTasksInProject.values()
         ].combinations()
+    }
+
+    def 'kotlin jvm and test suites (kotlin=#version)'() {
+
+        assumeFalse(version.startsWith("1.6."))
+        assumeFalse(version.startsWith("1.7."))
+        KotlinGradlePluginVersions.assumeCurrentJavaVersionIsSupportedBy(version)
+
+        given:
+        buildFile << """
+            plugins {
+                id 'org.jetbrains.kotlin.jvm' version '$version'
+            }
+
+            ${mavenCentralRepository()}
+
+            testing.suites.test {
+                useKotlinTest()
+            }
+
+            testing.suites.create("integTest", JvmTestSuite) {
+                targets.named("integTest") {
+                    testTask.configure {
+                        useJUnitPlatform()
+                    }
+                }
+                dependencies {
+                    implementation("org.junit.platform:junit-platform-launcher")
+                    // Version must be empty here to test for emitted deprecation
+                    implementation("org.jetbrains.kotlin:kotlin-test-junit5")
+                }
+            }
+        """
+
+        ["test", "integTest"].each {
+            file("src/$it/kotlin/MyTest.kt") << """
+                class MyTest {
+                    @kotlin.test.Test
+                    fun testSum() {
+                        assert(2 + 2 == 4)
+                    }
+                }
+            """
+        }
+
+        def versionNumber = VersionNumber.parse(version)
+
+        when:
+        def result = runner(ParallelTasksInProject.FALSE, versionNumber, 'test', 'integTest')
+            .deprecations(KotlinDeprecations) {
+                runner.expectLegacyDeprecationWarning("Mutating dependency DefaultExternalModuleDependency{group='org.jetbrains.kotlin', name='kotlin-test-junit5', version='null', configuration='default'} after it has been finalized has been deprecated. This will fail with an error in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#dependency_mutate_dependency_collector_after_finalize")
+            }.build()
+
+        then:
+        result.task(':test').outcome == SUCCESS
+        result.task(':integTest').outcome == SUCCESS
+
+        where:
+        version << TestedVersions.kotlin.versions
     }
 
     def 'kotlin javascript (kotlin=#version, workers=#parallelTasksInProject)'() {


### PR DESCRIPTION
A recent assertion added to DependencyCollector is being hit by Kotlin projects. Even though this is an incubating feature, we have decided to downgrade this to a warning due to how easy it is to reproduce. This will become a warning in Gradle 9.0

Along the way, a bug was discovered relating to addAllLater and withType. Tests have been added to reproduce this bug and have been annotated with @NotYetImplemented.

Finally, smoke tests have been added to verify Kotlin JVM and Test Suites work together.

Fixes #27679

Wrote up: https://github.com/gradle/gradle/issues/27717

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
