### PR TITLE
Offer alternative collection methods that honor conventions

### DIFF
--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/CollectionSupplier.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/CollectionSupplier.java
@@ -24,4 +24,9 @@ interface CollectionSupplier<T, C extends Collection<? extends T>> extends Value
     CollectionSupplier<T, C> plus(Collector<T> collector);
 
     ExecutionTimeValue<? extends C> calculateExecutionTimeValue();
+
+    /**
+     * Returns a view of this supplier that will calculate its value as empty if it would be missing.
+     */
+    CollectionSupplier<T, C> ignoringAbsent();
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/Collector.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/Collector.java
@@ -17,7 +17,12 @@
 package org.gradle.api.internal.provider;
 
 import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.Action;
+import org.gradle.internal.Cast;
+
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * A supplier of zero or more values of type {@link T}.
@@ -28,4 +33,52 @@ public interface Collector<T> extends ValueSupplier {
     int size();
 
     void calculateExecutionTimeValue(Action<? super ExecutionTimeValue<? extends Iterable<? extends T>>> visitor);
+
+    /**
+     * Returns a collector that never returns a missing value.
+     */
+    default Collector<T> absentIgnoring() {
+        Collector<T> delegate = this;
+        return new Collector<T>() {
+            @Override
+            public Value<Void> collectEntries(ValueConsumer consumer, ValueCollector<T> collector, ImmutableCollection.Builder<T> dest) {
+                ImmutableCollection.Builder<T> batch = ImmutableList.builder();
+                Value<Void> result = delegate.collectEntries(consumer, collector, batch);
+                if (result.isMissing()) {
+                    return Value.present();
+                }
+                dest.addAll(batch.build());
+                return result;
+            }
+
+            @Override
+            public int size() {
+                return delegate.size();
+            }
+
+            @Override
+            public void calculateExecutionTimeValue(Action<? super ExecutionTimeValue<? extends Iterable<? extends T>>> visitor) {
+                List<ExecutionTimeValue> values = new LinkedList<>();
+                delegate.calculateExecutionTimeValue(it -> collectIfPresent(values, it));
+                values.forEach(it -> visitor.execute(Cast.uncheckedNonnullCast(it)));
+            }
+
+            private void collectIfPresent(List<ExecutionTimeValue> values, ExecutionTimeValue<? extends Iterable<? extends T>> it) {
+                if (!it.isMissing()) {
+                    values.add(it);
+                }
+            }
+
+            @Override
+            public ValueProducer getProducer() {
+                return delegate.getProducer();
+            }
+
+            @Override
+            public boolean calculatePresence(ValueConsumer consumer) {
+                // always present
+                return true;
+            }
+        };
+    }
 }

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
@@ -125,7 +125,7 @@ public class DefaultProperty<T> extends AbstractProperty<T, ProviderInternal<? e
 
     @Override
     public Property<T> unset() {
-        discardValue();
+        super.unset();
         return this;
     }
 

--- a/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/MapSupplier.java
+++ b/platforms/core-configuration/model-core/src/main/java/org/gradle/api/internal/provider/MapSupplier.java
@@ -26,5 +26,10 @@ interface MapSupplier<K, V> extends ValueSupplier {
 
     MapSupplier<K, V> plus(MapCollector<K, V> collector);
 
-    ExecutionTimeValue<? extends Map<K, V>> calculateOwnExecutionTimeValue();
+    /**
+     * Returns a view of this supplier that will calculate its value as empty if it would be missing.
+     */
+    MapSupplier<K, V> ignoringAbsent();
+
+    ExecutionTimeValue<? extends Map<K, V>> calculateExecutionTimeValue();
 }

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
@@ -76,16 +76,19 @@ abstract class CollectionPropertySpec<C extends Collection<String>> extends Prop
 
     def property = property()
 
