### PR TITLE
`includeGroupAndSubgroup` content filters incorrectly apply inclusions to other repositories

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultRepositoryHandler.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultRepositoryHandler.java
@@ -199,7 +199,7 @@ public class DefaultRepositoryHandler extends DefaultArtifactRepositoryContainer
 
             @Override
             public void includeGroupAndSubgroups(String groupPrefix) {
-                desc.includeGroupAndSubgroups(groupPrefix);
+                desc.excludeGroupAndSubgroups(groupPrefix);
             }
 
             @Override

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultRepositoryHandlerTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultRepositoryHandlerTest.groovy
@@ -433,6 +433,50 @@ class DefaultRepositoryHandlerTest extends DefaultArtifactRepositoryContainerTes
         1 * repo3Content.excludeVersionByRegex("com.mycompany","core", "1.0")
         0 * _
     }
+
+    def "can include module by group and subgroups exclusively"() {
+        given:
+        def repo1 = Mock(TestMavenArtifactRepository) { getName() >> "Maven repo 1" }
+        def repo2 = Mock(TestMavenArtifactRepository) { getName() >> "Maven repo 2" }
+        def repo3 = Mock(TestMavenArtifactRepository) { getName() >> "Maven repo 3" }
+        def repo1Content = Mock(RepositoryContentDescriptor)
+        def repo2Content = Mock(RepositoryContentDescriptor)
+        def repo3Content = Mock(RepositoryContentDescriptor)
+
+        when:
+        handler.maven {}
+        handler.maven {}
+        handler.maven {}
+        handler.exclusiveContent {
+            it.forRepository { repo2 }
+            it.filter {
+                it.includeGroupAndSubgroups("com.mycompany")
+            }
+        }
+
+        then:
+        3 * repositoryFactory.createMavenRepository() >>> [repo1, repo2, repo3]
+        _ * repo1.getName() >> "Maven repo 1"
+        _ * repo2.getName() >> "Maven repo 2"
+        _ * repo3.getName() >> "Maven repo 3"
+        _ * repo1.setName(_)
+        _ * repo2.setName(_)
+        _ * repo3.setName(_)
+        1 * repo1.onAddToContainer(_)
+        1 * repo2.onAddToContainer(_)
+        1 * repo3.onAddToContainer(_)
+        1 * repo2.content(_) >> { args ->
+            args[0].execute(repo2Content)
+        }
+        1 * repo2Content.includeGroupAndSubgroups("com.mycompany")
+        1 * repo1.content(_) >> { args ->
+            args[0].execute(repo1Content)
+        }
+        1 * repo1Content.excludeGroupAndSubgroups("com.mycompany")
+        1 * repo3.content(_) >> { args ->
+            args[0].execute(repo3Content)
+        }
+        1 * repo3Content.excludeGroupAndSubgroups("com.mycompany")
+        0 * _
+    }
 }
-
-


### PR DESCRIPTION
Fixes #27339

### Context

This fixes an issue with `includeGroupAndSubgroup` exclusive content filters. 

The previous behavior would incorrectly add a corresponding `includeGroupAndSubgroups` to other declared repositories when it should be adding an exclusion instead. 