### PR TITLE
Add error-prone annotations

### DIFF
--- a/build-logic/dependency-modules/src/main/kotlin/gradlebuild/modules/extension/ExternalModulesExtension.kt
+++ b/build-logic/dependency-modules/src/main/kotlin/gradlebuild/modules/extension/ExternalModulesExtension.kt
@@ -54,6 +54,7 @@ abstract class ExternalModulesExtension(isBundleGroovy4: Boolean) {
     val commonsMath = "org.apache.commons:commons-math3"
     val configurationCacheReport = "org.gradle.buildtool.internal:configuration-cache-report:$configurationCacheReportVersion"
     val eclipseSisuPlexus = "org.eclipse.sisu:org.eclipse.sisu.plexus"
+    val errorProneAnnotations = "com.google.errorprone:error_prone_annotations"
     val fastutil = "it.unimi.dsi:fastutil"
     val gcs = "com.google.apis:google-api-services-storage"
     val googleApiClient = "com.google.api-client:google-api-client"

--- a/platforms/core-execution/file-watching/build.gradle.kts
+++ b/platforms/core-execution/file-watching/build.gradle.kts
@@ -4,12 +4,6 @@ plugins {
 
 description = "File system watchers for keeping the VFS up-to-date"
 
-errorprone {
-    disabledChecks.addAll(
-        "UnusedVariable", // 1 occurrences
-    )
-}
-
 dependencies {
     api(project(":snapshots"))
     api(project(":build-operations"))

--- a/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystem.java
+++ b/platforms/core-execution/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystem.java
@@ -46,7 +46,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nullable;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
@@ -231,7 +230,7 @@ public class WatchingVirtualFileSystem extends AbstractVirtualFileSystem impleme
                 if (watchMode.isEnabled()) {
                     if (reasonForNotWatchingFiles != null) {
                         // Log exception again so it doesn't get lost.
-                        logWatchingError(reasonForNotWatchingFiles, FILE_WATCHING_ERROR_MESSAGE_AT_END_OF_BUILD, watchMode);
+                        logWatchingError(reasonForNotWatchingFiles, FILE_WATCHING_ERROR_MESSAGE_AT_END_OF_BUILD);
                         reasonForNotWatchingFiles = null;
                     }
                     SnapshotHierarchy newRoot;
@@ -318,7 +317,7 @@ public class WatchingVirtualFileSystem extends AbstractVirtualFileSystem impleme
             watchableHierarchiesRegisteredEarly.clear();
             return newRoot;
         } catch (Exception ex) {
-            logWatchingError(ex, FILE_WATCHING_ERROR_MESSAGE_DURING_BUILD, null);
+            logWatchingError(ex, FILE_WATCHING_ERROR_MESSAGE_DURING_BUILD);
             closeUnderLock();
             return currentRoot.empty();
         }
@@ -442,12 +441,12 @@ public class WatchingVirtualFileSystem extends AbstractVirtualFileSystem impleme
         try {
             return supplier.get();
         } catch (Exception ex) {
-            logWatchingError(ex, FILE_WATCHING_ERROR_MESSAGE_DURING_BUILD, null);
+            logWatchingError(ex, FILE_WATCHING_ERROR_MESSAGE_DURING_BUILD);
             return stopWatchingAndInvalidateHierarchyAfterError(currentRoot);
         }
     }
 
-    private void logWatchingError(Exception exception, String fileWatchingErrorMessage, @Nullable WatchMode watchMode) {
+    private void logWatchingError(Exception exception, String fileWatchingErrorMessage) {
         if (exception instanceof InotifyInstanceLimitTooLowException) {
             warningLogger.warn("{}. The inotify instance limit is too low. {}",
                 fileWatchingErrorMessage,

--- a/platforms/core-runtime/base-annotations/build.gradle.kts
+++ b/platforms/core-runtime/base-annotations/build.gradle.kts
@@ -11,4 +11,5 @@ dependencies {
     compileOnly(libs.jetbrainsAnnotations)
 
     api(libs.jsr305)
+    api(libs.errorProneAnnotations)
 }

--- a/subprojects/distributions-dependencies/build.gradle.kts
+++ b/subprojects/distributions-dependencies/build.gradle.kts
@@ -72,6 +72,7 @@ dependencies {
         api(libs.commonsLang3)          { version { strictly("3.12.0") }}
         api(libs.commonsMath)           { version { strictly("3.6.1") }}
         api(libs.eclipseSisuPlexus)     { version { strictly("0.3.5"); because("transitive dependency of Maven modules to process POM metadata") }}
+        api(libs.errorProneAnnotations) { version { strictly("2.24.1") }}
         api(libs.gradleProfiler)        { version { strictly("0.21.0-alpha-3") }}
         api(libs.gradleEnterpriseTestAnnotation) { version { strictly("1.0") }}
         api(libs.gcs)                   { version { strictly("v1-rev20220705-1.32.1") }}

--- a/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
+++ b/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
@@ -34,7 +34,7 @@ import static org.hamcrest.MatcherAssert.assertThat
 
 abstract class DistributionIntegrationSpec extends AbstractIntegrationSpec {
 
-    protected static final THIRD_PARTY_LIB_COUNT = 148
+    protected static final THIRD_PARTY_LIB_COUNT = 149
 
     @Shared String baseVersion = GradleVersion.current().baseVersion.version
 


### PR DESCRIPTION
There are some useful annotations from Error Prone that we could use. Most importantly `@Keep` can be used to mark unused fields and methods if they are needed for some reason.

https://errorprone.info/api/latest/com/google/errorprone/annotations/package-summary.html