-    protected void assertValueIs(Collection<String> expected) {
+    protected void assertValueIs(Collection<String> expected, PropertyInternal<?> property = this.property) {
         assert property.present
         def actual = property.get()
         assert actual instanceof ImmutableCollection
         assert immutableCollectionType.isInstance(actual)
+        assertCollectionIs(actual, expected)
+    }
+
+    protected void assertCollectionIs(ImmutableCollection actual, Collection<String> expected) {
         assert actual == toImmutable(expected)
         actual.each {
             assert it instanceof String
         }
-        assert property.present
     }
 
     protected abstract C toImmutable(Collection<String> values)
@@ -1272,12 +1275,38 @@ The value of this property is derived from: <source>""")
         given:
         property.convention(Providers.of(["1"]))
         property.withActualValue {
-            it.addAll(Providers.of(["2"]))
+            it.add(Providers.of("2"))
             it.addAll(Providers.of(["3", "4"]))
         }
+
         expect:
         assertValueIs toImmutable(["1", "2", "3", "4"])
         property.explicit
+
+        when:
+        property.unset()
+
+        then:
+        assertValueIs toImmutable(["1"])
+        !property.explicit
+    }
+
+    def "can add to convention value with append"() {
+        given:
+        property.convention(Providers.of(["1"]))
+        property.append(Providers.of("2"))
+        property.appendAll(Providers.of(["3", "4"]))
+
+        expect:
+        assertValueIs toImmutable(["1", "2", "3", "4"])
+        property.explicit
+
+        when:
+        property.unset()
+
+        then:
+        assertValueIs toImmutable(["1"])
+        !property.explicit
     }
 
     def "can add to explicit value"() {
@@ -1287,6 +1316,17 @@ The value of this property is derived from: <source>""")
             it.addAll(Providers.of(["1", "2"]))
             it.addAll(Providers.of(["3", "4"]))
         }
