### PR TITLE
Track reasons for skipped tests

### DIFF
--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestCompleteEvent.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestCompleteEvent.java
@@ -25,6 +25,7 @@ import javax.annotation.Nullable;
 public class TestCompleteEvent {
     private final long endTime;
     private final TestResult.ResultType resultType;
+    private final String skipReason;
 
     @UsedByScanPlugin("test-distribution")
     public TestCompleteEvent(long endTime) {
@@ -33,8 +34,13 @@ public class TestCompleteEvent {
 
     @UsedByScanPlugin("test-distribution")
     public TestCompleteEvent(long endTime, TestResult.ResultType resultType) {
+        this(endTime, resultType, null);
+    }
+
+    public TestCompleteEvent(long endTime, TestResult.ResultType resultType, @Nullable String skipReason) {
         this.endTime = endTime;
         this.resultType = resultType;
+        this.skipReason = skipReason;
     }
 
     public long getEndTime() {
@@ -44,5 +50,10 @@ public class TestCompleteEvent {
     @Nullable
     public TestResult.ResultType getResultType() {
         return resultType;
+    }
+
+    @Nullable
+    public String getSkipReason() {
+        return skipReason;
     }
 }

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/TestCountLogger.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/logging/TestCountLogger.java
@@ -25,6 +25,9 @@ import org.gradle.util.internal.TextUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashSet;
+import java.util.Set;
+
 public class TestCountLogger implements TestListener {
     private final ProgressLoggerFactory factory;
     private ProgressLogger progressLogger;
@@ -34,6 +37,7 @@ public class TestCountLogger implements TestListener {
     private long failedTests;
     private long skippedTests;
     private boolean hadFailures;
+    private final Set<String> skipReasons = new HashSet<String>();
 
     public TestCountLogger(ProgressLoggerFactory factory) {
         this(factory, LoggerFactory.getLogger(TestCountLogger.class));
@@ -53,6 +57,7 @@ public class TestCountLogger implements TestListener {
         totalTests += result.getTestCount();
         failedTests += result.getFailedTestCount();
         skippedTests += result.getSkippedTestCount();
+        skipReasons.addAll(result.getSkipReasons());
         progressLogger.progress(summary());
     }
 
@@ -94,6 +99,7 @@ public class TestCountLogger implements TestListener {
 
     @Override
     public void afterSuite(TestDescriptor suite, TestResult result) {
+        skipReasons.addAll(result.getSkipReasons());
         if (suite.getParent() == null) {
             if (failedTests > 0) {
                 logger.error(TextUtil.getPlatformLineSeparator() + summary());
@@ -112,5 +118,13 @@ public class TestCountLogger implements TestListener {
 
     public long getTotalTests() {
         return totalTests;
+    }
+
+    public long getSkippedTests() {
+        return skippedTests;
+    }
+
+    public Set<String> getSkipReasons() {
+        return skipReasons;
     }
 }

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/DefaultTestResult.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/DefaultTestResult.java
@@ -23,9 +23,11 @@ import org.gradle.util.internal.CollectionUtils;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Set;
 
 public class DefaultTestResult implements TestResult, Serializable {
     private final List<TestFailure> failures;
+    private final Set<String> skipReasons;
     private final ResultType resultType;
     private final long startTime;
     private final long endTime;
@@ -34,10 +36,10 @@ public class DefaultTestResult implements TestResult, Serializable {
     private final long failedCount;
 
     public DefaultTestResult(TestState state) {
-        this(state.resultType, state.getStartTime(), state.getEndTime(), state.testCount, state.successfulCount, state.failedCount, state.failures);
+        this(state.resultType, state.getStartTime(), state.getEndTime(), state.testCount, state.successfulCount, state.failedCount, state.failures, state.skipReasons);
     }
 
-    public DefaultTestResult(ResultType resultType, long startTime, long endTime, long testCount, long successfulCount, long failedCount, List<TestFailure> failures) {
+    public DefaultTestResult(ResultType resultType, long startTime, long endTime, long testCount, long successfulCount, long failedCount, List<TestFailure> failures, Set<String> skipReasons) {
         this.resultType = resultType;
         this.startTime = startTime;
         this.endTime = endTime;
@@ -45,6 +47,7 @@ public class DefaultTestResult implements TestResult, Serializable {
         this.successfulCount = successfulCount;
         this.failedCount = failedCount;
         this.failures = failures;
+        this.skipReasons = skipReasons;
     }
 
     @Override
@@ -70,6 +73,11 @@ public class DefaultTestResult implements TestResult, Serializable {
     @Override
     public List<TestFailure> getFailures() {
         return failures;
+    }
+
+    @Override
+    public Set<String> getSkipReasons() {
+        return skipReasons;
     }
 
     @Override

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/TestState.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/results/TestState.java
@@ -23,8 +23,10 @@ import org.gradle.api.tasks.testing.TestFailure;
 import org.gradle.api.tasks.testing.TestResult;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class TestState {
     public final TestDescriptorInternal test;
@@ -32,6 +34,7 @@ public class TestState {
     private final Map<Object, TestState> executing;
     public boolean failedChild;
     public List<TestFailure> failures = new ArrayList<TestFailure>();
+    public Set<String> skipReasons = new HashSet<String>();
     public long testCount;
     public long successfulCount;
     public long failedCount;
@@ -77,6 +80,10 @@ public class TestState {
             }
         }
 
+        if (resultType == TestResult.ResultType.SKIPPED && event.getSkipReason() != null) {
+            skipReasons.add(event.getSkipReason());
+        }
+
         if (startEvent.getParentId() != null) {
             TestState parentState = executing.get(startEvent.getParentId());
             if (parentState != null) {
@@ -86,6 +93,7 @@ public class TestState {
                 parentState.testCount += testCount;
                 parentState.successfulCount += successfulCount;
                 parentState.failedCount += failedCount;
+                parentState.skipReasons.addAll(skipReasons);
             }
         }
     }

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/TestEventSerializer.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/TestEventSerializer.java
@@ -137,13 +137,15 @@ public class TestEventSerializer {
         public TestCompleteEvent read(Decoder decoder) throws Exception {
             long endTime = decoder.readLong();
             TestResult.ResultType result = typeSerializer.read(decoder);
-            return new TestCompleteEvent(endTime, result);
+            String skipReason = decoder.readNullableString();
+            return new TestCompleteEvent(endTime, result, skipReason);
         }
 
         @Override
         public void write(Encoder encoder, TestCompleteEvent value) throws Exception {
             encoder.writeLong(value.getEndTime());
             typeSerializer.write(encoder, value.getResultType());
+            encoder.writeNullableString(value.getSkipReason());
         }
     }
 

--- a/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/TestResult.java
+++ b/platforms/software/testing-base/src/main/java/org/gradle/api/tasks/testing/TestResult.java
@@ -20,6 +20,7 @@ import org.gradle.api.Incubating;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Describes a test result.
@@ -57,6 +58,16 @@ public interface TestResult {
      */
     @Incubating
     List<TestFailure> getFailures();
+
+    /**
+     * For all skipped tests, this will contain the reason why those tests were skipped, if any.
+     *
+     * @return The reported skip reasons.
+     *
+     * @since 8.7
+     */
+    @Incubating
+    Set<String> getSkipReasons();
 
     /**
      * If the test failed with any exceptions, this will contain the exceptions.  Some test frameworks do not fail

--- a/platforms/software/testing-base/src/testFixtures/groovy/org/gradle/api/internal/tasks/testing/SimpleTestResult.groovy
+++ b/platforms/software/testing-base/src/testFixtures/groovy/org/gradle/api/internal/tasks/testing/SimpleTestResult.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.tasks.testing.TestResult
 class SimpleTestResult implements TestResult {
     TestResult.ResultType resultType = TestResult.ResultType.SUCCESS
     List<Throwable> exceptions = []
+    Set<String> skipReasons = [] as Set
     Throwable exception = exceptions[0]
     List<TestFailure> failures
     long startTime = 0

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/precondition/RequiresExtension.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/precondition/RequiresExtension.groovy
@@ -79,8 +79,13 @@ class RequiresExtension implements IAnnotationDrivenExtension<Requires> {
         }
 
         PredicatesFile.checkValidCombinations(predicateClassNames, acceptedCombinations)
-        // If all preconditions are met, we DON'T skip the tests
-        specOfFeature.skipped |= !TestPrecondition.allSatisfied(annotation.value())
+
+        for (Class<? extends TestPrecondition> preconditionClass : annotation.value()) {
+            if (!TestPrecondition.satisfied(preconditionClass)) {
+                specOfFeature.skip("Precondition not satisfied: " + preconditionClass.simpleName)
+                return
+            }
+        }
     }
 
 }


### PR DESCRIPTION
It is frustrating when for some reason you try to run tests and for some reason they are all skipped. In this situation, Gradle does not tell you _why_ they were skipped. Now it does.

In this commit, we track the reason for any given test being skipped. At the end of the build, if no tests were selected, we add the skipped reasons to the message. We also deprecate running tests where all tests are skipped, similar to how we have deprecated running tests where all tests are filtered.

### Reviewing cheatsheet

Before merging the PR, comments starting with 
- ❌ ❓**must** be fixed
- 🤔 💅 **should** be fixed
- 💭 **may** be fixed
- 🎉 celebrate happy things
