### PR TITLE
Handle files left open with immutable workspace mechanics on Windows

### DIFF
--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/steps/AssignImmutableWorkspaceStep.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/steps/AssignImmutableWorkspaceStep.java
@@ -205,7 +205,7 @@ public class AssignImmutableWorkspaceStep<C extends IdentityContext> implements 
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug("Could not remove temporary workspace: {}", temporaryWorkspace.getAbsolutePath(), removeTempException);
             } else {
-                LOGGER.warn("Could not remove temporary workspace: {}: {}", temporaryWorkspace.getAbsolutePath(), removeTempException.getMessage());
+                LOGGER.info("Could not remove temporary workspace: {}: {}", temporaryWorkspace.getAbsolutePath(), removeTempException.getMessage());
             }
         }
     }

--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/steps/AssignImmutableWorkspaceStep.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/steps/AssignImmutableWorkspaceStep.java
@@ -107,7 +107,10 @@ public class AssignImmutableWorkspaceStep<C extends IdentityContext> implements 
         ImmutableListMultimap<String, HashCode> outputHashes = calculateOutputHashes(outputSnapshots);
         ImmutableWorkspaceMetadata metadata = workspaceMetadataStore.loadWorkspaceMetadata(immutableWorkspace);
         if (!metadata.getOutputPropertyHashes().equals(outputHashes)) {
-            throw new IllegalStateException("Workspace has been changed: " + immutableWorkspace.getAbsolutePath());
+            throw new IllegalStateException(
+                "Immutable workspace contents have been modified: " + immutableWorkspace.getAbsolutePath() + ". " +
+                "These workspace directories are not supposed to be modified once they are created. " +
+                "Deleting the directory in question can allow the content to be recreated.");
         }
 
         OriginMetadata originMetadata = metadata.getOriginMetadata();

--- a/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/steps/AssignImmutableWorkspaceStep.java
+++ b/platforms/core-execution/execution/src/main/java/org/gradle/internal/execution/steps/AssignImmutableWorkspaceStep.java
@@ -162,7 +162,7 @@ public class AssignImmutableWorkspaceStep<C extends IdentityContext> implements 
                 }
                 return new WorkspaceResult(delegateResult, immutableLocation);
             } else {
-                // TODO Do not try to capture the workspace in case of a failure
+                // TODO Do not capture a null workspace in case of a failure
                 return new WorkspaceResult(delegateResult, null);
             }
         });

--- a/platforms/core-execution/execution/src/test/groovy/org/gradle/internal/execution/steps/AssignImmutableWorkspaceStepTest.groovy
+++ b/platforms/core-execution/execution/src/test/groovy/org/gradle/internal/execution/steps/AssignImmutableWorkspaceStepTest.groovy
@@ -294,7 +294,9 @@ class AssignImmutableWorkspaceStepTest extends StepSpec<IdentityContext> impleme
 
         then:
         def ex = thrown IllegalStateException
-        ex.message.startsWith("Workspace has been changed")
+        ex.message == "Immutable workspace contents have been modified: ${immutableWorkspace.absolutePath}. " +
+            "These workspace directories are not supposed to be modified once they are created. " +
+            "Deleting the directory in question can allow the content to be recreated."
         0 * _
     }
 }

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -1227,6 +1227,73 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
         output.count("Transformed") == 0
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/27844")
+    def "non-incremental transform succeeds even if file handle leaks"() {
+        given:
+        buildFile << declareAttributes() << duplicatorTransform(incremental: false, normalization: "@Classpath") << """
+            class TestState {
+                static OutputStream fileKeptOpen = null
+            }
+
+            abstract class FileLeaker implements TransformAction<TransformParameters.None> {
+
+                @InputArtifact
+                @PathSensitive(PathSensitivity.NONE)
+                abstract Provider<FileSystemLocation> getInputArtifact()
+
+                @Override
+                void transform(TransformOutputs outputs) {
+                    // Simulate transform leaving file open
+                    def output = outputs.file("output.txt")
+                    output.createNewFile()
+                    TestState.fileKeptOpen = output.newOutputStream()
+                    TestState.fileKeptOpen << "output"
+                    TestState.fileKeptOpen.flush()
+                }
+            }
+
+            project(':lib') {
+                task jar1(type: Jar) {
+                    archiveFileName = 'lib1.jar'
+                }
+                tasks.withType(Jar) {
+                    destinationDirectory = buildDir
+                }
+                artifacts {
+                    compile jar1
+                }
+            }
+
+            project(':util') {
+                dependencies {
+                    compile project(':lib')
+                }
+            }
+
+            allprojects {
+                dependencies {
+                    registerTransform(FileLeaker) {
+                        from.attribute(artifactType, "jar")
+                        to.attribute(artifactType, "green")
+                    }
+                }
+                task resolve(type: Resolve) {
+                    artifacts = configurations.compile.incoming.artifactView {
+                        attributes { it.attribute(artifactType, 'green') }
+                    }.artifacts
+                    doLast {
+                        def artifactFiles = artifacts.get().artifactFiles
+                        assert artifactFiles.size() == 1
+                        assert artifactFiles[0].text == "output"
+                    }
+                }
+            }
+        """
+
+        expect:
+        succeeds ":util:resolve"
+    }
+
     def "long transformation chain works"() {
         given:
         buildFile << declareAttributes() << withJarTasks() << withFileLibDependency("lib3.jar") << withExternalLibDependency("lib4") << duplicatorTransform() << """

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -1285,6 +1285,9 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
                         def artifactFiles = artifacts.get().artifactFiles
                         assert artifactFiles.size() == 1
                         assert artifactFiles[0].text == "output"
+
+                        // Cleanup
+                        TestState.fileKeptOpen.close()
                     }
                 }
             }


### PR DESCRIPTION
Fixes #27844.

On Windows, immutable user work (typically non-incremental transforms) can leak file handles (i.e. leave files open), which prevents Windows from moving the temporary workspace to its immutable location, causing the related issue.

In this PR we handle this case better. When the move fails (for files left open or for another reason), we make a "defensive copy" of the workspace, where we control the state of file handles, and move that into the cache instead, then make a feeble attempt at removing the original temporary workspace, then log the problem.