### PR TITLE
docs: Fix erroneous link to Kotlin DSL

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/authoring-builds/basics/writing_build_scripts.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/authoring-builds/basics/writing_build_scripts.adoc
@@ -50,7 +50,7 @@ IMPORTANT: _Build scripts_ configure `Project` objects and their children.
 The `Project` object is part of the link:{javadocPath}org/gradle/api/Project.html[Gradle API].
 
 - In the Groovy DSL, the `Project` object documentation is found link:{groovyDslPath}/org.gradle.api.Project.html[here].
-- In the Kotlin DSL, the `Project` object documentation is found link:{kotlinDslPath}/gradle/org.gradle.api.initialization/-settings/index.html[here].
+- In the Kotlin DSL, the `Project` object documentation is found link:{kotlinDslPath}/gradle/org.gradle.api/-project/index.html[here].
 
 Many top-level properties and blocks in a build script are part of the Project API.
 


### PR DESCRIPTION
Changes the link to point to the Kotlin DSL documentation for the Project interface.

<!--- The issue this PR addresses -->
<!-- Fixes #? -->

### Context
The link previously pointed to the Kotlin DSL for the Settings interface, which seems wrong.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [N/A] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [N/A] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [N/A] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
