### PR TITLE
Introduce `FlowActionSpec#parameters(Action<P>)`

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheFlowScopeIntegrationTest.groovy
+++ b/platforms/core-configuration/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheFlowScopeIntegrationTest.groovy
@@ -42,7 +42,9 @@ class ConfigurationCacheFlowScopeIntegrationTest extends AbstractConfigurationCa
                     def sharedBeanProvider = flowProviders.buildWorkResult.map { sharedBean }
                     2.times {
                         flowScope.always(IncrementAndPrint) {
-                            parameters.bean = sharedBeanProvider
+                            parameters {
+                                bean = sharedBeanProvider
+                            }
                         }
                     }
                 }

--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/flow/BuildFlowScope.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/flow/BuildFlowScope.kt
@@ -177,6 +177,9 @@ open class DefaultFlowActionSpec<P : FlowParameters>(
     override fun getParameters(): P =
         parameters
 
+    override fun parameters(configureAction: Action<in P>) =
+        configureAction.execute(parameters)
+
     override fun toString(): String =
         "FlowActionSpec($parameters)"
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/flow/FlowActionSpec.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/flow/FlowActionSpec.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.flow;
 
+import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 
 /**
@@ -31,6 +32,14 @@ public interface FlowActionSpec<P extends FlowParameters> {
      * Returns the parameters defined by the configured {@link FlowAction dataflow action}.
      *
      * @return mutable parameters object, never null.
+     * @since 8.1
      */
     P getParameters();
+
+    /**
+     * Configures the {@link P parameters} for the {@link FlowAction flow action}.
+     *
+     * @since 8.7
+     */
+    void parameters(Action<? super P> configureAction);
 }


### PR DESCRIPTION
For consistency with how the _configurable work action_ pattern is implemented everywhere.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
