### PR TITLE
Fix include for introduction in userguide_single.adoc

### DIFF
--- a/platforms/documentation/docs/src/docs/userguide/userguide_single.adoc
+++ b/platforms/documentation/docs/src/docs/userguide/userguide_single.adoc
@@ -56,7 +56,7 @@ include::migrating_from_ant.adoc[leveloffset=+2]
 [[part:getting_started]]
 == **GETTING STARTED**
 
-include::introduction.adoc[leveloffset=+2]
+include::getting_started_eng.adoc[leveloffset=+2]
 include::installation.adoc[leveloffset=+2]
 
 [[part:running_builds]]


### PR DESCRIPTION
Introduction.adoc has been renamed.

Fixes https://github.com/gradle/gradle/issues/27847