### PR TITLE
Lock-in performance improvements from #27852

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ gradle.internal.testdistribution.writeTraceFile=false
 systemProp.gradle.internal.testdistribution.writeTraceFile=false
 systemProp.gradle.internal.testdistribution.queryResponseTimeout=PT20S
 # Default performance baseline
-defaultPerformanceBaselines=8.7-commit-9fd98b608e0
+defaultPerformanceBaselines=8.7-commit-6dd71551cc9
 
 # Skip dependency analysis for tests
 systemProp.dependency.analysis.test.analysis=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ gradle.internal.testdistribution.writeTraceFile=false
 systemProp.gradle.internal.testdistribution.writeTraceFile=false
 systemProp.gradle.internal.testdistribution.queryResponseTimeout=PT20S
 # Default performance baseline
-defaultPerformanceBaselines=8.7-commit-6dd71551cc9
+defaultPerformanceBaselines=8.7-commit-7e75d791284
 
 # Skip dependency analysis for tests
 systemProp.dependency.analysis.test.analysis=false


### PR DESCRIPTION
It is now faster to run up-to-date builds with the build cache enabled or the scan plugin applied due to https://github.com/gradle/gradle/pull/27852.
[All performance tests](https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_AllPerformanceTests_Trigger/77450170)

<img width="1412" alt="image" src="https://github.com/gradle/gradle/assets/423186/6f38ee23-213a-4d3a-b465-23e519941368">
