### PR TITLE
Remove update from public API of 8.6

### DIFF
--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/collections/DefaultConfigurableFileCollection.java
@@ -331,7 +331,6 @@ public class DefaultConfigurableFileCollection extends CompositeFileCollection i
         return result;
     }
 
-    @Override
     public void update(Transformer<? extends @org.jetbrains.annotations.Nullable FileCollection, ? super FileCollection> transform) {
         FileCollection newValue = transform.transform(shallowCopy());
         if (newValue != null) {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
@@ -241,7 +241,6 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, Defaul
         return new KeySetProvider();
     }
 
-    @Override
     public void update(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends Map<? extends K, ? extends V>>, ? super Provider<Map<K, V>>> transform) {
         Provider<? extends Map<? extends K, ? extends V>> newValue = transform.transform(shallowCopy());
         if (newValue != null) {

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
@@ -142,7 +142,6 @@ public class DefaultProperty<T> extends AbstractProperty<T, AbstractMinimalProvi
         return String.format("property(%s, %s)", type.getName(), getSupplier());
     }
 
-    @Override
     public void update(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends T>, ? super Provider<T>> transform) {
         Provider<? extends T> newValue = transform.transform(shallowCopy());
         if (newValue != null) {

--- a/platforms/documentation/docs/src/docs/release/notes.md
+++ b/platforms/documentation/docs/src/docs/release/notes.md
@@ -172,35 +172,6 @@ dependencies {
 project.version = "1.0.0"
 ```
 
-<a name="update-api"></a>
-#### New `update()` API allows safe self-referencing lazy properties
-
-[Lazy configuration](userguide/lazy_configuration.html) delays calculating a property’s value until it is required for the build.
-This can lead to accidental recursions when assigning property values of an object to itself:
-
-```
-var property = objects.property<String>()
-property.set("some value")
-property.set(property.map { "$it and more" })
-
-// Circular evaluation detected (or StackOverflowError, before 8.6)
-println(property.get()) // "some value and more"
-```
-
-Previously, Gradle did not support circular references when evaluating lazy properties.
-
-[`Property`](javadoc/org/gradle/api/provider/Property.html#update-org.gradle.api.Transformer-) and [`ConfigurableFileCollection`](javadoc/org/gradle/api/file/ConfigurableFileCollection.html#update-org.gradle.api.Transformer-) now provide their respective `update(Transformer<...>)` methods which allow self-referencing updates safely:
-
-```
-var property = objects.property<String>()
-property.set("some value")
-property.update { it.map { "$it and more" } }
-
-println(property.get()) // "some value and more"
-```
-
-Refer to the javadoc for [`Property.update(Transformer<>)`](javadoc/org/gradle/api/provider/Property.html#update-org.gradle.api.Transformer-) and [`ConfigurableFileCollection.update(Transformer<>)`](javadoc/org/gradle/api/file/ConfigurableFileCollection.html#update-org.gradle.api.Transformer-) for more details, including limitations.
-
 <a name="error-improvements"></a>
 ### Error and warning reporting improvements
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/ConfigurableFileCollection.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/ConfigurableFileCollection.java
@@ -15,10 +15,7 @@
  */
 package org.gradle.api.file;
 
-import groovy.lang.Closure;
-import org.gradle.api.Incubating;
 import org.gradle.api.SupportsKotlinAssignmentOverloading;
-import org.gradle.api.Transformer;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.HasConfigurableValue;
 
@@ -84,43 +81,4 @@ public interface ConfigurableFileCollection extends FileCollection, HasConfigura
      * @return this
      */
     ConfigurableFileCollection builtBy(Object... tasks);
-
-    /**
-     * Applies an eager transformation to the current contents of this file collection, without explicitly resolving it.
-     * The provided transformer is applied to the file collection representing the current contents, and the returned collection is used as a new content.
-     * The current contents collection can be used to derive the new value, but doesn't have to.
-     * Returning null from the transformer empties this collection.
-     * For example, it is possible to filter out all text files from the collection:
-     * <pre class='autoTested'>
-     *     def collection = files("a.txt", "b.md")
-     *
-     *     collection.update { it.filter { f -&gt; !f.name.endsWith(".txt") } }
-     *
-     *     println(collection.files) // ["b.md"]
-     * </pre>
-     * <p>
-     * <b>Further changes to this file collection, such as calls to {@link #setFrom(Object...)} or {@link #from(Object...)}, are not transformed, and override the update instead</b>.
-     * Because of this, this method inherently depends on the order of changes, and therefore must be used sparingly.
-     * <p>
-     * If this file collection consists of other mutable sources, then the current contents collection tracks the changes to these sources.
-     * For example, changes to the upstream collection are visible:
-     * <pre class='autoTested'>
-     *     def upstream = files("a.txt", "b.md")
-     *     def collection = files(upstream)
-     *
-     *     collection.update { it.filter { f -&gt; !f.name.endsWith(".txt") } }
-     *     upstream.from("c.md", "d.txt")
-     *
-     *     println(collection.files) // ["b.md", "c.md"]
-     * </pre>
-     * The provided transformation runs <b>eagerly</b>, so it can capture any objects without introducing memory leaks and without breaking configuration caching.
-     * However, transformations applied to the current contents collection (like {@link FileCollection#filter(Closure)}) are subject to the usual constraints.
-     * <p>
-     * The current contents collection inherits dependencies of this collection specified by {@link #builtBy(Object...)}.
-     *
-     * @param transform the transformation to apply to the current value. May return null, which empties this collection.
-     * @since 8.6
-     */
-    @Incubating
-    void update(Transformer<? extends @org.jetbrains.annotations.Nullable FileCollection, ? super FileCollection> transform);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ListProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ListProperty.java
@@ -16,9 +16,6 @@
 
 package org.gradle.api.provider;
 
-import org.gradle.api.Incubating;
-import org.gradle.api.Transformer;
-
 import javax.annotation.Nullable;
 import java.util.List;
 
@@ -64,47 +61,4 @@ public interface ListProperty<T> extends Provider<List<T>>, HasMultipleValues<T>
      */
     @Override
     ListProperty<T> convention(Provider<? extends Iterable<? extends T>> provider);
-
-    /**
-     * Applies an eager transformation to the current value of the property "in place", without explicitly obtaining it.
-     * The provided transformer is applied to the provider of the current value, and the returned provider is used as a new value.
-     * The provider of the value can be used to derive the new value, but doesn't have to.
-     * Returning null from the transformer unsets the property.
-     * For example, the current value of a string list property can be reversed:
-     * <pre class='autoTested'>
-     *     def property = objects.listProperty(String).value(["a", "b"])
-     *
-     *     property.update { it.map { value -&gt; value.reverse() } }
-     *
-     *     println(property.get()) // ["b", "a"]
-     * </pre>
-     * Note that simply writing {@code property.set(property.map { ... } } doesn't work and will cause an exception because of a circular reference evaluation at runtime.
-     * <p>
-     * <b>Further changes to the value of the property, such as calls to {@link #set(Iterable)}, are not transformed, and override the update instead</b>.
-     * Because of this, this method inherently depends on the order of property changes, and therefore must be used sparingly.
-     * <p>
-     * If the value of the property is specified via a provider, then the current value provider tracks that provider.
-     * For example, changes to the upstream property are visible:
-     * <pre class='autoTested'>
-     *     def upstream = objects.listProperty(String).value(["a", "b"])
-     *     def property = objects.listProperty(String).value(upstream)
-     *
-     *     property.update { it.map { value -&gt; value.reverse() } }
-     *     upstream.set(["c", "d"])
-     *
-     *     println(property.get()) // ["d", "c"]
-     * </pre>
-     * The provided transformation runs <b>eagerly</b>, so it can capture any objects without introducing memory leaks and without breaking configuration caching.
-     * However, transformations applied to the current value provider (like {@link Provider#map(Transformer)}) are subject to the usual constraints.
-     * <p>
-     * If the property has no explicit value set, then the current value comes from the convention.
-     * Changes to convention of this property do not affect the current value provider in this case, though upstream changes are still visible if the convention was set to a provider.
-     * If there is no convention too, then the current value is a provider without a value.
-     * The updated value becomes the explicit value of the property.
-     *
-     * @param transform the transformation to apply to the current value. May return null, which unsets the property.
-     * @since 8.6
-     */
-    @Incubating
-    void update(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends Iterable<? extends T>>, ? super Provider<List<T>>> transform);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/MapProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/MapProperty.java
@@ -16,9 +16,7 @@
 
 package org.gradle.api.provider;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.SupportsKotlinAssignmentOverloading;
-import org.gradle.api.Transformer;
 
 import javax.annotation.Nullable;
 import java.util.Map;
@@ -180,49 +178,6 @@ public interface MapProperty<K, V> extends Provider<Map<K, V>>, HasConfigurableV
      * @return this
      */
     MapProperty<K, V> convention(Provider<? extends Map<? extends K, ? extends V>> valueProvider);
-
-    /**
-     * Applies an eager transformation to the current value of the property "in place", without explicitly obtaining it.
-     * The provided transformer is applied to the provider of the current value, and the returned provider is used as a new value.
-     * The provider of the value can be used to derive the new value, but doesn't have to.
-     * Returning null from the transformer unsets the property.
-     * For example, the current value of a string map property can be filtered to retain only vowel keys:
-     * <pre class='autoTested'>
-     *     def property = objects.mapProperty(String, String).value(a: "a", b: "b")
-     *
-     *     property.update { it.map { value -&gt; value.subMap("a", "e", "i", "o", "u") } }
-     *
-     *     println(property.get()) // [a: "a"]
-     * </pre>
-     * Note that simply writing {@code property.set(property.map { ... } } doesn't work and will cause an exception because of a circular reference evaluation at runtime.
-     * <p>
-     * <b>Further changes to the value of the property, such as calls to {@link #set(Map)}, are not transformed, and override the update instead</b>.
-     * Because of this, this method inherently depends on the order of property changes, and therefore must be used sparingly.
-     * <p>
-     * If the value of the property is specified via a provider, then the current value provider tracks that provider.
-     * For example, changes to the upstream property are visible:
-     * <pre class='autoTested'>
-     *     def upstream = objects.mapProperty(String, String).value(a: "a", b: "b")
-     *     def property = objects.mapProperty(String, String).value(upstream)
-     *
-     *     property.update { it.map { value -&gt; value.subMap("a", "e", "i", "o", "u") } }
-     *     upstream.value(e: "e", f: "f")
-     *
-     *     println(property.get()) // [e: "e"]
-     * </pre>
-     * The provided transformation runs <b>eagerly</b>, so it can capture any objects without introducing memory leaks and without breaking configuration caching.
-     * However, transformations applied to the current value provider (like {@link Provider#map(Transformer)}) are subject to the usual constraints.
-     * <p>
-     * If the property has no explicit value set, then the current value comes from the convention.
-     * Changes to convention of this property do not affect the current value provider in this case, though upstream changes are still visible if the convention was set to a provider.
-     * If there is no convention too, then the current value is a provider without a value.
-     * The updated value becomes the explicit value of the property.
-
-     * @param transform the transformation to apply to the current value. May return null, which unsets the property.
-     * @since 8.6
-     */
-    @Incubating
-    void update(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends Map<? extends K, ? extends V>>, ? super Provider<Map<K, V>>> transform);
 
     /**
      * Disallows further changes to the value of this property. Calls to methods that change the value of this property, such as {@link #set(Map)} or {@link #put(Object, Object)} will fail.

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/Property.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/Property.java
@@ -16,9 +16,7 @@
 
 package org.gradle.api.provider;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.SupportsKotlinAssignmentOverloading;
-import org.gradle.api.Transformer;
 import org.gradle.api.model.ObjectFactory;
 
 import javax.annotation.Nullable;
@@ -180,47 +178,4 @@ public interface Property<T> extends Provider<T>, HasConfigurableValue {
      */
     @Override
     void finalizeValue();
-
-    /**
-     * Applies an eager transformation to the current value of the property "in place", without explicitly obtaining it.
-     * The provided transformer is applied to the provider of the current value, and the returned provider is used as a new value.
-     * The provider of the value can be used to derive the new value, but doesn't have to.
-     * Returning null from the transformer unsets the property.
-     * For example, the current value of a string property can be reversed:
-     * <pre class='autoTested'>
-     *     def property = objects.property(String).value("value")
-     *
-     *     property.update { it.map { value -&gt; value.reverse() } }
-     *
-     *     println(property.get()) // "eulav"
-     * </pre>
-     * Note that simply writing {@code property.set(property.map { ... } } doesn't work and will cause an exception because of a circular reference evaluation at runtime.
-     * <p>
-     * <b>Further changes to the value of the property, such as calls to {@link #set(Object)}, are not transformed, and override the update instead</b>.
-     * Because of this, this method inherently depends on the order of property changes, and therefore must be used sparingly.
-     * <p>
-     * If the value of the property is specified via a provider, then the current value provider tracks that provider.
-     * For example, changes to the upstream property are visible:
-     * <pre class='autoTested'>
-     *     def upstream = objects.property(String).value("value")
-     *     def property = objects.property(String).value(upstream)
-     *
-     *     property.update { it.map { value -&gt; value.reverse() } }
-     *     upstream.set("other")
-     *
-     *     println(property.get()) // "rehto"
-     * </pre>
-     * The provided transformation runs <b>eagerly</b>, so it can capture any objects without introducing memory leaks and without breaking configuration caching.
-     * However, transformations applied to the current value provider (like {@link Provider#map(Transformer)}) are subject to the usual constraints.
-     * <p>
-     * If the property has no explicit value set, then the current value comes from the convention.
-     * Changes to convention of this property do not affect the current value provider in this case, though upstream changes are still visible if the convention was set to a provider.
-     * If there is no convention too, then the current value is a provider without a value.
-     * The updated value becomes the explicit value of the property.
-     *
-     * @param transform the transformation to apply to the current value. May return null, which unsets the property.
-     * @since 8.6
-     */
-    @Incubating
-    void update(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends T>, ? super Provider<T>> transform);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/SetProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/SetProperty.java
@@ -16,9 +16,6 @@
 
 package org.gradle.api.provider;
 
-import org.gradle.api.Incubating;
-import org.gradle.api.Transformer;
-
 import javax.annotation.Nullable;
 import java.util.Set;
 
@@ -64,48 +61,4 @@ public interface SetProperty<T> extends Provider<Set<T>>, HasMultipleValues<T> {
      */
     @Override
     SetProperty<T> convention(Provider<? extends Iterable<? extends T>> provider);
-
-    /**
-     * Applies an eager transformation to the current value of the property "in place", without explicitly obtaining it.
-     * The provided transformer is applied to the provider of the current value, and the returned provider is used as a new value.
-     * The provider of the value can be used to derive the new value, but doesn't have to.
-     * Returning null from the transformer unsets the property.
-     * For example, the current value of a string set property can be filtered to exclude vowels:
-     * <pre class='autoTested'>
-     *     def property = objects.setProperty(String).value(["a", "b"])
-     *
-     *     property.update { it.map { value -&gt; value - ["a", "e", "i", "o", "u"] } }
-     *
-     *     println(property.get()) // ["b"]
-     * </pre>
-     * <p>
-     * Note that simply writing {@code property.set(property.map { ... } } doesn't work and will cause an exception because of a circular reference evaluation at runtime.
-     * <p>
-     * <b>Further changes to the value of the property, such as calls to {@link #set(Iterable)}, are not transformed, and override the update instead</b>.
-     * Because of this, this method inherently depends on the order of property changes, and therefore must be used sparingly.
-     * <p>
-     * If the value of the property is specified via a provider, then the current value provider tracks that provider.
-     * For example, changes to the upstream property are visible:
-     * <pre class='autoTested'>
-     *     def upstream = objects.setProperty(String).value(["a", "b"])
-     *     def property = objects.setProperty(String).value(upstream)
-     *
-     *     property.update { it.map { value -&gt; value - ["a", "e", "i", "o", "u"] } }
-     *     upstream.set(["e", "f"])
-     *
-     *     println(property.get()) // ["f"]
-     * </pre>
-     * The provided transformation runs <b>eagerly</b>, so it can capture any objects without introducing memory leaks and without breaking configuration caching.
-     * However, transformations applied to the current value provider (like {@link Provider#map(Transformer)}) are subject to the usual constraints.
-     * <p>
-     * If the property has no explicit value set, then the current value comes from the convention.
-     * Changes to convention of this property do not affect the current value provider in this case, though upstream changes are still visible if the convention was set to a provider.
-     * If there is no convention too, then the current value is a provider without a value.
-     * The updated value becomes the explicit value of the property.
-
-     * @param transform the transformation to apply to the current value. May return null, which unsets the property.
-     * @since 8.6
-     */
-    @Incubating
-    void update(Transformer<? extends @org.jetbrains.annotations.Nullable Provider<? extends Iterable<? extends T>>, ? super Provider<Set<T>>> transform);
 }


### PR DESCRIPTION
Fixes #27722 

### Context

The API is going to change in 8.7 in an incompatible way to play better with other features of that release.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
