### PR TITLE
Do not expand the API surface of published libraries

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,6 +25,7 @@ systemProp.dependency.analysis.test.analysis=false
 
 # List of project that still have dependency analysis warnings
 unmigratedProjects=\
+  build-cache-base,build-cache-packaging,hashing,snapshots,\
   diagnostics,enterprise,enterprise-logging,enterprise-plugin-performance,ide,ide-native,installation-beacon,internal-integ-testing,internal-performance-testing,internal-testing,ivy,jacoco,kotlin-dsl,kotlin-dsl-plugins,\
   kotlin-dsl-provider-plugins,kotlin-dsl-tooling-models,language-groovy,language-java,language-jvm,language-native,launcher,maven,performance,platform-base,platform-jvm,platform-native,plugin-development,\
   plugin-use,plugins,plugins-jvm-test-fixtures,plugins-jvm-test-suite,plugins-test-report-aggregation,problems,problems-api,publish,reporting,resources-gcs,resources-http,resources-s3,resources-sftp,scala,security,signing,testing-base,\

--- a/platforms/core-execution/build-cache-base/build.gradle.kts
+++ b/platforms/core-execution/build-cache-base/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
 description = "Common shared build cache classes"
 
 dependencies {
-    api(project(":files"))
-
     implementation(project(":base-annotations"))
+    implementation(project(":files"))
 }

--- a/platforms/core-execution/build-cache-packaging/build.gradle.kts
+++ b/platforms/core-execution/build-cache-packaging/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
 description = "Package build cache results"
 
 dependencies {
-    api(libs.guava)
 
     api(project(":build-cache-base"))
     api(project(":files"))
@@ -16,6 +15,7 @@ dependencies {
     implementation(project(":base-annotations"))
     implementation(libs.commonsCompress)
     implementation(libs.commonsIo)
+    implementation(libs.guava)
     implementation(libs.jsr305)
 
     testImplementation(project(":file-collections"))

--- a/platforms/core-execution/hashing/build.gradle.kts
+++ b/platforms/core-execution/hashing/build.gradle.kts
@@ -8,9 +8,8 @@ description = "Tools for creating secure hashes for files and other content"
 gradlebuildJava.usedInWorkers() // org.gradle.internal.nativeintegration.filesystem.Stat is used in workers
 
 dependencies {
-    api(project(":base-annotations"))
-
-    api(libs.jsr305)
+    implementation(project(":base-annotations"))
 
     implementation(libs.guava)
+    implementation(libs.jsr305)
 }

--- a/platforms/core-execution/snapshots/build.gradle.kts
+++ b/platforms/core-execution/snapshots/build.gradle.kts
@@ -6,15 +6,14 @@ plugins {
 description = "Tools to take immutable, comparable snapshots of files and other things"
 
 dependencies {
-    api(project(":base-annotations"))
     api(project(":files"))
     api(project(":functional"))
     api(project(":hashing"))
 
-    api(libs.jsr305)
-    api(libs.guava)
+    implementation(project(":base-annotations"))
 
-
+    implementation(libs.guava)
+    implementation(libs.jsr305)
     implementation(libs.slf4jApi)
 
     testImplementation(project(":process-services"))


### PR DESCRIPTION
This means that some of these projects are no longer free of dependency analysis warnings.