### PR TITLE
Revert the fix for NormalizingCopyActionDecorator

### DIFF
--- a/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileTreeElement.java
+++ b/platforms/core-configuration/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileTreeElement.java
@@ -18,8 +18,8 @@ package org.gradle.api.internal.file;
 import org.apache.commons.io.IOUtils;
 import org.gradle.api.GradleException;
 import org.gradle.api.UncheckedIOException;
-import org.gradle.api.file.FilePermissions;
 import org.gradle.api.file.FileTreeElement;
+import org.gradle.api.file.FilePermissions;
 import org.gradle.internal.exceptions.Contextual;
 import org.gradle.internal.file.Chmod;
 import org.gradle.util.internal.GFileUtils;
@@ -117,8 +117,8 @@ public abstract class AbstractFileTreeElement implements FileTreeElement {
     }
 
     @Contextual
-    protected static class CopyFileElementException extends GradleException {
-        public CopyFileElementException(String message, Throwable cause) {
+    private static class CopyFileElementException extends GradleException {
+        CopyFileElementException(String message, Throwable cause) {
             super(message, cause);
         }
     }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyPermissionsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyPermissionsIntegrationTest.groovy
@@ -495,40 +495,14 @@ class CopyPermissionsIntegrationTest extends AbstractIntegrationSpec implements 
         assertDestinationFilePermissions("r-xr-xrw-")
 
         where:
-        description        | setting
-        "permissions"      | """
+        description         | setting
+        "permissions"       | """
                                 eachFile {
                                     permissions = p
                                 }
                               """
-        "file mode"        | "fileMode = p.toUnixNumeric()"
-        "file permissions" | "filePermissions.set(p)"
-    }
-
-    @Requires(UnitTestPreconditions.FilePermissions)
-    def "permissions are set correctly for intermediate directories"() {
-        given:
-        withSourceFiles("r--------")
-
-        buildFile.delete()
-        buildKotlinFile.text = '''
-            tasks.register<Copy>("copy") {
-               into("dest")
-               into("prefix1/prefix2") {
-                 from("files")
-               }
-               dirPermissions {
-                  unix("rwxr-x---")
-               }
-            }
-        '''.stripIndent()
-
-        when:
-        run 'copy'
-
-        then:
-        file("dest/prefix1").permissions == "rwxr-x---"
-        file("dest/prefix1/prefix2").permissions == "rwxr-x---"
+        "file mode"         | "fileMode = p.toUnixNumeric()"
+        "file permissions"  | "filePermissions.set(p)"
     }
 
     private def withSourceFiles(String permissions) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/DefaultFileCopyDetails.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/DefaultFileCopyDetails.java
@@ -23,8 +23,8 @@ import org.gradle.api.file.ConfigurableFilePermissions;
 import org.gradle.api.file.ContentFilterable;
 import org.gradle.api.file.DuplicatesStrategy;
 import org.gradle.api.file.ExpandDetails;
-import org.gradle.api.file.FilePermissions;
 import org.gradle.api.file.FileVisitDetails;
+import org.gradle.api.file.FilePermissions;
 import org.gradle.api.file.RelativePath;
 import org.gradle.api.internal.file.AbstractFileTreeElement;
 import org.gradle.api.internal.file.DefaultConfigurableFilePermissions;
@@ -62,6 +62,11 @@ public class DefaultFileCopyDetails extends AbstractFileTreeElement implements F
         this.objectFactory = objectFactory;
         this.duplicatesStrategy = specResolver.getDuplicatesStrategy();
         this.defaultDuplicatesStrategy = specResolver.isDefaultDuplicateStrategy();
+    }
+
+    @Override
+    public boolean isIncludeEmptyDirs() {
+        return specResolver.getIncludeEmptyDirs();
     }
 
     @Override
@@ -261,11 +266,6 @@ public class DefaultFileCopyDetails extends AbstractFileTreeElement implements F
 
     public boolean isDefaultDuplicatesStrategy() {
         return defaultDuplicatesStrategy;
-    }
-
-    @Override
-    public CopySpecResolver getSpecResolver() {
-        return specResolver;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/FileCopyDetailsInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/FileCopyDetailsInternal.java
@@ -20,7 +20,7 @@ import org.gradle.api.file.FileCopyDetails;
 
 public interface FileCopyDetailsInternal extends FileCopyDetails {
 
-    boolean isDefaultDuplicatesStrategy();
+    boolean isIncludeEmptyDirs();
 
-    CopySpecResolver getSpecResolver();
+    boolean isDefaultDuplicatesStrategy();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/NormalizingCopyActionDecorator.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/NormalizingCopyActionDecorator.java
@@ -20,20 +20,17 @@ import com.google.common.collect.ListMultimap;
 import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.Transformer;
-import org.gradle.api.file.ConfigurableFilePermissions;
 import org.gradle.api.file.ContentFilterable;
 import org.gradle.api.file.DuplicatesStrategy;
 import org.gradle.api.file.ExpandDetails;
+import org.gradle.api.file.ConfigurableFilePermissions;
 import org.gradle.api.file.FilePermissions;
 import org.gradle.api.file.RelativePath;
 import org.gradle.api.internal.file.AbstractFileTreeElement;
 import org.gradle.api.internal.file.CopyActionProcessingStreamAction;
-import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.internal.file.Chmod;
-import org.gradle.util.internal.GFileUtils;
 
-import javax.annotation.Nullable;
 import java.io.File;
 import java.io.FilterReader;
 import java.io.InputStream;
@@ -71,7 +68,7 @@ public class NormalizingCopyActionDecorator implements CopyAction {
                         pendingDirs.put(path, details);
                     }
                 } else {
-                    maybeVisit(details.getRelativePath().getParent(), details.getSpecResolver(), action, visitedDirs, pendingDirs);
+                    maybeVisit(details.getRelativePath().getParent(), details.isIncludeEmptyDirs(), action, visitedDirs, pendingDirs);
                     action.processFile(details);
                 }
             });
@@ -79,8 +76,8 @@ public class NormalizingCopyActionDecorator implements CopyAction {
             for (RelativePath path : new LinkedHashSet<>(pendingDirs.keySet())) {
                 List<FileCopyDetailsInternal> detailsList = new ArrayList<>(pendingDirs.get(path));
                 for (FileCopyDetailsInternal details : detailsList) {
-                    if (details.getSpecResolver().getIncludeEmptyDirs()) {
-                        maybeVisit(path, details.getSpecResolver(), action, visitedDirs, pendingDirs);
+                    if (details.isIncludeEmptyDirs()) {
+                        maybeVisit(path, details.isIncludeEmptyDirs(), action, visitedDirs, pendingDirs);
                     }
                 }
             }
@@ -90,39 +87,37 @@ public class NormalizingCopyActionDecorator implements CopyAction {
         });
     }
 
-    private void maybeVisit(@Nullable RelativePath path, CopySpecResolver specResolver, CopyActionProcessingStreamAction delegateAction, Set<RelativePath> visitedDirs, ListMultimap<RelativePath, FileCopyDetailsInternal> pendingDirs) {
+    private void maybeVisit(RelativePath path, boolean includeEmptyDirs, CopyActionProcessingStreamAction delegateAction, Set<RelativePath> visitedDirs, ListMultimap<RelativePath, FileCopyDetailsInternal> pendingDirs) {
         if (path == null || path.getParent() == null || !visitedDirs.add(path)) {
             return;
         }
-
+        maybeVisit(path.getParent(), includeEmptyDirs, delegateAction, visitedDirs, pendingDirs);
         List<FileCopyDetailsInternal> detailsForPath = pendingDirs.removeAll(path);
+
         FileCopyDetailsInternal dir;
         if (detailsForPath.isEmpty()) {
             // TODO - this is pretty nasty, look at avoiding using a time bomb stub here
-            dir = new ParentDirectoryStub(specResolver, path, chmod);
+            dir = new StubbedFileCopyDetails(path, includeEmptyDirs, chmod);
         } else {
             dir = detailsForPath.get(0);
         }
-        maybeVisit(path.getParent(), dir.getSpecResolver(), delegateAction, visitedDirs, pendingDirs);
-
         delegateAction.processFile(dir);
     }
 
-    private static class ParentDirectoryStub extends AbstractFileTreeElement implements FileCopyDetailsInternal {
+    private static class StubbedFileCopyDetails extends AbstractFileTreeElement implements FileCopyDetailsInternal {
         private final RelativePath path;
+        private final boolean includeEmptyDirs;
+        private long lastModified = System.currentTimeMillis();
 
-        private final long lastModified = System.currentTimeMillis();
-
-        private final CopySpecResolver specResolver;
-
-        private ParentDirectoryStub(CopySpecResolver specResolver, RelativePath path, Chmod chmod) {
+        private StubbedFileCopyDetails(RelativePath path, boolean includeEmptyDirs, Chmod chmod) {
             super(chmod);
             this.path = path;
-            this.specResolver = specResolver;
+            this.includeEmptyDirs = includeEmptyDirs;
         }
 
-        private static UnsupportedOperationException unsupported() {
-            return new UnsupportedOperationException("It's a synthetic FileCopyDetails just to create parent directories");
+        @Override
+        public boolean isIncludeEmptyDirs() {
+            return includeEmptyDirs;
         }
 
         @Override
@@ -132,12 +127,12 @@ public class NormalizingCopyActionDecorator implements CopyAction {
 
         @Override
         public File getFile() {
-            throw unsupported();
+            throw new UnsupportedOperationException();
         }
 
         @Override
         public boolean isDirectory() {
-            return true;
+            return !path.isFile();
         }
 
         @Override
@@ -147,12 +142,12 @@ public class NormalizingCopyActionDecorator implements CopyAction {
 
         @Override
         public long getSize() {
-            throw unsupported();
+            throw new UnsupportedOperationException();
         }
 
         @Override
         public InputStream open() {
-            throw unsupported();
+            throw new UnsupportedOperationException();
         }
 
         @Override
@@ -161,124 +156,98 @@ public class NormalizingCopyActionDecorator implements CopyAction {
         }
 
         @Override
-        public boolean copyTo(File target) {
-            try {
-                GFileUtils.mkdirs(target);
-                getChmod().chmod(target, getPermissions().toUnixNumeric());
-                return true;
-            } catch (Exception e) {
-                throw new CopyFileElementException(String.format("Could not copy %s to '%s'.", getDisplayName(), target), e);
-            }
-        }
-
-        @Override
-        public FilePermissions getPermissions() {
-            Provider<FilePermissions> specMode = specResolver.getImmutableDirPermissions();
-            if (specMode.isPresent()) {
-                return specMode.get();
-            }
-
-            return super.getPermissions();
-        }
-
-        @Override
         public void exclude() {
-            throw unsupported();
+            throw new UnsupportedOperationException();
         }
 
         @Override
         public void setName(String name) {
-            throw unsupported();
+            throw new UnsupportedOperationException();
         }
 
         @Override
         public void setPath(String path) {
-            throw unsupported();
+            throw new UnsupportedOperationException();
         }
 
         @Override
         public void setRelativePath(RelativePath path) {
-            throw unsupported();
+            throw new UnsupportedOperationException();
         }
 
         @Override
         public void setMode(int mode) {
-            throw unsupported();
+            throw new UnsupportedOperationException();
         }
 
         @Override
         public void permissions(Action<? super ConfigurableFilePermissions> configureAction) {
-            throw unsupported();
+            throw new UnsupportedOperationException();
         }
 
         @Override
         public void setPermissions(FilePermissions permissions) {
-            throw unsupported();
+            throw new UnsupportedOperationException();
         }
 
         @Override
         public void setDuplicatesStrategy(DuplicatesStrategy strategy) {
-            throw unsupported();
+            throw new UnsupportedOperationException();
         }
 
         @Override
         public DuplicatesStrategy getDuplicatesStrategy() {
-            throw unsupported();
+            throw new UnsupportedOperationException();
         }
 
         @Override
         public boolean isDefaultDuplicatesStrategy() {
-            throw unsupported();
+            throw new UnsupportedOperationException();
         }
 
         @Override
         public String getSourceName() {
-            throw unsupported();
+            throw new UnsupportedOperationException();
         }
 
         @Override
         public String getSourcePath() {
-            throw unsupported();
+            throw new UnsupportedOperationException();
         }
 
         @Override
         public RelativePath getRelativeSourcePath() {
-            throw unsupported();
+            throw new UnsupportedOperationException();
         }
 
         @Override
         public ContentFilterable filter(Map<String, ?> properties, Class<? extends FilterReader> filterType) {
-            throw unsupported();
+            throw new UnsupportedOperationException();
         }
 
         @Override
         public ContentFilterable filter(Class<? extends FilterReader> filterType) {
-            throw unsupported();
+            throw new UnsupportedOperationException();
         }
 
         @Override
         public ContentFilterable filter(Closure closure) {
-            throw unsupported();
+            throw new UnsupportedOperationException();
         }
 
         @Override
         public ContentFilterable filter(Transformer<String, String> transformer) {
-            throw unsupported();
+            throw new UnsupportedOperationException();
         }
 
         @Override
         public ContentFilterable expand(Map<String, ?> properties) {
-            throw unsupported();
+            throw new UnsupportedOperationException();
         }
 
         @Override
         public ContentFilterable expand(Map<String, ?> properties, Action<? super ExpandDetails> action) {
-            throw unsupported();
-        }
-
-        @Override
-        public CopySpecResolver getSpecResolver() {
-            return specResolver;
+            throw new UnsupportedOperationException();
         }
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/NormalizingCopyActionDecoratorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/NormalizingCopyActionDecoratorTest.groovy
@@ -15,10 +15,13 @@
  */
 package org.gradle.api.internal.file.copy
 
-
+import org.gradle.api.file.FileCopyDetails
 import org.gradle.api.file.RelativePath
 import org.gradle.api.internal.file.CopyActionProcessingStreamAction
 import org.gradle.api.tasks.WorkResults
+import org.hamcrest.BaseMatcher
+import org.hamcrest.Description
+import org.hamcrest.Matcher
 import spock.lang.Specification
 
 import static org.gradle.api.internal.file.TestFiles.fileSystem
@@ -109,8 +112,19 @@ class NormalizingCopyActionDecoratorTest extends Specification {
         return Stub(FileCopyDetailsInternal) {
             getRelativePath() >> RelativePath.parse(false, path)
             isDirectory() >> isDir
-            getSpecResolver() >> Stub(CopySpecResolver) {
-                getIncludeEmptyDirs() >> includeEmptyDirs
+            isIncludeEmptyDirs() >> includeEmptyDirs
+        }
+    }
+
+    private Matcher<FileCopyDetailsInternal> hasPath(final String path) {
+        return new BaseMatcher<FileCopyDetailsInternal>() {
+            void describeTo(Description description) {
+                description.appendText("has path ").appendValue(path)
+            }
+
+            boolean matches(Object o) {
+                FileCopyDetails details = (FileCopyDetails) o
+                return details.getRelativePath().getPathString().equals(path)
             }
         }
     }


### PR DESCRIPTION
Fixes #27709
* https://github.com/gradle/gradle/issues/27709

Reverts:
* https://github.com/gradle/gradle/pull/27011

### Context
The original behavior is unclear and wasn't covered by tests properly.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
