### PR TITLE
Separate variant matching and legacy configuration selection

### DIFF
--- a/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftApplicationIntegrationTest.groovy
+++ b/platforms/native/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftApplicationIntegrationTest.groovy
@@ -489,7 +489,7 @@ class SwiftApplicationIntegrationTest extends AbstractSwiftIntegrationTest imple
 
         and:
         failure.assertHasCause("Could not resolve project :greeter.")
-        failure.assertHasCause("No matching variant of project :greeter was found. The consumer was configured to find attribute 'org.gradle.native.architecture' with value '${currentArchitecture}', attribute 'org.gradle.native.debuggable' with value 'true', attribute 'org.gradle.native.operatingSystem' with value '${currentOsFamilyName}', attribute 'org.gradle.native.optimized' with value 'false', attribute 'org.gradle.usage' with value 'native-runtime' but:")
+        failure.assertHasCause("A dependency was declared on configuration 'default' which is not declared in the descriptor for project :greeter.")
     }
 
     def "can compile and link against a static library"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/AbstractConfigurationAttributesResolveIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/AbstractConfigurationAttributesResolveIntegrationTest.groovy
@@ -648,8 +648,7 @@ All of them match the consumer attributes:
         fails ':a:checkDebug'
 
         then:
-        failure.assertHasCause """No matching variant of project :b was found. The consumer was configured to find attribute 'buildType' with value 'debug', attribute 'flavor' with value 'free' but:
-  - None of the variants have attributes."""
+        failure.assertHasCause """Selected configuration 'default' on 'project :b' but it can't be used as a project dependency because it isn't intended for consumption by other components."""
     }
 
     def "does not select explicit configuration when it's not consumable"() {

--- a/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentAttributesRulesIntegrationTest.groovy
+++ b/platforms/software/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentAttributesRulesIntegrationTest.groovy
@@ -82,7 +82,11 @@ class ComponentAttributesRulesIntegrationTest extends AbstractModuleDependencyRe
             }
         } else {
             fails ':checkDeps'
-            failure.assertHasCause("No matching variant of org.test:module:1.0 was found. The consumer was configured to find attribute 'quality' with value 'qa' but:")
+            if (useIvy() && !isGradleMetadataPublished()) {
+                failure.assertHasCause("Configuration 'default' in org.test:module:1.0 does not match the consumer attributes")
+            } else {
+                failure.assertHasCause("No matching variant of org.test:module:1.0 was found. The consumer was configured to find attribute 'quality' with value 'qa' but:")
+            }
             failure.assertThatCause(containsNormalizedString("Incompatible because this component declares attribute 'quality' with value 'canary' and the consumer needed attribute 'quality' with value 'qa'"))
         }
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/VariantResolvingArtifactSet.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/VariantResolvingArtifactSet.java
@@ -30,7 +30,6 @@ import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.model.ComponentArtifactResolveMetadata;
 import org.gradle.internal.component.model.ComponentGraphResolveState;
-import org.gradle.internal.component.model.GraphVariantSelectionResult;
 import org.gradle.internal.component.model.GraphVariantSelector;
 import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.component.model.VariantArtifactResolveState;
