### PR TITLE
Improve missing usesService deprecation warning

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceProviderNagger.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceProviderNagger.java
@@ -51,6 +51,7 @@ public class BuildServiceProviderNagger implements BuildServiceProvider.Listener
     private static void nagAboutUndeclaredUsageOf(BuildServiceProvider<?, ?> provider, TaskInternal task) {
         deprecateBehaviour(undeclaredBuildServiceUsage(provider, task))
             .withAdvice("Declare the association between the task and the build service using 'Task#usesService'.")
+            .withContext("The task '" + task.getIdentityPath() + "' uses the service.")
             .willBecomeAnErrorInGradle9()
             .withUpgradeGuideSection(7, "undeclared_build_service_usage")
             .nagUser();
@@ -58,7 +59,6 @@ public class BuildServiceProviderNagger implements BuildServiceProvider.Listener
 
     private static String undeclaredBuildServiceUsage(BuildServiceProvider<?, ?> provider, TaskInternal task) {
         return "Build service '" + provider.getName() + "'" +
-            " is being used by task '" + task.getIdentityPath() + "'" +
-            " without the corresponding declaration via 'Task#usesService'.";
+            " is being used by a task without the corresponding declaration via 'Task#usesService'.";
     }
 }


### PR DESCRIPTION
The message included the task name and that makes it very hard to group the deprecation in build scans since it affects all the tasks.

This changes adds the task name in the context, allowing scans to better group the message.

## Command line

Before:
```
> Task :build-logic:checkKotlinGradlePluginConfigurationErrors
Build service 'KotlinToolingDiagnosticsCollector_1533824702' is being used by task ':build-logic:checkKotlinGradlePluginConfigurationErrors' without the corresponding declaration via 'Task#usesService'. This behavior has been deprecated. This will fail with an error in Gradle 9.0. Declare the association between the task and the build service using 'Task#usesService'. Consult the upgrading guide for further information: https://docs.gradle.org/8.7-20240125101200+0000/userguide/upgrading_version_7.html#undeclared_build_service_usage
```

After:
```
> Task :build-logic:checkKotlinGradlePluginConfigurationErrors
Build service 'KotlinToolingDiagnosticsCollector_1065435516' is being used by a task without the corresponding declaration via 'Task#usesService'. This behavior has been deprecated. This will fail with an error in Gradle 9.0. The task ':build-logic:checkKotlinGradlePluginConfigurationErrors' uses the service. Declare the association between the task and the build service using 'Task#usesService'. Consult the upgrading guide for further information: https://docs.gradle.org/8.7-20240125105251+0000/userguide/upgrading_version_7.html#undeclared_build_service_usage
```

## Build Scan

[Before](https://ge.gradle.org/s/krosd4pmorqlg/deprecations):
<img width="1786" alt="image" src="https://github.com/gradle/gradle/assets/423186/9c564f15-3336-489c-8026-4c06f50d4e5e">


[After](https://ge.gradle.org/s/6pewqscibaaxq/deprecations):
<img width="1431" alt="image" src="https://github.com/gradle/gradle/assets/423186/27f3a569-b63a-4381-b4f4-603ac34fdc4a">
<img width="917" alt="image" src="https://github.com/gradle/gradle/assets/423186/a5e09fc5-c4d6-451c-abea-70f2817b1b23">