+
+        expect:
+        assertValueIs toImmutable(["1", "2", "3", "4"])
+        property.explicit
+    }
+
+    def "can add to explicit value with append"() {
+        given:
+        property.set([])
+        property.appendAll(Providers.of(["1", "2"]))
+        property.appendAll(Providers.of(["3", "4"]))
 
         expect:
         assertValueIs toImmutable(["1", "2", "3", "4"])
@@ -1303,8 +1343,141 @@ The value of this property is derived from: <source>""")
         expect:
         assertValueIs toImmutable(["1", "2", "3", "4"])
         property.explicit
+
+        when:
+        property.convention(Providers.of("0"))
+
+        then:
+        assertValueIs toImmutable(["1", "2", "3", "4"])
+        property.explicit
     }
 
+    def "can add to actual value without previous configuration with append"() {
+        given:
+        property.appendAll(Providers.of(["1", "2"]))
+        property.appendAll(Providers.of(["3", "4"]))
+
+        expect:
+        assertValueIs toImmutable(["1", "2", "3", "4"])
+        property.explicit
+    }
+
+    def "appending to an undefined property is undefined-safe"() {
+        given:
+        property.set((Iterable) null)
+        property.append(Providers.of("4"))
+
+        expect:
+        assertValueIs(toImmutable(["4"]))
+    }
+
+    def "appending after adding an undefined element provider is undefined-safe"() {
+        given:
+        property.addAll(Providers.of(["1", "2"]))
+        property.add(Providers.notDefined())
+        property.append(Providers.of("4"))
+
+        expect:
+        property.getOrNull() == toImmutable(["4"])
+    }
+
+    def "appending after adding an undefined iterable provider is undefined-safe"() {
+        given:
+        property.addAll(Providers.of(["1", "2"]))
+        property.addAll(Providers.notDefined())
+        property.append(Providers.of("4"))
+
+        expect:
+        property.getOrNull() == toImmutable(["4"])
+    }
+
+    def "appending an undefined element provider is undefined-safe"() {
+        given:
+        property.append(Providers.notDefined())
+
+        expect:
+        assertValueIs toImmutable([])
+    }
+
+    def "appending an undefined iterable provider is undefined-safe"() {
+        given:
+        property.appendAll(Providers.notDefined())
+
+        expect:
+        assertValueIs toImmutable([])
+    }
+
+    def "adding after appending an undefined element provider is undefined-safe"() {
+        given:
+        property.append(Providers.notDefined())
+        property.add("1")
+
+        expect:
+        assertValueIs toImmutable(["1"])
+    }
+
+    def "adding after appending an undefined iterable provider is undefined-safe"() {
+        given:
+        property.appendAll(Providers.notDefined())
+        property.add("1")
+
+        expect:
+        assertValueIs toImmutable(["1"])
+    }
+
+    def "property remains undefined-safe after restored"() {
+        given:
+        property.add(Providers.notDefined())
+        property.add("2")
+        property.addAll(supplierWithChangingExecutionTimeValues(['3'], ['3a'], ['3b'], ['3c'], ['3d']))
+        property.addAll(supplierWithValues(['4']))
+        property.append(Providers.notDefined())
+
+        when:
+        def execTimeValue = property.calculateExecutionTimeValue()
+        def property2 = property()
+        property2.fromState(execTimeValue)
+
+        then:
+        assertValueIs(['2', '3a', '4'], property2)
+
+        when:
+        property2.add("5")
+        property2.append("6")
+        property2.append(Providers.notDefined())
+        def execTimeValue2 = property2.calculateExecutionTimeValue()
+
+        then:
+        assertValueIs(['2', '3b', '4', '5', '6'], property2)
+
+        when:
+        def property3 = property()
+        property3.fromState(execTimeValue2)
+
+        then:
+        assertValueIs(['2', '3d', '4', '5', '6'], property3)
+    }
+
+    def "can alternate append and add"() {
+        when:
+        property.append("1")
+        property.add("2")
+        property.append("3")
+
+        then:
+        assertValueIs toImmutable(["1", "2", "3"])
+    }
+
+    def "can alternate add and append"() {
+        when:
+        property.add("1")
+        property.append("2")
+        property.add("3")
+
+        then:
+        assertValueIs toImmutable(["1", "2", "3"])
+    }
+    
     def "has meaningful toString for #valueDescription"(Closure<AbstractCollectionProperty<String, C>> initializer, String stringValue) {
         given:
         def p = initializer.call()
@@ -1325,5 +1498,60 @@ The value of this property is derived from: <source>""")
 
         // The following case abuses Groovy lax type-checking to put an invalid value into the property.
         "[provider {s1}]"     | { property().value([Providers.of("s1")]) }     || "$collectionName(class ${String.name}, [fixed(class ${String.name}, s1)])"
+    }
+    
+    def "can set explicit value to convention"() {
+        given:
+        property.convention(['1'])
+        property.value(['4'])
+
+        when:
+        property.setToConvention()
+
+        then:
+        assertValueIs(['1'])
+        property.explicit
+
+        when:
+        property.add('3')
+
+        then:
+        assertValueIs(['1', '3'])
+
+        when:
+        property.unset()
+
+        then:
+        assertValueIs(['1'])
+        !property.explicit
+    }
+
+    def "can set explicit value to convention if not set yet"() {
+        given:
+        property.convention(['1'])
+        property.value(['4'])
+
+        when:
+        property.setToConventionIfUnset()
+
+        then:
+        assertValueIs(['4'])
+
+        when:
+        property.unset()
+        property.setToConventionIfUnset()
+
+        then:
+        assertValueIs(['1'])
+        property.explicit
+    }
+
+    def "property is empty when setToConventionIfUnset if convention not set yet"() {
+        when:
+        property.setToConventionIfUnset()
+
+        then:
+        assertValueIs([])
+        !property.explicit
     }
 }

