### PR TITLE
Fix title for Gradle-managed Directories page

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/other/directory_layout.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/other/directory_layout.adoc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 [[directory_layout]]
-= Gradle Directories
+= Gradle-managed Directories
 
 Gradle uses two main directories to perform and manage its work: the <<#dir:gradle_user_home>> and the <<#dir:project_root>>.
 

--- a/platforms/documentation/docs/src/main/resources/header.html
+++ b/platforms/documentation/docs/src/main/resources/header.html
@@ -235,7 +235,7 @@
                 </li>
                 <li><a class="nav-dropdown" data-toggle="collapse" href="#other-developing-topics" aria-expanded="false" aria-controls="other-developing-topics">Other Topics</a>
                     <ul id="other-developing-topics">
-                        <li><a href="../userguide/directory_layout.html">Gradle managed Directories</a></li>
+                        <li><a href="../userguide/directory_layout.html">Gradle-managed Directories</a></li>
                         <li><a href="../userguide/working_with_files.html">Working with Files</a></li>
                         <li><a href="../userguide/logging.html">Working with Logging</a></li>
                         <li><a href="../userguide/potential_traps.html">Avoiding Traps</a></li>


### PR DESCRIPTION
I noticed the dash was missing, and I made the page use the same title as the sidebar.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
