### PR TITLE
Deprecate String.invoke() in domain object containers

### DIFF
--- a/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinDslContainerIntegrationTest.kt
+++ b/platforms/core-configuration/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinDslContainerIntegrationTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.integration
+
+import org.gradle.kotlin.dsl.fixtures.AbstractKotlinIntegrationTest
+import org.junit.Test
+
+
+class KotlinDslContainerIntegrationTest : AbstractKotlinIntegrationTest() {
+    @Test
+    fun `TaskContainerScope String#invoke() extension is deprecated in Kotlin DSL`() {
+        withBuildScript("""
+            tasks {
+                "help"()
+            }
+        """)
+
+        executer.expectDocumentedDeprecationWarning(
+            "Task 'help' found by String.invoke() notation. This behavior has been deprecated. " +
+                "This behavior is scheduled to be removed in Gradle 9.0. " +
+                "The \"name\"() notation can cause confusion with methods provided by Kotlin or the JDK. Use named(String) instead. " +
+                "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#string_invoke")
+        build("help")
+    }
+
+    @Test
+    fun `NamedDomainObjectContainerScope String#invoke() extension is deprecated in Kotlin DSL`() {
+        withBuildScript("""
+            configurations {
+                register("foo")
+                "foo"()
+            }
+        """)
+
+        executer.expectDocumentedDeprecationWarning(
+            "Domain object 'foo' found by String.invoke() notation. This behavior has been deprecated. " +
+                "This behavior is scheduled to be removed in Gradle 9.0. " +
+                "The \"name\"() notation can cause confusion with methods provided by Kotlin or the JDK. Use named(String) instead. " +
+                "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_8.html#string_invoke")
+        build("help")
+    }
+}

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectContainerExtensions.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectContainerExtensions.kt
@@ -262,7 +262,7 @@ internal constructor(
      *
      * @see [NamedDomainObjectContainer.named]
      */
-    @Deprecated("Use named(String) instead.", ReplaceWith("named(\"...\")"))
+    @Deprecated("Use named(String) instead.", ReplaceWith("named(this)"))
     operator fun String.invoke(): NamedDomainObjectProvider<T> {
         DeprecationLogger.deprecateBehaviour(String.format("Domain object '%s' found by String.invoke() notation.", this))
             .withContext("The \"name\"() notation can cause confusion with methods provided by Kotlin or the JDK.")

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectContainerExtensions.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectContainerExtensions.kt
@@ -20,6 +20,7 @@ import org.gradle.api.Action
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.NamedDomainObjectProvider
 import org.gradle.api.PolymorphicDomainObjectContainer
+import org.gradle.internal.deprecation.DeprecationLogger
 
 import org.gradle.kotlin.dsl.support.delegates.NamedDomainObjectContainerDelegate
 
@@ -254,15 +255,23 @@ internal constructor(
      * @see [NamedDomainObjectProvider.configure]
      */
     operator fun String.invoke(configuration: T.() -> Unit): NamedDomainObjectProvider<T> =
-        this().apply { configure(configuration) }
+        named(this).apply { configure(configuration) }
 
     /**
      * Locates an object by name, without triggering its creation or configuration, failing if there is no such object.
      *
      * @see [NamedDomainObjectContainer.named]
      */
-    operator fun String.invoke(): NamedDomainObjectProvider<T> =
-        delegate.named(this)
+    @Deprecated("Use named(String) instead.", ReplaceWith("named(\"...\")"))
+    operator fun String.invoke(): NamedDomainObjectProvider<T> {
+        DeprecationLogger.deprecateBehaviour(String.format("Domain object '%s' found by String.invoke() notation.", this))
+            .withContext("The \"name\"() notation can cause confusion with methods provided by Kotlin or the JDK.")
+            .withAdvice("Use named(String) instead.")
+            .willBeRemovedInGradle9()
+            .withUpgradeGuideSection(8, "string_invoke")
+            .nagUser()
+        return delegate.named(this)
+    }
 
     /**
      * Configures an object by name, without triggering its creation or configuration, failing if there is no such object.

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/TaskContainerExtensions.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/TaskContainerExtensions.kt
@@ -172,7 +172,7 @@ private constructor(
      *
      * @see [TaskContainer.named]
      */
-    @Deprecated("Use named(String) instead.", ReplaceWith("named(\"...\")"))
+    @Deprecated("Use named(String) instead.", ReplaceWith("named(this)"))
     operator fun String.invoke(): TaskProvider<Task> {
         DeprecationLogger.deprecateBehaviour(String.format("Task '%s' found by String.invoke() notation.", this))
             .withContext("The \"name\"() notation can cause confusion with methods provided by Kotlin or the JDK.")

--- a/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/TaskContainerExtensions.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/TaskContainerExtensions.kt
@@ -19,6 +19,7 @@ import org.gradle.api.Task
 import org.gradle.api.tasks.TaskCollection
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
+import org.gradle.internal.deprecation.DeprecationLogger
 
 import org.gradle.kotlin.dsl.support.delegates.TaskContainerDelegate
 
@@ -164,15 +165,23 @@ private constructor(
      * @see [TaskProvider.configure]
      */
     operator fun String.invoke(configuration: Task.() -> Unit): TaskProvider<Task> =
-        this().apply { configure(configuration) }
+        named(this).apply { configure(configuration) }
 
     /**
      * Locates a task by name, without triggering its creation or configuration, failing if there is no such task.
      *
      * @see [TaskContainer.named]
      */
-    operator fun String.invoke(): TaskProvider<Task> =
-        container.named(this)
+    @Deprecated("Use named(String) instead.", ReplaceWith("named(\"...\")"))
+    operator fun String.invoke(): TaskProvider<Task> {
+        DeprecationLogger.deprecateBehaviour(String.format("Task '%s' found by String.invoke() notation.", this))
+            .withContext("The \"name\"() notation can cause confusion with methods provided by Kotlin or the JDK.")
+            .withAdvice("Use named(String) instead.")
+            .willBeRemovedInGradle9()
+            .withUpgradeGuideSection(8, "string_invoke")
+            .nagUser()
+        return container.named(this)
+    }
 
     /**
      * Configures a task by name, without triggering its creation or configuration, failing if there is no such task.

--- a/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectContainerExtensionsTest.kt
+++ b/platforms/core-configuration/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/NamedDomainObjectContainerExtensionsTest.kt
@@ -205,6 +205,7 @@ class NamedDomainObjectContainerExtensionsTest {
             }
             val b = "bob"(type = DomainObjectBase.Bar::class)
             val j = "jim" {}
+            @Suppress("deprecation")
             val s = "steve"() // can invoke without a block, but must invoke
 
             assertThat(a.get(), sameInstance(alice))

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -50,21 +50,21 @@ The embedded Kotlin has been updated to link:https://github.com/JetBrains/kotlin
 ==== Referencing tasks and domain objects by `"name"()` in Kotlin DSL
 
 In Kotlin DSL, it is possible to reference a task or other domain object by its name using the `"name"()` notation.
-This isn't a very useful construct and link:https://github.com/gradle/gradle/issues/27699[causes hard to understand conflicts].
 
 There are several ways to look up an element in a container by name:
 ```
 tasks {
-    "wrapper"() // 1 returns TaskProvider<Task>
-    "wrapper"(Wrapper::class) // 2 returns TaskProvider<Wrapper>
-    "wrapper"(Wrapper::class) { // 3 configures a task named wrapper of type Wrapper
+    "wrapper"() // 1 - returns TaskProvider<Task>
+    "wrapper"(Wrapper::class) // 2 - returns TaskProvider<Wrapper>
+    "wrapper"(Wrapper::class) { // 3 - configures a task named wrapper of type Wrapper
     }
-    "wrapper" { // 4 configures a task named wrapper of type Task
+    "wrapper" { // 4 - configures a task named wrapper of type Task
     }
 }
 ```
 
-The first notation is now deprecated and will be removed in Gradle 9.0. Instead of using `"name"()` to reference a task or domain object, use `named("name")` or one of the other supported notations.
+The first notation is now deprecated and will be removed in Gradle 9.0.
+Instead of using `"name"()` to reference a task or domain object, use `named("name")` or one of the other supported notations.
 
 Groovy DSL build scripts and the Gradle API are not impacted by this.
 

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -46,6 +46,28 @@ The embedded Kotlin has been updated to link:https://github.com/JetBrains/kotlin
 
 === Deprecations
 
+[[string_invoke]]
+==== Referencing tasks and domain objects by `"name"()` in Kotlin DSL
+
+In Kotlin DSL, it is possible to reference a task or other domain object by its name using the `"name"()` notation.
+This isn't a very useful construct and link:https://github.com/gradle/gradle/issues/27699[causes hard to understand conflicts].
+
+There are several ways to look up an element in a container by name:
+```
+tasks {
+    "wrapper"() // 1 returns TaskProvider<Task>
+    "wrapper"(Wrapper::class) // 2 returns TaskProvider<Wrapper>
+    "wrapper"(Wrapper::class) { // 3 configures a task named wrapper of type Wrapper
+    }
+    "wrapper" { // 4 configures a task named wrapper of type Task
+    }
+}
+```
+
+The first notation is now deprecated and will be removed in Gradle 9.0. Instead of using `"name"()` to reference a task or domain object, use `named("name")` or one of the other supported notations.
+
+Groovy DSL build scripts and the Gradle API are not impacted by this.
+
 [[deprecated_invalid_url_decoding]]
 ==== Deprecated invalid URL decoding behavior
 Prior to Gradle 8.3, Gradle would decode a `CharSequence` given to `link:{groovyDslPath}/org.gradle.api.Project.html#org.gradle.api.Project:uri(java.lang.Object)[Project.uri(Object)]` using an algorithm that accepted invalid URLs and improperly decoded others.

--- a/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/releases/upgrading/upgrading_version_8.adoc
@@ -63,8 +63,15 @@ tasks {
 }
 ```
 
-The first notation is now deprecated and will be removed in Gradle 9.0.
+The first notation is deprecated and will be removed in Gradle 9.0.
 Instead of using `"name"()` to reference a task or domain object, use `named("name")` or one of the other supported notations.
+
+The above example would be written:
+```
+tasks {
+    named("wrapper") // returns TaskProvider<Task>
+}
+```
 
 Groovy DSL build scripts and the Gradle API are not impacted by this.
 


### PR DESCRIPTION
These extensions have low usability. They allow you to get a Provider<E> in a domain object container by name.

e.g.,

tasks {
   "help"()
}

This can cause very strange conflicts between methods that return String and Kotlin-provided extensions with the same name.

This is similar to what you can do in Groovy without the String notation, but retaining this similarity does not seem worth the trouble it causes.

refs #27699

<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
