### PR TITLE
Do not remove to-triage label automatically

### DIFF
--- a/.github/workflows/team-triage-stale.yml
+++ b/.github/workflows/team-triage-stale.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/stale@v9
         with:
           operations-per-run: 50
+          remove-stale-when-updated: false
 
           only-issue-labels: ':wave: team-triage'
           days-before-issue-stale: 14


### PR DESCRIPTION
### Context
The stale bot removes the to-triage label on any update on contributor PRs. Disable that, as it affects new PRs too.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
