### PR TITLE
Show only tasks in the execution progress bar

### DIFF
--- a/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/CrossProjectConfigurationReportingTaskExecutionGraph.kt
+++ b/platforms/core-configuration/configuration-cache/src/main/kotlin/org/gradle/configurationcache/CrossProjectConfigurationReportingTaskExecutionGraph.kt
@@ -207,6 +207,8 @@ class CrossProjectConfigurationReportingTaskExecutionGraph(
 
     override fun size(): Int = delegate.size()
 
+    override fun taskSize(): Int = delegate.taskSize()
+
     @Deprecated("Deprecated in Java")
     override fun addTaskExecutionListener(@Suppress("DEPRECATION") listener: org.gradle.api.execution.TaskExecutionListener) {
         @Suppress("DEPRECATION")

--- a/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/operations/BuildOperationCategory.java
+++ b/platforms/core-runtime/base-services/src/main/java/org/gradle/internal/operations/BuildOperationCategory.java
@@ -25,51 +25,53 @@ public enum BuildOperationCategory implements BuildOperationMetadata {
     /**
      * Configure the root build. May also include nested {@link #CONFIGURE_BUILD} and {@link #RUN_WORK} operations.
      */
-    CONFIGURE_ROOT_BUILD(false, false, false),
+    CONFIGURE_ROOT_BUILD(false, false, false, false),
 
     /**
      * Configure a nested build or a buildSrc build.
      */
-    CONFIGURE_BUILD(false, false, false),
+    CONFIGURE_BUILD(false, false, false, false),
 
     /**
      * Configure a single project in any build.
      */
-    CONFIGURE_PROJECT(true, false, false),
+    CONFIGURE_PROJECT(true, false, false, false),
 
     /**
      * Execute the main tasks of a build tree. Also known as the "execution phase".
      */
-    RUN_MAIN_TASKS(false, false, false),
+    RUN_MAIN_TASKS(false, false, false, false),
 
     /**
      * Execute all work in a particular build in the tree. Includes {@link #TASK} and Includes {@link #TRANSFORM} operations.
      */
-    RUN_WORK(false, false, false),
+    RUN_WORK(false, false, false, false),
 
     /**
      * Execute an individual task.
      */
-    TASK(true, true, true),
+    TASK(true, true, true, true),
 
     /**
      * Execute an individual transform.
      */
-    TRANSFORM(true, true, false),
+    TRANSFORM(true, true, false, false),
 
     /**
      * Operation doesn't belong to any category.
      */
-    UNCATEGORIZED(false, false, false);
+    UNCATEGORIZED(false, false, false, false);
 
     private final boolean grouped;
     private final boolean topLevelWorkItem;
     private final boolean showHeader;
+    private final boolean shownInExecutionProgressBar;
 
-    BuildOperationCategory(boolean grouped, boolean topLevelWorkItem, boolean showHeader) {
+    BuildOperationCategory(boolean grouped, boolean topLevelWorkItem, boolean showHeader, boolean shownInExecutionProgressBar) {
         this.grouped = grouped;
         this.topLevelWorkItem = topLevelWorkItem;
         this.showHeader = showHeader;
+        this.shownInExecutionProgressBar = shownInExecutionProgressBar;
     }
 
     public boolean isGrouped() {
@@ -78,6 +80,10 @@ public enum BuildOperationCategory implements BuildOperationMetadata {
 
     public boolean isTopLevelWorkItem() {
         return topLevelWorkItem;
+    }
+
+    public boolean isShownInExecutionProgressBar() {
+        return shownInExecutionProgressBar;
     }
 
     public boolean isShowHeader() {

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/console/BuildStatusRenderer.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/console/BuildStatusRenderer.java
@@ -93,7 +93,7 @@ public class BuildStatusRenderer implements OutputEventListener {
                 } else if (startEvent.getBuildOperationCategory() == BuildOperationCategory.RUN_WORK && currentPhase == Phase.Executing) {
                     // Any work execution happening in nested or buildSrc builds before the root build has started executing work is ignored
                     phaseHasMoreProgress(startEvent);
-                } else if (startEvent.getBuildOperationCategory().isTopLevelWorkItem() && currentPhase == Phase.Executing) {
+                } else if (startEvent.getBuildOperationCategory().isShownInExecutionProgressBar() && currentPhase == Phase.Executing) {
                     // Any work execution happening in nested or buildSrc builds before the root build has started executing work is ignored
                     currentPhaseChildren.add(startEvent.getProgressOperationId());
                 }

--- a/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/console/ProgressBar.java
+++ b/platforms/core-runtime/logging/src/main/java/org/gradle/internal/logging/console/ProgressBar.java
@@ -30,6 +30,7 @@ import java.util.concurrent.Executors;
 
 public class ProgressBar {
     private static final Logger LOGGER = LoggerFactory.getLogger(ProgressBar.class);
+    public static final String INCORRECT_PROGRESS_MESSAGE = "More progress was logged than there should be";
 
     private final TersePrettyDurationFormatter elapsedTimeFormatter = new TersePrettyDurationFormatter();
 
@@ -76,7 +77,7 @@ public class ProgressBar {
                 public void run() {
                     // do not do this directly or a deadlock happens
                     // to prevent that deadlock, execute it separately in another thread
-                    LOGGER.warn("More progress was logged than there should be ({} > {})", current, total);
+                    LOGGER.warn("{} ({} > {})", INCORRECT_PROGRESS_MESSAGE, current, total);
                 }
             });
         }

--- a/subprojects/core/src/main/java/org/gradle/execution/BuildOperationFiringBuildWorkerExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/BuildOperationFiringBuildWorkerExecutor.java
@@ -66,7 +66,7 @@ public class BuildOperationFiringBuildWorkerExecutor implements BuildWorkExecuto
                 builder.details(new RunRootBuildWorkBuildOperationType.Details(buildStartTime));
             }
             builder.metadata(BuildOperationCategory.RUN_WORK);
-            builder.totalProgress(gradle.getTaskGraph().size());
+            builder.totalProgress(gradle.getTaskGraph().taskSize());
             return builder;
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionGraph.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionGraph.java
@@ -267,6 +267,11 @@ public class DefaultTaskExecutionGraph implements TaskExecutionGraphInternal {
     }
 
     @Override
+    public int taskSize() {
+        return executionPlan.getContents().getTasks().size();
+    }
+
+    @Override
     public List<Task> getAllTasks() {
         return allTasks;
     }

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskExecutionGraphInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskExecutionGraphInternal.java
@@ -53,8 +53,15 @@ public interface TaskExecutionGraphInternal extends TaskExecutionGraph {
 
     /**
      * Returns the number of work items in this graph.
+     * Note: this is not the same as the number of tasks in this graph, but can include also other work items like artifact transforms.
      */
     int size();
+
+    /**
+     * Returns the number of tasks in this graph. Tasks are a subset of work items,
+     * so this relation is always true: size() >= taskSize().
+     */
+    int taskSize();
 
     /**
      * Returns all the work items in this graph scheduled for execution plus all


### PR DESCRIPTION
Before also artifact transforms were shown, but that can cause incorrect percentage with unplanned artifact transforms.

Fixes https://github.com/gradle/gradle/issues/24370.
