### PR TITLE
Re-enable -Werror for all Java compilation

### DIFF
--- a/build-logic/jvm/src/main/kotlin/gradlebuild/jvm/extension/StrictCompileExtension.kt
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild/jvm/extension/StrictCompileExtension.kt
@@ -42,11 +42,4 @@ abstract class StrictCompileExtension(val tasks: TaskContainer) {
             options.compilerArgs.add("-Xlint:-processing")
         }
     }
-
-    fun ignoreParameterizedVarargType() {
-        tasks.withType<JavaCompile>().configureEach {
-            // There is no way to ignore this warning, so we need to turn off "-Werror" completely
-            options.compilerArgs = options.compilerArgs - "-Werror"
-        }
-    }
 }

--- a/platforms/core-configuration/base-services-groovy/build.gradle.kts
+++ b/platforms/core-configuration/base-services-groovy/build.gradle.kts
@@ -14,7 +14,3 @@ dependencies {
 
     testImplementation(testFixtures(project(":core")))
 }
-
-strictCompile {
-    ignoreParameterizedVarargType() // [unchecked] Possible heap pollution from parameterized vararg type: org.gradle.api.specs.AndSpec.and()
-}

--- a/platforms/core-configuration/base-services-groovy/src/main/java/org/gradle/api/specs/AndSpec.java
+++ b/platforms/core-configuration/base-services-groovy/src/main/java/org/gradle/api/specs/AndSpec.java
@@ -71,7 +71,8 @@ public class AndSpec<T> extends CompositeSpec<T> {
         return null;
     }
 