@@ -145,7 +144,7 @@ public class VariantResolvingArtifactSet implements ArtifactSet {
      */
     private ImmutableSet<ResolvedVariant> getArtifactVariantsForReselection(ImmutableAttributes requestAttributes) {
         // First, find the graph variant containing the artifact variants to select among.
-        GraphVariantSelectionResult selectedGraphVariants = graphVariantSelector.selectVariantsLenient(
+        VariantGraphResolveState graphVariant = graphVariantSelector.selectByAttributeMatchingLenient(
             requestAttributes,
             capabilities,
             component,
@@ -155,14 +154,9 @@ public class VariantResolvingArtifactSet implements ArtifactSet {
 
         // It is fine if no graph variants satisfy our request.
         // Variant reselection allows no target variants to be found.
-        if (selectedGraphVariants.getVariants().isEmpty()) {
+        if (graphVariant == null) {
             return ImmutableSet.of();
         }
-
-        // The graphVariantSelector will always select a single variant.
-        // However, the interface does not reflect that since the type used here is shared with Ivy, which can select multiple variants.
-        assert selectedGraphVariants.getVariants().size() == 1;
-        VariantGraphResolveState graphVariant = selectedGraphVariants.getVariants().get(0);
 
         // Next, return all artifact variants for the selected graph variant.
         return getArtifactsForGraphVariant(graphVariant);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/DefaultMavenModuleResolveMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/DefaultMavenModuleResolveMetadata.java
@@ -180,10 +180,8 @@ public class DefaultMavenModuleResolveMetadata extends AbstractLazyModuleCompone
         return filteredDependencies == null ? ImmutableList.of() : filteredDependencies.build();
     }
 
-    private ModuleDependencyMetadata contextualize(ConfigurationMetadata config, ModuleComponentIdentifier componentId, MavenDependencyDescriptor incoming) {
-        ConfigurationBoundExternalDependencyMetadata dependency = new ConfigurationBoundExternalDependencyMetadata(config, componentId, incoming);
-        dependency.alwaysUseAttributeMatching();
-        return dependency;
+    private static ModuleDependencyMetadata contextualize(ConfigurationMetadata config, ModuleComponentIdentifier componentId, MavenDependencyDescriptor incoming) {
+        return new ConfigurationBoundExternalDependencyMetadata(config, componentId, incoming, true);
     }
 
     private boolean includeInOptionalConfiguration(MavenDependencyDescriptor dependency) {

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/RealisedMavenModuleResolveMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/RealisedMavenModuleResolveMetadata.java
@@ -224,9 +224,7 @@ public class RealisedMavenModuleResolveMetadata extends AbstractRealisedModuleCo
     }
 
     static ModuleDependencyMetadata contextualize(ConfigurationMetadata config, ModuleComponentIdentifier componentId, MavenDependencyDescriptor incoming) {
-        ConfigurationBoundExternalDependencyMetadata dependency = new ConfigurationBoundExternalDependencyMetadata(config, componentId, incoming);
-        dependency.alwaysUseAttributeMatching();
-        return dependency;
+        return new ConfigurationBoundExternalDependencyMetadata(config, componentId, incoming, true);
     }
 
     private final NamedObjectInstantiator objectInstantiator;

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/DslOriginDependencyMetadataWrapper.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/local/model/DslOriginDependencyMetadataWrapper.java
@@ -54,11 +54,6 @@ public class DslOriginDependencyMetadataWrapper extends DelegatingDependencyMeta
     }
 
     @Override
-    public String getDependencyConfiguration() {
-        return delegate.getDependencyConfiguration();
-    }
-
-    @Override
     public boolean isForce() {
         return delegate.isForce();
     }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/AbstractComponentGraphResolveState.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/AbstractComponentGraphResolveState.java
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.component.model;
 
-import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
@@ -35,7 +34,6 @@ import org.gradle.internal.resolve.result.BuildableArtifactSetResolveResult;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 public abstract class AbstractComponentGraphResolveState<T extends ComponentGraphResolveMetadata, S extends ComponentResolveMetadata> implements ComponentGraphResolveState, ComponentArtifactResolveState {
     private final long instanceId;
@@ -165,19 +163,6 @@ public abstract class AbstractComponentGraphResolveState<T extends ComponentGrap
         @Override
         public ConfigurationGraphResolveState getLegacyConfiguration() {
             return getConfiguration(Dependency.DEFAULT_CONFIGURATION);
-        }
-
-        @Override
-        public List<? extends ConfigurationGraphResolveMetadata> getCandidateConfigurations() {
-            Set<String> configurationNames = graphMetadata.getConfigurationNames();
-            ImmutableList.Builder<ConfigurationGraphResolveMetadata> builder = new ImmutableList.Builder<>();
-            for (String configurationName : configurationNames) {
-                ConfigurationGraphResolveMetadata configuration = graphMetadata.getConfiguration(configurationName);
-                if (configuration.isCanBeConsumed()) {
-                    builder.add(configuration);
-                }
-            }
-            return builder.build();
         }
     }
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/GraphSelectionCandidates.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/GraphSelectionCandidates.java
@@ -36,9 +36,4 @@ public interface GraphSelectionCandidates {
      */
     @Nullable
     ConfigurationGraphResolveState getLegacyConfiguration();
-
-    /**
-     * The set of consumable configurations available. Used for diagnostics.
-     */
-    List<? extends ConfigurationGraphResolveMetadata> getCandidateConfigurations();
 }

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/GraphVariantSelector.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/GraphVariantSelector.java
@@ -65,7 +65,8 @@ public class GraphVariantSelector {
 
     public VariantGraphResolveState selectByAttributeMatching(
         ImmutableAttributes consumerAttributes,
-        Collection<? extends Capability> explicitRequestedCapabilities, ComponentGraphResolveState targetComponentState,
+        Collection<? extends Capability> explicitRequestedCapabilities,
+        ComponentGraphResolveState targetComponentState,
         AttributesSchemaInternal consumerSchema,
         List<IvyArtifactName> requestedArtifacts
     ) {
@@ -140,11 +141,13 @@ public class GraphVariantSelector {
 
         if (matches.size() == 1) {
             return singleVariant(matches);
-        } else if (!matches.isEmpty()) {
-            throw failureProcessor.ambiguousGraphVariantsFailure(consumerSchema, attributeMatcher, consumerAttributes, matches, targetComponent);
-        } else {
-            return null;
         }
+
+        if (!matches.isEmpty()) {
+            throw failureProcessor.ambiguousGraphVariantsFailure(consumerSchema, attributeMatcher, consumerAttributes, matches, targetComponent);
+        }
+
+        return null;
     }
 
     /**

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
@@ -122,7 +122,7 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
             return new GraphVariantSelectionResult(Collections.singletonList(selected), true);
         }
 
-        // Otherwise, use legacy selection by configuration name.
+        // Otherwise, select a legacy configuration.
         VariantGraphResolveState selected;
         if (dependencyConfiguration != null) {
             selected = variantSelector.selectConfigurationByName(dependencyConfiguration, consumerAttributes, targetComponentState, consumerSchema);

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
@@ -18,13 +18,10 @@ package org.gradle.internal.component.model;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
-import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
-import org.gradle.internal.deprecation.DeprecationLogger;
-import org.gradle.util.internal.GUtil;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
@@ -94,73 +91,46 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
         return selector;
     }
 
-    @Override
-    public String getDependencyConfiguration() {
-        return GUtil.elvis(dependencyConfiguration, Dependency.DEFAULT_CONFIGURATION);
-    }
-
     /**
      * Choose a single target configuration based on: a) the consumer attributes, b) the target configuration name and c) the target component
      *
      * Use attribute matching to choose a single variant when:
      * - The target configuration name is not specified AND
-     * - Either: we have consumer attributes OR the target component has variants.
+     * - The target component has variants.
      *
      * Otherwise, revert to legacy selection of target configuration.
      *
      * @return A List containing a single `ConfigurationMetadata` representing the target variant.
      */
     @Override
-    public GraphVariantSelectionResult selectVariants(GraphVariantSelector variantSelector, ImmutableAttributes consumerAttributes, ComponentGraphResolveState targetComponentState, AttributesSchemaInternal consumerSchema, Collection<? extends Capability> explicitRequestedCapabilities) {
-        ComponentGraphResolveMetadata targetComponent = targetComponentState.getMetadata();
-        GraphSelectionCandidates candidates = targetComponentState.getCandidatesForGraphVariantSelection();
-        boolean consumerHasAttributes = !consumerAttributes.isEmpty();
-        boolean useConfigurationAttributes = dependencyConfiguration == null && (consumerHasAttributes || candidates.isUseVariants());
-        if (useConfigurationAttributes) {
-            return variantSelector.selectVariants(consumerAttributes, explicitRequestedCapabilities, targetComponentState, consumerSchema, getArtifacts());
+    public GraphVariantSelectionResult selectVariants(
+        GraphVariantSelector variantSelector,
+        ImmutableAttributes consumerAttributes,
+        ComponentGraphResolveState targetComponentState,
+        AttributesSchemaInternal consumerSchema,
+        Collection<? extends Capability> explicitRequestedCapabilities
+    ) {
+        // If the target component is variant-aware, and we haven't requested an explicit configuration, use variant aware matching.
+        boolean variantAware = targetComponentState.getCandidatesForGraphVariantSelection().isUseVariants();
+        if (dependencyConfiguration == null && variantAware) {
+            VariantGraphResolveState selected = variantSelector.selectByAttributeMatching(
+                consumerAttributes,
+                explicitRequestedCapabilities, targetComponentState,
+                consumerSchema,
+                getArtifacts()
+            );
+            return new GraphVariantSelectionResult(Collections.singletonList(selected), true);
+        }
+
+        // Otherwise, use legacy selection by configuration name.
+        VariantGraphResolveState selected;
+        if (dependencyConfiguration != null) {
+            selected = variantSelector.selectConfigurationByName(dependencyConfiguration, consumerAttributes, targetComponentState, consumerSchema);
         } else {
-            ConfigurationGraphResolveState toConfiguration = selectRequestedConfiguration(variantSelector, consumerAttributes, targetComponentState, consumerSchema, targetComponent, consumerHasAttributes);
-            return new GraphVariantSelectionResult(ImmutableList.of(toConfiguration.asVariant()), false);
-        }
-    }
-
-    private ConfigurationGraphResolveState selectRequestedConfiguration(GraphVariantSelector variantSelector, ImmutableAttributes consumerAttributes, ComponentGraphResolveState targetComponentState, AttributesSchemaInternal consumerSchema, ComponentGraphResolveMetadata targetComponent, boolean consumerHasAttributes) {
-        String targetConfiguration = getDependencyConfiguration();
-        ConfigurationGraphResolveState toConfiguration = targetComponentState.getConfiguration(targetConfiguration);
-        if (toConfiguration == null) {
-            throw variantSelector.getFailureProcessor().configurationNotFoundFailure(targetComponent.getId(), targetConfiguration);
+            selected = variantSelector.selectLegacyConfiguration(consumerAttributes, targetComponentState, consumerSchema);
         }
 
-        verifyConsumability(variantSelector, targetComponent, toConfiguration);
-        verifyAttributeCompatibility(variantSelector, consumerAttributes, consumerSchema, targetComponent, consumerHasAttributes, toConfiguration);
-
-        return toConfiguration;
-    }
-
-    private void verifyAttributeCompatibility(GraphVariantSelector variantSelector, ImmutableAttributes consumerAttributes, AttributesSchemaInternal consumerSchema, ComponentGraphResolveMetadata targetComponent, boolean consumerHasAttributes, ConfigurationGraphResolveState toConfiguration) {
-        if (consumerHasAttributes && !toConfiguration.getAttributes().isEmpty()) {
-            // need to validate that the selected configuration still matches the consumer attributes
-            // Note that this validation only occurs when `dependencyConfiguration != null` (otherwise we would select with attribute matching)
-            AttributesSchemaInternal producerAttributeSchema = targetComponent.getAttributesSchema();
-            if (!consumerSchema.withProducer(producerAttributeSchema).isMatching(toConfiguration.getAttributes(), consumerAttributes)) {
-                throw variantSelector.getFailureProcessor().incompatibleRequestedConfigurationFailure(consumerSchema, consumerSchema.withProducer(producerAttributeSchema), consumerAttributes, targetComponent, toConfiguration);
-            }
-        }
-    }
-
-    private void verifyConsumability(GraphVariantSelector variantSelector, ComponentGraphResolveMetadata targetComponent, ConfigurationGraphResolveState toConfiguration) {
-        ConfigurationGraphResolveMetadata metadata = toConfiguration.getMetadata();
-        if (!metadata.isCanBeConsumed()) {
-            throw variantSelector.getFailureProcessor().configurationNotConsumableFailure(targetComponent.getId(), toConfiguration.getName());
-        }
-
-        if (metadata.isDeprecatedForConsumption()) {
-            DeprecationLogger.deprecateConfiguration(toConfiguration.getName())
-                .forConsumption()
-                .willBecomeAnErrorInGradle9()
-                .withUserManual("declaring_dependencies", "sec:deprecated-configurations")
-                .nagUser();
-        }
+        return new GraphVariantSelectionResult(ImmutableList.of(selected), false);
     }
 
     @Override

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/LocalOriginDependencyMetadata.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/model/LocalOriginDependencyMetadata.java
@@ -26,8 +26,6 @@ import java.util.List;
  */
 public interface LocalOriginDependencyMetadata extends ForcingDependencyMetadata {
 
-    String getDependencyConfiguration();
-
     @Override
     LocalOriginDependencyMetadata withTarget(ComponentSelector target);
 

--- a/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/ResolutionCandidateAssessor.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/internal/component/resolution/failure/ResolutionCandidateAssessor.java
@@ -34,7 +34,6 @@ import org.gradle.internal.component.model.VariantGraphResolveMetadata;
 import org.gradle.internal.component.model.VariantGraphResolveState;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
@@ -90,16 +89,13 @@ public final class ResolutionCandidateAssessor {
     }
 
     public List<AssessedCandidate> assessGraphSelectionCandidates(GraphSelectionCandidates candidates) {
-        final List<? extends VariantGraphResolveMetadata> variantMetadatas;
-        if (candidates.isUseVariants()) {
-            variantMetadatas = candidates.getVariants().stream()
-                .map(VariantGraphResolveState::getMetadata)
-                .collect(Collectors.toList());
-        } else {
-            variantMetadatas = new ArrayList<>(candidates.getCandidateConfigurations()); // Need non-immutable copy to sort
-        }
+        assert candidates.isUseVariants() : "Cannot assess graph selection candidates when variants are not used.";
 
-        return assessVariantMetadatas(variantMetadatas);
+        return candidates.getVariants().stream()
+            .map(VariantGraphResolveState::getMetadata)
+            .map(variantMetadata -> assessCandidate(variantMetadata.getName(), variantMetadata.getCapabilities(), variantMetadata.getAttributes()))
+            .sorted(Comparator.comparing(AssessedCandidate::getDisplayName))
+            .collect(Collectors.toList());
     }
 
     public AssessedCandidate assessCandidate(

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/AbstractDependencyDescriptorFactoryInternalSpec.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/AbstractDependencyDescriptorFactoryInternalSpec.groovy
@@ -61,9 +61,6 @@ abstract class AbstractDependencyDescriptorFactoryInternalSpec extends Specifica
 
     protected static void assertDependencyDescriptorHasCommonFixtureValues(LocalOriginDependencyMetadata dependencyMetadata, boolean withArtifacts) {
         assert TEST_IVY_EXCLUDE_RULE == dependencyMetadata.getExcludes().get(0)
-        if (!withArtifacts) {
-            assert dependencyMetadata.getDependencyConfiguration() == TEST_DEP_CONF
-        }
         assert dependencyMetadata.isTransitive()
         if (withArtifacts) {
             assertDependencyDescriptorHasArtifacts(dependencyMetadata)

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/model/GraphVariantSelectorTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/model/GraphVariantSelectorTest.groovy
@@ -29,6 +29,7 @@ import org.gradle.api.internal.attributes.AttributesSchemaInternal
 import org.gradle.api.internal.attributes.DefaultAttributesSchema
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.internal.component.AmbiguousGraphVariantsException
+import org.gradle.internal.component.IncompatibleGraphVariantsException
 import org.gradle.internal.component.NoMatchingGraphVariantsException
 import org.gradle.internal.component.ResolutionFailureHandler
 import org.gradle.internal.component.external.model.ImmutableCapabilities
@@ -41,12 +42,11 @@ import spock.lang.Specification
 
 import static org.gradle.util.AttributeTestUtil.attributes
 
-class AttributeMatchingGraphArtifactVariantSelectorTest extends Specification {
+class GraphVariantSelectorTest extends Specification {
     private final AttributesSchemaInternal attributesSchema = new DefaultAttributesSchema(TestUtil.instantiatorFactory(), SnapshotTestUtil.isolatableFactory())
 
     private ComponentGraphResolveState targetState
     private ComponentGraphResolveMetadata targetComponent
-    private VariantGraphResolveState selected
     private ImmutableAttributes consumerAttributes = ImmutableAttributes.EMPTY
     private List<Capability> requestedCapabilities = []
     private List<IvyArtifactName> artifacts = []
@@ -63,7 +63,7 @@ class AttributeMatchingGraphArtifactVariantSelectorTest extends Specification {
         consumerAttributes('org.gradle.usage': usage)
 
         when:
-        performSelection()
+        def selected = performSelection()
 
         then:
         selected.name == expected
@@ -127,7 +127,7 @@ All of them match the consumer attributes:
         defaultConfiguration()
 
         when:
-        performSelection()
+        def selected = performSelection()
 
         then:
         selected.name == "default"
@@ -145,10 +145,10 @@ All of them match the consumer attributes:
         performSelection()
 
         then:
-        NoMatchingGraphVariantsException e = thrown()
-        failsWith(e, '''No matching variant of org:lib:1.0 was found. The consumer was configured to find attribute 'org.gradle.usage' with value 'cplusplus-headers' but:
-  - Variant 'default':
-      - Incompatible because this component declares attribute 'org.gradle.usage' with value 'java-api' and the consumer needed attribute 'org.gradle.usage' with value 'cplusplus-headers\'''')
+        IncompatibleGraphVariantsException e = thrown()
+        failsWith(e, '''Configuration 'default' in org:lib:1.0 does not match the consumer attributes
+Configuration 'default':
+  - Incompatible because this component declares attribute 'org.gradle.usage' with value 'java-api' and the consumer needed attribute 'org.gradle.usage' with value 'cplusplus-headers\'''')
     }
 
     def "can select a variant thanks to the capabilities"() {
@@ -163,7 +163,7 @@ All of them match the consumer attributes:
         requestCapability capability(cap)
 
         when:
-        performSelection()
+        def selected = performSelection()
 
         then:
         selected.name == expected
@@ -189,7 +189,7 @@ All of them match the consumer attributes:
         }
 
         when:
-        performSelection()
+        def selected = performSelection()
 
         then:
         selected.name == expected
@@ -333,7 +333,7 @@ All of them match the consumer attributes:
         consumerAttributes('org.gradle.usage': 'java-api')
 
         when:
-        performSelection()
+        def selected = performSelection()
 
         then:
         selected.name == 'first'
@@ -378,13 +378,12 @@ All of them match the consumer attributes:
         consumerAttributes('org.gradle.usage': 'java-api')
 
         when:
-        performSelection()
+        def selected = performSelection()
 
         then:
         selected.name == 'second'
 
     }
-
 
     def "should select the variant which matches the most attributes and producer doesn't have requested value"() {
         given:
@@ -399,7 +398,7 @@ All of them match the consumer attributes:
         consumerAttributes('org.gradle.usage': 'java-api', 'other': true)
 
         when:
-        performSelection()
+        def selected = performSelection()
 
         then:
         selected.name == 'second'
@@ -416,7 +415,7 @@ All of them match the consumer attributes:
         requireArtifact('foo', 'jar', 'jar', 'classy')
 
         when:
-        performSelection()
+        def selected = performSelection()
 
         then:
         selected.name == 'second'
@@ -434,7 +433,7 @@ All of them match the consumer attributes:
         requestCapability capability('first')
 
         when:
-        performSelection()
+        def selected = performSelection()
 
         then:
         selected.name == 'B' // B matches best: capabilities match exactly, attributes match exactly
@@ -456,22 +455,20 @@ All of them match the consumer attributes:
         requestCapability capability('first')
 
         when:
-        performSelection()
+        def selected = performSelection()
 
         then:
         selected.name == 'B' // B matches best: capabilities match exactly, attribute 'other' was requested and a compatible value is provided (variant C does not provide any value for 'other')
     }
 
-    private void performSelection() {
+    private VariantGraphResolveState performSelection() {
         def failureDescriberRegistry = DependencyManagementTestUtil.standardResolutionFailureDescriberRegistry()
         GraphVariantSelector variantSelector = new GraphVariantSelector(new ResolutionFailureHandler(failureDescriberRegistry))
-        selected = variantSelector.selectVariants(
-            consumerAttributes,
-            requestedCapabilities,
-            targetState,
-            attributesSchema,
-            artifacts
-        ).variants[0]
+        if (targetState.getCandidatesForGraphVariantSelection().isUseVariants()) {
+            return variantSelector.selectByAttributeMatching(consumerAttributes, requestedCapabilities, targetState, attributesSchema, artifacts)
+        } else {
+            return variantSelector.selectLegacyConfiguration(consumerAttributes, targetState, attributesSchema)
+        }
     }
 
     private void requireArtifact(String name = "foo", String type = "jar", String ext = "jar", String classifier = null) {
@@ -499,16 +496,17 @@ All of them match the consumer attributes:
     }
 
     private void defaultConfiguration(ImmutableAttributes attrs = attributes([:])) {
-        def variant = Stub(VariantGraphResolveState) {
+        def metadata = Stub(ConfigurationGraphResolveMetadata) {
             getName() >> 'default'
             getCapabilities() >> ImmutableCapabilities.of(capability('org', 'lib'))
             getAttributes() >> attrs
-        }
-        def metadata = Stub(ConfigurationGraphResolveMetadata) {
             isCanBeConsumed() >> true
-            getName() >> variant.getName()
+        }
+        def variant = Stub(VariantGraphResolveState) {
+            getCapabilities() >> ImmutableCapabilities.of(capability('org', 'lib'))
             getAttributes() >> attrs
-            getCapabilities() >> variant.getCapabilities()
+            getName() >> 'default'
+            getMetadata() >> metadata
         }
         defaultConfiguration = Stub(ConfigurationGraphResolveState) {
             getName() >> 'default'

--- a/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
+++ b/platforms/software/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
@@ -273,10 +273,8 @@ Configuration 'bar':
 
     def "fails to select target configuration when not present in the target component"() {
         def dep = new LocalComponentDependencyMetadata(Stub(ComponentSelector), "to", [] as List, [], false, false, true, false, false, null)
-        def toComponent = Stub(ComponentGraphResolveMetadata)
-        toComponent.id >> Stub(ComponentIdentifier) { getDisplayName() >> "thing b" }
         def toState = Stub(ComponentGraphResolveState) {
-            getMetadata() >> toComponent
+            getId() >> Stub(ComponentIdentifier) { getDisplayName() >> "thing b" }
         }
 
         given:

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyGraphIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyGraphIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.integtests.composite
 
-import org.gradle.api.JavaVersion
+
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.build.BuildTestFile
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
@@ -697,8 +697,7 @@ class CompositeBuildDependencyGraphIntegrationTest extends AbstractCompositeBuil
         checkDependenciesFails()
 
         then:
-        failure.assertHasCause("No matching variant of project :buildC was found. The consumer was configured to find a library for use during runtime, compatible with Java ${JavaVersion.current().majorVersion}, packaged as a jar, preferably optimized for standard JVMs, and its dependencies declared externally but:\n" +
-            "  - None of the variants have attributes.")
+        failure.assertHasCause("A dependency was declared on configuration 'default' which is not declared in the descriptor for project :buildC.")
     }
 
     public static final REPOSITORY_HINT = repositoryHint("Maven POM")


### PR DESCRIPTION
The `GraphVariantSelector` previously had a single method to both select the legacy default configuration and also select variants with attribute matching. Furthermore, the `LocalComponentDependencyMetadata` duplicated much of the legacy selection logic. This commit separates the `GraphVariantSelector`'s primary method into two, and updates the local dependency metadata to share legacy selection logic.

Along the way, this makes some error messages more accurately represent how Gradle is actually selecting target configurations/variants.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
