### PR TITLE
Add array helper methods

### DIFF
--- a/.idea/inspectionProfiles/Gradle.xml
+++ b/.idea/inspectionProfiles/Gradle.xml
@@ -1,6 +1,7 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="Gradle" />
+    <inspection_tool class="21f28a86-2ba8-3048-9ce1-b6f10d4d4a12" enabled="true" level="WEAK WARNING" enabled_by_default="true" editorAttributes="INFO_ATTRIBUTES" />
     <inspection_tool class="73cd39e8-e54e-3a38-ad1b-b883fff4b1eb" enabled="true" level="WEAK WARNING" enabled_by_default="true" editorAttributes="INFO_ATTRIBUTES" />
     <inspection_tool class="AsciiDocLinkResolve" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="CatchMayIgnoreException" enabled="true" level="ERROR" enabled_by_default="true" />
@@ -34,6 +35,14 @@
       </extension>
     </inspection_tool>
     <inspection_tool class="SSBasedInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <replaceConfiguration name="Join combined with collect" suppressId="join_with_collect" problemDescriptor="Use a `join` method overload" text="$callJoin$($sep$, $callCollect$($src$, $transform$))" recursive="false" caseInsensitive="false" type="JAVA" pattern_context="default" reformatAccordingToStyle="true" shortenFQN="true" useStaticImport="true" replacement="org.gradle.util.internal.CollectionUtils.join($sep$, $src$, $transform$)">
+        <constraint name="__context__" within="" contains="" />
+        <constraint name="src" within="" contains="" />
+        <constraint name="sep" nameOfExprType="String" exprTypeWithinHierarchy="true" within="" contains="" />
+        <constraint name="callJoin" regexp="join" within="" contains="" />
+        <constraint name="callCollect" regexp="collect" within="" contains="" />
+        <constraint name="transform" within="" contains="" />
+      </replaceConfiguration>
       <replaceConfiguration name="Manual array contains" description="Replace checking element presense in array with a utility function" suppressId="manual_array_contains" problemDescriptor="Replace manual array-contains check with utility function" text="for ($TYPE$ $ITEM$ : $ARR$) {&#10;    if ($ITEM$.equals($TARGET$)) {&#10;       return $RES$;&#10;    }&#10;}" recursive="false" caseInsensitive="false" type="JAVA" pattern_context="default" reformatAccordingToStyle="true" shortenFQN="true" useStaticImport="true" replacement="if (org.gradle.util.internal.ArrayUtils.contains($ARR$, $TARGET$)) {&#10;   return $RES$;&#10;}">
         <constraint name="__context__" within="" contains="" />
         <constraint name="TYPE" within="" contains="" />

--- a/.idea/inspectionProfiles/Gradle.xml
+++ b/.idea/inspectionProfiles/Gradle.xml
@@ -1,6 +1,7 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="Gradle" />
+    <inspection_tool class="73cd39e8-e54e-3a38-ad1b-b883fff4b1eb" enabled="true" level="WEAK WARNING" enabled_by_default="true" editorAttributes="INFO_ATTRIBUTES" />
     <inspection_tool class="AsciiDocLinkResolve" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="CatchMayIgnoreException" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="Convert2streamapi" enabled="false" level="INFORMATION" enabled_by_default="false" />