-    @SuppressWarnings("varargs")
+    // TODO Use @SafeVarargs and make method final
+    @SuppressWarnings("unchecked")
     public AndSpec<T> and(Spec<? super T>... specs) {
         if (specs.length == 0) {
             return this;

--- a/platforms/software/reporting/build.gradle.kts
+++ b/platforms/software/reporting/build.gradle.kts
@@ -52,7 +52,6 @@ dependencies {
 
 strictCompile {
     ignoreRawTypes() // raw types used in public API
-    ignoreParameterizedVarargType() // [unchecked] Possible heap pollution from parameterized vararg type: GenerateBuildDashboard.aggregate()
 }
 
 packageCycles {

--- a/platforms/software/reporting/src/main/java/org/gradle/api/reporting/GenerateBuildDashboard.java
+++ b/platforms/software/reporting/src/main/java/org/gradle/api/reporting/GenerateBuildDashboard.java
@@ -121,6 +121,7 @@ public abstract class GenerateBuildDashboard extends DefaultTask implements Repo
      *
      * @param reportings an array of {@link Reporting} instances that are to be aggregated
      */
+    // TODO Use @SafeVarargs and make method final
     @SuppressWarnings("unchecked")
     public void aggregate(Reporting<? extends ReportContainer<?>>... reportings) {
         aggregated.addAll(Arrays.asList(reportings));

--- a/platforms/software/reporting/src/main/java/org/gradle/api/reporting/GenerateBuildDashboard.java
+++ b/platforms/software/reporting/src/main/java/org/gradle/api/reporting/GenerateBuildDashboard.java
@@ -121,8 +121,8 @@ public abstract class GenerateBuildDashboard extends DefaultTask implements Repo
      *
      * @param reportings an array of {@link Reporting} instances that are to be aggregated
      */
-    // TODO Use @SafeVarargs and make method final
     @SuppressWarnings("unchecked")
+    // TODO Use @SafeVarargs and make method final
     public void aggregate(Reporting<? extends ReportContainer<?>>... reportings) {
         aggregated.addAll(Arrays.asList(reportings));
     }

--- a/platforms/software/reporting/src/main/java/org/gradle/api/reporting/internal/SimpleReport.java
+++ b/platforms/software/reporting/src/main/java/org/gradle/api/reporting/internal/SimpleReport.java
@@ -58,7 +58,6 @@ public abstract class SimpleReport implements ConfigurableReport {
 
     @Deprecated
     @Override
-    @Deprecated
     public void setDestination(File file) {
         DeprecationLogger.deprecateProperty(Report.class, "destination")
                 .replaceWith("outputLocation")

--- a/platforms/software/reporting/src/main/java/org/gradle/api/reporting/internal/SimpleReport.java
+++ b/platforms/software/reporting/src/main/java/org/gradle/api/reporting/internal/SimpleReport.java
@@ -58,6 +58,7 @@ public abstract class SimpleReport implements ConfigurableReport {
 
     @Deprecated
     @Override
+    @Deprecated
     public void setDestination(File file) {
         DeprecationLogger.deprecateProperty(Report.class, "destination")
                 .replaceWith("outputLocation")

--- a/platforms/software/resources-gcs/src/main/java/org/gradle/internal/resource/transport/gcp/gcs/GcsClient.java
+++ b/platforms/software/resources-gcs/src/main/java/org/gradle/internal/resource/transport/gcp/gcs/GcsClient.java
@@ -176,6 +176,7 @@ public class GcsClient {
     private static Supplier<Credential> getCredentialSupplier(final HttpTransport transport, final JsonFactory jsonFactory) {
         return Suppliers.memoize(new Supplier<Credential>() {
             @Override
+            @SuppressWarnings("deprecation")
             public Credential get() {
                 try {
                     GoogleCredential googleCredential = GoogleCredential.getApplicationDefault(transport, jsonFactory);

--- a/subprojects/core-api/build.gradle.kts
+++ b/subprojects/core-api/build.gradle.kts
@@ -60,7 +60,6 @@ packageCycles {
 
 strictCompile {
     ignoreRawTypes() // raw types used in public API
-    ignoreParameterizedVarargType() // [unchecked] Possible heap pollution from parameterized vararg type: ArtifactResolutionQuery, RepositoryContentDescriptor, HasMultipleValues
 }
 
 integTest.usesJavadocCodeSnippets = true

--- a/subprojects/core-api/src/main/java/org/gradle/api/Project.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Project.java
@@ -38,7 +38,6 @@ import org.gradle.api.invocation.Gradle;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.LoggingManager;
 import org.gradle.api.model.ObjectFactory;
-import org.gradle.api.plugins.Convention;
 import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.plugins.ExtensionContainer;
 import org.gradle.api.plugins.PluginAware;
@@ -150,7 +149,7 @@ import java.util.concurrent.Callable;
  * <li>The <em>extensions</em> added to the project by the plugins. Each extension is available as a read-only property with the same name as the extension.</li>
  *
  * <li>The <em>convention</em> properties added to the project by the plugins. A plugin can add properties and methods
- * to a project through the project's {@link Convention} object.  The properties of this scope may be readable or writable, depending on the convention objects.</li>
+ * to a project through the project's {@link org.gradle.api.plugins.Convention} object.  The properties of this scope may be readable or writable, depending on the convention objects.</li>
  *
  * <li>The tasks of the project.  A task is accessible by using its name as a property name.  The properties of this
  * scope are read-only. For example, a task called <code>compile</code> is accessible as the <code>compile</code>
@@ -204,7 +203,7 @@ import java.util.concurrent.Callable;
  * a closure or {@link org.gradle.api.Action} as a parameter.</li>
  *
  * <li>The <em>convention</em> methods added to the project by the plugins. A plugin can add properties and method to
- * a project through the project's {@link Convention} object.</li>
+ * a project through the project's {@link org.gradle.api.plugins.Convention} object.</li>
  *
  * <li>The tasks of the project. A method is added for each task, using the name of the task as the method name and
  * taking a single closure or {@link org.gradle.api.Action} parameter. The method calls the {@link Task#configure(groovy.lang.Closure)} method for the
@@ -403,7 +402,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      *
      * <li>The project object itself.  For example, the <code>rootDir</code> project property.</li>
      *
-     * <li>The project's {@link Convention} object.  For example, the <code>srcRootName</code> java plugin
+     * <li>The project's {@link org.gradle.api.plugins.Convention} object.  For example, the <code>srcRootName</code> java plugin
      * property.</li>
      *
      * <li>The project's extra properties.</li>
@@ -1264,7 +1263,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
     void artifacts(Action<? super ArtifactHandler> configureAction);
 
     /**
-     * <p>Returns the {@link Convention} for this project.</p> <p>You can access this property in your build file
+     * <p>Returns the {@link org.gradle.api.plugins.Convention} for this project.</p> <p>You can access this property in your build file
      * using <code>convention</code>. You can also access the properties and methods of the convention object
      * as if they were properties and methods of this project. See <a href="#properties">here</a> for more details</p>
      *
@@ -1273,7 +1272,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      * @see ExtensionAware#getExtensions()
      */
     @Deprecated
-    Convention getConvention();
+    org.gradle.api.plugins.Convention getConvention();
 
     /**
      * <p>Compares the nesting level of this project with another project of the multi-project hierarchy.</p>

--- a/subprojects/core-api/src/main/java/org/gradle/api/Task.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Task.java
@@ -21,7 +21,6 @@ import groovy.lang.DelegatesTo;
 import groovy.lang.MissingPropertyException;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.LoggingManager;
-import org.gradle.api.plugins.Convention;
 import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
@@ -137,7 +136,7 @@ import java.util.Set;
  * name as the extension.</li>
  *
  * <li>The <em>convention</em> properties added to the task by plugins. A plugin can add properties and methods to a task through
- * the task's {@link Convention} object.  The properties of this scope may be readable or writable, depending on the convention objects.</li>
+ * the task's {@link org.gradle.api.plugins.Convention} object.  The properties of this scope may be readable or writable, depending on the convention objects.</li>
  *
  * <li>The <em>extra properties</em> of the task. Each task object maintains a map of additional properties. These
  * are arbitrary name -&gt; value pairs which you can use to dynamically add properties to a task object.  Once defined, the properties
@@ -147,7 +146,7 @@ import java.util.Set;
  *
  * <h4>Dynamic Methods</h4>
  *
- * <p>A {@link Plugin} may add methods to a {@code Task} using its {@link Convention} object.</p>
+ * <p>A {@link Plugin} may add methods to a {@code Task} using its {@link org.gradle.api.plugins.Convention} object.</p>
  *
  * <h4>Parallel Execution</h4>
  * <p>
@@ -577,7 +576,7 @@ public interface Task extends Comparable<Task>, ExtensionAware {
     void setProperty(String name, Object value) throws MissingPropertyException;
 
     /**
-     * <p>Returns the {@link Convention} object for this task. A {@link Plugin} can use the convention object to
+     * <p>Returns the {@link org.gradle.api.plugins.Convention} object for this task. A {@link Plugin} can use the convention object to
      * contribute properties and methods to this task.</p>
      *
      * @return The convention object. Never returns null.
@@ -586,7 +585,7 @@ public interface Task extends Comparable<Task>, ExtensionAware {
      */
     @Internal
     @Deprecated
-    Convention getConvention();
+    org.gradle.api.plugins.Convention getConvention();
 
     /**
      * Returns the description of this task.

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/FileCollectionDependency.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/FileCollectionDependency.java
@@ -25,6 +25,7 @@ import java.util.Set;
  * A {@code FileCollectionDependency} is a {@link Dependency} on a collection of local files which are not stored in a
  * repository.
  */
+@SuppressWarnings("deprecation") // Because of SelfResolvingDependency
 public interface FileCollectionDependency extends SelfResolvingDependency {
     /**
      * Returns the files attached to this dependency.

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ProjectDependency.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ProjectDependency.java
@@ -26,6 +26,7 @@ import java.util.Set;
  * <p>A {@code ProjectDependency} is a {@link Dependency} on another project in the current project hierarchy.</p>
  */
 @HasInternalProtocol
+@SuppressWarnings("deprecation") // Because of SelfResolvingDependency
 public interface ProjectDependency extends ModuleDependency, SelfResolvingDependency {
     /**
      * Returns the project associated with this project dependency.
@@ -53,6 +54,7 @@ public interface ProjectDependency extends ModuleDependency, SelfResolvingDepend
      * @deprecated This class will no longer implement {@link SelfResolvingDependency} in Gradle 9.0
      */
     @Override
+    @Deprecated
     Set<File> resolve();
 
     /**
@@ -61,5 +63,6 @@ public interface ProjectDependency extends ModuleDependency, SelfResolvingDepend
      * @deprecated This class will no longer implement {@link SelfResolvingDependency} in Gradle 9.0
      */
     @Override
+    @Deprecated
     Set<File> resolve(boolean transitive);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/execution/TaskExecutionAdapter.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/execution/TaskExecutionAdapter.java
@@ -23,6 +23,7 @@ import org.gradle.api.tasks.TaskState;
  *
  * The methods in this class are empty. This class exists as convenience for creating listener objects.
  */
+@SuppressWarnings("deprecation")
 public class TaskExecutionAdapter implements TaskExecutionListener {
 
     @Override

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/HasMultipleValues.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/HasMultipleValues.java
@@ -191,6 +191,8 @@ public interface HasMultipleValues<T> extends HasConfigurableValue, SupportsConv
      * @since 8.7
      */
     @Incubating
+    @SuppressWarnings("unchecked")
+    // TODO Use @SafeVarargs and make method final
     void appendAll(T... elements);
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/util/CollectionUtils.java
+++ b/subprojects/core-api/src/main/java/org/gradle/util/CollectionUtils.java
@@ -517,6 +517,8 @@ public abstract class CollectionUtils {
      * @param <T> The element type of t1
      * @return t1
      */
+    // TODO Use @SafeVarargs and make method final
+    @SuppressWarnings("unchecked")
     public static <T, C extends Collection<? super T>> C addAll(C t1, T... t2) {
         logDeprecation(7);
         Collections.addAll(t1, t2);


### PR DESCRIPTION
We had a few subprojects where `-Werror` was disabled, mainly because of safe varargs warnings. This PR suppresses those warnings without having to disable `-Werror`, and fixes a few other deprecation warnings that were hidden by not failing on warnings.

This also enables failing on all Error Prone warnings introduces in https://github.com/gradle/gradle/pull/27833.

We should follow up in 9.0 by switching to `@afeVarargs` and making the methods `final`, see https://github.com/gradle/gradle/issues/27867.