### PR TITLE
Add `-Werror` test

### DIFF
--- a/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileProblemsIntegrationTest.groovy
+++ b/platforms/jvm/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileProblemsIntegrationTest.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.api.tasks.compile
 
+import groovy.transform.stc.ClosureParams
+import groovy.transform.stc.SimpleType
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.problems.ReceivedProblem
 import org.gradle.test.fixtures.file.TestFile
@@ -24,8 +26,17 @@ import org.gradle.test.fixtures.file.TestFile
  */
 class JavaCompileProblemsIntegrationTest extends AbstractIntegrationSpec {
 
-    // The `assertProblem` method will store visited files here, and `assertAllFilesVisited` will check it
-    List<String> assertedFileLocations = []
+    /**
+     * A map of all possible file locations, and the number of occurrences we expect to find in the problems.
+     */
+    private final Map<String, Integer> possibleFileLocations = [:]
+
+    /**
+     * A map of all visited file locations, and the number of occurrences we have found in the problems.
+     * <p>
+     * This field will be updated by {@link #assertProblem(ReceivedProblem, String, Closure)} as it asserts a problem.
+     */
+    private final Map<String, Integer> visitedFileLocations = [:]
 
     def setup() {
         enableProblemsApiCheck()
@@ -48,30 +59,30 @@ class JavaCompileProblemsIntegrationTest extends AbstractIntegrationSpec {
         """
     }
 
+    def cleanup() {
+        assert possibleFileLocations == visitedFileLocations: "Not all expected files were visited: ${possibleFileLocations.keySet() - visitedFileLocations.keySet()}"
+    }
+
     def "problem is received when a single-file compilation failure happens"() {
-        def files = [
-            writeJavaCausingTwoCompilationErrors("Foo")
-        ]
-        // Duplicate the entries, as we have two problems per file
-        files.addAll(files)
+        given:
+        possibleFileLocations.put(writeJavaCausingTwoCompilationErrors("Foo"), 2)
+
         when:
         fails("compileJava")
 
         then:
         collectedProblems.size() == 2
         for (def problem in collectedProblems) {
-            assertProblem(problem, files, "ERROR")
+            assertProblem(problem, "ERROR") { details, taskLocation ->
+                assert details == "';' expected"
+            }
         }
-        assertedFileLocations == files
     }
 
     def "problems are received when a multi-file compilation failure happens"() {
-        def files = [
-            writeJavaCausingTwoCompilationErrors("Foo"),
-            writeJavaCausingTwoCompilationErrors("Bar")
-        ]
-        // Duplicate the entries, as we have two problems per file
-        files.addAll(files)
+        given:
+        possibleFileLocations.put(writeJavaCausingTwoCompilationErrors("Foo"), 2)
+        possibleFileLocations.put(writeJavaCausingTwoCompilationErrors("Bar"), 2)
 
         when:
         fails("compileJava")
@@ -79,16 +90,15 @@ class JavaCompileProblemsIntegrationTest extends AbstractIntegrationSpec {
         then:
         collectedProblems.size() == 4
         for (def problem in collectedProblems) {
-            assertProblem(problem, files, "ERROR")
+            assertProblem(problem, "ERROR") { details, taskLocation ->
+                assert details == "';' expected"
+            }
         }
     }
 
     def "problem is received when a single-file warning happens"() {
-        def files = [
-            writeJavaCausingTwoCompilationWarnings("Foo")
-        ]
-        // Duplicate the entries, as we have two problems per file
-        files.addAll(files)
+        given:
+        possibleFileLocations.put(writeJavaCausingTwoCompilationWarnings("Foo"), 2)
 
         when:
         def result = run("compileJava")
@@ -96,17 +106,16 @@ class JavaCompileProblemsIntegrationTest extends AbstractIntegrationSpec {
         then:
         collectedProblems.size() == 2
         for (def problem in collectedProblems) {
-            assertProblem(problem, files, "WARNING")
+            assertProblem(problem, "WARNING") { details, taskLocation ->
+                assert details == "redundant cast to java.lang.String"
+            }
         }
     }
 
     def "problems are received when a multi-file warning happens"() {
-        def files = [
-            writeJavaCausingTwoCompilationWarnings("Foo"),
-            writeJavaCausingTwoCompilationWarnings("Bar")
-        ]
-        // Duplicate the entries, as we have two problems per file
-        files.addAll(files)
+        given:
+        possibleFileLocations.put(writeJavaCausingTwoCompilationWarnings("Foo"), 2)
+        possibleFileLocations.put(writeJavaCausingTwoCompilationWarnings("Bar"), 2)
 
         when:
         def result = run("compileJava")
@@ -114,17 +123,16 @@ class JavaCompileProblemsIntegrationTest extends AbstractIntegrationSpec {
         then:
         collectedProblems.size() == 4
         for (def problem in collectedProblems) {
-            assertProblem(problem, files, "WARNING")
+            assertProblem(problem, "WARNING") { details, taskLocation ->
+                assert details == "redundant cast to java.lang.String"
+            }
         }
     }
 
     def "only failures are received when a multi-file compilation failure and warning happens"() {
-        def files = [
-            writeJavaCausingTwoCompilationErrorsAndTwoWarnings("Foo"),
-            writeJavaCausingTwoCompilationErrorsAndTwoWarnings("Bar")
-        ]
-        // Duplicate the entries, as we have two problems per file
-        files.addAll(files)
+        given:
+        possibleFileLocations.put(writeJavaCausingTwoCompilationErrorsAndTwoWarnings("Foo"), 2)
+        possibleFileLocations.put(writeJavaCausingTwoCompilationErrorsAndTwoWarnings("Bar"), 2)
 
         when:
         def result = fails("compileJava")
@@ -132,58 +140,126 @@ class JavaCompileProblemsIntegrationTest extends AbstractIntegrationSpec {
         then:
         collectedProblems.size() == 4
         for (def problem in collectedProblems) {
-            assertProblem(problem, files, "ERROR")
+            assertProblem(problem, "ERROR") { details, taskLocation ->
+                assert details == "';' expected"
+            }
         }
     }
 
     def "problems are received when two separate compilation task is executed"() {
-        def files = [
-            writeJavaCausingTwoCompilationErrors("Foo"),
-            writeJavaCausingTwoCompilationErrors("FooTest", "test")
-        ]
-        // Duplicate the entries, as we have two problems per file
-        files.addAll(files)
+        given:
+        // The main source set will only cause warnings, as otherwise compilation will fail with the `compileJava` task
+        possibleFileLocations.put(writeJavaCausingTwoCompilationWarnings("Foo"), 2)
+        // The test source set will cause errors
+        possibleFileLocations.put(writeJavaCausingTwoCompilationErrors("FooTest", "test"), 2)
 
         when:
         // Special flag to fork the compiler, see the setup()
         fails("compileTestJava")
 
         then:
-        collectedProblems.size() == 2
-        for (def problem in collectedProblems) {
-            assertProblem(problem, files, "ERROR")
+        collectedProblems.size() == 4
+
+        def warningProblems = collectedProblems.findAll {
+            it["severity"] == "WARNING"
+        }
+        warningProblems.size() == 2
+        for (def problem in warningProblems) {
+            assertProblem(problem, "WARNING") {details, taskLocation ->
+                assert details == "redundant cast to java.lang.String"
+            }
+        }
+
+        def errorProblems = collectedProblems.findAll {
+            it["severity"] == "ERROR"
+        }
+        errorProblems.size() == 2
+        for (def problem in errorProblems) {
+            assertProblem(problem, "ERROR") { details, taskLocation ->
+                assert details == "';' expected"
+            }
+        }
+    }
+
+    def "the compiler flag -Werror correctly reports"() {
+        given:
+        buildFile << "tasks.compileJava.options.compilerArgs += ['-Werror']"
+        possibleFileLocations.put(writeJavaCausingTwoCompilationWarnings("Foo"), 3)
+
+        when:
+        fails("compileJava")
+
+        then:
+        // 2 warnings + 1 special error
+        collectedProblems.size() == 3
+
+        // The two expected warnings are still reported as warnings
+        def warningProblems = collectedProblems.findAll {
+            it["severity"] == "WARNING"
+        }
+        warningProblems.size() == 2
+        for (def problem in warningProblems) {
+            assertProblem(problem, "WARNING") {details, taskLocation ->
+                assert details == "redundant cast to java.lang.String"
+            }
+        }
+
+        // The compiler will report a single error, implying that the warnings were treated as errors
+        def errorProblems = collectedProblems.findAll {
+            it["severity"] == "ERROR"
+        }
+        errorProblems.size() == 1
+        assertProblem(errorProblems[0], "ERROR") {details, taskLocation ->
+            assert details == "warnings found and -Werror specified"
         }
     }
 
     /**
      * Assert if a compilation problems looks like how we expect it to look like.
      * <p>
-     * In addition, the method will update the {@code assertedFileLocations} with the location found in the problem.
+     * In addition, the method will update the {@link #possibleFileLocations} with the location found in the problem.
      * This could be used to assert that all expected files have been visited.
      *
      * @param problem the problem to assert
-     * @param possibleFiles the list of possible files that the problem could be in
      * @param severity the expected severity of the problem
+     * @param extraChecks an optional closure to perform any custom checks on the problem, like checking the precise message of the problem
      *
      * @throws AssertionError if the problem does not look like how we expect it to look like
      */
-    def assertProblem(ReceivedProblem problem, List<String> possibleFiles, String severity, boolean checkTaskLocation = true) {
+    void assertProblem(
+        ReceivedProblem problem,
+        String severity,
+        @ClosureParams(
+            value = SimpleType,
+            options = [
+                "java.lang.String",
+                "java.lang.String"
+            ]
+        )
+        Closure extraChecks = null
+    ) {
         assert problem["severity"] == severity: "Expected severity to be ${severity}, but was ${problem["severity"]}"
+        switch (severity) {
+            case "ERROR":
+                assert problem["label"] == "Java compilation error": "Expected label 'Java compilation error', but was ${problem["label"]}"
+                break
+            case "WARNING":
+                assert problem["label"] == "Java compilation warning": "Expected label 'Java compilation warning', but was ${problem["message"]}"
+                break
+            default:
+                throw new IllegalArgumentException("Unknown severity: ${severity}")
+        }
+
+        def details = problem["details"] as String
+        assert details: "Expected details to be non-null, but was null"
 
         def locations = problem["locations"] as List<Map<String, Object>>
-        if (checkTaskLocation) {
-            assert locations.size() == 2: "Expected two locations, but received ${locations.size()}"
-        } else {
-            assert locations.size() == 1: "Expected a single location, but received ${locations.size()}"
-        }
+        assert locations.size() == 2: "Expected two locations, but received ${locations.size()}"
 
-        if (checkTaskLocation) {
-            def taskLocation = locations.find {
-                it.containsKey("buildTreePath")
-            }
-            assert taskLocation != null: "Expected a task location, but it was null"
-            assert taskLocation["buildTreePath"] == ":compileJava": "Expected task location to be ':compileJava', but it was ${taskLocation["buildTreePath"]}"
+        def taskLocation = locations.find {
+            it.containsKey("buildTreePath")
         }
+        assert taskLocation != null: "Expected a task location, but it was null"
 
         def fileLocation = locations.find {
             it.containsKey("path") && it.containsKey("line") && it.containsKey("column") && it.containsKey("length")
@@ -194,9 +270,14 @@ class JavaCompileProblemsIntegrationTest extends AbstractIntegrationSpec {
         assert fileLocation["length"] != null: "Expected a length, but it was null"
 
         def fileLocationPath = fileLocation["path"] as String
-        assert possibleFiles.remove(fileLocationPath): "Not found file location '${fileLocationPath}' in the expected file locations: ${possibleFiles}"
+        def occurrences = possibleFileLocations.get(fileLocationPath)
+        assert occurrences: "Not found file location '${fileLocationPath}' in the expected file locations: ${possibleFileLocations.keySet()}"
+        visitedFileLocations.putIfAbsent(fileLocationPath, 0)
+        visitedFileLocations[fileLocationPath] += 1
 
-        return true
+        if (extraChecks != null) {
+            extraChecks.call(details, taskLocation)
+        }
     }
 
     String writeJavaCausingTwoCompilationErrors(String className, String sourceSet = "main") {


### PR DESCRIPTION
This PR establishes an acceptance test for #27770.
The test is about figuring out what happens when we apply the `-Werror` flag to the compiler, and what kind of diagnostics we can expect in that case.