@@ -33,6 +34,22 @@
       </extension>
     </inspection_tool>
     <inspection_tool class="SSBasedInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <replaceConfiguration name="Manual array contains" description="Replace checking element presense in array with a utility function" suppressId="manual_array_contains" problemDescriptor="Replace manual array-contains check with utility function" text="for ($TYPE$ $ITEM$ : $ARR$) {&#10;    if ($ITEM$.equals($TARGET$)) {&#10;       return $RES$;&#10;    }&#10;}" recursive="false" caseInsensitive="false" type="JAVA" pattern_context="default" reformatAccordingToStyle="true" shortenFQN="true" useStaticImport="true" replacement="if (org.gradle.util.internal.ArrayUtils.contains($ARR$, $TARGET$)) {&#10;   return $RES$;&#10;}">
+        <constraint name="__context__" within="" contains="" />
+        <constraint name="TYPE" within="" contains="" />
+        <constraint name="ARR" nameOfExprType=".*\[\]" within="" contains="" />
+        <constraint name="RES" nameOfExprType="boolean" exprTypeWithinHierarchy="true" within="" contains="" />
+        <constraint name="ITEM" within="" contains="" />
+        <constraint name="TARGET" within="" contains="" />
+      </replaceConfiguration>
+      <replaceConfiguration name="Manual array contains" text="for ($TYPE$ $ITEM$ : $ARR$) {&#10;    if ($TARGET$.equals($ITEM$)) {&#10;       return $RES$;&#10;    }&#10;}" recursive="false" caseInsensitive="false" type="JAVA" pattern_context="default" reformatAccordingToStyle="true" shortenFQN="true" useStaticImport="true" replacement="if (org.gradle.util.internal.ArrayUtils.contains($ARR$, $TARGET$)) {&#10;    return $RES$;&#10;}">
+        <constraint name="__context__" within="" contains="" />
+        <constraint name="TYPE" within="" contains="" />
+        <constraint name="ARR" nameOfExprType=".*\[\]" within="" contains="" />
+        <constraint name="RES" nameOfExprType="boolean" exprTypeWithinHierarchy="true" within="" contains="" />
+        <constraint name="ITEM" within="" contains="" />
+        <constraint name="TARGET" within="" contains="" />
+      </replaceConfiguration>
       <replaceConfiguration name="Treat some Guava Collection factory methods as Deprecated" uuid="82f9f9ab-9c3b-367f-99ad-40841dc13819" description="Many no-argument Guava Collection factory methods are marked in their javadoc &quot;Should be treated as deprecated&quot;.  These should not be used." suppressId="guava-collection-factory" problemDescriptor="Treat some Guava Collection factory methods as Deprecated" text="com.google.common.collect.Lists.newArrayList()" recursive="false" caseInsensitive="false" type="JAVA" pattern_context="default" reformatAccordingToStyle="true" shortenFQN="true" replacement="new java.util.ArrayList&lt;&gt;()">
         <constraint name="__context__" within="" contains="" />
       </replaceConfiguration>

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/InternalTransformer.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/InternalTransformer.java
@@ -18,7 +18,7 @@ package org.gradle.internal;
 
 /**
  * Equivalent to {@code Transformer}, but does not declare nullability due to Java 6 restrictions.
- * /**
+ *
  * <p>A {@code Transformer} transforms objects of type.</p>
  *
  * <p>Implementations are free to return new objects or mutate the incoming value.</p>

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/ServiceScopeValidator.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/ServiceScopeValidator.java
@@ -28,6 +28,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static org.gradle.util.internal.ArrayUtils.contains;
+
 /**
  * Checks that services are being declared in the correct scope.
  * <p>
@@ -65,13 +67,9 @@ class ServiceScopeValidator implements AnnotatedServiceLifecycleHandler {
             throw new IllegalArgumentException(String.format("Service '%s' is declared with empty scope list", serviceType.getName()));
         }
 
-        if (!containsScope(scope, serviceScopes)) {
+        if (!contains(serviceScopes, scope)) {
             throw new IllegalArgumentException(invalidScopeMessage(serviceType, serviceScopes));
         }
-    }
-
-    private static boolean containsScope(Class<? extends Scope> expectedScope, Class<? extends Scope>[] actualScopes) {
-        return Arrays.asList(actualScopes).contains(expectedScope);
     }
 
     private String invalidScopeMessage(Class<?> serviceType, Class<? extends Scope>[] actualScopes) {

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/ServiceScopeValidator.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/service/ServiceScopeValidator.java
@@ -20,15 +20,14 @@ import org.gradle.api.NonNullApi;
 import org.gradle.internal.InternalTransformer;
 import org.gradle.internal.service.scopes.Scope;
 import org.gradle.internal.service.scopes.ServiceScope;
-import org.gradle.util.internal.CollectionUtils;
 
 import javax.annotation.Nullable;
 import java.lang.annotation.Annotation;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 import static org.gradle.util.internal.ArrayUtils.contains;
+import static org.gradle.util.internal.CollectionUtils.join;
 
 /**
  * Checks that services are being declared in the correct scope.
@@ -90,12 +89,12 @@ class ServiceScopeValidator implements AnnotatedServiceLifecycleHandler {
             return "service scope '" + scopes[0].getSimpleName() + "'";
         }
 
-        return "service scopes " + CollectionUtils.join(", ", CollectionUtils.collect(Arrays.asList(scopes), new InternalTransformer<String, Class<? extends Scope>>() {
+        return "service scopes " + join(", ", scopes, new InternalTransformer<String, Class<? extends Scope>>() {
             @Override
             public String transform(Class<? extends Scope> aClass) {
                 return "'" + aClass.getSimpleName() + "'";
             }
-        }));
+        });
     }
 
     @Nullable

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/util/internal/ArrayUtils.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/util/internal/ArrayUtils.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.util.internal;
+
+import org.gradle.api.NonNullApi;
+
+import javax.annotation.Nullable;
+
+@NonNullApi
+public class ArrayUtils {
+
+    /**
+     * Checks if a value is contained in the array.
+     */
+    @SuppressWarnings("manual_array_contains")
+    public static <T> boolean contains(T[] array, @Nullable T value) {
+        if (value == null) {
+            for (T v : array) {
+                if (v == null) {
+                    return true;
+                }
+            }
+        } else {
+            for (T v : array) {
+                if (value.equals(v)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/util/internal/CollectionUtils.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/util/internal/CollectionUtils.java
@@ -53,6 +53,7 @@ import static org.gradle.internal.Cast.cast;
 import static org.gradle.internal.Cast.castNullable;
 import static org.gradle.internal.Cast.uncheckedNonnullCast;
 
+@SuppressWarnings("join_with_collect")
 public abstract class CollectionUtils {
 
     /**
@@ -541,6 +542,15 @@ public abstract class CollectionUtils {
     }
 
     /**
+     * Creates a string with {@code toString()} of each transformed object with the given separator.
+     *
+     * @see #join(String, Object[])
+     */
+    public static <R, I> String join(String separator, I[] objects, InternalTransformer<? extends R, ? super I> transformer) {
+        return join(separator, collect(objects, transformer));
+    }
+
+    /**
      * Creates a string with {@code toString()} of each object with the given separator.
      *
      * <pre>
@@ -574,6 +584,16 @@ public abstract class CollectionUtils {
             }
         }
         return string.toString();
+    }
+
+    /**
+     * Creates a string with {@code toString()} of each transformed object with the given separator.
+     *
+     * @see #join(String, Iterable)
+     */
+    public static <R, I> String join(String separator, Iterable<? extends I> objects, InternalTransformer<? extends R, ? super I> transformer) {
+        //noinspection join_with_collect
+        return join(separator, collect(objects, transformer));
     }
 
     /**

--- a/platforms/core-runtime/base-services/src/test/groovy/org/gradle/util/internal/ArrayUtilsTest.groovy
+++ b/platforms/core-runtime/base-services/src/test/groovy/org/gradle/util/internal/ArrayUtilsTest.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.util.internal
+
+
+import spock.lang.Specification
+
+class ArrayUtilsTest extends Specification {
+
+    def "contains"() {
+        expect:
+        ArrayUtils.contains(arr("a", "b", "c"), "b")
+        !ArrayUtils.contains(arr("a", "b", "c"), "d")
+        ArrayUtils.contains(arr("a", "b", null), null)
+        !ArrayUtils.contains(arr("a", "b", "c"), null)
+    }
+
+    def <T> T[] arr(T... items) {
+        items
+    }
+}


### PR DESCRIPTION
Adds small utility functions for working with arrays in Java 6 projects in gradle/gradle.
- `contains(array, target)`
- `join(separator, objects, transformer)` overload to avoid `join(..., collect(...))` calls

Both new utilities come with a custom inspection to make them discoverable. This is made possible by IDEA's [Structural search and replace inspections](https://www.jetbrains.com/help/idea/creating-custom-inspections.html#ssr-examples) functionality.

For instance, if you find yourself in a Java 6-based project, and write a manual array loop to check if an element is present in the array, the IDE will automatically suggest replacing that with a utility call.

<img width="1262" alt="image" src="https://github.com/gradle/gradle/assets/2759152/4921d33f-147a-469f-88a2-c539fba32cce">

A similar auto-replace is added for the `join(..., collect(...))` calls to use the new utility.

This makes such utilities much more discoverable.