### PR TITLE
Update GitHub Actions workflows to latest Gradle actions

### DIFF
--- a/.github/workflows/contributor-pr.yml
+++ b/.github/workflows/contributor-pr.yml
@@ -49,7 +49,7 @@ jobs:
             }
       - name: assemble
         id: gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v3
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/master' }}
           arguments: |
@@ -83,7 +83,7 @@ jobs:
           path: incoming-distributions/build-receipt.properties
       - name: ./gradlew sanityCheck
         id: gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v3
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/master' }}
           arguments: |
@@ -114,7 +114,7 @@ jobs:
           path: incoming-distributions/build-receipt.properties
       - name: ./gradlew test
         id: gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v3
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/master' }}
           arguments: |

--- a/.github/workflows/submit-github-dependency-graph.yml
+++ b/.github/workflows/submit-github-dependency-graph.yml
@@ -17,10 +17,11 @@ jobs:
         distribution: temurin
         java-version: 11
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
+      uses: gradle/actions/dependency-submission@v3
       with:
-        dependency-graph: generate-and-submit
-    - name: Run 'binDist' to generate dependency graph
-      run: ./gradlew binDist --no-configuration-cache -DdisableLocalCache=true -DcacheNode=us
+        # Action runs a custom dependencies task that fails with config-cache on Gradle 8.7 (works with 8.6)
+        additional-arguments: --no-configuration-cache
       env:
-        GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+        # Exclude some projects and configurations that should not contribute to the dependency graph
+        DEPENDENCY_GRAPH_EXCLUDE_PROJECTS: ':docs|:internal-performance-testing|:enterprise-plugin-performance|:performance|:internal-integ-testing'
+        DEPENDENCY_GRAPH_EXCLUDE_CONFIGURATIONS: 'ktlint|checkstyle|.*[Tt]est(Compile|Runtime)Classpath|.*[Tt]estImplementationDependenciesMetadata|.*[Tt]estFixtures(Compile|Runtime)Classpath|.*[Tt]estFixturesImplementationDependenciesMetadata'

--- a/build-logic-commons/build-platform/build.gradle.kts
+++ b/build-logic-commons/build-platform/build.gradle.kts
@@ -79,7 +79,7 @@ dependencies {
         api("org.ow2.asm:asm:$asmVersion")
         api("org.ow2.asm:asm-commons:$asmVersion")
         api("org.ow2.asm:asm-tree:$asmVersion")
-        api("xerces:xercesImpl:2.12.1") {
+        api("xerces:xercesImpl:2.12.2") {
             because("Maven Central and JCenter disagree on version 2.9.1 metadata")
         }
         api("net.bytebuddy:byte-buddy") { version { strictly("1.10.21") } }

--- a/build-logic-commons/build-platform/build.gradle.kts
+++ b/build-logic-commons/build-platform/build.gradle.kts
@@ -49,6 +49,9 @@ dependencies {
         api("com.vladsch.flexmark:flexmark-all:0.34.60") {
             because("Higher versions tested are either incompatible (0.62.2) or bring additional unwanted dependencies (0.36.8)")
         }
+        api("org.apache.pdfbox:pdfbox:2.0.24") {
+            because("Flexmark 0.34.60 brings in a vulnerable version of pdfbox")
+        }
         api("com.google.code.findbugs:jsr305:3.0.2")
         api("commons-io:commons-io:2.8.0")
         api("commons-lang:commons-lang:2.6")

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -1607,8 +1607,8 @@
             <sha256 value="55a2e95144acf1abe44fea91c2948525c9b1f00fcaa1d10e753e92872ffbdd1e" origin="Verified" reason="Artifact is not signed"/>
          </artifact>
       </component>
-      <component group="xerces" name="xercesImpl" version="2.12.1">
-         <artifact name="xercesImpl-2.12.1.jar">
+      <component group="xerces" name="xercesImpl" version="2.12.2">
+         <artifact name="xercesImpl-2.12.2.jar">
             <pgp value="6CB87B18A453990EAC9453F87D713008CC07E9AD"/>
          </artifact>
       </component>


### PR DESCRIPTION
### Context

The action `gradle/gradle-build-action@v2` was emitting a deprecation warning due to the
use of Node 16. This PR updates to use the latest version of the Gradle GitHub actions.

- Bumps `gradle/gradle-build-action` from `v2` to `v3`
- Changes the 'submit-github-dependency-graph' workflow to use `gradle/actions/dependency-submission@v3`. This simplifies the workflow and removes the need to execute `binDist` to generate the dependency graph.
- Bumps a couple of dependency versions to address vulnerability alerts.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
