### PR TITLE
Include base branch in GitHubMergeQueueCheckPass's trigger rules

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/GitHubMergeQueueCheckPass.kt
+++ b/.teamcity/src/main/kotlin/configurations/GitHubMergeQueueCheckPass.kt
@@ -32,6 +32,7 @@ class GitHubMergeQueueCheckPass(model: CIBuildModel) : BaseGradleBuildType(init 
         quietPeriodMode = VcsTrigger.QuietPeriodMode.DO_NOT_USE
         branchFilter = """
 +:gh-readonly-queue/${model.branch.branchName}/*
++${model.branch.branchName}
 """
     }
 


### PR DESCRIPTION
In this way, the GitHubMergeQueueCheckPass build will run on base branch (`master`/`release` etc.) so that we can see correct "X changes" message in branch builds.

![image](https://github.com/gradle/gradle/assets/12689835/7476db21-57c6-41b3-85a3-16290056a4c1)
