### PR TITLE
Ignore failing native tests with clang 14

### DIFF
--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationIntegrationTest.groovy
@@ -137,16 +137,14 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         result.assertTasksExecuted(tasks.release.allToInstall, tasks.release.extract, tasks.release.assemble)
 
         executable("build/exe/main/release/app").assertExists()
-        // clang 11: build/exe/main/release/app: ['greeter.cpp', 'main.cpp']
-        // clang 14: build/exe/main/release/app: ['greeter.cpp', 'std', '__ioinit', 'ios_base', 'Init', '_Ios_Iostate', '_S_goodbit', ... ]
-        executable("build/exe/main/release/app").assertHasStrippedDebugSymbolsFor(["greeter.cpp"])
+        executable("build/exe/main/release/app").assertHasStrippedDebugSymbolsFor(app.sourceFileNamesWithoutHeaders)
         installation("build/install/main/release").exec().out == app.withFeatureEnabled().expectedOutput
 
         succeeds tasks.debug.assemble
         result.assertTasksExecuted(tasks.debug.allToInstall, tasks.debug.assemble)
 
         executable("build/exe/main/debug/app").assertExists()
-        executable("build/exe/main/debug/app").assertHasDebugSymbolsFor(["greeter.cpp"])
+        executable("build/exe/main/debug/app").assertHasDebugSymbolsFor(app.sourceFileNamesWithoutHeaders)
         installation("build/install/main/debug").exec().out == app.withFeatureDisabled().expectedOutput
     }
 

--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationIntegrationTest.groovy
@@ -118,6 +118,7 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
 
     @ToBeFixedForConfigurationCache
     def "can build debug and release variants of executable"() {
+        assumeNotClang14()
         settingsFile << "rootProject.name = 'app'"
         def app = new CppAppWithOptionalFeature()
 

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/tasks/ExtractSymbolsIntegrationTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/tasks/ExtractSymbolsIntegrationTest.groovy
@@ -55,9 +55,7 @@ class ExtractSymbolsIntegrationTest extends AbstractInstalledToolChainIntegratio
 
         then:
         executedAndNotSkipped":extractSymbolsDebug"
-        // clang 11: [greeter.cpp, sum.cpp, multiply.cpp, main.cpp]
-        // clang 14: ['multiply.cpp', 'Multiply', 'multiply', 'int', 'this', 'a', 'b', ...]
-        fixture("build/symbols").assertHasDebugSymbolsFor(['multiply.cpp'])
+        fixture("build/symbols").assertHasDebugSymbolsFor(withoutHeaders(app.original))
     }
 
     @ToBeFixedForConfigurationCache
@@ -73,9 +71,7 @@ class ExtractSymbolsIntegrationTest extends AbstractInstalledToolChainIntegratio
 
         then:
         skipped":extractSymbolsDebug"
-        // clang 11: [greeter.cpp, sum.cpp, multiply.cpp, main.cpp]
-        // clang 14: ['multiply.cpp', 'Multiply', 'multiply', 'int', 'this', 'a', 'b', ...]
-        fixture("build/symbols").assertHasDebugSymbolsFor(['multiply.cpp'])
+        fixture("build/symbols").assertHasDebugSymbolsFor(withoutHeaders(app.original))
     }
 
     @ToBeFixedForConfigurationCache
@@ -92,9 +88,7 @@ class ExtractSymbolsIntegrationTest extends AbstractInstalledToolChainIntegratio
 
         then:
         executedAndNotSkipped":extractSymbolsDebug"
-        // clang 11: [greeter.cpp, renamed-sum.cpp, main.cpp]
-        // clang 14: ['greeter.cpp', 'std', '__ioinit', 'ios_base', 'Init', '__exception_ptr', 'exception_ptr', 'rethrow_exception', '__debug' ...]
-        fixture("build/symbols").assertHasDebugSymbolsFor(['greeter.cpp'])
+        fixture("build/symbols").assertHasDebugSymbolsFor(withoutHeaders(app.alternate))
     }
 
     NativeBinaryFixture fixture(String path) {

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/tasks/ExtractSymbolsIntegrationTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/tasks/ExtractSymbolsIntegrationTest.groovy
@@ -50,6 +50,8 @@ class ExtractSymbolsIntegrationTest extends AbstractInstalledToolChainIntegratio
 
     @ToBeFixedForConfigurationCache
     def "extracts symbols from binary"() {
+        assumeNotClang14()
+
         when:
         succeeds ":extractSymbolsDebug"
 
@@ -60,6 +62,8 @@ class ExtractSymbolsIntegrationTest extends AbstractInstalledToolChainIntegratio
 
     @ToBeFixedForConfigurationCache
     def "extract is skipped when there are no changes"() {
+        assumeNotClang14()
+
         when:
         succeeds ":extractSymbolsDebug"
 
@@ -76,6 +80,8 @@ class ExtractSymbolsIntegrationTest extends AbstractInstalledToolChainIntegratio
 
     @ToBeFixedForConfigurationCache
     def "extract is re-executed when changes are made"() {
+        assumeNotClang14()
+
         when:
         succeeds ":extractSymbolsDebug"
 

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/tasks/StripSymbolsIntegrationTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/tasks/StripSymbolsIntegrationTest.groovy
@@ -55,9 +55,7 @@ class StripSymbolsIntegrationTest extends AbstractInstalledToolChainIntegrationS
 
         then:
         executedAndNotSkipped":stripSymbolsDebug"
-        // clang 11: [greeter.cpp, sum.cpp, multiply.cpp, main.cpp]
-        // clang 14: ['multiply.cpp', 'Multiply', 'multiply', 'int', 'this', 'a', 'b', ...]
-        executable("build/exe/main/debug/app").assertHasDebugSymbolsFor(['multiply.cpp'])
+        executable("build/exe/main/debug/app").assertHasDebugSymbolsFor(withoutHeaders(app.original))
         binary("build/stripped").assertDoesNotHaveDebugSymbolsFor(withoutHeaders(app.original))
     }
 

--- a/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/tasks/StripSymbolsIntegrationTest.groovy
+++ b/platforms/native/platform-native/src/integTest/groovy/org/gradle/nativeplatform/tasks/StripSymbolsIntegrationTest.groovy
@@ -50,6 +50,8 @@ class StripSymbolsIntegrationTest extends AbstractInstalledToolChainIntegrationS
 
     @ToBeFixedForConfigurationCache
     def "strips symbols from binary"() {
+        assumeNotClang14()
+
         when:
         succeeds ":stripSymbolsDebug"
 

--- a/platforms/native/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AbstractInstalledToolChainIntegrationSpec.groovy
+++ b/platforms/native/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AbstractInstalledToolChainIntegrationSpec.groovy
@@ -27,6 +27,7 @@ import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.UnitTestPreconditions
+import org.junit.Assume
 
 /**
  * Runs a test separately for each installed tool chain.
@@ -56,6 +57,11 @@ abstract class AbstractInstalledToolChainIntegrationSpec extends AbstractIntegra
             usingInitScript(initScript)
             toolChain.configureExecuter(it)
         })
+    }
+
+    // https://github.com/gradle/gradle-private/issues/4099
+    void assumeNotClang14() {
+        Assume.assumeFalse(toolChain.displayName.contains("clang 14"))
     }
 
     String executableName(Object path) {


### PR DESCRIPTION
This PR includes 2 commits. 

The first commit reverts the changes in #27482 because that was not working. 

The second commit adds `assumeNotClang14()` to skip the failing tests on clang 14. See https://github.com/gradle/gradle-private/issues/4099 for the context.