### PR TITLE
Always calculate the cache key

### DIFF
--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/steps/ResolveCachingStateStep.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/steps/ResolveCachingStateStep.java
@@ -42,25 +42,20 @@ public class ResolveCachingStateStep<C extends ValidationFinishedContext> implem
     private static final CachingState VALIDATION_FAILED_STATE = CachingState.disabledWithoutInputs(VALIDATION_FAILED_REASON);
 
     private final BuildCacheController buildCache;
-    private final boolean buildScansEnabled;
     private final Step<? super CachingContext, ? extends UpToDateResult> delegate;
 
     public ResolveCachingStateStep(
         BuildCacheController buildCache,
-        boolean buildScansEnabled,
         Step<? super CachingContext, ? extends UpToDateResult> delegate
     ) {
         this.buildCache = buildCache;
-        this.buildScansEnabled = buildScansEnabled;
         this.delegate = delegate;
     }
 
     @Override
     public CachingResult execute(UnitOfWork work, C context) {
         CachingState cachingState;
-        if (!buildCache.isEnabled() && !buildScansEnabled) {
-            cachingState = BUILD_CACHE_DISABLED_STATE;
-        } else if (!context.getValidationProblems().isEmpty()) {
+        if (!context.getValidationProblems().isEmpty()) {
             cachingState = VALIDATION_FAILED_STATE;
         } else {
             cachingState = context.getBeforeExecutionState()

--- a/platforms/core-execution/execution/src/test/groovy/org/gradle/internal/execution/steps/ResolveCachingStateStepTest.groovy
+++ b/platforms/core-execution/execution/src/test/groovy/org/gradle/internal/execution/steps/ResolveCachingStateStepTest.groovy
@@ -27,7 +27,7 @@ import java.time.Duration
 class ResolveCachingStateStepTest extends StepSpec<ValidationFinishedContext> {
 
     def buildCache = Mock(BuildCacheController)
-    def step = new ResolveCachingStateStep(buildCache, true, delegate)
+    def step = new ResolveCachingStateStep(buildCache, delegate)
     def delegateResult = Stub(UpToDateResult)
 
     def setup() {

--- a/platforms/core-execution/execution/src/testFixtures/groovy/org/gradle/internal/execution/TestExecutionEngineFactory.java
+++ b/platforms/core-execution/execution/src/testFixtures/groovy/org/gradle/internal/execution/TestExecutionEngineFactory.java
@@ -70,7 +70,7 @@ public class TestExecutionEngineFactory {
             new LoadPreviousExecutionStateStep<>(
             new CaptureIncrementalStateBeforeExecutionStep<>(buildOperationExecutor, classloaderHierarchyHasher, outputSnapshotter, overlappingOutputDetector,
             new ValidateStep<>(virtualFileSystem, validationWarningReporter,
-            new ResolveCachingStateStep<>(buildCacheController, false,
+            new ResolveCachingStateStep<>(buildCacheController,
             new ResolveChangesStep<>(changeDetector,
             new SkipUpToDateStep<>(
             new StoreExecutionStateStep<>(

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsOperationIntegrationTest.groovy
@@ -84,13 +84,13 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
         result.outputPropertyNames == ['outputFile1', 'outputFile2']
     }
 
-    def "task output caching key is not exposed by default"() {
+    def "task output caching key is exposed by default"() {
         when:
         buildFile << customTaskCode('foo', 'bar')
         succeeds('customTask')
 
         then:
-        !operations.hasOperation(SnapshotTaskInputsBuildOperationType)
+        operations.hasOperation(SnapshotTaskInputsBuildOperationType)
     }
 
     def "handles task with no outputs"() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
@@ -57,9 +57,6 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
         APPLIED, NOT_APPLIED
     }
 
-    private final BuildCacheState buildCacheState;
-    private final ScanPluginState scanPluginState;
-
     private final ExecutionHistoryStore executionHistoryStore;
     private final BuildOperationExecutor buildOperationExecutor;
     private final AsyncWorkTracker asyncWorkTracker;
@@ -75,9 +72,6 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
     private final PathToFileResolver fileResolver;
 
     public ExecuteActionsTaskExecuter(
-        BuildCacheState buildCacheState,
-        ScanPluginState scanPluginState,
-
         ExecutionHistoryStore executionHistoryStore,
         BuildOperationExecutor buildOperationExecutor,
         AsyncWorkTracker asyncWorkTracker,
@@ -92,9 +86,6 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
         TaskDependencyFactory taskDependencyFactory,
         PathToFileResolver fileResolver
     ) {
-        this.buildCacheState = buildCacheState;
-        this.scanPluginState = scanPluginState;
-
         this.executionHistoryStore = executionHistoryStore;
         this.buildOperationExecutor = buildOperationExecutor;
         this.asyncWorkTracker = asyncWorkTracker;
@@ -112,11 +103,9 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
 
     @Override
     public TaskExecuterResult execute(TaskInternal task, TaskStateInternal state, TaskExecutionContext context) {
-        boolean emitLegacySnapshottingOperations = buildCacheState == BuildCacheState.ENABLED || scanPluginState == ScanPluginState.APPLIED;
         TaskExecution work = new TaskExecution(
             task,
             context,
-            emitLegacySnapshottingOperations,
             actionListener,
             asyncWorkTracker,
             buildOperationExecutor,

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
@@ -49,13 +49,6 @@ import static org.gradle.internal.execution.ExecutionEngine.ExecutionOutcome.EXE
  */
 @SuppressWarnings("deprecation")
 public class ExecuteActionsTaskExecuter implements TaskExecuter {
-    public enum BuildCacheState {
-        ENABLED, DISABLED
-    }
-
-    public enum ScanPluginState {
-        APPLIED, NOT_APPLIED
-    }
 
     private final ExecutionHistoryStore executionHistoryStore;
     private final BuildOperationExecutor buildOperationExecutor;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecution.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecution.java
@@ -98,7 +98,6 @@ public class TaskExecution implements MutableUnitOfWork {
 
     private final TaskInternal task;
     private final TaskExecutionContext context;
-    private final boolean emitLegacySnapshottingOperations;
 
     private final org.gradle.api.execution.TaskActionListener actionListener;
     private final AsyncWorkTracker asyncWorkTracker;
@@ -116,7 +115,6 @@ public class TaskExecution implements MutableUnitOfWork {
     public TaskExecution(
         TaskInternal task,
         TaskExecutionContext context,
-        boolean emitLegacySnapshottingOperations,
 
         org.gradle.api.execution.TaskActionListener actionListener,
         AsyncWorkTracker asyncWorkTracker,
@@ -133,7 +131,6 @@ public class TaskExecution implements MutableUnitOfWork {
     ) {
         this.task = task;
         this.context = context;
-        this.emitLegacySnapshottingOperations = emitLegacySnapshottingOperations;
 
         this.actionListener = actionListener;
         this.asyncWorkTracker = asyncWorkTracker;
@@ -439,13 +436,11 @@ public class TaskExecution implements MutableUnitOfWork {
     public void markLegacySnapshottingInputsStarted() {
         // Note: this operation should be added only if the scan plugin is applied, but SnapshotTaskInputsOperationIntegrationTest
         //   expects it to be added also when the build cache is enabled (but not the scan plugin)
-        if (emitLegacySnapshottingOperations) {
-            BuildOperationContext operationContext = buildOperationExecutor.start(BuildOperationDescriptor
-                .displayName("Snapshot task inputs for " + task.getIdentityPath())
-                .name("Snapshot task inputs")
-                .details(SNAPSHOT_TASK_INPUTS_DETAILS));
-            context.setSnapshotTaskInputsBuildOperationContext(operationContext);
-        }
+        BuildOperationContext operationContext = buildOperationExecutor.start(BuildOperationDescriptor
+            .displayName("Snapshot task inputs for " + task.getIdentityPath())
+            .name("Snapshot task inputs")
+            .details(SNAPSHOT_TASK_INPUTS_DETAILS));
+        context.setSnapshotTaskInputsBuildOperationContext(operationContext);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/execution/ProjectExecutionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/ProjectExecutionServices.java
@@ -39,7 +39,6 @@ import org.gradle.execution.plan.ExecutionNodeAccessHierarchies;
 import org.gradle.execution.plan.MissingTaskDependencyDetector;
 import org.gradle.execution.taskgraph.TaskExecutionGraphInternal;
 import org.gradle.execution.taskgraph.TaskListenerInternal;
-import org.gradle.internal.enterprise.core.GradleEnterprisePluginManager;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.execution.ExecutionEngine;
 import org.gradle.internal.execution.FileCollectionFingerprinterRegistry;
@@ -88,7 +87,6 @@ public class ProjectExecutionServices extends DefaultServiceRegistry {
     TaskExecuter createTaskExecuter(
         AsyncWorkTracker asyncWorkTracker,
         BuildOperationExecutor buildOperationExecutor,
-        GradleEnterprisePluginManager gradleEnterprisePluginManager,
         ClassLoaderHierarchyHasher classLoaderHierarchyHasher,
         ExecutionHistoryStore executionHistoryStore,
         FileCollectionFactory fileCollectionFactory,

--- a/subprojects/core/src/main/java/org/gradle/execution/ProjectExecutionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/ProjectExecutionServices.java
@@ -35,7 +35,6 @@ import org.gradle.api.internal.tasks.execution.ResolveTaskExecutionModeExecuter;
 import org.gradle.api.internal.tasks.execution.SkipOnlyIfTaskExecuter;
 import org.gradle.api.internal.tasks.execution.SkipTaskWithNoActionsExecuter;
 import org.gradle.api.internal.tasks.execution.TaskCacheabilityResolver;
-import org.gradle.caching.internal.controller.BuildCacheController;
 import org.gradle.execution.plan.ExecutionNodeAccessHierarchies;
 import org.gradle.execution.plan.MissingTaskDependencyDetector;
 import org.gradle.execution.taskgraph.TaskExecutionGraphInternal;
@@ -88,7 +87,6 @@ public class ProjectExecutionServices extends DefaultServiceRegistry {
 
     TaskExecuter createTaskExecuter(
         AsyncWorkTracker asyncWorkTracker,
-        BuildCacheController buildCacheController,
         BuildOperationExecutor buildOperationExecutor,
         GradleEnterprisePluginManager gradleEnterprisePluginManager,
         ClassLoaderHierarchyHasher classLoaderHierarchyHasher,
@@ -108,12 +106,6 @@ public class ProjectExecutionServices extends DefaultServiceRegistry {
         InputFingerprinter inputFingerprinter
     ) {
         TaskExecuter executer = new ExecuteActionsTaskExecuter(
-            buildCacheController.isEnabled()
-                ? ExecuteActionsTaskExecuter.BuildCacheState.ENABLED
-                : ExecuteActionsTaskExecuter.BuildCacheState.DISABLED,
-            gradleEnterprisePluginManager.isPresent()
-                ? ExecuteActionsTaskExecuter.ScanPluginState.APPLIED
-                : ExecuteActionsTaskExecuter.ScanPluginState.NOT_APPLIED,
             executionHistoryStore,
             buildOperationExecutor,
             asyncWorkTracker,

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGradleServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGradleServices.java
@@ -24,7 +24,6 @@ import org.gradle.cache.internal.InMemoryCacheDecoratorFactory;
 import org.gradle.cache.scopes.BuildScopedCacheBuilderFactory;
 import org.gradle.caching.internal.controller.BuildCacheController;
 import org.gradle.initialization.BuildCancellationToken;
-import org.gradle.internal.enterprise.core.GradleEnterprisePluginManager;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.execution.BuildOutputCleanupRegistry;
 import org.gradle.internal.execution.ExecutionEngine;
@@ -132,7 +131,6 @@ public class ExecutionGradleServices {
         BuildInvocationScopeId buildInvocationScopeId,
         BuildOperationExecutor buildOperationExecutor,
         BuildOutputCleanupRegistry buildOutputCleanupRegistry,
-        GradleEnterprisePluginManager gradleEnterprisePluginManager,
         ClassLoaderHierarchyHasher classLoaderHierarchyHasher,
         CurrentBuildOperationRef currentBuildOperationRef,
         Deleter deleter,
@@ -167,7 +165,7 @@ public class ExecutionGradleServices {
             new SkipEmptyNonIncrementalWorkStep(buildId, workInputListeners,
             new CaptureNonIncrementalStateBeforeExecutionStep<>(buildOperationExecutor, classLoaderHierarchyHasher,
             new ValidateStep<>(virtualFileSystem, validationWarningRecorder,
-            new ResolveCachingStateStep<>(buildCacheController, gradleEnterprisePluginManager.isPresent(),
+            new ResolveCachingStateStep<>(buildCacheController,
             new MarkSnapshottingInputsFinishedStep<>(
             new NeverUpToDateStep<>(
             new BuildCacheStep(buildCacheController, deleter, fileSystemAccess, outputChangeListener,
@@ -185,7 +183,7 @@ public class ExecutionGradleServices {
             new SkipEmptyIncrementalWorkStep(outputChangeListener, workInputListeners, skipEmptyWorkOutputsCleanerSupplier,
             new CaptureIncrementalStateBeforeExecutionStep<>(buildOperationExecutor, classLoaderHierarchyHasher, outputSnapshotter, overlappingOutputDetector,
             new ValidateStep<>(virtualFileSystem, validationWarningRecorder,
-            new ResolveCachingStateStep<>(buildCacheController, gradleEnterprisePluginManager.isPresent(),
+            new ResolveCachingStateStep<>(buildCacheController,
             new MarkSnapshottingInputsFinishedStep<>(
             new ResolveChangesStep<>(changeDetector,
             new SkipUpToDateStep<>(

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
@@ -155,8 +155,6 @@ class ExecuteActionsTaskExecuterTest extends Specification {
     )
 
     def executer = new ExecuteActionsTaskExecuter(
-        ExecuteActionsTaskExecuter.BuildCacheState.DISABLED,
-        ExecuteActionsTaskExecuter.ScanPluginState.NOT_APPLIED,
         executionHistoryStore,
         buildOperationExecutorForTaskExecution,
         asyncWorkTracker,

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
@@ -122,7 +122,9 @@ class ExecuteActionsTaskExecuterTest extends Specification {
     def actionListener = Stub(TaskActionListener)
     def outputChangeListener = Stub(OutputChangeListener)
     def changeDetector = new DefaultExecutionStateChangeDetector()
-    def taskCacheabilityResolver = Mock(TaskCacheabilityResolver)
+    def taskCacheabilityResolver = Stub(TaskCacheabilityResolver) {
+        shouldDisableCaching(_) >> Optional.empty()
+    }
     def buildCacheController = Stub(BuildCacheController)
     def listenerManager = Stub(ListenerManager)
     def classloaderHierarchyHasher = new ClassLoaderHierarchyHasher() {


### PR DESCRIPTION
even when the build cache is off and the Develocity plugin hasn't been applied.