### PR TITLE
Avoid ClientModule deprecation smoke test flakiness

### DIFF
--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractAndroidSantaTrackerSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractAndroidSantaTrackerSmokeTest.groovy
@@ -99,11 +99,8 @@ class AbstractAndroidSantaTrackerSmokeTest extends AbstractSmokeTest {
                 if (agpVersionNumber >= VersionNumber.parse("7.4")) {
                     // TODO - this is here because AGP > 7.3 reads build/generated/source/kapt/debug at configuration time
                     expectBuildIdentifierIsCurrentBuildDeprecation(agpVersion)
-                    // Not sure why this doesn't happen in 8.1.4. The warning prints without CC.
-                    if (agpVersionNumber < VersionNumber.parse("8.1.4")) {
-                        expectClientModuleDeprecationWarning(agpVersion)
-                    }
                 }
+                maybeExpectClientModuleDeprecationWarning(agpVersion)
             }
         }.build()
     }
@@ -145,11 +142,8 @@ class AbstractAndroidSantaTrackerSmokeTest extends AbstractSmokeTest {
                 if (agpVersionNumber >= VersionNumber.parse("7.4")) {
                     // TODO - this is here because AGP > 7.3 reads build/generated/source/kapt/debug at configuration time
                     expectBuildIdentifierIsCurrentBuildDeprecation(agpVersion)
-                    // Not sure why this doesn't happen in 8.1.4.
-                    if ((agpVersionNumber < VersionNumber.parse("8.1.4"))) {
-                        expectClientModuleDeprecationWarning(agpVersion)
-                    }
                 }
+                maybeExpectClientModuleDeprecationWarning(agpVersion)
             }.build()
     }
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithAndroidDeprecations.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithAndroidDeprecations.groovy
@@ -103,6 +103,16 @@ trait WithAndroidDeprecations implements WithReportDeprecations {
         )
     }
 
+    void maybeExpectClientModuleDeprecationWarning(String agpVersion) {
+        runner.maybeExpectLegacyDeprecationWarningIf(
+            versionIsLower(agpVersion, AGP_VERSION_WITHOUT_CLIENT_MODULE),
+            "Declaring client module dependencies has been deprecated. " +
+                "This is scheduled to be removed in Gradle 9.0. " +
+                "Please use component metadata rules instead. " +
+                "Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_8.html#declaring_client_module_dependencies",
+        )
+    }
+
     void expectBuildIdentifierIsCurrentBuildDeprecation(String agpVersion, String fixedVersion = '8.0.0') {
         VersionNumber agpVersionNumber = VersionNumber.parse(agpVersion)
         runner.expectLegacyDeprecationWarningIf(


### PR DESCRIPTION
This test is flaky and this deprecation is only emitted sometimes. Maybe expect the client module deprecation in these cases.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