--- a/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
+++ b/platforms/core-configuration/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
@@ -885,6 +885,25 @@ The value of this property is derived from: <source>""")
         e.message == "Cannot query the value of this provider because it has no value available."
     }
 
+    def "keySet provider has no value when any entry has no value"() {
+        given:
+        property.put("k1", "1")
+        property.put("k2", Providers.notDefined())
+        property.put("k3", "3")
+        def keySetProvider = property.keySet()
+
+        expect:
+        keySetProvider.getOrNull() == null
+        !keySetProvider.present
+
+        when:
+        keySetProvider.get()
+
+        then:
+        def e = thrown(MissingValueException)
+        e.message == "Cannot query the value of this provider because it has no value available."
+    }
+
     @Issue('gradle/gradle#11036')
     def "getting key set from provider throws NullPointerException if property has null key"() {
         given:
@@ -1202,16 +1221,42 @@ The value of this property is derived from: <source>""")
         "getOrElse" | _
     }
 
-    def "may configure convention value incrementally"() {
+    def "may configure incrementally based on convention value"() {
         given:
         property.convention(['k0': '1'])
         property.withActualValue {
             it.putAll(['k1': '2', 'k2': '3'])
             it.put('k2', '4')
         }
+
         expect:
         assertValueIs(['k0': '1', 'k1': '2', 'k2': '4'])
-        assert property.explicit
+        property.explicit
+
+        when:
+        property.unset()
+
+        then:
+        assertValueIs(['k0': '1'])
+        !property.explicit
+    }
+
+    def "may configure incrementally based on convention value using insert"() {
+        given:
+        property.convention(['k0': '1'])
+        property.insertAll(['k1': '2', 'k2': '3'])
+        property.insert('k2', '4')
+
+        expect:
+        assertValueIs(['k0': '1', 'k1': '2', 'k2': '4'])
+        property.explicit
+
+        when:
+        property.unset()
+
+        then:
+        assertValueIs(['k0': '1'])
+        !property.explicit
     }
 
     def "may configure explicit value incrementally"() {
@@ -1222,6 +1267,18 @@ The value of this property is derived from: <source>""")
             it.putAll(['k1': '2', 'k2': '3'])
             it.put('k2', '4')
         }
+        expect:
+        assertValueIs(['k0': '1', 'k1': '2', 'k2': '4'])
+        assert property.explicit
+    }
+
+    def "may configure explicit value incrementally using insert"() {
+        given:
+        property.set([:])
+        property.insert('k0', '1')
+        property.insertAll(['k1': '2', 'k2': '3'])
+        property.insert('k2', '4')
+
         expect:
         assertValueIs(['k0': '1', 'k1': '2', 'k2': '4'])
         assert property.explicit
@@ -1239,7 +1296,17 @@ The value of this property is derived from: <source>""")
         assert property.explicit
     }
 
