### PR TITLE
Revert "Remove flakiness annotation to check to capture data"

### DIFF
--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecDebugIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecDebugIntegrationTest.groovy
@@ -20,12 +20,14 @@ package org.gradle.api.tasks
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.jvm.JDWPUtil
 import org.gradle.test.fixtures.ConcurrentTestUtil
+import org.gradle.test.fixtures.Flaky
 import org.gradle.test.precondition.Requires
 import org.gradle.test.preconditions.UnitTestPreconditions
 import org.junit.Assume
 import org.junit.Rule
 import spock.lang.Issue
 
+@Flaky(because = "https://github.com/gradle/gradle-private/issues/3612")
 class JavaExecDebugIntegrationTest extends AbstractIntegrationSpec {
 
     @Rule


### PR DESCRIPTION
This reverts commit cc8f14fdfc4aadea55dd504cdc6df0096a6962f4.

It's happening again: https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_Quick_1_bucket13/77311037?buildTab=tests&orderBy=duration&order=desc

@ghale I'm afraid we can't collect metrics as you said in https://github.com/gradle/gradle/pull/24999 because the build timeouts and doesn't publish any build scans.