### PR TITLE
Update the contributing guide with developer experiences

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,12 @@
-# Contributing to Gradle
+# Contributing to the Gradle Build Tool
 
-Thank you for contributing to Gradle! This guide explains how to:
+Thank you for your interest in contributing to Gradle!
+This guide explains how to contribute to the core Gradle components, 
+extensions and documentation located in this repository.
+For other extensions and components, see the 
+[Gradle Community Resources](https://gradle.org/resources/).
+
+This guide will help you to...
 
 * maximize the chance of your changes being accepted
 * work on the Gradle code base
@@ -32,6 +38,8 @@ Contributors must follow the Code of Conduct outlined at [https://gradle.org/con
 ### Additional help
 
 If you run into any trouble, please reach out to us on the issue you are working on.
+There is a `#contributing` channel on the community Slack which you can use
+to ask any questions.
 
 ## Setting up your development environment
 
@@ -103,6 +111,13 @@ After making changes, you can test your code in 2 ways:
 - Use: `/any/path/bin/gradle taskName`.
 
 It's also a good idea to run `./gradlew sanityCheck` before submitting your change because this will help catch code style issues.
+
+> **NOTE:** Do **NOT** run `gradle build` on the local development environment,
+> even if you have Gradle or Develocity build caching enabled for the project.
+> The Gradle Build Tool repository is massive, and it will take ages to build on
+> a local machine without necessary parallelization and caching.
+> The full test suites are executed on the CI instance for multiple configurations,
+> and you can rely on it after doing initial sanity check and targeted local testing.
 
 ### Submitting Your Change
 


### PR DESCRIPTION
Just a few minor patches after my first contribution. I will keep expanding the guide incrementally, but I wanted to add a few small bits:

- Be specific the guide is for the Gradle Build Tool, not for the whole ecosystem
- References the contributing channel
- Discourage running `gradle build`

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