-    def "may replace convention values"() {
+    def "may configure actual value incrementally using insert"() {
+        given:
+        property.insert('k0', '1')
+        property.insertAll(['k1': '2', 'k2': '3'])
+        property.insert('k2', '4')
+        expect:
+        assertValueIs(['k0': '1', 'k1': '2', 'k2': '4'])
+        assert property.explicit
+    }
+
+    def "may replace values originally set via convention"() {
         given:
         property.convention(['k0': '1', 'k1': '2', 'k2': '3'])
         property.withActualValue {
@@ -1248,6 +1315,161 @@ The value of this property is derived from: <source>""")
         expect:
         assertValueIs(['k0': '1', 'k1': '4', 'k2': '3'])
         property.explicit
+    }
+
+    def "may replace values originally set via convention using insert"() {
+        given:
+        property.convention(['k0': '1', 'k1': '2', 'k2': '3'])
+        property.insert('k1', '4')
+        expect:
+        assertValueIs(['k0': '1', 'k1': '4', 'k2': '3'])
+        property.explicit
+    }
+
+    def "inserting into an undefined property is undefined-safe"() {
+        given:
+        property.set((Map) null)
+        property.insert('k4', '4')
+
+        expect:
+        assertValueIs(['k4': '4'])
+    }
+
+    def "inserting after putting an undefined element provider is undefined-safe"() {
+        given:
+        property.putAll(Providers.of([k1: '1', k2: '2']))
+        property.put('k3', Providers.notDefined())
+        property.insert('k4', '4')
+
+        expect:
+        assertValueIs([k4: '4'])
+    }
+
+    def "inserting after putting an undefined map provider is undefined-safe"() {
+        given:
+        property.putAll(Providers.of([k1: '1', k2: '2']))
+        property.putAll(Providers.notDefined())
+        property.insert('k4', '4')
+
+        expect:
+        assertValueIs([k4: '4'])
+    }
+
+    def "inserting an undefined value provider is undefined-safe"() {
+        given:
+        property.insert("k1", Providers.notDefined())
+
+        expect:
+        assertValueIs([:])
+    }
+
+    def "inserting an undefined map provider is undefined-safe"() {
+        given:
+        property.insertAll(Providers.notDefined())
+
+        expect:
+        assertValueIs([:])
+    }
+
+    def "putting after inserting an undefined map provider is undefined-safe"() {
+        given:
+        property.put("k0", "0")
+        property.insertAll(Providers.notDefined())
+        property.put("k1", "1")
+
+        expect:
+        assertValueIs([k0: '0', k1: '1'])
+    }
+
+    def "putting after inserting an undefined value provider is undefined-safe"() {
+        given:
+        property.put("k0", "0")
+        property.insert("k1", Providers.notDefined())
+        property.put("k2", "2")
+
+        expect:
+        assertValueIs([k0: '0', k2: '2'])
+    }
+
+    def "execution time value is present if only undefined-safe operations are performed"() {
+        given:
+        property.set(Providers.notDefined())
+        property.put("a", Providers.notDefined())
+        property.insert("b", "2")
+        property.putAll([c: '3'])
+        property.putAll([d: '4'])
+        property.insert("e", Providers.notDefined())
+
+        expect:
+        assertValueIs([b: '2', c: '3', d: '4'])
+
+        when:
+        def execTimeValue = property.calculateExecutionTimeValue()
+
+        then:
+        assertMapIs([b: '2', c: '3', d: '4'], execTimeValue.toValue().get())
+    }
+
+    def "property remains undefined-safe after restored"() {
+        given:
+        property.put("a", Providers.notDefined())
+        property.insert("b", "2")
+        // changing execution time values or else we would end up with fixed values
+        property.putAll(supplierWithChangingExecutionTimeValues([c: '3'], [c: '3a'], [c: '3b'], [c: '3c'], [c: '3d'], [c: '3e']))
+        property.putAll(supplierWithValues([d: '4']))
+        property.insert("e", Providers.notDefined())
+
+        when:
+        def execTimeValue = property.calculateExecutionTimeValue()
+        def property2 = property()
+        property2.fromState(execTimeValue)
+
+        then:
+        assertValueIs([b: '2', c: '3a', d: '4'], property2)
+
+        when:
+        property2.put("f", "6")
+        property2.insert("g", "7")
+        property2.insert("h", Providers.notDefined())
+        def execTimeValue2 = property2.calculateExecutionTimeValue()
+
+        then:
+        assertValueIs([b: '2', c: '3b', d: '4', f: '6', g: '7'], property2)
+
+        when:
+        def property3 = property()
+        property3.fromState(execTimeValue2)
+
+        then:
+        assertValueIs([b: '2', c: '3d', d: '4', f: '6', g: '7'], property3)
+    }
+
+    def "keySet provider has some values when property with no value is added via insert"() {
+        given:
+        property.set((Map) null)
+        property.put("k1", "1")
+        property.put("k2", Providers.notDefined())
+        property.insert("k3", "3")
+        property.put("k4", "4")
+        def keySetProvider = property.keySet()
+
+        expect:
+        keySetProvider.present
+        keySetProvider.get() == ["k3", "k4"] as Set
+    }
+
+    def "keySet provider has no value when property with no value is added via insert"() {
+        given:
+        property.set((Map) null)
+        property.put("k1", "1")
+        property.put("k2", Providers.notDefined())
+        property.insert("k3", "3")
+        property.put("k4", "4")
+        def keySetProvider = property.keySet()
+
+        expect:
+        keySetProvider.present
+        keySetProvider.get() == ["k3", "k4"] as Set
     }
 
     def "can set explicit value to convention"() {
@@ -1296,14 +1518,27 @@ The value of this property is derived from: <source>""")
         property.explicit
     }
 
+    def "property is empty when setToConventionIfUnset if convention not set yet"() {
+        when:
+        property.setToConventionIfUnset()
+
+        then:
+        assertValueIs([:])
+        !property.explicit
+    }
+
     private ProviderInternal<String> brokenValueSupplier() {
         return brokenSupplier(String)
     }
 
-    private void assertValueIs(Map<String, String> expected) {
+    private void assertValueIs(Map<String, String> expected, MapProperty<String, String> property = this.property) {
         assert property.present
         def actual = property.get()
         assertImmutable(actual)
+        assertMapIs(expected, actual)
+    }
+
+    protected void assertMapIs(Map<String, String> expected, Map<String, String> actual) {
         actual.each {
             assert it.key instanceof String
             assert it.value instanceof String
@@ -1399,6 +1634,28 @@ The value of this property is derived from: <source>""")
 
         then:
         1 * transform.transform(_)
+    }
+
+    def "can alternate insert and put"() {
+        when:
+        property.insert("k1", "1")
+        property.put("k2", "2")
+        property.insert("k3", "3")
+        property.put("k2", "4")
+
+        then:
+        assertValueIs(['k1': '1', 'k2': '4', 'k3': '3'])
+    }
+
+    def "can alternate put and insert"() {
+        when:
+        property.put("k1", "1")
+        property.insert("k2", "2")
+        property.put("k3", "3")
+        property.insert("k2", "4")
+
+        then:
+        assertValueIs(['k1': '1', 'k2': '4', 'k3': '3'])
     }
 
     static class MapPropertyCircularChainEvaluationTest extends PropertySpec.PropertyCircularChainEvaluationSpec<Map<String, String>> {

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/CollectionPropertyConfigurer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/CollectionPropertyConfigurer.java
@@ -29,8 +29,12 @@ import org.gradle.api.Incubating;
 public interface CollectionPropertyConfigurer<T> extends ConfigurableValue.Configurer {
     /**
      * Adds an element to the property value.
+     * <p>
+     * Contrary to {@link #append(Object)}, if this property has no value, this operation has no effect on the value of this property.
+     * </p>
      *
      * @param element The element
+     * @see #append(Object) for a more convenient
      */
     void add(T element);
 
@@ -38,7 +42,12 @@ public interface CollectionPropertyConfigurer<T> extends ConfigurableValue.Confi
      * Adds an element to the property value.
      *
      * <p>The given provider will be queried when the value of this property is queried.
-     * This property will have no value when the given provider has no value.
+     * <p>
+     * Contrary to {@link #append(Provider)}, if this property has no value, this operation has no effect on the value of this property.
+     * </p>
+     * <p>
+     * Also contrary to {@link #append(Provider)}, this property will have no value when the given provider has no value.
+     * </p>
      *
      * @param provider The provider of an element
      */
@@ -47,15 +56,22 @@ public interface CollectionPropertyConfigurer<T> extends ConfigurableValue.Confi
     /**
      * Adds zero or more elements to the property value.
      *
+     * <p>
+     * Contrary to {@link #appendAll(Object[])}, if this property has no value, this operation has no effect on the value of this property.
+     * </p>
+     *
      * @param elements The elements to add
      */
-    @SuppressWarnings("unchecked")
     void addAll(T... elements);
 
     /**
      * Adds zero or more elements to the property value.
      *
      * <p>The given iterable will be queried when the value of this property is queried.
+     *
+     * <p>
+     * Contrary to {@link #appendAll(Iterable)}, if this property has no value, this operation has no effect on the value of this property.
+     * </p>
      *
      * @param elements The elements to add.
      */
@@ -65,9 +81,97 @@ public interface CollectionPropertyConfigurer<T> extends ConfigurableValue.Confi
      * Adds zero or more elements to the property value.
      *
      * <p>The given provider will be queried when the value of this property is queried.
-     * This property will have no value when the given provider has no value.
+     * <p>
+     * Contrary to {@link #appendAll(Provider)}, if this property has no value, this operation has no effect on the value of this property.
+     * </p>
+     * <p>
+     * Also contrary to {@link #appendAll(Provider)}, this property will have no value when the given provider has no value.
+     * </p>
      *
      * @param provider Provider of elements
      */
     void addAll(Provider<? extends Iterable<? extends T>> provider);
+
+    /**
+     * Adds an element to the property value.
+     *
+     * <p>
+     * When invoked on a property with no value, this method first sets the value
+     * of the property to its current convention value, if set, or an empty collection.
+     * </p>
+     *
+     * @param element The element
+     * @since 8.7
+     */
+    @Incubating
+    void append(T element);
+
+    /**
+     * Adds an element to the property value.
+     *
+     * <p>The given provider will be queried when the value of this property is queried.
+     * This property will have no value when the given provider has no value.
+     *
+     * <p>
+     * When invoked on a property with no value, this method first sets the value
+     * of the property to its current convention value, if set, or an empty collection.
+     * </p>
+     * <p>Even if the given provider has no value, after this method is invoked,
+     * the actual value of this property is guaranteed to be present.</p>
+     *
+     * @param provider The provider of an element
+     * @since 8.7
+     */
+    @Incubating
+    void append(Provider<? extends T> provider);
+
+    /**
+     * Adds zero or more elements to the property value.
+     *
+     * <p>
+     * When invoked on a property with no value, this method first sets the value
+     * of the property to its current convention value, if set, or an empty collection.
+     * </p>
+     *
+     * @param elements The elements to add
+     * @since 8.7
+     */
+    @Incubating
+    @SuppressWarnings("unchecked")
+    void appendAll(T... elements);
+
+    /**
+     * Adds zero or more elements to the property value.
+     *
+     * <p>The given iterable will be queried when the value of this property is queried.
+     *
+     * <p>
+     * When invoked on a property with no value, this method first sets the value
+     * of the property to its current convention value, if set, or an empty collection.
+     * </p>
+     *
+     * @param elements The elements to add.
+     * @since 8.7
+     */
+    @Incubating
+    void appendAll(Iterable<? extends T> elements);
+
+    /**
+     * Adds zero or more elements to the property value.
+     *
+     * <p>The given provider will be queried when the value of this property is queried.
+     * This property will have no value when the given provider has no value.
+     *
+     * <p>
+     * When invoked on a property with no value, this method first sets the value
+     * of the property to its current convention value, if set, or an empty collection.
+     * </p>
+     * <p>Even if the given provider has no value, after this method is invoked,
+     * the actual value of this property is guaranteed to be present.</p>
+     *
+     * @param provider Provider of elements
+     * @since 8.7
+     */
+    @Incubating
+    void appendAll(Provider<? extends Iterable<? extends T>> provider);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/MapPropertyConfigurer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/MapPropertyConfigurer.java
@@ -32,6 +32,10 @@ public interface MapPropertyConfigurer<K, V>  extends ConfigurableValue.Configur
     /**
      * Adds a map entry to the property value.
      *
+     * <p>
+     * Contrary to {@link #insert(Object, Object)}, if this property has no value, this operation has no effect on the value of this property.
+     * </p>
+     *
      * @param key the key
      * @param value the value
      */
@@ -41,7 +45,12 @@ public interface MapPropertyConfigurer<K, V>  extends ConfigurableValue.Configur
      * Adds a map entry to the property value.
      *
      * <p>The given provider will be queried when the value of this property is queried.
-     * This property will have no value when the given provider has no value.
+     * <p>
+     * Contrary to {@link #insert(Object, Provider)}, if this property has no value, this operation has no effect on the value of this property.
+     * </p>
+     * <p>
+     * Also contrary to {@link #insert(Object, Provider)}, this property will have no value when the given provider has no value.
+     * </p>
      *
      * @param key the key
      * @param providerOfValue the provider of the value
@@ -51,6 +60,10 @@ public interface MapPropertyConfigurer<K, V>  extends ConfigurableValue.Configur
     /**
      * Adds all entries from another {@link Map} to the property value.
      *
+     * <p>
+     * Contrary to {@link #insertAll(Map)}, if this property has no value, this operation has no effect on the value of this property.
+     * </p>
+     *
      * @param entries a {@link Map} containing the entries to add
      */
     void putAll(Map<? extends K, ? extends V> entries);
@@ -59,9 +72,83 @@ public interface MapPropertyConfigurer<K, V>  extends ConfigurableValue.Configur
      * Adds all entries from another {@link Map} to the property value.
      *
      * <p>The given provider will be queried when the value of this property is queried.
-     * This property will have no value when the given provider has no value.
+     * <p>
+     * Contrary to {@link #insertAll(Provider)}, if this property has no value, this operation has no effect on the value of this property.
+     * </p>
+     * <p>
+     * Also contrary to {@link #insertAll(Provider)}, this property will have no value when the given provider has no value.
+     * </p>
      *
      * @param provider the provider of the entries
      */
     void putAll(Provider<? extends Map<? extends K, ? extends V>> provider);
+
+    /**
+     * Adds a map entry to the property value.
+     *
+     * <p>
+     * When invoked on a property with no value, this method first sets the value
+     * of the property to its current convention value, if set, or an empty map.
+     * </p>
+     *
+     * @param key the key
+     * @param value the value
+     *
+     * @since 8.7
+     */
+    @Incubating
+    void insert(K key, V value);
+
+    /**
+     * Adds a map entry to the property value.
+     *
+     * <p>The given provider will be queried when the value of this property is queried.
+     * <p>
+     * When invoked on a property with no value, this method first sets the value
+     * of the property to its current convention value, if set, or an empty map.
+     * </p>
+     * <p>Even if the given provider has no value, after this method is invoked,
+     * the actual value of this property is guaranteed to be present.</p>
+     *
+     * @param key the key
+     * @param providerOfValue the provider of the value
+     *
+     * @since 8.7
+     */
+    @Incubating
+    void insert(K key, Provider<? extends V> providerOfValue);
+
+    /**
+     * Adds all entries from another {@link Map} to the property value.
+     *
+     * <p>
+     * When invoked on a property with no value, this method first sets the value
+     * of the property to its current convention value, if set, or an empty map.
+     * </p>
+     *
+     * @param entries a {@link Map} containing the entries to add
+     *
+     * @since 8.7
+     */
+    @Incubating
+    void insertAll(Map<? extends K, ? extends V> entries);
+
+    /**
+     * Adds all entries from another {@link Map} to the property value.
+     *
+     * <p>The given provider will be queried when the value of this property is queried.
+     *
+     * <p>
+     * When invoked on a property with no value, this method first sets the value
+     * of the property to its current convention value, if set, or an empty map.
+     * </p>
+     * <p>Even if the given provider has no value, after this method is invoked,
+     * the actual value of this property is guaranteed to be present.</p>
+     *
+     * @param provider the provider of the entries
+     *
+     * @since 8.7
+     */
+    @Incubating
+    void insertAll(Provider<? extends Map<? extends K, ? extends V>> provider);
 }


### PR DESCRIPTION
This is a follow-up to #27531.

This exposes an alternative API for updating collection properties that honors convention:

* `(List|Set)Property.append*(...)`
* `MapProperty.insert*(...)`

Changes in behavior comparing to the original `add` and `put` methods:
* if a property has no explicit value, the convention will be applied before the change is applied
* if both explicit value and convention are effectively missing (set to a missing provider, or by containing a missing element provider), an empty collection will be applied before the change is applied
* if the actual value of the property is undefined, an empty default will be applied before the change is applied
* if the the addition is for a new element or iterable provider that is missing, the result will be as if no change was performed